### PR TITLE
Change Sentry error reporting plug-in

### DIFF
--- a/lib/galaxy/tools/error_reports/plugins/sentry.py
+++ b/lib/galaxy/tools/error_reports/plugins/sentry.py
@@ -70,7 +70,6 @@ class SentryPlugin(ErrorPlugin):
         user = job.get_user()
         sentry_user = {
             "id": user.id if user else None,
-            # TODO: What about anonymous users?
         }
         if user and not self.redact_user_details_in_bugreport:
             sentry_user.update(

--- a/lib/galaxy/tools/error_reports/plugins/sentry.py
+++ b/lib/galaxy/tools/error_reports/plugins/sentry.py
@@ -7,7 +7,6 @@ try:
 except ImportError:
     sentry_sdk = None
 
-from galaxy import web
 from galaxy.util import string_as_bool
 from . import ErrorPlugin
 
@@ -55,21 +54,6 @@ class SentryPlugin(ErrorPlugin):
             "tool_version": job.tool_version,
             "tool_xml": tool.config_file if tool else None,
         }
-
-        # - "request" context
-        # Getting the url allows us to link to the dataset info page in case
-        # anything is missing from this report.
-        try:
-            url = web.url_for(
-                controller="dataset",
-                action="show_params",
-                dataset_id=self.app.security.encode_id(dataset.id),
-                qualified=True,
-            )
-        except AttributeError:
-            # The above does not work when handlers are separate from the web handlers
-            url = None
-        contexts["request"] = {"url": url}
 
         # - "feedback" context
         # The User Feedback API https://docs.sentry.io/api/projects/submit-user-feedback/ would be a better approach for


### PR DESCRIPTION
Closes #16637.

- Use the tool's name (tool id without version) as issue title. This should merge reports for all versions of a tool. Report any other extra information in the contexts.

- Submit Galaxy Job error reports with level "error" rather than "info".

- Do not include the user's email in the "job" context. It is redundant because it was already being included in the "user" context.

- Move the user's feedback message to a new "feedback" context.

- Report the user's information as actual Sentry user information rather than a "user" context.

- Remove the "request" context. The request context's "url" field is otherwise filled with the text *"deprecated attribute, URL not filled in by server"*.

- Change existing tags. Use "tool" for `job.tool_id`, `tool.name` for the tool's name (tool id without version) and `tool.version` for the tool's version.

- Add a tag informing of whether the user provided feedback or not so that intentional bug reports can be quickly found.

I tested this in a local Galaxy + Sentry deployment. It looks as shown below.

![image](https://github.com/galaxyproject/galaxy/assets/43052541/9ddaef08-ca1c-4f72-9b16-904fba351e7e)
![image](https://github.com/galaxyproject/galaxy/assets/43052541/705bd885-b29b-4018-912d-f3c948344b49)

## How to test the changes?

- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Connect a Galaxy instance running this branch to a Sentry project.
  2. Trigger tool errors (for example, run [jq](https://toolshed.g2.bx.psu.edu/repository?repository_id=8ec62efa35f442f6) on a picture).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).




