### PR TITLE
Convert ISO to UTC for Date/Time in workflow reports

### DIFF
--- a/client/src/components/Markdown/Elements/InvocationTime.vue
+++ b/client/src/components/Markdown/Elements/InvocationTime.vue
@@ -19,8 +19,7 @@ export default {
     computed: {
         content() {
             const invocation = this.invocations[this.args.invocation_id];
-            const iso = new Date(invocation && invocation["create_time"]);
-            return iso.toUTCString();
+            return invocation && new Date(invocation["create_time"]).toUTCString();
         },
     },
 };

--- a/client/src/components/Markdown/Elements/InvocationTime.vue
+++ b/client/src/components/Markdown/Elements/InvocationTime.vue
@@ -19,7 +19,8 @@ export default {
     computed: {
         content() {
             const invocation = this.invocations[this.args.invocation_id];
-            return invocation && invocation["create_time"];
+            const iso = new Date(invocation && invocation["create_time"]);
+            return iso.toUTCString();
         },
     },
 };

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -348,7 +348,7 @@ class ReadyForExportMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHand
 
     def handle_invocation_time(self, line, invocation):
         self.ensure_rendering_data_for("invocations", invocation)["create_time"] = invocation.create_time.strftime(
-            "%Y-%m-/%d, %H:%M:%S"
+            "%Y-%m-%d, %H:%M:%S"
         )
 
     def handle_dataset_type(self, line, hda):
@@ -549,7 +549,7 @@ class ToBasicMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHandler):
         return (content, True)
 
     def handle_invocation_time(self, line, invocation):
-        content = literal_via_fence(invocation.create_time.strftime("%m/%d/%Y, %H:%M:%S"))
+        content = literal_via_fence(invocation.create_time.strftime("%Y-%m-%d, %H:%M:%S"))
         return (content, True)
 
     def handle_dataset_name(self, line, hda):

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -348,7 +348,7 @@ class ReadyForExportMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHand
 
     def handle_invocation_time(self, line, invocation):
         self.ensure_rendering_data_for("invocations", invocation)["create_time"] = invocation.create_time.strftime(
-            "%m/%d/%Y, %H:%M:%S"
+            "%Y-%m-/%d, %H:%M:%S"
         )
 
     def handle_dataset_type(self, line, hda):

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -347,7 +347,9 @@ class ReadyForExportMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHand
         pass
 
     def handle_invocation_time(self, line, invocation):
-        self.ensure_rendering_data_for("invocations", invocation)["create_time"] = invocation.create_time.strftime("%m/%d/%Y, %H:%M:%S")
+        self.ensure_rendering_data_for("invocations", invocation)["create_time"] = invocation.create_time.strftime(
+            "%m/%d/%Y, %H:%M:%S"
+        )
 
     def handle_dataset_type(self, line, hda):
         self.extend_history_dataset_rendering_data(hda, "ext", hda.ext, "*Unknown dataset type*")

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -347,7 +347,7 @@ class ReadyForExportMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHand
         pass
 
     def handle_invocation_time(self, line, invocation):
-        self.ensure_rendering_data_for("invocations", invocation)["create_time"] = invocation.create_time.isoformat()
+        self.ensure_rendering_data_for("invocations", invocation)["create_time"] = invocation.create_time.strftime("%m/%d/%Y, %H:%M:%S")
 
     def handle_dataset_type(self, line, hda):
         self.extend_history_dataset_rendering_data(hda, "ext", hda.ext, "*Unknown dataset type*")
@@ -547,7 +547,7 @@ class ToBasicMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHandler):
         return (content, True)
 
     def handle_invocation_time(self, line, invocation):
-        content = literal_via_fence(invocation.create_time.isoformat())
+        content = literal_via_fence(invocation.create_time.strftime("%m/%d/%Y, %H:%M:%S"))
         return (content, True)
 
     def handle_dataset_name(self, line, hda):

--- a/test/unit/app/managers/test_markdown_export.py
+++ b/test/unit/app/managers/test_markdown_export.py
@@ -280,7 +280,8 @@ invocation_time(invocation_id=1)
         invocation = self._new_invocation()
         self.app.workflow_manager.get_invocation.side_effect = [invocation]  # type: ignore[attr-defined,union-attr]
         result = self._to_basic(example)
-        assert f"\n    {invocation.create_time.isoformat()}" in result
+        expectedtime = invocation.create_time.strftime("%m/%d/%Y, %H:%M:%S")
+        assert f"\n    {expectedtime}" in result
 
     def test_job_parameters(self):
         job = model.Job()
@@ -412,7 +413,7 @@ invocation_time(invocation_id=1)
         result, extra_data = self._ready_export(example)
         assert "invocations" in extra_data
         assert "create_time" in extra_data["invocations"]["be8be0fd2ce547f6"]
-        assert extra_data["invocations"]["be8be0fd2ce547f6"]["create_time"] == invocation.create_time.isoformat()
+        assert extra_data["invocations"]["be8be0fd2ce547f6"]["create_time"] == invocation.create_time.strftime("%m/%d/%Y, %H:%M:%S")
 
     def _ready_export(self, example):
         return ready_galaxy_markdown_for_export(self.trans, example)

--- a/test/unit/app/managers/test_markdown_export.py
+++ b/test/unit/app/managers/test_markdown_export.py
@@ -414,7 +414,7 @@ invocation_time(invocation_id=1)
         assert "invocations" in extra_data
         assert "create_time" in extra_data["invocations"]["be8be0fd2ce547f6"]
         assert extra_data["invocations"]["be8be0fd2ce547f6"]["create_time"] == invocation.create_time.strftime(
-            "%m/%d/%Y, %H:%M:%S"
+            "%Y-%m-%d, %H:%M:%S"
         )
 
     def _ready_export(self, example):

--- a/test/unit/app/managers/test_markdown_export.py
+++ b/test/unit/app/managers/test_markdown_export.py
@@ -413,7 +413,9 @@ invocation_time(invocation_id=1)
         result, extra_data = self._ready_export(example)
         assert "invocations" in extra_data
         assert "create_time" in extra_data["invocations"]["be8be0fd2ce547f6"]
-        assert extra_data["invocations"]["be8be0fd2ce547f6"]["create_time"] == invocation.create_time.strftime("%m/%d/%Y, %H:%M:%S")
+        assert extra_data["invocations"]["be8be0fd2ce547f6"]["create_time"] == invocation.create_time.strftime(
+            "%m/%d/%Y, %H:%M:%S"
+        )
 
     def _ready_export(self, example):
         return ready_galaxy_markdown_for_export(self.trans, example)

--- a/test/unit/app/managers/test_markdown_export.py
+++ b/test/unit/app/managers/test_markdown_export.py
@@ -280,7 +280,7 @@ invocation_time(invocation_id=1)
         invocation = self._new_invocation()
         self.app.workflow_manager.get_invocation.side_effect = [invocation]  # type: ignore[attr-defined,union-attr]
         result = self._to_basic(example)
-        expectedtime = invocation.create_time.strftime("%m/%d/%Y, %H:%M:%S")
+        expectedtime = invocation.create_time.strftime("%Y-%m-%d, %H:%M:%S")
         assert f"\n    {expectedtime}" in result
 
     def test_job_parameters(self):


### PR DESCRIPTION
Part of #16556 
Instead of printing out ISO date time, dislpaying time format in UTC. 

## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. Create a Workflow report with "Time workflow was invoked" added to your report
  2. Note that the time that is displayed is in UTC/GMT time. 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
