### PR TITLE
[23.1] Fix ItemOwnerShipException in tag removal

### DIFF
--- a/lib/galaxy/job_execution/actions/post.py
+++ b/lib/galaxy/job_execution/actions/post.py
@@ -498,7 +498,7 @@ class RemoveTagDatasetAction(TagDatasetAction):
 
     @classmethod
     def _execute(cls, tag_handler, user, output, tags):
-        tag_handler.remove_tags_from_list(user, output, tags)
+        tag_handler.remove_tags_from_list(user, output, tags, flush=False)
 
 
 class ActionBox:


### PR DESCRIPTION
This is another way to fix
https://sentry.galaxyproject.org/share/issue/8308250826df4554aa456a94b45bbe6a/:

```
ItemOwnershipException: User does not own item.
  File "galaxy/workflow/run.py", line 233, in invoke
    incomplete_or_none = self._invoke_step(workflow_invocation_step)
  File "galaxy/workflow/run.py", line 309, in _invoke_step
    incomplete_or_none = invocation_step.workflow_step.module.execute(
  File "galaxy/workflow/modules.py", line 2274, in execute
    execution_tracker = execute(
  File "galaxy/tools/execute.py", line 169, in execute
    execute_single_job(execution_slice, completed_jobs[i], skip=skip)
  File "galaxy/tools/execute.py", line 116, in execute_single_job
    job, result = tool.handle_single_execution(
  File "galaxy/tools/__init__.py", line 1957, in handle_single_execution
    raise e
  File "galaxy/tools/__init__.py", line 1937, in handle_single_execution
    rval = self.execute(
  File "galaxy/tools/__init__.py", line 2034, in execute
    return self.tool_action.execute(
  File "galaxy/tools/actions/__init__.py", line 683, in execute
    job_callback(job)
  File "galaxy/workflow/modules.py", line 2284, in <lambda>
    job_callback=lambda job: self._handle_post_job_actions(
  File "galaxy/workflow/modules.py", line 2351, in _handle_post_job_actions
    ActionBox.execute(self.trans.app, self.trans.sa_session, pja, job, replacement_dict)
  File "galaxy/job_execution/actions/post.py", line 575, in execute
    ActionBox.actions[pja.action_type].execute(
  File "galaxy/job_execution/actions/post.py", line 477, in execute
    cls._execute(tag_handler, job.user, dataset_collection_assoc.dataset_collection_instance, tags)
  File "galaxy/job_execution/actions/post.py", line 501, in _execute
    tag_handler.remove_tags_from_list(user, output, tags)
  File "galaxy/model/tags.py", line 81, in remove_tags_from_list
    return self.set_tags_from_list(user, item, tags_set, flush=flush)
  File "galaxy/model/tags.py", line 94, in set_tags_from_list
    self.apply_item_tags(user, item, unicodify(new_tags_str, "utf-8"), flush=flush)
  File "galaxy/model/tags.py", line 270, in apply_item_tags
    self.apply_item_tag(user, item, name, value, flush=flush)
  File "galaxy/model/tags.py", line 222, in apply_item_tag
    self._ensure_user_owns_item(user, item)
  File "galaxy/model/tags.py", line 193, in _ensure_user_owns_item
    raise ItemOwnershipException("User does not own item.")
```

By not flushing on tag removal the item for which tag ownership is being checked will not have a primary id, so we know we can skip the ownership check.

I still haven't managed to actually reproduce this and basing this purely on the sentry trace, but this is clearly a performance bug.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
