### PR TITLE
Update build_a_job_runner.rst

### DIFF
--- a/doc/source/dev/build_a_job_runner.rst
+++ b/doc/source/dev/build_a_job_runner.rst
@@ -350,7 +350,7 @@ The following is a generic code snippet for the ``recover`` method.
 .. code-block:: python
 
     ajs = AsynchronousJobState(files_dir=job_wrapper.working_directory, job_wrapper=job_wrapper)
-    ajs.job_id = str(job_wrapper.get_job().job_runner_external_id)
+    asj.job_id = job.get_job_runner_external_id()
     ajs.job_destination = job_wrapper.job_destination
     job_wrapper.command_line = job.command_line
     ajs.job_wrapper = job_wrapper

--- a/doc/source/dev/build_a_job_runner.rst
+++ b/doc/source/dev/build_a_job_runner.rst
@@ -350,7 +350,7 @@ The following is a generic code snippet for the ``recover`` method.
 .. code-block:: python
 
     ajs = AsynchronousJobState(files_dir=job_wrapper.working_directory, job_wrapper=job_wrapper)
-    ajs.job_id = str(job_wrapper.job_id)
+    ajs.job_id = str(job_wrapper.get_job().job_runner_external_id)
     ajs.job_destination = job_wrapper.job_destination
     job_wrapper.command_line = job.command_line
     ajs.job_wrapper = job_wrapper


### PR DESCRIPTION
I believe the ajs job_id is supposed to be the external job runner id, not the galaxy id. job_wrapper.job_id is the galaxy id.

I might be missing something here though. 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
