### PR TITLE
Expose Workflow Checkpoint in Workflow Reports

### DIFF
--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -27,9 +27,9 @@
                     <h1 class="text-break align-middle">
                         Title: {{ markdownConfig.title || markdownConfig.model_class }}
                     </h1>
-                    <h3 v-if="workflowVersions" class="text-break align-middle">
+                    <h2 v-if="workflowVersions" class="text-break align-middle">
                         Workflow Checkpoint: {{ workflowVersions.version }}
-                    </h3>
+                    </h2>
                 </span>
             </div>
             <b-badge variant="info" class="w-100 rounded mb-3 white-space-normal">
@@ -172,7 +172,7 @@ export default {
     },
     created() {
         this.initConfig();
-        this.getWFversion();
+        this.fetchWorkflowForInstanceId(this.workflowID);
     },
     methods: {
         ...mapActions(useWorkflowStore, ["getStoredWorkflowByInstanceId", "fetchWorkflowForInstanceId"]),
@@ -191,9 +191,6 @@ export default {
                 this.loading = false;
                 this.workflowID = Object.keys(this.markdownConfig.workflows)[0];
             }
-        },
-        getWFversion() {
-            this.fetchWorkflowForInstanceId(this.workflowID);
         },
         splitMarkdown(markdown) {
             const sections = [];

--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -27,6 +27,9 @@
                     <h1 class="text-break align-middle">
                         Title: {{ markdownConfig.title || markdownConfig.model_class }}
                     </h1>
+                    <h3 v-if="workflowVersions" class="text-break align-middle">
+                        Workflow Checkpoint: {{ workflowVersions.version }}
+                    </h3>
                 </span>
             </div>
             <b-badge variant="info" class="w-100 rounded mb-3 white-space-normal">
@@ -67,8 +70,11 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import BootstrapVue from "bootstrap-vue";
 import MarkdownIt from "markdown-it";
 import markdownItRegexp from "markdown-it-regexp";
+import { mapActions } from "pinia";
 import store from "store";
 import Vue from "vue";
+
+import { useWorkflowStore } from "@/stores/workflowStore";
 
 import MarkdownContainer from "./MarkdownContainer.vue";
 import LoadingSpan from "components/LoadingSpan.vue";
@@ -131,6 +137,7 @@ export default {
             jobs: {},
             invocations: {},
             loading: true,
+            workflowID: "",
         };
     },
     computed: {
@@ -151,6 +158,9 @@ export default {
             }
             return "unavailable";
         },
+        workflowVersions() {
+            return this.getStoredWorkflowByInstanceId(this.workflowID);
+        },
         version() {
             return this.markdownConfig.generate_version || "Unknown Galaxy Version";
         },
@@ -162,8 +172,10 @@ export default {
     },
     created() {
         this.initConfig();
+        this.getWFversion();
     },
     methods: {
+        ...mapActions(useWorkflowStore, ["getStoredWorkflowByInstanceId", "fetchWorkflowForInstanceId"]),
         initConfig() {
             if (Object.keys(this.markdownConfig).length) {
                 const config = this.markdownConfig;
@@ -177,7 +189,11 @@ export default {
                 this.jobs = config.jobs || {};
                 this.invocations = config.invocations || {};
                 this.loading = false;
+                this.workflowID = Object.keys(this.markdownConfig.workflows)[0];
             }
+        },
+        getWFversion() {
+            this.fetchWorkflowForInstanceId(this.workflowID);
         },
         splitMarkdown(markdown) {
             const sections = [];


### PR DESCRIPTION
Part of #16556 
Exposing the workflow version as workflow checkpoint on report. See comments in #16682 for reasoning. 

## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. Create a Workflow Report
  2. Note how Workflow Checkpoint is below the Title
  3. Note: if you do not see the Checkpoint, that is because it is waiting on the store to provide it, refreshing may work.  But I have it rendering conditionally, so if it doesn't return from the store in time, nothing is printed there instead. 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
