### PR TITLE
Add EGI Check-in as OIDC authentication option

### DIFF
--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -165,6 +165,9 @@ class AuthnzManager:
             rtv["tenant_id"] = config_xml.find("tenant_id").text
         if config_xml.find("pkce_support") is not None:
             rtv["pkce_support"] = asbool(config_xml.find("pkce_support").text)
+        # this is a EGI Check-in specific config
+        if config_xml.find("checkin_env") is not None:
+            rtv["checkin_env"] = config_xml.find("checkin_env").text
 
         return rtv
 

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -42,6 +42,7 @@ BACKENDS = {
     "elixir": "social_core.backends.elixir.ElixirOpenIdConnect",
     "okta": "social_core.backends.okta_openidconnect.OktaOpenIdConnect",
     "azure": "social_core.backends.azuread_tenant.AzureADV2TenantOAuth2",
+    "checkin": "social_core.backends.checkin.CheckinOpenIdConnect",
 }
 
 BACKENDS_NAME = {
@@ -50,6 +51,7 @@ BACKENDS_NAME = {
     "elixir": "elixir",
     "okta": "okta-openidconnect",
     "azure": "azuread-v2-tenant-oauth2",
+    "checkin": "checkin",
 }
 
 AUTH_PIPELINE = (

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -42,7 +42,7 @@ BACKENDS = {
     "elixir": "social_core.backends.elixir.ElixirOpenIdConnect",
     "okta": "social_core.backends.okta_openidconnect.OktaOpenIdConnect",
     "azure": "social_core.backends.azuread_tenant.AzureADV2TenantOAuth2",
-    "egi_checkin": "social_core.backends.checkin.EGICheckinOpenIdConnect",
+    "egi_checkin": "social_core.backends.egi_checkin.EGICheckinOpenIdConnect",
 }
 
 BACKENDS_NAME = {

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -42,7 +42,7 @@ BACKENDS = {
     "elixir": "social_core.backends.elixir.ElixirOpenIdConnect",
     "okta": "social_core.backends.okta_openidconnect.OktaOpenIdConnect",
     "azure": "social_core.backends.azuread_tenant.AzureADV2TenantOAuth2",
-    "checkin": "social_core.backends.checkin.CheckinOpenIdConnect",
+    "egi_checkin": "social_core.backends.checkin.EGICheckinOpenIdConnect",
 }
 
 BACKENDS_NAME = {
@@ -51,7 +51,7 @@ BACKENDS_NAME = {
     "elixir": "elixir",
     "okta": "okta-openidconnect",
     "azure": "azuread-v2-tenant-oauth2",
-    "checkin": "checkin",
+    "egi_checkin": "egi-checkin",
 }
 
 AUTH_PIPELINE = (

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -198,8 +198,8 @@ Please mind `http` and `https`.
     </provider>
 
     <!-- Documentation: https://docs.egi.eu/providers/check-in/sp -->
-    <provider name="checkin">
-	<!-- Client id and secret can be obtained by registering your client at Check-in
+    <provider name="egi_checkin">
+	<!-- Client id and secret can be obtained by registering your client at EGI Check-in
 	Federation Registry: https://aai.egi.eu/federation -->
         <client_id>...</client_id>
         <client_secret>...</client_secret>

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -197,4 +197,18 @@ Please mind `http` and `https`.
         <api_url> ... </api_url>
     </provider>
 
+    <!-- Documentation: https://docs.egi.eu/providers/check-in/sp -->
+    <provider name="checkin">
+	<!-- Client id and secret can be obtained by registering your client at Check-in
+	Federation Registry: https://aai.egi.eu/federation -->
+        <client_id>...</client_id>
+        <client_secret>...</client_secret>
+	<redirect_uri>http://localhost:8080/authnz/checkin/callback</redirect_uri>
+	<icon>https://im.egi.eu/im-dashboard/static/images/egicheckin.png</icon>
+        <prompt>consent</prompt>
+	<!-- (Optional) Which Check-in environment to use (prod, demo, dev), default is prod -->
+	<!-- <checkin_env>dev</checkin_env> -->
+    </provider>
+
+
 </OIDC>


### PR DESCRIPTION
This PR adds a new EGI Check-in login option for Galaxy so users can authenticate with EGI credentials.

It depends on https://github.com/python-social-auth/social-core/pull/836 being released into python-social-auth. 

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows:
  

1. Update your social-core package with the changes in https://github.com/python-social-auth/social-core/pull/836

1. Create a Check-in client at https://aai.egi.eu/federation, set the redirect uri to `https://<your galaxy url>/authnz/egi_checkin/callback`

3. Enable oidc in the galaxy config, i.e. set `enable_oidc: true` 

4. Add the Check-in config to your oidc_backedns_config_file (`config/oidc_backends_config.xml`). Usually, the clients are created in the `demo` environment of Check-in so for testing you should use a configuration similar to this:
```
<!-- Documentation: https://docs.egi.eu/providers/check-in/sp -->
<provider name="egi_checkin">
   <!-- Client id and secret can be obtained by registering your client at EGI Check-in
	Federation Registry: https://aai.egi.eu/federation -->
   <client_id>...</client_id>
   <client_secret>...</client_secret>
   <redirect_uri>http://localhost:8080/authnz/egi_checkin/callback</redirect_uri>
   <icon>https://im.egi.eu/im-dashboard/static/images/egicheckin.png</icon>
   <prompt>consent</prompt>
   <checkin_env>demo</checkin_env>
</provider>
```

This will result in a login page similar to this:
![image](https://github.com/galaxyproject/galaxy/assets/1422438/c310d585-04eb-4a46-b1f2-38276ac3e553)

Once logged in, Galaxy will use EGI user identifier as "public name" and the email address as email address:

![image](https://github.com/galaxyproject/galaxy/assets/1422438/4e294f24-3d22-4043-ab7c-e50215d5682f)

5. When moving to production Check-in environment, the `<checkin_env>` in the oidc_backends_config file configuration can be set to `prod` or removed completely (`prod` is the default value)


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
