### PR TITLE
Fix selenium selector for collections

### DIFF
--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -809,7 +809,7 @@ invocations:
     step_output_collection_toggle: '[data-step="${order_index}"] .invocation-step-output-collection-details .name'
     step_output_collection_element_identifier:
       type: xpath
-      selector: '//span[@class="content-title name"][text()="${element_identifier}"]'
+      selector: '//span[contains(@class, "content-title name")][text()="${element_identifier}"]'
     step_output_collection_element_datatype: '[data-step="${order_index}"] .invocation-step-output-collection-details .not-loading .datatype .value'
     step_job_details: '[data-step="${order_index}"] .invocation-step-job-details'
     step_job_table: '[data-step="${order_index}"] .invocation-step-job-details table'

--- a/lib/galaxy_test/selenium/test_history_multi_view.py
+++ b/lib/galaxy_test/selenium/test_history_multi_view.py
@@ -28,9 +28,9 @@ class TestHistoryMultiView(SeleniumTestCase):
         method = self.dataset_collection_populator.create_list_of_list_in_history(history_id, wait=True).json
         self.prepare_multi_history_view(method)
         dataset_selector = self.history_panel_wait_for_hid_state(1, None, multi_history_panel=True)
-        self.click(dataset_selector)
+        dataset_selector.wait_for_and_click()
         dataset_selector = self.history_panel_wait_for_hid_state(3, None, multi_history_panel=True)
-        self.click(dataset_selector)
+        dataset_selector.wait_for_and_click()
         self.screenshot("multi_history_list_list")
 
     def prepare_multi_history_view(self, collection_populator_method):
@@ -42,5 +42,5 @@ class TestHistoryMultiView(SeleniumTestCase):
         self.home()
         self.open_history_multi_view()
         selector = self.history_panel_wait_for_hid_state(collection_hid, "ok", multi_history_panel=True)
-        self.click(selector)
+        selector.wait_for_and_click()
         return selector


### PR DESCRIPTION
Fixes

```
FAILED lib/galaxy_test/selenium/test_workflow_invocation_details.py::TestWorkflowInvocationDetails::test_job_details - selenium.common.exceptions.TimeoutException: Message: Timeout waiting on XPATH selector [//span[@class="content-title name"][text()="forward"]] to become clickable.
```


Many thanks to @ElectronicBlueberry for figuring out the issue!!

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
