### PR TITLE
Add Time Format to ``Generated with Galaxy {{ version }} on {{ time }} UTC`` statement

### DIFF
--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -30,7 +30,7 @@
                 </span>
             </div>
             <b-badge variant="info" class="w-100 rounded mb-3 white-space-normal">
-                <div class="float-left m-1 text-break">Generated with Galaxy {{ version }} on {{ time }}</div>
+                <div class="float-left m-1 text-break">Generated with Galaxy {{ version }} on {{ time }} UTC</div>
                 <div class="float-right m-1">Identifier: {{ markdownConfig.id }}</div>
             </b-badge>
             <div>


### PR DESCRIPTION
Requested as part of #16556 
Simply adding UTC to the time workflow was invoked to make it clear to users what time format we print there

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows:
  1. View a Workflow report, note that it says UTC following the time the workflow was generated

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
