### PR TITLE
[23.1] Fix collection id encoding

### DIFF
--- a/client/src/components/providers/test/json/DatasetCollection.error.json
+++ b/client/src/components/providers/test/json/DatasetCollection.error.json
@@ -11,7 +11,7 @@
     "name": "abcdef",
     "create_time": "2020-07-02T17:33:56.567412",
     "populated_state": "new",
-    "collection_id": 44,
+    "collection_id": "b887d74393f85b6d",
     "hid": 2,
     "job_source_id": "3da1fe6d8d16a505",
     "type_id": "dataset_collection-ba03619785539f8c",

--- a/client/src/components/providers/test/json/DatasetCollection.json
+++ b/client/src/components/providers/test/json/DatasetCollection.json
@@ -35,5 +35,5 @@
     "deleted": false,
     "populated": true,
     "update_time": "2020-06-26T14:22:58.435348",
-    "collection_id": 23
+    "collection_id": "f09437b8822035f7"
 }

--- a/client/src/components/providers/test/json/DatasetCollection.processing.json
+++ b/client/src/components/providers/test/json/DatasetCollection.processing.json
@@ -19,7 +19,7 @@
     "tags": [],
     "hid": 2,
     "url": "/api/histories/f7bb1edd6b95db62/contents/dataset_collections/ba03619785539f8c",
-    "collection_id": 44,
+    "collection_id": "b887d74393f85b6d",
     "job_state_summary": {
         "running": 3,
         "waiting": 0,

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -314,6 +314,7 @@ class HDCASerializer(DCASerializer, taggable.TaggableSerializerMixin, annotatabl
             "contents_url": self.generate_contents_url,
             "job_state_summary": self.serialize_job_state_summary,
             "elements_datatypes": self.serialize_elements_datatypes,
+            "collection_id": self.serialize_id,
         }
         self.serializers.update(serializers)
 


### PR DESCRIPTION
The encoding was missing at the serialization level.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
