### PR TITLE
[23.1] Fix metadata setting in extended metadata + outputs_to_working_directory mode

### DIFF
--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Run tests
         run: |
           mapfile -t TOOL_ARRAY < tool_list.txt
-          planemo test --galaxy_python_version ${{ matrix.python-version }} --galaxy_root 'galaxy root' "${TOOL_ARRAY[@]}"
+          planemo test --biocontainers --galaxy_python_version ${{ matrix.python-version }} --galaxy_root 'galaxy root' "${TOOL_ARRAY[@]}"
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -909,12 +909,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
         remote_job_config,
     ):
         metadata_kwds = {}
-        if remote_metadata and not job_wrapper.use_metadata_binary:
-            remote_system_properties = remote_job_config.get("system_properties", {})
-            remote_galaxy_home = remote_system_properties.get("galaxy_home", None)
-            if not remote_galaxy_home:
-                raise Exception(NO_REMOTE_GALAXY_FOR_METADATA_MESSAGE)
-            metadata_kwds["exec_dir"] = remote_galaxy_home
+        if remote_metadata:
             outputs_directory = remote_job_config["outputs_directory"]
             working_directory = remote_job_config["working_directory"]
             metadata_directory = remote_job_config["metadata_directory"]
@@ -937,15 +932,23 @@ class PulsarJobRunner(AsynchronousJobRunner):
                 if work_dir_output:
                     work_dir_output.false_path = pulsar_workdir_path
             metadata_kwds["output_fnames"] = list(real_path_to_output.values())
-            metadata_kwds["compute_tmp_dir"] = metadata_directory
-            metadata_kwds["config_root"] = remote_galaxy_home
-            default_config_file = os.path.join(remote_galaxy_home, "config/galaxy.ini")
-            metadata_kwds["config_file"] = remote_system_properties.get("galaxy_config_file", default_config_file)
-            metadata_kwds["dataset_files_path"] = remote_system_properties.get("galaxy_dataset_files_path", None)
+            remote_system_properties = remote_job_config.get("system_properties", {})
+            remote_galaxy_home = remote_system_properties.get("galaxy_home")
+            if not job_wrapper.use_metadata_binary:
+                if not remote_galaxy_home:
+                    raise Exception(NO_REMOTE_GALAXY_FOR_METADATA_MESSAGE)
+                metadata_kwds["exec_dir"] = remote_galaxy_home
+                metadata_kwds["compute_tmp_dir"] = metadata_directory
+                metadata_kwds["config_root"] = remote_galaxy_home
+                default_config_file = os.path.join(remote_galaxy_home, "config/galaxy.ini")
+                metadata_kwds["config_file"] = remote_system_properties.get("galaxy_config_file", default_config_file)
+                metadata_kwds["dataset_files_path"] = remote_system_properties.get("galaxy_dataset_files_path", None)
             if PulsarJobRunner.__use_remote_datatypes_conf(client):
-                remote_datatypes_config = remote_system_properties.get("galaxy_datatypes_config_file", None)
+                remote_datatypes_config = remote_system_properties.get("galaxy_datatypes_config_file")
                 if not remote_datatypes_config:
                     log.warning(NO_REMOTE_DATATYPES_CONFIG)
