### PR TITLE
MINERVA display application: enable cors, add for tabular

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -434,6 +434,7 @@
     <datatype extension="taxonomy" type="galaxy.datatypes.tabular:Taxonomy" display_in_upload="true"/>
     <datatype extension="tabular" type="galaxy.datatypes.tabular:Tabular" auto_compressed_types="gz" display_in_upload="true" description="Any data in tab delimited format (tabular)." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Tabular_.28tab_delimited.29">
       <converter file="tabular_to_csv.xml" target_datatype="csv"/>
+      <display file="minerva/tabular.xml"/>
     </datatype>
     <datatype extension="twobit" type="galaxy.datatypes.binary:TwoBit" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="sqmass" type="galaxy.datatypes.binary:SQmass" mimetype="application/octet-stream" display_in_upload="true"/>

--- a/lib/galaxy/datatypes/display_applications/configs/minerva/tabular.xml
+++ b/lib/galaxy/datatypes/display_applications/configs/minerva/tabular.xml
@@ -2,6 +2,6 @@
 	<link id="covid19" name="SARS-CoV-2 Minerva Map">
 		<url>https://covid19map.elixir-luxembourg.org/minerva/?plugins=3ca603e96a3412d52201ab76d5377ae3&amp;datasource=${data.url}</url>
 		<filter>${ $dataset.dbkey == "wuhCor1" or $dataset.dbkey == "NC_045512" }</filter>
-		<param type="data" name="data" url="galaxy_${DATASET_HASH}.tsv" />
+		<param type="data" name="data" url="galaxy_${DATASET_HASH}.tsv" allow_cors="true" />
 	</link>
 </display>


### PR DESCRIPTION
Didn't know `allow_cors="true"` was an option, super useful! This is now exposed for tabular datasets which it wasn't previously, it is very specific to tabular files that are annotated with a sars-cov-2 genome build so it shouldn't show up for most folks or be confusing. (minerva specifically accepts a file with four columns: gene id, logFC, pvalue, padj but that format will basically always be created by `cut` so didn't make sense to subclass an existing datatype.)


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
