### PR TITLE
[23.1] Fix public archived histories not importable

### DIFF
--- a/client/src/components/History/HistoryView.test.js
+++ b/client/src/components/History/HistoryView.test.js
@@ -12,13 +12,14 @@ import axios from "axios";
 const localVue = getLocalVue();
 jest.mock("stores/services/history.services");
 
-function create_history(historyId, userId, purged = false) {
+function create_history(historyId, userId, purged = false, archived = false) {
     const historyName = `${userId}'s History ${historyId}`;
     return {
         model_class: "History",
         id: historyId,
         name: historyName,
         purged: purged,
+        archived: archived,
         count: 10,
         annotation: "This is a history",
         tags: ["tag_1", "tag_2"],
@@ -163,13 +164,43 @@ describe("History center panel View", () => {
         const wrapper = await createWrapper(localVue, "user_1", history);
         expect(wrapper.vm.history).toEqual(history);
 
-        // switch/import buttons: purged they don't exist
+        // history purged, not switchable and not importable
         const switchButton = wrapper.find("[data-description='switch to history button']");
         const importButton = wrapper.find("[data-description='import history button']");
-        expect(switchButton.exists()).toBe(false);
+        expect(switchButton.attributes("disabled")).toBeTruthy();
         expect(importButton.exists()).toBe(false);
 
         // instead we have an alert
         expect(wrapper.find("[data-description='history state info']").text()).toBe("This history has been purged.");
+    });
+
+    it("should not display archived message and should be importable when user is not owner and history is archived", async () => {
+        const history = create_history("history_2", "user_2", false, true);
+        const wrapper = await createWrapper(localVue, "user_1", history);
+        expect(wrapper.vm.history).toEqual(history);
+
+        const switchButton = wrapper.find("[data-description='switch to history button']");
+        const importButton = wrapper.find("[data-description='import history button']");
+        expect(switchButton.exists()).toBe(false);
+        expect(importButton.exists()).toBe(true);
+        expect(importButton.attributes("disabled")).toBeFalsy();
+
+        expectCorrectLayout(wrapper);
+        expect(wrapper.find("[data-description='history state info']").exists()).toBe(false);
+    });
+
+    it("should display archived message and should not be importable when user is owner and history is archived", async () => {
+        const history = create_history("history_2", "user_1", false, true);
+        const wrapper = await createWrapper(localVue, "user_1", history);
+        expect(wrapper.vm.history).toEqual(history);
+
+        const switchButton = wrapper.find("[data-description='switch to history button']");
+        const importButton = wrapper.find("[data-description='import history button']");
+        expect(switchButton.exists()).toBe(true);
+        expect(switchButton.attributes("disabled")).toBeTruthy();
+        expect(importButton.exists()).toBe(false);
+
+        expectCorrectLayout(wrapper);
+        expect(wrapper.find("[data-description='history state info']").text()).toBe("This history has been archived.");
     });
 });

--- a/client/src/components/History/HistoryView.vue
+++ b/client/src/components/History/HistoryView.vue
@@ -8,7 +8,7 @@
                 v-if="userOwnsHistory"
                 size="sm"
                 variant="outline-info"
-                title="Switch to this history"
+                :title="setAsCurrentTitle"
                 :disabled="isSetAsCurrentDisabled"
                 data-description="switch to history button"
                 @click="setCurrentHistory(history.id)">
@@ -75,8 +75,23 @@ export default {
         userOwnsHistory() {
             return this.currentUser.id == this.history.user_id;
         },
+        isCurrentHistory() {
+            return this.currentHistory?.id == this.history?.id;
+        },
         isSetAsCurrentDisabled() {
-            return this.currentHistory?.id == this.history?.id || this.history.archived || this.history.purged;
+            return this.isCurrentHistory || this.history.archived || this.history.purged;
+        },
+        setAsCurrentTitle() {
+            if (this.isCurrentHistory) {
+                return "This history is already your current history.";
+            }
+            if (this.history.archived) {
+                return "This history has been archived and cannot be set as your current history. Unarchive it first.";
+            }
+            if (this.history.purged) {
+                return "This history has been purged and cannot be set as your current history.";
+            }
+            return "Switch to this history";
         },
         canEditHistory() {
             return this.userOwnsHistory && !this.history.archived && !this.history.purged;

--- a/client/src/components/History/HistoryView.vue
+++ b/client/src/components/History/HistoryView.vue
@@ -3,7 +3,7 @@
         <b-alert v-if="showHistoryStateInfo" variant="info" show data-description="history state info">
             {{ historyStateInfoMessage }}
         </b-alert>
-        <div v-else class="flex-row flex-grow-0 pb-3">
+        <div class="flex-row flex-grow-0 pb-3">
             <b-button
                 v-if="userOwnsHistory"
                 size="sm"
@@ -15,7 +15,7 @@
                 Switch to this history
             </b-button>
             <b-button
-                v-else
+                v-if="canImportHistory"
                 v-b-modal:copy-history-modal
                 size="sm"
                 variant="outline-info"
@@ -81,18 +81,24 @@ export default {
         canEditHistory() {
             return this.userOwnsHistory && !this.history.archived && !this.history.purged;
         },
+        showHistoryArchived() {
+            return this.history.archived && this.userOwnsHistory;
+        },
         showHistoryStateInfo() {
-            return this.history.archived || this.history.purged;
+            return this.showHistoryArchived || this.history.purged;
         },
         historyStateInfoMessage() {
-            if (this.history.archived && this.history.purged) {
+            if (this.showHistoryArchived && this.history.purged) {
                 return "This history has been archived and purged.";
-            } else if (this.history.archived) {
+            } else if (this.showHistoryArchived) {
                 return "This history has been archived.";
             } else if (this.history.purged) {
                 return "This history has been purged.";
             }
             return "";
+        },
+        canImportHistory() {
+            return !this.userOwnsHistory && !this.history.purged;
         },
     },
     created() {


### PR DESCRIPTION
Fixes #16764 (sorry for the oversight)

In addition, it displays the message `This history has been archived.` only to the owner of the history. Now, the owner will see the `Switch to this history` button but will be disabled.

## Owner View
![image](https://github.com/galaxyproject/galaxy/assets/46503462/10d222d8-6825-4f1a-a372-ba41fa22377a)

## Non-owner user View
![image](https://github.com/galaxyproject/galaxy/assets/46503462/73fae25e-7af9-48c3-80b6-4ae63c53aaf3)


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  - Follow the instructions in #16764

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
