### PR TITLE
Get rid of pulling from object store when calling dataset.file_name

### DIFF
--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -332,10 +332,15 @@ def export_history(
 def prepare_dataset_collection_download(
     request: PrepareDatasetCollectionDownload,
     collection_manager: DatasetCollectionManager,
+    session: galaxy_scoped_session,
     task_user_id: Optional[int] = None,
 ):
+    if task_user_id:
+        user = session.query(model.User).get(task_user_id)
+    else:
+        user = None
     """Create a short term storage file tracked and available for download of target collection."""
-    collection_manager.write_dataset_collection(request)
+    collection_manager.write_dataset_collection(request, user=user)
 
 
 @galaxy_task(action="preparing Galaxy Markdown PDF for download")

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -602,7 +602,8 @@ class BamNative(CompressedArchive, _BamOrSam):
         except Exception:
             return f"Binary bam alignments file ({nice_size(dataset.get_size())})"
 
-    def to_archive(self, dataset: DatasetProtocol, name: str = "") -> Iterable:
+    def to_archive(self, dataset: DatasetProtocol, name: str = "", trans=None) -> Iterable:
+        dataset.sync_cache(user=trans.user)
         rel_paths = []
         file_paths = []
         rel_paths.append(f"{name or dataset.file_name}.{dataset.extension}")
@@ -701,10 +702,12 @@ class BamNative(CompressedArchive, _BamOrSam):
         headers = kwd.get("headers", {})
         preview = util.string_as_bool(preview)
         if offset is not None:
+            dataset.sync_cache(user=trans.user)
             return self.get_chunk(trans, dataset, offset, ck_size), headers
         elif to_ext or not preview:
             return super().display_data(trans, dataset, preview, filename, to_ext, **kwd)
         else:
+            dataset.sync_cache(user=trans.user)
             column_names = dataset.metadata.column_names
             if not column_names:
                 column_names = []
@@ -2107,6 +2110,8 @@ class H5MLM(H5):
         if to_ext or not preview:
             to_ext = to_ext or dataset.extension
             return self._serve_raw(dataset, to_ext, headers, **kwd)
+
+        dataset.sync_cache(user=trans.user)
 
         out_dict: Dict = {}
         try:

--- a/lib/galaxy/datatypes/blast.py
+++ b/lib/galaxy/datatypes/blast.py
@@ -234,6 +234,9 @@ class _BlastDb(Data):
                 ck_size=ck_size,
                 **kwd,
             )
+
+        dataset.sync_cache(user=trans.user)
+
         if self.file_ext == "blastdbn":
             title = "This is a nucleotide BLAST database"
         elif self.file_ext == "blastdbp":

--- a/lib/galaxy/datatypes/isa.py
+++ b/lib/galaxy/datatypes/isa.py
@@ -284,6 +284,8 @@ class _Isa(Data):
         if not preview:
             return super().display_data(trans, dataset, preview, filename, to_ext, **kwd)
 
+        dataset.sync_cache(user=trans.user)
+
         # prepare the preview of the ISA dataset
         investigation = self._get_investigation(dataset)
         if investigation is None:

--- a/lib/galaxy/datatypes/protocols.py
+++ b/lib/galaxy/datatypes/protocols.py
@@ -83,6 +83,9 @@ class DatasetProtocol(
     def get_converted_files_by_type(self, file_type):
         ...
 
+    def sync_cache(self, **kwargs):
+        ...
+
     def get_mime(self) -> str:
         ...
 

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -774,6 +774,8 @@ class BaseFastq(Sequence):
         to_ext: Optional[str] = None,
         **kwd,
     ):
+        dataset.sync_cache(user=trans.user)
+
         headers = kwd.get("headers", {})
         if preview:
             with compression_utils.get_fileobj(dataset.file_name) as fh:

--- a/lib/galaxy/datatypes/spaln.py
+++ b/lib/galaxy/datatypes/spaln.py
@@ -142,6 +142,8 @@ class _SpalnDb(Data):
                 headers=headers,
                 **kwd,
             )
+        dataset.sync_cache(user=trans.user)
+
         if self.file_ext == "spalndbn":
             title = "This is a nucleotide-query spaln database"
         elif self.file_ext == "spalndbp":

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -175,6 +175,7 @@ class TabularData(Text):
         ck_size: Optional[int] = None,
         **kwd,
     ):
+        dataset.sync_cache(user=trans.user)
         headers = kwd.pop("headers", {})
         preview = util.string_as_bool(preview)
         if offset is not None:

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -219,6 +219,7 @@ class Ipynb(Json):
     ) -> Tuple[IO, Headers]:
         headers = kwd.pop("headers", {})
         preview = string_as_bool(preview)
+        dataset.sync_cache(user=trans.user)
         if to_ext or not preview:
             return self._serve_raw(dataset, to_ext, headers, **kwd)
         else:

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -857,10 +857,10 @@ class DatasetCollectionManager:
             qry = qry.offset(int(offset))
         return qry
 
