### PR TITLE
Implement instance URLs in Galaxy markdown.

### DIFF
--- a/client/src/components/Markdown/Elements/InstanceUrl.vue
+++ b/client/src/components/Markdown/Elements/InstanceUrl.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import ExternalLink from "@/components/ExternalLink.vue";
+import LoadingSpan from "@/components/LoadingSpan.vue";
+
+interface InstanceUrlProps {
+    href?: string;
+    title?: string;
+    loading: boolean;
+}
+
+const props = withDefaults(defineProps<InstanceUrlProps>(), {
+    href: null,
+    title: null,
+});
+
+const effectiveTitle = computed(() => {
+    return props.title ? props.title : props.href;
+});
+</script>
+
+<template>
+    <p>
+        <LoadingSpan v-if="props.loading" message="Loading instance configuration"> </LoadingSpan>
+        <ExternalLink v-else-if="props.href" :href="props.href">
+            {{ effectiveTitle }}
+        </ExternalLink>
+        <i v-else> Configuration value unset, please contact Galaxy admin. </i>
+    </p>
+</template>

--- a/client/src/components/Markdown/MarkdownContainer.test.js
+++ b/client/src/components/Markdown/MarkdownContainer.test.js
@@ -11,6 +11,13 @@ import MountTarget from "./MarkdownContainer.vue";
 jest.mock("utils/redirect");
 withPrefix.mockImplementation((url) => url);
 
+jest.mock("@/composables/config", () => ({
+    useConfig: jest.fn(() => ({
+        config: {},
+        isConfigLoaded: true,
+    })),
+}));
+
 const localVue = getLocalVue();
 const axiosMock = new MockAdapter(axios);
 

--- a/client/src/components/Markdown/MarkdownContainer.vue
+++ b/client/src/components/Markdown/MarkdownContainer.vue
@@ -1,6 +1,8 @@
 <script setup>
 import { computed, ref } from "vue";
 
+import { useConfig } from "@/composables/config";
+
 import HistoryDatasetAsImage from "./Elements/HistoryDatasetAsImage.vue";
 import HistoryDatasetCollectionDisplay from "./Elements/HistoryDatasetCollection/CollectionDisplay.vue";
 import HistoryDatasetDetails from "./Elements/HistoryDatasetDetails.vue";
@@ -8,6 +10,7 @@ import HistoryDatasetDisplay from "./Elements/HistoryDatasetDisplay.vue";
 import HistoryDatasetIndex from "./Elements/HistoryDatasetIndex.vue";
 import HistoryDatasetLink from "./Elements/HistoryDatasetLink.vue";
 import HistoryLink from "./Elements/HistoryLink.vue";
+import InstanceUrl from "./Elements/InstanceUrl.vue";
 import InvocationTime from "./Elements/InvocationTime.vue";
 import JobMetrics from "./Elements/JobMetrics.vue";
 import JobParameters from "./Elements/JobParameters.vue";
@@ -16,6 +19,8 @@ import Visualization from "./Elements/Visualization.vue";
 import WorkflowDisplay from "./Elements/Workflow/WorkflowDisplay.vue";
 import WorkflowImage from "./Elements/Workflow/WorkflowImage.vue";
 import WorkflowLicense from "./Elements/Workflow/WorkflowLicense.vue";
