### PR TITLE
[23.1] Copy the collection contents by default when copying a collection

### DIFF
--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -2445,8 +2445,8 @@ export interface components {
             content?: string | string;
             /**
              * Copy Elements
-             * @description If the source is a collection, whether to copy child HDAs into the target history as well, defaults to False but this is less than ideal and may be changed in future releases.
-             * @default false
+             * @description If the source is a collection, whether to copy child HDAs into the target history as well. Prior to the galaxy release 23.1 this defaulted to false.
+             * @default true
              */
             copy_elements?: boolean;
             /**
@@ -2616,7 +2616,7 @@ export interface components {
             /**
              * Copy Elements
              * @description Whether to create a copy of the source HDAs for the new collection.
-             * @default false
+             * @default true
              */
             copy_elements?: boolean;
             /**

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1366,7 +1366,7 @@ class CreateNewCollectionPayload(Model):
         description="Whether to mark the original HDAs as hidden.",
     )
     copy_elements: Optional[bool] = Field(
-        default=False,
+        default=True,
         title="Copy Elements",
         description="Whether to create a copy of the source HDAs for the new collection.",
     )

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -239,12 +239,11 @@ class CreateHistoryContentPayloadFromCollection(CreateHistoryContentPayloadFromC
         description="TODO",
     )
     copy_elements: Optional[bool] = Field(
-        default=False,
+        default=True,
         title="Copy Elements",
         description=(
             "If the source is a collection, whether to copy child HDAs into the target "
-            "history as well, defaults to False but this is less than ideal and may "
-            "be changed in future releases."
+            "history as well. Prior to the galaxy release 23.1 this defaulted to false."
         ),
     )
 

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -14,6 +14,7 @@ from galaxy.model import (
     EffectiveOutput,
     History,
     HistoryDatasetAssociation,
+    HistoryDatasetCollectionAssociation,
     LibraryDataset,
     LibraryDatasetDatasetAssociation,
     WorkflowInvocation,
@@ -400,7 +401,10 @@ def build_workflow_run_configs(
                         f"Unknown workflow input source '{input_source}' specified."
                     )
                 if add_to_history and content.history != history:
-                    content = content.copy(flush=False)
+                    if isinstance(content, HistoryDatasetCollectionAssociation):
+                        content = content.copy(element_destination=history, flush=False)
+                    else:
+                        content = content.copy(flush=False)
                     history.stage_addition(content)
                 input_dict["content"] = content
             except AssertionError:

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -553,7 +553,7 @@ class TestHistoryContentsApi(ApiTestCase):
         assert len(contents) == 1
         new_forward, _ = self.__get_paired_response_elements(history_id, contents[0])
         self._assert_has_keys(new_forward, "history_id")
-        assert new_forward["history_id"] == history_id
+        assert new_forward["history_id"] == second_history_id
 
     def test_hdca_copy_with_new_dbkey(self, history_id):
         fetch_response = self.dataset_collection_populator.create_pair_in_history(history_id, wait=True).json()

--- a/lib/galaxy_test/api/test_workflow_extraction.py
+++ b/lib/galaxy_test/api/test_workflow_extraction.py
@@ -97,17 +97,14 @@ class TestWorkflowExtractionApi(BaseWorkflowsApiTestCase):
         self.__assert_looks_like_randomlines_mapping_workflow(downloaded_workflow)
 
     def test_extract_copied_mapping_from_history(self, history_id):
-        old_history_id = self.dataset_populator.new_history()
-        hdca, job_id1, job_id2 = self.__run_random_lines_mapped_over_pair(old_history_id)
+        hdca, job_id1, job_id2 = self.__run_random_lines_mapped_over_pair(history_id)
 
-        old_contents = self._history_contents(old_history_id)
-        for old_content in old_contents:
-            self.__copy_content_to_history(history_id, old_content)
+        new_history_id = self.dataset_populator.copy_history(history_id).json()["id"]
         # API test is somewhat contrived since there is no good way
         # to retrieve job_id1, job_id2 like this for copied dataset
         # collections I don't think.
         downloaded_workflow = self._extract_and_download_workflow(
-            history_id,
+            new_history_id,
             dataset_collection_ids=[hdca["hid"]],
             job_ids=[job_id1, job_id2],
         )


### PR DESCRIPTION
That got left out when creating the new multi history view. Fixes https://github.com/galaxyproject/galaxy/issues/16716 and https://github.com/galaxyproject/galaxy/issues/16619.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
