### PR TITLE
Optimize iteration in DatasetInstance model + SA2.0 fix

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4486,12 +4486,12 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
 
     def ok_to_edit_metadata(self):
         # prevent modifying metadata when dataset is queued or running as input/output
-        # This code could be more efficient, i.e. by using mappers, but to prevent slowing down loading a History panel, we'll leave the code here for now
         sa_session = object_session(self)
-        stmt1 = select(JobToInputDatasetAssociation).filter_by(dataset_id=self.id)
-        stmt2 = select(JobToOutputDatasetAssociation).filter_by(dataset_id=self.id)
-        for job_to_dataset_association in chain(sa_session.scalars(stmt1), sa_session.scalars(stmt2)):
-            if job_to_dataset_association.job.state not in Job.terminal_states:
+        stmt1 = select(JobToInputDatasetAssociation.job_id).filter_by(dataset_id=self.id)
+        stmt2 = select(JobToOutputDatasetAssociation.job_id).filter_by(dataset_id=self.id)
+        for job_id in chain(sa_session.scalars(stmt1), sa_session.scalars(stmt2)):
+            state = sa_session.scalar(select(Job.state).where(Job.id == job_id))
+            if state not in Job.terminal_states:
                 return False
         return True
 


### PR DESCRIPTION
This is both an optimization and a SQLAlchemy 2.0 fix.

There's no need to prepopulate 2 lists pulling all records from the database, then concatenate them into one list, then iterate. Instead we simply chain the iterators: that way we don't pull everything from the database upfront, and exit the iteration early if condition met.

Ref: #12541


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