+                    if not remote_galaxy_home:
+                        raise Exception(NO_REMOTE_GALAXY_FOR_METADATA_MESSAGE)
                     remote_datatypes_config = os.path.join(remote_galaxy_home, "datatypes_conf.xml")
                 metadata_kwds["datatypes_config"] = remote_datatypes_config
             else:

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -2,6 +2,7 @@
 
 More information on Pulsar can be found at https://pulsar.readthedocs.io/ .
 """
+import copy
 import errno
 import logging
 import os
@@ -924,7 +925,8 @@ class PulsarJobRunner(AsynchronousJobRunner):
             # false_path to send the metadata command generation module.
             work_dir_outputs = self.get_work_dir_outputs(job_wrapper, tool_working_directory=working_directory)
             outputs = job_wrapper.job_io.get_output_fnames()
-            real_path_to_output = {o.real_path: o for o in outputs}
+            # copy fixes 'test/integration/test_pulsar_embedded_remote_metadata.py::test_tools[job_properties]'
+            real_path_to_output = {o.real_path: copy.copy(o) for o in outputs}
             rewritten_outputs = []
             for pulsar_workdir_path, real_path in work_dir_outputs:
                 work_dir_output = real_path_to_output.pop(real_path, None)

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -435,7 +435,7 @@ def set_metadata_portable(
                 if not object_store or not export_store:
                     # Can't happen, but type system doesn't know
                     raise Exception("object_store not built")
-                if not is_deferred and not link_data_only and os.path.getsize(external_filename):
+                if not is_deferred and not link_data_only:
                     # Here we might be updating a disk based objectstore when outputs_to_working_directory is used,
                     # or a remote object store from its cache path.
                     object_store_update_actions.append(

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -443,7 +443,7 @@ def set_metadata_portable(
                             object_store.update_from_file, dataset.dataset, file_name=external_filename, create=True
                         )
                     )
-                    object_store_update_actions.append(partial(reset_external_filename, dataset))
+                object_store_update_actions.append(partial(reset_external_filename, dataset))
                 object_store_update_actions.append(partial(export_store.add_dataset, dataset))
                 if dataset_instance_id not in unnamed_id_to_path:
                     object_store_update_actions.append(partial(collect_extra_files, object_store, dataset, "."))

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -399,9 +399,7 @@ def set_metadata_portable(
                 if not link_data_only:
                     # Only set external filename if we're dealing with files in job working directory.
                     # Fixes link_data_only uploads
-                    if not object_store:
-                        # overriding the external filename would break pushing to object stores
-                        dataset.dataset.external_filename = external_filename
+                    dataset.dataset.external_filename = external_filename
                     # We derive extra_files_dir_name from external_filename, because OutputsToWorkingDirectoryPathRewriter
                     # always rewrites the path to include the uuid, even if store_by is set to id, and the extra files
                     # rewrite is derived from the dataset path (since https://github.com/galaxyproject/galaxy/pull/16541).

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -435,9 +435,11 @@ def set_metadata_portable(
                 if not object_store or not export_store:
                     # Can't happen, but type system doesn't know
                     raise Exception("object_store not built")
-                if not is_deferred and not link_data_only:
+                if not is_deferred and not link_data_only and os.path.getsize(external_filename):
                     # Here we might be updating a disk based objectstore when outputs_to_working_directory is used,
                     # or a remote object store from its cache path.
+                    # empty files could happen when outputs are discovered from working dir,
+                    # empty file check needed for e.g. test/integration/test_extended_metadata_outputs_to_working_directory.py::test_tools[multi_output_assign_primary]
                     object_store_update_actions.append(
                         partial(
                             object_store.update_from_file, dataset.dataset, file_name=external_filename, create=True

--- a/test/functional/tools/from_work_dir_glob.xml
+++ b/test/functional/tools/from_work_dir_glob.xml
@@ -13,6 +13,7 @@ echo "hi" > output1.txt
                 <assert_contents>
                     <has_text text="hi" />
                 </assert_contents>
+                <metadata name="data_lines" value="1" />
                 <!-- This does not work with the default __copy_if_exists mechanism
                     <metadata name="created_from_basename" value="output1.txt" />
                 -->

--- a/test/functional/tools/job_properties.xml
+++ b/test/functional/tools/job_properties.xml
@@ -39,7 +39,9 @@
     <tests>
         <test expect_exit_code="0">
             <param name="thebool" value="true" />
-            <output name="out_file1" file="simple_line.txt" />
+            <output name="out_file1" file="simple_line.txt" >
+                <metadata name="data_lines" value="1" />
+            </output>
             <assert_command>
                 <has_text text="really" />
             </assert_command>

--- a/test/integration/test_extended_metadata.py
+++ b/test/integration/test_extended_metadata.py
@@ -6,6 +6,7 @@ from galaxy_test.base.populators import (
 from galaxy_test.driver import integration_util
 
 TEST_TOOL_IDS = [
+    "from_work_dir_glob",
     "job_properties",
     "multi_output",
     "multi_output_configured",

--- a/test/integration/test_extended_metadata_outputs_to_working_directory.py
+++ b/test/integration/test_extended_metadata_outputs_to_working_directory.py
@@ -14,7 +14,7 @@ class ExtendedMetadataOutputsToWorkingDirIntegrationInstance(ExtendedMetadataInt
     def handle_galaxy_config_kwds(cls, config):
         config["metadata_strategy"] = "extended"
         config["object_store_store_by"] = "uuid"
-        config["outpus_to_working_dir"] = True
+        config["outputs_to_working_directory"] = True
         config["retry_metadata_internally"] = False
 
 


### PR DESCRIPTION
```python
            outputs = [
                Bunch(false_path=os.path.join(outputs_directory, os.path.basename(path)), real_path=path)
                for path in self.get_output_files(job_wrapper)
            ]
```

would always set the false_path attribute, even if that is not correct
because outputs_to_working_directory isn't activated and pulsar doesn't
need to do any staging (e.g. with

```yaml
      default_file_action: copy
      # don't copy outputs, not needed.
      file_actions:
        paths:
          - path_types: output
            action: none
```

as done in embedded_pulsar_metadata_extended_job_conf.xml.

Fixing this allows us to eliminate the `if object_store:` guard to
setting the external filename, which in turn fixes the metadata value
setting if `outputs_to_working_directory: true` and `metadata_strategy:
extended` is used.

We didn't catch this previously because of the `outpus_to_working_dir` typo ...

The actual, isolated fix is in 8c5ac57c7d4d6a732e41b830f90343ff1a5dfde6, but I noticed that `use_metadata_binary` is probably broken in pulsar, so https://github.com/galaxyproject/galaxy/pull/16678/commits/6210267497f1b711c920127b88b2f1eaeb514613 should also fix that.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
