### PR TITLE
SQLAlchemy 2.0 upgrades (part 2)

### DIFF
--- a/lib/galaxy/datatypes/display_applications/util.py
+++ b/lib/galaxy/datatypes/display_applications/util.py
@@ -17,13 +17,13 @@ def decode_dataset_user(trans, dataset_hash, user_hash):
     # decode dataset id as usual
     # decode user id using the dataset create time as the key
     dataset_id = trans.security.decode_id(dataset_hash)
-    dataset = trans.sa_session.query(trans.app.model.HistoryDatasetAssociation).get(dataset_id)
+    dataset = trans.sa_session.get(trans.app.model.HistoryDatasetAssociation, dataset_id)
     assert dataset, "Bad Dataset id provided to decode_dataset_user"
     if user_hash in [None, "None"]:
         user = None
     else:
         security = IdEncodingHelper(id_secret=dataset.create_time)
         user_id = security.decode_id(user_hash)
-        user = trans.sa_session.query(trans.app.model.User).get(user_id)
+        user = trans.sa_session.get(trans.app.model.User, user_id)
         assert user, "A Bad user id was passed to decode_dataset_user"
     return dataset, user

--- a/lib/galaxy/managers/model_stores.py
+++ b/lib/galaxy/managers/model_stores.py
@@ -95,11 +95,11 @@ class ModelStoreManager:
         include_deleted = request.include_deleted
         store_directory = request.store_directory
 
-        history = self._sa_session.query(model.History).get(history_id)
+        history = self._sa_session.get(model.History, history_id)
         # symlink files on export, on worker files will tarred up in a dereferenced manner.
         with DirectoryModelExportStore(store_directory, app=self._app, export_files="symlink") as export_store:
             export_store.export_history(history, include_hidden=include_hidden, include_deleted=include_deleted)
-        job = self._sa_session.query(model.Job).get(job_id)
+        job = self._sa_session.get(model.Job, job_id)
         job.state = model.Job.states.NEW
         with transaction(self._sa_session):
             self._sa_session.commit()
@@ -137,10 +137,10 @@ class ModelStoreManager:
                 short_term_storage_target.path
             ) as export_store:
                 if request.content_type == HistoryContentType.dataset:
-                    hda = self._sa_session.query(model.HistoryDatasetAssociation).get(request.content_id)
+                    hda = self._sa_session.get(model.HistoryDatasetAssociation, request.content_id)
                     export_store.add_dataset(hda)
                 else:
-                    hdca = self._sa_session.query(model.HistoryDatasetCollectionAssociation).get(request.content_id)
+                    hdca = self._sa_session.get(model.HistoryDatasetCollectionAssociation, request.content_id)
                     export_store.export_collection(
                         hdca, include_hidden=request.include_hidden, include_deleted=request.include_deleted
                     )
@@ -157,7 +157,7 @@ class ModelStoreManager:
                 export_files=export_files,
                 bco_export_options=self._bco_export_options(request),
             )(short_term_storage_target.path) as export_store:
-                invocation = self._sa_session.query(model.WorkflowInvocation).get(request.invocation_id)
+                invocation = self._sa_session.get(model.WorkflowInvocation, request.invocation_id)
                 export_store.export_workflow_invocation(
                     invocation, include_hidden=request.include_hidden, include_deleted=request.include_deleted
                 )
@@ -174,7 +174,7 @@ class ModelStoreManager:
             bco_export_options=self._bco_export_options(request),
             user_context=user_context,
         )(target_uri) as export_store:
-            invocation = self._sa_session.query(model.WorkflowInvocation).get(request.invocation_id)
+            invocation = self._sa_session.get(model.WorkflowInvocation, request.invocation_id)
             export_store.export_workflow_invocation(
                 invocation, include_hidden=request.include_hidden, include_deleted=request.include_deleted
             )
@@ -199,10 +199,10 @@ class ModelStoreManager:
             self._app, model_store_format, export_files=export_files, user_context=user_context
         )(target_uri) as export_store:
             if request.content_type == HistoryContentType.dataset:
-                hda = self._sa_session.query(model.HistoryDatasetAssociation).get(request.content_id)
+                hda = self._sa_session.get(model.HistoryDatasetAssociation, request.content_id)
                 export_store.add_dataset(hda)
             else:
-                hdca = self._sa_session.query(model.HistoryDatasetCollectionAssociation).get(request.content_id)
+                hdca = self._sa_session.get(model.HistoryDatasetCollectionAssociation, request.content_id)
                 export_store.export_collection(
                     hdca, include_hidden=request.include_hidden, include_deleted=request.include_deleted
                 )
@@ -267,7 +267,7 @@ class ModelStoreManager:
         )
         history_id = request.history_id
         if history_id:
-            history = self._sa_session.query(model.History).get(history_id)
+            history = self._sa_session.get(model.History, history_id)
         else:
             history = None
         user_context = self._build_user_context(request.user.user_id)