+
+const { config, isConfigLoaded } = useConfig();
 
 const toggle = ref(false);
 const props = defineProps({
@@ -83,6 +88,39 @@ const isVisible = computed(() => !isCollapsible.value || toggle.value);
             <div v-else-if="name == 'workflow_license'" class="workflow-license">
                 <WorkflowLicense :license-id="workflows[args.workflow_id]['license']" />
             </div>
+            <InstanceUrl
+                v-else-if="name == 'instance_citation_link'"
+                :href="config.citation_url"
+                :loading="!isConfigLoaded">
+            </InstanceUrl>
+            <InstanceUrl v-else-if="name == 'instance_terms_link'" :href="config.terms_url" :loading="!isConfigLoaded">
+            </InstanceUrl>
+            <InstanceUrl
+                v-else-if="name == 'instance_support_link'"
+                :href="config.support_url"
+                :loading="!isConfigLoaded">
+            </InstanceUrl>
+            <InstanceUrl
+                v-else-if="name == 'instance_help_link'"
+                :href="config.helpsite_url"
+                :loading="!isConfigLoaded">
+            </InstanceUrl>
+            <InstanceUrl
+                v-else-if="name == 'instance_resources_link'"
+                :href="config.instance_resource_url"
+                :loading="!isConfigLoaded">
+            </InstanceUrl>
+            <InstanceUrl
+                v-else-if="name == 'instance_access_link'"
+                :href="config.instance_access_url"
+                :loading="!isConfigLoaded">
+            </InstanceUrl>
+            <InstanceUrl
+                v-else-if="name == 'instance_organization_link'"
+                :href="config.ga4gh_service_organization_url"
+                :title="config.ga4gh_service_organization_name"
+                :loading="!isConfigLoaded">
+            </InstanceUrl>
             <HistoryLink v-else-if="name == 'history_link'" :args="args" :histories="histories" />
             <HistoryDatasetAsImage v-else-if="name == 'history_dataset_as_image'" :args="args" />
             <HistoryDatasetLink v-else-if="name == 'history_dataset_link'" :args="args" />

--- a/client/src/components/Markdown/MarkdownToolBox.vue
+++ b/client/src/components/Markdown/MarkdownToolBox.vue
@@ -19,6 +19,7 @@
                     :expanded="true"
                     @onClick="onClick" />
                 <ToolSection v-else :category="workflowSection" :expanded="true" @onClick="onClick" />
+                <ToolSection :category="linksSection" :expanded="false" @onClick="onClick" />
                 <ToolSection :category="otherSection" :expanded="true" @onClick="onClick" />
                 <ToolSection
                     v-if="hasVisualizations"
@@ -250,6 +251,48 @@ export default {
                     },
                 ],
             },
