### PR TITLE
 Use fs.onedatarestfs for Onedata files source plugin implementation

### DIFF
--- a/lib/galaxy/config/sample/file_sources_conf.yml.sample
+++ b/lib/galaxy/config/sample/file_sources_conf.yml.sample
@@ -201,6 +201,6 @@
 - type: onedata
   id: onedata1
   label: Onedata
-  doc: Your Onedata files - configure an access token via the user preferences
+  doc: Your Onedata files - configure an access token via user preferences
   accessToken: ${user.preferences['onedata|access_token']}
   onezoneDomain: ${user.preferences['onedata|onezone_domain']}

--- a/lib/galaxy/config/sample/file_sources_conf.yml.sample
+++ b/lib/galaxy/config/sample/file_sources_conf.yml.sample
@@ -197,3 +197,10 @@
   doc: Invenio RDM turn-key research data management repository
   label: Invenio RDM Demo Repository
   url: https://inveniordm.web.cern.ch/
+
+- type: onedata
+  id: onedata1
+  label: Onedata
+  doc: Your Onedata files - configure an access token via the user preferences
+  accessToken: ${user.preferences['onedata|access_token']}
+  onezoneDomain: ${user.preferences['onedata|onezone_domain']}

--- a/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
+++ b/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
@@ -111,3 +111,16 @@ preferences:
               label: Whether to make draft records publicly available or restricted.
               type: boolean
               required: False
+
+    # Used in file_sources_conf.yml
+    onedata:
+        description: Your Onedata account
+        inputs:
+            - name: onezone_domain
+              label: Domain of the Onezone service (e.g. "demo.onedata.org")
+              type: text
+              required: False
+            - name: access_token
+              label: Your access token, suitable for REST API access in a Oneprovider service
+              type: password
+              required: False

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -265,7 +265,7 @@ class ConditionalDependencies:
     def check_google_cloud_storage(self):
         return "googlecloudstorage" in self.file_sources
 
-    def check_fs_onedatafs(self):
+    def check_fs_onedatarestfs(self):
         return "onedata" in self.file_sources
 
     def check_fs_basespace(self):

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -24,7 +24,7 @@ fs.googledrivefs # type: googledrive
 fs-gcsfs # type: googlecloudstorage
 # fs-gcsfs doesn't pin google-cloud-storage, and old versions log noisy exceptions and break test discovery
 google-cloud-storage>=2.8.0  # type: googlecloudstorage
-fs-onedatafs # type: onedata
+fs.onedatarestfs # type: onedata
 fs-basespace # type: basespace
 
 # Vault backend

--- a/lib/galaxy/files/sources/onedata.py
+++ b/lib/galaxy/files/sources/onedata.py
@@ -1,30 +1,25 @@
 try:
-    from fs.onedatafs import OnedataFS
+    from fs.onedatarestfs import OnedataRESTFS
 except ImportError:
-    OnedataFS = None
+    OnedataRESTFS = None
 
-from typing import (
-    Optional,
-    Union,
-)
-
-from . import (
-    FilesSourceOptions,
-    FilesSourceProperties,
-)
+from typing import Optional
+from . import FilesSourceOptions
 from ._pyfilesystem2 import PyFilesystem2FilesSource
 
 
-class OneDataFilesSource(PyFilesystem2FilesSource):
+class OnedataFilesSource(PyFilesystem2FilesSource):
     plugin_type = "onedata"
-    required_module = OnedataFS
-    required_package = "fs-onedatafs"
+    required_module = OnedataRESTFS
+    required_package = "fs.onedatarestfs"
 
     def _open_fs(self, user_context=None, opts: Optional[FilesSourceOptions] = None):
         props = self._serialization_props(user_context)
-        extra_props: Union[FilesSourceProperties, dict] = opts.extra_props or {} if opts else {}
-        handle = OnedataFS(**{**props, **extra_props})
+        onezone_domain = props.pop("onezoneDomain", {}) or ""
+        onezone_domain = onezone_domain.lstrip("https://").lstrip("http://")
+        access_token = props.pop("accessToken", {}) or ""
+        handle = OnedataRESTFS(onezone_domain, access_token)
         return handle
 
 
