### PR TITLE
Fix  bug in User.all_roles query + use SA2.0

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -836,32 +836,28 @@ class User(Base, Dictifiable, RepresentById):
         """
         Return a unique list of Roles associated with this user or any of their groups.
         """
-        try:
-            db_session = object_session(self)
-            user = (
-                db_session.query(User)
-                .filter_by(id=self.id)  # don't use get, it will use session variant.
-                .options(
-                    joinedload(User.roles),
-                    joinedload(User.roles.role),
-                    joinedload(User.groups),
-                    joinedload(User.groups.group),
-                    joinedload(User.groups.group.roles),
-                    joinedload(User.groups.group.roles.role),
-                )
-                .one()
-            )
-        except Exception:
-            # If not persistent user, just use models normaly and
-            # skip optimizations...
-            user = self
+        if self.id:  # if user persistent, retrieve from database
+            roles = self._get_all_user_roles_from_db()
+        else:
+            # else: use models normally
+            roles = [ura.role for ura in self.roles]
 
-        roles = [ura.role for ura in user.roles]
-        for group in [uga.group for uga in user.groups]:
+        for group in [uga.group for uga in self.groups]:
             for role in [gra.role for gra in group.roles]:
                 if role not in roles:
                     roles.append(role)
         return roles
+
+    def _get_all_user_roles_from_db(self):
+        user_roles = select(Role).join(UserRoleAssociation).join(User).where(UserRoleAssociation.user_id == self.id)
+        user_group_roles = (
+            select(Role)
+            .join(GroupRoleAssociation)
+            .join(UserGroupAssociation, UserGroupAssociation.group_id == GroupRoleAssociation.group_id)
+            .where(UserGroupAssociation.user_id == self.id)
+        )
+        roles = select(Role).from_statement(user_roles.union(user_group_roles))
+        return object_session(self).scalars(roles)
 
     def all_roles_exploiting_cache(self):
         """ """


### PR DESCRIPTION
I think this query never  worked as intended: it always raised an error (clauses like `joinedload(User.roles.role)` don't work). The error was caught and silenced, so it was never detected.

The proposed solution produces a simple and straightforward query:

```
SELECT role.id, role.create_time, role.update_time, role.name, role.description, role.type, role.deleted 
FROM role JOIN user_role_association ON role.id = user_role_association.role_id JOIN galaxy_user ON galaxy_user.id = user_role
WHERE user_role_association.user_id = :user_id_1 UNION SELECT role.id, role.create_time, role.update_time, role.name, role.des
FROM role JOIN group_role_association ON role.id = group_role_association.role_id JOIN user_group_association ON user_group_as
WHERE user_group_association.user_id = :user_id_2
```

We union the user roles with the group roles for groups to which the user belongs - no need to apply multiple joinedload options to the User.

Ref: #12541


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
