### PR TITLE
Migrate a part of the jobs API to Fast API

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -921,6 +921,10 @@ export interface paths {
         /** Submits a bug report via the API. */
         post: operations["report_error_api_jobs__id__error_post"];
     };
+    "/api/jobs/{id}/inputs": {
+        /** Returns input datasets created by job. */
+        get: operations["get_inputs_api_jobs__id__inputs_get"];
+    };
     "/api/jobs/{id}/resume": {
         /** Resumes a paused job. */
         put: operations["resume_paused_job_api_jobs__id__resume_put"];
@@ -14889,6 +14893,33 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["JobErrorSummary"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_inputs_api_jobs__id__inputs_get: {
+        /** Returns input datasets created by job. */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the job */
+            path: {
+                id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["JobAssociation"][];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -178,12 +178,7 @@ export interface paths {
         /**
          * Resolve parameters as a list for nested display.
          * @deprecated
-         * @description Resolve parameters as a list for nested display. More client logic
-         * here than is ideal but it is hard to reason about tool parameter
-         * types on the client relative to the server. Job accessibility checks
-         * are slightly different than dataset checks, so both methods are
-         * available.
-         *
+         * @description Resolve parameters as a list for nested display.
          * This API endpoint is unstable and tied heavily to Galaxy's JS client code,
          * this endpoint will change frequently.
          */
@@ -964,12 +959,7 @@ export interface paths {
     "/api/jobs/{job_id}/parameters_display": {
         /**
          * Resolve parameters as a list for nested display.
-         * @description Resolve parameters as a list for nested display. More client logic
-         * here than is ideal but it is hard to reason about tool parameter
-         * types on the client relative to the server. Job accessibility checks
-         * are slightly different than dataset checks, so both methods are
-         * available.
-         *
+         * @description Resolve parameters as a list for nested display.
          * This API endpoint is unstable and tied heavily to Galaxy's JS client code,
          * this endpoint will change frequently.
          */
@@ -11055,12 +11045,7 @@ export interface operations {
         /**
          * Resolve parameters as a list for nested display.
          * @deprecated
-         * @description Resolve parameters as a list for nested display. More client logic
-         * here than is ideal but it is hard to reason about tool parameter
-         * types on the client relative to the server. Job accessibility checks
-         * are slightly different than dataset checks, so both methods are
-         * available.
-         *
+         * @description Resolve parameters as a list for nested display.
          * This API endpoint is unstable and tied heavily to Galaxy's JS client code,
          * this endpoint will change frequently.
          */
@@ -15533,12 +15518,7 @@ export interface operations {
     resolve_parameters_display_api_jobs__job_id__parameters_display_get: {
         /**
          * Resolve parameters as a list for nested display.
-         * @description Resolve parameters as a list for nested display. More client logic
-         * here than is ideal but it is hard to reason about tool parameter
-         * types on the client relative to the server. Job accessibility checks
-         * are slightly different than dataset checks, so both methods are
-         * available.
-         *
+         * @description Resolve parameters as a list for nested display.
          * This API endpoint is unstable and tied heavily to Galaxy's JS client code,
          * this endpoint will change frequently.
          */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -932,6 +932,24 @@ export interface paths {
         /** Returns output datasets created by a job. */
         get: operations["get_outputs_api_jobs__id__outputs_get"];
     };
+    "/api/jobs/{id}/parameters_display": {
+        /**
+         * Resolve parameters as a list for nested display.
+         * @description # TODO is this still true?
+         *     Resolve parameters as a list for nested display. More client logic
+         *     here than is ideal but it is hard to reason about tool parameter
+         *     types on the client relative to the server. Job accessibility checks
+         *     are slightly different than dataset checks, so both methods are
+         *     available.
+         *
+         *     This API endpoint is unstable and tied heavily to Galaxy's JS client code,
+         *     this endpoint will change frequently.
+         *
+         * :rtype:     list
+         * :returns:   job parameters for for display
+         */
+        get: operations["resolve_parameters_display_api_jobs__id__parameters_display_get"];
+    };
     "/api/jobs/{id}/resume": {
         /** Resumes a paused job. */
         put: operations["resume_paused_job_api_jobs__id__resume_put"];
@@ -15185,6 +15203,51 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["JobAssociation"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resolve_parameters_display_api_jobs__id__parameters_display_get: {
+        /**
+         * Resolve parameters as a list for nested display.
+         * @description # TODO is this still true?
+         *     Resolve parameters as a list for nested display. More client logic
+         *     here than is ideal but it is hard to reason about tool parameter
+         *     types on the client relative to the server. Job accessibility checks
+         *     are slightly different than dataset checks, so both methods are
+         *     available.
+         *
+         *     This API endpoint is unstable and tied heavily to Galaxy's JS client code,
+         *     this endpoint will change frequently.
+         *
+         * :rtype:     list
+         * :returns:   job parameters for for display
+         */
+        parameters: {
+            /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
+            query: {
+                hda_ldda: components["schemas"]["DatasetSourceType"];
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the job */
+            path: {
+                id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6545,6 +6545,44 @@ export interface components {
             active: boolean;
         };
         /**
+         * JobMetric
+         * @description Base model definition with common configuration used by all derived models.
+         * @example {
+         *   "name": "start_epoch",
+         *   "plugin": "core",
+         *   "raw_value": "1614261340.0000000",
+         *   "title": "Job Start Time",
+         *   "value": "2021-02-25 14:55:40"
+         * }
+         */
+        JobMetric: {
+            /**
+             * Name
+             * @description The name of the metric variable.
+             */
+            name: string;
+            /**
+             * Plugin
+             * @description The instrumenter plugin that generated this metric.
+             */
+            plugin: string;
+            /**
+             * Raw Value
+             * @description The raw value of the metric as a string.
+             */
+            raw_value: string;
+            /**
+             * Title
+             * @description A descriptive title for this metric.
+             */
+            title: string;
+            /**
+             * Value
+             * @description The textual representation of the metric value.
+             */
+            value: string;
+        };
+        /**
          * JobSourceType
          * @description Available types of job sources (model classes) that produce dataset collections.
          * @enum {string}
@@ -11103,7 +11141,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["JobMetric"][];
                 };
             };
             /** @description Validation Error */
@@ -15281,7 +15319,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["JobMetric"][];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -896,14 +896,7 @@ export interface paths {
     "/api/jobs/search": {
         /**
          * Return jobs for current user
-         * @description :type   payload: dict
-         * :param  payload: Dictionary containing description of requested job. This is in the same format as
-         *     a request to POST /apt/tools would take to initiate a job
-         *
-         * :rtype:     list
-         * :returns:   list of dictionaries containing summary job information of the jobs that match the requested job run
-         *
-         * This method is designed to scan the list of previously run jobs and find records of jobs that had
+         * @description This method is designed to scan the list of previously run jobs and find records of jobs that had
          * the exact some input parameters and datasets. This can be used to minimize the amount of repeated work, and simply
          * recycle the old results.
          */
@@ -925,11 +918,7 @@ export interface paths {
         get: operations["check_common_problems_api_jobs__id__common_problems_get"];
     };
     "/api/jobs/{id}/error": {
-        /**
-         * Submits a bug report via the API.
-         * @description :rtype:     dictionary
-         * :returns:   dictionary containing information regarding where the error report was sent.
-         */
+        /** Submits a bug report via the API. */
         post: operations["report_error_api_jobs__id__error_post"];
     };
     "/api/jobs/{id}/resume": {
@@ -6143,8 +6132,15 @@ export interface components {
          * @description Base model definition with common configuration used by all derived models.
          */
         JobAssociation: {
+            /**
+             * dataset
+             * @description The associated dataset.
+             */
             dataset: components["schemas"]["EncodedDatasetSourceId"];
-            /** Name */
+            /**
+             * name
+             * @description The name of the associated dataset.
+             */
             name: string;
         };
         /**
@@ -6152,7 +6148,10 @@ export interface components {
          * @description Base model definition with common configuration used by all derived models.
          */
         JobErrorSummary: {
-            /** Messages */
+            /**
+             * Error messages
+             * @description The error messages for the specified job.
+             */
             messages: string[][];
         };
         /**
@@ -6302,9 +6301,15 @@ export interface components {
          * @description Base model definition with common configuration used by all derived models.
          */
         JobInputSummary: {
-            /** Has Duplicate Inputs */
+            /**
+             * Duplicate inputs
+             * @description Job has duplicate inputs.
+             */
             has_duplicate_inputs: boolean;
-            /** Has Empty Inputs */
+            /**
+             * Empty inputs
+             * @description Job has empty inputs.
+             */
             has_empty_inputs: boolean;
         };
         /** JobLock */
@@ -8180,13 +8185,17 @@ export interface components {
          */
         ReportJobErrorPayload: {
             /**
-             * Dataset Id
+             * Dataset ID
+             * @description The dataset ID related to the error.
              * @example 0123456789ABCDEF
              */
             dataset_id: string;
             /** Email */
             email?: string;
-            /** Message */
+            /**
+             * Message
+             * @description The optional message sent with the error report.
+             */
             message?: string;
         };
         /**
@@ -8285,11 +8294,20 @@ export interface components {
          * @description Base model definition with common configuration used by all derived models.
          */
         SearchJobsPayload: {
-            /** Inputs */
+            /**
+             * Inputs
+             * @description The inputs of the job as a JSON dump.
+             */
             inputs: string;
-            /** State */
+            /**
+             * State
+             * @description The state of the job.
+             */
             state: string;
-            /** Tool Id */
+            /**
+             * Tool ID
+             * @description The tool ID related to the job.
+             */
             tool_id: string;
         };
         /**
@@ -14756,14 +14774,7 @@ export interface operations {
     search_jobs_api_jobs_search_post: {
         /**
          * Return jobs for current user
-         * @description :type   payload: dict
-         * :param  payload: Dictionary containing description of requested job. This is in the same format as
-         *     a request to POST /apt/tools would take to initiate a job
-         *
-         * :rtype:     list
-         * :returns:   list of dictionaries containing summary job information of the jobs that match the requested job run
-         *
-         * This method is designed to scan the list of previously run jobs and find records of jobs that had
+         * @description This method is designed to scan the list of previously run jobs and find records of jobs that had
          * the exact some input parameters and datasets. This can be used to minimize the amount of repeated work, and simply
          * recycle the old results.
          */
@@ -14857,11 +14868,7 @@ export interface operations {
         };
     };
     report_error_api_jobs__id__error_post: {
-        /**
-         * Submits a bug report via the API.
-         * @description :rtype:     dictionary
-         * :returns:   dictionary containing information regarding where the error report was sent.
-         */
+        /** Submits a bug report via the API. */
         parameters: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -167,6 +167,24 @@ export interface paths {
         /** For internal use, this endpoint may change without warning. */
         get: operations["show_inheritance_chain_api_datasets__dataset_id__inheritance_chain_get"];
     };
+    "/api/datasets/{dataset_id}/metrics": {
+        /** Return job metrics for specified job. */
+        get: operations["get_metrics_api_datasets__dataset_id__metrics_get"];
+    };
+    "/api/datasets/{dataset_id}/parameters_display": {
+        /**
+         * Resolve parameters as a list for nested display.
+         * @description Resolve parameters as a list for nested display. More client logic
+         * here than is ideal but it is hard to reason about tool parameter
+         * types on the client relative to the server. Job accessibility checks
+         * are slightly different than dataset checks, so both methods are
+         * available.
+         *
+         * This API endpoint is unstable and tied heavily to Galaxy's JS client code,
+         * this endpoint will change frequently.
+         */
+        get: operations["resolve_parameters_display_api_datasets__dataset_id__parameters_display_get"];
+    };
     "/api/datasets/{dataset_id}/permissions": {
         /**
          * Set permissions of the given history dataset to the given role ids.
@@ -195,25 +213,6 @@ export interface paths {
         get: operations["datasets__get_metadata_file"];
         /** Check if metadata file can be downloaded. */
         head: operations["get_metadata_file_datasets_api_datasets__history_content_id__metadata_file_head"];
-    };
-    "/api/datasets/{id}/metrics": {
-        /** Return job metrics for specified job. */
-        get: operations["get_metrics_api_datasets__id__metrics_get"];
-    };
-    "/api/datasets/{id}/parameters_display": {
-        /**
-         * Resolve parameters as a list for nested display.
-         * @description # TODO is this still true?
-         * Resolve parameters as a list for nested display. More client logic
-         * here than is ideal but it is hard to reason about tool parameter
-         * types on the client relative to the server. Job accessibility checks
-         * are slightly different than dataset checks, so both methods are
-         * available.
-         *
-         * This API endpoint is unstable and tied heavily to Galaxy's JS client code,
-         * this endpoint will change frequently.
-         */
-        get: operations["resolve_parameters_display_api_datasets__id__parameters_display_get"];
     };
     "/api/datatypes": {
         /**
@@ -921,12 +920,6 @@ export interface paths {
          */
         post: operations["search_jobs_api_jobs_search_post"];
     };
-    "/api/jobs/{id}": {
-        /** Return dictionary containing description of job data. */
-        get: operations["show_job_api_jobs__id__get"];
-        /** Cancels specified job */
-        delete: operations["cancel_job_api_jobs__id__delete"];
-    };
     "/api/jobs/{id}/common_problems": {
         /** Check inputs and job for common potential problems to aid in error reporting */
         get: operations["check_common_problems_api_jobs__id__common_problems_get"];
@@ -939,19 +932,39 @@ export interface paths {
         /** Returns input datasets created by a job. */
         get: operations["get_inputs_api_jobs__id__inputs_get"];
     };
-    "/api/jobs/{id}/metrics": {
-        /** Return job metrics for specified job. */
-        get: operations["get_metrics_api_jobs__id__metrics_get"];
-    };
     "/api/jobs/{id}/outputs": {
         /** Returns output datasets created by a job. */
         get: operations["get_outputs_api_jobs__id__outputs_get"];
     };
-    "/api/jobs/{id}/parameters_display": {
+    "/api/jobs/{id}/resume": {
+        /** Resumes a paused job. */
+        put: operations["resume_paused_job_api_jobs__id__resume_put"];
+    };
+    "/api/jobs/{job_id}": {
+        /** Return dictionary containing description of job data. */
+        get: operations["show_job_api_jobs__job_id__get"];
+        /** Cancels specified job */
+        delete: operations["cancel_job_api_jobs__job_id__delete"];
+    };
+    "/api/jobs/{job_id}/destination_params": {
+        /** Return destination parameters for specified job. */
+        get: operations["destination_params_job_api_jobs__job_id__destination_params_get"];
+    };
+    "/api/jobs/{job_id}/metrics": {
+        /** Return job metrics for specified job. */
+        get: operations["get_metrics_api_jobs__job_id__metrics_get"];
+    };
+    "/api/jobs/{job_id}/oidc-tokens": {
+        /**
+         * Get a fresh OIDC token
+         * @description Allows remote job running mechanisms to get a fresh OIDC token that can be used on remote side to authorize user. It is not meant to represent part of Galaxy's stable, user facing API
+         */
+        get: operations["get_token_api_jobs__job_id__oidc_tokens_get"];
+    };
+    "/api/jobs/{job_id}/parameters_display": {
         /**
          * Resolve parameters as a list for nested display.
-         * @description # TODO is this still true?
-         * Resolve parameters as a list for nested display. More client logic
+         * @description Resolve parameters as a list for nested display. More client logic
          * here than is ideal but it is hard to reason about tool parameter
          * types on the client relative to the server. Job accessibility checks
          * are slightly different than dataset checks, so both methods are
@@ -960,22 +973,7 @@ export interface paths {
          * This API endpoint is unstable and tied heavily to Galaxy's JS client code,
          * this endpoint will change frequently.
          */
-        get: operations["resolve_parameters_display_api_jobs__id__parameters_display_get"];
-    };
-    "/api/jobs/{id}/resume": {
-        /** Resumes a paused job. */
-        put: operations["resume_paused_job_api_jobs__id__resume_put"];
-    };
-    "/api/jobs/{job_id}/destination_params": {
-        /** Return destination parameters for specified job. */
-        get: operations["destination_params_job_api_jobs__job_id__destination_params_get"];
-    };
-    "/api/jobs/{job_id}/oidc-tokens": {
-        /**
-         * Get a fresh OIDC token
-         * @description Allows remote job running mechanisms to get a fresh OIDC token that can be used on remote side to authorize user. It is not meant to represent part of Galaxy's stable, user facing API
-         */
-        get: operations["get_token_api_jobs__job_id__oidc_tokens_get"];
+        get: operations["resolve_parameters_display_api_jobs__job_id__parameters_display_get"];
     };
     "/api/libraries": {
         /**
@@ -3447,6 +3445,12 @@ export interface components {
             )[];
         };
         /**
+         * DataItemSourceType
+         * @description An enumeration.
+         * @enum {string}
+         */
+        DataItemSourceType: "hda" | "ldda" | "hdca" | "dce" | "dc";
+        /**
          * DatasetAssociationRoles
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -4151,6 +4155,23 @@ export interface components {
          */
         ElementsFromType: "archive" | "bagit" | "bagit_archive" | "directory";
         /**
+         * EncodedDataItemSourceId
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        EncodedDataItemSourceId: {
+            /**
+             * ID
+             * @description The encoded ID of this entity.
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /**
+             * Source
+             * @description The source of this dataset, either `hda`, `ldda`, `hdca`, `dce` or `dc` depending of its origin.
+             */
+            src: components["schemas"]["DataItemSourceType"];
+        };
+        /**
          * EncodedDatasetJobInfo
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -4163,15 +4184,16 @@ export interface components {
             id: string;
             /**
              * Source
-             * @description The source of this dataset, either `hda` or `ldda` depending of its origin.
+             * @description The source of this dataset, either `hda`, `ldda`, `hdca`, `dce` or `dc` depending of its origin.
              */
-            src: components["schemas"]["DatasetSourceType"];
+            src: components["schemas"]["DataItemSourceType"];
             /**
              * UUID
              * Format: uuid4
+             * @deprecated
              * @description Universal unique identifier for this dataset.
              */
-            uuid: string;
+            uuid?: string;
         };
         /**
          * EncodedDatasetSourceId
@@ -4189,6 +4211,23 @@ export interface components {
              * @description The source of this dataset, either `hda` or `ldda` depending of its origin.
              */
             src: components["schemas"]["DatasetSourceType"];
+        };
+        /**
+         * EncodedHdcaSourceId
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        EncodedHdcaSourceId: {
+            /**
+             * ID
+             * @description The encoded ID of this entity.
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /**
+             * Source
+             * @description The source of this dataset, which in the case of the model can only be `hdca`.
+             */
+            src: components["schemas"]["Hdca"];
         };
         /**
          * EncodedHistoryContentItem
@@ -4224,7 +4263,7 @@ export interface components {
             command_version: string;
             /**
              * Copied from Job-ID
-             * @description ?
+             * @description Reference to cached job if job execution was cached.
              * @example 0123456789ABCDEF
              */
             copied_from_job_id?: string;
@@ -4264,7 +4303,7 @@ export interface components {
             id: string;
             /**
              * Inputs
-             * @description Dictionary mapping all the tool inputs (by name) with the corresponding dataset information.
+             * @description Dictionary mapping all the tool inputs (by name) to the corresponding data references.
              * @default {}
              */
             inputs?: {
@@ -4279,13 +4318,14 @@ export interface components {
             model_class: "Job";
             /**
              * Output collections
-             * @description ?
              * @default {}
              */
-            output_collections?: Record<string, never>;
+            output_collections?: {
+                [key: string]: components["schemas"]["EncodedHdcaSourceId"] | undefined;
+            };
             /**
              * Outputs
-             * @description Dictionary mapping all the tool outputs (by name) with the corresponding dataset information.
+             * @description Dictionary mapping all the tool outputs (by name) to the corresponding data references.
              * @default {}
              */
             outputs?: {
@@ -5688,6 +5728,12 @@ export interface components {
             type: "hdas";
         };
         /**
+         * Hdca
+         * @description An enumeration.
+         * @enum {string}
+         */
+        Hdca: "hdca";
+        /**
          * HdcaDataItemsFromTarget
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -6324,12 +6370,12 @@ export interface components {
         JobAssociation: {
             /**
              * dataset
-             * @description The associated dataset.
+             * @description Reference to the associated item.
              */
-            dataset: components["schemas"]["EncodedDatasetSourceId"];
+            dataset: components["schemas"]["EncodedDataItemSourceId"];
             /**
              * name
-             * @description The name of the associated dataset.
+             * @description Name of the job parameter.
              */
             name: string;
         };
@@ -6340,17 +6386,17 @@ export interface components {
         JobDestinationParams: {
             /**
              * Handler
-             * @description ?
+             * @description Name of the process that handled the job.
              */
             Handler: string;
             /**
              * Runner
-             * @description ?
+             * @description Job runner class
              */
             Runner: string;
             /**
              * Runner Job ID
-             * @description ?
+             * @description ID assigned to submitted job by external job running system
              */
             "Runner Job ID": string;
         };
@@ -6603,10 +6649,10 @@ export interface components {
              */
             label: Record<string, never>;
             /**
-             * dataset
+             * Dataset
              * @description The associated dataset.
              */
-            value: components["schemas"]["EncodedDatasetSourceId"];
+            value: components["schemas"]["EncodedDataItemSourceId"];
         };
         /**
          * JobParameter
@@ -6619,7 +6665,7 @@ export interface components {
              */
             depth: number;
             /**
-             * notes
+             * Notes
              * @description Notes associated with the job parameter.
              */
             notes?: string;
@@ -6632,53 +6678,7 @@ export interface components {
              * Value
              * @description The values of the job parameter
              */
-            value:
-                | components["schemas"]["JobParameterValuesSimple"][]
-                | components["schemas"]["JobParameterValuesExtensive"]
-                | string;
-        };
-        /**
-         * JobParameterValuesExtensive
-         * @description Base model definition with common configuration used by all derived models.
-         */
-        JobParameterValuesExtensive: {
-            /**
-             * Check Content
-             * @description Flag to check content
-             */
-            check_content: boolean;
-            /**
-             * Targets
-             * @description List of job value targets
-             */
-            targets: components["schemas"]["JobTarget"][];
-        };
-        /**
-         * JobParameterValuesSimple
-         * @description Base model definition with common configuration used by all derived models.
-         */
-        JobParameterValuesSimple: {
-            /**
-             * HID
-             * @description The index position of this item in the History.
-             */
-            hid: number;
-            /**
-             * ID
-             * @description The encoded ID of this entity.
-             * @example 0123456789ABCDEF
-             */
-            id: string;
-            /**
-             * Name
-             * @description The name of the item.
-             */
-            name: string;
-            /**
-             * Source
-             * @description The source of this dataset, either `hda` or `ldda` depending of its origin.
-             */
-            src: components["schemas"]["DatasetSourceType"];
+            value: Record<string, never>;
         };
         /**
          * JobSourceType
@@ -6738,90 +6738,6 @@ export interface components {
             states?: {
                 [key: string]: number | undefined;
             };
-        };
-        /**
-         * JobTarget
-         * @description Base model definition with common configuration used by all derived models.
-         */
-        JobTarget: {
-            /**
-             * Destination
-             * @description Destination details
-             */
-            destination: components["schemas"]["JobTargetDestination"];
-            /**
-             * Elements
-             * @description List of job target elements
-             */
-            elements: components["schemas"]["JobTargetElement"][];
-        };
-        /**
-         * JobTargetDestination
-         * @description Base model definition with common configuration used by all derived models.
-         */
-        JobTargetDestination: {
-            /**
-             * Type
-             * @description Type of destination, either `hda` or `ldda` depending on the destination
-             */
-            type: string;
-        };
-        /**
-         * JobTargetElement
-         * @description Base model definition with common configuration used by all derived models.
-         */
-        JobTargetElement: {
-            /**
-             * Auto Decompress
-             * @description Flag indicating if to auto decompress
-             */
-            auto_decompress: boolean;
-            /**
-             * Database Key
-             * @description Database key
-             */
-            dbkey: string;
-            /**
-             * Extension
-             * @description Extension
-             */
-            ext: string;
-            /**
-             * Hashes
-             * @description List of hashes
-             */
-            hashes: string[];
-            /**
-             * Name
-             * @description Name of the element
-             */
-            name: string;
-            /**
-             * Object ID
-             * @description Object ID
-             * @example 0123456789ABCDEF
-             */
-            object_id: string;
-            /**
-             * Paste Content
-             * @description Content to paste
-             */
-            paste_content: string;
-            /**
-             * Purge Source
-             * @description Flag indicating if to purge the source
-             */
-            purge_source: boolean;
-            /**
-             * Source
-             * @description Source
-             */
-            src: string;
-            /**
-             * To POSIX Lines
-             * @description Flag indicating if to convert to POSIX lines
-             */
-            to_posix_lines: boolean;
         };
         /**
          * LabelValuePair
@@ -8629,12 +8545,15 @@ export interface components {
          */
         ReportJobErrorPayload: {
             /**
-             * Dataset ID
-             * @description The dataset ID related to the error.
+             * History Dataset Association ID
+             * @description The History Dataset Association ID related to the error.
              * @example 0123456789ABCDEF
              */
             dataset_id: string;
-            /** Email */
+            /**
+             * Email
+             * @description Email address for communication with the user. Only required for anonymous users.
+             */
             email?: string;
             /**
              * Message
@@ -8745,9 +8664,9 @@ export interface components {
             inputs: string;
             /**
              * State
-             * @description The state of the job.
+             * @description Current state of the job.
              */
-            state: string;
+            state: components["schemas"]["JobState"];
             /**
              * Tool ID
              * @description The tool ID related to the job.
@@ -11083,6 +11002,78 @@ export interface operations {
             };
         };
     };
+    get_metrics_api_datasets__dataset_id__metrics_get: {
+        /** Return job metrics for specified job. */
+        parameters: {
+            /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
+            query?: {
+                hda_ldda?: components["schemas"]["DatasetSourceType"];
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the dataset */
+            path: {
+                dataset_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["JobMetric"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resolve_parameters_display_api_datasets__dataset_id__parameters_display_get: {
+        /**
+         * Resolve parameters as a list for nested display.
+         * @description Resolve parameters as a list for nested display. More client logic
+         * here than is ideal but it is hard to reason about tool parameter
+         * types on the client relative to the server. Job accessibility checks
+         * are slightly different than dataset checks, so both methods are
+         * available.
+         *
+         * This API endpoint is unstable and tied heavily to Galaxy's JS client code,
+         * this endpoint will change frequently.
+         */
+        parameters: {
+            /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
+            query?: {
+                hda_ldda?: components["schemas"]["DatasetSourceType"];
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the dataset */
+            path: {
+                dataset_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["JobDisplayParametersSummary"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     update_permissions_api_datasets__dataset_id__permissions_put: {
         /**
          * Set permissions of the given history dataset to the given role ids.
@@ -11289,79 +11280,6 @@ export interface operations {
             200: {
                 content: {
                     "application/json": Record<string, never>;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_metrics_api_datasets__id__metrics_get: {
-        /** Return job metrics for specified job. */
-        parameters: {
-            /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
-            query?: {
-                hda_ldda?: components["schemas"]["DatasetSourceType"];
-            };
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description The ID of the dataset */
-            path: {
-                id: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["JobMetric"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    resolve_parameters_display_api_datasets__id__parameters_display_get: {
-        /**
-         * Resolve parameters as a list for nested display.
-         * @description # TODO is this still true?
-         * Resolve parameters as a list for nested display. More client logic
-         * here than is ideal but it is hard to reason about tool parameter
-         * types on the client relative to the server. Job accessibility checks
-         * are slightly different than dataset checks, so both methods are
-         * available.
-         *
-         * This API endpoint is unstable and tied heavily to Galaxy's JS client code,
-         * this endpoint will change frequently.
-         */
-        parameters: {
-            /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
-            query?: {
-                hda_ldda?: components["schemas"]["DatasetSourceType"];
-            };
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description The ID of the dataset */
-            path: {
-                id: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["JobDisplayParametersSummary"];
                 };
             };
             /** @description Validation Error */
@@ -15321,69 +15239,6 @@ export interface operations {
             };
         };
     };
-    show_job_api_jobs__id__get: {
-        /** Return dictionary containing description of job data. */
-        parameters: {
-            /** @description Show extra information. */
-            query?: {
-                full?: boolean;
-            };
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description The ID of the job */
-            path: {
-                id: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": Record<string, never>;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cancel_job_api_jobs__id__delete: {
-        /** Cancels specified job */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description The ID of the job */
-            path: {
-                id: string;
-            };
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["DeleteJobPayload"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": boolean;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     check_common_problems_api_jobs__id__common_problems_get: {
         /** Check inputs and job for common potential problems to aid in error reporting */
         parameters: {
@@ -15470,37 +15325,6 @@ export interface operations {
             };
         };
     };
-    get_metrics_api_jobs__id__metrics_get: {
-        /** Return job metrics for specified job. */
-        parameters: {
-            /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
-            query?: {
-                hda_ldda?: components["schemas"]["DatasetSourceType"];
-            };
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description The ID of the job */
-            path: {
-                id: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["JobMetric"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     get_outputs_api_jobs__id__outputs_get: {
         /** Returns output datasets created by a job. */
         parameters: {
@@ -15518,48 +15342,6 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["JobAssociation"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    resolve_parameters_display_api_jobs__id__parameters_display_get: {
-        /**
-         * Resolve parameters as a list for nested display.
-         * @description # TODO is this still true?
-         * Resolve parameters as a list for nested display. More client logic
-         * here than is ideal but it is hard to reason about tool parameter
-         * types on the client relative to the server. Job accessibility checks
-         * are slightly different than dataset checks, so both methods are
-         * available.
-         *
-         * This API endpoint is unstable and tied heavily to Galaxy's JS client code,
-         * this endpoint will change frequently.
-         */
-        parameters: {
-            /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
-            query?: {
-                hda_ldda?: components["schemas"]["DatasetSourceType"];
-            };
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description The ID of the job */
-            path: {
-                id: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["JobDisplayParametersSummary"];
                 };
             };
             /** @description Validation Error */
@@ -15597,6 +15379,69 @@ export interface operations {
             };
         };
     };
+    show_job_api_jobs__job_id__get: {
+        /** Return dictionary containing description of job data. */
+        parameters: {
+            /** @description Show extra information. */
+            query?: {
+                full?: boolean;
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the job */
+            path: {
+                job_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_job_api_jobs__job_id__delete: {
+        /** Cancels specified job */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the job */
+            path: {
+                job_id: string;
+            };
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["DeleteJobPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": boolean;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     destination_params_job_api_jobs__job_id__destination_params_get: {
         /** Return destination parameters for specified job. */
         parameters: {
@@ -15614,6 +15459,37 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["JobDestinationParams"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_metrics_api_jobs__job_id__metrics_get: {
+        /** Return job metrics for specified job. */
+        parameters: {
+            /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
+            query?: {
+                hda_ldda?: components["schemas"]["DatasetSourceType"];
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the job */
+            path: {
+                job_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["JobMetric"][];
                 };
             };
             /** @description Validation Error */
@@ -15649,6 +15525,47 @@ export interface operations {
             200: {
                 content: {
                     "text/plain": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resolve_parameters_display_api_jobs__job_id__parameters_display_get: {
+        /**
+         * Resolve parameters as a list for nested display.
+         * @description Resolve parameters as a list for nested display. More client logic
+         * here than is ideal but it is hard to reason about tool parameter
+         * types on the client relative to the server. Job accessibility checks
+         * are slightly different than dataset checks, so both methods are
+         * available.
+         *
+         * This API endpoint is unstable and tied heavily to Galaxy's JS client code,
+         * this endpoint will change frequently.
+         */
+        parameters: {
+            /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
+            query?: {
+                hda_ldda?: components["schemas"]["DatasetSourceType"];
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the job */
+            path: {
+                job_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["JobDisplayParametersSummary"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -196,6 +196,14 @@ export interface paths {
         /** Check if metadata file can be downloaded. */
         head: operations["get_metadata_file_datasets_api_datasets__history_content_id__metadata_file_head"];
     };
+    "/api/datasets/{id}/metrics": {
+        /**
+         * Return job metrics for specified job.
+         * @description :rtype:     list
+         * :returns:   list containing job metrics
+         */
+        get: operations["get_metrics_api_datasets__id__metrics_get"];
+    };
     "/api/datatypes": {
         /**
          * Lists all available data types
@@ -11053,6 +11061,41 @@ export interface operations {
             };
         };
     };
+    get_metrics_api_datasets__id__metrics_get: {
+        /**
+         * Return job metrics for specified job.
+         * @description :rtype:     list
+         * :returns:   list containing job metrics
+         */
+        parameters: {
+            /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
+            query?: {
+                hda_ldda?: components["schemas"]["DatasetSourceType"];
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the dataset */
+            path: {
+                id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     index_api_datatypes_get: {
         /**
          * Lists all available data types
@@ -14917,7 +14960,7 @@ export interface operations {
              * : The tool ID corresponding to the job. (The tag `t` can be used a short hand alias for this tag to filter on this attribute.)
              *
              * `runner`
-             * : The job runner name used to execte the job. (The tag `r` can be used a short hand alias for this tag to filter on this attribute.) This tag is only available for requests using admin keys and/or sessions.
+             * : The job runner name used to execute the job. (The tag `r` can be used a short hand alias for this tag to filter on this attribute.) This tag is only available for requests using admin keys and/or sessions.
              *
              * `handler`
              * : The job handler name used to execute the job. (The tag `h` can be used a short hand alias for this tag to filter on this attribute.) This tag is only available for requests using admin keys and/or sessions.
@@ -15159,8 +15202,8 @@ export interface operations {
          */
         parameters: {
             /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
-            query: {
-                hda_ldda: components["schemas"]["DatasetSourceType"];
+            query?: {
+                hda_ldda?: components["schemas"]["DatasetSourceType"];
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -15231,8 +15274,8 @@ export interface operations {
          */
         parameters: {
             /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
-            query: {
-                hda_ldda: components["schemas"]["DatasetSourceType"];
+            query?: {
+                hda_ldda?: components["schemas"]["DatasetSourceType"];
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -922,8 +922,12 @@ export interface paths {
         post: operations["report_error_api_jobs__id__error_post"];
     };
     "/api/jobs/{id}/inputs": {
-        /** Returns input datasets created by job. */
+        /** Returns input datasets created by a job. */
         get: operations["get_inputs_api_jobs__id__inputs_get"];
+    };
+    "/api/jobs/{id}/outputs": {
+        /** Returns output datasets created by a job. */
+        get: operations["get_outputs_api_jobs__id__outputs_get"];
     };
     "/api/jobs/{id}/resume": {
         /** Resumes a paused job. */
@@ -14904,7 +14908,34 @@ export interface operations {
         };
     };
     get_inputs_api_jobs__id__inputs_get: {
-        /** Returns input datasets created by job. */
+        /** Returns input datasets created by a job. */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the job */
+            path: {
+                id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["JobAssociation"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_outputs_api_jobs__id__outputs_get: {
+        /** Returns output datasets created by a job. */
         parameters: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -908,6 +908,10 @@ export interface paths {
         /** Check inputs and job for common potential problems to aid in error reporting */
         get: operations["check_common_problems_api_jobs__id__common_problems_get"];
     };
+    "/api/jobs/{id}/resume": {
+        /** Resumes a paused job. */
+        put: operations["resume_paused_job_api_jobs__id__resume_put"];
+    };
     "/api/jobs/{job_id}/oidc-tokens": {
         /**
          * Get a fresh OIDC token
@@ -6110,6 +6114,15 @@ export interface components {
          * @enum {string}
          */
         ItemsFromSrc: "url" | "files" | "path" | "ftp_import" | "server_dir";
+        /**
+         * JobAssociation
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        JobAssociation: {
+            dataset: components["schemas"]["EncodedDatasetSourceId"];
+            /** Name */
+            name: string;
+        };
         /**
          * JobExportHistoryArchiveListResponse
          * @description Base model definition with common configuration used by all derived models.
@@ -14724,7 +14737,7 @@ export interface operations {
             header?: {
                 "run-as"?: string;
             };
-            /** @description TODO */
+            /** @description The ID of the job */
             path: {
                 id: string;
             };
@@ -14734,6 +14747,33 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["JobInputSummary"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resume_paused_job_api_jobs__id__resume_put: {
+        /** Resumes a paused job. */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the job */
+            path: {
+                id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["JobAssociation"][];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -4103,6 +4103,29 @@ export interface components {
          */
         ElementsFromType: "archive" | "bagit" | "bagit_archive" | "directory";
         /**
+         * EncodedDatasetJobInfo
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        EncodedDatasetJobInfo: {
+            /**
+             * ID
+             * @description The encoded ID of this entity.
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /**
+             * Source
+             * @description The source of this dataset, either `hda` or `ldda` depending of its origin.
+             */
+            src: components["schemas"]["DatasetSourceType"];
+            /**
+             * UUID
+             * Format: uuid4
+             * @description Universal unique identifier for this dataset.
+             */
+            uuid: string;
+        };
+        /**
          * EncodedDatasetSourceId
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -4135,6 +4158,116 @@ export interface components {
              * @example 0123456789ABCDEF
              */
             id: string;
+        };
+        /**
+         * EncodedJobDetails
+         * @description Basic information about a job.
+         */
+        EncodedJobDetails: {
+            /**
+             * Command Line
+             * @description The command line produced by the job. Users can see this value if allowed in the configuration, administrator can always see this value.
+             */
+            command_line?: string;
+            /**
+             * Command Version
+             * @description Tool version indicated during job execution.
+             */
+            command_version: string;
+            /**
+             * Copied from Job-ID
+             * @description ?
+             */
+            copied_from_job_id?: Record<string, never>;
+            /**
+             * Create Time
+             * Format: date-time
+             * @description The time and date this item was created.
+             */
+            create_time: string;
+            /**
+             * Exit Code
+             * @description The exit code returned by the tool. Can be unset if the job is not completed yet.
+             */
+            exit_code?: number;
+            /**
+             * External ID
+             * @description The job id used by the external job runner (Condor, Pulsar, etc.)Only administrator can see this value.
+             */
+            external_id?: string;
+            /**
+             * Galaxy Version
+             * @description The (major) version of Galaxy used to create this job.
+             * @example 21.05
+             */
+            galaxy_version: string;
+            /**
+             * History ID
+             * @description The encoded ID of the history associated with this item.
+             * @example 0123456789ABCDEF
+             */
+            history_id?: string;
+            /**
+             * ID
+             * @description The encoded ID of this entity.
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /**
+             * Inputs
+             * @description Dictionary mapping all the tool inputs (by name) with the corresponding dataset information.
+             * @default {}
+             */
+            inputs?: {
+                [key: string]: components["schemas"]["EncodedDatasetJobInfo"] | undefined;
+            };
+            /**
+             * Model class
+             * @description The name of the database model class.
+             * @default Job
+             * @enum {string}
+             */
+            model_class: "Job";
+            /**
+             * Output collections
+             * @description ?
+             * @default {}
+             */
+            output_collections?: Record<string, never>;
+            /**
+             * Outputs
+             * @description Dictionary mapping all the tool outputs (by name) with the corresponding dataset information.
+             * @default {}
+             */
+            outputs?: {
+                [key: string]: components["schemas"]["EncodedDatasetJobInfo"] | undefined;
+            };
+            /**
+             * Parameters
+             * @description Object containing all the parameters of the tool associated with this job. The specific parameters depend on the tool itself.
+             */
+            params: Record<string, never>;
+            /**
+             * State
+             * @description Current state of the job.
+             */
+            state: components["schemas"]["JobState"];
+            /**
+             * Tool ID
+             * @description Identifier of the tool that generated this job.
+             */
+            tool_id: string;
+            /**
+             * Update Time
+             * Format: date-time
+             * @description The last time and date this item was updated.
+             */
+            update_time: string;
+            /**
+             * User Email
+             * @description The email of the user that owns this job. Only the owner of the job and administrators can see this value.
+             */
+            user_email?: string;
         };
         /**
          * ExportHistoryArchivePayload
@@ -14801,7 +14934,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["EncodedJobDetails"][];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6376,17 +6376,17 @@ export interface components {
              * Handler
              * @description Name of the process that handled the job.
              */
-            Handler: string;
+            Handler?: string;
             /**
              * Runner
              * @description Job runner class
              */
-            Runner: string;
+            Runner?: string;
             /**
              * Runner Job ID
              * @description ID assigned to submitted job by external job running system
              */
-            "Runner Job ID": string;
+            "Runner Job ID"?: string;
         };
         /**
          * JobDisplayParametersSummary

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -904,6 +904,10 @@ export interface paths {
          */
         get: operations["show_api_jobs__id__get"];
     };
+    "/api/jobs/{id}/common_problems": {
+        /** Check inputs and job for common potential problems to aid in error reporting */
+        get: operations["check_common_problems_api_jobs__id__common_problems_get"];
+    };
     "/api/jobs/{job_id}/oidc-tokens": {
         /**
          * Get a fresh OIDC token
@@ -6248,6 +6252,16 @@ export interface components {
          * @enum {string}
          */
         JobIndexViewEnum: "collection" | "admin_job_list";
+        /**
+         * JobInputSummary
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        JobInputSummary: {
+            /** Has Duplicate Inputs */
+            has_duplicate_inputs: boolean;
+            /** Has Empty Inputs */
+            has_empty_inputs: boolean;
+        };
         /** JobLock */
         JobLock: {
             /**
@@ -14693,6 +14707,33 @@ export interface operations {
             200: {
                 content: {
                     "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    check_common_problems_api_jobs__id__common_problems_get: {
+        /** Check inputs and job for common potential problems to aid in error reporting */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description TODO */
+            path: {
+                id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["JobInputSummary"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -204,6 +204,24 @@ export interface paths {
          */
         get: operations["get_metrics_api_datasets__id__metrics_get"];
     };
+    "/api/datasets/{id}/parameters_display": {
+        /**
+         * Resolve parameters as a list for nested display.
+         * @description # TODO is this still true?
+         *     Resolve parameters as a list for nested display. More client logic
+         *     here than is ideal but it is hard to reason about tool parameter
+         *     types on the client relative to the server. Job accessibility checks
+         *     are slightly different than dataset checks, so both methods are
+         *     available.
+         *
+         *     This API endpoint is unstable and tied heavily to Galaxy's JS client code,
+         *     this endpoint will change frequently.
+         *
+         * :rtype:     list
+         * :returns:   job parameters for for display
+         */
+        get: operations["resolve_parameters_display_api_datasets__id__parameters_display_get"];
+    };
     "/api/datatypes": {
         /**
          * Lists all available data types
@@ -11066,6 +11084,51 @@ export interface operations {
          * Return job metrics for specified job.
          * @description :rtype:     list
          * :returns:   list containing job metrics
+         */
+        parameters: {
+            /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
+            query?: {
+                hda_ldda?: components["schemas"]["DatasetSourceType"];
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the dataset */
+            path: {
+                id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resolve_parameters_display_api_datasets__id__parameters_display_get: {
+        /**
+         * Resolve parameters as a list for nested display.
+         * @description # TODO is this still true?
+         *     Resolve parameters as a list for nested display. More client logic
+         *     here than is ideal but it is hard to reason about tool parameter
+         *     types on the client relative to the server. Job accessibility checks
+         *     are slightly different than dataset checks, so both methods are
+         *     available.
+         *
+         *     This API endpoint is unstable and tied heavily to Galaxy's JS client code,
+         *     this endpoint will change frequently.
+         *
+         * :rtype:     list
+         * :returns:   job parameters for for display
          */
         parameters: {
             /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -903,15 +903,8 @@ export interface paths {
         post: operations["search_jobs_api_jobs_search_post"];
     };
     "/api/jobs/{id}": {
-        /**
-         * Show
-         * @description Return dictionary containing description of job data
-         *
-         * Parameters
-         * - id: ID of job to return
-         * - full: Return extra information ?
-         */
-        get: operations["show_api_jobs__id__get"];
+        /** Return dictionary containing description of job data. */
+        get: operations["show_job_api_jobs__id__get"];
         /** Cancels specified job */
         delete: operations["cancel_job_api_jobs__id__delete"];
     };
@@ -934,6 +927,10 @@ export interface paths {
     "/api/jobs/{id}/resume": {
         /** Resumes a paused job. */
         put: operations["resume_paused_job_api_jobs__id__resume_put"];
+    };
+    "/api/jobs/{job_id}/destination_params": {
+        /** Return destination parameters for specified job. */
+        get: operations["destination_params_job_api_jobs__job_id__destination_params_get"];
     };
     "/api/jobs/{job_id}/oidc-tokens": {
         /**
@@ -6296,6 +6293,27 @@ export interface components {
              * @description The name of the associated dataset.
              */
             name: string;
+        };
+        /**
+         * JobDestinationParams
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        JobDestinationParams: {
+            /**
+             * Handler
+             * @description ?
+             */
+            Handler: Record<string, never>;
+            /**
+             * Runner
+             * @description ?
+             */
+            Runner: Record<string, never>;
+            /**
+             * Runner Job ID
+             * @description ?
+             */
+            "Runner Job ID": Record<string, never>;
         };
         /**
          * JobErrorSummary
@@ -14958,16 +14976,10 @@ export interface operations {
             };
         };
     };
-    show_api_jobs__id__get: {
-        /**
-         * Show
-         * @description Return dictionary containing description of job data
-         *
-         * Parameters
-         * - id: ID of job to return
-         * - full: Return extra information ?
-         */
+    show_job_api_jobs__id__get: {
+        /** Return dictionary containing description of job data. */
         parameters: {
+            /** @description Show extra information. */
             query?: {
                 full?: boolean;
             };
@@ -14975,6 +14987,7 @@ export interface operations {
             header?: {
                 "run-as"?: string;
             };
+            /** @description The ID of the job */
             path: {
                 id: string;
             };
@@ -15156,6 +15169,33 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["JobAssociation"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    destination_params_job_api_jobs__job_id__destination_params_get: {
+        /** Return destination parameters for specified job. */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the job */
+            path: {
+                job_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["JobDestinationParams"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -914,11 +914,6 @@ export interface paths {
     "/api/jobs": {
         /** Index */
         get: operations["index_api_jobs_get"];
-        /**
-         * Not implemented.
-         * @description See the create method in tools.py in order to submit a job.
-         */
-        post: operations["create_job_api_jobs_post"];
     };
     "/api/jobs/search": {
         /**
@@ -15220,35 +15215,6 @@ export interface operations {
             200: {
                 content: {
                     "application/json": Record<string, never>[];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_job_api_jobs_post: {
-        /**
-         * Not implemented.
-         * @description See the create method in tools.py in order to submit a job.
-         */
-        parameters: {
-            query: {
-                kwd: Record<string, never>;
-            };
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -929,35 +929,27 @@ export interface paths {
          */
         post: operations["search_jobs_api_jobs_search_post"];
     };
-    "/api/jobs/{id}/common_problems": {
-        /** Check inputs and job for common potential problems to aid in error reporting */
-        get: operations["check_common_problems_api_jobs__id__common_problems_get"];
-    };
-    "/api/jobs/{id}/error": {
-        /** Submits a bug report via the API. */
-        post: operations["report_error_api_jobs__id__error_post"];
-    };
-    "/api/jobs/{id}/inputs": {
-        /** Returns input datasets created by a job. */
-        get: operations["get_inputs_api_jobs__id__inputs_get"];
-    };
-    "/api/jobs/{id}/outputs": {
-        /** Returns output datasets created by a job. */
-        get: operations["get_outputs_api_jobs__id__outputs_get"];
-    };
-    "/api/jobs/{id}/resume": {
-        /** Resumes a paused job. */
-        put: operations["resume_paused_job_api_jobs__id__resume_put"];
-    };
     "/api/jobs/{job_id}": {
         /** Return dictionary containing description of job data. */
         get: operations["show_job_api_jobs__job_id__get"];
         /** Cancels specified job */
         delete: operations["cancel_job_api_jobs__job_id__delete"];
     };
+    "/api/jobs/{job_id}/common_problems": {
+        /** Check inputs and job for common potential problems to aid in error reporting */
+        get: operations["check_common_problems_api_jobs__job_id__common_problems_get"];
+    };
     "/api/jobs/{job_id}/destination_params": {
         /** Return destination parameters for specified job. */
         get: operations["destination_params_job_api_jobs__job_id__destination_params_get"];
+    };
+    "/api/jobs/{job_id}/error": {
+        /** Submits a bug report via the API. */
+        post: operations["report_error_api_jobs__job_id__error_post"];
+    };
+    "/api/jobs/{job_id}/inputs": {
+        /** Returns input datasets created by a job. */
+        get: operations["get_inputs_api_jobs__job_id__inputs_get"];
     };
     "/api/jobs/{job_id}/metrics": {
         /** Return job metrics for specified job. */
@@ -969,6 +961,10 @@ export interface paths {
          * @description Allows remote job running mechanisms to get a fresh OIDC token that can be used on remote side to authorize user. It is not meant to represent part of Galaxy's stable, user facing API
          */
         get: operations["get_token_api_jobs__job_id__oidc_tokens_get"];
+    };
+    "/api/jobs/{job_id}/outputs": {
+        /** Returns output datasets created by a job. */
+        get: operations["get_outputs_api_jobs__job_id__outputs_get"];
     };
     "/api/jobs/{job_id}/parameters_display": {
         /**
@@ -983,6 +979,10 @@ export interface paths {
          * this endpoint will change frequently.
          */
         get: operations["resolve_parameters_display_api_jobs__job_id__parameters_display_get"];
+    };
+    "/api/jobs/{job_id}/resume": {
+        /** Resumes a paused job. */
+        put: operations["resume_paused_job_api_jobs__job_id__resume_put"];
     };
     "/api/libraries": {
         /**
@@ -15292,146 +15292,6 @@ export interface operations {
             };
         };
     };
-    check_common_problems_api_jobs__id__common_problems_get: {
-        /** Check inputs and job for common potential problems to aid in error reporting */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description The ID of the job */
-            path: {
-                id: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["JobInputSummary"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    report_error_api_jobs__id__error_post: {
-        /** Submits a bug report via the API. */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description The ID of the job */
-            path: {
-                id: string;
-            };
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ReportJobErrorPayload"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["JobErrorSummary"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_inputs_api_jobs__id__inputs_get: {
-        /** Returns input datasets created by a job. */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description The ID of the job */
-            path: {
-                id: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["JobInputAssociation"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_outputs_api_jobs__id__outputs_get: {
-        /** Returns output datasets created by a job. */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description The ID of the job */
-            path: {
-                id: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["JobOutputAssociation"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    resume_paused_job_api_jobs__id__resume_put: {
-        /** Resumes a paused job. */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description The ID of the job */
-            path: {
-                id: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["JobOutputAssociation"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     show_job_api_jobs__job_id__get: {
         /** Return dictionary containing description of job data. */
         parameters: {
@@ -15495,6 +15355,33 @@ export interface operations {
             };
         };
     };
+    check_common_problems_api_jobs__job_id__common_problems_get: {
+        /** Check inputs and job for common potential problems to aid in error reporting */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the job */
+            path: {
+                job_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["JobInputSummary"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     destination_params_job_api_jobs__job_id__destination_params_get: {
         /** Return destination parameters for specified job. */
         parameters: {
@@ -15512,6 +15399,65 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["JobDestinationParams"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    report_error_api_jobs__job_id__error_post: {
+        /** Submits a bug report via the API. */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the job */
+            path: {
+                job_id: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReportJobErrorPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["JobErrorSummary"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_inputs_api_jobs__job_id__inputs_get: {
+        /** Returns input datasets created by a job. */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the job */
+            path: {
+                job_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["JobInputAssociation"][];
                 };
             };
             /** @description Validation Error */
@@ -15591,6 +15537,33 @@ export interface operations {
             };
         };
     };
+    get_outputs_api_jobs__job_id__outputs_get: {
+        /** Returns output datasets created by a job. */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the job */
+            path: {
+                job_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["JobOutputAssociation"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     resolve_parameters_display_api_jobs__job_id__parameters_display_get: {
         /**
          * Resolve parameters as a list for nested display.
@@ -15625,6 +15598,33 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["JobDisplayParametersSummary"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resume_paused_job_api_jobs__job_id__resume_put: {
+        /** Resumes a paused job. */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the job */
+            path: {
+                job_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["JobOutputAssociation"][];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -168,12 +168,16 @@ export interface paths {
         get: operations["show_inheritance_chain_api_datasets__dataset_id__inheritance_chain_get"];
     };
     "/api/datasets/{dataset_id}/metrics": {
-        /** Return job metrics for specified job. */
+        /**
+         * Return job metrics for specified job.
+         * @deprecated
+         */
         get: operations["get_metrics_api_datasets__dataset_id__metrics_get"];
     };
     "/api/datasets/{dataset_id}/parameters_display": {
         /**
          * Resolve parameters as a list for nested display.
+         * @deprecated
          * @description Resolve parameters as a list for nested display. More client logic
          * here than is ideal but it is hard to reason about tool parameter
          * types on the client relative to the server. Job accessibility checks
@@ -910,6 +914,11 @@ export interface paths {
     "/api/jobs": {
         /** Index */
         get: operations["index_api_jobs_get"];
+        /**
+         * Not implemented.
+         * @description See the create method in tools.py in order to submit a job.
+         */
+        post: operations["create_job_api_jobs_post"];
     };
     "/api/jobs/search": {
         /**
@@ -11003,7 +11012,10 @@ export interface operations {
         };
     };
     get_metrics_api_datasets__dataset_id__metrics_get: {
-        /** Return job metrics for specified job. */
+        /**
+         * Return job metrics for specified job.
+         * @deprecated
+         */
         parameters: {
             /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
             query?: {
@@ -11036,6 +11048,7 @@ export interface operations {
     resolve_parameters_display_api_datasets__dataset_id__parameters_display_get: {
         /**
          * Resolve parameters as a list for nested display.
+         * @deprecated
          * @description Resolve parameters as a list for nested display. More client logic
          * here than is ideal but it is hard to reason about tool parameter
          * types on the client relative to the server. Job accessibility checks
@@ -15206,6 +15219,35 @@ export interface operations {
             };
         };
     };
+    create_job_api_jobs_post: {
+        /**
+         * Not implemented.
+         * @description See the create method in tools.py in order to submit a job.
+         */
+        parameters: {
+            query: {
+                kwd: Record<string, never>;
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     search_jobs_api_jobs_search_post: {
         /**
          * Return jobs for current user
@@ -15472,7 +15514,10 @@ export interface operations {
     get_metrics_api_jobs__job_id__metrics_get: {
         /** Return job metrics for specified job. */
         parameters: {
-            /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
+            /**
+             * @deprecated
+             * @description Whether this dataset belongs to a history (HDA) or a library (LDDA).
+             */
             query?: {
                 hda_ldda?: components["schemas"]["DatasetSourceType"];
             };
@@ -15548,7 +15593,10 @@ export interface operations {
          * this endpoint will change frequently.
          */
         parameters: {
-            /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
+            /**
+             * @deprecated
+             * @description Whether this dataset belongs to a history (HDA) or a library (LDDA).
+             */
             query?: {
                 hda_ldda?: components["schemas"]["DatasetSourceType"];
             };

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -4235,8 +4235,9 @@ export interface components {
             /**
              * Source
              * @description The source of this dataset, which in the case of the model can only be `hdca`.
+             * @enum {string}
              */
-            src: components["schemas"]["Hdca"];
+            src: "hdca";
         };
         /**
          * EncodedHistoryContentItem
@@ -5736,12 +5737,6 @@ export interface components {
              */
             type: "hdas";
         };
-        /**
-         * Hdca
-         * @description An enumeration.
-         * @enum {string}
-         */
-        Hdca: "hdca";
         /**
          * HdcaDataItemsFromTarget
          * @description Base model definition with common configuration used by all derived models.
@@ -8684,9 +8679,9 @@ export interface components {
         SearchJobsPayload: {
             /**
              * Inputs
-             * @description The inputs of the job as a JSON dump.
+             * @description The inputs of the job.
              */
-            inputs: string;
+            inputs: Record<string, never>;
             /**
              * State
              * @description Current state of the job.

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -204,17 +204,14 @@ export interface paths {
         /**
          * Resolve parameters as a list for nested display.
          * @description # TODO is this still true?
-         *     Resolve parameters as a list for nested display. More client logic
-         *     here than is ideal but it is hard to reason about tool parameter
-         *     types on the client relative to the server. Job accessibility checks
-         *     are slightly different than dataset checks, so both methods are
-         *     available.
+         * Resolve parameters as a list for nested display. More client logic
+         * here than is ideal but it is hard to reason about tool parameter
+         * types on the client relative to the server. Job accessibility checks
+         * are slightly different than dataset checks, so both methods are
+         * available.
          *
-         *     This API endpoint is unstable and tied heavily to Galaxy's JS client code,
-         *     this endpoint will change frequently.
-         *
-         * :rtype:     list
-         * :returns:   job parameters for for display
+         * This API endpoint is unstable and tied heavily to Galaxy's JS client code,
+         * this endpoint will change frequently.
          */
         get: operations["resolve_parameters_display_api_datasets__id__parameters_display_get"];
     };
@@ -11337,17 +11334,14 @@ export interface operations {
         /**
          * Resolve parameters as a list for nested display.
          * @description # TODO is this still true?
-         *     Resolve parameters as a list for nested display. More client logic
-         *     here than is ideal but it is hard to reason about tool parameter
-         *     types on the client relative to the server. Job accessibility checks
-         *     are slightly different than dataset checks, so both methods are
-         *     available.
+         * Resolve parameters as a list for nested display. More client logic
+         * here than is ideal but it is hard to reason about tool parameter
+         * types on the client relative to the server. Job accessibility checks
+         * are slightly different than dataset checks, so both methods are
+         * available.
          *
-         *     This API endpoint is unstable and tied heavily to Galaxy's JS client code,
-         *     this endpoint will change frequently.
-         *
-         * :rtype:     list
-         * :returns:   job parameters for for display
+         * This API endpoint is unstable and tied heavily to Galaxy's JS client code,
+         * this endpoint will change frequently.
          */
         parameters: {
             /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -893,6 +893,22 @@ export interface paths {
         /** Index */
         get: operations["index_api_jobs_get"];
     };
+    "/api/jobs/search": {
+        /**
+         * Return jobs for current user
+         * @description :type   payload: dict
+         * :param  payload: Dictionary containing description of requested job. This is in the same format as
+         *     a request to POST /apt/tools would take to initiate a job
+         *
+         * :rtype:     list
+         * :returns:   list of dictionaries containing summary job information of the jobs that match the requested job run
+         *
+         * This method is designed to scan the list of previously run jobs and find records of jobs that had
+         * the exact some input parameters and datasets. This can be used to minimize the amount of repeated work, and simply
+         * recycle the old results.
+         */
+        post: operations["search_jobs_api_jobs_search_post"];
+    };
     "/api/jobs/{id}": {
         /**
          * Show
@@ -8265,6 +8281,18 @@ export interface components {
             url: string;
         };
         /**
+         * SearchJobsPayload
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        SearchJobsPayload: {
+            /** Inputs */
+            inputs: string;
+            /** State */
+            state: string;
+            /** Tool Id */
+            tool_id: string;
+        };
+        /**
          * ServerDirElement
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -14715,6 +14743,46 @@ export interface operations {
             200: {
                 content: {
                     "application/json": Record<string, never>[];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    search_jobs_api_jobs_search_post: {
+        /**
+         * Return jobs for current user
+         * @description :type   payload: dict
+         * :param  payload: Dictionary containing description of requested job. This is in the same format as
+         *     a request to POST /apt/tools would take to initiate a job
+         *
+         * :rtype:     list
+         * :returns:   list of dictionaries containing summary job information of the jobs that match the requested job run
+         *
+         * This method is designed to scan the list of previously run jobs and find records of jobs that had
+         * the exact some input parameters and datasets. This can be used to minimize the amount of repeated work, and simply
+         * recycle the old results.
+         */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SearchJobsPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -912,6 +912,8 @@ export interface paths {
          * - full: Return extra information ?
          */
         get: operations["show_api_jobs__id__get"];
+        /** Cancels specified job */
+        delete: operations["cancel_job_api_jobs__id__delete"];
     };
     "/api/jobs/{id}/common_problems": {
         /** Check inputs and job for common potential problems to aid in error reporting */
@@ -3955,6 +3957,17 @@ export interface components {
              * @default false
              */
             purge?: boolean;
+        };
+        /**
+         * DeleteJobPayload
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        DeleteJobPayload: {
+            /**
+             * Job message
+             * @description Stop message
+             */
+            message?: string;
         };
         /**
          * DeleteLibraryPayload
@@ -14971,6 +14984,38 @@ export interface operations {
             200: {
                 content: {
                     "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_job_api_jobs__id__delete: {
+        /** Cancels specified job */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the job */
+            path: {
+                id: string;
+            };
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["DeleteJobPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": boolean;
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -920,6 +920,14 @@ export interface paths {
         /** Returns input datasets created by a job. */
         get: operations["get_inputs_api_jobs__id__inputs_get"];
     };
+    "/api/jobs/{id}/metrics": {
+        /**
+         * Return job metrics for specified job.
+         * @description :rtype:     list
+         * :returns:   list containing job metrics
+         */
+        get: operations["get_metrics_api_jobs__id__metrics_get"];
+    };
     "/api/jobs/{id}/outputs": {
         /** Returns output datasets created by a job. */
         get: operations["get_outputs_api_jobs__id__outputs_get"];
@@ -15115,6 +15123,41 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["JobAssociation"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_metrics_api_jobs__id__metrics_get: {
+        /**
+         * Return job metrics for specified job.
+         * @description :rtype:     list
+         * :returns:   list containing job metrics
+         */
+        parameters: {
+            /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
+            query: {
+                hda_ldda: components["schemas"]["DatasetSourceType"];
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the job */
+            path: {
+                id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -908,6 +908,14 @@ export interface paths {
         /** Check inputs and job for common potential problems to aid in error reporting */
         get: operations["check_common_problems_api_jobs__id__common_problems_get"];
     };
+    "/api/jobs/{id}/error": {
+        /**
+         * Submits a bug report via the API.
+         * @description :rtype:     dictionary
+         * :returns:   dictionary containing information regarding where the error report was sent.
+         */
+        post: operations["report_error_api_jobs__id__error_post"];
+    };
     "/api/jobs/{id}/resume": {
         /** Resumes a paused job. */
         put: operations["resume_paused_job_api_jobs__id__resume_put"];
@@ -6124,6 +6132,14 @@ export interface components {
             name: string;
         };
         /**
+         * JobErrorSummary
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        JobErrorSummary: {
+            /** Messages */
+            messages: string[][];
+        };
+        /**
          * JobExportHistoryArchiveListResponse
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -8141,6 +8157,21 @@ export interface components {
              * @description Email of the user
              */
             remote_user_email: string;
+        };
+        /**
+         * ReportJobErrorPayload
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        ReportJobErrorPayload: {
+            /**
+             * Dataset Id
+             * @example 0123456789ABCDEF
+             */
+            dataset_id: string;
+            /** Email */
+            email?: string;
+            /** Message */
+            message?: string;
         };
         /**
          * RequestDataType
@@ -14747,6 +14778,42 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["JobInputSummary"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    report_error_api_jobs__id__error_post: {
+        /**
+         * Submits a bug report via the API.
+         * @description :rtype:     dictionary
+         * :returns:   dictionary containing information regarding where the error report was sent.
+         */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the job */
+            path: {
+                id: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReportJobErrorPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["JobErrorSummary"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1787,10 +1787,7 @@ export interface components {
              */
             link: string;
         };
-        /**
-         * AnonUserModel
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** AnonUserModel */
         AnonUserModel: {
             /**
              * Nice total disc usage
@@ -1808,10 +1805,7 @@ export interface components {
              */
             total_disk_usage: number;
         };
-        /**
-         * ArchiveHistoryRequestPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ArchiveHistoryRequestPayload */
         ArchiveHistoryRequestPayload: {
             /**
              * Export Record ID
@@ -2042,10 +2036,7 @@ export interface components {
              */
             url: string;
         };
-        /**
-         * AsyncFile
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** AsyncFile */
         AsyncFile: {
             /**
              * Storage Request Id
@@ -2054,10 +2045,7 @@ export interface components {
             storage_request_id: string;
             task: components["schemas"]["AsyncTaskResultSummary"];
         };
-        /**
-         * AsyncTaskResultSummary
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** AsyncTaskResultSummary */
         AsyncTaskResultSummary: {
             /**
              * ID
@@ -2098,10 +2086,7 @@ export interface components {
                   )
                 | ("cloud" | "quota" | "no_quota" | "restricted");
         };
-        /**
-         * BasicRoleModel
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** BasicRoleModel */
         BasicRoleModel: {
             /**
              * ID
@@ -2150,10 +2135,7 @@ export interface components {
             /** Targets */
             targets: Record<string, never>;
         };
-        /**
-         * BroadcastNotificationContent
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** BroadcastNotificationContent */
         BroadcastNotificationContent: {
             /**
              * Action links
@@ -2274,10 +2256,7 @@ export interface components {
              */
             variant: components["schemas"]["NotificationVariant"];
         };
-        /**
-         * BrowsableFilesSourcePlugin
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** BrowsableFilesSourcePlugin */
         BrowsableFilesSourcePlugin: {
             /**
              * Browsable
@@ -2331,19 +2310,13 @@ export interface components {
              */
             writable: boolean;
         };
-        /**
-         * BulkOperationItemError
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** BulkOperationItemError */
         BulkOperationItemError: {
             /** Error */
             error: string;
             item: components["schemas"]["EncodedHistoryContentItem"];
         };
-        /**
-         * ChangeDatatypeOperationParams
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ChangeDatatypeOperationParams */
         ChangeDatatypeOperationParams: {
             /** Datatype */
             datatype: string;
@@ -2353,10 +2326,7 @@ export interface components {
              */
             type: "change_datatype";
         };
-        /**
-         * ChangeDbkeyOperationParams
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ChangeDbkeyOperationParams */
         ChangeDbkeyOperationParams: {
             /** Dbkey */
             dbkey: string;
@@ -2366,10 +2336,7 @@ export interface components {
              */
             type: "change_dbkey";
         };
-        /**
-         * CheckForUpdatesResponse
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CheckForUpdatesResponse */
         CheckForUpdatesResponse: {
             /**
              * Message
@@ -2399,10 +2366,7 @@ export interface components {
              */
             type: string;
         };
-        /**
-         * CleanableItemsSummary
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CleanableItemsSummary */
         CleanableItemsSummary: {
             /**
              * Total Items
@@ -2415,18 +2379,12 @@ export interface components {
              */
             total_size: number;
         };
-        /**
-         * CleanupStorageItemsRequest
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CleanupStorageItemsRequest */
         CleanupStorageItemsRequest: {
             /** Item Ids */
             item_ids: string[];
         };
-        /**
-         * CloudDatasets
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CloudDatasets */
         CloudDatasets: {
             /**
              * Authentication ID
@@ -2457,10 +2415,7 @@ export interface components {
              */
             overwrite_existing?: boolean;
         };
-        /**
-         * CloudDatasetsResponse
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CloudDatasetsResponse */
         CloudDatasetsResponse: {
             /**
              * Bucket
@@ -2478,10 +2433,7 @@ export interface components {
              */
             sent_dataset_labels: string[];
         };
-        /**
-         * CloudObjects
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CloudObjects */
         CloudObjects: {
             /**
              * Authentication ID
@@ -2511,10 +2463,7 @@ export interface components {
              */
             objects: string[];
         };
-        /**
-         * CollectionElementIdentifier
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CollectionElementIdentifier */
         CollectionElementIdentifier: {
             /**
              * Collection Type
@@ -2554,10 +2503,7 @@ export interface components {
          * @enum {string}
          */
         ColletionSourceType: "hda" | "ldda" | "hdca" | "new_collection";
-        /**
-         * CompositeDataElement
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CompositeDataElement */
         CompositeDataElement: {
             /** Md5 */
             MD5?: string;
@@ -2642,10 +2588,7 @@ export interface components {
             /** To posix lines */
             to_posix_lines: boolean;
         };
-        /**
-         * CompositeItems
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CompositeItems */
         CompositeItems: {
             /** Elements */
             elements: (
@@ -2657,10 +2600,7 @@ export interface components {
                 | components["schemas"]["FtpImportElement"]
             )[];
         };
-        /**
-         * ComputeDatasetHashPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ComputeDatasetHashPayload */
         ComputeDatasetHashPayload: {
             /**
              * Extra Files Path
@@ -2721,10 +2661,7 @@ export interface components {
         ConvertedDatasetsMap: {
             [key: string]: string | undefined;
         };
-        /**
-         * CreateEntryPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CreateEntryPayload */
         CreateEntryPayload: {
             /**
              * Name
@@ -2738,10 +2675,7 @@ export interface components {
              */
             target: string;
         };
-        /**
-         * CreateHistoryContentFromStore
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CreateHistoryContentFromStore */
         CreateHistoryContentFromStore: {
             model_store_format?: components["schemas"]["ModelStoreFormat"];
             /** Store Content Uri */
@@ -2749,10 +2683,7 @@ export interface components {
             /** Store Dict */
             store_dict?: Record<string, never>;
         };
-        /**
-         * CreateHistoryContentPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CreateHistoryContentPayload */
         CreateHistoryContentPayload: {
             /**
              * Collection Type
@@ -2826,10 +2757,7 @@ export interface components {
              */
             type?: components["schemas"]["HistoryContentType"];
         };
-        /**
-         * CreateHistoryFromStore
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CreateHistoryFromStore */
         CreateHistoryFromStore: {
             model_store_format?: components["schemas"]["ModelStoreFormat"];
             /** Store Content Uri */
@@ -2837,10 +2765,7 @@ export interface components {
             /** Store Dict */
             store_dict?: Record<string, never>;
         };
-        /**
-         * CreateLibrariesFromStore
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CreateLibrariesFromStore */
         CreateLibrariesFromStore: {
             model_store_format?: components["schemas"]["ModelStoreFormat"];
             /** Store Content Uri */
@@ -2848,10 +2773,7 @@ export interface components {
             /** Store Dict */
             store_dict?: Record<string, never>;
         };
-        /**
-         * CreateLibraryFilePayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CreateLibraryFilePayload */
         CreateLibraryFilePayload: {
             /**
              * From HDA ID
@@ -2872,10 +2794,7 @@ export interface components {
              */
             ldda_message?: string;
         };
-        /**
-         * CreateLibraryFolderPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CreateLibraryFolderPayload */
         CreateLibraryFolderPayload: {
             /**
              * Description
@@ -2889,10 +2808,7 @@ export interface components {
              */
             name: string;
         };
-        /**
-         * CreateLibraryPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CreateLibraryPayload */
         CreateLibraryPayload: {
             /**
              * Description
@@ -2928,10 +2844,7 @@ export interface components {
              */
             metrics?: components["schemas"]["Metric"][];
         };
-        /**
-         * CreateNewCollectionPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CreateNewCollectionPayload */
         CreateNewCollectionPayload: {
             /**
              * Collection Type
@@ -2980,10 +2893,7 @@ export interface components {
              */
             name?: string;
         };
-        /**
-         * CreatePagePayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CreatePagePayload */
         CreatePagePayload: {
             /**
              * Annotation
@@ -3019,10 +2929,7 @@ export interface components {
              */
             title: string;
         };
-        /**
-         * CreateQuotaParams
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CreateQuotaParams */
         CreateQuotaParams: {
             /**
              * Amount
@@ -3109,10 +3016,7 @@ export interface components {
              */
             url: string;
         };
-        /**
-         * CreatedEntryResponse
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CreatedEntryResponse */
         CreatedEntryResponse: {
             /**
              * External link
@@ -3191,10 +3095,7 @@ export interface components {
              */
             username: string;
         };
-        /**
-         * CustomBuildCreationPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CustomBuildCreationPayload */
         CustomBuildCreationPayload: {
             /**
              * Length type
@@ -3218,10 +3119,7 @@ export interface components {
          * @enum {string}
          */
         CustomBuildLenType: "file" | "fasta" | "text";
-        /**
-         * CustomBuildModel
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CustomBuildModel */
         CustomBuildModel: {
             /**
              * Count
@@ -3262,10 +3160,7 @@ export interface components {
          * @description The custom builds associated with the user.
          */
         CustomBuildsCollection: components["schemas"]["CustomBuildModel"][];
-        /**
-         * CustomBuildsMetadataResponse
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** CustomBuildsMetadataResponse */
         CustomBuildsMetadataResponse: {
             /**
              * Fasta HDAs
@@ -3381,10 +3276,7 @@ export interface components {
              */
             populated?: boolean;
         };
-        /**
-         * DataElementsFromTarget
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DataElementsFromTarget */
         DataElementsFromTarget: {
             /**
              * Auto Decompress
@@ -3408,10 +3300,7 @@ export interface components {
             /** Url */
             url?: string;
         };
-        /**
-         * DataElementsTarget
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DataElementsTarget */
         DataElementsTarget: {
             /**
              * Auto Decompress
@@ -3444,10 +3333,7 @@ export interface components {
          * @enum {string}
          */
         DataItemSourceType: "hda" | "ldda" | "hdca" | "dce" | "dc";
-        /**
-         * DatasetAssociationRoles
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DatasetAssociationRoles */
         DatasetAssociationRoles: {
             /**
              * Access Roles
@@ -3468,10 +3354,7 @@ export interface components {
              */
             modify_item_roles?: string[][];
         };
-        /**
-         * DatasetCollectionAttributesResult
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DatasetCollectionAttributesResult */
         DatasetCollectionAttributesResult: {
             /**
              * Dbkey
@@ -3514,10 +3397,7 @@ export interface components {
          * @enum {string}
          */
         DatasetContentType: "meta" | "attr" | "stats" | "data";
-        /**
-         * DatasetErrorMessage
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DatasetErrorMessage */
         DatasetErrorMessage: {
             /**
              * Dataset
@@ -3532,14 +3412,10 @@ export interface components {
         };
         /**
          * DatasetInheritanceChain
-         * @description Base model definition with common configuration used by all derived models.
          * @default []
          */
         DatasetInheritanceChain: components["schemas"]["DatasetInheritanceChainEntry"][];
-        /**
-         * DatasetInheritanceChainEntry
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DatasetInheritanceChainEntry */
         DatasetInheritanceChainEntry: {
             /**
              * Dep
@@ -3570,10 +3446,7 @@ export interface components {
              */
             manage?: string[];
         };
-        /**
-         * DatasetSourceId
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DatasetSourceId */
         DatasetSourceId: {
             /**
              * ID
@@ -3611,10 +3484,7 @@ export interface components {
             | "failed_metadata"
             | "deferred"
             | "discarded";
-        /**
-         * DatasetStorageDetails
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DatasetStorageDetails */
         DatasetStorageDetails: {
             /**
              * Badges
@@ -3667,10 +3537,7 @@ export interface components {
              */
             sources: Record<string, never>[];
         };
-        /**
-         * DatasetSummary
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DatasetSummary */
         DatasetSummary: {
             /**
              * Create Time
@@ -3712,15 +3579,9 @@ export interface components {
              */
             uuid: string;
         };
-        /**
-         * DatasetSummaryList
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DatasetSummaryList */
         DatasetSummaryList: components["schemas"]["DatasetSummary"][];
-        /**
-         * DatasetTextContentDetails
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DatasetTextContentDetails */
         DatasetTextContentDetails: {
             /**
              * Item Data
@@ -3869,10 +3730,7 @@ export interface components {
                 [key: string]: string | undefined;
             };
         };
-        /**
-         * DefaultQuota
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DefaultQuota */
         DefaultQuota: {
             /**
              * Model class
@@ -3901,10 +3759,7 @@ export interface components {
          * @enum {string}
          */
         DefaultQuotaValues: "unregistered" | "registered" | "no";
-        /**
-         * DeleteDatasetBatchPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DeleteDatasetBatchPayload */
         DeleteDatasetBatchPayload: {
             /**
              * Datasets
@@ -3918,10 +3773,7 @@ export interface components {
              */
             purge?: boolean;
         };
-        /**
-         * DeleteDatasetBatchResult
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DeleteDatasetBatchResult */
         DeleteDatasetBatchResult: {
             /**
              * Errors
@@ -3934,10 +3786,7 @@ export interface components {
              */
             success_count: number;
         };
-        /**
-         * DeleteHistoryContentPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DeleteHistoryContentPayload */
         DeleteHistoryContentPayload: {
             /**
              * Purge
@@ -3991,10 +3840,7 @@ export interface components {
              */
             purge?: boolean;
         };
-        /**
-         * DeleteJobPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DeleteJobPayload */
         DeleteJobPayload: {
             /**
              * Job message
@@ -4002,10 +3848,7 @@ export interface components {
              */
             message?: string;
         };
-        /**
-         * DeleteLibraryPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DeleteLibraryPayload */
         DeleteLibraryPayload: {
             /**
              * Undelete
@@ -4013,10 +3856,7 @@ export interface components {
              */
             undelete: boolean;
         };
-        /**
-         * DeleteQuotaPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DeleteQuotaPayload */
         DeleteQuotaPayload: {
             /**
              * Purge
@@ -4025,10 +3865,7 @@ export interface components {
              */
             purge?: boolean;
         };
-        /**
-         * DeletedCustomBuild
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DeletedCustomBuild */
         DeletedCustomBuild: {
             /**
              * Deletion message
@@ -4036,10 +3873,7 @@ export interface components {
              */
             message: string;
         };
-        /**
-         * DetailedUserModel
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** DetailedUserModel */
         DetailedUserModel: {
             /**
              * Deleted
@@ -4148,10 +3982,7 @@ export interface components {
          * @enum {string}
          */
         ElementsFromType: "archive" | "bagit" | "bagit_archive" | "directory";
-        /**
-         * EncodedDataItemSourceId
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** EncodedDataItemSourceId */
         EncodedDataItemSourceId: {
             /**
              * ID
@@ -4165,10 +3996,7 @@ export interface components {
              */
             src: components["schemas"]["DataItemSourceType"];
         };
-        /**
-         * EncodedDatasetJobInfo
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** EncodedDatasetJobInfo */
         EncodedDatasetJobInfo: {
             /**
              * ID
@@ -4189,10 +4017,7 @@ export interface components {
              */
             uuid?: string;
         };
-        /**
-         * EncodedDatasetSourceId
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** EncodedDatasetSourceId */
         EncodedDatasetSourceId: {
             /**
              * ID
@@ -4206,10 +4031,7 @@ export interface components {
              */
             src: components["schemas"]["DatasetSourceType"];
         };
-        /**
-         * EncodedHdcaSourceId
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** EncodedHdcaSourceId */
         EncodedHdcaSourceId: {
             /**
              * ID
@@ -4353,10 +4175,7 @@ export interface components {
              */
             user_email?: string;
         };
-        /**
-         * ExportHistoryArchivePayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ExportHistoryArchivePayload */
         ExportHistoryArchivePayload: {
             /**
              * Directory URI
@@ -4387,18 +4206,12 @@ export interface components {
              */
             include_hidden?: boolean;
         };
-        /**
-         * ExportObjectMetadata
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ExportObjectMetadata */
         ExportObjectMetadata: {
             request_data: components["schemas"]["ExportObjectRequestMetadata"];
             result_data?: components["schemas"]["ExportObjectResultMetadata"];
         };
-        /**
-         * ExportObjectRequestMetadata
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ExportObjectRequestMetadata */
         ExportObjectRequestMetadata: {
             /**
              * Object Id
@@ -4416,10 +4229,7 @@ export interface components {
              */
             user_id?: string;
         };
-        /**
-         * ExportObjectResultMetadata
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ExportObjectResultMetadata */
         ExportObjectResultMetadata: {
             /** Error */
             error?: string;
@@ -4466,15 +4276,9 @@ export interface components {
              */
             target_uri: string;
         };
-        /**
-         * ExportTaskListResponse
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ExportTaskListResponse */
         ExportTaskListResponse: components["schemas"]["ObjectExportTaskResponse"][];
-        /**
-         * ExtraFiles
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ExtraFiles */
         ExtraFiles: {
             /**
              * Fuzzy Root
@@ -4486,10 +4290,7 @@ export interface components {
             items_from?: string;
             src: components["schemas"]["Src"];
         };
-        /**
-         * FavoriteObject
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** FavoriteObject */
         FavoriteObject: {
             /**
              * Object ID
@@ -4503,10 +4304,7 @@ export interface components {
          * @enum {string}
          */
         FavoriteObjectType: "tools";
-        /**
-         * FavoriteObjectsSummary
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** FavoriteObjectsSummary */
         FavoriteObjectsSummary: {
             /**
              * Favorite tools
@@ -4514,10 +4312,7 @@ export interface components {
              */
             tools: string[];
         };
-        /**
-         * FetchDataPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** FetchDataPayload */
         FetchDataPayload: {
             /**
              * History ID
@@ -4534,10 +4329,7 @@ export interface components {
                 | components["schemas"]["FtpImportTarget"]
             )[];
         };
-        /**
-         * FileDataElement
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** FileDataElement */
         FileDataElement: {
             /** Md5 */
             MD5?: string;
@@ -4590,10 +4382,7 @@ export interface components {
              */
             to_posix_lines?: boolean;
         };
-        /**
-         * FileLibraryFolderItem
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** FileLibraryFolderItem */
         FileLibraryFolderItem: {
             /** Can Manage */
             can_manage: boolean;
@@ -4652,10 +4441,7 @@ export interface components {
              */
             update_time: string;
         };
-        /**
-         * FilesSourcePlugin
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** FilesSourcePlugin */
         FilesSourcePlugin: {
             /**
              * Browsable
@@ -4705,7 +4491,6 @@ export interface components {
         };
         /**
          * FilesSourcePluginList
-         * @description Base model definition with common configuration used by all derived models.
          * @default []
          * @example [
          *   {
@@ -4723,10 +4508,7 @@ export interface components {
             | components["schemas"]["BrowsableFilesSourcePlugin"]
             | components["schemas"]["FilesSourcePlugin"]
         )[];
-        /**
-         * FolderLibraryFolderItem
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** FolderLibraryFolderItem */
         FolderLibraryFolderItem: {
             /** Can Manage */
             can_manage: boolean;
@@ -4765,10 +4547,7 @@ export interface components {
              */
             update_time: string;
         };
-        /**
-         * FtpImportElement
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** FtpImportElement */
         FtpImportElement: {
             /** Md5 */
             MD5?: string;
@@ -4823,10 +4602,7 @@ export interface components {
              */
             to_posix_lines?: boolean;
         };
-        /**
-         * FtpImportTarget
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** FtpImportTarget */
         FtpImportTarget: {
             /**
              * Auto Decompress
@@ -4874,10 +4650,7 @@ export interface components {
              */
             name: string;
         };
-        /**
-         * GroupQuota
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** GroupQuota */
         GroupQuota: {
             /**
              * Group
@@ -4892,15 +4665,9 @@ export interface components {
              */
             model_class: "GroupQuotaAssociation";
         };
-        /**
-         * GroupRoleListResponse
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** GroupRoleListResponse */
         GroupRoleListResponse: components["schemas"]["GroupRoleResponse"][];
-        /**
-         * GroupRoleResponse
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** GroupRoleResponse */
         GroupRoleResponse: {
             /**
              * ID
@@ -4920,15 +4687,9 @@ export interface components {
              */
             url: string;
         };
-        /**
-         * GroupUserListResponse
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** GroupUserListResponse */
         GroupUserListResponse: components["schemas"]["GroupUserResponse"][];
-        /**
-         * GroupUserResponse
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** GroupUserResponse */
         GroupUserResponse: {
             /**
              * Email
@@ -5711,10 +5472,7 @@ export interface components {
          * @enum {string}
          */
         HashFunctionNameEnum: "MD5" | "SHA-1" | "SHA-256" | "SHA-512";
-        /**
-         * HdaDestination
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** HdaDestination */
         HdaDestination: {
             /**
              * Type
@@ -5722,10 +5480,7 @@ export interface components {
              */
             type: "hdas";
         };
-        /**
-         * HdcaDataItemsFromTarget
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** HdcaDataItemsFromTarget */
         HdcaDataItemsFromTarget: {
             /**
              * Auto Decompress
@@ -5751,10 +5506,7 @@ export interface components {
             /** Url */
             url?: string;
         };
-        /**
-         * HdcaDataItemsTarget
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** HdcaDataItemsTarget */
         HdcaDataItemsTarget: {
             /**
              * Auto Decompress
@@ -5783,10 +5535,7 @@ export interface components {
             /** Tags */
             tags?: string[];
         };
-        /**
-         * HdcaDestination
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** HdcaDestination */
         HdcaDestination: {
             /**
              * Type
@@ -5794,10 +5543,7 @@ export interface components {
              */
             type: "hdca";
         };
-        /**
-         * HistoryContentBulkOperationPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** HistoryContentBulkOperationPayload */
         HistoryContentBulkOperationPayload: {
             /** Items */
             items?: components["schemas"]["HistoryContentItem"][];
@@ -5808,10 +5554,7 @@ export interface components {
                 | components["schemas"]["ChangeDbkeyOperationParams"]
                 | components["schemas"]["TagOperationParams"];
         };
-        /**
-         * HistoryContentBulkOperationResult
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** HistoryContentBulkOperationResult */
         HistoryContentBulkOperationResult: {
             /** Errors */
             errors: components["schemas"]["BulkOperationItemError"][];
@@ -5856,10 +5599,7 @@ export interface components {
          * @enum {string}
          */
         HistoryContentSource: "hda" | "hdca" | "library" | "library_folder" | "new_collection";
-        /**
-         * HistoryContentStats
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** HistoryContentStats */
         HistoryContentStats: {
             /**
              * Total Matches
@@ -6136,10 +5876,7 @@ export interface components {
              */
             text: string;
         };
-        /**
-         * ImplicitCollectionJobsStateSummary
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ImplicitCollectionJobsStateSummary */
         ImplicitCollectionJobsStateSummary: {
             /**
              * ID
@@ -6175,10 +5912,7 @@ export interface components {
                 | components["schemas"]["ImportToolDataBundleDatasetSource"]
                 | components["schemas"]["ImportToolDataBundleUriSource"];
         };
-        /**
-         * ImportToolDataBundleDatasetSource
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ImportToolDataBundleDatasetSource */
         ImportToolDataBundleDatasetSource: {
             /**
              * ID
@@ -6193,10 +5927,7 @@ export interface components {
              */
             src: "hda" | "ldda";
         };
-        /**
-         * ImportToolDataBundleUriSource
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ImportToolDataBundleUriSource */
         ImportToolDataBundleUriSource: {
             /**
              * src
@@ -6210,10 +5941,7 @@ export interface components {
              */
             uri: string;
         };
-        /**
-         * InputArguments
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** InputArguments */
         InputArguments: {
             /**
              * Database Key
@@ -6240,10 +5968,7 @@ export interface components {
              */
             to_posix_lines?: "Yes" | boolean;
         };
-        /**
-         * InstalledRepositoryToolShedStatus
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** InstalledRepositoryToolShedStatus */
         InstalledRepositoryToolShedStatus: {
             /**
              * Latest installed revision
@@ -6260,10 +5985,7 @@ export interface components {
             /** Revision Upgrade */
             revision_upgrade?: string;
         };
-        /**
-         * InstalledToolShedRepository
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** InstalledToolShedRepository */
         InstalledToolShedRepository: {
             /**
              * Changeset revision
@@ -6324,10 +6046,7 @@ export interface components {
             /** Uninstalled */
             uninstalled: boolean;
         };
-        /**
-         * ItemTagsPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ItemTagsPayload */
         ItemTagsPayload: {
             /**
              * Item class
@@ -6352,10 +6071,7 @@ export interface components {
          * @enum {string}
          */
         ItemsFromSrc: "url" | "files" | "path" | "ftp_import" | "server_dir";
-        /**
-         * JobDestinationParams
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** JobDestinationParams */
         JobDestinationParams: {
             /**
              * Handler
@@ -6373,10 +6089,7 @@ export interface components {
              */
             "Runner Job ID"?: string;
         };
-        /**
-         * JobDisplayParametersSummary
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** JobDisplayParametersSummary */
         JobDisplayParametersSummary: {
             /**
              * Has parameter errors
@@ -6396,10 +6109,7 @@ export interface components {
              */
             parameters: components["schemas"]["JobParameter"][];
         };
-        /**
-         * JobErrorSummary
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** JobErrorSummary */
         JobErrorSummary: {
             /**
              * Error messages
@@ -6407,15 +6117,9 @@ export interface components {
              */
             messages: string[][];
         };
-        /**
-         * JobExportHistoryArchiveListResponse
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** JobExportHistoryArchiveListResponse */
         JobExportHistoryArchiveListResponse: components["schemas"]["JobExportHistoryArchiveModel"][];
-        /**
-         * JobExportHistoryArchiveModel
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** JobExportHistoryArchiveModel */
         JobExportHistoryArchiveModel: {
             /**
              * Download URL
@@ -6474,10 +6178,7 @@ export interface components {
              */
             job_id: string;
         };
-        /**
-         * JobImportHistoryResponse
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** JobImportHistoryResponse */
         JobImportHistoryResponse: {
             /**
              * Create Time
@@ -6549,10 +6250,7 @@ export interface components {
          * @enum {string}
          */
         JobIndexViewEnum: "collection" | "admin_job_list";
-        /**
-         * JobInputAssociation
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** JobInputAssociation */
         JobInputAssociation: {
             /**
              * dataset
@@ -6565,10 +6263,7 @@ export interface components {
              */
             name: string;
         };
-        /**
-         * JobInputSummary
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** JobInputSummary */
         JobInputSummary: {
             /**
              * Duplicate inputs
@@ -6591,7 +6286,6 @@ export interface components {
         };
         /**
          * JobMetric
-         * @description Base model definition with common configuration used by all derived models.
          * @example {
          *   "name": "start_epoch",
          *   "plugin": "core",
@@ -6627,10 +6321,7 @@ export interface components {
              */
             value: string;
         };
-        /**
-         * JobOutput
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** JobOutput */
         JobOutput: {
             /**
              * Output label
@@ -6643,10 +6334,7 @@ export interface components {
              */
             value: components["schemas"]["EncodedDataItemSourceId"];
         };
-        /**
-         * JobOutputAssociation
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** JobOutputAssociation */
         JobOutputAssociation: {
             /**
              * dataset
@@ -6659,10 +6347,7 @@ export interface components {
              */
             name: string;
         };
-        /**
-         * JobParameter
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** JobParameter */
         JobParameter: {
             /**
              * Depth
@@ -6712,10 +6397,7 @@ export interface components {
             | "stop"
             | "stopped"
             | "skipped";
-        /**
-         * JobStateSummary
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** JobStateSummary */
         JobStateSummary: {
             /**
              * ID
@@ -6760,10 +6442,7 @@ export interface components {
              */
             value: string;
         };
-        /**
-         * LegacyLibraryPermissionsPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** LegacyLibraryPermissionsPayload */
         LegacyLibraryPermissionsPayload: {
             /**
              * Access IDs
@@ -6790,10 +6469,7 @@ export interface components {
              */
             LIBRARY_MODIFY_in?: string[] | string;
         };
-        /**
-         * LibraryAvailablePermissions
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** LibraryAvailablePermissions */
         LibraryAvailablePermissions: {
             /**
              * Page
@@ -6816,10 +6492,7 @@ export interface components {
              */
             total: number;
         };
-        /**
-         * LibraryCurrentPermissions
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** LibraryCurrentPermissions */
         LibraryCurrentPermissions: {
             /**
              * Access Role List
@@ -6842,10 +6515,7 @@ export interface components {
              */
             modify_library_role_list: string[][];
         };
-        /**
-         * LibraryDestination
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** LibraryDestination */
         LibraryDestination: {
             /**
              * Description
@@ -6868,10 +6538,7 @@ export interface components {
              */
             type: "library";
         };
-        /**
-         * LibraryFolderContentsIndexResult
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** LibraryFolderContentsIndexResult */
         LibraryFolderContentsIndexResult: {
             /** Folder Contents */
             folder_contents: (
@@ -6880,10 +6547,7 @@ export interface components {
             )[];
             metadata: components["schemas"]["LibraryFolderMetadata"];
         };
-        /**
-         * LibraryFolderCurrentPermissions
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** LibraryFolderCurrentPermissions */
         LibraryFolderCurrentPermissions: {
             /**
              * Add Role List
@@ -6901,10 +6565,7 @@ export interface components {
              */
             modify_folder_role_list: string[][];
         };
-        /**
-         * LibraryFolderDestination
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** LibraryFolderDestination */
         LibraryFolderDestination: {
             /**
              * Library Folder Id
@@ -6917,10 +6578,7 @@ export interface components {
              */
             type: "library_folder";
         };
-        /**
-         * LibraryFolderDetails
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** LibraryFolderDetails */
         LibraryFolderDetails: {
             /**
              * Deleted
@@ -6987,10 +6645,7 @@ export interface components {
              */
             update_time: string;
         };
-        /**
-         * LibraryFolderMetadata
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** LibraryFolderMetadata */
         LibraryFolderMetadata: {
             /** Can Add Library Item */
             can_add_library_item: boolean;
@@ -7016,10 +6671,7 @@ export interface components {
          * @enum {string}
          */
         LibraryFolderPermissionAction: "set_permissions";
-        /**
-         * LibraryFolderPermissionsPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** LibraryFolderPermissionsPayload */
         LibraryFolderPermissionsPayload: {
             /**
              * Action
@@ -7045,10 +6697,7 @@ export interface components {
              */
             "modify_ids[]"?: string[] | string;
         };
-        /**
-         * LibraryLegacySummary
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** LibraryLegacySummary */
         LibraryLegacySummary: {
             /**
              * Create Time
@@ -7109,10 +6758,7 @@ export interface components {
          * @enum {string}
          */
         LibraryPermissionScope: "current" | "available";
-        /**
-         * LibraryPermissionsPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** LibraryPermissionsPayload */
         LibraryPermissionsPayload: {
             /**
              * Access IDs
@@ -7144,10 +6790,7 @@ export interface components {
              */
             "modify_ids[]"?: string[] | string;
         };
-        /**
-         * LibrarySummary
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** LibrarySummary */
         LibrarySummary: {
             /**
              * Can User Add
@@ -7224,7 +6867,6 @@ export interface components {
         };
         /**
          * LibrarySummaryList
-         * @description Base model definition with common configuration used by all derived models.
          * @default []
          */
         LibrarySummaryList: components["schemas"]["LibrarySummary"][];
@@ -7338,10 +6980,7 @@ export interface components {
          * @enum {string}
          */
         MandatoryNotificationCategory: "broadcast";
-        /**
-         * MaterializeDatasetInstanceAPIRequest
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** MaterializeDatasetInstanceAPIRequest */
         MaterializeDatasetInstanceAPIRequest: {
             /**
              * Content
@@ -7358,10 +6997,7 @@ export interface components {
              */
             source: components["schemas"]["DatasetSourceType"];
         };
-        /**
-         * MessageNotificationContent
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** MessageNotificationContent */
         MessageNotificationContent: {
             /**
              * Category
@@ -7516,10 +7152,7 @@ export interface components {
          * @enum {string}
          */
         ModelStoreFormat: "tgz" | "tar" | "tar.gz" | "bag.zip" | "bag.tar" | "bag.tgz" | "rocrate.zip" | "bco.json";
-        /**
-         * NestedElement
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** NestedElement */
         NestedElement: {
             /** Md5 */
             MD5?: string;
@@ -7580,10 +7213,7 @@ export interface components {
              */
             to_posix_lines?: boolean;
         };
-        /**
-         * NewSharedItemNotificationContent
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** NewSharedItemNotificationContent */
         NewSharedItemNotificationContent: {
             /**
              * Category
@@ -7737,10 +7367,7 @@ export interface components {
              */
             recipients: components["schemas"]["NotificationRecipients"];
         };
-        /**
-         * NotificationCreatedResponse
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** NotificationCreatedResponse */
         NotificationCreatedResponse: {
             /**
              * Notification
@@ -7865,10 +7492,7 @@ export interface components {
          * @enum {string}
          */
         NotificationVariant: "info" | "warning" | "urgent";
-        /**
-         * NotificationsBatchRequest
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** NotificationsBatchRequest */
         NotificationsBatchRequest: {
             /**
              * Notification IDs
@@ -7887,10 +7511,7 @@ export interface components {
              */
             updated_count: number;
         };
-        /**
-         * ObjectExportTaskResponse
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ObjectExportTaskResponse */
         ObjectExportTaskResponse: {
             /**
              * Create Time
@@ -7949,10 +7570,7 @@ export interface components {
          * @enum {string}
          */
         PageContentFormat: "markdown" | "html";
-        /**
-         * PageDetails
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** PageDetails */
         PageDetails: {
             /**
              * Content
@@ -8049,10 +7667,7 @@ export interface components {
              */
             username: string;
         };
-        /**
-         * PageSummary
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** PageSummary */
         PageSummary: {
             /**
              * Create Time
@@ -8129,14 +7744,10 @@ export interface components {
         };
         /**
          * PageSummaryList
-         * @description Base model definition with common configuration used by all derived models.
          * @default []
          */
         PageSummaryList: components["schemas"]["PageSummary"][];
-        /**
-         * PastedDataElement
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** PastedDataElement */
         PastedDataElement: {
             /** Md5 */
             MD5?: string;
@@ -8194,10 +7805,7 @@ export interface components {
              */
             to_posix_lines?: boolean;
         };
-        /**
-         * PathDataElement
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** PathDataElement */
         PathDataElement: {
             /** Md5 */
             MD5?: string;
@@ -8267,10 +7875,7 @@ export interface components {
          * @enum {string}
          */
         PluginKind: "rfs" | "drs" | "rdm" | "stock";
-        /**
-         * PrepareStoreDownloadPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** PrepareStoreDownloadPayload */
         PrepareStoreDownloadPayload: {
             /**
              * Bco Merge History Metadata
@@ -8446,7 +8051,6 @@ export interface components {
         };
         /**
          * QuotaSummaryList
-         * @description Base model definition with common configuration used by all derived models.
          * @default []
          */
         QuotaSummaryList: components["schemas"]["QuotaSummary"][];
@@ -8459,10 +8063,7 @@ export interface components {
             /** Reloaded */
             reloaded: string[];
         };
-        /**
-         * RemoteDirectory
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** RemoteDirectory */
         RemoteDirectory: {
             /**
              * Class
@@ -8485,10 +8086,7 @@ export interface components {
              */
             uri: string;
         };
-        /**
-         * RemoteFile
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** RemoteFile */
         RemoteFile: {
             /**
              * Class
@@ -8533,10 +8131,7 @@ export interface components {
          * @enum {string}
          */
         RemoteFilesFormat: "flat" | "jstree" | "uri";
-        /**
-         * RemoteUserCreationPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** RemoteUserCreationPayload */
         RemoteUserCreationPayload: {
             /**
              * Email
@@ -8544,10 +8139,7 @@ export interface components {
              */
             remote_user_email: string;
         };
-        /**
-         * ReportJobErrorPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ReportJobErrorPayload */
         ReportJobErrorPayload: {
             /**
              * History Dataset Association ID
@@ -8586,10 +8178,7 @@ export interface components {
          * @enum {string}
          */
         Requirement: "logged_in" | "new_history" | "admin";
-        /**
-         * RoleDefinitionModel
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** RoleDefinitionModel */
         RoleDefinitionModel: {
             /**
              * Description
@@ -8612,15 +8201,9 @@ export interface components {
              */
             user_ids?: string[];
         };
-        /**
-         * RoleListResponse
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** RoleListResponse */
         RoleListResponse: components["schemas"]["RoleModelResponse"][];
-        /**
-         * RoleModelResponse
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** RoleModelResponse */
         RoleModelResponse: {
             /**
              * Description
@@ -8657,10 +8240,7 @@ export interface components {
              */
             url: string;
         };
-        /**
-         * SearchJobsPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** SearchJobsPayload */
         SearchJobsPayload: {
             /**
              * Inputs
@@ -8678,10 +8258,7 @@ export interface components {
              */
             tool_id: string;
         };
-        /**
-         * ServerDirElement
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ServerDirElement */
         ServerDirElement: {
             /** Md5 */
             MD5?: string;
@@ -8826,10 +8403,7 @@ export interface components {
              */
             version: string;
         };
-        /**
-         * SetSlugPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** SetSlugPayload */
         SetSlugPayload: {
             /**
              * New Slug
@@ -8837,10 +8411,7 @@ export interface components {
              */
             new_slug: string;
         };
-        /**
-         * ShareWithExtra
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ShareWithExtra */
         ShareWithExtra: {
             /**
              * Can Share
@@ -8849,10 +8420,7 @@ export interface components {
              */
             can_share?: boolean;
         };
-        /**
-         * ShareWithPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ShareWithPayload */
         ShareWithPayload: {
             /**
              * Share Option
@@ -8869,10 +8437,7 @@ export interface components {
              */
             user_ids: (string | string)[];
         };
-        /**
-         * ShareWithStatus
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ShareWithStatus */
         ShareWithStatus: {
             /**
              * Encoded Email
@@ -8934,10 +8499,7 @@ export interface components {
          * @enum {string}
          */
         SharingOptions: "make_public" | "make_accessible_to_shared" | "no_changes";
-        /**
-         * SharingStatus
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** SharingStatus */
         SharingStatus: {
             /**
              * Encoded Email
@@ -8982,10 +8544,7 @@ export interface components {
              */
             users_shared_with?: components["schemas"]["UserEmail"][];
         };
-        /**
-         * ShortTermStoreExportPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** ShortTermStoreExportPayload */
         ShortTermStoreExportPayload: {
             /** Duration */
             duration?: number | number;
@@ -9024,10 +8583,7 @@ export interface components {
          * @enum {string}
          */
         Src: "url" | "pasted" | "files" | "path" | "composite" | "ftp_import" | "server_dir";
-        /**
-         * StorageItemCleanupError
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** StorageItemCleanupError */
         StorageItemCleanupError: {
             /** Error */
             error: string;
@@ -9037,10 +8593,7 @@ export interface components {
              */
             item_id: string;
         };
-        /**
-         * StorageItemsCleanupResult
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** StorageItemsCleanupResult */
         StorageItemsCleanupResult: {
             /** Errors */
             errors: components["schemas"]["StorageItemCleanupError"][];
@@ -9051,10 +8604,7 @@ export interface components {
             /** Total Item Count */
             total_item_count: number;
         };
-        /**
-         * StoreExportPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** StoreExportPayload */
         StoreExportPayload: {
             /**
              * Include deleted
@@ -9080,10 +8630,7 @@ export interface components {
              */
             model_store_format?: components["schemas"]["ModelStoreFormat"];
         };
-        /**
-         * StoredItem
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** StoredItem */
         StoredItem: {
             /**
              * Id
@@ -9109,10 +8656,7 @@ export interface components {
          * @enum {string}
          */
         StoredItemOrderBy: "name-asc" | "name-dsc" | "size-asc" | "size-dsc" | "update_time-asc" | "update_time-dsc";
-        /**
-         * SuitableConverter
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** SuitableConverter */
         SuitableConverter: {
             /**
              * Name
@@ -9150,10 +8694,7 @@ export interface components {
          * ]
          */
         TagCollection: string[];
-        /**
-         * TagOperationParams
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** TagOperationParams */
         TagOperationParams: {
             /** Tags */
             tags: string[];
@@ -9468,10 +9009,7 @@ export interface components {
              */
             visible?: boolean;
         };
-        /**
-         * UpdateLibraryFolderPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** UpdateLibraryFolderPayload */
         UpdateLibraryFolderPayload: {
             /**
              * Description
@@ -9484,10 +9022,7 @@ export interface components {
              */
             name?: string;
         };
-        /**
-         * UpdateLibraryPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** UpdateLibraryPayload */
         UpdateLibraryPayload: {
             /**
              * Description
@@ -9505,10 +9040,7 @@ export interface components {
              */
             synopsis?: string;
         };
-        /**
-         * UpdateQuotaParams
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** UpdateQuotaParams */
         UpdateQuotaParams: {
             /**
              * Amount
@@ -9576,10 +9108,7 @@ export interface components {
                 [key: string]: components["schemas"]["NotificationCategorySettings"] | undefined;
             };
         };
-        /**
-         * UrlDataElement
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** UrlDataElement */
         UrlDataElement: {
             /** Md5 */
             MD5?: string;
@@ -9637,10 +9166,7 @@ export interface components {
              */
             url: string;
         };
-        /**
-         * UserBeaconSetting
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** UserBeaconSetting */
         UserBeaconSetting: {
             /**
              * Enabled
@@ -9648,10 +9174,7 @@ export interface components {
              */
             enabled: boolean;
         };
-        /**
-         * UserCreationPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** UserCreationPayload */
         UserCreationPayload: {
             /**
              * Email
@@ -9669,10 +9192,7 @@ export interface components {
              */
             username: string;
         };
-        /**
-         * UserDeletionPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** UserDeletionPayload */
         UserDeletionPayload: {
             /**
              * Purge user
@@ -9680,10 +9200,7 @@ export interface components {
              */
             purge: boolean;
         };
-        /**
-         * UserEmail
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** UserEmail */
         UserEmail: {
             /**
              * Email
@@ -9877,10 +9394,7 @@ export interface components {
              */
             notification_ids: string[];
         };
-        /**
-         * UserQuota
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** UserQuota */
         UserQuota: {
             /**
              * Model class
@@ -9917,15 +9431,9 @@ export interface components {
             /** Error Type */
             type: string;
         };
-        /**
-         * Visualization
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** Visualization */
         Visualization: Record<string, never>;
-        /**
-         * VisualizationSummary
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** VisualizationSummary */
         VisualizationSummary: {
             /**
              * Annotation
@@ -9993,14 +9501,10 @@ export interface components {
         };
         /**
          * VisualizationSummaryList
-         * @description Base model definition with common configuration used by all derived models.
          * @default []
          */
         VisualizationSummaryList: components["schemas"]["VisualizationSummary"][];
-        /**
-         * WorkflowInvocationStateSummary
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** WorkflowInvocationStateSummary */
         WorkflowInvocationStateSummary: {
             /**
              * ID
@@ -10029,10 +9533,7 @@ export interface components {
                 [key: string]: number | undefined;
             };
         };
-        /**
-         * WriteInvocationStoreToPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** WriteInvocationStoreToPayload */
         WriteInvocationStoreToPayload: {
             /**
              * Bco Merge History Metadata
@@ -10095,10 +9596,7 @@ export interface components {
              */
             target_uri: string;
         };
-        /**
-         * WriteStoreToPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
+        /** WriteStoreToPayload */
         WriteStoreToPayload: {
             /**
              * Include deleted

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6374,7 +6374,10 @@ export interface components {
             outputs: {
                 [key: string]: components["schemas"]["JobOutput"][] | undefined;
             };
-            /** Parameters */
+            /**
+             * Parameters
+             * @description The parameters of the job in a nested format.
+             */
             parameters: components["schemas"]["JobParameter"][];
         };
         /**
@@ -6601,7 +6604,7 @@ export interface components {
              * Output label
              * @description The output label
              */
-            label: string;
+            label: Record<string, never>;
             /**
              * dataset
              * @description The associated dataset.
@@ -6619,18 +6622,45 @@ export interface components {
              */
             depth: number;
             /**
+             * notes
+             * @description Notes associated with the job parameter.
+             */
+            notes?: string;
+            /**
              * Text
              * @description Text associated with the job parameter.
              */
             text: string;
-            /** Value */
-            value: components["schemas"]["JobParameterValues"][];
+            /**
+             * Value
+             * @description The values of the job parameter
+             */
+            value:
+                | components["schemas"]["JobParameterValuesSimple"][]
+                | components["schemas"]["JobParameterValuesExtensive"]
+                | string;
         };
         /**
-         * JobParameterValues
+         * JobParameterValuesExtensive
          * @description Base model definition with common configuration used by all derived models.
          */
-        JobParameterValues: {
+        JobParameterValuesExtensive: {
+            /**
+             * Check Content
+             * @description Flag to check content
+             */
+            check_content: boolean;
+            /**
+             * Targets
+             * @description List of job value targets
+             */
+            targets: components["schemas"]["JobTarget"][];
+        };
+        /**
+         * JobParameterValuesSimple
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        JobParameterValuesSimple: {
             /**
              * HID
              * @description The index position of this item in the History.
@@ -6711,6 +6741,90 @@ export interface components {
             states?: {
                 [key: string]: number | undefined;
             };
+        };
+        /**
+         * JobTarget
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        JobTarget: {
+            /**
+             * Destination
+             * @description Destination details
+             */
+            destination: components["schemas"]["JobTargetDestination"];
+            /**
+             * Elements
+             * @description List of job target elements
+             */
+            elements: components["schemas"]["JobTargetElement"][];
+        };
+        /**
+         * JobTargetDestination
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        JobTargetDestination: {
+            /**
+             * Type
+             * @description Type of destination, either `hda` or `ldda` depending on the destination
+             */
+            type: string;
+        };
+        /**
+         * JobTargetElement
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        JobTargetElement: {
+            /**
+             * Auto Decompress
+             * @description Flag indicating if to auto decompress
+             */
+            auto_decompress: boolean;
+            /**
+             * Database Key
+             * @description Database key
+             */
+            dbkey: string;
+            /**
+             * Extension
+             * @description Extension
+             */
+            ext: string;
+            /**
+             * Hashes
+             * @description List of hashes
+             */
+            hashes: string[];
+            /**
+             * Name
+             * @description Name of the element
+             */
+            name: string;
+            /**
+             * Object ID
+             * @description Object ID
+             * @example 0123456789ABCDEF
+             */
+            object_id: string;
+            /**
+             * Paste Content
+             * @description Content to paste
+             */
+            paste_content: string;
+            /**
+             * Purge Source
+             * @description Flag indicating if to purge the source
+             */
+            purge_source: boolean;
+            /**
+             * Source
+             * @description Source
+             */
+            src: string;
+            /**
+             * To POSIX Lines
+             * @description Flag indicating if to convert to POSIX lines
+             */
+            to_posix_lines: boolean;
         };
         /**
          * LabelValuePair
@@ -11253,7 +11367,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["JobDisplayParametersSummary"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -197,11 +197,7 @@ export interface paths {
         head: operations["get_metadata_file_datasets_api_datasets__history_content_id__metadata_file_head"];
     };
     "/api/datasets/{id}/metrics": {
-        /**
-         * Return job metrics for specified job.
-         * @description :rtype:     list
-         * :returns:   list containing job metrics
-         */
+        /** Return job metrics for specified job. */
         get: operations["get_metrics_api_datasets__id__metrics_get"];
     };
     "/api/datasets/{id}/parameters_display": {
@@ -947,11 +943,7 @@ export interface paths {
         get: operations["get_inputs_api_jobs__id__inputs_get"];
     };
     "/api/jobs/{id}/metrics": {
-        /**
-         * Return job metrics for specified job.
-         * @description :rtype:     list
-         * :returns:   list containing job metrics
-         */
+        /** Return job metrics for specified job. */
         get: operations["get_metrics_api_jobs__id__metrics_get"];
     };
     "/api/jobs/{id}/outputs": {
@@ -962,17 +954,14 @@ export interface paths {
         /**
          * Resolve parameters as a list for nested display.
          * @description # TODO is this still true?
-         *     Resolve parameters as a list for nested display. More client logic
-         *     here than is ideal but it is hard to reason about tool parameter
-         *     types on the client relative to the server. Job accessibility checks
-         *     are slightly different than dataset checks, so both methods are
-         *     available.
+         * Resolve parameters as a list for nested display. More client logic
+         * here than is ideal but it is hard to reason about tool parameter
+         * types on the client relative to the server. Job accessibility checks
+         * are slightly different than dataset checks, so both methods are
+         * available.
          *
-         *     This API endpoint is unstable and tied heavily to Galaxy's JS client code,
-         *     this endpoint will change frequently.
-         *
-         * :rtype:     list
-         * :returns:   job parameters for for display
+         * This API endpoint is unstable and tied heavily to Galaxy's JS client code,
+         * this endpoint will change frequently.
          */
         get: operations["resolve_parameters_display_api_jobs__id__parameters_display_get"];
     };
@@ -4239,8 +4228,9 @@ export interface components {
             /**
              * Copied from Job-ID
              * @description ?
+             * @example 0123456789ABCDEF
              */
-            copied_from_job_id?: Record<string, never>;
+            copied_from_job_id?: string;
             /**
              * Create Time
              * Format: date-time
@@ -6355,17 +6345,37 @@ export interface components {
              * Handler
              * @description ?
              */
-            Handler: Record<string, never>;
+            Handler: string;
             /**
              * Runner
              * @description ?
              */
-            Runner: Record<string, never>;
+            Runner: string;
             /**
              * Runner Job ID
              * @description ?
              */
-            "Runner Job ID": Record<string, never>;
+            "Runner Job ID": string;
+        };
+        /**
+         * JobDisplayParametersSummary
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        JobDisplayParametersSummary: {
+            /**
+             * Has parameter errors
+             * @description The job has parameter errors
+             */
+            has_parameter_errors: boolean;
+            /**
+             * Outputs
+             * @description Dictionary mapping all the tool outputs (by name) with the corresponding dataset information in a nested format.
+             */
+            outputs: {
+                [key: string]: components["schemas"]["JobOutput"][] | undefined;
+            };
+            /** Parameters */
+            parameters: components["schemas"]["JobParameter"][];
         };
         /**
          * JobErrorSummary
@@ -6581,6 +6591,67 @@ export interface components {
              * @description The textual representation of the metric value.
              */
             value: string;
+        };
+        /**
+         * JobOutput
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        JobOutput: {
+            /**
+             * Output label
+             * @description The output label
+             */
+            label: string;
+            /**
+             * dataset
+             * @description The associated dataset.
+             */
+            value: components["schemas"]["EncodedDatasetSourceId"];
+        };
+        /**
+         * JobParameter
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        JobParameter: {
+            /**
+             * Depth
+             * @description The depth of the job parameter.
+             */
+            depth: number;
+            /**
+             * Text
+             * @description Text associated with the job parameter.
+             */
+            text: string;
+            /** Value */
+            value: components["schemas"]["JobParameterValues"][];
+        };
+        /**
+         * JobParameterValues
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        JobParameterValues: {
+            /**
+             * HID
+             * @description The index position of this item in the History.
+             */
+            hid: number;
+            /**
+             * ID
+             * @description The encoded ID of this entity.
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /**
+             * Name
+             * @description The name of the item.
+             */
+            name: string;
+            /**
+             * Source
+             * @description The source of this dataset, either `hda` or `ldda` depending of its origin.
+             */
+            src: components["schemas"]["DatasetSourceType"];
         };
         /**
          * JobSourceType
@@ -11118,11 +11189,7 @@ export interface operations {
         };
     };
     get_metrics_api_datasets__id__metrics_get: {
-        /**
-         * Return job metrics for specified job.
-         * @description :rtype:     list
-         * :returns:   list containing job metrics
-         */
+        /** Return job metrics for specified job. */
         parameters: {
             /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
             query?: {
@@ -15296,11 +15363,7 @@ export interface operations {
         };
     };
     get_metrics_api_jobs__id__metrics_get: {
-        /**
-         * Return job metrics for specified job.
-         * @description :rtype:     list
-         * :returns:   list containing job metrics
-         */
+        /** Return job metrics for specified job. */
         parameters: {
             /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
             query?: {
@@ -15361,17 +15424,14 @@ export interface operations {
         /**
          * Resolve parameters as a list for nested display.
          * @description # TODO is this still true?
-         *     Resolve parameters as a list for nested display. More client logic
-         *     here than is ideal but it is hard to reason about tool parameter
-         *     types on the client relative to the server. Job accessibility checks
-         *     are slightly different than dataset checks, so both methods are
-         *     available.
+         * Resolve parameters as a list for nested display. More client logic
+         * here than is ideal but it is hard to reason about tool parameter
+         * types on the client relative to the server. Job accessibility checks
+         * are slightly different than dataset checks, so both methods are
+         * available.
          *
-         *     This API endpoint is unstable and tied heavily to Galaxy's JS client code,
-         *     this endpoint will change frequently.
-         *
-         * :rtype:     list
-         * :returns:   job parameters for for display
+         * This API endpoint is unstable and tied heavily to Galaxy's JS client code,
+         * this endpoint will change frequently.
          */
         parameters: {
             /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
@@ -15391,7 +15451,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["JobDisplayParametersSummary"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6373,22 +6373,6 @@ export interface components {
          */
         ItemsFromSrc: "url" | "files" | "path" | "ftp_import" | "server_dir";
         /**
-         * JobAssociation
-         * @description Base model definition with common configuration used by all derived models.
-         */
-        JobAssociation: {
-            /**
-             * dataset
-             * @description Reference to the associated item.
-             */
-            dataset: components["schemas"]["EncodedDataItemSourceId"];
-            /**
-             * name
-             * @description Name of the job parameter.
-             */
-            name: string;
-        };
-        /**
          * JobDestinationParams
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -6586,6 +6570,22 @@ export interface components {
          */
         JobIndexViewEnum: "collection" | "admin_job_list";
         /**
+         * JobInputAssociation
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        JobInputAssociation: {
+            /**
+             * dataset
+             * @description Reference to the associated item.
+             */
+            dataset: components["schemas"]["EncodedDataItemSourceId"];
+            /**
+             * name
+             * @description Name of the job input parameter.
+             */
+            name: string;
+        };
+        /**
          * JobInputSummary
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -6662,6 +6662,22 @@ export interface components {
              * @description The associated dataset.
              */
             value: components["schemas"]["EncodedDataItemSourceId"];
+        };
+        /**
+         * JobOutputAssociation
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        JobOutputAssociation: {
+            /**
+             * dataset
+             * @description Reference to the associated item.
+             */
+            dataset: components["schemas"]["EncodedDataItemSourceId"];
+            /**
+             * name
+             * @description Name of the job output parameter.
+             */
+            name: string;
         };
         /**
          * JobParameter
@@ -15356,7 +15372,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["JobAssociation"][];
+                    "application/json": components["schemas"]["JobInputAssociation"][];
                 };
             };
             /** @description Validation Error */
@@ -15383,7 +15399,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["JobAssociation"][];
+                    "application/json": components["schemas"]["JobOutputAssociation"][];
                 };
             };
             /** @description Validation Error */
@@ -15410,7 +15426,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["JobAssociation"][];
+                    "application/json": components["schemas"]["JobOutputAssociation"][];
                 };
             };
             /** @description Validation Error */

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -880,6 +880,8 @@ def summarize_job_parameters(trans, job):
     Precondition: the caller has verified the job is accessible to the user
     represented by the trans parameter.
     """
+    # More client logic here than is ideal but it is hard to reason about
+    # tool parameter types on the client relative to the server.
 
     def inputs_recursive(input_params, param_values, depth=1, upgrade_messages=None):
         if upgrade_messages is None:

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -103,6 +103,14 @@ class SearchJobsPayload(Model):
         extra = Extra.allow  # This is used for items named file_ and __file_
 
 
+class DeleteJobPayload(Model):
+    message: Optional[str] = Field(
+        default=None,
+        title="Job message",
+        description="Stop message",
+    )
+
+
 class EncodedDatasetJobInfo(EncodedDatasetSourceId):
     uuid: UUID4 = UuidField
 

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -135,8 +135,10 @@ class DeleteJobPayload(Model):
         description="Stop message",
     )
 
+
 class SrcItem(Model):
     src: DataItemSourceType
+
 
 class EncodedHdcaSourceId(SrcItem):
     id: EncodedDatabaseIdField = EntityIdField
@@ -145,6 +147,7 @@ class EncodedHdcaSourceId(SrcItem):
         title="Source",
         description="The source of this dataset, which in the case of the model can only be `hdca`.",
     )
+
 
 class EncodedDatasetJobInfo(EncodedDataItemSourceId):
     uuid: Optional[UUID4] = Field(

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -105,8 +105,6 @@ class SearchJobsPayload(Model):
         title="Tool ID",
         description="The tool ID related to the job.",
     )
-    # TODO the inputs are actually a dict, but are passed as a JSON dump
-    # maybe change it?
     inputs: Dict[str, Any] = Field(
         default=Required,
         title="Inputs",

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -3,7 +3,7 @@ from typing import (
     Optional,
 )
 
-from pydantic import Extra
+from pydantic import Extra, Field, Required
 
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
@@ -13,31 +13,78 @@ from galaxy.schema.schema import (
 
 
 class JobInputSummary(Model):
-    has_empty_inputs: bool
-    has_duplicate_inputs: bool
+    has_empty_inputs: bool = Field(
+        default=Required,
+        title="Empty inputs",
+        description="Job has empty inputs.",
+    )
+    has_duplicate_inputs: bool = Field(
+        default=Required,
+        title="Duplicate inputs",
+        description="Job has duplicate inputs.",
+    )
 
 
 # TODO: Use Tuple again when `make update-client-api-schema` supports them
 class JobErrorSummary(Model):
     # messages: List[Union[Tuple[str, str], List[str]]]
-    messages: List[List[str]]
+    messages: List[List[str]] = Field(
+        default=Required,
+        title="Error messages",
+        description="The error messages for the specified job.",
+    )
 
 
 class JobAssociation(Model):
-    name: str
-    dataset: EncodedDatasetSourceId
+    name: str = Field(
+        default=Required,
+        title="name",
+        description="The name of the associated dataset.",
+    )
+    dataset: EncodedDatasetSourceId = Field(
+        default=Required,
+        title="dataset",
+        description="The associated dataset.",
+    )
 
 
 class ReportJobErrorPayload(Model):
-    dataset_id: DecodedDatabaseIdField
-    email: Optional[str] = None
-    message: Optional[str] = None
+    dataset_id: DecodedDatabaseIdField = Field(
+        default=Required,
+        title="Dataset ID",
+        description="The dataset ID related to the error.",
+    )
+    # TODO add description
+    email: Optional[str] = Field(
+        default=None,
+        title="Email",
+        description="",
+    )
+    message: Optional[str] = Field(
+        default=None,
+        title="Message",
+        description="The optional message sent with the error report.",
+    )
 
 
 class SearchJobsPayload(Model):
-    tool_id: str
-    inputs: str
-    state: str
+    tool_id: str = Field(
+        default=Required,
+        title="Tool ID",
+        description="The tool ID related to the job.",
+    )
+    # TODO the inputs are actually a dict, but are passed as a JSON string
+    # maybe change it?
+    inputs: str = Field(
+        default=Required,
+        title="Inputs",
+        description="The inputs of the job as a JSON string.",
+    )
+    state: str = Field(
+        default=Required,
+        title="State",
+        description="The state of the job.",
+    )
 
     class Config:
         extra = Extra.allow  # This is used for items named file_ and __file_

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -1,3 +1,4 @@
+import json
 from enum import Enum
 from typing import (
     Any,
@@ -11,6 +12,7 @@ from pydantic import (
     Field,
     Required,
     UUID4,
+    validator,
 )
 
 from galaxy.schema.fields import (
@@ -104,16 +106,22 @@ class SearchJobsPayload(Model):
     )
     # TODO the inputs are actually a dict, but are passed as a JSON dump
     # maybe change it?
-    inputs: str = Field(
+    inputs: Dict[str, Any] = Field(
         default=Required,
         title="Inputs",
-        description="The inputs of the job as a JSON dump.",
+        description="The inputs of the job.",
     )
     state: JobState = Field(
         default=Required,
         title="State",
         description="Current state of the job.",
     )
+
+    @validator("inputs", pre=True)
+    def decode_json(cls, v):
+        if isinstance(v, str):
+            return json.loads(v)
+        return v
 
     class Config:
         extra = Extra.allow  # This is used for items named file_ and __file_

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -1,6 +1,11 @@
-from galaxy.schema.schema import Model
+from galaxy.schema.schema import EncodedDatasetSourceId, Model
 
 
 class JobInputSummary(Model):
     has_empty_inputs: bool
     has_duplicate_inputs: bool
+
+
+class JobAssociation(Model):
+    name: str
+    dataset: EncodedDatasetSourceId

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -3,6 +3,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Union,
 )
 
 from pydantic import (
@@ -164,11 +165,11 @@ class JobDestinationParams(Model):
 
 
 class JobOutput(Model):
-    label: str = Field(default=Required, title="Output label", description="The output label")
+    label: Any = Field(default=Required, title="Output label", description="The output label")  # check if this is true
     value: EncodedDatasetSourceId = Field(default=Required, title="dataset", description="The associated dataset.")
 
 
-class JobParameterValues(Model):
+class JobParameterValuesSimple(Model):
     src: DatasetSourceType = Field(
         default=Required,
         title="Source",
@@ -187,6 +188,55 @@ class JobParameterValues(Model):
     )
 
 
+class JobTargetElement(Model):  # TODO rename?
+    name: str = Field(default=Required, title="Name", description="Name of the element")  # TODO check correctness
+    dbkey: str = Field(default=Required, title="Database Key", description="Database key")  # TODO check correctness
+    ext: str = Field(default=Required, title="Extension", description="Extension")  # TODO check correctness
+    to_posix_lines: bool = Field(
+        default=Required, title="To POSIX Lines", description="Flag indicating if to convert to POSIX lines"
+    )  # TODO check correctness
+    auto_decompress: bool = Field(
+        default=Required, title="Auto Decompress", description="Flag indicating if to auto decompress"
+    )  # TODO check correctness
+    src: str = Field(default=Required, title="Source", description="Source")  # TODO check correctness
+    paste_content: str = Field(
+        default=Required, title="Paste Content", description="Content to paste"
+    )  # TODO check correctness
+    hashes: List[str] = Field(default=Required, title="Hashes", description="List of hashes")  # TODO check correctness
+    purge_source: bool = Field(
+        default=Required, title="Purge Source", description="Flag indicating if to purge the source"
+    )  # TODO check correctness
+    object_id: EncodedDatabaseIdField = Field(
+        default=Required, title="Object ID", description="Object ID"
+    )  # TODO check correctness
+
+
+class JobTargetDestination(Model):
+    type: str = Field(
+        default=Required,
+        title="Type",
+        description="Type of destination, either `hda` or `ldda` depending on the destination",
+    )  # TODO check correctness
+
+
+class JobTarget(Model):  # TODO rename?
+    destination: JobTargetDestination = Field(
+        default=Required, title="Destination", description="Destination details"
+    )  # TODO check correctness
+    elements: List[JobTargetElement] = Field(
+        default=Required, title="Elements", description="List of job target elements"
+    )  # TODO check correctness
+
+
+class JobParameterValuesExtensive(Model):  # TODO rename?
+    targets: List[JobTarget] = Field(
+        default=Required, title="Targets", description="List of job value targets"
+    )  # TODO check correctness
+    check_content: bool = Field(
+        default=Required, title="Check Content", description="Flag to check content"
+    )  # TODO check correctness
+
+
 class JobParameter(Model):
     text: str = Field(
         default=Required,
@@ -198,11 +248,16 @@ class JobParameter(Model):
         title="Depth",
         description="The depth of the job parameter.",
     )
-    value: List[JobParameterValues]
+    value: Union[List[JobParameterValuesSimple], JobParameterValuesExtensive, str] = Field(
+        default=Required, title="Value", description="The values of the job parameter"
+    )
+    notes: Optional[str] = Field(default=None, title="notes", description="Notes associated with the job parameter.")
 
 
 class JobDisplayParametersSummary(Model):
-    parameters: List[JobParameter]
+    parameters: List[JobParameter] = Field(
+        default=Required, title="Parameters", description="The parameters of the job in a nested format."
+    )
     has_parameter_errors: bool = Field(
         default=Required, title="Has parameter errors", description="The job has parameter errors"
     )
@@ -211,29 +266,3 @@ class JobDisplayParametersSummary(Model):
         title="Outputs",
         description="Dictionary mapping all the tool outputs (by name) with the corresponding dataset information in a nested format.",
     )
-
-
-# class ParameterValueModel(Model):
-#     src: str
-#     id: str
-#     hid: int
-#     name: str
-
-
-# class ParametersModel(Model):
-#     text: str
-#     depth: int
-#     value: List[Optional[ParameterValueModel]]
-
-
-# class OutputsModel(Model):
-#     label: Optional[str]
-#     value: EncodedDatasetSourceId
-
-
-# class MyPydanticModel(Model):
-#     parameters: List[ParametersModel]
-#     has_parameter_errors: bool
-#     outputs: dict[str, List[OutputsModel]]
-
-# = Field(default="",title="",description="")

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -17,6 +17,7 @@ from galaxy.schema.fields import (
     EncodedDatabaseIdField,
 )
 from galaxy.schema.schema import (
+    DatasetSourceType,
     EncodedDatasetSourceId,
     EntityIdField,
     JobSummary,
@@ -149,12 +150,90 @@ class EncodedJobDetails(JobSummary, EncodedJobIDs):
         description="Dictionary mapping all the tool outputs (by name) with the corresponding dataset information.",
     )
     # TODO add description, check type and add proper default
-    copied_from_job_id: Any = Field(default=None, title="Copied from Job-ID", description="?")
+    copied_from_job_id: Optional[EncodedDatabaseIdField] = Field(
+        default=None, title="Copied from Job-ID", description="?"
+    )
     output_collections: Any = Field(default={}, title="Output collections", description="?")
 
 
 class JobDestinationParams(Model):
     # TODO add description, check type and add proper default
-    runner: Any = Field(default=Required, title="Runner", description="?", alias="Runner")
-    runner_job_id: Any = Field(default=Required, title="Runner Job ID", description="?", alias="Runner Job ID")
-    handler: Any = Field(default=Required, title="Handler", description="?", alias="Handler")
+    runner: str = Field(default=Required, title="Runner", description="?", alias="Runner")
+    runner_job_id: str = Field(default=Required, title="Runner Job ID", description="?", alias="Runner Job ID")
+    handler: str = Field(default=Required, title="Handler", description="?", alias="Handler")
+
+
+class JobOutput(Model):
+    label: str = Field(default=Required, title="Output label", description="The output label")
+    value: EncodedDatasetSourceId = Field(default=Required, title="dataset", description="The associated dataset.")
+
+
+class JobParameterValues(Model):
+    src: DatasetSourceType = Field(
+        default=Required,
+        title="Source",
+        description="The source of this dataset, either `hda` or `ldda` depending of its origin.",
+    )
+    id: EncodedDatabaseIdField = EntityIdField
+    name: str = Field(
+        default=Required,
+        title="Name",
+        description="The name of the item.",
+    )
+    hid: int = Field(
+        default=Required,
+        title="HID",
+        description="The index position of this item in the History.",
+    )
+
+
+class JobParameter(Model):
+    text: str = Field(
+        default=Required,
+        title="Text",
+        description="Text associated with the job parameter.",
+    )
+    depth: int = Field(
+        default=Required,
+        title="Depth",
+        description="The depth of the job parameter.",
+    )
+    value: List[JobParameterValues]
+
+
+class JobDisplayParametersSummary(Model):
+    parameters: List[JobParameter]
+    has_parameter_errors: bool = Field(
+        default=Required, title="Has parameter errors", description="The job has parameter errors"
+    )
+    outputs: Dict[str, List[JobOutput]] = Field(
+        default=Required,
+        title="Outputs",
+        description="Dictionary mapping all the tool outputs (by name) with the corresponding dataset information in a nested format.",
+    )
+
+
+# class ParameterValueModel(Model):
+#     src: str
+#     id: str
+#     hid: int
+#     name: str
+
+
+# class ParametersModel(Model):
+#     text: str
+#     depth: int
+#     value: List[Optional[ParameterValueModel]]
+
+
+# class OutputsModel(Model):
+#     label: Optional[str]
+#     value: EncodedDatasetSourceId
+
+
+# class MyPydanticModel(Model):
+#     parameters: List[ParametersModel]
+#     has_parameter_errors: bool
+#     outputs: dict[str, List[OutputsModel]]
+
+# = Field(default="",title="",description="")

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -156,16 +156,7 @@ class EncodedDatasetJobInfo(EncodedDataItemSourceId):
     )
 
 
-class EncodedJobIDs(Model):
-    id: EncodedDatabaseIdField = EntityIdField
-    history_id: Optional[EncodedDatabaseIdField] = Field(
-        None,
-        title="History ID",
-        description="The encoded ID of the history associated with this item.",
-    )
-
-
-class EncodedJobDetails(JobSummary, EncodedJobIDs):
+class EncodedJobDetails(JobSummary):
     command_version: str = Field(
         ...,
         title="Command Version",

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -3,6 +3,8 @@ from typing import (
     Optional,
 )
 
+from pydantic import Extra
+
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     EncodedDatasetSourceId,
@@ -30,3 +32,12 @@ class ReportJobErrorPayload(Model):
     dataset_id: DecodedDatabaseIdField
     email: Optional[str] = None
     message: Optional[str] = None
+
+
+class SearchJobsPayload(Model):
+    tool_id: str
+    inputs: str
+    state: str
+
+    class Config:
+        extra = Extra.allow  # This is used for items named file_ and __file_

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -1,4 +1,7 @@
-from galaxy.schema.schema import EncodedDatasetSourceId, Model
+from galaxy.schema.schema import (
+    EncodedDatasetSourceId,
+    Model,
+)
 
 
 class JobInputSummary(Model):

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -62,6 +62,22 @@ class JobAssociation(Model):
     )
 
 
+class JobInputAssociation(JobAssociation):
+    name: str = Field(
+        default=Required,
+        title="name",
+        description="Name of the job input parameter.",
+    )
+
+
+class JobOutputAssociation(JobAssociation):
+    name: str = Field(
+        default=Required,
+        title="name",
+        description="Name of the job output parameter.",
+    )
+
+
 class ReportJobErrorPayload(Model):
     dataset_id: DecodedDatabaseIdField = Field(
         default=Required,

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import (
     Any,
     Dict,
@@ -110,12 +111,24 @@ class DeleteJobPayload(Model):
     )
 
 
+class EncodedHdcaSourceId(Model):
+    class Hdca(str, Enum):
+        hdca = "hdca"
+
+    id: EncodedDatabaseIdField = EntityIdField
+    src: Hdca = Field(
+        default=Required,
+        title="Source",
+        description="The source of this dataset, which in the case of the model can only be `hdca`.",
+    )
+
+
 class EncodedDatasetJobInfo(EncodedDataItemSourceId):
     uuid: Optional[UUID4] = Field(
         default=None,
         deprecated=True,
         title="UUID",
-        description="Universal unique identifier for this dataset. In this context the uuid is optional and marked as deprecated.",
+        description="Universal unique identifier for this dataset.",
     )
 
 
@@ -156,7 +169,7 @@ class EncodedJobDetails(JobSummary, EncodedJobIDs):
     copied_from_job_id: Optional[EncodedDatabaseIdField] = Field(
         default=None, title="Copied from Job-ID", description="Reference to cached job if job execution was cached."
     )
-    output_collections: Any = Field(default=None, title="Output collections", description="?")
+    output_collections: Dict[str, EncodedHdcaSourceId] = Field(default={}, title="Output collections", description="?")
 
 
 class JobDestinationParams(Model):
@@ -173,7 +186,7 @@ class JobDestinationParams(Model):
 
 class JobOutput(Model):
     label: Any = Field(default=Required, title="Output label", description="The output label")  # check if this is true
-    value: EncodedDataItemSourceId = Field(default=Required, title="dataset", description="The associated dataset.")
+    value: EncodedDataItemSourceId = Field(default=Required, title="Dataset", description="The associated dataset.")
 
 
 class JobParameter(Model):
@@ -188,7 +201,7 @@ class JobParameter(Model):
         description="The depth of the job parameter.",
     )
     value: Any = Field(default=Required, title="Value", description="The values of the job parameter")
-    notes: Optional[str] = Field(default=None, title="notes", description="Notes associated with the job parameter.")
+    notes: Optional[str] = Field(default=None, title="Notes", description="Notes associated with the job parameter.")
 
 
 class JobDisplayParametersSummary(Model):

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -154,6 +154,7 @@ class EncodedJobDetails(JobSummary, EncodedJobIDs):
 
 
 class JobDestinationParams(Model):
+    # TODO add description, check type and add proper default
     runner: Any = Field(default=Required, title="Runner", description="?", alias="Runner")
     runner_job_id: Any = Field(default=Required, title="Runner Job ID", description="?", alias="Runner Job ID")
     handler: Any = Field(default=Required, title="Handler", description="?", alias="Handler")

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -151,3 +151,9 @@ class EncodedJobDetails(JobSummary, EncodedJobIDs):
     # TODO add description, check type and add proper default
     copied_from_job_id: Any = Field(default=None, title="Copied from Job-ID", description="?")
     output_collections: Any = Field(default={}, title="Output collections", description="?")
+
+
+class JobDestinationParams(Model):
+    runner: Any = Field(default=Required, title="Runner", description="?", alias="Runner")
+    runner_job_id: Any = Field(default=Required, title="Runner Job ID", description="?", alias="Runner Job ID")
+    handler: Any = Field(default=Required, title="Handler", description="?", alias="Handler")

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -103,6 +103,10 @@ class SearchJobsPayload(Model):
         extra = Extra.allow  # This is used for items named file_ and __file_
 
 
+class EncodedDatasetJobInfo(EncodedDatasetSourceId):
+    uuid: UUID4 = UuidField
+
+
 class EncodedJobIDs(Model):
     id: EncodedDatabaseIdField = EntityIdField
     history_id: Optional[EncodedDatabaseIdField] = Field(
@@ -112,11 +116,7 @@ class EncodedJobIDs(Model):
     )
 
 
-class EncodedDatasetJobInfo(EncodedDatasetSourceId):
-    uuid: UUID4 = UuidField
-
-
-class EncodedJobDetails(JobSummary, EncodedDatasetSourceId):
+class EncodedJobDetails(JobSummary, EncodedJobIDs):
     command_version: str = Field(
         ...,
         title="Command Version",

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -165,15 +165,13 @@ class EncodedJobDetails(JobSummary, EncodedJobIDs):
         title="Outputs",
         description="Dictionary mapping all the tool outputs (by name) to the corresponding data references.",
     )
-    # TODO add description, check type and add proper default
     copied_from_job_id: Optional[EncodedDatabaseIdField] = Field(
         default=None, title="Copied from Job-ID", description="Reference to cached job if job execution was cached."
     )
-    output_collections: Dict[str, EncodedHdcaSourceId] = Field(default={}, title="Output collections", description="?")
+    output_collections: Dict[str, EncodedHdcaSourceId] = Field(default={}, title="Output collections", description="")
 
 
 class JobDestinationParams(Model):
-    # TODO add description, check type and add proper default
     runner: str = Field(default=Required, title="Runner", description="Job runner class", alias="Runner")
     runner_job_id: str = Field(
         default=Required,
@@ -181,7 +179,9 @@ class JobDestinationParams(Model):
         description="ID assigned to submitted job by external job running system",
         alias="Runner Job ID",
     )
-    handler: str = Field(default=Required, title="Handler", description="?", alias="Handler")
+    handler: str = Field(
+        default=Required, title="Handler", description="Name of the process that handled the job.", alias="Handler"
+    )
 
 
 class JobOutput(Model):

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -1,3 +1,9 @@
+from typing import (
+    List,
+    Optional,
+)
+
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     EncodedDatasetSourceId,
     Model,
@@ -9,6 +15,18 @@ class JobInputSummary(Model):
     has_duplicate_inputs: bool
 
 
+# TODO: Use Tuple again when `make update-client-api-schema` supports them
+class JobErrorSummary(Model):
+    # messages: List[Union[Tuple[str, str], List[str]]]
+    messages: List[List[str]]
+
+
 class JobAssociation(Model):
     name: str
     dataset: EncodedDatasetSourceId
+
+
+class ReportJobErrorPayload(Model):
+    dataset_id: DecodedDatabaseIdField
+    email: Optional[str] = None
+    message: Optional[str] = None

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -1,0 +1,6 @@
+from galaxy.schema.schema import Model
+
+
+class JobInputSummary(Model):
+    has_empty_inputs: bool
+    has_duplicate_inputs: bool

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -54,26 +54,25 @@ class JobAssociation(Model):
     name: str = Field(
         default=Required,
         title="name",
-        description="The name of the associated dataset.",
+        description="Name of the job parameter.",
     )
     dataset: EncodedDatasetSourceId = Field(
         default=Required,
         title="dataset",
-        description="The associated dataset.",
+        description="Reference to the associated item.",
     )
 
 
 class ReportJobErrorPayload(Model):
     dataset_id: DecodedDatabaseIdField = Field(
         default=Required,
-        title="Dataset ID",
-        description="The dataset ID related to the error.",
+        title="History Dataset Association ID",
+        description="The History Dataset Association ID related to the error.",
     )
-    # TODO add description
     email: Optional[str] = Field(
         default=None,
         title="Email",
-        description="",
+        description="Email address for communication with the user. Only required for anonymous users.",
     )
     message: Optional[str] = Field(
         default=None,
@@ -143,24 +142,29 @@ class EncodedJobDetails(JobSummary, EncodedJobIDs):
     inputs: Dict[str, EncodedDatasetJobInfo] = Field(
         {},
         title="Inputs",
-        description="Dictionary mapping all the tool inputs (by name) with the corresponding dataset information.",
+        description="Dictionary mapping all the tool inputs (by name) to the corresponding data references.",
     )
     outputs: Dict[str, EncodedDatasetJobInfo] = Field(
         {},
         title="Outputs",
-        description="Dictionary mapping all the tool outputs (by name) with the corresponding dataset information.",
+        description="Dictionary mapping all the tool outputs (by name) to the corresponding data references.",
     )
     # TODO add description, check type and add proper default
     copied_from_job_id: Optional[EncodedDatabaseIdField] = Field(
-        default=None, title="Copied from Job-ID", description="?"
+        default=None, title="Copied from Job-ID", description="Reference to cached job if job execution was cached."
     )
     output_collections: Any = Field(default={}, title="Output collections", description="?")
 
 
 class JobDestinationParams(Model):
     # TODO add description, check type and add proper default
-    runner: str = Field(default=Required, title="Runner", description="?", alias="Runner")
-    runner_job_id: str = Field(default=Required, title="Runner Job ID", description="?", alias="Runner Job ID")
+    runner: str = Field(default=Required, title="Runner", description="Job runner class", alias="Runner")
+    runner_job_id: str = Field(
+        default=Required,
+        title="Runner Job ID",
+        description="ID assigned to submitted job by external job running system",
+        alias="Runner Job ID",
+    )
     handler: str = Field(default=Required, title="Handler", description="?", alias="Handler")
 
 

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -1,14 +1,27 @@
 from typing import (
+    Any,
+    Dict,
     List,
     Optional,
 )
 
-from pydantic import Extra, Field, Required
+from pydantic import (
+    Extra,
+    Field,
+    Required,
+    UUID4,
+)
 
-from galaxy.schema.fields import DecodedDatabaseIdField
+from galaxy.schema.fields import (
+    DecodedDatabaseIdField,
+    EncodedDatabaseIdField,
+)
 from galaxy.schema.schema import (
     EncodedDatasetSourceId,
+    EntityIdField,
+    JobSummary,
     Model,
+    UuidField,
 )
 
 
@@ -73,12 +86,12 @@ class SearchJobsPayload(Model):
         title="Tool ID",
         description="The tool ID related to the job.",
     )
-    # TODO the inputs are actually a dict, but are passed as a JSON string
+    # TODO the inputs are actually a dict, but are passed as a JSON dump
     # maybe change it?
     inputs: str = Field(
         default=Required,
         title="Inputs",
-        description="The inputs of the job as a JSON string.",
+        description="The inputs of the job as a JSON dump.",
     )
     state: str = Field(
         default=Required,
@@ -88,3 +101,45 @@ class SearchJobsPayload(Model):
 
     class Config:
         extra = Extra.allow  # This is used for items named file_ and __file_
+
+
+class EncodedJobIDs(Model):
+    id: EncodedDatabaseIdField = EntityIdField
+    history_id: Optional[EncodedDatabaseIdField] = Field(
+        None,
+        title="History ID",
+        description="The encoded ID of the history associated with this item.",
+    )
+
+
+class EncodedDatasetJobInfo(EncodedDatasetSourceId):
+    uuid: UUID4 = UuidField
+
+
+class EncodedJobDetails(JobSummary, EncodedDatasetSourceId):
+    command_version: str = Field(
+        ...,
+        title="Command Version",
+        description="Tool version indicated during job execution.",
+    )
+    params: Any = Field(
+        ...,
+        title="Parameters",
+        description=(
+            "Object containing all the parameters of the tool associated with this job. "
+            "The specific parameters depend on the tool itself."
+        ),
+    )
+    inputs: Dict[str, EncodedDatasetJobInfo] = Field(
+        {},
+        title="Inputs",
+        description="Dictionary mapping all the tool inputs (by name) with the corresponding dataset information.",
+    )
+    outputs: Dict[str, EncodedDatasetJobInfo] = Field(
+        {},
+        title="Outputs",
+        description="Dictionary mapping all the tool outputs (by name) with the corresponding dataset information.",
+    )
+    # TODO add description, check type and add proper default
+    copied_from_job_id: Any = Field(default=None, title="Copied from Job-ID", description="?")
+    output_collections: Any = Field(default={}, title="Output collections", description="?")

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -187,15 +187,15 @@ class EncodedJobDetails(JobSummary):
 
 
 class JobDestinationParams(Model):
-    runner: str = Field(default=Required, title="Runner", description="Job runner class", alias="Runner")
-    runner_job_id: str = Field(
-        default=Required,
+    runner: Optional[str] = Field(None, title="Runner", description="Job runner class", alias="Runner")
+    runner_job_id: Optional[str] = Field(
+        None,
         title="Runner Job ID",
         description="ID assigned to submitted job by external job running system",
         alias="Runner Job ID",
     )
-    handler: str = Field(
-        default=Required, title="Handler", description="Name of the process that handled the job.", alias="Handler"
+    handler: Optional[str] = Field(
+        None, title="Handler", description="Name of the process that handled the job.", alias="Handler"
     )
 
 

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -1,5 +1,4 @@
 import json
-from enum import Enum
 from typing import (
     Any,
     Dict,
@@ -14,12 +13,14 @@ from pydantic import (
     UUID4,
     validator,
 )
+from typing_extensions import Literal
 
 from galaxy.schema.fields import (
     DecodedDatabaseIdField,
     EncodedDatabaseIdField,
 )
 from galaxy.schema.schema import (
+    DataItemSourceType,
     EncodedDataItemSourceId,
     EntityIdField,
     JobState,
@@ -134,18 +135,16 @@ class DeleteJobPayload(Model):
         description="Stop message",
     )
 
+class SrcItem(Model):
+    src: DataItemSourceType
 
-class EncodedHdcaSourceId(Model):
-    class Hdca(str, Enum):
-        hdca = "hdca"
-
+class EncodedHdcaSourceId(SrcItem):
     id: EncodedDatabaseIdField = EntityIdField
-    src: Hdca = Field(
+    src: Literal[DataItemSourceType.hdca] = Field(
         default=Required,
         title="Source",
         description="The source of this dataset, which in the case of the model can only be `hdca`.",
     )
-
 
 class EncodedDatasetJobInfo(EncodedDataItemSourceId):
     uuid: Optional[UUID4] = Field(

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1820,18 +1820,21 @@ class JobIdResponse(Model):
     )
 
 
-class JobBaseModel(Model):
+class JobIDs(Model):
     id: DecodedDatabaseIdField = EntityIdField
+    history_id: Optional[DecodedDatabaseIdField] = Field(
+        None,
+        title="History ID",
+        description="The encoded ID of the history associated with this item.",
+    )
+
+
+class JobBaseModel(Model):
     model_class: JOB_MODEL_CLASS = ModelClassField(JOB_MODEL_CLASS)
     tool_id: str = Field(
         ...,
         title="Tool ID",
         description="Identifier of the tool that generated this job.",
-    )
-    history_id: Optional[DecodedDatabaseIdField] = Field(
-        None,
-        title="History ID",
-        description="The encoded ID of the history associated with this item.",
     )
     state: JobState = Field(
         ...,
@@ -1853,7 +1856,7 @@ class JobBaseModel(Model):
     )
 
 
-class JobImportHistoryResponse(JobBaseModel):
+class JobImportHistoryResponse(JobBaseModel, JobIDs):
     message: str = Field(
         ...,
         title="Message",
@@ -1929,7 +1932,7 @@ class DatasetJobInfo(DatasetSourceId):
     uuid: UUID4 = UuidField
 
 
-class JobDetails(JobSummary):
+class JobDetails(JobSummary, JobIDs):
     command_version: str = Field(
         ...,
         title="Command Version",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3631,3 +3631,8 @@ class DatasetSummary(Model):
     file_size: int
     total_size: int
     uuid: UUID4 = UuidField
+
+
+class JobInputSummary(Model):
+    has_empty_inputs: bool
+    has_duplicate_inputs: bool

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1941,7 +1941,7 @@ class EncodedDataItemSourceId(Model):
     src: DataItemSourceType = Field(
         ...,
         title="Source",
-        description="The source of this dataset, either `hda` or `ldda` depending of its origin.",
+        description="The source of this dataset, either `hda`, `ldda`, `hdca`, `dce` or `dc` depending of its origin.",
     )
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -475,6 +475,14 @@ class DatasetSourceType(str, Enum):
     ldda = "ldda"
 
 
+class DataItemSourceType(str, Enum):
+    hda = "hda"
+    ldda = "ldda"
+    hdca = "hdca"
+    dce = "dce"
+    dc = "dc"
+
+
 class ColletionSourceType(str, Enum):
     hda = "hda"
     ldda = "ldda"
@@ -1926,6 +1934,15 @@ class DatasetSourceId(DatasetSourceIdBase):
 
 class EncodedDatasetSourceId(DatasetSourceIdBase):
     id: EncodedDatabaseIdField = EntityIdField
+
+
+class EncodedDataItemSourceId(Model):
+    id: EncodedDatabaseIdField = EntityIdField
+    src: DataItemSourceType = Field(
+        ...,
+        title="Source",
+        description="The source of this dataset, either `hda` or `ldda` depending of its origin.",
+    )
 
 
 class DatasetJobInfo(DatasetSourceId):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3631,8 +3631,3 @@ class DatasetSummary(Model):
     file_size: int
     total_size: int
     uuid: UUID4 = UuidField
-
-
-class JobInputSummary(Model):
-    has_empty_inputs: bool
-    has_duplicate_inputs: bool

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1828,16 +1828,13 @@ class JobIdResponse(Model):
     )
 
 
-class JobIDs(Model):
-    id: DecodedDatabaseIdField = EntityIdField
-    history_id: Optional[DecodedDatabaseIdField] = Field(
+class JobBaseModel(Model):
+    id: EncodedDatabaseIdField = EntityIdField
+    history_id: Optional[EncodedDatabaseIdField] = Field(
         None,
         title="History ID",
         description="The encoded ID of the history associated with this item.",
     )
-
-
-class JobBaseModel(Model):
     model_class: JOB_MODEL_CLASS = ModelClassField(JOB_MODEL_CLASS)
     tool_id: str = Field(
         ...,
@@ -1864,7 +1861,7 @@ class JobBaseModel(Model):
     )
 
 
-class JobImportHistoryResponse(JobBaseModel, JobIDs):
+class JobImportHistoryResponse(JobBaseModel):
     message: str = Field(
         ...,
         title="Message",
@@ -1949,7 +1946,7 @@ class DatasetJobInfo(DatasetSourceId):
     uuid: UUID4 = UuidField
 
 
-class JobDetails(JobSummary, JobIDs):
+class JobDetails(JobSummary):
     command_version: str = Field(
         ...,
         title="Command Version",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -257,8 +257,6 @@ FlexibleUserIdType = Union[DecodedDatabaseIdField, Literal["current"]]
 
 
 class Model(BaseModel):
-    """Base model definition with common configuration used by all derived models."""
-
     class Config:
         use_enum_values = True  # when using .dict()
         allow_population_by_field_name = True

--- a/lib/galaxy/security/idencoding.py
+++ b/lib/galaxy/security/idencoding.py
@@ -35,9 +35,11 @@ class IdEncodingHelper:
         per_kind_id_secret_base = config.get("per_kind_id_secret_base", self.id_secret)
         self.id_ciphers_for_kind = _cipher_cache(per_kind_id_secret_base)
 
-    def encode_id(self, obj_id, kind=None):
+    def encode_id(self, obj_id, kind=None, strict_integer=False):
         if obj_id is None:
             raise galaxy.exceptions.MalformedId("Attempted to encode None id")
+        if strict_integer and not isinstance(obj_id, int):
+            raise galaxy.exceptions.MalformedId("Attempted to encode id that is not an integer")
         id_cipher = self.__id_cipher(kind)
         # Convert to bytes
         s = smart_str(obj_id)

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -32,7 +32,6 @@ from galaxy.managers.context import (
     ProvidesUserContext,
 )
 from galaxy.managers.jobs import (
-    JobLock,
     JobManager,
     JobSearch,
     summarize_destination_params,
@@ -171,6 +170,7 @@ SearchQueryParam: Optional[str] = search_query_param(
 @router.cbv
 class FastAPIJobs:
     service: JobsService = depends(JobsService)
+    manager: JobManager = depends(JobManager)
 
     @router.get("/api/jobs/{id}")
     def show(
@@ -547,23 +547,3 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
         )
 
         return {"messages": messages}
-
-    @require_admin
-    @expose_api
-    def show_job_lock(self, trans: ProvidesUserContext, **kwd):
-        """
-        * GET /api/job_lock
-            return boolean indicating if job lock active.
-        """
-        return self.job_manager.job_lock()
-
-    @require_admin
-    @expose_api
-    def update_job_lock(self, trans: ProvidesUserContext, payload, **kwd):
-        """
-        * PUT /api/job_lock
-            return boolean indicating if job lock active.
-        """
-        active = payload.get("active")
-        job_lock = JobLock(active=active)
-        return self.job_manager.update_job_lock(job_lock)

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -27,11 +27,7 @@ from fastapi import (
 from pydantic import Required
 from typing_extensions import Annotated
 
-from galaxy import (
-    exceptions,
-    model,
-)
-from galaxy.managers import hdas
+from galaxy import exceptions
 from galaxy.managers.context import (
     ProvidesHistoryContext,
     ProvidesUserContext,
@@ -58,6 +54,7 @@ from galaxy.schema.jobs import (
 from galaxy.schema.schema import (
     DatasetSourceType,
     JobIndexSortByEnum,
+    JobMetric,
 )
 from galaxy.schema.types import OffsetNaiveDatetime
 from galaxy.web import (
@@ -422,13 +419,13 @@ class FastAPIJobs:
         id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
         hda_ldda: Annotated[DatasetSourceType, HdaLddaQueryParam] = DatasetSourceType.hda,
         trans: ProvidesUserContext = DependsOnTrans,
-    ):
+    ) -> List[Optional[JobMetric]]:
         """
         :rtype:     list
         :returns:   list containing job metrics
         """
         job = self.service.get_job(trans, job_id=id, hda_ldda=hda_ldda)
-        return summarize_job_metrics(trans, job)
+        return [JobMetric(**metric) for metric in summarize_job_metrics(trans, job)]
 
     # TODO add pydantic model for return value
     @router.get(
@@ -441,13 +438,13 @@ class FastAPIJobs:
         id: Annotated[DecodedDatabaseIdField, DatasetIdPathParam],
         hda_ldda: Annotated[DatasetSourceType, HdaLddaQueryParam] = DatasetSourceType.hda,
         trans: ProvidesUserContext = DependsOnTrans,
-    ):
+    ) -> List[Optional[JobMetric]]:
         """
         :rtype:     list
         :returns:   list containing job metrics
         """
         job = self.service.get_job(trans, dataset_id=id, hda_ldda=hda_ldda)
-        return summarize_job_metrics(trans, job)
+        return [JobMetric(**metric) for metric in summarize_job_metrics(trans, job)]
 
     @router.get(
         "/api/jobs/{job_id}/destination_params",

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -180,22 +180,6 @@ class FastAPIJobs:
     service: JobsService = depends(JobsService)
     manager: JobManager = depends(JobManager)
 
-    @router.get("/api/jobs/{id}")
-    def show(
-        self,
-        id: DecodedDatabaseIdField,
-        trans: ProvidesUserContext = DependsOnTrans,
-        full: Optional[bool] = False,
-    ) -> Dict[str, Any]:
-        """
-        Return dictionary containing description of job data
-
-        Parameters
-        - id: ID of job to return
-        - full: Return extra information ?
-        """
-        return self.service.show(trans, id, bool(full))
-
     @router.get("/api/jobs")
     def index(
         self,
@@ -283,6 +267,22 @@ class FastAPIJobs:
         else:
             exceptions.RequestParameterInvalidException(f"Job with id '{job.tool_id}' is not paused")
         return self.service.dictify_associations(trans, job.output_datasets, job.output_library_datasets)
+
+    @router.get("/api/jobs/{id}")
+    def show(
+        self,
+        id: DecodedDatabaseIdField,
+        trans: ProvidesUserContext = DependsOnTrans,
+        full: Optional[bool] = False,
+    ) -> Dict[str, Any]:
+        """
+        Return dictionary containing description of job data
+
+        Parameters
+        - id: ID of job to return
+        - full: Return extra information ?
+        """
+        return self.service.show(trans, id, bool(full))
 
 
 class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -576,22 +576,6 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
             raise exceptions.ConfigDoesNotAllowException(f"Tool '{job.tool_id}' cannot be rerun.")
         return tool.to_json(trans, {}, job=job)
 
-    def __dictify_associations(self, trans, *association_lists) -> List[dict]:
-        rval: List[dict] = []
-        for association_list in association_lists:
-            rval.extend(self.__dictify_association(trans, a) for a in association_list)
-        return rval
-
-    def __dictify_association(self, trans, job_dataset_association) -> dict:
-        dataset_dict = None
-        dataset = job_dataset_association.dataset
-        if dataset:
-            if isinstance(dataset, model.HistoryDatasetAssociation):
-                dataset_dict = dict(src="hda", id=trans.security.encode_id(dataset.id))
-            else:
-                dataset_dict = dict(src="ldda", id=trans.security.encode_id(dataset.id))
-        return dict(name=job_dataset_association.name, dataset=dataset_dict)
-
     def __get_job(self, trans, job_id=None, dataset_id=None, **kwd):
         if job_id is not None:
             decoded_job_id = self.decode_id(job_id)

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -181,8 +181,14 @@ SearchQueryParam: Optional[str] = search_query_param(
 )
 
 FullShowQueryParam: Optional[bool] = Query(title="Full show", description="Show extra information.")
+DeprecatedHdaLddaQueryParam: DatasetSourceType = Query(
+    deprecated=True,
+    title="HDA or LDDA",
+    description="Whether this dataset belongs to a history (HDA) or a library (LDDA).",
+)
 HdaLddaQueryParam: DatasetSourceType = Query(
-    title="HDA or LDDA", description="Whether this dataset belongs to a history (HDA) or a library (LDDA)."
+    title="HDA or LDDA",
+    description="Whether this dataset belongs to a history (HDA) or a library (LDDA).",
 )
 
 
@@ -354,7 +360,7 @@ class FastAPIJobs:
     def parameters_display_by_job(
         self,
         job_id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
-        hda_ldda: Annotated[DatasetSourceType, HdaLddaQueryParam] = DatasetSourceType.hda,
+        hda_ldda: Annotated[Optional[DatasetSourceType], DeprecatedHdaLddaQueryParam] = DatasetSourceType.hda,
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> JobDisplayParametersSummary:
         """
@@ -403,7 +409,7 @@ class FastAPIJobs:
     def metrics_by_job(
         self,
         job_id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
-        hda_ldda: Annotated[DatasetSourceType, HdaLddaQueryParam] = DatasetSourceType.hda,
+        hda_ldda: Annotated[Optional[DatasetSourceType], DeprecatedHdaLddaQueryParam] = DatasetSourceType.hda,
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> List[Optional[JobMetric]]:
         job = self.service.get_job(trans, job_id=job_id, hda_ldda=hda_ldda)
@@ -413,7 +419,7 @@ class FastAPIJobs:
         "/api/datasets/{dataset_id}/metrics",
         name="get_metrics",
         summary="Return job metrics for specified job.",
-        deprecated=True, 
+        deprecated=True,
     )
     def metrics_by_dataset(
         self,

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -371,7 +371,6 @@ class FastAPIJobs:
         job = self.service.get_job(trans, job_id=id, hda_ldda=hda_ldda)
         return summarize_job_parameters(trans, job)
 
-    # TODO add pydantic model for return
     @router.get(
         "/api/datasets/{id}/parameters_display",
         name="resolve_parameters_display",
@@ -382,20 +381,17 @@ class FastAPIJobs:
         id: Annotated[DecodedDatabaseIdField, DatasetIdPathParam],
         hda_ldda: Annotated[DatasetSourceType, HdaLddaQueryParam] = DatasetSourceType.hda,
         trans: ProvidesUserContext = DependsOnTrans,
-    ):
+    ) -> JobDisplayParametersSummary:
         """
-            # TODO is this still true?
-            Resolve parameters as a list for nested display. More client logic
-            here than is ideal but it is hard to reason about tool parameter
-            types on the client relative to the server. Job accessibility checks
-            are slightly different than dataset checks, so both methods are
-            available.
+        # TODO is this still true?
+        Resolve parameters as a list for nested display. More client logic
+        here than is ideal but it is hard to reason about tool parameter
+        types on the client relative to the server. Job accessibility checks
+        are slightly different than dataset checks, so both methods are
+        available.
 
-            This API endpoint is unstable and tied heavily to Galaxy's JS client code,
-            this endpoint will change frequently.
-
-        :rtype:     list
-        :returns:   job parameters for for display
+        This API endpoint is unstable and tied heavily to Galaxy's JS client code,
+        this endpoint will change frequently.
         """
         job = self.service.get_job(trans, dataset_id=id, hda_ldda=hda_ldda)
         return summarize_job_parameters(trans, job)

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -355,6 +355,64 @@ class FastAPIJobs:
 
     # TODO add pydantic model for output
     @router.get(
+        "/api/jobs/{id}/parameters_display",
+        name="resolve_parameters_display",
+        summary="Resolve parameters as a list for nested display.",
+    )
+    def parameters_display_by_job(
+        self,
+        id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
+        hda_ldda: Annotated[DatasetSourceType, HdaLddaQueryParam],
+        trans: ProvidesUserContext = DependsOnTrans,
+    ):
+        """
+            # TODO is this still true?
+            Resolve parameters as a list for nested display. More client logic
+            here than is ideal but it is hard to reason about tool parameter
+            types on the client relative to the server. Job accessibility checks
+            are slightly different than dataset checks, so both methods are
+            available.
+
+            This API endpoint is unstable and tied heavily to Galaxy's JS client code,
+            this endpoint will change frequently.
+
+        :rtype:     list
+        :returns:   job parameters for for display
+        """
+        job = self.service.get_job(trans, job_id=id, hda_ldda=hda_ldda)
+        return summarize_job_parameters(trans, job)
+
+    # TODO add pydantic model for output and get this running
+    # @router.get(
+    #     "/api/datasets/{id}/parameters_display",
+    #     name="resolve_parameters_display",
+    #     summary="Resolve parameters as a list for nested display.",
+    # )
+    # def parameters_display_by_dataset(
+    #     self,
+    #     id: Annotated[DecodedDatabaseIdField, DatasetIdPathParam],
+    #     hda_ldda: Annotated[DatasetSourceType, HdaLddaQueryParam],
+    #     trans: ProvidesUserContext = DependsOnTrans,
+    # ):
+    #     """
+    #         # TODO is this still true?
+    #         Resolve parameters as a list for nested display. More client logic
+    #         here than is ideal but it is hard to reason about tool parameter
+    #         types on the client relative to the server. Job accessibility checks
+    #         are slightly different than dataset checks, so both methods are
+    #         available.
+
+    #         This API endpoint is unstable and tied heavily to Galaxy's JS client code,
+    #         this endpoint will change frequently.
+
+    #     :rtype:     list
+    #     :returns:   job parameters for for display
+    #     """
+    #     job = self.service.get_job(trans, dataset_id=id, hda_ldda=hda_ldda)
+    #     return summarize_job_parameters(trans, job)
+
+    # TODO add pydantic model for output
+    @router.get(
         "/api/jobs/{id}/metrics",
         name="get_metrics",
         summary="Return job metrics for specified job.",
@@ -521,7 +579,6 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
     def parameters_display(self, trans: ProvidesUserContext, **kwd):
         """
         * GET /api/jobs/{job_id}/parameters_display
-        * GET /api/datasets/{dataset_id}/parameters_display
 
             Resolve parameters as a list for nested display. More client logic
             here than is ideal but it is hard to reason about tool parameter

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -347,18 +347,17 @@ class FastAPIJobs:
         return self.service.dictify_associations(trans, job.output_datasets, job.output_library_datasets)
 
     @router.get(
-        "/api/jobs/{id}/parameters_display",
+        "/api/jobs/{job_id}/parameters_display",
         name="resolve_parameters_display",
         summary="Resolve parameters as a list for nested display.",
     )
     def parameters_display_by_job(
         self,
-        id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
+        job_id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
         hda_ldda: Annotated[DatasetSourceType, HdaLddaQueryParam] = DatasetSourceType.hda,
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> JobDisplayParametersSummary:
         """
-        # TODO is this still true?
         Resolve parameters as a list for nested display. More client logic
         here than is ideal but it is hard to reason about tool parameter
         types on the client relative to the server. Job accessibility checks
@@ -368,22 +367,21 @@ class FastAPIJobs:
         This API endpoint is unstable and tied heavily to Galaxy's JS client code,
         this endpoint will change frequently.
         """
-        job = self.service.get_job(trans, job_id=id, hda_ldda=hda_ldda)
+        job = self.service.get_job(trans, job_id=job_id, hda_ldda=hda_ldda)
         return summarize_job_parameters(trans, job)
 
     @router.get(
-        "/api/datasets/{id}/parameters_display",
+        "/api/datasets/{dataset_id}/parameters_display",
         name="resolve_parameters_display",
         summary="Resolve parameters as a list for nested display.",
     )
     def parameters_display_by_dataset(
         self,
-        id: Annotated[DecodedDatabaseIdField, DatasetIdPathParam],
+        dataset_id: Annotated[DecodedDatabaseIdField, DatasetIdPathParam],
         hda_ldda: Annotated[DatasetSourceType, HdaLddaQueryParam] = DatasetSourceType.hda,
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> JobDisplayParametersSummary:
         """
-        # TODO is this still true?
         Resolve parameters as a list for nested display. More client logic
         here than is ideal but it is hard to reason about tool parameter
         types on the client relative to the server. Job accessibility checks
@@ -393,35 +391,35 @@ class FastAPIJobs:
         This API endpoint is unstable and tied heavily to Galaxy's JS client code,
         this endpoint will change frequently.
         """
-        job = self.service.get_job(trans, dataset_id=id, hda_ldda=hda_ldda)
+        job = self.service.get_job(trans, dataset_id=dataset_id, hda_ldda=hda_ldda)
         return summarize_job_parameters(trans, job)
 
     @router.get(
-        "/api/jobs/{id}/metrics",
+        "/api/jobs/{job_id}/metrics",
         name="get_metrics",
         summary="Return job metrics for specified job.",
     )
     def metrics_by_job(
         self,
-        id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
+        job_id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
         hda_ldda: Annotated[DatasetSourceType, HdaLddaQueryParam] = DatasetSourceType.hda,
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> List[Optional[JobMetric]]:
-        job = self.service.get_job(trans, job_id=id, hda_ldda=hda_ldda)
+        job = self.service.get_job(trans, job_id=job_id, hda_ldda=hda_ldda)
         return [JobMetric(**metric) for metric in summarize_job_metrics(trans, job)]
 
     @router.get(
-        "/api/datasets/{id}/metrics",
+        "/api/datasets/{dataset_id}/metrics",
         name="get_metrics",
         summary="Return job metrics for specified job.",
     )
     def metrics_by_dataset(
         self,
-        id: Annotated[DecodedDatabaseIdField, DatasetIdPathParam],
+        dataset_id: Annotated[DecodedDatabaseIdField, DatasetIdPathParam],
         hda_ldda: Annotated[DatasetSourceType, HdaLddaQueryParam] = DatasetSourceType.hda,
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> List[Optional[JobMetric]]:
-        job = self.service.get_job(trans, dataset_id=id, hda_ldda=hda_ldda)
+        job = self.service.get_job(trans, dataset_id=dataset_id, hda_ldda=hda_ldda)
         return [JobMetric(**metric) for metric in summarize_job_metrics(trans, job)]
 
     @router.get(
@@ -487,32 +485,32 @@ class FastAPIJobs:
         return [EncodedJobDetails(**single_job.to_dict("element")) for single_job in jobs]
 
     @router.get(
-        "/api/jobs/{id}",
+        "/api/jobs/{job_id}",
         name="show_job",
         summary="Return dictionary containing description of job data.",
     )
     def show(
         self,
-        id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
+        job_id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
         full: Annotated[Optional[bool], FullShowQueryParam] = False,
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> Dict[str, Any]:
-        return self.service.show(trans, id, bool(full))
+        return self.service.show(trans, job_id, bool(full))
 
     # TODO find the mapping of the legacy route
     # TODO rename? --> function cancels/stops job (no deletion involved?)
     @router.delete(
-        "/api/jobs/{id}",
+        "/api/jobs/{job_id}",
         name="cancel_job",
         summary="Cancels specified job",
     )
     def delete(
         self,
-        id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
+        job_id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
         trans: ProvidesUserContext = DependsOnTrans,
         payload: Annotated[Optional[DeleteJobPayload], DeleteJobBody] = None,
     ) -> bool:
-        job = self.service.get_job(trans=trans, job_id=id)
+        job = self.service.get_job(trans=trans, job_id=job_id)
         if payload:
             message = payload.message
         else:

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -313,6 +313,19 @@ class FastAPIJobs:
         )
         return JobErrorSummary(messages=messages)
 
+    @router.get(
+        "/api/jobs/{id}/inputs",
+        name="get_inputs",
+        summary="Returns input datasets created by job.",
+    )
+    def inputs(
+        self,
+        id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
+        trans: ProvidesUserContext = DependsOnTrans,
+    ) -> List[JobAssociation]:
+        job = self.service.get_job(trans=trans, job_id=id)
+        return self.service.dictify_associations(trans, job.input_datasets, job.input_library_datasets)
+
     @router.post(
         "/api/jobs/search",
         name="search_jobs",
@@ -383,22 +396,6 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
     job_search = depends(JobSearch)
     service = depends(JobsService)
     hda_manager = depends(hdas.HDAManager)
-
-    @expose_api
-    def inputs(self, trans: ProvidesUserContext, id, **kwd) -> List[dict]:
-        """
-        GET /api/jobs/{id}/inputs
-
-        returns input datasets created by job
-
-        :type   id: string
-        :param  id: Encoded job id
-
-        :rtype:     list of dicts
-        :returns:   list of dictionaries containing input dataset associations
-        """
-        job = self.__get_job(trans, id)
-        return self.__dictify_associations(trans, job.input_datasets, job.input_library_datasets)
 
     @expose_api
     def outputs(self, trans: ProvidesUserContext, id, **kwd) -> List[dict]:

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -333,7 +333,7 @@ class FastAPIJobs:
         tool = trans.app.toolbox.get_tool(tool_id)
         if tool is None:
             raise exceptions.ObjectNotFound("Requested tool not found")
-        # TODO the inputs are actually a dict, but are passed as a JSON string
+        # TODO the inputs are actually a dict, but are passed as a JSON dump
         # maybe change it?
         inputs = json.loads(payload.inputs)
         # Find files coming in as multipart file data and add to inputs.

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -408,7 +408,6 @@ class FastAPIJobs:
         job = self.service.get_job(trans, dataset_id=id, hda_ldda=hda_ldda)
         return summarize_job_parameters(trans, job)
 
-    # TODO add pydantic model for output
     @router.get(
         "/api/jobs/{id}/metrics",
         name="get_metrics",
@@ -427,7 +426,6 @@ class FastAPIJobs:
         job = self.service.get_job(trans, job_id=id, hda_ldda=hda_ldda)
         return [JobMetric(**metric) for metric in summarize_job_metrics(trans, job)]
 
-    # TODO add pydantic model for return value
     @router.get(
         "/api/datasets/{id}/metrics",
         name="get_metrics",

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -372,12 +372,7 @@ class FastAPIJobs:
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> JobDisplayParametersSummary:
         """
-        Resolve parameters as a list for nested display. More client logic
-        here than is ideal but it is hard to reason about tool parameter
-        types on the client relative to the server. Job accessibility checks
-        are slightly different than dataset checks, so both methods are
-        available.
-
+        Resolve parameters as a list for nested display.
         This API endpoint is unstable and tied heavily to Galaxy's JS client code,
         this endpoint will change frequently.
         """
@@ -398,12 +393,7 @@ class FastAPIJobs:
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> JobDisplayParametersSummary:
         """
-        Resolve parameters as a list for nested display. More client logic
-        here than is ideal but it is hard to reason about tool parameter
-        types on the client relative to the server. Job accessibility checks
-        are slightly different than dataset checks, so both methods are
-        available.
-
+        Resolve parameters as a list for nested display.
         This API endpoint is unstable and tied heavily to Galaxy's JS client code,
         this endpoint will change frequently.
         """

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -316,7 +316,7 @@ class FastAPIJobs:
     @router.get(
         "/api/jobs/{id}/inputs",
         name="get_inputs",
-        summary="Returns input datasets created by job.",
+        summary="Returns input datasets created by a job.",
     )
     def inputs(
         self,
@@ -325,6 +325,19 @@ class FastAPIJobs:
     ) -> List[JobAssociation]:
         job = self.service.get_job(trans=trans, job_id=id)
         return self.service.dictify_associations(trans, job.input_datasets, job.input_library_datasets)
+
+    @router.get(
+        "/api/jobs/{id}/outputs",
+        name="get_outputs",
+        summary="Returns output datasets created by a job.",
+    )
+    def outputs(
+        self,
+        id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
+        trans: ProvidesUserContext = DependsOnTrans,
+    ) -> List[JobAssociation]:
+        job = self.service.get_job(trans=trans, job_id=id)
+        return self.service.dictify_associations(trans, job.output_datasets, job.output_library_datasets)
 
     @router.post(
         "/api/jobs/search",
@@ -396,22 +409,6 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
     job_search = depends(JobSearch)
     service = depends(JobsService)
     hda_manager = depends(hdas.HDAManager)
-
-    @expose_api
-    def outputs(self, trans: ProvidesUserContext, id, **kwd) -> List[dict]:
-        """
-        outputs( trans, id )
-        * GET /api/jobs/{id}/outputs
-            returns output datasets created by job
-
-        :type   id: string
-        :param  id: Encoded job id
-
-        :rtype:     list of dicts
-        :returns:   list of dictionaries containing output dataset associations
-        """
-        job = self.__get_job(trans, id)
-        return self.__dictify_associations(trans, job.output_datasets, job.output_library_datasets)
 
     @expose_api
     def delete(self, trans: ProvidesUserContext, id, **kwd):

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -374,6 +374,7 @@ class FastAPIJobs:
         "/api/datasets/{dataset_id}/parameters_display",
         name="resolve_parameters_display",
         summary="Resolve parameters as a list for nested display.",
+        deprecated=True,
     )
     def parameters_display_by_dataset(
         self,
@@ -412,6 +413,7 @@ class FastAPIJobs:
         "/api/datasets/{dataset_id}/metrics",
         name="get_metrics",
         summary="Return job metrics for specified job.",
+        deprecated=True, 
     )
     def metrics_by_dataset(
         self,

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -382,34 +382,34 @@ class FastAPIJobs:
         job = self.service.get_job(trans, job_id=id, hda_ldda=hda_ldda)
         return summarize_job_parameters(trans, job)
 
-    # TODO add pydantic model for output and get this running
-    # @router.get(
-    #     "/api/datasets/{id}/parameters_display",
-    #     name="resolve_parameters_display",
-    #     summary="Resolve parameters as a list for nested display.",
-    # )
-    # def parameters_display_by_dataset(
-    #     self,
-    #     id: Annotated[DecodedDatabaseIdField, DatasetIdPathParam],
-    #     hda_ldda: Annotated[DatasetSourceType, HdaLddaQueryParam]  = DatasetSourceType.hda,
-    #     trans: ProvidesUserContext = DependsOnTrans,
-    # ):
-    #     """
-    #         # TODO is this still true?
-    #         Resolve parameters as a list for nested display. More client logic
-    #         here than is ideal but it is hard to reason about tool parameter
-    #         types on the client relative to the server. Job accessibility checks
-    #         are slightly different than dataset checks, so both methods are
-    #         available.
+    # TODO add pydantic model for return
+    @router.get(
+        "/api/datasets/{id}/parameters_display",
+        name="resolve_parameters_display",
+        summary="Resolve parameters as a list for nested display.",
+    )
+    def parameters_display_by_dataset(
+        self,
+        id: Annotated[DecodedDatabaseIdField, DatasetIdPathParam],
+        hda_ldda: Annotated[DatasetSourceType, HdaLddaQueryParam] = DatasetSourceType.hda,
+        trans: ProvidesUserContext = DependsOnTrans,
+    ):
+        """
+            # TODO is this still true?
+            Resolve parameters as a list for nested display. More client logic
+            here than is ideal but it is hard to reason about tool parameter
+            types on the client relative to the server. Job accessibility checks
+            are slightly different than dataset checks, so both methods are
+            available.
 
-    #         This API endpoint is unstable and tied heavily to Galaxy's JS client code,
-    #         this endpoint will change frequently.
+            This API endpoint is unstable and tied heavily to Galaxy's JS client code,
+            this endpoint will change frequently.
 
-    #     :rtype:     list
-    #     :returns:   job parameters for for display
-    #     """
-    #     job = self.service.get_job(trans, dataset_id=id, hda_ldda=hda_ldda)
-    #     return summarize_job_parameters(trans, job)
+        :rtype:     list
+        :returns:   job parameters for for display
+        """
+        job = self.service.get_job(trans, dataset_id=id, hda_ldda=hda_ldda)
+        return summarize_job_parameters(trans, job)
 
     # TODO add pydantic model for output
     @router.get(
@@ -550,36 +550,6 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
     job_search = depends(JobSearch)
     service = depends(JobsService)
     hda_manager = depends(hdas.HDAManager)
-
-    @expose_api_anonymous
-    def parameters_display(self, trans: ProvidesUserContext, **kwd):
-        """
-        * GET /api/jobs/{job_id}/parameters_display
-
-            Resolve parameters as a list for nested display. More client logic
-            here than is ideal but it is hard to reason about tool parameter
-            types on the client relative to the server. Job accessibility checks
-            are slightly different than dataset checks, so both methods are
-            available.
-
-            This API endpoint is unstable and tied heavily to Galaxy's JS client code,
-            this endpoint will change frequently.
-
-        :type   job_id: string
-        :param  job_id: Encoded job id
-
-        :type   dataset_id: string
-        :param  dataset_id: Encoded HDA or LDDA id
-
-        :type   hda_ldda: string
-        :param  hda_ldda: hda if dataset_id is an HDA id (default), ldda if
-                          it is an ldda id.
-
-        :rtype:     list
-        :returns:   job parameters for for display
-        """
-        job = self.__get_job(trans, **kwd)
-        return summarize_job_parameters(trans, job)
 
     @expose_api_anonymous
     def build_for_rerun(self, trans: ProvidesHistoryContext, id, **kwd):

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -20,7 +20,6 @@ from typing import (
 from fastapi import (
     Body,
     Depends,
-    HTTPException,
     Path,
     Query,
 )
@@ -240,19 +239,6 @@ class FastAPIJobs:
             offset=offset,
         )
         return self.service.index(trans, payload)
-
-    @router.post(
-        "/api/jobs",
-        name="create_job",
-        summary="Not implemented.",
-    )
-    def create(
-        self,
-        trans: ProvidesUserContext = DependsOnTrans,
-        **kwd,
-    ):
-        """See the create method in tools.py in order to submit a job."""
-        raise HTTPException(status_code=501, detail="Please POST to /api/tools instead.")
 
     @router.get(
         "/api/jobs/{job_id}/common_problems",

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -46,6 +46,7 @@ from galaxy.managers.jobs import (
 )
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.jobs import (
+    EncodedJobDetails,
     JobAssociation,
     JobErrorSummary,
     JobInputSummary,
@@ -348,7 +349,7 @@ class FastAPIJobs:
         self,
         payload: Annotated[SearchJobsPayload, SearchJobBody],
         trans: ProvidesHistoryContext = DependsOnTrans,
-    ):
+    ) -> List[EncodedJobDetails]:
         """
         This method is designed to scan the list of previously run jobs and find records of jobs that had
         the exact some input parameters and datasets. This can be used to minimize the amount of repeated work, and simply
@@ -385,7 +386,8 @@ class FastAPIJobs:
             )
             if job:
                 jobs.append(job)
-        return [self.service.encode_all_ids(single_job.to_dict("element"), True) for single_job in jobs]
+        # return [self.service.job_to_encoded_details(job=single_job.to_dict("element")) for single_job in jobs]
+        return [EncodedJobDetails(**single_job.to_dict("element")) for single_job in jobs]
 
     @router.get("/api/jobs/{id}")
     def show(

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -41,7 +41,10 @@ from galaxy.managers.jobs import (
     summarize_job_parameters,
 )
 from galaxy.schema.fields import DecodedDatabaseIdField
-from galaxy.schema.jobs import JobAssociation, JobInputSummary
+from galaxy.schema.jobs import (
+    JobAssociation,
+    JobInputSummary,
+)
 from galaxy.schema.schema import JobIndexSortByEnum
 from galaxy.schema.types import OffsetNaiveDatetime
 from galaxy.web import (

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -291,10 +291,6 @@ class FastAPIJobs:
         id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> JobErrorSummary:
-        """
-        :rtype:     dictionary
-        :returns:   dictionary containing information regarding where the error report was sent.
-        """
         # Get dataset on which this error was triggered
         dataset_id = payload.dataset_id
         dataset = self.hda_manager.get_accessible(id=dataset_id, user=trans.user)
@@ -328,13 +324,6 @@ class FastAPIJobs:
         trans: ProvidesHistoryContext = DependsOnTrans,
     ):
         """
-        :type   payload: dict
-        :param  payload: Dictionary containing description of requested job. This is in the same format as
-            a request to POST /apt/tools would take to initiate a job
-
-        :rtype:     list
-        :returns:   list of dictionaries containing summary job information of the jobs that match the requested job run
-
         This method is designed to scan the list of previously run jobs and find records of jobs that had
         the exact some input parameters and datasets. This can be used to minimize the amount of repeated work, and simply
         recycle the old results.
@@ -344,6 +333,8 @@ class FastAPIJobs:
         tool = trans.app.toolbox.get_tool(tool_id)
         if tool is None:
             raise exceptions.ObjectNotFound("Requested tool not found")
+        # TODO the inputs are actually a dict, but are passed as a JSON string
+        # maybe change it?
         inputs = json.loads(payload.inputs)
         # Find files coming in as multipart file data and add to inputs.
         for k, v in payload.__annotations__.items():

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -547,9 +547,6 @@ class FastAPIJobs:
 
 class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
     job_manager = depends(JobManager)
-    job_search = depends(JobSearch)
-    service = depends(JobsService)
-    hda_manager = depends(hdas.HDAManager)
 
     @expose_api_anonymous
     def build_for_rerun(self, trans: ProvidesHistoryContext, id, **kwd):

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -4,7 +4,6 @@ API operations on a jobs.
 .. seealso:: :class:`galaxy.model.Jobs`
 """
 
-import json
 import logging
 from datetime import (
     date,
@@ -492,7 +491,7 @@ class FastAPIJobs:
             raise exceptions.ObjectNotFound("Requested tool not found")
         # TODO the inputs are actually a dict, but are passed as a JSON dump
         # maybe change it?
-        inputs = json.loads(payload.inputs)
+        inputs = payload.inputs
         # Find files coming in as multipart file data and add to inputs.
         for k, v in payload.__annotations__.items():
             if k.startswith("files_") or k.startswith("__files_"):

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -940,19 +940,8 @@ def populate_api_routes(webapp, app):
         conditions=dict(method=["GET"]),
     )
     webapp.mapper.connect(
-        "resume", "/api/jobs/{id}/resume", controller="jobs", action="resume", conditions=dict(method=["PUT"])
-    )
-    webapp.mapper.connect(
         "job_error", "/api/jobs/{id}/error", controller="jobs", action="error", conditions=dict(method=["POST"])
     )
-    # webapp.mapper.connect(
-    #     "common_problems",
-    #     "/api/jobs/{id}/common_problems",
-    #     controller="jobs",
-    #     action="common_problems",
-    #     conditions=dict(method=["GET"]),
-    # )
-    # Job metrics and parameters by job id or dataset id (for slightly different accessibility checking)
     webapp.mapper.connect(
         "destination_params",
         "/api/jobs/{job_id}/destination_params",

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -924,9 +924,6 @@ def populate_api_routes(webapp, app):
 
     webapp.mapper.resource("job", "jobs", path_prefix="/api")
     webapp.mapper.connect(
-        "job_inputs", "/api/jobs/{id}/inputs", controller="jobs", action="inputs", conditions=dict(method=["GET"])
-    )
-    webapp.mapper.connect(
         "job_outputs", "/api/jobs/{id}/outputs", controller="jobs", action="outputs", conditions=dict(method=["GET"])
     )
     webapp.mapper.connect(

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -940,9 +940,6 @@ def populate_api_routes(webapp, app):
         conditions=dict(method=["GET"]),
     )
     webapp.mapper.connect(
-        "job_error", "/api/jobs/{id}/error", controller="jobs", action="error", conditions=dict(method=["POST"])
-    )
-    webapp.mapper.connect(
         "destination_params",
         "/api/jobs/{job_id}/destination_params",
         controller="jobs",

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -940,13 +940,6 @@ def populate_api_routes(webapp, app):
         conditions=dict(method=["GET"]),
     )
     webapp.mapper.connect(
-        "parameters_display",
-        "/api/jobs/{job_id}/parameters_display",
-        controller="jobs",
-        action="parameters_display",
-        conditions=dict(method=["GET"]),
-    )
-    webapp.mapper.connect(
         "dataset_parameters_display",
         "/api/datasets/{dataset_id}/parameters_display",
         controller="jobs",

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -922,8 +922,6 @@ def populate_api_routes(webapp, app):
         webapp, name_prefix="library_dataset_", path_prefix="/api/libraries/{library_id}/contents/{library_content_id}"
     )
 
-    webapp.mapper.resource("job", "jobs", path_prefix="/api")
-
     webapp.mapper.connect(
         "build_for_rerun",
         "/api/jobs/{id}/build_for_rerun",

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -931,13 +931,6 @@ def populate_api_routes(webapp, app):
         action="build_for_rerun",
         conditions=dict(method=["GET"]),
     )
-    webapp.mapper.connect(
-        "dataset_parameters_display",
-        "/api/datasets/{dataset_id}/parameters_display",
-        controller="jobs",
-        action="parameters_display",
-        conditions=dict(method=["GET"]),
-    )
 
     # Job files controllers. Only for consumption by remote job runners.
     webapp.mapper.resource(

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -923,9 +923,7 @@ def populate_api_routes(webapp, app):
     )
 
     webapp.mapper.resource("job", "jobs", path_prefix="/api")
-    webapp.mapper.connect(
-        "job_outputs", "/api/jobs/{id}/outputs", controller="jobs", action="outputs", conditions=dict(method=["GET"])
-    )
+
     webapp.mapper.connect(
         "build_for_rerun",
         "/api/jobs/{id}/build_for_rerun",

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -931,13 +931,7 @@ def populate_api_routes(webapp, app):
         action="build_for_rerun",
         conditions=dict(method=["GET"]),
     )
-    webapp.mapper.connect(
-        "destination_params",
-        "/api/jobs/{job_id}/destination_params",
-        controller="jobs",
-        action="destination_params",
-        conditions=dict(method=["GET"]),
-    )
+
     webapp.mapper.connect(
         "metrics",
         "/api/jobs/{job_id}/metrics",

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -931,14 +931,6 @@ def populate_api_routes(webapp, app):
         action="build_for_rerun",
         conditions=dict(method=["GET"]),
     )
-
-    webapp.mapper.connect(
-        "dataset_metrics",
-        "/api/datasets/{dataset_id}/metrics",
-        controller="jobs",
-        action="metrics",
-        conditions=dict(method=["GET"]),
-    )
     webapp.mapper.connect(
         "dataset_parameters_display",
         "/api/datasets/{dataset_id}/parameters_display",

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -924,9 +924,6 @@ def populate_api_routes(webapp, app):
 
     webapp.mapper.resource("job", "jobs", path_prefix="/api")
     webapp.mapper.connect(
-        "job_search", "/api/jobs/search", controller="jobs", action="search", conditions=dict(method=["POST"])
-    )
-    webapp.mapper.connect(
         "job_inputs", "/api/jobs/{id}/inputs", controller="jobs", action="inputs", conditions=dict(method=["GET"])
     )
     webapp.mapper.connect(

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -945,13 +945,13 @@ def populate_api_routes(webapp, app):
     webapp.mapper.connect(
         "job_error", "/api/jobs/{id}/error", controller="jobs", action="error", conditions=dict(method=["POST"])
     )
-    webapp.mapper.connect(
-        "common_problems",
-        "/api/jobs/{id}/common_problems",
-        controller="jobs",
-        action="common_problems",
-        conditions=dict(method=["GET"]),
-    )
+    # webapp.mapper.connect(
+    #     "common_problems",
+    #     "/api/jobs/{id}/common_problems",
+    #     controller="jobs",
+    #     action="common_problems",
+    #     conditions=dict(method=["GET"]),
+    # )
     # Job metrics and parameters by job id or dataset id (for slightly different accessibility checking)
     webapp.mapper.connect(
         "destination_params",

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -933,13 +933,6 @@ def populate_api_routes(webapp, app):
     )
 
     webapp.mapper.connect(
-        "metrics",
-        "/api/jobs/{job_id}/metrics",
-        controller="jobs",
-        action="metrics",
-        conditions=dict(method=["GET"]),
-    )
-    webapp.mapper.connect(
         "dataset_metrics",
         "/api/datasets/{dataset_id}/metrics",
         controller="jobs",

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -117,8 +117,10 @@ class JobsService(ServiceBase):
                 dataset_instance = self.hda_manager.get_accessible(id=dataset_id, user=trans.user)
             else:
                 dataset_instance = self.hda_manager.ldda_manager.get(trans, id=dataset_id)
-        # TODO Raise error if no ID passed? Never happens when called from Job API endpoints
-        return dataset_instance.creating_job
+            return dataset_instance.creating_job
+        else:
+            # Raise an exception if neither job_id nor dataset_id is provided
+            raise ValueError("Either job_id or dataset_id must be provided.")
 
     def dictify_associations(self, trans, *association_lists) -> List[JobAssociation]:
         rval: List[JobAssociation] = []

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -92,3 +92,21 @@ class JobsService:
             raise exceptions.AdminRequiredException("Only admins can index the jobs with user details enabled")
         if decoded_user_id is not None and decoded_user_id != trans_user_id:
             raise exceptions.AdminRequiredException("Only admins can index the jobs of others")
+
+    def get_job(
+        self,
+        trans: ProvidesUserContext,
+        job_id: Optional[int] = None,
+        dataset_id: Optional[int] = None,
+        hda_ldda: str = "hda",
+    ):
+        if job_id is not None:
+            return self.job_manager.get_accessible_job(trans, decoded_job_id=job_id)
+        elif dataset_id is not None:
+            # Following checks dataset accessible
+            if hda_ldda == "hda":
+                dataset_instance = self.hda_manager.get_accessible(id=dataset_id, user=trans.user)
+            else:
+                dataset_instance = self.hda_manager.ldda_manager.get(trans, id=dataset_id)
+        # TODO Raise error if no ID passed? Never happens when called from Job API endpoints
+        return dataset_instance

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -23,6 +23,8 @@ from galaxy.schema.schema import (
     EncodedDatasetSourceId,
     JobIndexQueryPayload,
 )
+from galaxy.security.idencoding import IdEncodingHelper
+from galaxy.webapps.galaxy.services.base import ServiceBase
 
 
 class JobIndexViewEnum(str, Enum):
@@ -34,17 +36,19 @@ class JobIndexPayload(JobIndexQueryPayload):
     view: JobIndexViewEnum = JobIndexViewEnum.collection
 
 
-class JobsService:
+class JobsService(ServiceBase):
     job_manager: JobManager
     job_search: JobSearch
     hda_manager: hdas.HDAManager
 
     def __init__(
         self,
+        security: IdEncodingHelper,
         job_manager: JobManager,
         job_search: JobSearch,
         hda_manager: hdas.HDAManager,
     ):
+        super().__init__(security=security)
         self.job_manager = job_manager
         self.job_search = job_search
         self.hda_manager = hda_manager

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -18,8 +18,11 @@ from galaxy.managers.jobs import (
     view_show_job,
 )
 from galaxy.schema.fields import DecodedDatabaseIdField
-from galaxy.schema.schema import EncodedDatasetSourceId, JobIndexQueryPayload
 from galaxy.schema.jobs import JobAssociation
+from galaxy.schema.schema import (
+    EncodedDatasetSourceId,
+    JobIndexQueryPayload,
+)
 
 
 class JobIndexViewEnum(str, Enum):
@@ -114,7 +117,7 @@ class JobsService:
         return dataset_instance
 
     def dictify_associations(self, trans, *association_lists) -> List[JobAssociation]:
-        rval: List[dict] = []
+        rval: List[JobAssociation] = []
         for association_list in association_lists:
             rval.extend(self.__dictify_association(trans, a) for a in association_list)
         return rval

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -118,7 +118,7 @@ class JobsService(ServiceBase):
             else:
                 dataset_instance = self.hda_manager.ldda_manager.get(trans, id=dataset_id)
         # TODO Raise error if no ID passed? Never happens when called from Job API endpoints
-        return dataset_instance
+        return dataset_instance.creating_job
 
     def dictify_associations(self, trans, *association_lists) -> List[JobAssociation]:
         rval: List[JobAssociation] = []

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -960,22 +960,23 @@ steps:
         assert job_first_output.get("dataset").get("id") == job_first_output_values.get("id")
         assert job_first_output.get("dataset").get("src") == job_first_output_values.get("src")
 
-    # @pytest.mark.require_new_history
-    # def test_delete_job(self, history_id):
-    #     dataset_id = self.__history_with_ok_dataset(history_id)
-    #     inputs = json.dumps({"input1": {"src": "hda", "id": dataset_id}})
-    #     search_response = self._create_and_search_job(history_id, inputs, tool_id="cat1")
-    #     job_id = search_response.json()[0]["id"]
-    #     # delete the job without message
-    #     delete_job_response = self._delete(f"jobs/{job_id}")
-    #     self._assert_status_code_is(delete_job_response, 200)
-    #     # TODO the job is finished as such it is not stopped Think of another way to test it
-    #     assert delete_job_response.json() == True
-    #     # now that we deleted the job we should not find it anymore
-    #     search_payload = self._search_payload(history_id=history_id, tool_id="cat1", inputs=inputs)
-    #     empty_search_response = self._post("jobs/search", data=search_payload, json=True)
-    #     self._assert_status_code_is(empty_search_response, 200)
-    #     assert len(empty_search_response.json()) == 0
+    @pytest.mark.require_new_history
+    def test_delete_job(self, history_id):
+        dataset_id = self.__history_with_ok_dataset(history_id)
+        inputs = json.dumps({"input1": {"src": "hda", "id": dataset_id}})
+        search_payload = self._search_payload(history_id=history_id, tool_id="cat1", inputs=inputs)
+        # create a job
+        tool_response = self._post("tools", data=search_payload)
+        job_id = tool_response.json()["jobs"][0]["id"]
+        # delete the job without message
+        delete_job_response = self._delete(f"jobs/{job_id}")
+        self._assert_status_code_is(delete_job_response, 200)
+        assert delete_job_response.json() is True
+        # now that we deleted the job we should not find it anymore
+        search_payload = self._search_payload(history_id=history_id, tool_id="cat1", inputs=inputs)
+        empty_search_response = self._post("jobs/search", data=search_payload, json=True)
+        self._assert_status_code_is(empty_search_response, 200)
+        assert len(empty_search_response.json()) == 0
 
     @pytest.mark.require_new_history
     def test_destination_params(self, history_id):

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -987,6 +987,19 @@ steps:
         self._assert_status_code_is(destination_params_response, 200)
         # TODO maybe extend test?
 
+    @pytest.mark.require_new_history
+    def test_job_metrics(self, history_id):
+        dataset_id = self.__history_with_ok_dataset(history_id)
+        inputs = json.dumps({"input1": {"src": "hda", "id": dataset_id}})
+        search_response = self._create_and_search_job(history_id, inputs, tool_id="cat1")
+        job_id = search_response.json()[0]["id"]
+        metrics_by_job_response = self._get(f"/api/jobs/{job_id}/metrics", data={"hda_ldda": "hda"})
+        self._assert_status_code_is(metrics_by_job_response, 200)
+        # TODO enable this once metrics_by_dataset_works
+        metrics_by_dataset_response = self._get(f"/api/datasets/{dataset_id}/metrics", data={"hda_ldda": "hda"})
+        self._assert_status_code_is(metrics_by_dataset_response, 200)
+        # TODO maybe extend test?
+
     def _create_and_search_job(self, history_id, inputs, tool_id):
         # create a job
         search_payload = self._search_payload(history_id=history_id, tool_id=tool_id, inputs=inputs)

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -985,7 +985,6 @@ steps:
         job_id = search_response.json()[0]["id"]
         destination_params_response = self._get(f"/api/jobs/{job_id}/destination_params", admin=True)
         self._assert_status_code_is(destination_params_response, 200)
-        # TODO maybe extend test?
 
     @pytest.mark.require_new_history
     def test_job_metrics(self, history_id):
@@ -997,7 +996,6 @@ steps:
         self._assert_status_code_is(metrics_by_job_response, 200)
         metrics_by_dataset_response = self._get(f"/api/datasets/{dataset_id}/metrics", data={"hda_ldda": "hda"})
         self._assert_status_code_is(metrics_by_dataset_response, 200)
-        # TODO maybe extend test?
 
     @pytest.mark.require_new_history
     def test_parameters_display(self, history_id):
@@ -1013,7 +1011,6 @@ steps:
             f"/api/datasets/{dataset_id}/parameters_display", data={"hda_ldda": "hda"}
         )
         self._assert_status_code_is(display_parameters_by_dataset_response, 200)
-        # TODO maybe extend test
 
     def _create_and_search_job(self, history_id, inputs, tool_id):
         # create a job
@@ -1095,4 +1092,5 @@ steps:
         self._assert_status_code_is(jobs_response, 200)
         jobs = jobs_response.json()
         assert isinstance(jobs, list)
+        return jobs
         return jobs

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -977,6 +977,16 @@ steps:
     #     self._assert_status_code_is(empty_search_response, 200)
     #     assert len(empty_search_response.json()) == 0
 
+    @pytest.mark.require_new_history
+    def test_destination_params(self, history_id):
+        dataset_id = self.__history_with_ok_dataset(history_id)
+        inputs = json.dumps({"input1": {"src": "hda", "id": dataset_id}})
+        search_response = self._create_and_search_job(history_id, inputs, tool_id="cat1")
+        job_id = search_response.json()[0]["id"]
+        destination_params_response = self._get(f"/api/jobs/{job_id}/destination_params", admin=True)
+        self._assert_status_code_is(destination_params_response, 200)
+        # TODO maybe extend test?
+
     def _create_and_search_job(self, history_id, inputs, tool_id):
         # create a job
         search_payload = self._search_payload(history_id=history_id, tool_id=tool_id, inputs=inputs)

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -995,7 +995,6 @@ steps:
         job_id = search_response.json()[0]["id"]
         metrics_by_job_response = self._get(f"/api/jobs/{job_id}/metrics", data={"hda_ldda": "hda"})
         self._assert_status_code_is(metrics_by_job_response, 200)
-        # TODO enable this once metrics_by_dataset works
         metrics_by_dataset_response = self._get(f"/api/datasets/{dataset_id}/metrics", data={"hda_ldda": "hda"})
         self._assert_status_code_is(metrics_by_dataset_response, 200)
         # TODO maybe extend test?
@@ -1010,7 +1009,6 @@ steps:
             f"/api/jobs/{job_id}/parameters_display", data={"hda_ldda": "hda"}
         )
         self._assert_status_code_is(display_parameters_by_job_response, 200)
-        # TODO enable this once parameters_display_by_dataset works
         display_parameters_by_dataset_response = self._get(
             f"/api/datasets/{dataset_id}/parameters_display", data={"hda_ldda": "hda"}
         )

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -939,7 +939,7 @@ steps:
 
     def _job_search(self, tool_id, history_id, inputs):
         search_payload = self._search_payload(history_id=history_id, tool_id=tool_id, inputs=inputs)
-        empty_search_response = self._post("jobs/search", data=search_payload)
+        empty_search_response = self._post("jobs/search", data=search_payload, json=True)
         self._assert_status_code_is(empty_search_response, 200)
         assert len(empty_search_response.json()) == 0
         tool_response = self._post("tools", data=search_payload)
@@ -966,7 +966,7 @@ steps:
         return search_count
 
     def _search_count(self, search_payload):
-        search_response = self._post("jobs/search", data=search_payload)
+        search_response = self._post("jobs/search", data=search_payload, json=True)
         self._assert_status_code_is(search_response, 200)
         search_json = search_response.json()
         return len(search_json)

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -488,7 +488,7 @@ steps:
         job_id = run_response["jobs"][0]["id"]
         self.dataset_populator.wait_for_job(job_id)
         dataset_id = run_response["outputs"][0]["id"]
-        response = self._post(f"jobs/{job_id}/error", data={"dataset_id": dataset_id})
+        response = self._post(f"jobs/{job_id}/error", data={"dataset_id": dataset_id}, json=True)
         assert response.status_code == 200, response.text
 
     @skip_without_tool("detect_errors_aggressive")

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -995,10 +995,27 @@ steps:
         job_id = search_response.json()[0]["id"]
         metrics_by_job_response = self._get(f"/api/jobs/{job_id}/metrics", data={"hda_ldda": "hda"})
         self._assert_status_code_is(metrics_by_job_response, 200)
-        # TODO enable this once metrics_by_dataset_works
+        # TODO enable this once metrics_by_dataset works
         metrics_by_dataset_response = self._get(f"/api/datasets/{dataset_id}/metrics", data={"hda_ldda": "hda"})
         self._assert_status_code_is(metrics_by_dataset_response, 200)
         # TODO maybe extend test?
+
+    @pytest.mark.require_new_history
+    def test_parameters_display(self, history_id):
+        dataset_id = self.__history_with_ok_dataset(history_id)
+        inputs = json.dumps({"input1": {"src": "hda", "id": dataset_id}})
+        search_response = self._create_and_search_job(history_id, inputs, tool_id="cat1")
+        job_id = search_response.json()[0]["id"]
+        display_parameters_by_job_response = self._get(
+            f"/api/jobs/{job_id}/parameters_display", data={"hda_ldda": "hda"}
+        )
+        self._assert_status_code_is(display_parameters_by_job_response, 200)
+        # TODO enable this once parameters_display_by_dataset works
+        display_parameters_by_dataset_response = self._get(
+            f"/api/datasets/{dataset_id}/parameters_display", data={"hda_ldda": "hda"}
+        )
+        self._assert_status_code_is(display_parameters_by_dataset_response, 200)
+        # TODO maybe extend test
 
     def _create_and_search_job(self, history_id, inputs, tool_id):
         # create a job

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -1093,4 +1093,3 @@ steps:
         jobs = jobs_response.json()
         assert isinstance(jobs, list)
         return jobs
-        return jobs

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -937,6 +937,27 @@ steps:
         )
         assert rerun_content == run_content
 
+    @pytest.mark.require_new_history
+    def test_get_inputs(self, history_id):
+        dataset_id = self.__history_with_ok_dataset(history_id)
+        inputs = json.dumps({"input1": {"src": "hda", "id": dataset_id}})
+        # create a job
+        search_payload = self._search_payload(history_id=history_id, tool_id="cat1", inputs=inputs)
+        tool_response = self._post("tools", data=search_payload)
+        self.dataset_populator.wait_for_tool_run(history_id, run_response=tool_response)
+        # search for the job and get the corresponding id
+        search_response = self._post("jobs/search", data=search_payload, json=True)
+        self._assert_status_code_is(search_response, 200)
+        job_id = search_response.json()[0]["id"]
+        # get the inputs of the job
+        job_response = self._get(f"jobs/{job_id}/inputs")
+        self._assert_status_code_is(job_response, 200)
+        job_inputs = job_response.json()[0]
+        # validate response
+        assert job_inputs["name"] == "input1"
+        assert job_inputs.get("name") == "input1"
+        assert job_inputs.get("dataset") == {"src": "hda", "id": dataset_id}
+
     def _job_search(self, tool_id, history_id, inputs):
         search_payload = self._search_payload(history_id=history_id, tool_id=tool_id, inputs=inputs)
         empty_search_response = self._post("jobs/search", data=search_payload, json=True)


### PR DESCRIPTION
This is a part of #10889.

## Summary
- [x] Refactored API routes
- [x] Added pydantic models
- [x] Operations now return pydanctic models
- [x] Removed the mapping to the legacy routes

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] I added automated tests for the operations missing tests
- [x] Instructions for manual testing are as follows:
    You can find the interactive API documentation here: [http://127.0.0.1:8080/api/docs#/jobs](url)

![image](https://github.com/galaxyproject/galaxy/assets/117033448/da5dbd07-9b5b-4791-9b68-1dcf794a235b)



## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