+            linksSection: {
+                title: "Galaxy Instance Links",
+                name: "links",
+                elems: [
+                    {
+                        id: "instance_access_link",
+                        name: "Access",
+                        description: "(link used to access this Galaxy)",
+                    },
+                    {
+                        id: "instance_resources_link",
+                        name: "Resources",
+                        description: "(link for more information about this Galaxy)",
+                    },
+                    {
+                        id: "instance_help_link",
+                        name: "Help",
+                        description: "(link for finding help content for this Galaxy)",
+                    },
+                    {
+                        id: "instance_support_link",
+                        name: "Support",
+                        description: "(link for support for this Galaxy)",
+                    },
+                    {
+                        id: "instance_citation_link",
+                        name: "Citation",
+                        description: "(link describing how to cite this Galaxy instance)",
+                    },
+                    {
+                        id: "instance_terms_link",
+                        name: "Terms and Conditions",
+                        description: "(link describing terms and conditions for using this Galaxy instance)",
+                    },
+                    {
+                        id: "instance_organization_link",
+                        name: "Organization",
+                        description: "(link describing organization that runs this Galaxy instance)",
+                    },
+                ],
+            },
+
             visualizationSection: {
                 title: "Visualizations",
                 name: "visualizations",

--- a/client/src/components/PageDisplay/PageDisplay.vue
+++ b/client/src/components/PageDisplay/PageDisplay.vue
@@ -12,7 +12,7 @@
                     @onEdit="onEdit" />
                 <PageHtml v-else :page="page" />
             </div>
-            <b-alert v-else variant="info" show>Unsupported page format.</b-alert>
+            <LoadingSpan v-else message="Loading Galaxy configuration" />
         </template>
     </PublishedItem>
 </template>
@@ -27,10 +27,12 @@ import { urlData } from "@/utils/url";
 
 import PageHtml from "./PageHtml.vue";
 import PublishedItem from "@/components/Common/PublishedItem.vue";
+import LoadingSpan from "@/components/LoadingSpan.vue";
 import Markdown from "@/components/Markdown/Markdown.vue";
 
 export default {
     components: {
+        LoadingSpan,
         Markdown,
         PageHtml,
         PublishedItem,

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1650,9 +1650,22 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    URL of the support resource for the galaxy instance.  Used in
-    activation emails.
+    URL of the support resource for the galaxy instance.  Used outside
+    of web contexts such as in activation emails and in Galaxy
+    markdown report generation.
     Example value 'https://galaxyproject.org/'
+:Default: ``None``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~~~
+``instance_access_url``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    URL used to access this Galaxy server. Used outside of web
+    contexts such as in Galaxy markdown report generation.
+    Example value 'https://usegalaxy.org'
 :Default: ``None``
 :Type: str
 
@@ -4036,6 +4049,42 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~
+``organization_name``
+~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    The name of the organization that operates this Galaxy instance.
+    Serves as the default for the GA4GH service organization name and
+    can be exposed through Galaxy markdown for reports and such. For
+    instance, "Not Evil Corporation".
+    For GA4GH APIs, this is exposed via the service-info endpoint for
+    the Galaxy DRS API. If unset, one will be generated using
+    ga4gh_service_id (but only in the context of GA4GH APIs).
+    For more information on GA4GH service definitions - check out
+    https://github.com/ga4gh-discovery/ga4gh-service-registry and
+    https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/service-registry.yaml
+:Default: ``None``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~
+``organization_url``
+~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    The URL of the organization that operates this Galaxy instance.
+    Serves as the default for the GA4GH service organization name and
+    can be exposed through Galaxy markdown for reports and such. For
+    instance, "notevilcorp.com".
+    For GA4GH APIs, this is exposed via the service-info endpoint.
+    For more information on GA4GH service definitions - check out
+    https://github.com/ga4gh-discovery/ga4gh-service-registry and
+    https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/service-registry.yaml
+:Default: ``None``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~~~~~~
 ``ga4gh_service_id``
 ~~~~~~~~~~~~~~~~~~~~
@@ -4053,37 +4102,6 @@
     append the service type to this ID. For instance for the DRS
     service "id" (available via the DRS API) for the above
     configuration value would be org.usegalaxy.drs.
-:Default: ``None``
-:Type: str
-
-
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``ga4gh_service_organization_name``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    Service name for host organization (exposed via the service-info
-    endpoint for the Galaxy DRS API). If unset, one will be generated
-    using ga4gh_service_id.
-    For more information on GA4GH service definitions - check out
-    https://github.com/ga4gh-discovery/ga4gh-service-registry and
-    https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/service-registry.yaml
-:Default: ``None``
-:Type: str
-
-
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``ga4gh_service_organization_url``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    Organization URL for host organization (exposed via the
-    service-info endpoint for the Galaxy DRS API). If unset, one will
-    be generated using the URL the target API requests are made
-    against.
-    For more information on GA4GH service definitions - check out
-    https://github.com/ga4gh-discovery/ga4gh-service-registry and
-    https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/service-registry.yaml
 :Default: ``None``
 :Type: str
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -637,6 +637,8 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         "fetch_url_whitelist": "fetch_url_allowlist",
         "containers_resolvers_config_file": "container_resolvers_config_file",
         "activation_email": "email_from",
+        "ga4gh_service_organization_name": "organization_name",
+        "ga4gh_service_organization_url": "organization_url",
     }
 
     deprecated_options = list(renamed_options.keys()) + [

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -203,6 +203,8 @@ OPTION_ACTIONS: Dict[str, _OptionAction] = {
     "legacy_eager_objectstore_initialization": _DeprecatedAndDroppedAction(),
     "enable_openid": _DeprecatedAndDroppedAction(),
     "openid_consumer_cache_path": _DeprecatedAndDroppedAction(),
+    "ga4gh_service_organization_name": _RenameAction("organization_name"),
+    "ga4gh_service_organization_url": _RenameAction("organization_url"),
 }
 
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1116,10 +1116,16 @@ galaxy:
   # message, before the 'Your Galaxy Team' signature.
   #custom_activation_email_message: null
 
-  # URL of the support resource for the galaxy instance.  Used in
-  # activation emails.
+  # URL of the support resource for the galaxy instance.  Used outside
+  # of web contexts such as in activation emails and in Galaxy markdown
+  # report generation.
   # Example value 'https://galaxyproject.org/'
   #instance_resource_url: null
+
+  # URL used to access this Galaxy server. Used outside of web contexts
+  # such as in Galaxy markdown report generation.
+  # Example value 'https://usegalaxy.org'
+  #instance_access_url: null
 
   # E-mail domains blocklist is used for filtering out users that are
   # using disposable email addresses at registration.  If their
@@ -2187,6 +2193,28 @@ galaxy:
   # production server.
   #bootstrap_admin_api_key: null
 
+  # The name of the organization that operates this Galaxy instance.
+  # Serves as the default for the GA4GH service organization name and
+  # can be exposed through Galaxy markdown for reports and such. For
+  # instance, "Not Evil Corporation".
+  # For GA4GH APIs, this is exposed via the service-info endpoint for
+  # the Galaxy DRS API. If unset, one will be generated using
+  # ga4gh_service_id (but only in the context of GA4GH APIs).
+  # For more information on GA4GH service definitions - check out
+  # https://github.com/ga4gh-discovery/ga4gh-service-registry and
+  # https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/service-registry.yaml
+  #organization_name: null
+
+  # The URL of the organization that operates this Galaxy instance.
+  # Serves as the default for the GA4GH service organization name and
+  # can be exposed through Galaxy markdown for reports and such. For
+  # instance, "notevilcorp.com".
+  # For GA4GH APIs, this is exposed via the service-info endpoint.
+  # For more information on GA4GH service definitions - check out
+  # https://github.com/ga4gh-discovery/ga4gh-service-registry and
+  # https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/service-registry.yaml
+  #organization_url: null
+
   # Service ID for GA4GH services (exposed via the service-info endpoint
   # for the Galaxy DRS API). If unset, one will be generated using the
   # URL the target API requests are made against.
@@ -2200,22 +2228,6 @@ galaxy:
   # (available via the DRS API) for the above configuration value would
   # be org.usegalaxy.drs.
   #ga4gh_service_id: null
-
-  # Service name for host organization (exposed via the service-info
-  # endpoint for the Galaxy DRS API). If unset, one will be generated
-  # using ga4gh_service_id.
-  # For more information on GA4GH service definitions - check out
-  # https://github.com/ga4gh-discovery/ga4gh-service-registry and
-  # https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/service-registry.yaml
-  #ga4gh_service_organization_name: null
-
-  # Organization URL for host organization (exposed via the service-info
-  # endpoint for the Galaxy DRS API). If unset, one will be generated
-  # using the URL the target API requests are made against.
-  # For more information on GA4GH service definitions - check out
-  # https://github.com/ga4gh-discovery/ga4gh-service-registry and
-  # https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/service-registry.yaml
-  #ga4gh_service_organization_url: null
 
   # Service environment (exposed via the service-info endpoint for the
   # Galaxy DRS API) for implemented GA4GH services.

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -15,6 +15,10 @@ tool_shed:
   # installation directory.
   #hgweb_config_dir: null
 
+  # Allow pushing directly to mercurial repositories directly and
+  # without authentication.
+  #config_hg_for_dev: null
+
   # Where Tool Shed repositories are stored.
   #file_path: database/community_files
 
@@ -187,6 +191,50 @@ tool_shed:
 
   # Address to join mailing list
   #mailing_join_addr: galaxy-announce-join@bx.psu.edu
+
+  # Service ID for GA4GH services.
+  # If unset, one will be generated using the URL the target API
+  # requests are made against.
+  # For more information on GA4GH service definitions - check out
+  # https://github.com/ga4gh-discovery/ga4gh-service-registry and
+  # https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/service-registry.yaml
+  # This value should likely reflect your service's URL. For instance
+  # for usegalaxy.org this value should be org.usegalaxy. Particular
+  # Galaxy implementations will treat this value as a prefix and append
+  # the service type to this ID. For instance for the DRS service "id"
+  # (available via the DRS API) for the above configuration value would
+  # be org.usegalaxy.drs.
+  #ga4gh_service_id: null
+
+  # The name of the organization that operates this Galaxy instance.
+  # Serves as the default for the GA4GH service organization name and
+  # can be exposed through Galaxy markdown for reports and such. For
+  # instance, "Not Evil Corporation".
+  # For GA4GH APIs, this is exposed via the service-info endpoint for
+  # the Galaxy DRS API. If unset, one will be generated using
+  # ga4gh_service_id (but only in the context of GA4GH APIs).
+  # For more information on GA4GH service definitions - check out
+  # https://github.com/ga4gh-discovery/ga4gh-service-registry and
+  # https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/service-registry.yaml
+  #organization_name: null
+
+  # The URL of the organization that operates this Galaxy instance.
+  # Serves as the default for the GA4GH service organization name and
+  # can be exposed through Galaxy markdown for reports and such. For
+  # instance, "notevilcorp.com".
+  # For GA4GH APIs, this is exposed via the service-info endpoint.
+  # For more information on GA4GH service definitions - check out
+  # https://github.com/ga4gh-discovery/ga4gh-service-registry and
+  # https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/service-registry.yaml
+  #organization_url: null
+
+  # Service environment (exposed via the service-info endpoint for the
+  # Galaxy DRS API) for implemented GA4GH services.
+  # Suggested values are prod, test, dev, staging.
+  # For more information on GA4GH service definitions - check out
+  # https://github.com/ga4gh-discovery/ga4gh-service-registry and
+  # https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/service-registry.yaml
+  #ga4gh_service_environment: null
 
   # Write thread status periodically to 'heartbeat.log' (careful, uses
   # disk  space rapidly!)

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -1180,10 +1180,19 @@ mapping:
         type: str
         required: false
         desc: |
-          URL of the support resource for the galaxy instance.  Used in activation
-          emails.
+          URL of the support resource for the galaxy instance.  Used outside of web contexts
+          such as in activation emails and in Galaxy markdown report generation.
 
           Example value 'https://galaxyproject.org/'
+
+      instance_access_url:
+        type: str
+        required: false
+        desc: |
+          URL used to access this Galaxy server. Used outside of web contexts
+          such as in Galaxy markdown report generation.
+
+          Example value 'https://usegalaxy.org'
 
       email_domain_blocklist_file:
         type: str
@@ -2931,6 +2940,36 @@ mapping:
           a real admin user account via API.
           You should probably not set this on a production server.
 
+      organization_name:
+        type: str
+        required: false
+        desc: |
+          The name of the organization that operates this Galaxy instance. Serves as the
+          default for the GA4GH service organization name and can be exposed through Galaxy
+          markdown for reports and such. For instance, "Not Evil Corporation".
+
+          For GA4GH APIs, this is exposed via the service-info endpoint for the Galaxy DRS API.
+          If unset, one will be generated using ga4gh_service_id (but only in the context
+          of GA4GH APIs).
+
+          For more information on GA4GH service definitions - check out
+          https://github.com/ga4gh-discovery/ga4gh-service-registry
+          and https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/service-registry.yaml
+
+      organization_url:
+        type: str
+        required: false
+        desc: |
+          The URL of the organization that operates this Galaxy instance. Serves as the
+          default for the GA4GH service organization name and can be exposed through Galaxy
+          markdown for reports and such. For instance, "notevilcorp.com".
+
+          For GA4GH APIs, this is exposed via the service-info endpoint.
+
+          For more information on GA4GH service definitions - check out
+          https://github.com/ga4gh-discovery/ga4gh-service-registry
+          and https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/service-registry.yaml
+
       ga4gh_service_id:
         type: str
         required: false
@@ -2947,28 +2986,6 @@ mapping:
           value as a prefix and append the service type to this ID. For instance for the DRS
           service "id" (available via the DRS API) for the above configuration value would be
           org.usegalaxy.drs.
-
-      ga4gh_service_organization_name:
-        type: str
-        required: false
-        desc: |
-          Service name for host organization (exposed via the service-info endpoint for the Galaxy DRS API).
-          If unset, one will be generated using ga4gh_service_id.
-
-          For more information on GA4GH service definitions - check out
-          https://github.com/ga4gh-discovery/ga4gh-service-registry
-          and https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/service-registry.yaml
-
-      ga4gh_service_organization_url:
-        type: str
-        required: False
-        desc: |
-          Organization URL for host organization (exposed via the service-info endpoint for the Galaxy DRS API).
-          If unset, one will be generated using the URL the target API requests are made against.
-
-          For more information on GA4GH service definitions - check out
-          https://github.com/ga4gh-discovery/ga4gh-service-registry
-          and https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/service-registry.yaml
 
       ga4gh_service_environment:
         type: str

--- a/lib/galaxy/config/schemas/tool_shed_config_schema.yml
+++ b/lib/galaxy/config/schemas/tool_shed_config_schema.yml
@@ -353,7 +353,8 @@ mapping:
         type: str
         required: false
         desc: |
-          Service ID for GA4GH services (exposed via the service-info endpoint for the Galaxy DRS API).
+          Service ID for GA4GH services.
+
           If unset, one will be generated using the URL the target API requests are made against.
 
           For more information on GA4GH service definitions - check out
@@ -366,23 +367,31 @@ mapping:
           service "id" (available via the DRS API) for the above configuration value would be
           org.usegalaxy.drs.
 
-      ga4gh_service_organization_name:
+      organization_name:
         type: str
         required: false
         desc: |
-          Service name for host organization (exposed via the service-info endpoint for the Galaxy DRS API).
-          If unset, one will be generated using ga4gh_service_id.
+          The name of the organization that operates this Galaxy instance. Serves as the
+          default for the GA4GH service organization name and can be exposed through Galaxy
+          markdown for reports and such. For instance, "Not Evil Corporation".
+
+          For GA4GH APIs, this is exposed via the service-info endpoint for the Galaxy DRS API.
+          If unset, one will be generated using ga4gh_service_id (but only in the context
+          of GA4GH APIs).
 
           For more information on GA4GH service definitions - check out
           https://github.com/ga4gh-discovery/ga4gh-service-registry
           and https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/service-registry.yaml
 
-      ga4gh_service_organization_url:
+      organization_url:
         type: str
-        required: False
+        required: false
         desc: |
-          Organization URL for host organization (exposed via the service-info endpoint for the Galaxy DRS API).
-          If unset, one will be generated using the URL the target API requests are made against.
+          The URL of the organization that operates this Galaxy instance. Serves as the
+          default for the GA4GH service organization name and can be exposed through Galaxy
+          markdown for reports and such. For instance, "notevilcorp.com".
+
+          For GA4GH APIs, this is exposed via the service-info endpoint.
 
           For more information on GA4GH service definitions - check out
           https://github.com/ga4gh-discovery/ga4gh-service-registry

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -213,6 +213,10 @@ class ConfigSerializer(base.ModelSerializer):
             "tool_training_recommendations_link": _use_config,
             "tool_training_recommendations_api_url": _use_config,
             "enable_notification_system": _use_config,
+            "instance_resource_url": _use_config,
+            "instance_access_url": _use_config,
+            "organization_name": _use_config,
+            "organization_url": _use_config,
         }
 
 

--- a/lib/galaxy/managers/markdown_parse.py
+++ b/lib/galaxy/managers/markdown_parse.py
@@ -46,6 +46,13 @@ VALID_ARGUMENTS: Dict[str, Union[List[str], DynamicArguments]] = {
     "tool_stdout": ["step", "job_id"],
     "generate_galaxy_version": [],
     "generate_time": [],
+    "instance_access_link": [],
+    "instance_resources_link": [],
+    "instance_help_link": [],
+    "instance_support_link": [],
+    "instance_citation_link": [],
+    "instance_terms_link": [],
+    "instance_organization_link": [],
     "visualization": DYNAMIC_ARGUMENTS,
     # Invocation Flavored Markdown
     "invocation_time": ["invocation_id"],

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -183,6 +183,28 @@ class GalaxyInternalMarkdownDirectiveHandler(metaclass=abc.ABCMeta):
                 rval = self.handle_generate_galaxy_version(line, version)
             elif container == "generate_time":
                 rval = self.handle_generate_time(line, now())
+            elif container == "instance_access_link":
+                url = trans.app.config.instance_access_url
+                rval = self.handle_instance_access_link(line, url)
+            elif container == "instance_resources_link":
+                url = trans.app.config.instance_resource_url
+                rval = self.handle_instance_resources_link(line, url)
+            elif container == "instance_help_link":
+                url = trans.app.config.helpsite_url
+                rval = self.handle_instance_help_link(line, url)
+            elif container == "instance_support_link":
+                url = trans.app.config.support_url
+                rval = self.handle_instance_support_link(line, url)
+            elif container == "instance_citation_link":
+                url = trans.app.config.citation_url
+                rval = self.handle_instance_citation_link(line, url)
+            elif container == "instance_terms_link":
+                url = trans.app.config.terms_url
+                rval = self.handle_instance_terms_link(line, url)
+            elif container == "instance_organization_link":
+                title = trans.app.config.organization_name
+                url = trans.app.config.organization_url
+                rval = self.handle_instance_organization_link(line, title, url)
             elif container == "invocation_time":
                 invocation = workflow_manager.get_invocation(trans, object_id)
                 rval = self.handle_invocation_time(line, invocation)
@@ -288,6 +310,34 @@ class GalaxyInternalMarkdownDirectiveHandler(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
+    def handle_instance_access_link(self, line, url):
+        pass
+
+    @abc.abstractmethod
+    def handle_instance_resources_link(self, line, url):
+        pass
+
+    @abc.abstractmethod
+    def handle_instance_help_link(self, line, url):
+        pass
+
+    @abc.abstractmethod
+    def handle_instance_support_link(self, line, url):
+        pass
+
+    @abc.abstractmethod
+    def handle_instance_citation_link(self, line, url):
+        pass
+
+    @abc.abstractmethod
+    def handle_instance_terms_link(self, line, url):
+        pass
+
+    @abc.abstractmethod
+    def handle_instance_organization_link(self, line, title, url):
+        pass
+
+    @abc.abstractmethod
     def handle_invocation_time(self, line, date):
         pass
 
@@ -369,6 +419,27 @@ class ReadyForExportMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHand
         pass
 
     def handle_generate_time(self, line, generate_time):
+        pass
+
+    def handle_instance_access_link(self, line, url):
+        pass
+
+    def handle_instance_resources_link(self, line, url):
+        pass
+
+    def handle_instance_help_link(self, line, url):
+        pass
+
+    def handle_instance_support_link(self, line, url):
+        pass
+
+    def handle_instance_citation_link(self, line, url):
+        pass
+
+    def handle_instance_terms_link(self, line, url):
+        pass
+
+    def handle_instance_organization_link(self, line, title, url):
         pass
 
     def handle_invocation_time(self, line, invocation):
@@ -595,6 +666,35 @@ class ToBasicMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHandler):
     def handle_generate_time(self, line, generate_time):
         content = literal_via_fence(generate_time.isoformat())
         return (content, True)
+
+    def handle_instance_access_link(self, line, url):
+        return self._handle_link(url)
+
+    def handle_instance_resources_link(self, line, url):
+        return self._handle_link(url)
+
+    def handle_instance_help_link(self, line, url):
+        return self._handle_link(url)
+
+    def handle_instance_support_link(self, line, url):
+        return self._handle_link(url)
+
+    def handle_instance_citation_link(self, line, url):
+        return self._handle_link(url)
+
+    def handle_instance_terms_link(self, line, url):
+        return self._handle_link(url)
+
+    def handle_instance_organization_link(self, line, title, url):
+        return self._handle_link(url, title)
+
+    def _handle_link(self, url, title=None):
+        if not url:
+            content = "*Not configured, please contact Galaxy admin*"
+            return (content, True)
+        elif not title:
+            title = url
+        return (f"[{title}]({url})", True)
 
     def handle_invocation_time(self, line, invocation):
         content = literal_via_fence(invocation.create_time.strftime("%Y-%m-%d, %H:%M:%S"))

--- a/lib/galaxy/webapps/galaxy/api/drs.py
+++ b/lib/galaxy/webapps/galaxy/api/drs.py
@@ -51,8 +51,8 @@ class DrsApi:
         default_organization_id = ".".join(reversed(hostname.split(".")))
         config = self.config
         organization_id = config.ga4gh_service_id or default_organization_id
-        organization_name = config.ga4gh_service_organization_name or organization_id
-        organization_url = config.ga4gh_service_organization_url or f"{components.scheme}://{components.netloc}"
+        organization_name = config.organization_name or organization_id
+        organization_url = config.organization_url or f"{components.scheme}://{components.netloc}"
 
         organization = ServiceOrganization(
             url=organization_url,

--- a/lib/tool_shed/managers/trs.py
+++ b/lib/tool_shed/managers/trs.py
@@ -44,8 +44,8 @@ def service_info(app: ToolShedApp, request_url: URL):
     default_organization_id = ".".join(reversed(hostname.split(".")))
     config = app.config
     organization_id = cast(str, config.ga4gh_service_id or default_organization_id)
-    organization_name = cast(str, config.ga4gh_service_organization_name or organization_id)
-    organization_url = cast(str, config.ga4gh_service_organization_url or f"{components.scheme}://{components.netloc}")
+    organization_name = cast(str, config.organization_name or organization_id)
+    organization_url = cast(str, config.organization_url or f"{components.scheme}://{components.netloc}")
 
     organization = Organization(
         url=organization_url,


### PR DESCRIPTION
Working my way through some of the ideas on https://github.com/galaxyproject/galaxy/issues/16556.

The request was for "current citation for the Galaxy instance it ran on". I think there is a bunch of different things along these lines that would all be useful depending on the application. See the comments on the above issue for more discussion. This adds PR adds 7 new Galaxy markdown link directives - these are for the Galaxy URL, the organization URL, the citation URL, the support URL, the help URL, the terms URL, and the "resources URL" (what we call galaxyproject.org for main).

Most of these are already defined in Galaxy and we just reuse what is there - I did create one new config option and sort of reworked, generalized two existing ones to support this. This is as discussed below:

``instance_resources_link()`` - We define the config value in config_schema.yml called ``instance_resource_url`` and we use it for linking to galaxyproject.org in activation e-mails. This seems like a reasonable configuration value to re-use for reports/pages and expose for general statements about learning more about Galaxy and such.

```instance_access_link()``` - I added ``instance_access_url`` to mirror ``instance_resource_url`` and serve as a way for admins to configure the endpoint URL they want to use for accessing the Galaxy instance. For main, I assume we'd set this to ``https://usegalaxy.org``.

``instance_organization_link()`` - We already had configuration values called ``ga4gh_service_organization_name`` and ``ga4gh_service_organization_url`` that we needed to expose for GA4GH APIs. All the APIs use similar service endpoint descriptions. I added new configuration values that are more general called ``organization_url`` and ``organization_name`` for building links that describe the organization hosting Galaxy. The GA4GH values can still be set to more specific things (i.e. if you wanted to define "Evil Corp" as the organization and "Evil Corp - GA4GH Department" as the service provider) but setting the organization-level values make the most sense 99% of the time I think.

``instance_citation_link()`` - Already used in the UI, set via ``citation_url`` in Galaxy's config, and defaults to  .
https://galaxyproject.org/citing-galaxy

``instance_support_link()`` - Already used in the UI, set via ``support_url`` in Galaxy's config, and defaults to https://galaxyproject.org/support/ .

``instance_help_link()`` - Already used in the UI, set via ``helpsite_url`` in Galaxy's config, and defaults to https://help.galaxyproject.org/.

``instance_terms_link()`` - Already used in the UI, set via ``terms_url`` in Galaxy's config, and has no default.

The inputs:

<img width="836" alt="Screenshot 2023-09-11 at 4 13 46 PM" src="https://github.com/galaxyproject/galaxy/assets/216771/f5b7e04e-9f16-450b-b983-1d0954107529">

The result:

<img width="718" alt="Screenshot 2023-09-11 at 4 14 02 PM" src="https://github.com/galaxyproject/galaxy/assets/216771/9d7da36a-b8cc-43e1-b248-83943f68c29d">

The PDF:

<img width="1173" alt="Screenshot 2023-09-11 at 4 14 16 PM" src="https://github.com/galaxyproject/galaxy/assets/216771/db95aedb-5b33-4297-84a6-84f274a89a92">

These are sort of niche - so I don't expand the toolbox section with these link directives by default - but they are available if you expand that section:

<img width="321" alt="Screenshot 2023-09-11 at 4 13 53 PM" src="https://github.com/galaxyproject/galaxy/assets/216771/02e1dfd8-9914-490c-8bff-796923099e1c">

The config.yaml entries I added for this:
<img width="840" alt="Screenshot 2023-09-11 at 4 16 56 PM" src="https://github.com/galaxyproject/galaxy/assets/216771/7c066669-97cd-48b1-80c4-dfef33b9afcf">

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Create a new page and mimic the screenshots.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