-__all__ = ("OneDataFilesSource",)
+__all__ = ("OnedataFilesSource",)

--- a/lib/galaxy/files/sources/onedata.py
+++ b/lib/galaxy/files/sources/onedata.py
@@ -4,13 +4,14 @@ except ImportError:
     OnedataRESTFS = None
 
 from typing import Optional
+
 from . import FilesSourceOptions
 from ._pyfilesystem2 import PyFilesystem2FilesSource
 
 
 def remove_prefix(prefix, string):
     if string.startswith(prefix):
-        string = string[len(prefix):]
+        string = string[len(prefix) :]
     return string
 
 

--- a/lib/galaxy/files/sources/onedata.py
+++ b/lib/galaxy/files/sources/onedata.py
@@ -8,6 +8,12 @@ from . import FilesSourceOptions
 from ._pyfilesystem2 import PyFilesystem2FilesSource
 
 
+def remove_prefix(prefix, string):
+    if string.startswith(prefix):
+        string = string[len(prefix):]
+    return string
+
+
 class OnedataFilesSource(PyFilesystem2FilesSource):
     plugin_type = "onedata"
     required_module = OnedataRESTFS
@@ -16,7 +22,7 @@ class OnedataFilesSource(PyFilesystem2FilesSource):
     def _open_fs(self, user_context=None, opts: Optional[FilesSourceOptions] = None):
         props = self._serialization_props(user_context)
         onezone_domain = props.pop("onezoneDomain", {}) or ""
-        onezone_domain = onezone_domain.lstrip("https://").lstrip("http://")
+        onezone_domain = remove_prefix("http://", remove_prefix("https://", onezone_domain))
         access_token = props.pop("accessToken", {}) or ""
         handle = OnedataRESTFS(onezone_domain, access_token)
         return handle

--- a/lib/galaxy/files/sources/onedata.py
+++ b/lib/galaxy/files/sources/onedata.py
@@ -21,9 +21,9 @@ class OnedataFilesSource(PyFilesystem2FilesSource):
 
     def _open_fs(self, user_context=None, opts: Optional[FilesSourceOptions] = None):
         props = self._serialization_props(user_context)
-        onezone_domain = props.pop("onezoneDomain", {}) or ""
+        onezone_domain = props.pop("onezoneDomain", "") or ""
         onezone_domain = remove_prefix("http://", remove_prefix("https://", onezone_domain))
-        access_token = props.pop("accessToken", {}) or ""
+        access_token = props.pop("accessToken", "") or ""
         handle = OnedataRESTFS(onezone_domain, access_token)
         return handle
 


### PR DESCRIPTION
The fs.onedatarestfs depends on a simple REST-based client for the Onedata system. The fs.onedatafs that was in the codebase until now was not a viable option - it could not be easily installed using pip due to the giant amount of dependent libraries, many of which were in C/C++.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Add the `fs.onedatarestfs` package to currently used requirements (can be found in conditional-requirements.txt).
  2. Create `file_sources_conf.yml` file in the config dir, copy the part concerning onedata from `file_sources_conf.yml.sample`.
  3. Create `user_preferences_extra_conf.yml` file in the config dir, copy the part concerning onedata from `user_preferences_extra_conf.yml.sample`.
  4. Create `galaxy.yml` file in the config dir with the following content
  ```
  galaxy:
    file_sources_config_file: file_sources_conf.yml
    user_preferences_extra_conf_path: user_preferences_extra_conf.yml
  ```

  5. Start the galaxy server, log in.
  6. You will need an account in a Onedata system instance. I'll be happy to provide you with a test account if that's desired. Then, it's enough to place the Onezone domain and your access token in the Galaxy's User Information panel and you are good to go. 
 
There are no automated tests, as I believe specific file source plugins are not automatically tested.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
