### PR TITLE
16556/enhancements for wf reports

### DIFF
--- a/client/src/components/Markdown/Elements/InvocationTime.vue
+++ b/client/src/components/Markdown/Elements/InvocationTime.vue
@@ -19,7 +19,8 @@ export default {
     computed: {
         content() {
             const invocation = this.invocations[this.args.invocation_id];
-            return invocation && invocation["create_time"];
+            const iso = new Date(invocation && invocation["create_time"]);
+            return iso.toUTCString();
         },
     },
 };

--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -37,7 +37,9 @@
                     <h1 class="text-break align-middle">
                         Title: {{ markdownConfig.title || markdownConfig.model_class }}
                     </h1>
-                    <h3 v-if="workflowVersions" class="text-break align-middle">Workflow Checkpoint: {{ workflowVersions.version }}</h3>
+                    <h3 v-if="workflowVersions" class="text-break align-middle">
+                        Workflow Checkpoint: {{ workflowVersions.version }}
+                    </h3>
                 </span>
             </div>
             <b-badge variant="info" class="w-100 rounded mb-3 white-space-normal">

--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -30,7 +30,7 @@
                 </span>
             </div>
             <b-badge variant="info" class="w-100 rounded mb-3 white-space-normal">
-                <div class="float-left m-1 text-break">Generated with Galaxy {{ version }} on {{ time }}</div>
+                <div class="float-left m-1 text-break">Generated with Galaxy {{ version }} on {{ time }} UTC</div>
                 <div class="float-right m-1">Identifier: {{ markdownConfig.id }}</div>
             </b-badge>
             <div>

--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -176,7 +176,6 @@ export default {
                 this.workflowVersion = workflow.version;
             }
         });
-    
     },
     methods: {
         ...mapActions(useWorkflowStore, ["getStoredWorkflowByInstanceId", "fetchWorkflowForInstanceId"]),

--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -27,6 +27,7 @@
                     <h1 class="text-break align-middle">
                         Title: {{ markdownConfig.title || markdownConfig.model_class }}
                     </h1>
+                    <h3 class="text-break align-middle">Workflow Version: {{ workflowVersions }}</h3>
                 </span>
             </div>
             <b-badge variant="info" class="w-100 rounded mb-3 white-space-normal">
@@ -67,8 +68,11 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import BootstrapVue from "bootstrap-vue";
 import MarkdownIt from "markdown-it";
 import markdownItRegexp from "markdown-it-regexp";
+import { mapActions } from "pinia";
 import store from "store";
 import Vue from "vue";
+
+import { useWorkflowStore } from "@/stores/workflowStore";
 
 import MarkdownContainer from "./MarkdownContainer.vue";
 import LoadingSpan from "components/LoadingSpan.vue";
@@ -131,6 +135,7 @@ export default {
             jobs: {},
             invocations: {},
             loading: true,
+            workflowVersion: null,
         };
     },
     computed: {
@@ -151,6 +156,9 @@ export default {
             }
             return "unavailable";
         },
+        workflowVersions() {
+            return this.workflowVersion;
+        },
         version() {
             return this.markdownConfig.generate_version || "Unknown Galaxy Version";
         },
@@ -162,8 +170,16 @@ export default {
     },
     created() {
         this.initConfig();
+        this.fetchWorkflowForInstanceId(Object.keys(this.markdownConfig.workflows)[0]).then((data) => {
+            var workflow = this.getStoredWorkflowByInstanceId(Object.keys(this.markdownConfig.workflows)[0]);
+            if (workflow) {
+                this.workflowVersion = workflow.version;
+            }
+        });
+    
     },
     methods: {
+        ...mapActions(useWorkflowStore, ["getStoredWorkflowByInstanceId", "fetchWorkflowForInstanceId"]),
         initConfig() {
             if (Object.keys(this.markdownConfig).length) {
                 const config = this.markdownConfig;


### PR DESCRIPTION
Some completed enhancements requested in #16556 
- For: Insert current time as text. Time shows as "16 August 2023 at 06:42", it would be good to specify this is UTC
- For: Time workflow was invoked. Shows as "2023-08-16T06:33:14.822141". Would be good to format more clearly, and specify as UTC
- Useful inclusion: workflow version

## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. Create a Workflow
  2. In the edit report view, select the option to add Time a Workflow was invoked
  3. View the workflow report
  4. Note that there is a workflow version at the top, below the title
  5. Note that the current time indicates that it is in UTC
  6. Note that the Time a Workflow was invoked is formatted clearly and indicates it is in UTC

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
