### PR TITLE
[23.1] FileInput no longer accept 'U' in the file mode

### DIFF
--- a/tools/filters/convert_characters.py
+++ b/tools/filters/convert_characters.py
@@ -22,7 +22,7 @@ def __main__():
         from_ch += "+"
 
     skipped = 0
-    with open(args[0], "rU") as fin:
+    with open(args[0]) as fin:
         with open(args[2], "w") as fout:
             for line in fin:
                 if options.strip:


### PR DESCRIPTION
From the 3.11 release notes:

> [FileInput](https://docs.python.org/3/library/fileinput.html#fileinput.FileInput) no longer accept 'U' (“universal newline”) in the file mode. In Python 3, “universal newline” mode is used by default whenever a file is opened in text mode, and the 'U' flag has been deprecated since Python 3.3.

See also https://docs.python.org/3.5/library/functions.html#open

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
