### PR TITLE
[23.1] Only show 'edit' on published pages when viewer is the owner. 

### DIFF
--- a/client/src/components/PageDisplay/PageDisplay.vue
+++ b/client/src/components/PageDisplay/PageDisplay.vue
@@ -9,6 +9,7 @@
                         :enable_beta_markdown_export="config.enable_beta_markdown_export"
                         :download-endpoint="stsUrl(config)"
                         :export-link="exportUrl"
+                        :read-only="!userOwnsPage"
                         @onEdit="onEdit" />
                     <PageHtml v-else :page="page" />
                 </div>
@@ -22,6 +23,8 @@
 import { urlData } from "utils/url";
 import { withPrefix } from "utils/redirect";
 import ConfigProvider from "components/providers/ConfigProvider";
+import { mapState } from "pinia";
+import { useUserStore } from "@/stores/userStore";
 import Markdown from "components/Markdown/Markdown";
 import Published from "components/Common/Published";
 import PageHtml from "./PageHtml";
@@ -45,6 +48,10 @@ export default {
         };
     },
     computed: {
+        ...mapState(useUserStore, ["currentUser"]),
+        userOwnsPage() {
+            return this.currentUser.username === this.page.username;
+        },
         dataUrl() {
             return `/api/pages/${this.pageId}`;
         },


### PR DESCRIPTION
Sharing pages doesn't grant edit permissions so I don't think we don't have to look at roles/etc.  We'd generally prefer using encoded userId for comparison, but that's not available here for the page and actual security is enforced in the API, so this just displays (or not) the UI.

Following up in dev with an update to script setup+ts.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
