### PR TITLE
readd smtplib connect() for tls connections

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1556,6 +1556,7 @@ def send_mail(frm, to, subject, body, config, html=None):
         s = smtplib.SMTP_SSL(config.smtp_server)
     else:
         s = smtplib.SMTP(config.smtp_server)
+        s.connect()
     if not smtp_ssl:
         try:
             s.starttls()


### PR DESCRIPTION
We got an error sending error reports from galaxy:

```
galaxy.tools.error_reports DEBUG 2023-09-11 14:59:14,469 [pN:main.2,p:4081449,tN:WSGI_1] Bug report plugin <galaxy.tools.error_reports.plugins.email.EmailPlugin object at 0x7fedf844f5e0> generated response ('An error occurred sending the report by email: [SSL: UNSUPPORTED_PROTOCOL] unsupported protocol (_ssl.c:1129)', 'danger')
```

The reason turned out to be the missing `s.connect()` call:

```
>>> s = smtplib.SMTP("smtp.server")
>>> s.starttls()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/galaxy/mamba-envs/_galaxy_/lib/python3.9/smtplib.py", line 790, in starttls
    self.sock = context.wrap_socket(self.sock,
  File "/galaxy/mamba-envs/_galaxy_/lib/python3.9/ssl.py", line 501, in wrap_socket
    return self.sslsocket_class._create(
  File "/galaxy/mamba-envs/_galaxy_/lib/python3.9/ssl.py", line 1041, in _create
    self.do_handshake()
  File "/galaxy/mamba-envs/_galaxy_/lib/python3.9/ssl.py", line 1310, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: UNSUPPORTED_PROTOCOL] unsupported protocol (_ssl.c:1129)
>>> s.connect()
(220, b'gbcs.localdomain ESMTP Postfix')
>>> s.starttls()
(220, b'2.0.0 Ready to start TLS')
>>> s.sendmail("scholtal@embl.de", "scholtal@embl.de", "A message")
{}
```

## How to test the changes?

- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  see above

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
