### PR TITLE
Skip node installation for ``check_indexes`` tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,6 @@ setenv =
     mulled,unit: GALAXY_VIRTUAL_ENV={envdir}
     unit: GALAXY_ENABLE_BETA_COMPRESSED_GENBANK_SNIFFING=1
     unit: marker=not external_dependency_management
-    check_indexes: GALAXY_SKIP_CLIENT_BUILD=1
 deps =
     coverage: coverage
     lint,lint_docstring,lint_docstring_include_list: -rlib/galaxy/dependencies/pinned-lint-requirements.txt
@@ -69,6 +68,6 @@ commands = bash .ci/check_controller.sh
 
 [testenv:check_indexes]
 commands =
-    bash scripts/common_startup.sh
+    bash scripts/common_startup.sh --skip-node --skip-client-build
     bash manage_db.sh init
     bash check_model.sh


### PR DESCRIPTION
Prevents node installation failures, and it's faster.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
