### PR TITLE
Fix notifications icon not showing in Masthead

### DIFF
--- a/client/src/components/Masthead/Masthead.vue
+++ b/client/src/components/Masthead/Masthead.vue
@@ -6,7 +6,7 @@ import { withPrefix } from "utils/redirect";
 import { onBeforeMount, onMounted, reactive, ref, watch } from "vue";
 import { useRoute } from "vue-router/composables";
 
-import { isConfigLoaded, useConfig } from "@/composables/config";
+import { useConfig } from "@/composables/config";
 import { useUserStore } from "@/stores/userStore";
 
 import { loadWebhookMenuItems } from "./_webhooks";
@@ -19,7 +19,7 @@ import NotificationsBell from "@/components/Notifications/NotificationsBell.vue"
 const { isAnonymous, showActivityBar } = storeToRefs(useUserStore());
 
 const route = useRoute();
-const { config } = useConfig();
+const { config, isConfigLoaded } = useConfig();
 
 const emit = defineEmits(["open-url"]);
 


### PR DESCRIPTION
When the ActivityBar is hidden the Notifications icon must be visible in the Masthead.

Only broken on `dev`, the `isConfigLoaded` was always undefined as it was imported from an incorrect place.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
