### PR TITLE
Replace ELIXIR AAI button with Life Science login

### DIFF
--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -39,7 +39,7 @@ log = logging.getLogger(__name__)
 # Note: This if for backward compatibility. Icons can be specified in oidc_backends_config.xml.
 DEFAULT_OIDC_IDP_ICONS = {
     "google": "https://developers.google.com/identity/images/btn_google_signin_light_normal_web.png",
-    "elixir": "https://lifescience-ri.eu/fileadmin/lifescience-ri/media/Images/login-grey-wide.jpg.png",
+    "elixir": "https://lifescience-ri.eu/fileadmin/lifescience-ri/media/Images/button-login-small.png",
     "okta": "https://www.okta.com/sites/all/themes/Okta/images/blog/Logos/Okta_Logo_BrightBlue_Medium.png",
 }
 

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -39,7 +39,7 @@ log = logging.getLogger(__name__)
 # Note: This if for backward compatibility. Icons can be specified in oidc_backends_config.xml.
 DEFAULT_OIDC_IDP_ICONS = {
     "google": "https://developers.google.com/identity/images/btn_google_signin_light_normal_web.png",
-    "elixir": "https://elixir-europe.org/sites/default/files/images/login-button-orange.png",
+    "elixir": "https://lifescience-ri.eu/fileadmin/lifescience-ri/media/Images/login-grey-wide.jpg.png",
     "okta": "https://www.okta.com/sites/all/themes/Okta/images/blog/Logos/Okta_Logo_BrightBlue_Medium.png",
 }
 

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -158,7 +158,7 @@ Please mind `http` and `https`.
         <client_secret>...</client_secret>
         <redirect_uri>http://localhost:8080/authnz/elixir/callback</redirect_uri>
         <prompt>consent</prompt>
-        <icon>https://elixir-europe.org/sites/default/files/images/login-button-orange.png</icon>
+        <icon>https://lifescience-ri.eu/fileadmin/lifescience-ri/media/Images/button-login-small.png</icon>
         <!-- (Optional) Extra scopes you need to request for your implementation -->
         <!-- <extra_scopes>offline_access,something-else</extra_scopes> -->
     </provider>


### PR DESCRIPTION
Galaxy has been reviewed recently in the course of ELIXIR's Recommended Interoperability Resources evaluation (we applied).
A minor criticism was that still the old ELIXIR AAI login button is in use; [ELIXIR migrated to Life Science (LS) Login with April 2022](https://elixir-europe.org/AAI-migration). [Life Science RI recommends](https://lifescience-ri.eu/ls-login/news-and-links/elixir-migration-news.html) using the button introduced in this PR.
Appearantly, underlying technical changes will follow for the particular resources upon being contacted by Life Science RI. Until then, the ELIXIR implementation remains:

> Q: What is the plan for migrating my service to the LS Login?
> 
> A: Services will be updated one by one, we will contact you separately, timing depends on the functionality your service is using and its support in LS Login. Please wait for us to contact you with detailed instructions.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
