### PR TITLE
Selective bold text

### DIFF
--- a/client/src/components/Dataset/DatasetName.vue
+++ b/client/src/components/Dataset/DatasetName.vue
@@ -2,7 +2,7 @@
     <div>
         <b-link
             id="dataset-dropdown"
-            class="workflow-dropdown font-weight-bold p-2"
+            class="workflow-dropdown p-2"
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -9,7 +9,7 @@
         @keydown="onKeyDown">
         <div class="p-1 cursor-pointer" draggable @dragstart="onDragStart" @dragend="onDragEnd" @click.stop="onClick">
             <div class="d-flex justify-content-between">
-                <span class="p-1 font-weight-bold" data-description="content item header info">
+                <span class="p-1" data-description="content item header info">
                     <b-button v-if="selectable" class="selector p-0" @click.stop="$emit('update:selected', !selected)">
                         <icon v-if="selected" fixed-width size="lg" :icon="['far', 'check-square']" />
                         <icon v-else fixed-width size="lg" :icon="['far', 'square']" />
@@ -46,7 +46,7 @@
                         <icon fixed-width :icon="contentState.icon" :spin="contentState.spin" />
                     </span>
                     <span class="id hid">{{ id }}:</span>
-                    <span class="content-title name">{{ name }}</span>
+                    <span class="content-title name font-weight-bold">{{ name }}</span>
                 </span>
                 <span v-if="item.purged" class="align-self-start btn-group p-1">
                     <b-badge variant="secondary" title="This dataset has been permanently deleted">

--- a/client/src/components/Workflow/InvocationsList.vue
+++ b/client/src/components/Workflow/InvocationsList.vue
@@ -60,7 +60,7 @@
                     :title="`<b>Switch to</b><br>${getHistoryNameById(data.item.history_id)}`"
                     class="truncate">
                     <b-link id="switch-to-history" href="#" @click.stop="switchHistory(data.item.history_id)">
-                        <b>{{ getHistoryNameById(data.item.history_id) }}</b>
+                        {{ getHistoryNameById(data.item.history_id) }}
                     </b-link>
                 </div>
             </template>

--- a/client/src/components/Workflow/InvocationsList.vue
+++ b/client/src/components/Workflow/InvocationsList.vue
@@ -50,7 +50,7 @@
                     :title="getStoredWorkflowNameByInstanceId(data.item.workflow_id)"
                     class="truncate">
                     <b-link href="#" @click.stop="swapRowDetails(data)">
-                        <b>{{ getStoredWorkflowNameByInstanceId(data.item.workflow_id) }}</b>
+                        {{ getStoredWorkflowNameByInstanceId(data.item.workflow_id) }}
                     </b-link>
                 </div>
             </template>


### PR DESCRIPTION
Due to corrections made in #16515  issue where bold text became visible in Chrome and seeing that bold-text was used in too many places, this new PR corrects that by only selectively applies bold text to reflect actual "emphasis" when placed next to non-emphasized text. Commits in order of priority (ie. can be selectively cherry-picked as needed). Fix for #16631  issue.

![1  and 3  before-after Workflows Invocations v2 (high and low priority)](https://github.com/galaxyproject/galaxy/assets/3672779/7815bc1e-f979-41c7-8f75-3a7a72220126)
![2  before-after History Panel enumerations (moderate priority)](https://github.com/galaxyproject/galaxy/assets/3672779/5006c097-9e98-44b0-aa53-952fa640d906)
![3  before-after Datasets Lists v2 (low priority)](https://github.com/galaxyproject/galaxy/assets/3672779/59e4b461-c406-4065-892d-1edf4eb50d00)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