--- a/lib/galaxy/managers/pages.py
+++ b/lib/galaxy/managers/pages.py
@@ -16,6 +16,7 @@ from typing import (
 )
 
 from sqlalchemy import (
+    desc,
     false,
     or_,
     select,
@@ -42,7 +43,12 @@ from galaxy.managers.markdown_util import (
     ready_galaxy_markdown_for_export,
     ready_galaxy_markdown_for_import,
 )
-from galaxy.model import PageRevision
+from galaxy.model import (
+    Page,
+    PageRevision,
+    PageUserShareAssociation,
+    User,
+)
 from galaxy.model.base import transaction
 from galaxy.model.index_filter_util import (
     append_user_filter,
@@ -631,3 +637,28 @@ def placeholderRenderForSave(trans: ProvidesHistoryContext, item_class, item_id,
 def get_page_revision(session: Session, page_id: int):
     stmt = select(PageRevision).filter_by(page_id=page_id)
     return session.scalars(stmt)
+
+
+def get_shared_pages(session: Session, user: User):
+    stmt = (
+        select(PageUserShareAssociation)
+        .where(PageUserShareAssociation.user == user)
+        .join(Page)
+        .where(Page.deleted == false())
+        .order_by(desc(Page.update_time))
+    )
+    return session.scalars(stmt)
+
+
+def get_page(session: Session, user: User, slug: str):
+    stmt = _build_page_query(select(Page), user, slug)
+    return session.scalar(stmt).first()
+
+
+def page_exists(session: Session, user: User, slug: str) -> bool:
+    stmt = _build_page_query(select(Page.id), user, slug)
+    return session.scalar(stmt).first() is not None
+
+
+def _build_page_query(select_clause, user: User, slug: str):
+    return select_clause.where(Page.user == user).where(Page.slug == slug).where(Page.deleted == false()).limit(1)

--- a/lib/galaxy/managers/roles.py
+++ b/lib/galaxy/managers/roles.py
@@ -4,7 +4,10 @@ Manager and Serializer for Roles.
 import logging
 from typing import List
 
-from sqlalchemy import false
+from sqlalchemy import (
+    false,
+    select,
+)
 from sqlalchemy.orm import exc as sqlalchemy_exceptions
 
 import galaxy.exceptions
@@ -44,7 +47,8 @@ class RoleManager(base.ModelManager[model.Role]):
         :raises: InconsistentDatabase, RequestParameterInvalidException, InternalServerError
         """
         try:
-            role = self.session().query(self.model_class).filter(self.model_class.id == role_id).one()
+            stmt = select(self.model_class).where(self.model_class.id == role_id)
+            role = self.session().execute(stmt).scalar_one()
         except sqlalchemy_exceptions.MultipleResultsFound:
             raise galaxy.exceptions.InconsistentDatabase("Multiple roles found with the same id.")
         except sqlalchemy_exceptions.NoResultFound:
@@ -59,7 +63,8 @@ class RoleManager(base.ModelManager[model.Role]):
 
     def list_displayable_roles(self, trans: ProvidesUserContext) -> List[Role]:
         roles = []
-        for role in trans.sa_session.query(Role).filter(Role.deleted == false()):
+        stmt = select(Role).where(Role.deleted == false())
+        for role in trans.sa_session.scalars(stmt):
             if trans.user_is_admin or trans.app.security_agent.ok_to_display(trans.user, role):
                 roles.append(role)
         return roles
@@ -70,15 +75,16 @@ class RoleManager(base.ModelManager[model.Role]):
         user_ids = role_definition_model.user_ids or []
         group_ids = role_definition_model.group_ids or []
 
-        if trans.sa_session.query(Role).filter(Role.name == name).first():
+        stmt = select(Role).where(Role.name == name).limit(1)
+        if trans.sa_session.scalars(stmt).first():
             raise RequestParameterInvalidException(f"A role with that name already exists [{name}]")
 
         role_type = Role.types.ADMIN  # TODO: allow non-admins to create roles
 
         role = Role(name=name, description=description, type=role_type)
         trans.sa_session.add(role)
-        users = [trans.sa_session.query(model.User).get(i) for i in user_ids]
-        groups = [trans.sa_session.query(model.Group).get(i) for i in group_ids]
+        users = [trans.sa_session.get(model.User, i) for i in user_ids]
+        groups = [trans.sa_session.get(model.Group, i) for i in group_ids]
 
         # Create the UserRoleAssociations
         for user in users:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8142,16 +8142,13 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
 
     @staticmethod
     def poll_unhandled_workflow_ids(sa_session):
-        and_conditions = [
-            WorkflowInvocation.state == WorkflowInvocation.states.NEW,
-            WorkflowInvocation.handler.is_(None),
-        ]
-        query = (
-            sa_session.query(WorkflowInvocation.id)
-            .filter(and_(*and_conditions))
-            .order_by(WorkflowInvocation.table.c.id.asc())
+        stmt = (
+            select(WorkflowInvocation.id)
+            .where(WorkflowInvocation.state == WorkflowInvocation.states.NEW)
+            .where(WorkflowInvocation.handler.is_(None))
+            .order_by(WorkflowInvocation.id.asc())
         )
-        return [wid for wid in query.all()]
+        return [wid for wid in sa_session.scalars(stmt)]
 
     @staticmethod
     def poll_active_workflow_ids(engine, scheduler=None, handler=None):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4837,13 +4837,9 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
         # Check dataset state and return any messages.
         msg = None
         if converted_dataset and converted_dataset.state == Dataset.states.ERROR:
-            job_id = (
-                trans.sa_session.query(JobToOutputDatasetAssociation)
-                .filter_by(dataset_id=converted_dataset.id)
-                .first()
-                .job_id
-            )
-            job = trans.sa_session.query(Job).get(job_id)
+            stmt = select(JobToOutputDatasetAssociation.job_id).filter_by(dataset_id=converted_dataset.id).limit(1)
+            job_id = trans.sa_session.scalars(stmt).first()
+            job = trans.sa_session.get(Job, job_id)
             msg = {"kind": self.conversion_messages.ERROR, "message": job.stderr}
         elif not converted_dataset or converted_dataset.state != Dataset.states.OK:
             msg = self.conversion_messages.PENDING

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3263,8 +3263,8 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
 
     @property
     def paused_jobs(self):
-        db_session = object_session(self)
-        return db_session.query(Job).filter(Job.history_id == self.id, Job.state == Job.states.PAUSED).all()
+        stmt = select(Job).where(Job.history_id == self.id, Job.state == Job.states.PAUSED)
+        return object_session(self).scalars(stmt).all()
 
     @hybrid.hybrid_property
     def disk_size(self):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9510,18 +9510,19 @@ class UserAuthnzToken(Base, UserMixin, RepresentById):
     def get_social_auth(cls, provider, uid):
         uid = str(uid)
         try:
-            return cls.sa_session.query(cls).filter_by(provider=provider, uid=uid)[0]
+            stmt = select(UserAuthnzToken).filter_by(provider=provider, uid=uid).limit(1)
+            return cls.sa_session.scalars(stmt).first()
         except IndexError:
             return None
 
     @classmethod
     def get_social_auth_for_user(cls, user, provider=None, id=None):
-        qs = cls.sa_session.query(cls).filter_by(user_id=user.id)
+        stmt = select(UserAuthnzToken).filter_by(user_id=user.id)
         if provider:
-            qs = qs.filter_by(provider=provider)
+            stmt = stmt.filter_by(provider=provider)
         if id:
-            qs = qs.filter_by(id=id)
-        return qs
+            stmt = stmt.filter_by(id=id)
+        return cls.sa_session.scalars(stmt)
 
     @classmethod
     def create_social_auth(cls, user, uid, provider):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2838,12 +2838,12 @@ class HistoryAudit(Base, RepresentById):
     @classmethod
     def prune(cls, sa_session):
         latest_subq = (
-            sa_session.query(cls.history_id, func.max(cls.update_time).label("max_update_time"))
+            select(cls.history_id, func.max(cls.update_time).label("max_update_time"))
             .group_by(cls.history_id)
             .subquery()
         )
         not_latest_query = (
-            sa_session.query(cls.history_id, cls.update_time)
+            select(cls.history_id, cls.update_time)
             .select_from(latest_subq)
             .join(
                 cls,

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3356,19 +3356,18 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
     @property
     def active_visible_dataset_collections(self):
         if not hasattr(self, "_active_visible_dataset_collections"):
-            db_session = object_session(self)
-            query = (
-                db_session.query(HistoryDatasetCollectionAssociation)
-                .filter(HistoryDatasetCollectionAssociation.table.c.history_id == self.id)
-                .filter(not_(HistoryDatasetCollectionAssociation.deleted))
-                .filter(HistoryDatasetCollectionAssociation.visible)
-                .order_by(HistoryDatasetCollectionAssociation.table.c.hid.asc())
+            stmt = (
+                select(HistoryDatasetCollectionAssociation)
+                .where(HistoryDatasetCollectionAssociation.history_id == self.id)
+                .where(not_(HistoryDatasetCollectionAssociation.deleted))
+                .where(HistoryDatasetCollectionAssociation.visible)
+                .order_by(HistoryDatasetCollectionAssociation.hid.asc())
                 .options(
                     joinedload(HistoryDatasetCollectionAssociation.collection),
                     joinedload(HistoryDatasetCollectionAssociation.tags),
                 )
             )
-            self._active_visible_dataset_collections = query.all()
+            self._active_visible_dataset_collections = object_session(self).scalars(stmt).unique().all()
         return self._active_visible_dataset_collections
 
     @property

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9336,7 +9336,8 @@ class PSACode(Base, CodeMixin, RepresentById):
 
     @classmethod
     def get_code(cls, code):
-        return cls.sa_session.query(cls).filter(cls.code == code).first()
+        stmt = select(PSACode).where(PSACode.code == code).limit(1)
+        return cls.sa_session.scalars(stmt).first()
 
 
 class PSANonce(Base, NonceMixin, RepresentById):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7331,14 +7331,13 @@ class StoredWorkflow(Base, HasTags, Dictifiable, RepresentById):
 
     def show_in_tool_panel(self, user_id):
         sa_session = object_session(self)
-        return bool(
-            sa_session.query(StoredWorkflowMenuEntry)
-            .filter(
-                StoredWorkflowMenuEntry.stored_workflow_id == self.id,
-                StoredWorkflowMenuEntry.user_id == user_id,
-            )
-            .count()
+        stmt = (
+            select(func.count())
+            .select_from(StoredWorkflowMenuEntry)
+            .where(StoredWorkflowMenuEntry.stored_workflow_id == self.id)
+            .where(StoredWorkflowMenuEntry.user_id == user_id)
         )
+        return bool(sa_session.scalar(stmt))
 
     def copy_tags_from(self, target_user, source_workflow):
         # Override to only copy owner tags.

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9399,13 +9399,17 @@ class PSAPartial(Base, PartialMixin, RepresentById):
 
     @classmethod
     def load(cls, token):
-        return cls.sa_session.query(cls).filter(cls.token == token).first()
+        stmt = select(PSAPartial).where(PSAPartial.token == token).limit(1)
+        return cls.sa_session.scalars(stmt).first()
 
     @classmethod
     def destroy(cls, token):
         partial = cls.load(token)
         if partial:
-            cls.sa_session.delete(partial)
+            session = cls.sa_session
+            session.execute(delete(partial))
+            with transaction(session):
+                session.commit()
 
 
 class UserAuthnzToken(Base, UserMixin, RepresentById):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9364,7 +9364,8 @@ class PSANonce(Base, NonceMixin, RepresentById):
     @classmethod
     def use(cls, server_url, timestamp, salt):
         try:
-            return cls.sa_session.query(cls).filter_by(server_url=server_url, timestamp=timestamp, salt=salt)[0]
+            stmt = select(PSANonce).where(server_url=server_url, timestamp=timestamp, salt=salt).limit(1)
+            return cls.sa_session.scalars(stmt).first()
         except IndexError:
             instance = cls(server_url=server_url, timestamp=timestamp, salt=salt)
             cls.sa_session.add(instance)

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -20,6 +20,7 @@ from typing import (
     Union,
 )
 
+from sqlalchemy import select
 from sqlalchemy.orm import object_session
 from sqlalchemy.orm.attributes import flag_modified
 
@@ -602,9 +603,9 @@ class FileParameter(MetadataParameter):
         if isinstance(value, galaxy.model.MetadataFile) or isinstance(value, MetadataTempFile):
             return value
         if isinstance(value, int):
-            return session.query(galaxy.model.MetadataFile).get(value)
+            return session.get(galaxy.model.MetadataFile, value)
         else:
-            return session.query(galaxy.model.MetadataFile).filter_by(uuid=value).one()
+            return session.execute(select(galaxy.model.MetadataFile).filter_by(uuid=value)).scalar_one()
 
     def make_copy(self, value, target_context: MetadataCollection, source_context):
         session = target_context._object_session(target_context.parent)

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -9,12 +9,29 @@ from typing import List
 from sqlalchemy import (
     and_,
     false,
+    func,
     not_,
     or_,
+    select,
 )
 from sqlalchemy.orm import joinedload
 
 import galaxy.model
+from galaxy.model import (
+    Dataset,
+    DatasetPermissions,
+    Group,
+    GroupRoleAssociation,
+    HistoryDatasetAssociationDisplayAtAuthorization,
+    Library,
+    LibraryDataset,
+    LibraryDatasetPermissions,
+    LibraryPermissions,
+    Role,
+    User,
+    UserGroupAssociation,
+    UserRoleAssociation,
+)
 from galaxy.model.base import transaction
 from galaxy.security import (
     Action,
@@ -65,17 +82,12 @@ class GalaxyRBACAgent(RBACAgent):
         """
         non-private, non-sharing roles
         """
-        return (
-            trans.sa_session.query(trans.app.model.Role)
-            .filter(
-                and_(
-                    self.model.Role.deleted == false(),
-                    self.model.Role.type != self.model.Role.types.PRIVATE,
-                    self.model.Role.type != self.model.Role.types.SHARING,
-                )
-            )
-            .order_by(self.model.Role.name)
+        stmt = (
+            select(Role)
+            .where(and_(Role.deleted == false(), Role.type != Role.types.PRIVATE, Role.type != Role.types.SHARING))
+            .order_by(Role.name)
         )
+        return trans.sa_session.scalars(stmt)
 
     def get_all_roles(self, trans, cntrller):
         admin_controller = cntrller in ["library_admin"]
@@ -84,11 +96,8 @@ class GalaxyRBACAgent(RBACAgent):
             return self._get_npns_roles(trans)
         if admin_controller:
             # The library is public and the user is an admin, so all roles are legitimate
-            for role in (
-                trans.sa_session.query(trans.app.model.Role)
-                .filter(self.model.Role.deleted == false())
-                .order_by(self.model.Role.name)
-            ):
+            stmt = select(Role).where(Role.deleted == false()).order_by(Role.name)
+            for role in trans.sa_session.scalars(stmt):
                 roles.add(role)
         else:
             # Add the current user's private role
@@ -146,27 +155,30 @@ class GalaxyRBACAgent(RBACAgent):
         # Admins can always choose from all non-deleted roles
         if trans.user_is_admin or trans.app.config.expose_user_email:
             if trans.user_is_admin:
-                db_query = trans.sa_session.query(trans.app.model.Role).filter(self.model.Role.deleted == false())
+                stmt = select(Role).where(Role.deleted == false())
             else:
                 # User is not an admin but the configuration exposes all private roles to all users.
-                db_query = trans.sa_session.query(trans.app.model.Role).filter(
-                    and_(self.model.Role.deleted == false(), self.model.Role.type == self.model.Role.types.PRIVATE)
-                )
+                stmt = select(Role).where(and_(Role.deleted == false(), Role.type == Role.types.PRIVATE))
             if search_query:
-                db_query = db_query.filter(self.model.Role.name.like(search_query, escape="/"))
-            total_count = db_query.count()
+                stmt = stmt.where(Role.name.like(search_query, escape="/"))
+
+            count_stmt = select(func.count()).select_from(stmt)
+            total_count = trans.sa_session.scalar(count_stmt)
+
             if limit is not None:
                 # Takes the least number of results from beginning that includes the requested page
-                roles = db_query.order_by(self.model.Role.name).limit(limit).all()
+                stmt = stmt.order_by(Role.name).limit(limit)
                 page_start = (page * page_limit) - page_limit
                 page_end = page_start + page_limit
                 if total_count < page_start + 1:
                     # Return empty list if there are less results than the requested position
                     roles = []
                 else:
+                    roles = trans.sa_session.scalars(stmt).all()
                     roles = roles[page_start:page_end]
             else:
-                roles = db_query.order_by(self.model.Role.name)
+                stmt = stmt.order_by(Role.name)
+                roles = trans.sa_session.scalars(stmt).all()
         # Non-admin and public item
         elif is_public_item:
             # Add the current user's private role
@@ -324,17 +336,13 @@ class GalaxyRBACAgent(RBACAgent):
             # SM: NB: LibraryDatasets became Datasets for some odd reason.
             if isinstance(permission_items[0], trans.model.LibraryDataset):
                 ids = [item.library_dataset_id for item in permission_items]
-                permissions = (
-                    trans.sa_session.query(trans.model.LibraryDatasetPermissions)
-                    .filter(
-                        and_(
-                            trans.model.LibraryDatasetPermissions.library_dataset_id.in_(ids),
-                            trans.model.LibraryDatasetPermissions.action == action.action,
-                        )
+                stmt = select(LibraryDatasetPermissions).where(
+                    and_(
+                        LibraryDatasetPermissions.library_dataset_id.in_(ids),
+                        LibraryDatasetPermissions.action == action.action,
                     )
-                    .all()
                 )
-
+                permissions = trans.sa_session.scalars(stmt)
                 # Massage the return data. We will return a list of permissions
                 # for each library dataset. So we initialize the return list to
                 # have an empty list for each dataset. Then each permission is
@@ -347,17 +355,11 @@ class GalaxyRBACAgent(RBACAgent):
                     ret_permissions[permission.library_dataset_id].append(permission)
             elif isinstance(permission_items[0], trans.model.Dataset):
                 ids = [item.id for item in permission_items]
-                permissions = (
-                    trans.sa_session.query(trans.model.DatasetPermissions)
-                    .filter(
-                        and_(
-                            trans.model.DatasetPermissions.dataset_id.in_(ids),
-                            trans.model.DatasetPermissions.action == action.action,
-                        )
-                    )
-                    .all()
-                )
 
+                stmt = select(DatasetPermissions).where(
+                    and_(DatasetPermissions.dataset_id.in_(ids), DatasetPermissions.action == action.action)
+                )
+                permissions = trans.sa_session.scalars(stmt)
                 # Massage the return data. We will return a list of permissions
                 # for each library dataset. So we initialize the return list to
                 # have an empty list for each dataset. Then each permission is
@@ -540,38 +542,34 @@ class GalaxyRBACAgent(RBACAgent):
         accessible_libraries = []
         current_user_role_ids = [role.id for role in user.all_roles()]
         library_access_action = self.permitted_actions.LIBRARY_ACCESS.action
-        restricted_library_ids = [
-            lp.library_id
-            for lp in trans.sa_session.query(trans.model.LibraryPermissions)
-            .filter(trans.model.LibraryPermissions.table.c.action == library_access_action)
-            .distinct()
-        ]
-        accessible_restricted_library_ids = [
-            lp.library_id
-            for lp in trans.sa_session.query(trans.model.LibraryPermissions).filter(
-                and_(
-                    trans.model.LibraryPermissions.table.c.action == library_access_action,
-                    trans.model.LibraryPermissions.table.c.role_id.in_(current_user_role_ids),
-                )
+
+        stmt = select(LibraryPermissions).where(LibraryPermissions.action == library_access_action).distinct()
+        restricted_library_ids = [lp.library_id for lp in trans.sa_session.scalars(stmt)]
+
+        stmt = select(LibraryPermissions).where(
+            and_(
+                LibraryPermissions.action == library_access_action,
+                LibraryPermissions.role_id.in_(current_user_role_ids),
             )
-        ]
+        )
+        accessible_restricted_library_ids = [lp.library_id for lp in trans.sa_session.scalars(stmt)]
+
         # Filter to get libraries accessible by the current user.  Get both
         # public libraries and restricted libraries accessible by the current user.
-        for library in (
-            trans.sa_session.query(trans.model.Library)
-            .filter(
+        stmt = (
+            select(Library)
+            .where(
                 and_(
-                    trans.model.Library.table.c.deleted == false(),
-                    (
-                        or_(
-                            not_(trans.model.Library.table.c.id.in_(restricted_library_ids)),
-                            trans.model.Library.table.c.id.in_(accessible_restricted_library_ids),
-                        )
+                    Library.deleted == false(),
+                    or_(
+                        not_(Library.id.in_(restricted_library_ids)),
+                        Library.id.in_(accessible_restricted_library_ids),
                     ),
                 )
             )
-            .order_by(trans.app.model.Library.name)
-        ):
+            .order_by(Library.name)
+        )
+        for library in trans.sa_session.scalars(stmt):
             accessible_libraries.append(library)
         return accessible_libraries
 
@@ -589,12 +587,10 @@ class GalaxyRBACAgent(RBACAgent):
         return False
 
     def has_accessible_library_datasets(self, trans, folder, user, roles, search_downward=True):
-        for library_dataset in trans.sa_session.query(trans.model.LibraryDataset).filter(
-            and_(
-                trans.model.LibraryDataset.table.c.deleted == false(),
-                trans.app.model.LibraryDataset.table.c.folder_id == folder.id,
-            )
-        ):
+        stmt = select(LibraryDataset).where(
+            and_(LibraryDataset.deleted == false(), LibraryDataset.folder_id == folder.id)
+        )
+        for library_dataset in trans.sa_session.scalars(stmt):
             if self.can_access_library_item(roles, library_dataset, user):
                 return True
         if search_downward:
@@ -749,17 +745,14 @@ class GalaxyRBACAgent(RBACAgent):
         return self.get_private_user_role(user)
 
     def get_private_user_role(self, user, auto_create=False):
-        role = (
-            self.sa_session.query(self.model.Role)
-            .filter(
-                and_(
-                    self.model.UserRoleAssociation.table.c.user_id == user.id,
-                    self.model.Role.id == self.model.UserRoleAssociation.table.c.role_id,
-                    self.model.Role.type == self.model.Role.types.PRIVATE,
-                )
+        stmt = select(Role).where(
+            and_(
+                UserRoleAssociation.user_id == user.id,
+                Role.id == UserRoleAssociation.role_id,
+                Role.type == Role.types.PRIVATE,
             )
-            .one_or_none()
         )
+        role = self.sa_session.execute(stmt).scalar_one_or_none()
         if not role:
             if auto_create:
                 return self.create_private_user_role(user)
@@ -770,21 +763,18 @@ class GalaxyRBACAgent(RBACAgent):
     def get_role(self, name, type=None):
         type = type or self.model.Role.types.SYSTEM
         # will raise exception if not found
-        return (
-            self.sa_session.query(self.model.Role)
-            .filter(and_(self.model.Role.name == name, self.model.Role.type == type))
-            .one()
-        )
+        stmt = select(Role).where(and_(Role.name == name, Role.type == type))
+        return self.sa_session.execute(stmt).scalar_one()
 
     def create_role(self, name, description, in_users, in_groups, create_group_for_role=False, type=None):
         type = type or self.model.Role.types.SYSTEM
         role = self.model.Role(name=name, description=description, type=type)
         self.sa_session.add(role)
         # Create the UserRoleAssociations
-        for user in [self.sa_session.query(self.model.User).get(x) for x in in_users]:
+        for user in [self.sa_session.get(User, x) for x in in_users]:
             self.associate_user_role(user, role)
         # Create the GroupRoleAssociations
-        for group in [self.sa_session.query(self.model.Group).get(x) for x in in_groups]:
+        for group in [self.sa_session.get(Group, x) for x in in_groups]:
             self.associate_group_role(group, role)
         if create_group_for_role:
             # Create the group
@@ -800,12 +790,10 @@ class GalaxyRBACAgent(RBACAgent):
         return role, num_in_groups
 
     def get_sharing_roles(self, user):
-        return self.sa_session.query(self.model.Role).filter(
-            and_(
-                (self.model.Role.name).like(f"Sharing role for: %{user.email}%"),
-                self.model.Role.type == self.model.Role.types.SHARING,
-            )
+        stmt = select(Role).where(
+            and_((Role.name).like(f"Sharing role for: %{user.email}%"), Role.type == Role.types.SHARING)
         )
+        return self.sa_session.scalars(stmt)
 
     def user_set_default_permissions(
         self,
@@ -1217,16 +1205,13 @@ class GalaxyRBACAgent(RBACAgent):
             datasets_public[dataset_id] = True
 
         # Now get all datasets which have DATASET_ACCESS actions:
-        access_data_perms = (
-            trans.sa_session.query(trans.app.model.DatasetPermissions)
-            .filter(
-                and_(
-                    trans.app.model.DatasetPermissions.dataset_id.in_(dataset_ids),
-                    trans.app.model.DatasetPermissions.action == self.permitted_actions.DATASET_ACCESS.action,
-                )
+        stmt = select(DatasetPermissions).where(
+            and_(
+                DatasetPermissions.dataset_id.in_(dataset_ids),
+                DatasetPermissions.action == self.permitted_actions.DATASET_ACCESS.action,
             )
-            .all()
         )
+        access_data_perms = trans.sa_session.scalars(stmt)
         # Every dataset returned has "access" privileges associated with it,
         # so it's not public.
         for permission in access_data_perms:
@@ -1264,14 +1249,14 @@ class GalaxyRBACAgent(RBACAgent):
         error = False
         for k, v in get_permitted_actions(filter="DATASET").items():
             # Change for removing the prefix '_in' from the roles select box
-            in_roles = [self.sa_session.query(self.model.Role).get(x) for x in listify(kwd[k])]
+            in_roles = [self.sa_session.get(Role, x) for x in listify(kwd[k])]
             if not in_roles:
-                in_roles = [self.sa_session.query(self.model.Role).get(x) for x in listify(kwd.get(f"{k}_in", []))]
+                in_roles = [self.sa_session.get(Role, x) for x in listify(kwd.get(f"{k}_in", []))]
             if v == self.permitted_actions.DATASET_ACCESS and in_roles:
                 if library:
-                    item = self.sa_session.query(self.model.Library).get(item_id)
+                    item = self.sa_session.get(Library, item_id)
                 else:
-                    item = self.sa_session.query(self.model.Dataset).get(item_id)
+                    item = self.sa_session.get(Dataset, item_id)
                 if (library and not self.library_is_public(item)) or (not library and not self.dataset_is_public(item)):
                     # Ensure that roles being associated with DATASET_ACCESS are a subset of the legitimate roles
                     # derived from the roles associated with the access permission on item if it's not public.  This
@@ -1387,11 +1372,8 @@ class GalaxyRBACAgent(RBACAgent):
             libraries = trans.app.security_agent.get_permitted_libraries( trans, user,
                 [ trans.app.security_agent.permitted_actions.LIBRARY_ADD ] )
         """
-        all_libraries = (
-            trans.sa_session.query(trans.app.model.Library)
-            .filter(trans.app.model.Library.table.c.deleted == false())
-            .order_by(trans.app.model.Library.name)
-        )
+        stmt = select(Library).where(Library.deleted == false()).order_by(Library.name)
+        all_libraries = trans.sa_session.scalars(stmt)
         roles = user.all_roles()
         actions_to_check = actions
         # The libraries dictionary looks like: { library : '1,2' }, library : '3' }
@@ -1520,31 +1502,23 @@ class GalaxyRBACAgent(RBACAgent):
         assert len(kwd) == 2, "You must specify exactly 2 Galaxy security components to check for associations."
         if "dataset" in kwd:
             if "action" in kwd:
-                return (
-                    self.sa_session.query(self.model.DatasetPermissions)
+                stmt = (
+                    select(DatasetPermissions)
                     .filter_by(action=kwd["action"].action, dataset_id=kwd["dataset"].id)
-                    .first()
+                    .limit(1)
                 )
+                return self.sa_session.scalars(stmt).first()
         elif "user" in kwd:
             if "group" in kwd:
-                return (
-                    self.sa_session.query(self.model.UserGroupAssociation)
-                    .filter_by(group_id=kwd["group"].id, user_id=kwd["user"].id)
-                    .first()
-                )
+                stmt = select(UserGroupAssociation).filter_by(group_id=kwd["group"].id, user_id=kwd["user"].id).limit(1)
+                return self.sa_session.scalars(stmt).first()
             elif "role" in kwd:
-                return (
-                    self.sa_session.query(self.model.UserRoleAssociation)
-                    .filter_by(role_id=kwd["role"].id, user_id=kwd["user"].id)
-                    .first()
-                )
+                stmt = select(UserRoleAssociation).filter_by(role_id=kwd["role"].id, user_id=kwd["user"].id).limit(1)
+                return self.sa_session.scalars(stmt).first()
         elif "group" in kwd:
             if "role" in kwd:
-                return (
-                    self.sa_session.query(self.model.GroupRoleAssociation)
-                    .filter_by(role_id=kwd["role"].id, group_id=kwd["group"].id)
-                    .first()
-                )
+                stmt = select(GroupRoleAssociation).filter_by(role_id=kwd["role"].id, group_id=kwd["group"].id).limit(1)
+                return self.sa_session.scalars(stmt).first()
         raise Exception(f"No valid method of associating provided components: {kwd}")
 
     def check_folder_contents(self, user, roles, folder, hidden_folder_ids=""):
@@ -1635,11 +1609,12 @@ class HostAgent(RBACAgent):
             ]:
                 log.debug("Allowing access to public dataset with hda: %i." % hda.id)
                 return True  # dataset has no roles associated with the access permission, thus is already public
-            hdadaa = (
-                self.sa_session.query(self.model.HistoryDatasetAssociationDisplayAtAuthorization)
+            stmt = (
+                select(HistoryDatasetAssociationDisplayAtAuthorization)
                 .filter_by(history_dataset_association_id=hda.id)
-                .first()
+                .limit(1)
             )
+            hdadaa = self.sa_session.scalars(stmt).first()
             if not hdadaa:
                 log.debug(
                     "Denying access to private dataset with hda: %i.  No hdadaa record for this dataset." % hda.id
@@ -1677,11 +1652,12 @@ class HostAgent(RBACAgent):
             raise Exception("The dataset access permission is the only valid permission in the host security agent.")
 
     def set_dataset_permissions(self, hda, user, site):
-        hdadaa = (
-            self.sa_session.query(self.model.HistoryDatasetAssociationDisplayAtAuthorization)
+        stmt = (
+            select(HistoryDatasetAssociationDisplayAtAuthorization)
             .filter_by(history_dataset_association_id=hda.id)
-            .first()
+            .limit(1)
         )
+        hdadaa = self.sa_session.scalars(stmt).first()
         if hdadaa:
             hdadaa.update_time = datetime.utcnow()
         else:

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -828,7 +828,7 @@ def persist_hdas(elements, model_persistence_context, final_job_state="ok"):
                     sa_session = (
                         model_persistence_context.sa_session or model_persistence_context.import_store.sa_session
                     )
-                    primary_dataset = sa_session.query(galaxy.model.HistoryDatasetAssociation).get(hda_id)
+                    primary_dataset = sa_session.get(galaxy.model.HistoryDatasetAssociation, hda_id)
 
                 sources = fields_match.sources
                 hashes = fields_match.hashes

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -287,12 +287,12 @@ class TagHandler:
 
     def get_tag_by_id(self, tag_id):
         """Get a Tag object from a tag id."""
-        return self.sa_session.query(galaxy.model.Tag).filter_by(id=tag_id).first()
+        return self.sa_session.get(galaxy.model.Tag, tag_id)
 
     def get_tag_by_name(self, tag_name):
         """Get a Tag object from a tag name (string)."""
         if tag_name:
-            return self.sa_session.query(galaxy.model.Tag).filter_by(name=tag_name.lower()).first()
+            return self.sa_session.scalars(select(galaxy.model.Tag).filter_by(name=tag_name.lower()).limit(1)).first()
         return None
 
     def _create_tag(self, tag_str: str):
@@ -317,7 +317,7 @@ class TagHandler:
         return tag
 
     def _get_tag(self, tag_name):
-        return self.sa_session.query(galaxy.model.Tag).filter_by(name=tag_name).first()
+        return self.sa_session.scalars(select(galaxy.model.Tag).filter_by(name=tag_name).limit(1)).first()
 
     def _create_tag_instance(self, tag_name):
         # For good performance caller should first check if there's already an appropriate tag


### PR DESCRIPTION
Follow-up to #16434. Covers ORM usage ([ref](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-orm-usage)). This PR is ready for review.

**For follow-up PRs:**
- [ ] lib/galaxy/datatypes
- [ ] lib/galaxy/jobs
- [ ] lib/galaxy/managers
- [ ] lib/galaxy/metadata
- [ ] lib/galaxy/tool_shed
- [ ] lib/galaxy/web
- [ ] lib/galaxy/webapps/galaxy/controllers
- [ ] lib/galaxy_test
- [ ] lib/tool_shed
- [ ] `build_initial_query` and friends (`web/framework/*`, `webapps/*`)
- [ ] #16761
- [ ] `model.DatasetCollection._get_nested_collection_attributes()`
- [ ] `model.DatasetCollection.populated_optimized`
- [ ] managers.users (tags: convert from Query, apply union correctly)

Ref: #12541

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
