### PR TITLE
[23.1] Fix workflow output display without label

### DIFF
--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -90,9 +90,9 @@ const visibleHint = computed(() => {
     }
 });
 const label = computed(() => {
-    const activeLabel = workflowOutput.value?.label || props.output.name;
-    return `${activeLabel} (${extensions.value.join(", ")})`;
+    return workflowOutput.value?.label || props.output.name;
 });
+
 const rowClass = computed(() => {
     const classes = ["form-row", "dataRow", "output-data-row"];
     if ("valid" in props.output && props.output?.valid === false) {
@@ -129,7 +129,7 @@ function onToggleActive() {
             (workflowOutput) => workflowOutput.output_name !== output.value.name
         );
     } else {
-        stepWorkflowOutputs.push({ output_name: output.value.name });
+        stepWorkflowOutputs.push({ output_name: output.value.name, label: output.value.name });
     }
     stepStore.updateStep({ ...step, workflow_outputs: stepWorkflowOutputs });
 }
@@ -269,6 +269,22 @@ const outputDetails = computed(() => {
     return outputType;
 });
 
+const isDuplicateLabel = computed(() => {
+    const duplicateLabels = stepStore.duplicateLabels;
+    return Boolean(label.value && duplicateLabels.has(label.value));
+});
+
+const labelClass = computed(() => {
+    if (isDuplicateLabel.value) {
+        return "alert-info";
+    }
+    return null;
+});
+
+const labelToolTipTitle = computed(() => {
+    return `Output label '${workflowOutput.value?.label}' is not unique`;
+});
+
 onBeforeUnmount(() => {
     stateStore.deleteOutputTerminalPosition(props.stepId, props.output.name);
 });
@@ -304,7 +320,17 @@ const removeTagsAction = computed(() => {
                     @click="onToggleVisible">
                     <i :class="['mark-terminal', visibleClass]" />
                 </div>
-                {{ label }}
+                <span class="flex-gapx-1">
+                    <span
+                        v-b-tooltip
+                        :title="labelToolTipTitle"
+                        :class="labelClass"
+                        :disabled="!isDuplicateLabel"
+                        style="display: inline-block">
+                        {{ label }}
+                    </span>
+                    <span style="display: inline-block"> ({{ extensions.join(", ") }}) </span>
+                </span>
             </div>
 
             <div

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -320,16 +320,16 @@ const removeTagsAction = computed(() => {
                     @click="onToggleVisible">
                     <i :class="['mark-terminal', visibleClass]" />
                 </div>
-                <span class="flex-gapx-1">
+                <span>
                     <span
                         v-b-tooltip
                         :title="labelToolTipTitle"
+                        class="d-inline-block rounded"
                         :class="labelClass"
-                        :disabled="!isDuplicateLabel"
-                        style="display: inline-block">
+                        :disabled="!isDuplicateLabel">
                         {{ label }}
                     </span>
-                    <span style="display: inline-block"> ({{ extensions.join(", ") }}) </span>
+                    <span> ({{ extensions.join(", ") }}) </span>
                 </span>
             </div>
 

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -180,6 +180,23 @@ export const useWorkflowStepStore = defineStore("workflowStepStore", {
             });
             return workflowOutputs;
         },
+        duplicateLabels(state: State) {
+            const duplicateLabels: Set<string> = new Set();
+            const labels: Set<string> = new Set();
+            Object.values(state.steps).forEach((step) => {
+                if (step.workflow_outputs?.length) {
+                    step.workflow_outputs.forEach((workflowOutput) => {
+                        if (workflowOutput.label) {
+                            if (labels.has(workflowOutput.label)) {
+                                duplicateLabels.add(workflowOutput.label);
+                            }
+                            labels.add(workflowOutput.label);
+                        }
+                    });
+                }
+            });
+            return duplicateLabels;
+        },
     },
     actions: {
         addStep(newStep: NewStep): Step {

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -671,7 +671,7 @@ workflow_editor:
       clone: '${_} .node-clone'
       output_data_row:
         type: xpath
-        selector: '//div[contains(@class, "output-data-row") and contains(string(), "${output_name} (${extension})")]'
+        selector: '//div[@data-output-name="${output_name}"]//span[contains(text(), "(${extension})")]'
       output_terminal: "${_} [output-name='${name}']"
       input_terminal: "${_} [input-name='${name}']"
       input_mapping_icon: "${_} [input-name='${name}'].multiple"

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8364,7 +8364,7 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
                 # TODO: does this work correctly if outputs are mapped over?
                 label = output_assoc.workflow_output.label
                 if not label:
-                    continue
+                    label = f"{output_assoc.workflow_output.output_name} (Step {output_assoc.workflow_output.workflow_step.order_index + 1})"
 
                 outputs[label] = {
                     "src": "hda",
@@ -8376,7 +8376,9 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
             for output_assoc in self.output_dataset_collections:
                 label = output_assoc.workflow_output.label
                 if not label:
-                    continue
+                    label = (
+                        label
+                    ) = f"{output_assoc.workflow_output.output_name} (Step {output_assoc.workflow_output.workflow_step.order_index + 1})"
 
                 output_collections[label] = {
                     "src": "hdca",


### PR DESCRIPTION
@Delphine-L noticed that workflow outputs without a label were not shown in the invocation page. The first commit makes it so that when you add a workflow output it default to using the output_name as the label. It also warns you when that output label is not unique. The second commit provides a fallback label for invocation outputs.


![workflow output label duplicates](https://github.com/galaxyproject/galaxy/assets/6804901/d04e6ac1-eb94-4a0e-9823-ea9507e705c6)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
