### PR TITLE
[23.1] Allow importing history with same name as original history

### DIFF
--- a/client/src/components/History/Modals/CopyModal.vue
+++ b/client/src/components/History/Modals/CopyModal.vue
@@ -61,7 +61,7 @@ export default {
         };
     },
     computed: {
-        ...mapState(useUserStore, ["isAnonymous"]),
+        ...mapState(useUserStore, ["currentUser", "isAnonymous"]),
         title() {
             return `Copying History: ${this.history.name}`;
         },
@@ -71,9 +71,12 @@ export default {
         saveVariant() {
             return this.loading ? "info" : this.formValid ? "primary" : "secondary";
         },
+        userOwnsHistory() {
+            return this.currentUser.id == this.history.user_id;
+        },
         newNameValid() {
-            if (this.name == this.history.name) {
-                return null;
+            if (this.userOwnsHistory && this.name == this.history.name) {
+                return false;
             }
             return this.name.length > 0;
         },


### PR DESCRIPTION
This only applies if the history is an external one, for current user's histories we still disallow the same name (while importing).

By default, the pre-filled value is still "Copy of Original Name"

Fixes https://github.com/galaxyproject/galaxy/issues/16643

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
