### PR TITLE
[23.0] Show MessageException in invocation UI

### DIFF
--- a/client/src/components/WorkflowInvocationState/InvocationMessage.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationMessage.vue
@@ -146,6 +146,9 @@ const infoString = computed(() => {
             invocationMessage.workflow_step_id + 1
         } is a conditional step and the result of the when expression is not a boolean type.`;
     } else if (reason === "unexpected_failure") {
+        if (invocationMessage.details) {
+            return `${failFragment} an unexpected failure occurred: '${invocationMessage.details}'`;
+        }
         return `${failFragment} an unexpected failure occurred.`;
     } else if (reason === "workflow_output_not_found") {
         return `Defined workflow output '${invocationMessage.output_name}' was not found in step ${


### PR DESCRIPTION
This was the intention from the start, just forgot adding it in the UI component.

Turns 
![Screenshot 2023-09-30 at 12 02 25](https://github.com/galaxyproject/galaxy/assets/6804901/26007665-4f59-4e0a-a2bb-9060bee1d234)

into `Invocation scheduling failed because an unexpected failure occurred: 'User does not own item.'`

which ... is a bug, but there are other message exceptions with non-bug usage errors, e.g. https://github.com/galaxyproject/galaxy/issues/16736

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
