### PR TITLE
[23.1] Fix legend not scrollable in storage overview charts

### DIFF
--- a/client/src/components/User/DiskUsage/Visualizations/Charts/BarChart.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/Charts/BarChart.vue
@@ -2,7 +2,6 @@
 import { BCard } from "bootstrap-vue";
 import { computed, onMounted, ref, watch } from "vue";
 import * as d3 from "d3";
-
 import type { DataValuePoint } from ".";
 
 interface BarChartProps {
@@ -184,6 +183,17 @@ function createLegend() {
         .attr("fill", "black")
         .text((d) => props.labelFormatter(d));
 
+    // Set the width of the SVG to the width of the widest entry
+    let maxWidth = 0;
+    for (const node of entries.nodes()) {
+        const width = (node as HTMLElement).getBoundingClientRect().width;
+        maxWidth = Math.max(maxWidth, width);
+    }
+    const svg = container.node()?.closest("svg");
+    if (svg) {
+        svg.setAttribute("width", `${maxWidth}`);
+    }
+
     return entries;
 }
 
@@ -294,7 +304,7 @@ function setTooltipPosition(mouseX: number, mouseY: number): void {
 </script>
 
 <template>
-    <b-card class="mb-3 mx-3">
+    <b-card class="mb-3">
         <template v-slot:header>
             <h3 class="text-center my-1">
                 <slot name="title">
@@ -337,7 +347,7 @@ function setTooltipPosition(mouseX: number, mouseY: number): void {
 }
 
 .bar-chart {
-    float: right;
+    float: left;
 
     &:deep(svg) {
         overflow: visible;
@@ -349,12 +359,9 @@ function setTooltipPosition(mouseX: number, mouseY: number): void {
 }
 
 .legend {
-    float: left;
+    float: right;
     height: 400px;
-
-    &:deep(svg) {
-        overflow: visible;
-    }
+    overflow: auto;
 
     &:deep(.legend-item) {
         font-size: 14px;


### PR DESCRIPTION
Fixes #16697 and hopefully #16698 too.

It took me a while to discover that the SVG inside the legend had a fixed size but I had no clue where it was coming from... the black magic of CSS I guess... If somebody knows a better solution I'm all in.

![image](https://github.com/galaxyproject/galaxy/assets/46503462/b6ed3010-6e6b-46b4-8c0b-2a1127600b1e)


## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Follow the steps in the referenced issues

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