-    def write_dataset_collection(self, request: PrepareDatasetCollectionDownload):
+    def write_dataset_collection(self, request: PrepareDatasetCollectionDownload, user: model.User):
         short_term_storage_monitor = self.short_term_storage_monitor
         instance_id = request.history_dataset_collection_association_id
         with storage_context(request.short_term_storage_request_id, short_term_storage_monitor) as target:
             collection_instance = self.model.context.query(model.HistoryDatasetCollectionAssociation).get(instance_id)
             with ZipFile(target.path, "w") as zip_f:
-                write_dataset_collection(collection_instance, zip_f)
+                write_dataset_collection(collection_instance, zip_f, user=user)

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -27,23 +27,23 @@ from galaxy.util.zipstream import ZipstreamWrapper
 log = logging.getLogger(__name__)
 
 
-def stream_dataset_collection(dataset_collection_instance, upstream_mod_zip=False, upstream_gzip=False):
+def stream_dataset_collection(dataset_collection_instance, upstream_mod_zip=False, upstream_gzip=False, user=None):
     archive_name = f"{dataset_collection_instance.hid}: {dataset_collection_instance.name}"
     archive = ZipstreamWrapper(
         archive_name=archive_name,
         upstream_mod_zip=upstream_mod_zip,
         upstream_gzip=upstream_gzip,
     )
-    write_dataset_collection(dataset_collection_instance, archive)
+    write_dataset_collection(dataset_collection_instance, archive, user)
     return archive
 
 
-def write_dataset_collection(dataset_collection_instance, archive):
+def write_dataset_collection(dataset_collection_instance, archive, user):
     names, hdas = get_hda_and_element_identifiers(dataset_collection_instance)
     for name, hda in zip(names, hdas):
         if hda.state != hda.states.OK:
             continue
-        for file_path, relpath in hda.datatype.to_archive(dataset=hda, name=name):
+        for file_path, relpath in hda.datatype.to_archive(dataset=hda, name=name, user=user):
             archive.write(file_path, relpath)
     return archive
 

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -436,6 +436,9 @@ class BaseObjectStore(ObjectStore):
     def get_filename(self, obj, **kwargs):
         return self._invoke("get_filename", obj, **kwargs)
 
+    def sync_cache(self, obj, **kwargs):
+        return self._invoke("sync_cache", obj, **kwargs)
+
     def update_from_file(self, obj, **kwargs):
         return self._invoke("update_from_file", obj, **kwargs)
 
@@ -560,6 +563,9 @@ class ConcreteObjectStore(BaseObjectStore):
 
     def _get_store_by(self, obj):
         return self.store_by
+
+    def _sync_cache(self, obj, **kwargs):
+        pass
 
     def _is_private(self, obj):
         return self.private
@@ -962,6 +968,9 @@ class NestedObjectStore(BaseObjectStore):
     def _get_object_url(self, obj, **kwargs):
         """For the first backend that has this `obj`, get its URL."""
         return self._call_method("_get_object_url", obj, None, False, **kwargs)
+
+    def _sync_cache(self, obj, **kwargs):
+        return self._call_method("_sync_cache", obj, ObjectNotFound, True, **kwargs)
 
     def _get_concrete_store_name(self, obj):
         return self._call_method("_get_concrete_store_name", obj, None, False)

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -506,6 +506,18 @@ class AzureBlobObjectStore(ConcreteObjectStore):
         if base_dir and dir_only and obj_dir:
             return os.path.abspath(rel_path)
 
+        return self._get_cache_path(rel_path)
+
+    def _sync_cache(self, obj, **kwargs):
+        rel_path = self._construct_path(obj, **kwargs)
+        base_dir = kwargs.get("base_dir", None)
+        dir_only = kwargs.get("dir_only", False)
+        obj_dir = kwargs.get("obj_dir", False)
+
+        # for JOB_WORK directory
+        if base_dir and dir_only and obj_dir:
+            return os.path.abspath(rel_path)
+
         cache_path = self._get_cache_path(rel_path)
         # S3 does not recognize directories as files so cannot check if those exist.
         # So, if checking dir only, ensure given dir exists in cache and return

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -626,6 +626,18 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
         if base_dir and dir_only and obj_dir:
             return os.path.abspath(rel_path)
 
+        return self._get_cache_path(rel_path)
+
+    def _sync_cache(self, obj, **kwargs):
+        base_dir = kwargs.get("base_dir", None)
+        dir_only = kwargs.get("dir_only", False)
+        obj_dir = kwargs.get("obj_dir", False)
+        rel_path = self._construct_path(obj, **kwargs)
+
+        # for JOB_WORK directory
+        if base_dir and dir_only and obj_dir:
+            return os.path.abspath(rel_path)
+
         cache_path = self._get_cache_path(rel_path)
         # S3 does not recognize directories as files so cannot check if those exist.
         # So, if checking dir only, ensure given dir exists in cache and return

--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -711,6 +711,18 @@ class IRODSObjectStore(DiskObjectStore, CloudConfigMixin):
         return content
 
     def _get_filename(self, obj, **kwargs):
