### PR TITLE
[23.1] Add missing requirements to perl tools

### DIFF
--- a/tools/filters/CreateInterval.xml
+++ b/tools/filters/CreateInterval.xml
@@ -1,5 +1,8 @@
 <tool id="createInterval" name="Create single interval" version="1.0.0">
   <description>as a new dataset</description>
+  <requirements>
+    <requirement type="package" version="5.26">perl</requirement>
+  </requirements>
   <command>
 perl '$__tool_directory__/CreateInterval.pl' '$chrom' $start $end '$name' $strand '$out_file1'
   </command>

--- a/tools/filters/changeCase.xml
+++ b/tools/filters/changeCase.xml
@@ -1,5 +1,8 @@
 <tool id="ChangeCase" name="Change Case" version="1.0.0">
   <description> of selected columns</description>
+  <requirements>
+    <requirement type="package" version="5.26">perl</requirement>
+  </requirements>
   <stdio>
     <exit_code range="1:" err_level="fatal" />
   </stdio>

--- a/tools/filters/commWrapper.xml
+++ b/tools/filters/commWrapper.xml
@@ -1,5 +1,8 @@
 <tool id="Comm1" name="Find Similarities and Differences" version="1.0.0">
   <description>between two datasets</description>
+  <requirements>
+    <requirement type="package" version="5.26">perl</requirement>
+  </requirements>
   <edam_operations>
     <edam_operation>operation_3695</edam_operation>
   </edam_operations>

--- a/tools/filters/condense_characters.xml
+++ b/tools/filters/condense_characters.xml
@@ -1,5 +1,8 @@
 <tool id="Condense characters1" name="Condense" version="1.0.0">
   <description>consecutive characters</description>
+  <requirements>
+    <requirement type="package" version="5.26">perl</requirement>
+  </requirements>
   <command><![CDATA[
 perl '$__tool_directory__/condense_characters.pl'
 '$input'

--- a/tools/filters/cutWrapper.xml
+++ b/tools/filters/cutWrapper.xml
@@ -1,5 +1,8 @@
 <tool id="Cut1" name="Cut" version="1.0.2">
   <description>columns from a table</description>
+  <requirements>
+    <requirement type="package" version="5.26">perl</requirement>
+  </requirements>
   <edam_operations>
     <edam_operation>operation_3695</edam_operation>
   </edam_operations>

--- a/tools/filters/pasteWrapper.xml
+++ b/tools/filters/pasteWrapper.xml
@@ -1,5 +1,9 @@
 <tool id="Paste1" name="Paste" version="1.0.0">
   <description>two files side by side</description>
+  <requirements>
+    <requirement type="package" version="5.26">perl</requirement>
+    <requirement type="package" version="8.31">coreutils</requirement>
+  </requirements>
   <command>perl '$__tool_directory__/pasteWrapper.pl' '$input1' '$input2' $delimiter '$out_file1'</command>
   <inputs>
 <!--    <display>paste $input1 and $input2 using $delimiter as delimiter</display> -->

--- a/tools/filters/remove_beginning.xml
+++ b/tools/filters/remove_beginning.xml
@@ -1,5 +1,8 @@
 <tool id="Remove beginning1" name="Remove beginning" version="1.0.0">
   <description>of a file</description>
+  <requirements>
+    <requirement type="package" version="5.26">perl</requirement>
+  </requirements>
   <command>
 perl '$__tool_directory__/remove_beginning.pl' '$input' $num_lines '$out_file1'
   </command>


### PR DESCRIPTION
This is the most minimal change possible, so I don't think we'll need to bump the tool versions. It should have little impact on admins, if the dependencies are not installed then well, nothing changes ... . Cut1 and Paste1 are failing on usegalaxy.org currently because of the missing dependency (https://github.com/galaxyproject/usegalaxy-tools/issues/635) and while we could fix this with a wider default image this will fix it for everyone.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

```
git clone https://github.com/galaxyproject/galaxy-test-data
rsync -av --remove-source-files --exclude .git galaxy-test-data/ test-data
planemo test --biocontainers tools/filters/CreateInterval.xml tools/filters/changeCase.xml tools/filters/commWrapper.xml tools/filters/condense_characters.xml tools/filters/cutWrapper.xml tools/filters/pasteWrapper.xml tools/filters/remove_beginning.xml
```

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
