### PR TITLE
Fix bug (missing commit) + SA2.0 usage in model.Job.update_hdca_update_time_for_job

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1860,26 +1860,29 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
 
     def update_hdca_update_time_for_job(self, update_time, sa_session, supports_skip_locked):
         subq = (
-            sa_session.query(HistoryDatasetCollectionAssociation.id)
+            select(HistoryDatasetCollectionAssociation.id)
             .join(ImplicitCollectionJobs)
             .join(ImplicitCollectionJobsJobAssociation)
             .filter(ImplicitCollectionJobsJobAssociation.job_id == self.id)
         )
         if supports_skip_locked:
-            subq = subq.with_for_update(skip_locked=True).subquery()
+            subq = subq.with_for_update(skip_locked=True)
+        subq = subq.subquery()
         implicit_statement = (
-            HistoryDatasetCollectionAssociation.table.update()
-            .where(HistoryDatasetCollectionAssociation.table.c.id.in_(select(subq)))
+            update(HistoryDatasetCollectionAssociation)
+            .where(HistoryDatasetCollectionAssociation.id.in_(subq))
             .values(update_time=update_time)
         )
         explicit_statement = (
-            HistoryDatasetCollectionAssociation.table.update()
-            .where(HistoryDatasetCollectionAssociation.table.c.job_id == self.id)
+            update(HistoryDatasetCollectionAssociation)
+            .where(HistoryDatasetCollectionAssociation.job_id == self.id)
             .values(update_time=update_time)
         )
         sa_session.execute(explicit_statement)
         if supports_skip_locked:
             sa_session.execute(implicit_statement)
+            with transaction(sa_session):
+                sa_session.commit()
         else:
             conn = sa_session.connection(execution_options={"isolation_level": "SERIALIZABLE"})
             with conn.begin() as trans:


### PR DESCRIPTION
This was missing a commit statement: with `autocommit=False` if `skip_locked` is supported `sa_session.execute(implicit_statement)` will be rolled back. (unless it's committed later, which we shouldn't rely upon).

In fact, i wonder whether we shouldn't just use a connection here instead of the session (we are in the `else` clause). but, in any case, the commit was missing.

(pulled out of #16724 for convenience)
Ref #12541

UPDATE: nope, this doesn't work. Maybe try a connection instead...

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
