### PR TITLE
[23.1] Fix job search query

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -420,7 +420,7 @@ class JobSearch:
                     c = aliased(model.HistoryDatasetAssociation)
                     d = aliased(model.JobParameter)
                     e = aliased(model.HistoryDatasetAssociationHistory)
-                    query.add_columns(a.dataset_id)
+                    query = query.add_columns(a.dataset_id)
                     used_ids.append(a.dataset_id)
                     query = query.join(a, a.job_id == model.Job.id)
                     stmt = select([model.HistoryDatasetAssociation.id]).where(


### PR DESCRIPTION
We need to add the dataset_id to the select here (just like in the cases below) ... just calling query.add_columns() doesn't change the query in place.

Fixes the new error @bwlang ran into in https://help.galaxyproject.org/t/i-tried-to-run-a-new-workflow-but-it-stopped-scheduling-at-some-point-seems-like-a-better-error-message-is-in-order/10719

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
