### PR TITLE
[23.1] force wrap long parameter names in the workflow form

### DIFF
--- a/client/src/style/scss/workflow.scss
+++ b/client/src/style/scss/workflow.scss
@@ -69,6 +69,9 @@
                     border-bottom: dotted $brand-primary 1px;
                     margin: 0 5px;
                 }
+                .output-data-row {
+                    overflow-wrap: anywhere;
+                }
             }
         }
         .workflow-canvas {


### PR DESCRIPTION
backport of https://github.com/galaxyproject/galaxy/pull/16731 since the location of css for this component changed and cannot be easily merged forward

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