+        base_dir = kwargs.get("base_dir", None)
+        dir_only = kwargs.get("dir_only", False)
+        obj_dir = kwargs.get("obj_dir", False)
+        rel_path = self._construct_path(obj, **kwargs)
+
+        # for JOB_WORK directory
+        if base_dir and dir_only and obj_dir:
+            return os.path.abspath(rel_path)
+
+        return self._get_cache_path(rel_path)
+
+    def _sync_cache(self, obj, **kwargs):
         ipt_timer = ExecutionTimer()
         base_dir = kwargs.get("base_dir", None)
         dir_only = kwargs.get("dir_only", False)

--- a/lib/galaxy/objectstore/pithos.py
+++ b/lib/galaxy/objectstore/pithos.py
@@ -381,6 +381,17 @@ class PithosObjectStore(ConcreteObjectStore):
         return content
 
     def _get_filename(self, obj, **kwargs):
+        base_dir = kwargs.get("base_dir", None)
+        dir_only = kwargs.get("dir_only", False)
+        obj_dir = kwargs.get("obj_dir", False)
+        path = self._construct_path(obj, **kwargs)
+
+        # for JOB_WORK directory
+        if base_dir and dir_only and obj_dir:
+            return os.path.abspath(path)
+        return self._get_cache_path(path)
+
+    def _sync_cache(self, obj, **kwargs):
         """Get the expected filename with absolute path"""
         base_dir = kwargs.get("base_dir", None)
         dir_only = kwargs.get("dir_only", False)

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -653,6 +653,18 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
         if base_dir and dir_only and obj_dir:
             return os.path.abspath(rel_path)
 
+        return self._get_cache_path(rel_path)
+
+    def _sync_cache(self, obj, **kwargs):
+        base_dir = kwargs.get("base_dir", None)
+        dir_only = kwargs.get("dir_only", False)
+        obj_dir = kwargs.get("obj_dir", False)
+        rel_path = self._construct_path(obj, **kwargs)
+
+        # for JOB_WORK directory
+        if base_dir and dir_only and obj_dir:
+            return os.path.abspath(rel_path)
+
         cache_path = self._get_cache_path(rel_path)
         # S3 does not recognize directories as files so cannot check if those exist.
         # So, if checking dir only, ensure given dir exists in cache and return

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -585,10 +585,12 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
                 if filename and filename != "index":
                     object_store = trans.app.object_store
                     dir_name = dataset_instance.dataset.extra_files_path_name
+                    dataset_instance.sync_cache(extra_dir=dir_name, alt_name=filename, user=trans.user)
                     file_path = object_store.get_filename(
                         dataset_instance.dataset, extra_dir=dir_name, alt_name=filename
                     )
                 else:
+                    dataset_instance.sync_cache(user=trans.user)
                     file_path = dataset_instance.file_name
                 rval = open(file_path, "rb")
             else:
@@ -647,6 +649,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         headers = {}
         headers["Content-Type"] = "application/octet-stream"
         headers["Content-Disposition"] = f'attachment; filename="Galaxy{hda.hid}-[{fname}].{file_ext}"'
+        hda.metadata.get(metadata_file).sync_cache(user=trans.user)
         file_path = hda.metadata.get(metadata_file).file_name
         if open_file:
             return open(file_path, "rb"), headers

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -499,7 +499,9 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
 
     def __stream_dataset_collection(self, trans, dataset_collection_instance):
         archive = hdcas.stream_dataset_collection(
-            dataset_collection_instance=dataset_collection_instance, upstream_mod_zip=trans.app.config.upstream_mod_zip
+            dataset_collection_instance=dataset_collection_instance,
+            upstream_mod_zip=trans.app.config.upstream_mod_zip,
+            user=trans.user,
         )
         return archive
 

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -1173,3 +1173,6 @@ class MockObjectStore:
             return True
         else:
             return False
+
+    def sync_cache(self, *arg, **kwds):
+        pass


### PR DESCRIPTION
As a side effect, a dataset's `file_name` property (or `get_filename` function) pulls data from an object store into the local cache (see, e.g. [here](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/objectstore/irods.py#L738)). One example - I debugged stuff in PyCharm, and when I clicked on dataset properties, it displayed, among others, the filename for me, which triggered pulling from the object store. Cost me a couple of hours to understand what was going on.

This commit removes that behavior and pulls data from the object store explicitly where this is needed. This way, we do not force storing a copy of a file in the local cache, which might be even not feasible for large data files. Only when something should be done with the file from the Galaxy side (preview, download, etc.) we perform sync with the object store. In the future, we can also implement a partial copy (e.g., for preview). When syncing with an object store, we also now pass the user object there. This is required for authz in the object store based on user credentials (i.e. OIDC tokens). 

**Note**: `file_name` is called from hundreds of places. I'm not sure I found all the relevant ones. Also, it would be nice to automatically test the new functionality, but I'd need some help there.  

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Configure Galaxy and Pulsar to use some object store (e.g., S3), and configure Pulsar to manage external metadata.
  2. Run a job that runs remotely via Pulsar and uploads a file into the object store.
  3. Check that the local Galaxy cache does not have that file (actually, the file will be there, but with zero file size).
  4. Click on the view button to display the file in the web interface.
  5. The file should be displayed and will now be in the local Galaxy cache.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
