### PR TITLE
Fix package version handling for initial minor releases

### DIFF
--- a/packages/build_scripts/new_version.py
+++ b/packages/build_scripts/new_version.py
@@ -19,7 +19,10 @@ def main(argv):
     if not DEV_RELEASE:
         # Discard epoch, release numbers after micro, pre-, post-, dev-release segments and local version
         new_version_tuple = list(version_obj.release[:3])
-        new_version_tuple[2] += 1
+        if len(new_version_tuple) < 3:
+            new_version_tuple.append(0)
+        else:
+            new_version_tuple[2] += 1
         new_version = ".".join(map(str, new_version_tuple))
     else:
         dev_number = version_obj.dev


### PR DESCRIPTION
Fixes version handling for `build_packages` for the initial release -- the version will be something like `23.0` without a patch version, yet, so we'll start at `0`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
