### PR TITLE
Include `regex` when linting validators

### DIFF
--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -83,10 +83,13 @@ class LintMessage:
     def __eq__(self, other) -> bool:
         """
         add equal operator to easy lookup of a message in a
-        List[LintMessage] which is usefull in tests
+        List[LintMessage] which is useful in tests.
+
+        If the other object is a string, it is loosely checked if the
+        string is contained in the message.
         """
         if isinstance(other, str):
-            return self.message == other
+            return other in self.message
         if isinstance(other, LintMessage):
             return self.message == other.message
         return False

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -395,10 +395,10 @@ def lint_inputs(tool_source: "ToolSource", lint_ctx: "LintContext"):
                         f"Parameter [{param_name}]: attribute '{attrib}' is incompatible with validator of type '{vtype}'",
                         node=validator,
                     )
-            if vtype == "expression":
+            if vtype in ["expression", "regex"]:
                 if validator.text is None:
                     lint_ctx.error(
-                        f"Parameter [{param_name}]: expression validators are expected to contain text", node=validator
+                        f"Parameter [{param_name}]: {vtype} validators are expected to contain text", node=validator
                     )
                 else:
                     try:

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -1,4 +1,5 @@
 """This module contains a linting functions for tool inputs."""
+import ast
 import re
 from typing import TYPE_CHECKING
 
@@ -400,9 +401,12 @@ def lint_inputs(tool_source: "ToolSource", lint_ctx: "LintContext"):
                     lint_ctx.error(
                         f"Parameter [{param_name}]: {vtype} validators are expected to contain text", node=validator
                     )
-                elif vtype == "regex":
+                else:
                     try:
-                        re.compile(validator.text)
+                        if vtype == "regex":
+                            re.compile(validator.text)
+                        else:
+                            ast.parse(validator.text, mode="eval")
                     except Exception as e:
                         lint_ctx.error(
                             f"Parameter [{param_name}]: '{validator.text}' is no valid regular expression: {str(e)}",

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -400,7 +400,7 @@ def lint_inputs(tool_source: "ToolSource", lint_ctx: "LintContext"):
                     lint_ctx.error(
                         f"Parameter [{param_name}]: {vtype} validators are expected to contain text", node=validator
                     )
-                else:
+                elif vtype == "regex":
                     try:
                         re.compile(validator.text)
                     except Exception as e:

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -412,6 +412,7 @@ INPUTS_VALIDATOR_INCOMPATIBILITIES = """
             <validator type="expression"/>
             <validator type="regex">[</validator>
             <validator type="expression">(</validator>
+            <validator type="expression">value and "," not in value</validator>
             <validator type="value_in_data_table"/>
         </param>
         <param name="another_param_name" type="data" format="bed">

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1391,10 +1391,7 @@ def test_inputs_validator_incompatibilities(lint_ctx):
         "Parameter [param_name]: '[' is no valid regular expression: unterminated character set at position 0"
         in lint_ctx.error_messages
     )
-    assert (
-        "Parameter [param_name]: '(' is no valid regular expression: unexpected EOF while parsing (<unknown>, line 1)"
-        in lint_ctx.error_messages
-    )
+    assert "Parameter [param_name]: '(' is no valid regular expression" in lint_ctx.error_messages
     assert (
         "Parameter [another_param_name]: 'metadata' validators need to define the 'check' or 'skip' attribute(s)"
         in lint_ctx.error_messages

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -411,6 +411,7 @@ INPUTS_VALIDATOR_INCOMPATIBILITIES = """
             <validator type="regex" filename="blah"/>
             <validator type="expression"/>
             <validator type="regex">[</validator>
+            <validator type="expression">(</validator>
             <validator type="value_in_data_table"/>
         </param>
         <param name="another_param_name" type="data" format="bed">
@@ -1390,6 +1391,10 @@ def test_inputs_validator_incompatibilities(lint_ctx):
         in lint_ctx.error_messages
     )
     assert (
+        "Parameter [param_name]: '(' is no valid regular expression: unexpected EOF while parsing (<unknown>, line 1)"
+        in lint_ctx.error_messages
+    )
+    assert (
         "Parameter [another_param_name]: 'metadata' validators need to define the 'check' or 'skip' attribute(s)"
         in lint_ctx.error_messages
     )
@@ -1408,7 +1413,7 @@ def test_inputs_validator_incompatibilities(lint_ctx):
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages
     assert len(lint_ctx.warn_messages) == 1
-    assert len(lint_ctx.error_messages) == 10
+    assert len(lint_ctx.error_messages) == 11
 
 
 def test_inputs_validator_correct(lint_ctx):

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -410,7 +410,7 @@ INPUTS_VALIDATOR_INCOMPATIBILITIES = """
             <validator type="in_range">TEXT</validator>
             <validator type="regex" filename="blah"/>
             <validator type="expression"/>
-            <validator type="expression">[</validator>
+            <validator type="regex">[</validator>
             <validator type="value_in_data_table"/>
         </param>
         <param name="another_param_name" type="data" format="bed">

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1384,6 +1384,7 @@ def test_inputs_validator_incompatibilities(lint_ctx):
         in lint_ctx.error_messages
     )
     assert "Parameter [param_name]: expression validators are expected to contain text" in lint_ctx.error_messages
+    assert "Parameter [param_name]: regex validators are expected to contain text" in lint_ctx.error_messages
     assert (
         "Parameter [param_name]: '[' is no valid regular expression: unterminated character set at position 0"
         in lint_ctx.error_messages
@@ -1407,7 +1408,7 @@ def test_inputs_validator_incompatibilities(lint_ctx):
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages
     assert len(lint_ctx.warn_messages) == 1
-    assert len(lint_ctx.error_messages) == 9
+    assert len(lint_ctx.error_messages) == 10
 
 
 def test_inputs_validator_correct(lint_ctx):


### PR DESCRIPTION
I think this should catch invalid `regex` expressions too when linting validators.

See https://github.com/galaxyproject/galaxy/issues/16676#issuecomment-1717275714

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
