### PR TITLE
Replace file_name property with get_file_name function

### DIFF
--- a/doc/source/admin/jobs.md
+++ b/doc/source/admin/jobs.md
@@ -254,7 +254,7 @@ def ncbi_blastn_wrapper(job):
     # Allocate extra time
     inp_data = dict( [ ( da.name, da.dataset ) for da in job.input_datasets ] )
     inp_data.update( [ ( da.name, da.dataset ) for da in job.input_library_datasets ] )
-    query_file = inp_data[ "query" ].file_name
+    query_file = inp_data[ "query" ].get_file_name()
     query_size = os.path.getsize( query_file )
     if query_size > 1024 * 1024:
         walltime_str = "walltime=24:00:00/"

--- a/doc/source/dev/data_types.md
+++ b/doc/source/dev/data_types.md
@@ -282,7 +282,7 @@ we're setting metadata about the file.
 
 ```python
     def set_meta(self, dataset, **kwd):
-        dataset.metadata.number_of_sequences = self._count_genbank_sequences(dataset.file_name)
+        dataset.metadata.number_of_sequences = self._count_genbank_sequences(dataset.get_file_name())
 ```
 
 Now we'll need to make use of this in our `set_peek`
@@ -297,7 +297,7 @@ override:
             else:
                 dataset.blurb = "%s sequences" % dataset.metadata.number_of_sequences
             # Get standard text peek from dataset
-            dataset.peek = data.get_file_peek(dataset.file_name, is_multi_byte=is_multi_byte)
+            dataset.peek = data.get_file_peek(dataset.get_file_name(), is_multi_byte=is_multi_byte)
         else:
             dataset.peek = 'file does not exist'
             dataset.blurb = 'file purged from disk'
@@ -332,7 +332,7 @@ class Genbank(data.Text):
             else:
                 dataset.blurb = "%s sequences" % dataset.metadata.number_of_sequences
             # Get
-            dataset.peek = data.get_file_peek(dataset.file_name, is_multi_byte=is_multi_byte)
+            dataset.peek = data.get_file_peek(dataset.get_file_name(), is_multi_byte=is_multi_byte)
         else:
             dataset.peek = 'file does not exist'
             dataset.blurb = 'file purged from disk'
@@ -348,7 +348,7 @@ class Genbank(data.Text):
         """
         Set the number of sequences in dataset.
         """
-        dataset.metadata.number_of_sequences = self._count_genbank_sequences(dataset.file_name)
+        dataset.metadata.number_of_sequences = self._count_genbank_sequences(dataset.get_file_name())
 
     def _count_genbank_sequences(self, filename):
         """

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -152,7 +152,7 @@ def change_datatype(
         log.info(f"Changing datatype is not allowed for {model_class} {dataset_instance.id}")
         return
     if datatype == "auto":
-        path = dataset_instance.dataset.file_name
+        path = dataset_instance.dataset.get_file_name()
         datatype = sniff.guess_ext(path, datatypes_registry.sniff_order)
     datatypes_registry.change_datatype(dataset_instance, datatype)
     with transaction(sa_session):

--- a/lib/galaxy/datatypes/annotation.py
+++ b/lib/galaxy/datatypes/annotation.py
@@ -23,7 +23,7 @@ class SnapHmm(Text):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.blurb = "SNAP HMM model"
         else:
             dataset.peek = "file does not exist"

--- a/lib/galaxy/datatypes/assembly.py
+++ b/lib/galaxy/datatypes/assembly.py
@@ -238,7 +238,7 @@ class Velvet(Html):
                 else:
                     rval.append(f'<li><a href="{fn}" type="text/plain">{fn}</a>{opt_text}</li>')
         rval.append("</ul></div></html>")
-        with open(dataset.file_name, "w") as f:
+        with open(dataset.get_file_name(), "w") as f:
             f.write("\n".join(rval))
             f.write("\n")
 

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -231,7 +231,7 @@ class Cel(Binary):
         """
         Set metadata for Cel file.
         """
-        with open(dataset.file_name, "rb") as handle:
+        with open(dataset.get_file_name(), "rb") as handle:
             header_bytes = handle.read(8)
         if struct.unpack("<ii", header_bytes[:9]) == (64, 4):
             dataset.metadata.version = "4"
@@ -243,7 +243,7 @@ class Cel(Binary):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
             dataset.blurb = f"Cel version: {dataset.metadata.version}"
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
         else:
             dataset.peek = "file does not exist"
             dataset.blurb = "file purged from disk"
@@ -454,7 +454,7 @@ class _BamOrSam:
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         try:
-            bam_file = pysam.AlignmentFile(dataset.file_name, mode="rb")
+            bam_file = pysam.AlignmentFile(dataset.get_file_name(), mode="rb")
             # TODO: Reference names, lengths, read_groups and headers can become very large, truncate when necessary
             dataset.metadata.reference_names = list(bam_file.references)
             dataset.metadata.reference_lengths = list(bam_file.lengths)
@@ -605,12 +605,12 @@ class BamNative(CompressedArchive, _BamOrSam):
     def to_archive(self, dataset: DatasetProtocol, name: str = "") -> Iterable:
         rel_paths = []
         file_paths = []
-        rel_paths.append(f"{name or dataset.file_name}.{dataset.extension}")
-        file_paths.append(dataset.file_name)
+        rel_paths.append(f"{name or dataset.get_file_name()}.{dataset.extension}")
+        file_paths.append(dataset.get_file_name())
         # We may or may not have a bam index file (BamNative doesn't have it, but also index generation may have failed)
         if dataset.metadata.bam_index:
-            rel_paths.append(f"{name or dataset.file_name}.{dataset.extension}.bai")
-            file_paths.append(dataset.metadata.bam_index.file_name)
+            rel_paths.append(f"{name or dataset.get_file_name()}.{dataset.extension}.bai")
+            file_paths.append(dataset.metadata.bam_index.get_file_name())
         return zip(file_paths, rel_paths)
 
     def groom_dataset_content(self, file_name: str) -> None:
@@ -648,7 +648,7 @@ class BamNative(CompressedArchive, _BamOrSam):
     def get_chunk(self, trans, dataset: HasFileName, offset: int = 0, ck_size: Optional[int] = None) -> str:
         if not offset == -1:
             try:
-                with pysam.AlignmentFile(dataset.file_name, "rb", check_sq=False) as bamfile:
+                with pysam.AlignmentFile(dataset.get_file_name(), "rb", check_sq=False) as bamfile:
                     if ck_size is None:
                         ck_size = 300  # 300 lines
                     if offset == 0:
@@ -727,9 +727,9 @@ class BamNative(CompressedArchive, _BamOrSam):
             )
 
     def validate(self, dataset: DatasetProtocol, **kwd) -> DatatypeValidation:
-        if not BamNative.is_bam(dataset.file_name):
+        if not BamNative.is_bam(dataset.get_file_name()):
             return DatatypeValidation.invalid("This dataset does not appear to a BAM file.")
-        elif self.dataset_content_needs_grooming(dataset.file_name):
+        elif self.dataset_content_needs_grooming(dataset.get_file_name()):
             return DatatypeValidation.invalid(
                 "This BAM file does not appear to have the correct sorting for declared datatype."
             )
@@ -820,7 +820,7 @@ class Bam(BamNative):
     ) -> None:
         # These metadata values are not accessible by users, always overwrite
         super().set_meta(dataset=dataset, overwrite=overwrite, **kwd)
-        index_flag = self.get_index_flag(dataset.file_name)
+        index_flag = self.get_index_flag(dataset.get_file_name())
         if index_flag == "-b":
             spec_key = "bam_index"
             index_file = dataset.metadata.bam_index
@@ -833,9 +833,9 @@ class Bam(BamNative):
             )
         if index_flag == "-b":
             # IOError: No such file or directory: '-b' if index_flag is set to -b (pysam 0.15.4)
-            pysam.index("-o", index_file.file_name, dataset.file_name)  # type: ignore [attr-defined]
+            pysam.index("-o", index_file.get_file_name(), dataset.get_file_name())  # type: ignore [attr-defined]
         else:
-            pysam.index(index_flag, "-o", index_file.file_name, dataset.file_name)  # type: ignore [attr-defined]
+            pysam.index(index_flag, "-o", index_file.get_file_name(), dataset.get_file_name())  # type: ignore [attr-defined]
         dataset.metadata.bam_index = index_file
 
     def sniff(self, filename: str) -> bool:
@@ -1004,7 +1004,7 @@ class CRAM(Binary):
     def set_meta(
         self, dataset: DatasetProtocol, overwrite: bool = True, metadata_tmp_files_dir: Optional[str] = None, **kwd
     ) -> None:
-        major_version, minor_version = self.get_cram_version(dataset.file_name)
+        major_version, minor_version = self.get_cram_version(dataset.get_file_name())
         if major_version != -1:
             dataset.metadata.cram_version = f"{str(major_version)}.{str(minor_version)}"
 
@@ -1026,7 +1026,7 @@ class CRAM(Binary):
 
     def set_index_file(self, dataset: HasFileName, index_file) -> bool:
         try:
-            pysam.index("-o", index_file.file_name, dataset.file_name)  # type: ignore [attr-defined]
+            pysam.index("-o", index_file.get_file_name(), dataset.get_file_name())  # type: ignore [attr-defined]
             return True
         except Exception as exc:
             log.warning("%s, set_index_file Exception: %s", self, exc)
@@ -1096,14 +1096,14 @@ class Bcf(BaseBcf):
             )
         # Create the bcf index
         dataset_symlink = os.path.join(
-            os.path.dirname(index_file.file_name),
-            "__dataset_%d_%s" % (dataset.id, os.path.basename(index_file.file_name)),
+            os.path.dirname(index_file.get_file_name()),
+            "__dataset_%d_%s" % (dataset.id, os.path.basename(index_file.get_file_name())),
         )
-        os.symlink(dataset.file_name, dataset_symlink)
+        os.symlink(dataset.get_file_name(), dataset_symlink)
         try:
             cmd = ["python", "-c", f"import pysam.bcftools; pysam.bcftools.index('{dataset_symlink}')"]
             subprocess.check_call(cmd)
-            shutil.move(f"{dataset_symlink}.csi", index_file.file_name)
+            shutil.move(f"{dataset_symlink}.csi", index_file.get_file_name())
         except Exception as e:
             raise Exception(f"Error setting BCF metadata: {util.unicodify(e)}")
         finally:
@@ -1199,7 +1199,7 @@ class H5(Binary):
         This allows the h5web visualization tool (https://github.com/silx-kit/h5web)
         to be used directly with Galaxy datasets.
         """
-        with get_content_from_file(dataset.file_name, path, self._create_error) as content:
+        with get_content_from_file(dataset.get_file_name(), path, self._create_error) as content:
             if content_type == "attr":
                 assert isinstance(content, ResolvedEntityContent)
                 resp = encode(content.attributes(), "json")
@@ -1326,7 +1326,7 @@ class Loom(H5):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         try:
-            with h5py.File(dataset.file_name, "r") as loom_file:
+            with h5py.File(dataset.get_file_name(), "r") as loom_file:
                 dataset.metadata.title = loom_file.attrs.get("title")
                 dataset.metadata.description = loom_file.attrs.get("description")
                 dataset.metadata.url = loom_file.attrs.get("url")
@@ -1470,7 +1470,7 @@ class Anndata(H5):
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
-        with h5py.File(dataset.file_name, "r") as anndata_file:
+        with h5py.File(dataset.get_file_name(), "r") as anndata_file:
             dataset.metadata.title = anndata_file.attrs.get("title")
             dataset.metadata.description = anndata_file.attrs.get("description")
             dataset.metadata.url = anndata_file.attrs.get("url")
@@ -1665,7 +1665,7 @@ class Grib(Binary):
         """
         Set the GRIB edition.
         """
-        dataset.metadata.grib_edition = self._get_grib_edition(dataset.file_name)
+        dataset.metadata.grib_edition = self._get_grib_edition(dataset.get_file_name())
 
     def _get_grib_edition(self, filename: str) -> int:
         _uint8struct = struct.Struct(b">B")
@@ -1831,7 +1831,7 @@ class Biom2(H5):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         try:
-            with h5py.File(dataset.file_name, "r") as f:
+            with h5py.File(dataset.get_file_name(), "r") as f:
                 attributes = f.attrs
 
                 dataset.metadata.id = util.unicodify(attributes["id"])
@@ -1854,7 +1854,7 @@ class Biom2(H5):
         if not dataset.dataset.purged:
             lines = ["Biom2 (HDF5) file"]
             try:
-                with h5py.File(dataset.file_name) as f:
+                with h5py.File(dataset.get_file_name()) as f:
                     for k, v in f.attrs.items():
                         lines.append(f"{k}:  {util.unicodify(v)}")
             except Exception as e:
@@ -2023,10 +2023,10 @@ class H5MLM(H5):
                 params_file = dataset.metadata.spec[spec_key].param.new_file(
                     dataset=dataset, metadata_tmp_files_dir=metadata_tmp_files_dir
                 )
-            with h5py.File(dataset.file_name, "r") as handle:
+            with h5py.File(dataset.get_file_name(), "r") as handle:
                 hyper_params = handle[self.HYPERPARAMETER][()]
             hyper_params = json.loads(util.unicodify(hyper_params))
-            with open(params_file.file_name, "w") as f:
+            with open(params_file.get_file_name(), "w") as f:
                 f.write("\tParameter\tValue\n")
                 for p in hyper_params:
                     f.write("\t".join(p) + "\n")
@@ -2079,7 +2079,7 @@ class H5MLM(H5):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            repr = self.get_repr(dataset.file_name)
+            repr = self.get_repr(dataset.get_file_name())
             dataset.peek = repr[: self.max_peek_size]
             dataset.blurb = nice_size(dataset.get_size())
         else:
@@ -2110,7 +2110,7 @@ class H5MLM(H5):
 
         out_dict: Dict = {}
         try:
-            with h5py.File(dataset.file_name, "r") as handle:
+            with h5py.File(dataset.get_file_name(), "r") as handle:
                 out_dict["Attributes"] = {}
                 attributes = handle.attrs
                 for k in set(attributes.keys()) - {self.HTTP_REPR, self.REPR, self.URL}:
@@ -2118,13 +2118,13 @@ class H5MLM(H5):
         except Exception as e:
             log.warning(e)
 
-        config = self.get_config_string(dataset.file_name)
+        config = self.get_config_string(dataset.get_file_name())
         out_dict["Config"] = json.loads(config) if config else ""
         out = json.dumps(out_dict, sort_keys=True, indent=2)
         out = out[: self.max_preview_size]
 
-        repr = self.get_repr(dataset.file_name)
-        html_repr = self.get_html_repr(dataset.file_name)
+        repr = self.get_repr(dataset.get_file_name())
+        html_repr = self.get_html_repr(dataset.get_file_name())
 
         return f"<div>{html_repr}</div><div><pre>{repr}</pre></div><div><pre>{out}</pre></div>", headers
 
@@ -2209,7 +2209,7 @@ class HexrdMaterials(H5):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         try:
-            with h5py.File(dataset.file_name, "r") as mat_file:
+            with h5py.File(dataset.get_file_name(), "r") as mat_file:
                 dataset.metadata.materials = list(mat_file.keys())
                 sgn = dict()
                 lp = dict()
@@ -2404,7 +2404,7 @@ class SQlite(Binary):
             tables = []
             columns = dict()
             rowcounts = dict()
-            conn = sqlite.connect(dataset.file_name)
+            conn = sqlite.connect(dataset.get_file_name())
             c = conn.cursor()
             tables_query = "SELECT name,sql FROM sqlite_master WHERE type='table' ORDER BY name"
             rslt = c.execute(tables_query).fetchall()
@@ -2513,7 +2513,7 @@ class GeminiSQLite(SQlite):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         try:
-            conn = sqlite.connect(dataset.file_name)
+            conn = sqlite.connect(dataset.get_file_name())
             c = conn.cursor()
             tables_query = "SELECT version FROM version"
             result = c.execute(tables_query).fetchall()
@@ -2595,7 +2595,7 @@ class CuffDiffSQlite(SQlite):
         try:
             genes = []
             samples = []
-            conn = sqlite.connect(dataset.file_name)
+            conn = sqlite.connect(dataset.get_file_name())
             c = conn.cursor()
             tables_query = "SELECT value FROM runInfo where param = 'version'"
             result = c.execute(tables_query).fetchall()
@@ -2795,7 +2795,7 @@ class BlibSQlite(SQlite):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         try:
-            conn = sqlite.connect(dataset.file_name)
+            conn = sqlite.connect(dataset.get_file_name())
             c = conn.cursor()
             tables_query = "SELECT majorVersion,minorVersion FROM LibInfo"
             (majorVersion, minorVersion) = c.execute(tables_query).fetchall()[0]
@@ -2848,7 +2848,7 @@ class DlibSQlite(SQlite):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         try:
-            conn = sqlite.connect(dataset.file_name)
+            conn = sqlite.connect(dataset.get_file_name())
             c = conn.cursor()
             tables_query = "SELECT Value FROM metadata WHERE Key = 'version'"
             version = c.execute(tables_query).fetchall()[0]
@@ -2892,7 +2892,7 @@ class ElibSQlite(SQlite):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         try:
-            conn = sqlite.connect(dataset.file_name)
+            conn = sqlite.connect(dataset.get_file_name())
             c = conn.cursor()
             tables_query = "SELECT Value FROM metadata WHERE Key = 'version'"
             version = c.execute(tables_query).fetchall()[0]
@@ -2988,7 +2988,7 @@ class GAFASQLite(SQlite):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         try:
-            conn = sqlite.connect(dataset.file_name)
+            conn = sqlite.connect(dataset.get_file_name())
             c = conn.cursor()
             version_query = "SELECT version FROM meta"
             results = c.execute(version_query).fetchall()
@@ -3034,7 +3034,7 @@ class NcbiTaxonomySQlite(SQlite):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         try:
-            conn = sqlite.connect(dataset.file_name)
+            conn = sqlite.connect(dataset.get_file_name())
             c = conn.cursor()
             version_query = "SELECT version FROM __diesel_schema_migrations ORDER BY run_on DESC LIMIT 1"
             results = c.execute(version_query).fetchall()
@@ -3157,7 +3157,7 @@ class RData(CompressedArchive):
     >>> from galaxy.util.bunch import Bunch
     >>> dataset = Bunch()
     >>> dataset.metadata = Bunch
-    >>> dataset.file_name = fname
+    >>> dataset.get_file_name = lambda : fname
     >>> dataset.has_data = lambda: True
     >>> RData().set_meta(dataset)
     >>> dataset.metadata.version
@@ -3180,7 +3180,7 @@ class RData(CompressedArchive):
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
-        _, fh = compression_utils.get_fileobj_raw(dataset.file_name, "rb")
+        _, fh = compression_utils.get_fileobj_raw(dataset.get_file_name(), "rb")
         try:
             dataset.metadata.version = self._parse_rdata_header(fh)
         except Exception:
@@ -3220,7 +3220,7 @@ class RDS(CompressedArchive):
     >>> from galaxy.util.bunch import Bunch
     >>> dataset = Bunch()
     >>> dataset.metadata = Bunch
-    >>> dataset.file_name = get_test_fname('int-r4.rds')
+    >>> dataset.get_file_name = lambda : get_test_fname('int-r4.rds')
     >>> dataset.has_data = lambda: True
     >>> RDS().set_meta(dataset)
     >>> dataset.metadata.version
@@ -3263,7 +3263,7 @@ class RDS(CompressedArchive):
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
-        _, fh = compression_utils.get_fileobj_raw(dataset.file_name, "rb")
+        _, fh = compression_utils.get_fileobj_raw(dataset.get_file_name(), "rb")
         try:
             (
                 _,
@@ -3511,8 +3511,8 @@ class PostgresqlArchive(CompressedArchive):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         try:
-            if dataset and tarfile.is_tarfile(dataset.file_name):
-                with tarfile.open(dataset.file_name, "r") as temptar:
+            if dataset and tarfile.is_tarfile(dataset.get_file_name()):
+                with tarfile.open(dataset.get_file_name(), "r") as temptar:
                     pg_version_file = temptar.extractfile("postgresql/db/PG_VERSION")
                     if not pg_version_file:
                         raise Exception("Error setting PostgresqlArchive metadata: PG_VERSION file not found")
@@ -3567,8 +3567,8 @@ class MongoDBArchive(CompressedArchive):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         try:
-            if dataset and tarfile.is_tarfile(dataset.file_name):
-                with tarfile.open(dataset.file_name, "r") as temptar:
+            if dataset and tarfile.is_tarfile(dataset.get_file_name()):
+                with tarfile.open(dataset.get_file_name(), "r") as temptar:
                     metrics_file = next(
                         filter(lambda x: x.startswith("mongo_db/diagnostic.data/metrics"), temptar.getnames()), None
                     )
@@ -3643,8 +3643,8 @@ class Fast5Archive(CompressedArchive):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         try:
-            if dataset and tarfile.is_tarfile(dataset.file_name):
-                with tarfile.open(dataset.file_name, "r") as temptar:
+            if dataset and tarfile.is_tarfile(dataset.get_file_name()):
+                with tarfile.open(dataset.get_file_name(), "r") as temptar:
                     dataset.metadata.fast5_count = sum(1 for f in temptar if f.name.endswith(".fast5"))
         except Exception as e:
             log.warning("%s, set_meta Exception: %s", self, e)
@@ -3751,8 +3751,8 @@ class SearchGuiArchive(CompressedArchive):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         try:
-            if dataset and zipfile.is_zipfile(dataset.file_name):
-                with zipfile.ZipFile(dataset.file_name) as tempzip:
+            if dataset and zipfile.is_zipfile(dataset.get_file_name()):
+                with zipfile.ZipFile(dataset.get_file_name()) as tempzip:
                     if "searchgui.properties" in tempzip.namelist():
                         with tempzip.open("searchgui.properties") as fh:
                             for line in io.TextIOWrapper(fh):
@@ -4308,7 +4308,7 @@ class Npz(CompressedArchive):
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         try:
-            with np.load(dataset.file_name) as npz:
+            with np.load(dataset.get_file_name()) as npz:
                 dataset.metadata.nfiles = len(npz.files)
                 dataset.metadata.files = npz.files
         except Exception as e:
@@ -4377,7 +4377,7 @@ class HexrdImagesNpz(Npz):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         try:
-            with np.load(dataset.file_name) as npz:
+            with np.load(dataset.get_file_name()) as npz:
                 if "panel_id" in npz.files:
                     dataset.metadata.panel_id = str(npz["panel_id"])
                 if "omega" in npz.files:
@@ -4443,7 +4443,7 @@ class HexrdEtaOmeNpz(Npz):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         try:
-            with np.load(dataset.file_name) as npz:
+            with np.load(dataset.get_file_name()) as npz:
                 dataset.metadata.HKLs = npz["iHKLList"].tolist()
                 dataset.metadata.nframes = len(npz["omegas"])
         except Exception as e:
@@ -4516,7 +4516,7 @@ class FITS(Binary):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         try:
-            with fits.open(dataset.file_name) as hdul:
+            with fits.open(dataset.get_file_name()) as hdul:
                 dataset.metadata.HDUs = []
                 for i in range(len(hdul)):
                     dataset.metadata.HDUs.append(

--- a/lib/galaxy/datatypes/blast.py
+++ b/lib/galaxy/datatypes/blast.py
@@ -70,7 +70,7 @@ class BlastXml(GenericXml):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.blurb = "NCBI Blast XML data"
         else:
             dataset.peek = "file does not exist"
@@ -246,7 +246,7 @@ class _BlastDb(Data):
         msg = ""
         try:
             # Try to use any text recorded in the dummy index file:
-            with open(dataset.file_name, encoding="utf-8") as handle:
+            with open(dataset.get_file_name(), encoding="utf-8") as handle:
                 msg = handle.read().strip()
         except Exception:
             pass

--- a/lib/galaxy/datatypes/chain.py
+++ b/lib/galaxy/datatypes/chain.py
@@ -39,7 +39,7 @@ class Chain(data.Text):
         """
         data_lines = 0
         chains = 0
-        with compression_utils.get_fileobj(dataset.file_name) as fh:
+        with compression_utils.get_fileobj(dataset.get_file_name()) as fh:
             for line in fh:
                 line = line.strip()
                 if line and line.startswith("#"):
@@ -55,7 +55,7 @@ class Chain(data.Text):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             if dataset.metadata.chains:
                 dataset.blurb = f"{commaify(str(dataset.metadata.chains))} chains"
             else:

--- a/lib/galaxy/datatypes/constructive_solid_geometry.py
+++ b/lib/galaxy/datatypes/constructive_solid_geometry.py
@@ -106,7 +106,7 @@ class Ply:
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         if dataset.has_data():
-            with open(dataset.file_name, errors="ignore") as fh:
+            with open(dataset.get_file_name(), errors="ignore") as fh:
                 for line in fh:
                     line = line.strip()
                     if not line:
@@ -129,7 +129,7 @@ class Ply:
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.blurb = f"Faces: {str(dataset.metadata.face)}, Vertices: {str(dataset.metadata.vertex)}"
         else:
             dataset.peek = "File does not exist"
@@ -292,7 +292,7 @@ class Vtk:
             field_components = {}
             dataset_structure_complete = False
             processing_field_section = False
-            with open(dataset.file_name, errors="ignore") as fh:
+            with open(dataset.get_file_name(), errors="ignore") as fh:
                 for i, line in enumerate(fh):
                     line = line.strip()
                     if not line:
@@ -463,7 +463,7 @@ class Vtk:
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.blurb = self.get_blurb(dataset)
         else:
             dataset.peek = "File does not exist"
@@ -556,7 +556,7 @@ class NeperTess(data.Text):
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         if dataset.has_data():
-            with open(dataset.file_name, errors="ignore") as fh:
+            with open(dataset.get_file_name(), errors="ignore") as fh:
                 for i, line in enumerate(fh):
                     line = line.strip()
                     if not line or i > 6:
@@ -572,7 +572,7 @@ class NeperTess(data.Text):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name, line_count=7)
+            dataset.peek = get_file_peek(dataset.get_file_name(), line_count=7)
             dataset.blurb = f"format: {str(dataset.metadata.format)} dim: {str(dataset.metadata.dimension)} cells: {str(dataset.metadata.cells)}"
         else:
             dataset.peek = "File does not exist"
@@ -627,7 +627,7 @@ class NeperTesr(Binary):
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         if dataset.has_data():
-            with open(dataset.file_name, errors="ignore") as fh:
+            with open(dataset.get_file_name(), errors="ignore") as fh:
                 field = ""
                 for i, line in enumerate(fh):
                     line = line.strip()
@@ -659,7 +659,7 @@ class NeperTesr(Binary):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name, line_count=9)
+            dataset.peek = get_file_peek(dataset.get_file_name(), line_count=9)
             dataset.blurb = f"format: {str(dataset.metadata.format)} dim: {str(dataset.metadata.dimension)} cells: {str(dataset.metadata.cells)}"
         else:
             dataset.peek = "File does not exist"
@@ -681,7 +681,7 @@ class NeperPoints(data.Text):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         data.Text.set_meta(self, dataset, overwrite=overwrite, **kwd)
         if dataset.has_data():
-            with open(dataset.file_name, errors="ignore") as fh:
+            with open(dataset.get_file_name(), errors="ignore") as fh:
                 dataset.metadata.dimension = self._get_dimension(fh)
 
     def _get_dimension(self, fh: "TextIOBase", maxlines: int = 100, sep: Optional[str] = None) -> Optional[float]:
@@ -723,7 +723,7 @@ class NeperPointsTabular(NeperPoints, Tabular):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         Tabular.set_meta(self, dataset, overwrite=overwrite, **kwd)
         if dataset.has_data():
-            with open(dataset.file_name, errors="ignore") as fh:
+            with open(dataset.get_file_name(), errors="ignore") as fh:
                 dataset.metadata.dimension = self._get_dimension(fh)
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
@@ -768,7 +768,7 @@ class GmshMsh(Binary):
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         if dataset.has_data():
-            with open(dataset.file_name, errors="ignore") as fh:
+            with open(dataset.get_file_name(), errors="ignore") as fh:
                 for i, line in enumerate(fh):
                     line = line.strip()
                     if not line or i > 1:
@@ -784,7 +784,7 @@ class GmshMsh(Binary):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name, line_count=3)
+            dataset.peek = get_file_peek(dataset.get_file_name(), line_count=3)
             dataset.blurb = f"Gmsh verion: {str(dataset.metadata.version)} {str(dataset.metadata.format)}"
         else:
             dataset.peek = "File does not exist"

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -183,7 +183,7 @@ def _get_file_size(data):
         if data.dataset.object_store:
             file_size = data.dataset.object_store.size(data.dataset)
         else:
-            file_size = os.stat(data.file_name).st_size
+            file_size = os.stat(data.get_file_name()).st_size
     return file_size
 
 
@@ -389,7 +389,7 @@ class Data(metaclass=DataMeta):
         error = False
         msg = ""
         ext = data.extension
-        path = data.file_name
+        path = data.get_file_name()
         efp = data.extra_files_path
         # Add any central file to the archive,
 
@@ -424,7 +424,7 @@ class Data(metaclass=DataMeta):
     def _serve_raw(
         self, dataset: DatasetHasHidProtocol, to_ext: Optional[str], headers: Headers, **kwd
     ) -> Tuple[IO, Headers]:
-        headers["Content-Length"] = str(os.stat(dataset.file_name).st_size)
+        headers["Content-Length"] = str(os.stat(dataset.get_file_name()).st_size)
         headers[
             "content-type"
         ] = "application/octet-stream"  # force octet-stream so Safari doesn't append mime extensions to filename
@@ -436,7 +436,7 @@ class Data(metaclass=DataMeta):
             filename_pattern=kwd.get("filename_pattern"),
         )
         headers["Content-Disposition"] = f'attachment; filename="{filename}"'
-        return open(dataset.file_name, mode="rb"), headers
+        return open(dataset.get_file_name(), mode="rb"), headers
 
     def to_archive(self, dataset: DatasetProtocol, name: str = "") -> Iterable:
         """
@@ -451,13 +451,13 @@ class Data(metaclass=DataMeta):
         if dataset.datatype.composite_type or dataset.extension.endswith("html"):
             main_file = f"{name}.html"
             rel_paths.append(main_file)
-            file_paths.append(dataset.file_name)
+            file_paths.append(dataset.get_file_name())
             for fpath, rpath in self.__archive_extra_files_path(dataset.extra_files_path):
                 rel_paths.append(os.path.join(name, rpath))
                 file_paths.append(fpath)
         else:
-            rel_paths.append(f"{name or dataset.file_name}.{dataset.extension}")
-            file_paths.append(dataset.file_name)
+            rel_paths.append(f"{name or dataset.get_file_name()}.{dataset.extension}")
+            file_paths.append(dataset.get_file_name())
         return zip(file_paths, rel_paths)
 
     def _serve_file_download(self, headers, data, trans, to_ext, file_size, **kwd):
@@ -480,7 +480,7 @@ class Data(metaclass=DataMeta):
                 "content-type"
             ] = "application/octet-stream"  # force octet-stream so Safari doesn't append mime extensions to filename
             headers["Content-Disposition"] = f'attachment; filename="{filename}"'
-            return open(data.file_name, "rb"), headers
+            return open(data.get_file_name(), "rb"), headers
 
     def _serve_binary_file_contents_as_text(self, trans, data, headers, file_size, max_peek_size):
         headers["content-type"] = "text/html"
@@ -488,7 +488,7 @@ class Data(metaclass=DataMeta):
             trans.fill_template_mako(
                 "/dataset/binary_file.mako",
                 data=data,
-                file_contents=open(data.file_name, "rb").read(max_peek_size),
+                file_contents=open(data.get_file_name(), "rb").read(max_peek_size),
                 file_size=util.nice_size(file_size),
                 truncated=file_size > max_peek_size,
             ),
@@ -500,13 +500,15 @@ class Data(metaclass=DataMeta):
 
         preview = util.string_as_bool(preview)
         if not preview or isinstance(data.datatype, images.Image) or file_size < max_peek_size:
-            return self._yield_user_file_content(trans, data, data.file_name, headers), headers
+            return self._yield_user_file_content(trans, data, data.get_file_name(), headers), headers
 
         # preview large text file
         headers["content-type"] = "text/html"
         return (
             trans.fill_template_mako(
-                "/dataset/large_file.mako", truncated_data=open(data.file_name, "rb").read(max_peek_size), data=data
+                "/dataset/large_file.mako",
+                truncated_data=open(data.get_file_name(), "rb").read(max_peek_size),
+                data=data,
             ),
             headers,
         )
@@ -581,8 +583,8 @@ class Data(metaclass=DataMeta):
         downloading = to_ext is not None
         file_size = _get_file_size(dataset)
 
-        if not os.path.exists(dataset.file_name):
-            raise ObjectNotFound(f"File Not Found ({dataset.file_name}).")
+        if not os.path.exists(dataset.get_file_name()):
+            raise ObjectNotFound(f"File Not Found ({dataset.get_file_name()}).")
 
         if downloading:
             trans.log_event(f"Download dataset id: {str(dataset.id)}")
@@ -618,7 +620,7 @@ class Data(metaclass=DataMeta):
         if self.is_binary:
             result = "*cannot display binary content*\n"
         else:
-            with open(dataset_instance.file_name) as f:
+            with open(dataset_instance.get_file_name()) as f:
                 contents = f.read(DEFAULT_MAX_PEEK_SIZE)
             result = literal_via_fence(contents)
             if len(contents) == DEFAULT_MAX_PEEK_SIZE:
@@ -1038,12 +1040,12 @@ class Text(Data):
         """
         sample_size = 1048576
         try:
-            with compression_utils.get_fileobj(dataset.file_name) as dataset_fh:
+            with compression_utils.get_fileobj(dataset.get_file_name()) as dataset_fh:
                 dataset_read = dataset_fh.read(sample_size)
             sample_lines = dataset_read.count("\n")
             return int(sample_lines * (float(dataset.get_size()) / float(sample_size)))
         except UnicodeDecodeError:
-            log.error(f"Unable to estimate lines in file {dataset.file_name}")
+            log.error(f"Unable to estimate lines in file {dataset.get_file_name()}")
             return None
 
     def count_data_lines(self, dataset: HasFileName) -> Optional[int]:
@@ -1053,7 +1055,7 @@ class Text(Data):
         """
         CHUNK_SIZE = 2**15  # 32Kb
         data_lines = 0
-        with compression_utils.get_fileobj(dataset.file_name) as in_file:
+        with compression_utils.get_fileobj(dataset.get_file_name()) as in_file:
             # FIXME: Potential encoding issue can prevent the ability to iterate over lines
             # causing set_meta process to fail otherwise OK jobs. A better solution than
             # a silent try/except is desirable.
@@ -1063,7 +1065,7 @@ class Text(Data):
                     if line and not line.startswith("#"):
                         data_lines += 1
             except UnicodeDecodeError:
-                log.error(f"Unable to count lines in file {dataset.file_name}")
+                log.error(f"Unable to count lines in file {dataset.get_file_name()}")
                 return None
         return data_lines
 
@@ -1078,7 +1080,7 @@ class Text(Data):
 
         if not dataset.dataset.purged:
             # The file must exist on disk for the get_file_peek() method
-            dataset.peek = get_file_peek(dataset.file_name, width=width, skipchars=skipchars, line_wrap=line_wrap)
+            dataset.peek = get_file_peek(dataset.get_file_name(), width=width, skipchars=skipchars, line_wrap=line_wrap)
             if line_count is None:
                 # See if line_count is stored in the metadata
                 if dataset.metadata.data_lines:
@@ -1117,7 +1119,7 @@ class Text(Data):
 
         if len(input_datasets) > 1:
             raise Exception("Text file splitting does not support multiple files")
-        input_files = [ds.file_name for ds in input_datasets]
+        input_files = [ds.get_file_name() for ds in input_datasets]
 
         lines_per_file = None
         chunk_size = None

--- a/lib/galaxy/datatypes/dataproviders/dataset.py
+++ b/lib/galaxy/datatypes/dataproviders/dataset.py
@@ -53,7 +53,7 @@ class DatasetDataProvider(base.DataProvider):
         # this dataset file is obviously the source
         # TODO: this might be a good place to interface with the object_store...
         mode = "rb" if dataset.datatype.is_binary else "r"
-        super().__init__(open(dataset.file_name, mode))
+        super().__init__(open(dataset.get_file_name(), mode))
 
     # TODO: this is a bit of a mess
     @classmethod
@@ -655,7 +655,7 @@ class SamtoolsDataProvider(line.RegexLineDataProvider):
         command = ["samtools", subcommand]
         # add options and switches, input file, regions list (if any)
         command.extend(self.to_options_list(options_string, options_dict))
-        command.append(self.dataset.file_name)
+        command.append(self.dataset.get_file_name())
         command.extend(regions)
         return command
 
@@ -714,7 +714,7 @@ class SQliteDataProvider(base.DataProvider):
 
     def __init__(self, source, query=None, **kwargs):
         self.query = query
-        self.connection = sqlite.connect(source.dataset.file_name)
+        self.connection = sqlite.connect(source.dataset.get_file_name())
         super().__init__(source, **kwargs)
 
     def __iter__(self):
@@ -736,7 +736,7 @@ class SQliteDataTableProvider(base.DataProvider):
         self.query = query
         self.headers = headers
         self.limit = limit
-        self.connection = sqlite.connect(source.dataset.file_name)
+        self.connection = sqlite.connect(source.dataset.get_file_name())
         super().__init__(source, **kwargs)
 
     def __iter__(self):
@@ -763,7 +763,7 @@ class SQliteDataDictProvider(base.DataProvider):
 
     def __init__(self, source, query=None, **kwargs):
         self.query = query
-        self.connection = sqlite.connect(source.dataset.file_name)
+        self.connection = sqlite.connect(source.dataset.get_file_name())
         super().__init__(source, **kwargs)
 
     def __iter__(self):

--- a/lib/galaxy/datatypes/dataproviders/external.py
+++ b/lib/galaxy/datatypes/dataproviders/external.py
@@ -158,7 +158,7 @@ class TempfileDataProvider(base.DataProvider):
     """
     Writes the data from the given source to a temp file, allowing
     it to be used as a source where a file_name is needed (e.g. as a parameter
-    to a command line tool: samtools view -t <this_provider.source.file_name>)
+    to a command line tool: samtools view -t <this_provider.source.get_file_name()>)
     """
 
     def __init__(self, source, **kwargs):

--- a/lib/galaxy/datatypes/display_applications/parameters.py
+++ b/lib/galaxy/datatypes/display_applications/parameters.py
@@ -106,7 +106,7 @@ class DisplayApplicationDataParameter(DisplayApplicationParameter):
         if self.metadata:
             rval = getattr(data.metadata, self.metadata, None)
             assert rval, f'Unknown metadata name "{self.metadata}" provided for dataset type "{data.ext}".'
-            return Bunch(file_name=rval.file_name, state=data.state, states=data.states, extension="data")
+            return Bunch(file_name=rval.get_file_name(), state=data.state, states=data.states, extension="data")
         elif self.extensions and (self.force_conversion or not isinstance(data.datatype, self.formats)):
             for ext in self.extensions:
                 rval = data.get_converted_files_by_type(ext)
@@ -261,7 +261,7 @@ class DisplayDataValueWrapper(DisplayParameterValueWrapper):
 
     def __str__(self):
         # string of data param is filename
-        return str(self.value.file_name)
+        return str(self.value.get_file_name())
 
     def mime_type(self, action_param_extra=None):
         if self.parameter.mime_type is not None:

--- a/lib/galaxy/datatypes/genetics.py
+++ b/lib/galaxy/datatypes/genetics.py
@@ -78,7 +78,7 @@ class GenomeGraphs(Tabular):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         dataset.metadata.markerCol = 1
-        header = open(dataset.file_name).readlines()[0].strip().split("\t")
+        header = open(dataset.get_file_name()).readlines()[0].strip().split("\t")
         dataset.metadata.columns = len(header)
         t = ["numeric" for x in header]
         t[0] = "string"
@@ -88,7 +88,7 @@ class GenomeGraphs(Tabular):
         """
         Returns file
         """
-        return open(dataset.file_name, "rb")
+        return open(dataset.get_file_name(), "rb")
 
     def ucsc_links(self, dataset: DatasetProtocol, type: str, app, base_url: str, request) -> List:
         """
@@ -153,7 +153,7 @@ class GenomeGraphs(Tabular):
         """
         try:
             out = ['<table cellspacing="0" cellpadding="3">']
-            with open(dataset.file_name) as f:
+            with open(dataset.get_file_name()) as f:
                 d = f.readlines()[:5]
             if len(d) == 0:
                 return f"Cannot find anything to parse in {dataset.name}"
@@ -182,7 +182,7 @@ class GenomeGraphs(Tabular):
         """
         Validate a gg file - all numeric after header row
         """
-        with open(dataset.file_name) as infile:
+        with open(dataset.get_file_name()) as infile:
             next(infile)  # header
             for row in infile:
                 ll = row.strip().split("\t")[1:]  # first is alpha feature identifier
@@ -338,7 +338,7 @@ class Rgenetics(Html):
             f, e = os.path.splitext(fname)
             rval.append(f'<li><a href="{sfname}">{sfname}</a></li>')
         rval.append("</ul></body></html>")
-        with open(dataset.file_name, "w") as f:
+        with open(dataset.get_file_name(), "w") as f:
             f.write("\n".join(rval))
             f.write("\n")
 
@@ -614,7 +614,7 @@ class IdeasPre(Html):
             fn = os.path.split(fname)[-1]
             rval.append(f'<li><a href="{fn}">{fn}</a></li>')
         rval.append("</ul></body></html>")
-        with open(dataset.file_name, "w") as f:
+        with open(dataset.get_file_name(), "w") as f:
             f.write("\n".join(rval))
             f.write("\n")
 
@@ -831,7 +831,7 @@ class RexpBase(Html):
             sfname = os.path.split(fname)[-1]
             rval.append(f'<li><a href="{sfname}">{sfname}</a>')
         rval.append("</ul></html>")
-        with open(dataset.file_name, "w") as f:
+        with open(dataset.get_file_name(), "w") as f:
             f.write("\n".join(rval))
             f.write("\n")
 

--- a/lib/galaxy/datatypes/goldenpath.py
+++ b/lib/galaxy/datatypes/goldenpath.py
@@ -26,7 +26,7 @@ class GoldenPath(Tabular):
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         # AGPFile reads and validates entire file.
-        AGPFile(dataset.file_name)
+        AGPFile(dataset.get_file_name())
         super().set_meta(dataset, overwrite=overwrite, **kwd)
 
     def sniff_prefix(self, file_prefix: FilePrefix) -> bool:

--- a/lib/galaxy/datatypes/graph.py
+++ b/lib/galaxy/datatypes/graph.py
@@ -33,7 +33,7 @@ class Xgmml(xml.GenericXml):
         Set the peek and blurb text
         """
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "XGMML data"
         else:
             dataset.peek = "file does not exist"
@@ -81,7 +81,7 @@ class Sif(tabular.Tabular):
         Set the peek and blurb text
         """
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "SIF data"
         else:
             dataset.peek = "file does not exist"

--- a/lib/galaxy/datatypes/images.py
+++ b/lib/galaxy/datatypes/images.py
@@ -68,7 +68,7 @@ class Image(data.Data):
     def handle_dataset_as_image(self, hda: DatasetProtocol) -> str:
         dataset = hda.dataset
         name = hda.name or ""
-        with open(dataset.file_name, "rb") as f:
+        with open(dataset.get_file_name(), "rb") as f:
             base64_image_data = base64.b64encode(f.read()).decode("utf-8")
         return f"![{name}](data:image/{self.file_ext};base64,{base64_image_data})"
 
@@ -113,9 +113,9 @@ class OMETiff(Tiff):
             offsets_file = dataset.metadata.spec[spec_key].param.new_file(
                 dataset=dataset, metadata_tmp_files_dir=metadata_tmp_files_dir
             )
-        with tifffile.TiffFile(dataset.file_name) as tif:
+        with tifffile.TiffFile(dataset.get_file_name()) as tif:
             offsets = [page.offset for page in tif.pages]
-        with open(offsets_file.file_name, "w") as f:
+        with open(offsets_file.get_file_name(), "w") as f:
             json.dump(offsets, f)
         dataset.metadata.offsets = offsets_file
 
@@ -493,7 +493,7 @@ class Star(data.Text):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "Relion STAR data"
         else:
             dataset.peek = "file does not exist"

--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -135,7 +135,7 @@ class Interval(Tabular):
         if dataset.has_data():
             empty_line_count = 0
             num_check_lines = 100  # only check up to this many non empty lines
-            with compression_utils.get_fileobj(dataset.file_name) as in_fh:
+            with compression_utils.get_fileobj(dataset.get_file_name()) as in_fh:
                 for i, line in enumerate(in_fh):
                     line = line.rstrip("\r\n")
                     if line:
@@ -229,7 +229,7 @@ class Interval(Tabular):
             start = sys.maxsize
             end = 0
             max_col = max(chrom_col, start_col, end_col)
-            with compression_utils.get_fileobj(dataset.file_name) as fh:
+            with compression_utils.get_fileobj(dataset.get_file_name()) as fh:
                 for line in util.iter_start_of_line(fh, VIEWPORT_READLINE_BUFFER_SIZE):
                     # Skip comment lines
                     if not line.startswith("#"):
@@ -280,7 +280,7 @@ class Interval(Tabular):
             )
             c, s, e, t, n = int(c) - 1, int(s) - 1, int(e) - 1, int(t) - 1, int(n) - 1
             if t >= 0:  # strand column (should) exists
-                for i, elems in enumerate(compression_utils.file_iter(dataset.file_name)):
+                for i, elems in enumerate(compression_utils.file_iter(dataset.get_file_name())):
                     strand = "+"
                     name = "region_%i" % i
                     if n >= 0 and n < len(elems):
@@ -290,14 +290,14 @@ class Interval(Tabular):
                     tmp = [elems[c], elems[s], elems[e], name, "0", strand]
                     fh.write("%s\n" % "\t".join(tmp))
             elif n >= 0:  # name column (should) exists
-                for i, elems in enumerate(compression_utils.file_iter(dataset.file_name)):
+                for i, elems in enumerate(compression_utils.file_iter(dataset.get_file_name())):
                     name = "region_%i" % i
                     if n >= 0 and n < len(elems):
                         name = cast(str, elems[n])
                     tmp = [elems[c], elems[s], elems[e], name]
                     fh.write("%s\n" % "\t".join(tmp))
             else:
-                for elems in compression_utils.file_iter(dataset.file_name):
+                for elems in compression_utils.file_iter(dataset.get_file_name()):
                     tmp = [elems[c], elems[s], elems[e]]
                     fh.write("%s\n" % "\t".join(tmp))
             return compression_utils.get_fileobj(fh.name, mode="rb")
@@ -368,7 +368,7 @@ class Interval(Tabular):
             dataset.metadata.strandCol,
         )
         c, s, e, t = int(c) - 1, int(s) - 1, int(e) - 1, int(t) - 1
-        with compression_utils.get_fileobj(dataset.file_name, "r") as infile:
+        with compression_utils.get_fileobj(dataset.get_file_name(), "r") as infile:
             reader = GenomicIntervalReader(infile, chrom_col=c, start_col=s, end_col=e, strand_col=t)
 
             while True:
@@ -445,7 +445,7 @@ class BedGraph(Interval):
         Returns file contents as is with no modifications.
         TODO: this is a functional stub and will need to be enhanced moving forward to provide additional support for bedgraph.
         """
-        return open(dataset.file_name, "rb")
+        return open(dataset.get_file_name(), "rb")
 
     def get_estimated_display_viewport(
         self,
@@ -512,7 +512,7 @@ class Bed(Interval):
         """Sets the metadata information for datasets previously determined to be in bed format."""
         if dataset.has_data():
             i = 0
-            for i, line in enumerate(open(dataset.file_name)):  # noqa: B007
+            for i, line in enumerate(open(dataset.get_file_name())):  # noqa: B007
                 line = line.rstrip("\r\n")
                 if line and not line.startswith("#"):
                     elems = line.split("\t")
@@ -531,7 +531,7 @@ class Bed(Interval):
 
     def as_ucsc_display_file(self, dataset: DatasetProtocol, **kwd) -> Union[FileObjType, str]:
         """Returns file contents with only the bed data. If bed 6+, treat as interval."""
-        for line in open(dataset.file_name):
+        for line in open(dataset.get_file_name()):
             line = line.strip()
             if line == "" or line.startswith("#"):
                 continue
@@ -567,7 +567,7 @@ class Bed(Interval):
             break
 
         try:
-            return open(dataset.file_name, "rb")
+            return open(dataset.get_file_name(), "rb")
         except Exception:
             return "This item contains no content"
 
@@ -839,7 +839,7 @@ class Gff(Tabular, _RemoteCallMixin):
         # not found in the first N lines will not have metadata.
         num_lines = 200
         attribute_types = {}
-        with compression_utils.get_fileobj(dataset.file_name) as in_fh:
+        with compression_utils.get_fileobj(dataset.get_file_name()) as in_fh:
             for i, line in enumerate(in_fh):
                 if line and not line.startswith("#"):
                     elems = line.split("\t")
@@ -874,7 +874,7 @@ class Gff(Tabular, _RemoteCallMixin):
         self.set_attribute_metadata(dataset)
 
         i = 0
-        with compression_utils.get_fileobj(dataset.file_name) as in_fh:
+        with compression_utils.get_fileobj(dataset.get_file_name()) as in_fh:
             for i, line in enumerate(in_fh):  # noqa: B007
                 line = line.rstrip("\r\n")
                 if line and not line.startswith("#"):
@@ -906,7 +906,7 @@ class Gff(Tabular, _RemoteCallMixin):
                 seqid = None
                 start = sys.maxsize
                 stop = 0
-                with compression_utils.get_fileobj(dataset.file_name) as fh:
+                with compression_utils.get_fileobj(dataset.get_file_name()) as fh:
                     for line in util.iter_start_of_line(fh, VIEWPORT_READLINE_BUFFER_SIZE):
                         try:
                             if line.startswith("##sequence-region"):  # ##sequence-region IV 6000000 6030000
@@ -1092,7 +1092,7 @@ class Gff3(Gff):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         self.set_attribute_metadata(dataset)
         i = 0
-        with compression_utils.get_fileobj(dataset.file_name) as in_fh:
+        with compression_utils.get_fileobj(dataset.get_file_name()) as in_fh:
             for i, line in enumerate(in_fh):  # noqa: B007
                 line = line.rstrip("\r\n")
                 if line and not line.startswith("#"):
@@ -1317,7 +1317,7 @@ class Wiggle(Tabular, _RemoteCallMixin):
                 end = 0
                 span = 1
                 step = None
-                with open(dataset.file_name) as fh:
+                with open(dataset.get_file_name()) as fh:
                     for line in util.iter_start_of_line(fh, VIEWPORT_READLINE_BUFFER_SIZE):
                         try:
                             if line.startswith("browser"):
@@ -1404,7 +1404,7 @@ class Wiggle(Tabular, _RemoteCallMixin):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         max_data_lines = None
         i = 0
-        for i, line in enumerate(open(dataset.file_name)):  # noqa: B007
+        for i, line in enumerate(open(dataset.get_file_name())):  # noqa: B007
             line = line.rstrip("\r\n")
             if line and not line.startswith("#"):
                 elems = line.split("\t")
@@ -1505,7 +1505,7 @@ class CustomTrack(Tabular):
         span = 1
         if self.displayable(dataset):
             try:
-                with open(dataset.file_name) as fh:
+                with open(dataset.get_file_name()) as fh:
                     for line in util.iter_start_of_line(fh, VIEWPORT_READLINE_BUFFER_SIZE):
                         if not line.startswith("#"):
                             try:
@@ -1822,8 +1822,8 @@ class IntervalTabix(Interval):
         try:
             # tabix_index columns are 0-based while in the command line it is 1-based
             pysam.tabix_index(
-                dataset.file_name,
-                index=index_file.file_name,
+                dataset.get_file_name(),
+                index=index_file.get_file_name(),
                 seq_col=dataset.metadata.chromCol - 1,
                 start_col=dataset.metadata.startCol - 1,
                 end_col=dataset.metadata.endCol - 1,

--- a/lib/galaxy/datatypes/media.py
+++ b/lib/galaxy/datatypes/media.py
@@ -73,7 +73,7 @@ class Audio(Binary):
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         if which("ffprobe"):
-            metadata, streams = ffprobe(dataset.file_name)
+            metadata, streams = ffprobe(dataset.get_file_name())
 
             dataset.metadata.duration = metadata["duration"]
             dataset.metadata.audio_codecs = [
@@ -159,7 +159,7 @@ class Video(Binary):
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         if which("ffprobe"):
-            metadata, streams = ffprobe(dataset.file_name)
+            metadata, streams = ffprobe(dataset.get_file_name())
             (w, h, fps) = self._get_resolution(streams)
             dataset.metadata.resolution_w = w
             dataset.metadata.resolution_h = h
@@ -281,7 +281,7 @@ class Wav(Audio):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         """Set the metadata for this dataset from the file contents."""
         try:
-            with wave.open(dataset.dataset.file_name, "rb") as fd:
+            with wave.open(dataset.dataset.get_file_name(), "rb") as fd:
                 dataset.metadata.rate = fd.getframerate()
                 dataset.metadata.nframes = fd.getnframes()
                 dataset.metadata.sampwidth = fd.getsampwidth()

--- a/lib/galaxy/datatypes/microarrays.py
+++ b/lib/galaxy/datatypes/microarrays.py
@@ -83,7 +83,7 @@ class GenericMicroarrayFile(data.Text):
                 dataset.blurb = f"{dataset.metadata.file_type} {dataset.metadata.version_number}: Format {dataset.metadata.file_format}, 1 block, {dataset.metadata.number_of_optional_header_records} headers and {dataset.metadata.number_of_data_columns} columns"
             else:
                 dataset.blurb = f"{dataset.metadata.file_type} {dataset.metadata.version_number}: Format {dataset.metadata.file_format}, {dataset.metadata.block_count} blocks, {dataset.metadata.number_of_optional_header_records} headers and {dataset.metadata.number_of_data_columns} columns"
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
         else:
             dataset.peek = "file does not exist"
             dataset.blurb = "file purged from disk"
@@ -122,7 +122,7 @@ class Gal(GenericMicroarrayFile):
         Set metadata for Gal file.
         """
         super().set_meta(dataset, overwrite=overwrite, **kwd)
-        headers = get_headers(dataset.file_name, sep="\t", count=5)
+        headers = get_headers(dataset.get_file_name(), sep="\t", count=5)
         dataset.metadata.file_format = headers[0][0]
         dataset.metadata.version_number = headers[0][1]
         dataset.metadata.number_of_optional_header_records = int(headers[1][0])
@@ -164,7 +164,7 @@ class Gpr(GenericMicroarrayFile):
         Set metadata for Gpr file.
         """
         super().set_meta(dataset, overwrite=overwrite, **kwd)
-        headers = get_headers(dataset.file_name, sep="\t", count=5)
+        headers = get_headers(dataset.get_file_name(), sep="\t", count=5)
         dataset.metadata.file_format = headers[0][0]
         dataset.metadata.version_number = headers[0][1]
         dataset.metadata.number_of_optional_header_records = int(headers[1][0])

--- a/lib/galaxy/datatypes/molecules.py
+++ b/lib/galaxy/datatypes/molecules.py
@@ -75,7 +75,7 @@ class GenericMolFile(Text):
                 dataset.blurb = "1 molecule"
             else:
                 dataset.blurb = f"{dataset.metadata.number_of_molecules} molecules"
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
         else:
             dataset.peek = "file does not exist"
             dataset.blurb = "file purged from disk"
@@ -258,7 +258,7 @@ class SDF(GenericMolFile):
         """
         Set the number of molecules in dataset.
         """
-        dataset.metadata.number_of_molecules = count_special_lines(r"^\$\$\$\$$", dataset.file_name)
+        dataset.metadata.number_of_molecules = count_special_lines(r"^\$\$\$\$$", dataset.get_file_name())
 
     @classmethod
     def split(cls, input_datasets: List, subdir_generator_function: Callable, split_params: Dict) -> None:
@@ -270,7 +270,7 @@ class SDF(GenericMolFile):
 
         if len(input_datasets) > 1:
             raise Exception("SD-file splitting does not support multiple files")
-        input_files = [ds.file_name for ds in input_datasets]
+        input_files = [ds.get_file_name() for ds in input_datasets]
 
         chunk_size = None
         if split_params["split_mode"] == "number_of_parts":
@@ -341,7 +341,7 @@ class MOL2(GenericMolFile):
         """
         Set the number of lines of data in dataset.
         """
-        dataset.metadata.number_of_molecules = count_special_lines("@<TRIPOS>MOLECULE", dataset.file_name)
+        dataset.metadata.number_of_molecules = count_special_lines("@<TRIPOS>MOLECULE", dataset.get_file_name())
 
     @classmethod
     def split(cls, input_datasets: List, subdir_generator_function: Callable, split_params: Dict) -> None:
@@ -353,7 +353,7 @@ class MOL2(GenericMolFile):
 
         if len(input_datasets) > 1:
             raise Exception("MOL2-file splitting does not support multiple files")
-        input_files = [ds.file_name for ds in input_datasets]
+        input_files = [ds.get_file_name() for ds in input_datasets]
 
         chunk_size = None
         if split_params["split_mode"] == "number_of_parts":
@@ -427,7 +427,7 @@ class FPS(GenericMolFile):
         """
         Set the number of lines of data in dataset.
         """
-        dataset.metadata.number_of_molecules = count_special_lines("^#", dataset.file_name, invert=True)
+        dataset.metadata.number_of_molecules = count_special_lines("^#", dataset.get_file_name(), invert=True)
 
     @classmethod
     def split(cls, input_datasets: List, subdir_generator_function: Callable, split_params: Dict) -> None:
@@ -439,7 +439,7 @@ class FPS(GenericMolFile):
 
         if len(input_datasets) > 1:
             raise Exception("FPS-file splitting does not support multiple files")
-        input_files = [ds.file_name for ds in input_datasets]
+        input_files = [ds.get_file_name() for ds in input_datasets]
 
         chunk_size = None
         if split_params["split_mode"] == "number_of_parts":
@@ -568,7 +568,7 @@ class DRF(GenericMolFile):
         """
         Set the number of lines of data in dataset.
         """
-        dataset.metadata.number_of_molecules = count_special_lines('"ligand id"', dataset.file_name, invert=True)
+        dataset.metadata.number_of_molecules = count_special_lines('"ligand id"', dataset.get_file_name(), invert=True)
 
 
 class PHAR(GenericMolFile):
@@ -580,7 +580,7 @@ class PHAR(GenericMolFile):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.blurb = "pharmacophore"
         else:
             dataset.peek = "file does not exist"
@@ -637,7 +637,7 @@ class PDB(GenericMolFile):
         """
         try:
             chain_ids = set()
-            with open(dataset.file_name) as fh:
+            with open(dataset.get_file_name()) as fh:
                 for line in fh:
                     if line.startswith("ATOM  ") or line.startswith("HETATM"):
                         if line[21] != " ":
@@ -649,10 +649,10 @@ class PDB(GenericMolFile):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            atom_numbers = count_special_lines("^ATOM", dataset.file_name)
-            hetatm_numbers = count_special_lines("^HETATM", dataset.file_name)
+            atom_numbers = count_special_lines("^ATOM", dataset.get_file_name())
+            hetatm_numbers = count_special_lines("^HETATM", dataset.get_file_name())
             chain_ids = ",".join(dataset.metadata.chain_ids) if len(dataset.metadata.chain_ids) > 0 else "None"
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.blurb = f"{atom_numbers} atoms and {hetatm_numbers} HET-atoms\nchain_ids: {chain_ids}"
         else:
             dataset.peek = "file does not exist"
@@ -702,9 +702,9 @@ class PDBQT(GenericMolFile):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            root_numbers = count_special_lines("^ROOT", dataset.file_name)
-            branch_numbers = count_special_lines("^BRANCH", dataset.file_name)
-            dataset.peek = get_file_peek(dataset.file_name)
+            root_numbers = count_special_lines("^ROOT", dataset.get_file_name())
+            branch_numbers = count_special_lines("^BRANCH", dataset.get_file_name())
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.blurb = f"{root_numbers} roots and {branch_numbers} branches"
         else:
             dataset.peek = "file does not exist"
@@ -792,7 +792,7 @@ class PQR(GenericMolFile):
         try:
             prog = self.get_matcher()
             chain_ids = set()
-            with open(dataset.file_name) as fh:
+            with open(dataset.get_file_name()) as fh:
                 for line in fh:
                     if line.startswith("REMARK"):
                         continue
@@ -806,10 +806,10 @@ class PQR(GenericMolFile):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            atom_numbers = count_special_lines("^ATOM", dataset.file_name)
-            hetatm_numbers = count_special_lines("^HETATM", dataset.file_name)
+            atom_numbers = count_special_lines("^ATOM", dataset.get_file_name())
+            hetatm_numbers = count_special_lines("^HETATM", dataset.get_file_name())
             chain_ids = ",".join(dataset.metadata.chain_ids) if len(dataset.metadata.chain_ids) > 0 else "None"
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.blurb = f"{atom_numbers} atoms and {hetatm_numbers} HET-atoms\nchain_ids: {chain_ids}"
         else:
             dataset.peek = "file does not exist"
@@ -893,7 +893,7 @@ class Cell(GenericMolFile):
         else:
             # enhanced metadata
             try:
-                ase_data = ase_io.read(dataset.file_name, format="castep-cell")
+                ase_data = ase_io.read(dataset.get_file_name(), format="castep-cell")
             except Exception as e:
                 log.warning("%s, set_meta Exception during ASE read: %s", self, unicodify(e))
                 self.meta_error = True
@@ -924,7 +924,7 @@ class Cell(GenericMolFile):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.info = self.get_dataset_info(dataset.metadata)
             structure_string = "structure" if dataset.metadata.number_of_molecules == 1 else "structures"
             dataset.blurb = f"CASTEP CELL file containing {dataset.metadata.number_of_molecules} {structure_string}"
@@ -1054,7 +1054,7 @@ class CIF(GenericMolFile):
         else:
             # enhanced metadata
             try:
-                ase_data = ase_io.read(dataset.file_name, index=":", format="cif")
+                ase_data = ase_io.read(dataset.get_file_name(), index=":", format="cif")
             except Exception as e:
                 log.warning("%s, set_meta Exception during ASE read: %s", self, unicodify(e))
                 self.meta_error = True
@@ -1091,7 +1091,7 @@ class CIF(GenericMolFile):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.info = self.get_dataset_info(dataset.metadata)
             structure_string = "structure" if dataset.metadata.number_of_molecules == 1 else "structures"
             dataset.blurb = f"CIF file containing {dataset.metadata.number_of_molecules} {structure_string}"
@@ -1252,7 +1252,7 @@ class XYZ(GenericMolFile):
             # enhanced metadata
             try:
                 # ASE recommend always parsing as extended xyz
-                ase_data = ase_io.read(dataset.file_name, index=":", format="extxyz")
+                ase_data = ase_io.read(dataset.get_file_name(), index=":", format="extxyz")
             except Exception as e:
                 log.warning("%s, set_meta Exception during ASE read: %s", self, unicodify(e))
                 self.meta_error = True
@@ -1289,7 +1289,7 @@ class XYZ(GenericMolFile):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.info = self.get_dataset_info(dataset.metadata)
             structure_string = "structure" if dataset.metadata.number_of_molecules == 1 else "structures"
             dataset.blurb = f"XYZ file containing {dataset.metadata.number_of_molecules} {structure_string}"
@@ -1452,7 +1452,7 @@ class grd(Text):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.blurb = "grids for docking"
         else:
             dataset.peek = "file does not exist"
@@ -1506,7 +1506,7 @@ class InChI(Tabular):
                 dataset.blurb = "1 molecule"
             else:
                 dataset.blurb = f"{dataset.metadata.number_of_molecules} molecules"
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
         else:
             dataset.peek = "file does not exist"
             dataset.blurb = "file purged from disk"
@@ -1571,7 +1571,7 @@ class SMILES(Tabular):
                 dataset.blurb = "1 molecule"
             else:
                 dataset.blurb = f"{dataset.metadata.number_of_molecules} molecules"
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
         else:
             dataset.peek = "file does not exist"
             dataset.blurb = "file purged from disk"
@@ -1599,7 +1599,7 @@ class CML(GenericXml):
         """
         Set the number of lines of data in dataset.
         """
-        dataset.metadata.number_of_molecules = count_special_lines(r"^\s*<molecule", dataset.file_name)
+        dataset.metadata.number_of_molecules = count_special_lines(r"^\s*<molecule", dataset.get_file_name())
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
@@ -1607,7 +1607,7 @@ class CML(GenericXml):
                 dataset.blurb = "1 molecule"
             else:
                 dataset.blurb = f"{dataset.metadata.number_of_molecules} molecules"
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
         else:
             dataset.peek = "file does not exist"
             dataset.blurb = "file purged from disk"
@@ -1640,7 +1640,7 @@ class CML(GenericXml):
 
         if len(input_datasets) > 1:
             raise Exception("CML-file splitting does not support multiple files")
-        input_files = [ds.file_name for ds in input_datasets]
+        input_files = [ds.get_file_name() for ds in input_datasets]
 
         chunk_size = None
         if split_params["split_mode"] == "number_of_parts":
@@ -1761,7 +1761,7 @@ class GRO(GenericMolFile):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             atom_number = int(dataset.peek.split("\n")[1])
             dataset.blurb = f"{atom_number} atoms"
         else:

--- a/lib/galaxy/datatypes/mothur.py
+++ b/lib/galaxy/datatypes/mothur.py
@@ -45,7 +45,7 @@ class Otu(Text):
         >>> dataset = Bunch()
         >>> dataset.metadata = Bunch
         >>> otu = Otu()
-        >>> dataset.file_name = get_test_fname( 'mothur_datatypetest_true.mothur.otu' )
+        >>> dataset.get_file_name = lambda : get_test_fname( 'mothur_datatypetest_true.mothur.otu' )
         >>> dataset.has_data = lambda: True
         >>> otu.set_meta(dataset)
         >>> dataset.metadata.columns
@@ -64,8 +64,8 @@ class Otu(Text):
             data_lines = 0
             comment_lines = 0
 
-            headers = iter_headers(dataset.file_name, sep="\t", count=-1)
-            first_line = get_headers(dataset.file_name, sep="\t", count=1)
+            headers = iter_headers(dataset.get_file_name(), sep="\t", count=-1)
+            first_line = get_headers(dataset.get_file_name(), sep="\t", count=1)
             if first_line:
                 first_line = first_line[0]
             # set otulabels
@@ -184,7 +184,7 @@ class GroupAbund(Otu):
             comment_lines = 0
             ncols = 0
 
-            headers = iter_headers(dataset.file_name, sep="\t", count=-1)
+            headers = iter_headers(dataset.get_file_name(), sep="\t", count=-1)
             for line in headers:
                 if line[0] == "label" and line[1] == "Group":
                     skip = 1
@@ -357,7 +357,7 @@ class DistanceMatrix(Text):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, skip: Optional[int] = 0, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, skip=skip, **kwd)
 
-        headers = iter_headers(dataset.file_name, sep="\t")
+        headers = iter_headers(dataset.get_file_name(), sep="\t")
         for line in headers:
             if not line[0].startswith("@"):
                 try:
@@ -606,7 +606,7 @@ class Group(Tabular):
         super().set_meta(dataset, overwrite=overwrite, skip=skip, max_data_lines=max_data_lines, **kwd)
 
         group_names = set()
-        headers = iter_headers(dataset.file_name, sep="\t", count=-1)
+        headers = iter_headers(dataset.get_file_name(), sep="\t", count=-1)
         for line in headers:
             if len(line) > 1:
                 group_names.add(line[1])
@@ -853,7 +853,7 @@ class CountTable(Tabular):
     ) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
 
-        headers = get_headers(dataset.file_name, sep="\t", count=1)
+        headers = get_headers(dataset.get_file_name(), sep="\t", count=1)
         colnames = headers[0]
         dataset.metadata.column_types = ["str"] + (["int"] * (len(headers[0]) - 1))
         if len(colnames) > 1:
@@ -1065,7 +1065,7 @@ class SffFlow(Tabular):
     ) -> None:
         super().set_meta(dataset, overwrite=overwrite, skip=1, max_data_lines=max_data_lines, **kwd)
 
-        headers = get_headers(dataset.file_name, sep="\t", count=1)
+        headers = get_headers(dataset.get_file_name(), sep="\t", count=1)
         try:
             flow_values = int(headers[0][0])
             dataset.metadata.flow_values = flow_values

--- a/lib/galaxy/datatypes/msa.py
+++ b/lib/galaxy/datatypes/msa.py
@@ -56,12 +56,12 @@ class InfernalCM(Text):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             if dataset.metadata.number_of_models == 1:
                 dataset.blurb = "1 model"
             else:
                 dataset.blurb = f"{dataset.metadata.number_of_models} models"
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
         else:
             dataset.peek = "file does not exist"
             dataset.blurb = "file purged from disc"
@@ -82,8 +82,8 @@ class InfernalCM(Text):
         """
         Set the number of models and the version of CM file in dataset.
         """
-        dataset.metadata.number_of_models = generic_util.count_special_lines("^INFERNAL", dataset.file_name)
-        with open(dataset.file_name) as f:
+        dataset.metadata.number_of_models = generic_util.count_special_lines("^INFERNAL", dataset.get_file_name())
+        with open(dataset.get_file_name()) as f:
             first_line = f.readline()
             if first_line.startswith("INFERNAL"):
                 dataset.metadata.cm_version = (first_line.split()[0]).replace("INFERNAL", "")
@@ -96,7 +96,7 @@ class Hmmer(Text):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.blurb = "HMMER Database"
         else:
             dataset.peek = "file does not exist"
@@ -187,7 +187,7 @@ class Stockholm_1_0(Text):
                 dataset.blurb = "1 alignment"
             else:
                 dataset.blurb = f"{dataset.metadata.number_of_models} alignments"
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
         else:
             dataset.peek = "file does not exist"
             dataset.blurb = "file purged from disc"
@@ -201,7 +201,7 @@ class Stockholm_1_0(Text):
         Set the number of models in dataset.
         """
         dataset.metadata.number_of_models = generic_util.count_special_lines(
-            "^#[[:space:]+]STOCKHOLM[[:space:]+]1.0", dataset.file_name
+            "^#[[:space:]+]STOCKHOLM[[:space:]+]1.0", dataset.get_file_name()
         )
 
     @classmethod
@@ -215,7 +215,7 @@ class Stockholm_1_0(Text):
 
         if len(input_datasets) > 1:
             raise Exception("STOCKHOLM-file splitting does not support multiple files")
-        input_files = [ds.file_name for ds in input_datasets]
+        input_files = [ds.get_file_name() for ds in input_datasets]
 
         chunk_size = None
         if split_params["split_mode"] == "number_of_parts":
@@ -277,7 +277,7 @@ class MauveXmfa(Text):
                 dataset.blurb = "1 alignment"
             else:
                 dataset.blurb = f"{dataset.metadata.number_of_models} alignments"
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
         else:
             dataset.peek = "file does not exist"
             dataset.blurb = "file purged from disc"
@@ -287,7 +287,7 @@ class MauveXmfa(Text):
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         dataset.metadata.number_of_models = generic_util.count_special_lines(
-            "^#Sequence([[:digit:]]+)Entry", dataset.file_name
+            "^#Sequence([[:digit:]]+)Entry", dataset.get_file_name()
         )
 
 

--- a/lib/galaxy/datatypes/ngsindex.py
+++ b/lib/galaxy/datatypes/ngsindex.py
@@ -58,7 +58,7 @@ class BowtieIndex(Html):
             sfname = os.path.split(fname)[-1]
             rval.append(f'<li><a href="{sfname}">{sfname}</a>')
         rval.append("</ul></html>")
-        with open(dataset.file_name, "w") as f:
+        with open(dataset.get_file_name(), "w") as f:
             f.write("\n".join(rval))
             f.write("\n")
 

--- a/lib/galaxy/datatypes/phylip.py
+++ b/lib/galaxy/datatypes/phylip.py
@@ -44,13 +44,13 @@ class Phylip(Text):
         """
         dataset.metadata.data_lines = self.count_data_lines(dataset)
         try:
-            dataset.metadata.sequences = int(open(dataset.file_name).readline().split()[0])
+            dataset.metadata.sequences = int(open(dataset.get_file_name()).readline().split()[0])
         except Exception:
             raise Exception("Header does not correspond to PHYLIP header.")
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             if dataset.metadata.sequences:
                 dataset.blurb = f"{util.commaify(str(dataset.metadata.sequences))} sequences"
             else:

--- a/lib/galaxy/datatypes/plant_tribes.py
+++ b/lib/galaxy/datatypes/plant_tribes.py
@@ -30,7 +30,7 @@ class Smat(Text):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.blurb = "ESTScan scores matrices"
         else:
             dataset.peek = "file does not exist"
@@ -107,7 +107,7 @@ class PlantTribesKsComponents(Tabular):
         """
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         significant_components = []
-        with open(dataset.file_name) as fh:
+        with open(dataset.get_file_name()) as fh:
             for i, line in enumerate(fh):
                 if i == 0:
                     # Skip the first line.
@@ -124,7 +124,7 @@ class PlantTribesKsComponents(Tabular):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             if dataset.metadata.number_comp == 1:
                 dataset.blurb = "1 significant component"
             else:

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -148,7 +148,7 @@ class MzTab(Text):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "mzTab Format"
         else:
             dataset.peek = "file does not exist"
@@ -199,7 +199,7 @@ class MzTab2(MzTab):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "mzTab2 Format"
         else:
             dataset.peek = "file does not exist"
@@ -438,7 +438,7 @@ class Dta(TabularData):
         data_row: List = []
         data_lines = 0
         if dataset.has_data():
-            with open(dataset.file_name) as dtafile:
+            with open(dataset.get_file_name()) as dtafile:
                 for _ in dtafile:
                     data_lines += 1
 
@@ -510,7 +510,7 @@ class Dta2d(TabularData):
         data_lines = 0
         delim = None
         if dataset.has_data():
-            with open(dataset.file_name) as dtafile:
+            with open(dataset.get_file_name()) as dtafile:
                 for line in dtafile:
                     if delim is None:
                         delim = self._parse_delimiter(line)
@@ -647,7 +647,7 @@ class Edta(TabularData):
         delim = None
         tpe = None
         if dataset.has_data():
-            with open(dataset.file_name) as dtafile:
+            with open(dataset.get_file_name()) as dtafile:
                 for idx, line in enumerate(dtafile):
                     if idx == 0:
                         delim = self._parse_delimiter(line)
@@ -719,7 +719,7 @@ class ProteomicsXml(GenericXml):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "ProteomicsXML data"
         else:
             dataset.peek = "file does not exist"
@@ -888,7 +888,7 @@ class Mgf(Text):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "mgf Mascot Generic Format"
         else:
             dataset.peek = "file does not exist"
@@ -918,7 +918,7 @@ class MascotDat(Text):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "mascotdat Mascot Search Results"
         else:
             dataset.peek = "file does not exist"
@@ -1004,7 +1004,7 @@ class SPLibNoIndex(Text):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "Spectral Library without index files"
         else:
             dataset.peek = "file does not exist"
@@ -1046,7 +1046,7 @@ class SPLib(Msp):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "splib Spectral Library Format"
         else:
             dataset.peek = "file does not exist"

--- a/lib/galaxy/datatypes/protocols.py
+++ b/lib/galaxy/datatypes/protocols.py
@@ -30,7 +30,8 @@ class HasExtraFilesPath(Protocol):
 
 
 class HasFileName(Protocol):
-    file_name: Any
+    def get_file_name(self) -> str:
+        ...
 
 
 class HasHid(Protocol):

--- a/lib/galaxy/datatypes/qiime2.py
+++ b/lib/galaxy/datatypes/qiime2.py
@@ -34,7 +34,7 @@ class _QIIME2ResultBase(CompressedZipArchive):
     MetadataElement(name="version", readonly=True)
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
-        metadata = _get_metadata_from_archive(dataset.file_name)
+        metadata = _get_metadata_from_archive(dataset.get_file_name())
         for key, value in metadata.items():
             if value:
                 setattr(dataset.metadata, key, value)
@@ -123,7 +123,7 @@ class QIIME2Metadata(Tabular):
         super().set_meta(dataset, overwrite=overwrite, **kwd)
 
         if dataset.has_data():
-            with open(dataset.file_name) as dataset_fh:
+            with open(dataset.get_file_name()) as dataset_fh:
                 line = None
                 for line, _ in zip(dataset_fh, range(self._search_lines)):
                     if line.startswith(self._TYPES_DIRECTIVE):

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -72,9 +72,9 @@ class SequenceSplitLocations(data.Text):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
             try:
-                parsed_data = json.load(open(dataset.file_name))
+                parsed_data = json.load(open(dataset.get_file_name()))
                 # dataset.peek = json.dumps(data, sort_keys=True, indent=4)
-                dataset.peek = data.get_file_peek(dataset.file_name)
+                dataset.peek = data.get_file_peek(dataset.get_file_name())
                 dataset.blurb = "%d sections" % len(parsed_data["sections"])
             except Exception:
                 dataset.peek = "Not FQTOC file"
@@ -112,7 +112,7 @@ class Sequence(data.Text):
         """
         data_lines = 0
         sequences = 0
-        with compression_utils.get_fileobj(dataset.file_name) as fh:
+        with compression_utils.get_fileobj(dataset.get_file_name()) as fh:
             for line in fh:
                 line = line.strip()
                 if line and line.startswith("#"):
@@ -128,7 +128,7 @@ class Sequence(data.Text):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             if dataset.metadata.sequences:
                 dataset.blurb = f"{util.commaify(str(dataset.metadata.sequences))} sequences"
             else:
@@ -164,7 +164,7 @@ class Sequence(data.Text):
         if input_datasets[0].metadata is not None and input_datasets[0].metadata.sequences is not None:
             total_sequences = input_datasets[0].metadata.sequences
         else:
-            with compression_utils.get_fileobj(input_datasets[0].file_name) as in_file:
+            with compression_utils.get_fileobj(input_datasets[0].get_file_name()) as in_file:
                 total_sequences = sum(1 for line in in_file)
             total_sequences /= 4
 
@@ -173,7 +173,7 @@ class Sequence(data.Text):
 
     @classmethod
     def do_fast_split(cls, input_datasets, toc_file_datasets, subdir_generator_function, split_params):
-        data = json.load(open(toc_file_datasets[0].file_name))
+        data = json.load(open(toc_file_datasets[0].get_file_name()))
         sections = data["sections"]
         total_sequences = 0
         for section in sections:
@@ -200,17 +200,17 @@ class Sequence(data.Text):
             dir = get_subdir(part_no)
             for ds_no in range(len(input_datasets)):
                 ds = input_datasets[ds_no]
-                base_name = os.path.basename(ds.file_name)
+                base_name = os.path.basename(ds.get_file_name())
                 part_path = os.path.join(dir, base_name)
                 split_data = dict(
                     class_name=f"{cls.__module__}.{cls.__name__}",
                     output_name=part_path,
-                    input_name=ds.file_name,
+                    input_name=ds.get_file_name(),
                     args=dict(start_sequence=start_sequence, num_sequences=sequences_per_file[part_no]),
                 )
                 if toc_file_datasets is not None:
                     toc = toc_file_datasets[ds_no]
-                    split_data["args"]["toc_file"] = toc.file_name
+                    split_data["args"]["toc_file"] = toc.get_file_name()
                 with open(os.path.join(dir, f"split_info_{base_name}.json"), "w") as f:
                     json.dump(split_data, f)
             start_sequence += sequences_per_file[part_no]
@@ -418,7 +418,7 @@ class Fasta(Sequence):
             return
         if len(input_datasets) > 1:
             raise Exception("FASTA file splitting does not support multiple files")
-        input_file = input_datasets[0].file_name
+        input_file = input_datasets[0].get_file_name()
 
         # Counting chunk size as number of sequences.
         if "split_mode" not in split_params:
@@ -639,7 +639,7 @@ class Fastg(Sequence):
         return False
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
-        with open(dataset.file_name) as fh:
+        with open(dataset.get_file_name()) as fh:
             for i, line in enumerate(fh):
                 if not line:
                     break  # EOF
@@ -665,7 +665,7 @@ class Fastg(Sequence):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             if dataset.metadata.sequences:
                 dataset.blurb = f"{util.commaify(str(dataset.metadata.sequences))} sequences"
             else:
@@ -700,7 +700,7 @@ class BaseFastq(Sequence):
         data_lines = 0
         sequences = 0
         seq_counter = 0  # blocks should be 4 lines long
-        with compression_utils.get_fileobj(dataset.file_name) as in_file:
+        with compression_utils.get_fileobj(dataset.get_file_name()) as in_file:
             for line in in_file:
                 line = line.strip()
                 if line and line.startswith("#") and not data_lines:
@@ -776,9 +776,9 @@ class BaseFastq(Sequence):
     ):
         headers = kwd.get("headers", {})
         if preview:
-            with compression_utils.get_fileobj(dataset.file_name) as fh:
+            with compression_utils.get_fileobj(dataset.get_file_name()) as fh:
                 max_peek_size = 1000000  # 1 MB
-                if os.stat(dataset.file_name).st_size < max_peek_size:
+                if os.stat(dataset.get_file_name()).st_size < max_peek_size:
                     mime = "text/plain"
                     self._clean_and_set_mime_type(trans, mime, headers)
                     return fh.read(), headers
@@ -872,12 +872,12 @@ class BaseFastq(Sequence):
         return False
 
     def validate(self, dataset: DatasetProtocol, **kwd) -> DatatypeValidation:
-        headers = iter_headers(dataset.file_name, sep="\n", count=-1)
+        headers = iter_headers(dataset.get_file_name(), sep="\n", count=-1)
         # check to see if the base qualities match
         if not self.quality_check(headers):
             return DatatypeValidation.invalid("Invalid quality score(s) found for this fastq datatype.")
 
-        headers = iter_headers(dataset.file_name, sep="\n", count=-1)
+        headers = iter_headers(dataset.get_file_name(), sep="\n", count=-1)
         while True:
             block = list(islice(headers, 4))
             if len(block) == 0:
@@ -1021,7 +1021,7 @@ class Maf(Alignment):
         # Imported here to avoid circular dependency
         from galaxy.tools.util.maf_utilities import build_maf_index_species_chromosomes
 
-        indexes, species, species_chromosomes, blocks = build_maf_index_species_chromosomes(dataset.file_name)
+        indexes, species, species_chromosomes, blocks = build_maf_index_species_chromosomes(dataset.get_file_name())
         if indexes is None:
             return  # this is not a MAF file
         dataset.metadata.species = species
@@ -1033,7 +1033,7 @@ class Maf(Alignment):
             chrom_file = dataset.metadata.spec["species_chromosomes"].param.new_file(
                 dataset=dataset, metadata_tmp_files_dir=metadata_tmp_files_dir
             )
-        with open(chrom_file.file_name, "w") as chrom_out:
+        with open(chrom_file.get_file_name(), "w") as chrom_out:
             for spec, chroms in species_chromosomes.items():
                 chrom_out.write("{}\t{}\n".format(spec, "\t".join(chroms)))
         dataset.metadata.species_chromosomes = chrom_file
@@ -1043,13 +1043,13 @@ class Maf(Alignment):
             index_file = dataset.metadata.spec["maf_index"].param.new_file(
                 dataset=dataset, metadata_tmp_files_dir=metadata_tmp_files_dir
             )
-        indexes.write(open(index_file.file_name, "wb"))
+        indexes.write(open(index_file.get_file_name(), "wb"))
         dataset.metadata.maf_index = index_file
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
             # The file must exist on disk for the get_file_peek() method
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             if dataset.metadata.blocks:
                 dataset.blurb = f"{util.commaify(str(dataset.metadata.blocks))} blocks"
             else:
@@ -1148,7 +1148,7 @@ class MafCustomTrack(data.Text):
         forward_strand_start = math.inf
         forward_strand_end = 0
         try:
-            maf_file = open(dataset.file_name)
+            maf_file = open(dataset.get_file_name())
             maf_file.readline()  # move past track line
             for i, block in enumerate(bx.align.maf.Reader(maf_file)):
                 ref_comp = block.get_component_by_src_start(dataset.metadata.dbkey)
@@ -1324,7 +1324,7 @@ class DotBracket(Sequence):
         data_lines = 0
         sequences = 0
 
-        for line in open(dataset.file_name):
+        for line in open(dataset.get_file_name()):
             line = line.strip()
             data_lines += 1
 

--- a/lib/galaxy/datatypes/spaln.py
+++ b/lib/galaxy/datatypes/spaln.py
@@ -94,7 +94,7 @@ class _SpalnDb(Data):
             f, e = os.path.splitext(fname)
             rval.append(f'<li><a href="{sfname}">{sfname}</a></li>')
         rval.append("</ul></body></html>")
-        with open(dataset.file_name, "w") as f:
+        with open(dataset.get_file_name(), "w") as f:
             f.write("\n".join(rval))
             f.write("\n")
 
@@ -154,7 +154,7 @@ class _SpalnDb(Data):
         msg = ""
         try:
             # Try to use any text recorded in the dummy index file:
-            with open(dataset.file_name, encoding="utf-8") as handle:
+            with open(dataset.get_file_name(), encoding="utf-8") as handle:
                 msg = handle.read().strip()
         except Exception:
             pass

--- a/lib/galaxy/datatypes/speech.py
+++ b/lib/galaxy/datatypes/speech.py
@@ -100,7 +100,7 @@ class BPF(Text):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         """Set the metadata for this dataset from the file contents"""
         types = set()
-        with open(dataset.dataset.file_name) as fd:
+        with open(dataset.dataset.get_file_name()) as fd:
             for line in fd:
                 # Split the line on a colon rather than regexing it
                 parts = line.split(":")

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -153,7 +153,7 @@ class TabularData(Text):
         )
 
     def _read_chunk(self, trans, dataset: HasFileName, offset: int, ck_size: Optional[int] = None):
-        with compression_utils.get_fileobj(dataset.file_name) as f:
+        with compression_utils.get_fileobj(dataset.get_file_name()) as f:
             f.seek(offset)
             ck_data = f.read(ck_size or trans.app.config.display_chunk_size)
             if ck_data and ck_data[-1] != "\n":
@@ -187,15 +187,15 @@ class TabularData(Text):
             # We should add a new datatype 'matrix', with its own draw method, suitable for this kind of data.
             # For now, default to the old behavior, ugly as it is.  Remove this after adding 'matrix'.
             max_peek_size = 1000000  # 1 MB
-            if os.stat(dataset.file_name).st_size < max_peek_size:
+            if os.stat(dataset.get_file_name()).st_size < max_peek_size:
                 self._clean_and_set_mime_type(trans, dataset.get_mime(), headers)
-                return open(dataset.file_name, mode="rb"), headers
+                return open(dataset.get_file_name(), mode="rb"), headers
             else:
                 headers["content-type"] = "text/html"
                 return (
                     trans.fill_template_mako(
                         "/dataset/large_file.mako",
-                        truncated_data=open(dataset.file_name).read(max_peek_size),
+                        truncated_data=open(dataset.get_file_name()).read(max_peek_size),
                         data=dataset,
                     ),
                     headers,
@@ -225,7 +225,7 @@ class TabularData(Text):
             )
 
     def display_as_markdown(self, dataset_instance: DatasetProtocol) -> str:
-        with open(dataset_instance.file_name) as f:
+        with open(dataset_instance.get_file_name()) as f:
             contents = f.read(data.DEFAULT_MAX_PEEK_SIZE)
         markdown = self.make_html_table(dataset_instance, peek=contents)
         if len(contents) == data.DEFAULT_MAX_PEEK_SIZE:
@@ -511,7 +511,7 @@ class Tabular(TabularData):
         first_line_column_types = [default_column_type]  # default value is one column of type str
         if dataset.has_data():
             # NOTE: if skip > num_check_lines, we won't detect any metadata, and will use default
-            with compression_utils.get_fileobj(dataset.file_name) as dataset_fh:
+            with compression_utils.get_fileobj(dataset.get_file_name()) as dataset_fh:
                 i = 0
                 for line in iter(dataset_fh.readline, ""):
                     line = line.rstrip("\r\n")
@@ -579,10 +579,10 @@ class Tabular(TabularData):
             dataset.metadata.column_names = column_names
 
     def as_gbrowse_display_file(self, dataset: HasFileName, **kwd) -> Union[FileObjType, str]:
-        return open(dataset.file_name, "rb")
+        return open(dataset.get_file_name(), "rb")
 
     def as_ucsc_display_file(self, dataset: DatasetProtocol, **kwd) -> Union[FileObjType, str]:
-        return open(dataset.file_name, "rb")
+        return open(dataset.get_file_name(), "rb")
 
 
 class SraManifest(Tabular):
@@ -808,7 +808,7 @@ class Sam(Tabular, _BamOrSam):
         ['ref', 'ref2']
         """
         if dataset.has_data():
-            with open(dataset.file_name) as dataset_fh:
+            with open(dataset.get_file_name()) as dataset_fh:
                 comment_lines = 0
                 if (
                     self.max_optional_metadata_filesize >= 0
@@ -1048,7 +1048,7 @@ class BaseVcf(Tabular):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         line = None
-        with compression_utils.get_fileobj(dataset.file_name) as fh:
+        with compression_utils.get_fileobj(dataset.get_file_name()) as fh:
             # Skip comments.
             for line in fh:
                 if not line.startswith("##"):
@@ -1076,7 +1076,7 @@ class BaseVcf(Tabular):
             if len(row) < 8:
                 raise Exception("Not enough columns in row %s" % row.join("\t"))
 
-        validate_tabular(dataset.file_name, sep="\t", validate_row=validate_row, comment_designator="#")
+        validate_tabular(dataset.get_file_name(), sep="\t", validate_row=validate_row, comment_designator="#")
         return DatatypeValidation.validated()
 
     # Dataproviders
@@ -1139,7 +1139,7 @@ class VcfGz(BaseVcf, binary.Binary):
 
         try:
             pysam.tabix_index(
-                dataset.file_name, index=index_file.file_name, preset="vcf", keep_original=True, force=True
+                dataset.get_file_name(), index=index_file.get_file_name(), preset="vcf", keep_original=True, force=True
             )
         except Exception as e:
             raise Exception(f"Error setting VCF.gz metadata: {util.unicodify(e)}")
@@ -1297,7 +1297,7 @@ class Eland(Tabular):
         **kwd,
     ) -> None:
         if dataset.has_data():
-            with compression_utils.get_fileobj(dataset.file_name, compressed_formats=["gzip"]) as dataset_fh:
+            with compression_utils.get_fileobj(dataset.get_file_name(), compressed_formats=["gzip"]) as dataset_fh:
                 dataset_fh = cast(FileObjTypeStr, dataset_fh)
                 lanes = {}
                 tiles = {}
@@ -1313,7 +1313,7 @@ class Eland(Tabular):
                     if line:
                         line_pieces = line.split("\t")
                         if len(line_pieces) != 22:
-                            raise Exception("%s:%d:Corrupt line!" % (dataset.file_name, i))
+                            raise Exception("%s:%d:Corrupt line!" % (dataset.get_file_name(), i))
                         lanes[line_pieces[2]] = 1
                         tiles[line_pieces[3]] = 1
                         barcodes[line_pieces[6]] = 1
@@ -1458,7 +1458,7 @@ class BaseCSV(TabularData):
         data_row = []
         data_lines = 0
         if dataset.has_data():
-            with open(dataset.file_name, newline="") as csvfile:
+            with open(dataset.get_file_name(), newline="") as csvfile:
                 # Parse file with the correct dialect
                 reader = csv.reader(csvfile, self.dialect)
                 try:
@@ -1537,7 +1537,7 @@ class ConnectivityTable(Tabular):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         data_lines = 0
 
-        with open(dataset.file_name) as fh:
+        with open(dataset.get_file_name()) as fh:
             for _ in fh:
                 data_lines += 1
 
@@ -1677,7 +1677,7 @@ class MatrixMarket(TabularData):
     ) -> None:
         if dataset.has_data():
             # If the dataset is larger than optional_metadata, just count comment lines.
-            with open(dataset.file_name) as dataset_fh:
+            with open(dataset.get_file_name()) as dataset_fh:
                 line = ""
                 data_lines = 0
                 comment_lines = 0
@@ -1804,7 +1804,7 @@ class CMAP(TabularData):
         **kwd,
     ) -> None:
         if dataset.has_data():
-            with open(dataset.file_name) as dataset_fh:
+            with open(dataset.get_file_name()) as dataset_fh:
                 comment_lines = 0
                 column_headers = None
                 cleaned_column_types = None

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -91,7 +91,7 @@ class Json(Text):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.blurb = "JavaScript Object Notation (JSON)"
         else:
             dataset.peek = "file does not exist"
@@ -145,7 +145,7 @@ class ExpressionJson(Json):
         """ """
         if dataset.has_data():
             json_type = "null"
-            file_path = dataset.file_name
+            file_path = dataset.get_file_name()
             try:
                 with open(file_path) as f:
                     obj = json.load(f)
@@ -170,7 +170,7 @@ class Ipynb(Json):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.blurb = "Jupyter Notebook"
         else:
             dataset.peek = "file does not exist"
@@ -232,14 +232,14 @@ class Ipynb(Json):
                     "html",
                     "--template",
                     "full",
-                    dataset.file_name,
+                    dataset.get_file_name(),
                     "--output",
                     ofilename,
                 ]
                 subprocess.check_call(cmd)
                 ofilename = f"{ofilename}.html"
             except subprocess.CalledProcessError:
-                ofilename = dataset.file_name
+                ofilename = dataset.get_file_name()
                 log.exception(
                     'Command "%s" failed. Could not convert the Jupyter Notebook to HTML, defaulting to plain text.',
                     shlex_join(cmd),
@@ -424,7 +424,7 @@ class Biom1(Json):
         Store metadata information from the BIOM file.
         """
         if dataset.has_data():
-            with open(dataset.file_name) as fh:
+            with open(dataset.get_file_name()) as fh:
                 try:
                     json_dict = json.load(fh)
                 except Exception:
@@ -525,7 +525,7 @@ class ImgtJson(Json):
         Store metadata information from the imgt file.
         """
         if dataset.has_data():
-            with open(dataset.file_name) as fh:
+            with open(dataset.get_file_name()) as fh:
                 try:
                     json_dict = json.load(fh)
                     tax_names = []
@@ -610,7 +610,7 @@ class Obo(Text):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.blurb = "Open Biomedical Ontology (OBO)"
         else:
             dataset.peek = "file does not exist"
@@ -652,7 +652,7 @@ class Arff(Text):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name)
+            dataset.peek = get_file_peek(dataset.get_file_name())
             dataset.blurb = "Attribute-Relation File Format (ARFF)"
             dataset.blurb += f", {dataset.metadata.comment_lines} comments, {dataset.metadata.columns} attributes"
         else:
@@ -698,7 +698,7 @@ class Arff(Text):
         if dataset.has_data():
             first_real_line = False
             data_block = False
-            with open(dataset.file_name) as handle:
+            with open(dataset.get_file_name()) as handle:
                 for line in handle:
                     line = line.strip()
                     if not line:
@@ -805,7 +805,7 @@ class SnpEffDb(Text):
             dataset.metadata.regulation = regulations
             dataset.metadata.annotation = annotations
             try:
-                with open(dataset.file_name, "w") as fh:
+                with open(dataset.get_file_name(), "w") as fh:
                     fh.write(f"{genome_version}\n" if genome_version else "Genome unknown")
                     fh.write(f"{snpeff_version}\n" if snpeff_version else "SnpEff version unknown")
                     if annotations:
@@ -869,7 +869,7 @@ class SnpSiftDbNSFP(Text):
         cannot do this until we are setting metadata
         """
         annotations = f"dbNSFP Annotations: {','.join(dataset.metadata.annotation)}\n"
-        with open(dataset.file_name, "a") as f:
+        with open(dataset.get_file_name(), "a") as f:
             if dataset.metadata.bgzip:
                 bn = dataset.metadata.bgzip
                 f.write(bn)
@@ -898,7 +898,7 @@ class SnpSiftDbNSFP(Text):
         except Exception as e:
             log.warning(
                 "set_meta fname: %s  %s",
-                dataset.file_name if dataset and dataset.file_name else "Unkwown",
+                dataset.get_file_name() if dataset and dataset.get_file_name() else "Unkwown",
                 unicodify(e),
             )
 
@@ -1148,7 +1148,7 @@ class BCSLts(Json):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
             lines = "States: {}\nTransitions: {}\nUnique agents: {}\nInitial state: {}"
-            ts = json.load(open(dataset.file_name))
+            ts = json.load(open(dataset.get_file_name()))
             dataset.peek = lines.format(len(ts["nodes"]), len(ts["edges"]), len(ts["ordering"]), ts["initial"])
             dataset.blurb = nice_size(dataset.get_size())
         else:
@@ -1206,7 +1206,7 @@ class StormCheck(Text):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            with open(dataset.file_name) as result:
+            with open(dataset.get_file_name()) as result:
                 answer = ""
                 for line in result:
                     if "Result (for initial states):" in line:
@@ -1234,7 +1234,7 @@ class CTLresult(Text):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            with open(dataset.file_name) as result:
+            with open(dataset.get_file_name()) as result:
                 answer = ""
                 for line in result:
                     if "Result:" in line:

--- a/lib/galaxy/datatypes/triples.py
+++ b/lib/galaxy/datatypes/triples.py
@@ -40,7 +40,7 @@ class Triples(data.Data):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "Triple data"
         else:
             dataset.peek = "file does not exist"
@@ -65,7 +65,7 @@ class NTriples(data.Text, Triples):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "N-Triples triple data"
         else:
             dataset.peek = "file does not exist"
@@ -89,7 +89,7 @@ class N3(data.Text, Triples):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "Notation-3 Triple data"
         else:
             dataset.peek = "file does not exist"
@@ -117,7 +117,7 @@ class Turtle(data.Text, Triples):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "Turtle triple data"
         else:
             dataset.peek = "file does not exist"
@@ -146,7 +146,7 @@ class Rdf(xml.GenericXml, Triples):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "RDF/XML triple data"
         else:
             dataset.peek = "file does not exist"
@@ -172,7 +172,7 @@ class Jsonld(text.Json, Triples):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "JSON-LD triple data"
         else:
             dataset.peek = "file does not exist"
@@ -196,7 +196,7 @@ class HDT(binary.Binary, Triples):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "HDT triple data"
         else:
             dataset.peek = "file does not exist"

--- a/lib/galaxy/datatypes/xml.py
+++ b/lib/galaxy/datatypes/xml.py
@@ -37,7 +37,7 @@ class GenericXml(data.Text):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "XML data"
         else:
             dataset.peek = "file does not exist"
@@ -90,7 +90,7 @@ class MEMEXml(GenericXml):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "MEME XML data"
         else:
             dataset.peek = "file does not exist"
@@ -106,7 +106,7 @@ class CisML(GenericXml):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "CisML data"
         else:
             dataset.peek = "file does not exist"
@@ -148,7 +148,7 @@ class Dzi(GenericXml):
         super().__init__(**kwd)
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
-        tree = util.parse_xml(dataset.file_name)
+        tree = util.parse_xml(dataset.get_file_name())
         root = tree.getroot()
         dataset.metadata.format = root.get("Format")
         dataset.metadata.tile_size = root.get("TileSize")
@@ -166,7 +166,7 @@ class Dzi(GenericXml):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "Deep Zoom Image"
         else:
             dataset.peek = "file does not exist"
@@ -200,7 +200,7 @@ class Phyloxml(GenericXml):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "Phyloxml data"
         else:
             dataset.peek = "file does not exist"
@@ -234,7 +234,7 @@ class Owl(GenericXml):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "Web Ontology Language OWL"
         else:
             dataset.peek = "file does not exist"
@@ -259,7 +259,7 @@ class Sbml(GenericXml):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
             dataset.blurb = "System Biology Markup Language SBML"
         else:
             dataset.peek = "file does not exist"

--- a/lib/galaxy/job_execution/datasets.py
+++ b/lib/galaxy/job_execution/datasets.py
@@ -112,7 +112,7 @@ class TaskPathRewriter(DatasetPathRewriter):
 
     def rewrite_dataset_path(self, dataset, dataset_type):
         """ """
-        dataset_file_name = dataset.file_name
+        dataset_file_name = dataset.get_file_name()
         job_file_name = self.job_dataset_path_rewriter.rewrite_dataset_path(dataset, dataset_type) or dataset_file_name
         return os.path.join(self.working_directory, os.path.basename(job_file_name))
 

--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -176,12 +176,12 @@ class JobIO(Dictifiable):
         return cast(OutputHdasAndType, self._output_hdas_and_paths)
 
     def get_input_dataset_fnames(self, ds: DatasetInstance) -> List[str]:
-        filenames = [ds.file_name]
+        filenames = [ds.get_file_name()]
         # we will need to stage in metadata file names also
         # TODO: would be better to only stage in metadata files that are actually needed (found in command line, referenced in config files, etc.)
         for value in ds.metadata.values():
             if isinstance(value, MetadataFile):
-                filenames.append(value.file_name)
+                filenames.append(value.get_file_name())
         return filenames
 
     def get_input_fnames(self) -> List[str]:
@@ -201,7 +201,7 @@ class JobIO(Dictifiable):
         return paths
 
     def get_input_path(self, dataset: DatasetInstance) -> DatasetPath:
-        real_path = dataset.file_name
+        real_path = dataset.get_file_name()
         false_path = self.dataset_path_rewriter.rewrite_dataset_path(dataset, "input")
         return DatasetPath(
             dataset.dataset.id,
@@ -220,7 +220,7 @@ class JobIO(Dictifiable):
 
     def get_output_path(self, dataset):
         if getattr(dataset, "fake_dataset_association", False):
-            return dataset.file_name
+            return dataset.get_file_name()
         assert dataset.id is not None, f"{dataset} needs to be flushed to find output path"
         for hda, dataset_path in self.output_hdas_and_paths.values():
             if hda.id == dataset.id:
@@ -246,7 +246,7 @@ class JobIO(Dictifiable):
             da_false_path = dataset_path_rewriter.rewrite_dataset_path(da.dataset, "output")
             mutable = da.dataset.dataset.external_filename is None
             dataset_path = DatasetPath(
-                da.dataset.dataset.id, da.dataset.file_name, false_path=da_false_path, mutable=mutable
+                da.dataset.dataset.id, da.dataset.get_file_name(), false_path=da_false_path, mutable=mutable
             )
             results.append((da.name, da.dataset, dataset_path))
 
@@ -254,7 +254,7 @@ class JobIO(Dictifiable):
         self._output_hdas_and_paths = {t[0]: t[1:] for t in results}
         if special:
             false_path = dataset_path_rewriter.rewrite_dataset_path(special, "output")
-            dsp = DatasetPath(special.dataset.id, special.dataset.file_name, false_path)
+            dsp = DatasetPath(special.dataset.id, special.dataset.get_file_name(), false_path)
             self._output_paths.append(dsp)
             self._output_hdas_and_paths["output_file"] = (special.fda, dsp)
 

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1723,8 +1723,8 @@ class MinimalJobWrapper(HasResourceParameters):
             while trynum < self.app.config.retry_job_output_collection:
                 try:
                     # Attempt to short circuit NFS attribute caching
-                    os.stat(dataset.dataset.file_name)
-                    os.chown(dataset.dataset.file_name, os.getuid(), -1)
+                    os.stat(dataset.dataset.get_file_name())
+                    os.chown(dataset.dataset.get_file_name(), os.getuid(), -1)
                     trynum = self.app.config.retry_job_output_collection
                 except (OSError, ObjectNotFound) as e:
                     trynum += 1
@@ -1777,7 +1777,7 @@ class MinimalJobWrapper(HasResourceParameters):
                     # If Galaxy was expected to sniff type and didn't - do so.
                     if dataset.ext == "_sniff_":
                         extension = sniff.handle_uploaded_dataset_file(
-                            dataset.dataset.file_name, self.app.datatypes_registry
+                            dataset.dataset.get_file_name(), self.app.datatypes_registry
                         )
                         dataset.extension = extension
 

--- a/lib/galaxy/jobs/dynamic_tool_destination.py
+++ b/lib/galaxy/jobs/dynamic_tool_destination.py
@@ -1345,17 +1345,17 @@ def map_tool_to_destination(job, app, tool, user_email, test=False, path=None, j
         for da in inp_data:
             try:
                 # If the input is a file, check and add the size
-                if inp_data[da] is not None and os.path.isfile(inp_data[da].file_name):
+                if inp_data[da] is not None and os.path.isfile(inp_data[da].get_file_name()):
                     num_input_datasets += 1
                     if verbose:
                         message = f"Loading file: {str(da)}"
-                        message += str(inp_data[da].file_name)
+                        message += str(inp_data[da].get_file_name())
                         log.debug(message)
 
                     # Add to records if the file type is fasta
                     if inp_data[da].ext == "fasta":
                         if records_rule_present:
-                            inp_db = open(inp_data[da].file_name)
+                            inp_db = open(inp_data[da].get_file_name())
 
                             # Try to find automatically computed sequences
                             metadata = inp_data[da].get_metadata()
@@ -1367,7 +1367,7 @@ def map_tool_to_destination(job, app, tool, user_email, test=False, path=None, j
                                     if line[0] == ">":
                                         records += 1
                     if filesize_rule_present:
-                        query_file = str(inp_data[da].file_name)
+                        query_file = str(inp_data[da].get_file_name())
                         file_size += os.path.getsize(query_file)
             except AttributeError:
                 # Otherwise, say that input isn't a file

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -767,7 +767,7 @@ class JobHandlerQueue(BaseJobHandlerQueue):
             # don't run jobs for which the input dataset was deleted
             if idata.deleted:
                 self.job_wrappers.pop(job.id, self.job_wrapper(job)).fail(
-                    f"input data {idata.hid} (file: {idata.file_name}) was deleted before the job started"
+                    f"input data {idata.hid} (file: {idata.get_file_name()}) was deleted before the job started"
                 )
                 return JOB_INPUT_DELETED
             # an error in the input data causes us to bail immediately

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -1122,7 +1122,7 @@ class PulsarComputeEnvironment(ComputeEnvironment):
         if local_input_path_rewrite is not None:
             local_input_path = local_input_path_rewrite
         else:
-            local_input_path = dataset.file_name
+            local_input_path = dataset.get_file_name()
         remote_path = self.path_mapper.remote_input_path_rewrite(local_input_path)
         return remote_path
 
@@ -1131,7 +1131,7 @@ class PulsarComputeEnvironment(ComputeEnvironment):
         if local_output_path_rewrite is not None:
             local_output_path = local_output_path_rewrite
         else:
-            local_output_path = dataset.file_name
+            local_output_path = dataset.get_file_name()
         remote_path = self.path_mapper.remote_output_path_rewrite(local_output_path)
         return remote_path
 

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -145,7 +145,7 @@ class DatasetManager(base.ModelManager[model.Dataset], secured.AccessibleManager
             extra_dir = dataset.extra_files_path_name
             file_path = self.app.object_store.get_filename(dataset, extra_dir=extra_dir, alt_name=extra_files_path)
         else:
-            file_path = dataset.file_name
+            file_path = dataset.get_file_name()
         hash_function = request.hash_function
         calculated_hash_value = memory_bound_hexdigest(hash_func_name=hash_function, path=file_path)
         extra_files_path = request.extra_files_path
@@ -275,7 +275,7 @@ class DatasetSerializer(base.ModelSerializer[DatasetManager], deletable.Purgable
         # expensive: allow config option due to cost of operation
         if is_admin or self.app.config.expose_dataset_path:
             if not dataset.purged:
-                return dataset.file_name
+                return dataset.get_file_name()
         self.skip()
 
     def serialize_extra_files_path(self, item, key, user=None, **context):
@@ -480,7 +480,7 @@ class DatasetAssociationManager(
         data = trans.sa_session.query(self.model_class).get(dataset_assoc.id)
         self.ensure_can_change_datatype(data)
         self.ensure_can_set_metadata(data)
-        path = data.dataset.file_name
+        path = data.dataset.get_file_name()
         datatype = sniff.guess_ext(path, trans.app.datatypes_registry.sniff_order)
         trans.app.datatypes_registry.change_datatype(data, datatype)
         with transaction(trans.sa_session):
@@ -671,7 +671,7 @@ class _UnflattenedMetadataDatasetAssociationSerializer(base.ModelSerializer[T], 
                 # only when explicitly set: fetching filepaths can be expensive
                 if not self.app.config.expose_dataset_path:
                     continue
-                val = val.file_name
+                val = val.get_file_name()
             # TODO:? possibly split this off?
             # If no value for metadata, look in datatype for metadata.
             elif val is None and hasattr(dataset_assoc.datatype, name):

--- a/lib/galaxy/managers/dbkeys.py
+++ b/lib/galaxy/managers/dbkeys.py
@@ -125,7 +125,7 @@ class GenomeBuilds:
         if trans:
             db_dataset = trans.db_dataset_for(dbkey)
             if db_dataset:
-                chrom_info = db_dataset.file_name
+                chrom_info = db_dataset.get_file_name()
             else:
                 # Do Custom Build handling
                 if (
@@ -145,10 +145,12 @@ class GenomeBuilds:
                         build_fasta_dataset = trans.sa_session.get(
                             HistoryDatasetAssociation, custom_build_dict["fasta"]
                         )
-                        chrom_info = build_fasta_dataset.get_converted_dataset(trans, "len").file_name
+                        chrom_info = build_fasta_dataset.get_converted_dataset(trans, "len").get_file_name()
                     elif "len" in custom_build_dict:
                         # Build is defined by len file, so use it.
-                        chrom_info = trans.sa_session.get(HistoryDatasetAssociation, custom_build_dict["len"]).file_name
+                        chrom_info = trans.sa_session.get(
+                            HistoryDatasetAssociation, custom_build_dict["len"]
+                        ).get_file_name()
         # Check Data table
         if not chrom_info:
             dbkey_table = self._app.tool_data_tables.get(self._data_table_name, None)

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -309,11 +309,11 @@ class HDAManager(
         # For now, cannot get data from non-text datasets.
         if not isinstance(hda.datatype, datatypes.data.Text):
             return truncated, hda_data
-        if not os.path.exists(hda.file_name):
+        if not os.path.exists(hda.get_file_name()):
             return truncated, hda_data
 
-        truncated = preview and os.stat(hda.file_name).st_size > MAX_PEEK_SIZE
-        hda_data = open(hda.file_name).read(MAX_PEEK_SIZE)
+        truncated = preview and os.stat(hda.get_file_name()).st_size > MAX_PEEK_SIZE
+        hda_data = open(hda.get_file_name()).read(MAX_PEEK_SIZE)
         return truncated, hda_data
 
     # .... annotatable

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -428,7 +428,7 @@ class ToBasicMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHandler):
             filepath = path_match.group(2)
             file = os.path.join(hda.extra_files_path, filepath)
         else:
-            file = dataset.file_name
+            file = dataset.get_file_name()
 
         with open(file, "rb") as f:
             base64_image_data = base64.b64encode(f.read()).decode("utf-8")

--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -186,7 +186,7 @@ class PortableDirectoryMetadataGenerator(MetadataCollectionStrategy):
             )
 
             outputs[name] = {
-                "filename_override": _get_filename_override(output_fnames, dataset.file_name),
+                "filename_override": _get_filename_override(output_fnames, dataset.get_file_name()),
                 "validate": validate_outputs,
                 "object_store_store_by": dataset.dataset.store_by,
                 "id": dataset.id,
@@ -327,7 +327,7 @@ def _initialize_metadata_inputs(dataset, path_for_part, tmp_dir, kwds, real_meta
             if not real_metadata_object:
                 metadata_temp = MetadataTempFile()
                 metadata_temp.tmp_dir = tmp_dir
-                shutil.copy(dataset.metadata.get(meta_key, None).file_name, metadata_temp.file_name)
+                shutil.copy(dataset.metadata.get(meta_key, None).get_file_name(), metadata_temp.get_file_name())
                 override_metadata.append((meta_key, metadata_temp.to_JSON()))
 
     with open(filename_override_metadata, "w+") as f:

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -118,7 +118,7 @@ def set_meta_with_tool_provided(
     extension = dataset_instance.extension
     if extension == "_sniff_":
         try:
-            extension = sniff.handle_uploaded_dataset_file(dataset_instance.dataset.file_name, datatypes_registry)
+            extension = sniff.handle_uploaded_dataset_file(dataset_instance.dataset.get_file_name(), datatypes_registry)
             # We need to both set the extension so it is available to set_meta
             # and record it in the metadata so it can be reloaded on the server
             # side and the model updated (see MetadataCollection.{from,to}_JSON_dict)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2518,8 +2518,10 @@ class FakeDatasetAssociation:
 
     def __init__(self, dataset=None):
         self.dataset = dataset
-        self.file_name = dataset.file_name
         self.metadata = dict()
+
+    def get_file_name(self):
+        return self.dataset.get_file_name()
 
     def __eq__(self, other):
         return isinstance(other, FakeDatasetAssociation) and self.dataset == other.dataset
@@ -3971,8 +3973,6 @@ class Dataset(Base, StorableObject, Serializable):
         else:
             self.external_filename = filename
 
-    file_name = property(get_file_name, set_file_name)
-
     def _assert_object_store_set(self):
         assert self.object_store is not None, f"Object Store has not been initialized for dataset {self.id}"
         return self.object_store
@@ -4406,10 +4406,8 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
     def set_file_name(self, filename: str):
         return self.dataset.set_file_name(filename)
 
-    file_name = property(get_file_name, set_file_name)
-
     def link_to(self, path):
-        self.file_name = os.path.abspath(path)
+        self.dataset.set_file_name(os.path.abspath(path))
         # Since we are not copying the file into Galaxy's managed
         # default file location, the dataset should never be purgable.
         self.dataset.purgable = False
@@ -4461,7 +4459,7 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
             file_ext = metadata.spec[metadata_name].file_ext
             metadata_file = metadata[metadata_name]
             if metadata_file:
-                path = metadata_file.file_name
+                path = metadata_file.get_file_name()
                 metadata_files.append((file_ext, path))
         return metadata_files
 
@@ -4670,7 +4668,7 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
             if dataset_ext == "bai" and name == "bam_index" and isinstance(value, MetadataFile):
                 # HACK: MetadataFile objects cannot be used by tools, so return
                 # a fake HDA that points to metadata file.
-                fake_dataset = Dataset(state=Dataset.states.OK, external_filename=value.file_name)
+                fake_dataset = Dataset(state=Dataset.states.OK, external_filename=value.get_file_name())
                 fake_hda = HistoryDatasetAssociation(dataset=fake_dataset)
                 return fake_hda
 
@@ -5205,7 +5203,7 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
                 # only when explicitly set: fetching filepaths can be expensive
                 if not expose_dataset_path:
                     continue
-                val = val.file_name
+                val = val.get_file_name()
             # If no value for metadata, look in datatype for metadata.
             elif not hda.metadata.element_is_set(name) and hasattr(hda.datatype, name):
                 val = getattr(hda.datatype, name)
@@ -5640,7 +5638,7 @@ class LibraryDataset(Base, Serializable):
             model_class=self.__class__.__name__,
             state=ldda.state,
             name=ldda.name,
-            file_name=ldda.file_name,
+            file_name=ldda.get_file_name(),
             created_from_basename=ldda.created_from_basename,
             uploaded_by=ldda.user and ldda.user.email,
             message=ldda.message,
@@ -5661,7 +5659,7 @@ class LibraryDataset(Base, Serializable):
         for name in ldda.metadata.spec.keys():
             val = ldda.metadata.get(name)
             if isinstance(val, MetadataFile):
-                val = val.file_name
+                val = val.get_file_name()
             elif isinstance(val, list):
                 val = ", ".join(str(v) for v in val)
             rval[f"metadata_{name}"] = val
@@ -5788,7 +5786,7 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, Serializable):
             state=ldda.state,
             library_dataset_id=ldda.library_dataset_id,
             file_size=file_size,
-            file_name=ldda.file_name,
+            file_name=ldda.get_file_name(),
             update_time=ldda.update_time.isoformat(),
             file_ext=ldda.ext,
             data_type=f"{ldda.datatype.__class__.__module__}.{ldda.datatype.__class__.__name__}",
@@ -5807,7 +5805,7 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, Serializable):
         for name in ldda.metadata.spec.keys():
             val = ldda.metadata.get(name)
             if isinstance(val, MetadataFile):
-                val = val.file_name
+                val = val.get_file_name()
             # If no value for metadata, look in datatype for metadata.
             elif val is None and hasattr(ldda.datatype, name):
                 val = getattr(ldda.datatype, name)
@@ -6043,9 +6041,9 @@ class ImplicitlyConvertedDatasetAssociation(Base, RepresentById):
         if purge and self.dataset.deleted:  # do something with purging
             self.purged = True
             try:
-                os.unlink(self.file_name)
+                os.unlink(self.get_file_name())
             except Exception as e:
-                log.error(f"Failed to purge associated file ({self.file_name}) from disk: {unicodify(e)}")
+                log.error(f"Failed to purge associated file ({self.get_file_name()}) from disk: {unicodify(e)}")
 
 
 DEFAULT_COLLECTION_NAME = "Unnamed Collection"
@@ -6257,7 +6255,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
         q = self._get_nested_collection_attributes(
             element_attributes=("element_identifier",), hda_attributes=("extension",), return_entities=(Dataset,)
         )
-        return [(row[:-2], row.extension, row.Dataset.file_name) for row in q]
+        return [(row[:-2], row.extension, row.Dataset.get_file_name()) for row in q]
 
     @property
     def element_identifiers_extensions_paths_and_metadata_files(
@@ -6272,7 +6270,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
             )
             # element_identifiers, extension, path
             for row in q:
-                result = [row[:-3], row.extension, row.Dataset.file_name]
+                result = [row[:-3], row.extension, row.Dataset.get_file_name()]
                 hda = row.HistoryDatasetAssociation
                 result.append(hda.get_metadata_file_paths_and_extensions())
                 results.append(result)
@@ -6284,7 +6282,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
                     [
                         dataset_element._identifiers,
                         dataset_element.hda.extension,
-                        dataset_element.hda.file_name,
+                        dataset_element.hda.get_file_name(),
                         dataset_element.hda.get_metadata_file_paths_and_extensions(),
                     ]
                 )
@@ -9072,11 +9070,10 @@ class MetadataFile(Base, StorableObject, Serializable):
             file_name=file_name,
             extra_dir="_metadata_files",
             extra_dir_at_root=True,
-            alt_name=os.path.basename(self.file_name),
+            alt_name=os.path.basename(self.get_file_name()),
         )
 
-    @property
-    def file_name(self):
+    def get_file_name(self):
         # Ensure the directory structure and the metadata file object exist
         try:
             da = self.history_dataset or self.library_dataset

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -585,7 +585,7 @@ class FileParameter(MetadataParameter):
     def to_string(self, value):
         if not value:
             return str(self.spec.no_value)
-        return value.file_name
+        return value.get_file_name()
 
     def to_safe_string(self, value):
         # We do not sanitize file names
@@ -621,12 +621,12 @@ class FileParameter(MetadataParameter):
             new_value = galaxy.model.MetadataFile(dataset=target_context.parent, name=self.spec.name)
             session.add(new_value)
             try:
-                new_value.update_from_file(value.file_name)
+                new_value.update_from_file(value.get_file_name())
             except AssertionError:
                 tmp_session = session(target_context.parent)
                 with transaction(tmp_session):
                     tmp_session.commit()
-                new_value.update_from_file(value.file_name)
+                new_value.update_from_file(value.get_file_name())
             return self.unwrap(new_value)
         return None
 
@@ -652,7 +652,7 @@ class FileParameter(MetadataParameter):
             if mf is None:
                 mf = self.new_file(dataset=parent, **value.kwds)
             # Ensure the metadata file gets updated with content
-            file_name = value.file_name
+            file_name = value.get_file_name()
             if path_rewriter:
                 # Job may have run with a different (non-local) tmp/working
                 # directory. Correct.
@@ -701,8 +701,7 @@ class MetadataTempFile:
             self.tmp_dir = metadata_tmp_files_dir
         self._filename = None
 
-    @property
-    def file_name(self):
+    def get_file_name(self):
         if self._filename is None:
             # we need to create a tmp file, accessable across all nodes/heads, save the name, and return it
             self._filename = abspath(tempfile.NamedTemporaryFile(dir=self.tmp_dir, prefix="metadata_temp_file_").name)
@@ -710,7 +709,7 @@ class MetadataTempFile:
         return self._filename
 
     def to_JSON(self):
-        return {"__class__": self.__class__.__name__, "filename": self.file_name, "kwds": self.kwds}
+        return {"__class__": self.__class__.__name__, "filename": self.get_file_name(), "kwds": self.kwds}
 
     @classmethod
     def from_JSON(cls, json_dict):
@@ -730,9 +729,9 @@ class MetadataTempFile:
                 for value in json.load(fh).values():
                     if cls.is_JSONified_value(value):
                         value = cls.from_JSON(value)
-                    if isinstance(value, cls) and os.path.exists(value.file_name):
-                        log.debug("Cleaning up abandoned MetadataTempFile file: %s", value.file_name)
-                        os.unlink(value.file_name)
+                    if isinstance(value, cls) and os.path.exists(value.get_file_name()):
+                        log.debug("Cleaning up abandoned MetadataTempFile file: %s", value.get_file_name())
+                        os.unlink(value.get_file_name())
         except Exception as e:
             log.debug("Failed to cleanup MetadataTempFile temp files from %s: %s", filename, unicodify(e))
 

--- a/lib/galaxy/model/none_like.py
+++ b/lib/galaxy/model/none_like.py
@@ -37,3 +37,6 @@ class NoneDataset(RecursiveNone):
 
     def missing_meta(self):
         return False
+
+    def get_file_name(self):
+        return "None"

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1908,7 +1908,7 @@ class DirectoryModelExportStore(ModelExportStore):
 
         file_name, extra_files_path = None, None
         try:
-            _file_name = dataset.file_name
+            _file_name = dataset.get_file_name()
             if os.path.exists(_file_name):
                 file_name = _file_name
         except ObjectNotFound:
@@ -1972,7 +1972,7 @@ class DirectoryModelExportStore(ModelExportStore):
         for dataset in self.included_datasets:
             for metadata_element in dataset.metadata.values():
                 if isinstance(metadata_element, model.MetadataFile):
-                    metadata_element.update_from_file(metadata_element.file_name)
+                    metadata_element.update_from_file(metadata_element.get_file_name())
 
     def export_job(self, job: model.Job, tool=None, include_job_data=True):
         self.export_jobs([job], include_job_data=include_job_data)
@@ -2230,7 +2230,7 @@ class DirectoryModelExportStore(ModelExportStore):
 
     def _ensure_dataset_file_exists(self, dataset: model.DatasetInstance) -> None:
         state = dataset.dataset.state
-        if state in [model.Dataset.states.OK] and not dataset.file_name:
+        if state in [model.Dataset.states.OK] and not dataset.get_file_name():
             log.error(
                 f"Dataset [{dataset.id}] does not exists on on object store [{dataset.dataset.object_store_id or 'None'}], while trying to export."
             )

--- a/lib/galaxy/tool_util/cwl/representation.py
+++ b/lib/galaxy/tool_util/cwl/representation.py
@@ -151,7 +151,7 @@ def type_descriptions_for_field_types(field_types):
 
 def dataset_wrapper_to_file_json(inputs_dir, dataset_wrapper):
     if dataset_wrapper.ext == "expression.json":
-        with open(dataset_wrapper.file_name) as f:
+        with open(dataset_wrapper.get_file_name()) as f:
             return json.load(f)
 
     if dataset_wrapper.ext == "directory":
@@ -201,7 +201,7 @@ def dataset_wrapper_to_directory_json(inputs_dir, dataset_wrapper):
 
     # get archive location
     try:
-        archive_location = dataset_wrapper.unsanitized.file_name
+        archive_location = dataset_wrapper.unsanitized.get_file_name()
     except Exception:
         archive_location = None
 

--- a/lib/galaxy/tool_util/data/__init__.py
+++ b/lib/galaxy/tool_util/data/__init__.py
@@ -888,9 +888,11 @@ class DirectoryAsExtraFiles(HasExtraFiles):
         return True
 
 
-class OutputDataset(HasExtraFiles):
+class OutputDataset(HasExtraFiles, Protocol):
     ext: str
-    file_name: str
+
+    def get_file_name(self) -> str:
+        ...
 
 
 class ToolDataTableManager(Dictifiable):
@@ -1219,7 +1221,7 @@ def _data_manager_dict(out_data: Dict[str, OutputDataset], ensure_single_output:
         found_output = True
 
         try:
-            output_dict = json.loads(open(output_dataset.file_name).read())
+            output_dict = json.loads(open(output_dataset.get_file_name()).read())
         except Exception as e:
             log.warning(f'Error reading DataManagerTool json for "{output_name}": {e}')
             continue

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -6219,7 +6219,7 @@ tool config.
       xrange = c(NULL, NULL)
       yrange = c(NULL, NULL)
       #for $i, $s in enumerate($series)
-          s${i} = read.table("${s.input.file_name}")
+          s${i} = read.table("${s.input.get_file_name()}")
           x${i} = s${i}[,${s.xcol}]
           y${i} = s${i}[,${s.ycol}]
           xrange = range(x${i}, xrange)

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2850,7 +2850,7 @@ class ExpressionTool(Tool):
                 # Skip filtered outputs
                 continue
             if val.output_type == "data":
-                with open(out_data[key].file_name) as f:
+                with open(out_data[key].get_file_name()) as f:
                     src = json.load(f)
                 assert isinstance(src, dict), f"Expected dataset 'src' to be a dictionary - actual type is {type(src)}"
                 dataset_id = src["id"]
@@ -3491,7 +3491,7 @@ class FilterEmptyDatasetsTool(FilterDatasetsTool):
         dataset_instance: model.DatasetInstance = element.element_object
         if dataset_instance.has_data():
             # We have data, but it might just be a compressed archive of nothing
-            file_name = dataset_instance.file_name
+            file_name = dataset_instance.get_file_name()
             _, fh = get_fileobj_raw(file_name, mode="rb")
             if len(fh.read(1)):
                 return True
@@ -3551,7 +3551,7 @@ class SortTool(DatabaseOperationTool):
                 for element in elements:
                     old_elements_dict[element.element_identifier] = element
                 try:
-                    with open(hda.file_name) as fh:
+                    with open(hda.get_file_name()) as fh:
                         sorted_elements = [old_elements_dict[line.strip()] for line in fh]
                 except KeyError:
                     hdca_history_name = f"{hdca.hid}: {hdca.name}"
@@ -3602,7 +3602,7 @@ class RelabelFromFileTool(DatabaseOperationTool):
                 copied_value = dce_object.copy()
             new_elements[new_label] = copied_value
 
-        new_labels_path = new_labels_dataset_assoc.file_name
+        new_labels_path = new_labels_dataset_assoc.get_file_name()
         with open(new_labels_path) as fh:
             new_labels = fh.readlines(1024 * 1000000)
         if strict and len(hdca.collection.elements) != len(new_labels):
@@ -3726,7 +3726,7 @@ class TagFromFileTool(DatabaseOperationTool):
                     )
             new_elements[dce.element_identifier] = copied_value
 
-        new_tags_path = new_tags_dataset_assoc.file_name
+        new_tags_path = new_tags_dataset_assoc.get_file_name()
         with open(new_tags_path) as fh:
             new_tags = fh.readlines(1024 * 1000000)
         # We have a tabular file, where the first column is an existing element identifier,
@@ -3751,7 +3751,7 @@ class FilterFromFileTool(DatabaseOperationTool):
         filtered_elements = {}
         discarded_elements = {}
 
-        filtered_path = filter_dataset_assoc.file_name
+        filtered_path = filter_dataset_assoc.get_file_name()
         with open(filtered_path) as fh:
             filtered_identifiers = [i.strip() for i in fh.readlines(1024 * 1000000)]
 

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -675,7 +675,7 @@ class DefaultToolAction(ToolAction):
                 data.state = "ok"
                 data.blurb = "skipped"
                 data.visible = False
-                with open(data.dataset.file_name, "w") as out:
+                with open(data.dataset.get_file_name(), "w") as out:
                     out.write(json.dumps(None))
         job.preferred_object_store_id = preferred_object_store_id
         self._record_inputs(trans, tool, job, incoming, inp_data, inp_dataset_collections)

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -106,7 +106,7 @@ class SetMetadataToolAction(ToolAction):
         # add parameters to job_parameter table
         # Store original dataset state, so we can restore it. A separate table might be better (no chance of 'losing' the original state)?
         incoming["__ORIGINAL_DATASET_STATE__"] = dataset.state
-        input_paths = [DatasetPath(dataset.id, real_path=dataset.file_name, mutable=False)]
+        input_paths = [DatasetPath(dataset.id, real_path=dataset.get_file_name(), mutable=False)]
         app.object_store.create(job, base_dir="job_work", dir_only=True, extra_dir=str(job.id))
         job_working_dir = app.object_store.get_filename(job, base_dir="job_work", dir_only=True, extra_dir=str(job.id))
         datatypes_config = os.path.join(job_working_dir, "registry.xml")

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2197,7 +2197,7 @@ class DataToolParameter(BaseDataToolParameter):
     def to_param_dict_string(self, value, other_values=None):
         if value is None:
             return "None"
-        return value.file_name
+        return value.get_file_name()
 
     def to_text(self, value):
         if value and not isinstance(value, list):

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -714,10 +714,10 @@ class DynamicOptions:
                     if getattr(dataset, "purged", False) or getattr(dataset, "deleted", False):
                         log.warning(f"The metadata file inferred from key `{meta_file_key}` was deleted!")
                         continue
-                if not hasattr(dataset, "file_name"):
+                if not hasattr(dataset, "get_file_name"):
                     continue
                 # Ensure parsing dynamic options does not consume more than a megabyte worth memory.
-                path = dataset.file_name
+                path = dataset.get_file_name()
                 if os.path.getsize(path) < 1048576:
                     with open(path) as fh:
                         options += self.parse_file_fields(fh)

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -468,12 +468,12 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
         if self.false_path is not None:
             return self.false_path
         else:
-            return str(self.unsanitized.file_name)
+            return str(self.unsanitized.get_file_name())
 
     def __getattr__(self, key: Any) -> Any:
-        if self.false_path is not None and key == "file_name":
+        if self.false_path is not None and key == "get_file_name":
             # Path to dataset was rewritten for this job.
-            return self.false_path
+            return lambda *args, **kwargs: self.false_path
         elif key in ("extra_files_path", "files_path"):
             if not self.compute_environment:
                 # Only happens in WrappedParameters context, refactor!

--- a/lib/galaxy/visualization/data_providers/basic.py
+++ b/lib/galaxy/visualization/data_providers/basic.py
@@ -144,7 +144,7 @@ class ColumnDataProvider(BaseDataProvider):
             return val
 
         returning_data = False
-        f = open(self.original_dataset.file_name)
+        f = open(self.original_dataset.get_file_name())
         # TODO: add f.seek if given fptr in kwargs
         for count, line in enumerate(f):
             # check line v. desired start, end

--- a/lib/galaxy/visualization/data_providers/genome.py
+++ b/lib/galaxy/visualization/data_providers/genome.py
@@ -107,9 +107,9 @@ class FeatureLocationIndexDataProvider(BaseDataProvider):
 
     def get_data(self, query):
         # Init.
-        textloc_file = open(self.converted_dataset.file_name)
+        textloc_file = open(self.converted_dataset.get_file_name())
         line_len = int(textloc_file.readline())
-        file_len = os.path.getsize(self.converted_dataset.file_name)
+        file_len = os.path.getsize(self.converted_dataset.get_file_name())
         query = query.lower()
 
         # Find query in file using binary search.
@@ -349,8 +349,8 @@ class TabixDataProvider(GenomeDataProvider, FilterableMixin):
     def open_data_file(self):
         # We create a symlink to the index file. This is
         # required until https://github.com/pysam-developers/pysam/pull/586 is merged.
-        index_path = self.converted_dataset.file_name
-        with pysam.TabixFile(self.dependencies["bgzip"].file_name, index=index_path) as f:
+        index_path = self.converted_dataset.get_file_name()
+        with pysam.TabixFile(self.dependencies["bgzip"].get_file_name(), index=index_path) as f:
             yield f
 
     def get_iterator(self, data_file, chrom, start, end, **kwargs) -> Iterator[str]:
@@ -587,7 +587,7 @@ class RawBedDataProvider(BedDataProvider):
         data_file.seek(0)
 
         def line_filter_iter():
-            with open(self.original_dataset.file_name) as data_file:
+            with open(self.original_dataset.get_file_name()) as data_file:
                 for line in data_file:
                     if line.startswith("track") or line.startswith("browser"):
                         continue
@@ -774,7 +774,7 @@ class RawVcfDataProvider(VcfDataProvider):
 
     @contextmanager
     def open_data_file(self):
-        with open(self.original_dataset.file_name) as f:
+        with open(self.original_dataset.get_file_name()) as f:
             yield f
 
     def get_iterator(self, data_file, chrom, start, end, **kwargs):
@@ -840,7 +840,7 @@ class BamDataProvider(GenomeDataProvider, FilterableMixin):
 
         # Open current BAM file using index.
         bamfile = pysam.AlignmentFile(
-            self.original_dataset.file_name, mode="rb", index_filename=self.converted_dataset.file_name
+            self.original_dataset.get_file_name(), mode="rb", index_filename=self.converted_dataset.get_file_name()
         )
 
         # TODO: write headers as well?
@@ -874,7 +874,7 @@ class BamDataProvider(GenomeDataProvider, FilterableMixin):
     def open_data_file(self):
         # Attempt to open the BAM file with index
         with pysam.AlignmentFile(
-            self.original_dataset.file_name, mode="rb", index_filename=self.converted_dataset.file_name
+            self.original_dataset.get_file_name(), mode="rb", index_filename=self.converted_dataset.get_file_name()
         ) as f:
             yield f
 
@@ -1292,7 +1292,7 @@ class BBIDataProvider(GenomeDataProvider):
 class BigBedDataProvider(BBIDataProvider):
     def _get_dataset(self):
         # Nothing converts to bigBed so we don't consider converted dataset
-        f = open(self.original_dataset.file_name, "rb")
+        f = open(self.original_dataset.get_file_name(), "rb")
         return f, BigBedFile(file=f)
 
 
@@ -1304,9 +1304,9 @@ class BigWigDataProvider(BBIDataProvider):
 
     def _get_dataset(self):
         if self.converted_dataset is not None:
-            f = open(self.converted_dataset.file_name, "rb")
+            f = open(self.converted_dataset.get_file_name(), "rb")
         else:
-            f = open(self.original_dataset.file_name, "rb")
+            f = open(self.original_dataset.get_file_name(), "rb")
         return f, BigWigFile(file=f)
 
 
@@ -1320,8 +1320,8 @@ class IntervalIndexDataProvider(GenomeDataProvider, FilterableMixin):
     dataset_type = "interval_index"
 
     def write_data_to_file(self, regions, filename):
-        index = Indexes(self.converted_dataset.file_name)
-        with open(self.original_dataset.file_name) as source, open(filename, "w") as out:
+        index = Indexes(self.converted_dataset.get_file_name())
+        with open(self.original_dataset.get_file_name()) as source, open(filename, "w") as out:
             for region in regions:
                 # Write data from region.
                 chrom = region.chrom
@@ -1342,7 +1342,7 @@ class IntervalIndexDataProvider(GenomeDataProvider, FilterableMixin):
 
     @contextmanager
     def open_data_file(self):
-        i = Indexes(self.converted_dataset.file_name)
+        i = Indexes(self.converted_dataset.get_file_name())
         yield i
 
     def get_iterator(self, data_file, chrom, start, end, **kwargs) -> Iterator[str]:
@@ -1358,7 +1358,7 @@ class IntervalIndexDataProvider(GenomeDataProvider, FilterableMixin):
     def process_data(self, iterator, start_val=0, max_vals=None, **kwargs):
         results = []
         message = None
-        with open(self.original_dataset.file_name) as source:
+        with open(self.original_dataset.get_file_name()) as source:
             # Build data to return. Payload format is:
             # [ <guid/offset>, <start>, <end>, <name>, <score>, <strand>, <thick_start>,
             #   <thick_end>, <blocks> ]
@@ -1402,7 +1402,7 @@ class RawGFFDataProvider(GenomeDataProvider):
         Returns an iterator that provides data in the region chrom:start-end as well as
         a file offset.
         """
-        source = open(self.original_dataset.file_name)
+        source = open(self.original_dataset.get_file_name())
 
         # Read first line in order to match chrom naming format.
         line = source.readline()

--- a/lib/galaxy/visualization/data_providers/phyloviz/__init__.py
+++ b/lib/galaxy/visualization/data_providers/phyloviz/__init__.py
@@ -23,7 +23,7 @@ class PhylovizDataProvider(BaseDataProvider):
         """
 
         file_ext = self.original_dataset.datatype.file_ext
-        file_name = self.original_dataset.file_name
+        file_name = self.original_dataset.get_file_name()
         parseMsg = None
         jsonDicts = []
         rval: Dict[str, Any] = {"dataset_type": self.dataset_type}

--- a/lib/galaxy/visualization/genomes.py
+++ b/lib/galaxy/visualization/genomes.py
@@ -313,7 +313,7 @@ class Genomes:
                 # If there's a fasta for genome, convert to 2bit for later use.
                 if "fasta" in dbkey_attributes:
                     build_fasta = session.get(HistoryDatasetAssociation, dbkey_attributes["fasta"])
-                    len_file = build_fasta.get_converted_dataset(trans, "len").file_name
+                    len_file = build_fasta.get_converted_dataset(trans, "len").get_file_name()
                     build_fasta.get_converted_dataset(trans, "twobit")
                     # HACK: set twobit_file to True rather than a file name because
                     # get_converted_dataset returns null during conversion even though
@@ -321,7 +321,7 @@ class Genomes:
                     twobit_file = True
                 # Backwards compatibility: look for len file directly.
                 elif "len" in dbkey_attributes:
-                    len_file = session.get(HistoryDatasetAssociation, user_keys[dbkey]["len"]).file_name
+                    len_file = session.get(HistoryDatasetAssociation, user_keys[dbkey]["len"]).get_file_name()
                 if len_file:
                     genome = Genome(dbkey, dbkey_name, len_file=len_file, twobit_file=twobit_file)
 
@@ -330,7 +330,7 @@ class Genomes:
             # Look in history for chromosome len file.
             len_ds = trans.db_dataset_for(dbkey)
             if len_ds:
-                genome = Genome(dbkey, dbkey_name, len_file=len_ds.file_name)
+                genome = Genome(dbkey, dbkey_name, len_file=len_ds.get_file_name())
             # Look in system builds.
             elif dbkey in self.genomes:
                 genome = self.genomes[dbkey]
@@ -393,7 +393,7 @@ class Genomes:
                 return msg
             else:
                 twobit_dataset = fasta_dataset.get_converted_dataset(trans, "twobit")
-                twobit_file_name = twobit_dataset.file_name
+                twobit_file_name = twobit_dataset.get_file_name()
 
         return self._get_reference_data(twobit_file_name, chrom, low, high)
 

--- a/lib/galaxy/webapps/galaxy/api/job_files.py
+++ b/lib/galaxy/webapps/galaxy/api/job_files.py
@@ -155,7 +155,7 @@ class JobFilesAPIController(BaseGalaxyAPIController):
                 dataset = job_dataset_association.dataset
                 if not dataset:
                     continue
-                if os.path.abspath(dataset.file_name) == os.path.abspath(path):
+                if os.path.abspath(dataset.get_file_name()) == os.path.abspath(path):
                     return True
                 elif util.in_directory(path, dataset.extra_files_path):
                     return True

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -693,22 +693,22 @@ class LibraryDatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin,
                         zpath = f"{zpath}.html"  # fake the real nature of the html file
                     try:
                         if archive_format == "zip":
-                            archive.write(ldda.dataset.file_name, zpath)  # add the primary of a composite set
+                            archive.write(ldda.dataset.get_file_name(), zpath)  # add the primary of a composite set
                         else:
-                            archive.write(ldda.dataset.file_name, zpath)  # add the primary of a composite set
+                            archive.write(ldda.dataset.get_file_name(), zpath)  # add the primary of a composite set
                     except OSError:
                         log.exception(
                             "Unable to add composite parent %s to temporary library download archive",
-                            ldda.dataset.file_name,
+                            ldda.dataset.get_file_name(),
                         )
                         raise exceptions.InternalServerError("Unable to create archive for download.")
                     except ObjectNotFound:
-                        log.exception("Requested dataset %s does not exist on the host.", ldda.dataset.file_name)
+                        log.exception("Requested dataset %s does not exist on the host.", ldda.dataset.get_file_name())
                         raise exceptions.ObjectNotFound("Requested dataset not found. ")
                     except Exception as e:
                         log.exception(
                             "Unable to add composite parent %s to temporary library download archive",
-                            ldda.dataset.file_name,
+                            ldda.dataset.get_file_name(),
                         )
                         raise exceptions.InternalServerError(
                             f"Unable to add composite parent to temporary library download archive. {util.unicodify(e)}"
@@ -734,19 +734,19 @@ class LibraryDatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin,
                             )
                 else:
                     try:
-                        archive.write(ldda.dataset.file_name, path)
+                        archive.write(ldda.dataset.get_file_name(), path)
                     except OSError:
                         log.exception(
-                            "Unable to write %s to temporary library download archive", ldda.dataset.file_name
+                            "Unable to write %s to temporary library download archive", ldda.dataset.get_file_name()
                         )
                         raise exceptions.InternalServerError("Unable to create archive for download")
                     except ObjectNotFound:
-                        log.exception("Requested dataset %s does not exist on the host.", ldda.dataset.file_name)
+                        log.exception("Requested dataset %s does not exist on the host.", ldda.dataset.get_file_name())
                         raise exceptions.ObjectNotFound("Requested dataset not found.")
                     except Exception as e:
                         log.exception(
                             "Unable to add %s to temporary library download archive %s",
-                            ldda.dataset.file_name,
+                            ldda.dataset.get_file_name(),
                             outfname,
                         )
                         raise exceptions.InternalServerError(f"Unknown error. {util.unicodify(e)}")
@@ -761,14 +761,14 @@ class LibraryDatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin,
                 single_ld = library_datasets[0]
                 ldda = single_ld.library_dataset_dataset_association
                 dataset = ldda.dataset
-                fStat = os.stat(dataset.file_name)
+                fStat = os.stat(dataset.get_file_name())
                 trans.response.set_content_type(ldda.get_mime())
                 trans.response.headers["Content-Length"] = str(fStat.st_size)
                 fname = f"{ldda.name}.{ldda.extension}"
                 fname = "".join(c in util.FILENAME_VALID_CHARS and c or "_" for c in fname)[0:150]
                 trans.response.headers["Content-Disposition"] = f'attachment; filename="{fname}"'
                 try:
-                    return open(dataset.file_name, "rb")
+                    return open(dataset.get_file_name(), "rb")
                 except Exception:
                     raise exceptions.InternalServerError("This dataset contains no content.")
         else:

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -468,7 +468,7 @@ class FastAPIUsers:
                     trans.sa_session.commit()
                 counter = 0
                 lines_skipped = 0
-                with open(new_len.file_name, "w") as f:
+                with open(new_len.get_file_name(), "w") as f:
                     # LEN files have format:
                     #   <chrom_name><tab><chrom_length>
                     for line in len_value.split("\n"):
@@ -528,7 +528,7 @@ class FastAPIUsers:
                     and not chrom_count_dataset.deleted
                     and chrom_count_dataset.state == trans.app.model.HistoryDatasetAssociation.states.OK
                 ):
-                    chrom_count = int(open(chrom_count_dataset.file_name).readline())
+                    chrom_count = int(open(chrom_count_dataset.get_file_name()).readline())
                     dbkey["count"] = chrom_count
                     valid_dbkeys[key] = dbkey
                     update = True

--- a/lib/galaxy/webapps/galaxy/controllers/data_manager.py
+++ b/lib/galaxy/webapps/galaxy/controllers/data_manager.py
@@ -129,7 +129,7 @@ class DataManager(BaseUIController):
                     "name": hda.name,
                     "created": unicodify(hda.create_time.strftime(trans.app.config.pretty_datetime_format)),
                     "fileSize": nice_size(hda.dataset.file_size),
-                    "fileName": hda.file_name,
+                    "fileName": hda.get_file_name(),
                     "infoUrl": web.url_for(
                         controller="dataset", action="show_params", dataset_id=trans.security.encode_id(hda.id)
                     ),

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -384,7 +384,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                         "This dataset is currently being used as input or output.  You cannot change datatype until the jobs have completed or you have canceled them.",
                     )
                 else:
-                    path = data.dataset.file_name
+                    path = data.dataset.get_file_name()
                     datatype = guess_ext(path, trans.app.datatypes_registry.sniff_order)
                     trans.app.datatypes_registry.change_datatype(data, datatype)
                     with transaction(trans.sa_session):
@@ -501,7 +501,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             or isinstance(dataset.datatype, datatypes.text.Html)
         ):
             trans.response.set_content_type(dataset.get_mime())
-            return open(dataset.file_name, "rb")
+            return open(dataset.get_file_name(), "rb")
         else:
             return trans.fill_template_mako(
                 "/dataset/display.mako",
@@ -674,7 +674,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                                     ), f"Extra file content requested ({action_param_extra}), but allow_extra_files_access is False."
                                     file_name = os.path.join(value.extra_files_path, action_param_extra)
                                 else:
-                                    file_name = value.file_name
+                                    file_name = value.get_file_name()
                                 content_length = os.path.getsize(file_name)
                                 rval = open(file_name, "rb")
                             except OSError as e:

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -590,7 +590,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
                         dataset_instance.dataset, extra_dir=dir_name, alt_name=filename
                     )
                 else:
-                    file_path = dataset_instance.file_name
+                    file_path = dataset_instance.get_file_name()
                 rval = open(file_path, "rb")
             else:
                 if offset is not None:
@@ -648,7 +648,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         headers = {}
         headers["Content-Type"] = "application/octet-stream"
         headers["Content-Disposition"] = f'attachment; filename="Galaxy{hda.hid}-[{fname}].{file_ext}"'
-        file_path = hda.metadata.get(metadata_file).file_name
+        file_path = hda.metadata.get(metadata_file).get_file_name()
         if open_file:
             return open(file_path, "rb"), headers
         return file_path, headers

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -823,7 +823,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
             # ---- for composite files, we use id and name for a directory and, inside that, ...
             if self.hda_manager.is_composite(content):
                 # ...save the 'main' composite file (gen. html)
-                paths_and_files.append((content.file_name, os.path.join(archive_path, f"{content.name}.html")))
+                paths_and_files.append((content.get_file_name(), os.path.join(archive_path, f"{content.name}.html")))
                 for extra_file in self.hda_manager.extra_files(content):
                     extra_file_basename = os.path.basename(extra_file)
                     archive_extra_file_path = os.path.join(archive_path, extra_file_basename)
@@ -835,7 +835,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
                 # some dataset names can contain their original file extensions, don't repeat
                 if not archive_path.endswith(f".{content.extension}"):
                     archive_path += f".{content.extension}"
-                paths_and_files.append((content.file_name, archive_path))
+                paths_and_files.append((content.get_file_name(), archive_path))
 
         # filter the contents that contain datasets using any filters possible from index above and map the datasets
         filters = self.history_contents_filters.parse_query_filters(filter_query_params)

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -140,7 +140,7 @@ def to_cwl(value, hda_references, step):
                 )
             )
         if value.ext == "expression.json":
-            with open(value.file_name) as f:
+            with open(value.get_file_name()) as f:
                 # OUR safe_loads won't work, will not load numbers, etc...
                 return json.load(f)
         else:
@@ -2186,7 +2186,7 @@ class ToolModule(WorkflowModule):
                         elif isinstance(replacement, model.DatasetInstance):
                             dataset_instance = replacement
                         if dataset_instance and dataset_instance.extension == "expression.json":
-                            with open(dataset_instance.file_name) as f:
+                            with open(dataset_instance.get_file_name()) as f:
                                 replacement = json.load(f)
                     found_replacement_keys.add(prefixed_name)  # noqa: B023
 

--- a/scripts/cleanup_datasets/cleanup_datasets.py
+++ b/scripts/cleanup_datasets/cleanup_datasets.py
@@ -599,13 +599,13 @@ def _delete_dataset(dataset, app, remove_from_disk, info_only=False, is_deletabl
                 )
                 if remove_from_disk:
                     try:
-                        log.info("Removing disk file %s", metadata_file.file_name)
-                        os.unlink(metadata_file.file_name)
+                        log.info("Removing disk file %s", metadata_file.get_file_name())
+                        os.unlink(metadata_file.get_file_name())
                     except Exception as e:
                         log.info(
                             "Error, exception: %s caught attempting to purge metadata file %s\n",
                             unicodify(e),
-                            metadata_file.file_name,
+                            metadata_file.get_file_name(),
                         )
                     metadata_file.purged = True
                     app.sa_session.add(metadata_file)
@@ -615,7 +615,7 @@ def _delete_dataset(dataset, app, remove_from_disk, info_only=False, is_deletabl
                 app.sa_session.add(metadata_file)
                 with transaction(session):
                     session.commit()
-            log.info(metadata_file.file_name)
+            log.info(metadata_file.get_file_name())
         if not info_only:
             log.info("Deleting dataset id %d", dataset.id)
             dataset.deleted = True
@@ -635,8 +635,8 @@ def _purge_dataset(app, dataset, remove_from_disk, info_only=False):
                     # Remove files from disk and update the database
                     if remove_from_disk:
                         # TODO: should permissions on the dataset be deleted here?
-                        log.info("Removing disk, file %s", dataset.file_name)
-                        os.unlink(dataset.file_name)
+                        log.info("Removing disk, file %s", dataset.get_file_name())
+                        os.unlink(dataset.get_file_name())
                         # Remove associated extra files from disk if they exist
                         if dataset.extra_files_path and os.path.exists(dataset.extra_files_path):
                             shutil.rmtree(
@@ -662,7 +662,7 @@ def _purge_dataset(app, dataset, remove_from_disk, info_only=False):
                 log.info(
                     "This dataset (%d) is not purgable, the file (%s) will not be removed.\n",
                     dataset.id,
-                    dataset.file_name,
+                    dataset.get_file_name(),
                 )
         except OSError as exc:
             log.error("Error, dataset file has already been removed: %s", unicodify(exc))
@@ -674,9 +674,9 @@ def _purge_dataset(app, dataset, remove_from_disk, info_only=False):
         except ObjectNotFound:
             log.error("Dataset %d cannot be found in the object store", dataset.id)
         except Exception as exc:
-            log.error("Error attempting to purge data file: %s error: %s", dataset.file_name, unicodify(exc))
+            log.error("Error attempting to purge data file: %s error: %s", dataset.get_file_name(), unicodify(exc))
     else:
-        log.info("Error: '%s' has not previously been deleted, so it cannot be purged\n", dataset.file_name)
+        log.info("Error: '%s' has not previously been deleted, so it cannot be purged\n", dataset.get_file_name())
 
 
 def _purge_folder(folder, app, remove_from_disk, info_only=False):

--- a/scripts/helper.py
+++ b/scripts/helper.py
@@ -44,7 +44,7 @@ if args.hda_id:
     except Exception:
         hda_id = int(helper.decode_id(args.hda_id))
     hda = model.session.get(model.HistoryDatasetAssociation, hda_id)
-    print(f'HDA "{hda.id}" is Dataset "{hda.dataset.id}" at: {hda.file_name}')
+    print(f'HDA "{hda.id}" is Dataset "{hda.dataset.id}" at: {hda.get_file_name()}')
 
 if args.ldda_id:
     try:
@@ -52,4 +52,4 @@ if args.ldda_id:
     except Exception:
         ldda_id = int(helper.decode_id(args.ldda_id))
     ldda = model.session.get(model.LibraryDatasetDatasetAssociation, ldda_id)
-    print(f'LDDA "{ldda.id}" is Dataset "{ldda.dataset.id}" at: {ldda.file_name}')
+    print(f'LDDA "{ldda.id}" is Dataset "{ldda.dataset.id}" at: {ldda.get_file_name()}')

--- a/test/integration/test_job_files.py
+++ b/test/integration/test_job_files.py
@@ -61,7 +61,7 @@ class TestJobFilesIntegration(integration_util.IntegrationTestCase):
     def test_read_by_state(self):
         job, _, _ = self.create_static_job_with_state("running")
         job_id, job_key = self._api_job_keys(job)
-        data = {"path": self.input_hda.file_name, "job_key": job_key}
+        data = {"path": self.input_hda.get_file_name(), "job_key": job_key}
         get_url = self._api_url(f"jobs/{job_id}/files", use_key=True)
         response = requests.get(get_url, params=data)
         api_asserts.assert_status_code_is_ok(response)

--- a/test/unit/app/jobs/dynamic_tool_destination/mockGalaxy.py
+++ b/test/unit/app/jobs/dynamic_tool_destination/mockGalaxy.py
@@ -34,7 +34,7 @@ class NotAFile:
 
 class Dataset:
     def __init__(self, file_name, file_ext, value):
-        self.file_name = file_name
+        self.file_name_ = file_name
         self.datatype = Datatype(file_ext)
         self.ext = file_ext
         self.metadata = dict()
@@ -42,6 +42,9 @@ class Dataset:
 
     def get_metadata(self):
         return self.metadata
+
+    def get_file_name(self, **_kwargs):
+        return self.file_name_
 
 
 class Datatype:

--- a/test/unit/app/tools/test_history_imp_exp.py
+++ b/test/unit/app/tools/test_history_imp_exp.py
@@ -172,9 +172,9 @@ def test_export_dataset():
     dataset_source = datasets[0].dataset.sources[0]
     assert dataset_source.source_uri == "http://google.com/mycooldata.txt"
 
-    with open(datasets[0].file_name) as f:
+    with open(datasets[0].get_file_name()) as f:
         assert f.read().startswith("chr1    4225    19670")
-    with open(datasets[1].file_name) as f:
+    with open(datasets[1].get_file_name()) as f:
         assert f.read().startswith("chr1\t147962192\t147962580\tNM_005997_cds_0_0_chr1_147962193_r\t0\t-")
 
 
@@ -275,9 +275,9 @@ def test_multi_inputs():
     for hid in [1, 2]:
         assert hid in hids
 
-    with open(datasets[0].file_name) as f:
+    with open(datasets[0].get_file_name()) as f:
         assert f.read().startswith("chr1    4225    19670")
-    with open(datasets[1].file_name) as f:
+    with open(datasets[1].get_file_name()) as f:
         assert f.read().startswith("chr1\t147962192\t147962580\tNM_005997_cds_0_0_chr1_147962193_r\t0\t-")
 
 

--- a/test/unit/app/tools/test_metadata.py
+++ b/test/unit/app/tools/test_metadata.py
@@ -188,7 +188,7 @@ class TestMetadata(TestCase, tools_support.UsesTools):
             f.write(contents)
 
     def _write_output_dataset_contents(self, output_dataset, contents):
-        with open(output_dataset.dataset.file_name, "w") as f:
+        with open(output_dataset.dataset.get_file_name(), "w") as f:
             f.write(contents)
 
     def _write_galaxy_json(self, contents):
@@ -217,7 +217,7 @@ class TestMetadata(TestCase, tools_support.UsesTools):
         safe_makedirs(os.path.join(self.job_working_directory, "metadata"))
         self.app.datatypes_registry.to_xml_file(path=datatypes_config)
         job_metadata = os.path.join(self.tool_working_directory, self.tool.provided_metadata_file)
-        output_fnames = [DatasetPath(o.dataset.id, o.dataset.file_name, None) for o in output_datasets.values()]
+        output_fnames = [DatasetPath(o.dataset.id, o.dataset.get_file_name(), None) for o in output_datasets.values()]
         command = metadata_compute_strategy.setup_external_metadata(
             output_datasets,
             output_collections,

--- a/test/unit/app/tools/test_wrappers.py
+++ b/test/unit/app/tools/test_wrappers.py
@@ -207,7 +207,7 @@ def test_dataset_wrapper():
     dataset = cast(DatasetInstance, MockDataset())
     wrapper = DatasetFilenameWrapper(dataset)
     assert str(wrapper) == MOCK_DATASET_PATH
-    assert wrapper.file_name == MOCK_DATASET_PATH
+    assert wrapper.get_file_name() == MOCK_DATASET_PATH
 
     assert wrapper.ext == MOCK_DATASET_EXT
 
@@ -219,7 +219,7 @@ def test_dataset_wrapper_false_path():
         dataset, compute_environment=cast(ComputeEnvironment, MockComputeEnvironment(false_path=new_path))
     )
     assert str(wrapper) == new_path
-    assert wrapper.file_name == new_path
+    assert wrapper.get_file_name() == new_path
 
 
 class MockComputeEnvironment:
@@ -308,10 +308,12 @@ MOCK_DATASET_EXT = "bam"
 class MockDataset:
     def __init__(self):
         self.metadata = MetadataSpecCollection({})
-        self.file_name = MOCK_DATASET_PATH
         self.extra_files_path = MOCK_DATASET_EXTRA_FILES_PATH
         self.ext = MOCK_DATASET_EXT
         self.tags = []
+
+    def get_file_name(self):
+        return MOCK_DATASET_PATH
 
 
 class MockTool:

--- a/test/unit/data/datatypes/test_bam.py
+++ b/test/unit/data/datatypes/test_bam.py
@@ -48,7 +48,9 @@ def test_set_meta_presorted():
     with get_dataset("1.bam") as dataset:
         b.set_meta(dataset=dataset)
         assert dataset.metadata.sort_order == "coordinate"
-        bam_file = AlignmentFile(dataset.file_name, mode="rb", index_filename=dataset.metadata.bam_index.file_name)
+        bam_file = AlignmentFile(
+            dataset.get_file_name(), mode="rb", index_filename=dataset.metadata.bam_index.get_file_name()
+        )
         assert bam_file.has_index() is True
 
 

--- a/test/unit/data/datatypes/test_bcsl.py
+++ b/test/unit/data/datatypes/test_bcsl.py
@@ -33,7 +33,7 @@ def test_bcsl_set_peek(bcsl_loader, input_file, expected_peek):
     loader = bcsl_loader()
     with get_input_files(input_file) as input_files:
         dataset = MockDataset(1)
-        dataset.file_name = input_files[0]
-        dataset.dataset = MockDatasetDataset(dataset.file_name)
+        dataset.set_file_name(input_files[0])
+        dataset.dataset = MockDatasetDataset(dataset.get_file_name())
         loader.set_peek(dataset)
         assert dataset.peek == expected_peek

--- a/test/unit/data/datatypes/test_connectivity_table.py
+++ b/test/unit/data/datatypes/test_connectivity_table.py
@@ -9,7 +9,8 @@ from galaxy.util import galaxy_directory
 @pytest.fixture
 def dataset():
     class MockDataset:
-        file_name = os.path.join(galaxy_directory(), "test-data/1.ct")
+        def get_file_name(self):
+            return os.path.join(galaxy_directory(), "test-data/1.ct")
 
     return MockDataset()
 

--- a/test/unit/data/datatypes/test_cram.py
+++ b/test/unit/data/datatypes/test_cram.py
@@ -12,5 +12,5 @@ def test_cram():
     with get_input_files("2.cram") as input_files, get_dataset(input_files[0], index_attr="cram_index") as dataset:
         assert c.set_index_file(dataset=dataset, index_file=dataset.metadata.cram_index) is True
         c.set_meta(dataset)
-        pysam.AlignmentFile(dataset.file_name, index_filename=dataset.metadata.cram_index.file_name)
+        pysam.AlignmentFile(dataset.get_file_name(), index_filename=dataset.metadata.cram_index.get_file_name())
     assert dataset.metadata.cram_version == "3.0"

--- a/test/unit/data/datatypes/test_qiime2.py
+++ b/test/unit/data/datatypes/test_qiime2.py
@@ -22,7 +22,7 @@ def test_qza_set_meta():
     qza = QIIME2Artifact()
     with get_input_files("qiime2.qza") as input_files:
         dataset = MockDataset(1)
-        dataset.file_name = input_files[0]
+        dataset.set_file_name(input_files[0])
 
         qza.set_meta(dataset)
 
@@ -37,7 +37,7 @@ def test_qza_set_peek():
     qza = QIIME2Artifact()
     with get_input_files("qiime2.qza") as input_files:
         dataset = MockDataset(1)
-        dataset.file_name = input_files[0]
+        dataset.set_file_name(input_files[0])
 
         qza.set_meta(dataset)
         qza.set_peek(dataset)
@@ -64,7 +64,7 @@ def test_qzv_set_meta():
     qzv = QIIME2Visualization()
     with get_input_files("qiime2.qzv") as input_files:
         dataset = MockDataset(1)
-        dataset.file_name = input_files[0]
+        dataset.set_file_name(input_files[0])
 
         qzv.set_meta(dataset)
 
@@ -78,7 +78,7 @@ def test_qzv_set_peek():
     qzv = QIIME2Visualization()
     with get_input_files("qiime2.qzv") as input_files:
         dataset = MockDataset(1)
-        dataset.file_name = input_files[0]
+        dataset.set_file_name(input_files[0])
 
         qzv.set_meta(dataset)
         qzv.set_peek(dataset)
@@ -110,7 +110,7 @@ def test_qiime2tabular_set_meta():
     q2md = QIIME2Metadata()
     with get_input_files("qiime2.qiime2.tabular") as input_files:
         dataset = MockDataset(1)
-        dataset.file_name = input_files[0]
+        dataset.set_file_name(input_files[0])
 
         q2md.set_meta(dataset)
 

--- a/test/unit/data/datatypes/test_storm.py
+++ b/test/unit/data/datatypes/test_storm.py
@@ -35,7 +35,7 @@ def test_storm_set_peek(storm_loader, input_file, expected_peek):
     loader = storm_loader()
     with get_input_files(input_file) as input_files:
         dataset = MockDataset(1)
-        dataset.file_name = input_files[0]
-        dataset.dataset = MockDatasetDataset(dataset.file_name)
+        dataset.set_file_name(input_files[0])
+        dataset.dataset = MockDatasetDataset(dataset.get_file_name())
         loader.set_peek(dataset)
         assert dataset.peek == expected_peek

--- a/test/unit/data/datatypes/test_tabular.py
+++ b/test/unit/data/datatypes/test_tabular.py
@@ -13,5 +13,5 @@ def test_tabular_set_meta_large_file():
             test_file.write("A\tB\n")
         test_file.flush()
         dataset = MockDataset(id=1)
-        dataset.file_name = test_file.name
+        dataset.set_file_name(test_file.name)
         Tabular().set_meta(dataset)  # type: ignore [arg-type]

--- a/test/unit/data/datatypes/test_validation.py
+++ b/test/unit/data/datatypes/test_validation.py
@@ -57,5 +57,8 @@ def _run_validation(extension, file_name):
 
 class MockDataset:
     def __init__(self, file_name, datatype):
-        self.file_name = file_name
+        self.file_name_ = file_name
         self.datatype = datatype
+
+    def get_file_name(self):
+        return self.file_name_

--- a/test/unit/data/datatypes/test_vcf.py
+++ b/test/unit/data/datatypes/test_vcf.py
@@ -30,5 +30,5 @@ def test_vcf_bgzip_set_meta():
         input_files[0], index_attr="tabix_index"
     ) as dataset:
         vcf_bgzip_datatype.set_meta(dataset)
-        f = pysam.VariantFile(dataset.file_name, index_filename=dataset.metadata.tabix_index.file_name)
+        f = pysam.VariantFile(dataset.get_file_name(), index_filename=dataset.metadata.tabix_index.get_file_name())
         assert isinstance(f.index, pysam.libcbcf.TabixIndex) is True

--- a/test/unit/data/datatypes/util.py
+++ b/test/unit/data/datatypes/util.py
@@ -10,36 +10,53 @@ from galaxy.util.hash_util import md5_hash_file
 
 class MockDatasetDataset:
     def __init__(self, file_name):
-        self.file_name = file_name
         self.purged = False
+        self.file_name_ = file_name
+
+    def get_file_name(self):
+        return self.file_name_
+
+    def set_file_name(self, file_name):
+        self.file_name_ = file_name
 
 
 class MockMetadata:
-    file_name: Optional[str] = None
+    file_name_: Optional[str] = None
+
+    def get_file_name(self):
+        return self.file_name_
+
+    def set_file_name(self, file_name):
+        self.file_name_ = file_name
 
 
 class MockDataset:
-    file_name: Optional[str] = None
-
     def __init__(self, id):
         self.id = id
         self.metadata = MockMetadata()
         self.dataset = None
+        self.file_name_: Optional[str] = None
+
+    def get_file_name(self):
+        return self.file_name_
+
+    def set_file_name(self, file_name):
+        self.file_name_ = file_name
 
     def has_data(self):
         return True
 
     def get_size(self):
-        return self.dataset and os.path.getsize(self.dataset.file_name)
+        return self.dataset and os.path.getsize(self.dataset.get_file_name())
 
 
 @contextmanager
 def get_dataset(filename, index_attr="bam_index", dataset_id=1, has_data=True):
     dataset = MockDataset(dataset_id)
     with get_input_files(filename) as input_files, get_tmp_path(should_exist=True) as index_path:
-        dataset.file_name = input_files[0]
+        dataset.set_file_name(input_files[0])
         index = MockMetadata()
-        index.file_name = index_path
+        index.set_file_name(index_path)
         setattr(dataset.metadata, index_attr, index)
         yield dataset
 

--- a/test/unit/data/model/test_model_discovery.py
+++ b/test/unit/data/model/test_model_discovery.py
@@ -47,7 +47,7 @@ def test_model_create_context_persist_hdas():
     assert len(tags) == 1
     assert tags[0].value == "value"
 
-    with open(imported_hda.file_name) as f:
+    with open(imported_hda.get_file_name()) as f:
         assert f.read().startswith("hello world\n")
 
 
@@ -112,7 +112,7 @@ def test_persist_target_library_dataset():
     assert len(new_root.datasets) == 1
     ldda = new_root.datasets[0].library_dataset_dataset_association
     assert ldda.metadata.data_lines == 2
-    with open(ldda.file_name) as f:
+    with open(ldda.get_file_name()) as f:
         assert f.read().startswith("hello world\n")
 
 
@@ -156,7 +156,7 @@ def test_persist_target_library_folder():
     assert len(child_folder.datasets) == 1
     ldda = child_folder.datasets[0].library_dataset_dataset_association
     assert ldda.metadata.data_lines == 2
-    with open(ldda.file_name) as f:
+    with open(ldda.get_file_name()) as f:
         assert f.read().startswith("hello world\n")
 
 
@@ -206,9 +206,9 @@ def test_persist_target_hdca():
     dataset0 = datasets[0]
     dataset1 = datasets[1]
 
-    with open(dataset0.file_name) as f:
+    with open(dataset0.get_file_name()) as f:
         assert f.read().startswith("hello world\n")
-    with open(dataset1.file_name) as f:
+    with open(dataset1.get_file_name()) as f:
         assert f.read().startswith("file 2 contents")
 
 

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -828,9 +828,9 @@ def _assert_simple_cat_job_imported(imported_history, state="ok"):
     assert imported_job.input_datasets
     assert imported_job.input_datasets[0].dataset == datasets[0]
 
-    with open(datasets[0].file_name) as f:
+    with open(datasets[0].get_file_name()) as f:
         assert f.read().startswith("chr1    4225    19670")
-    with open(datasets[1].file_name) as f:
+    with open(datasets[1].get_file_name()) as f:
         assert f.read().startswith("chr1\t147962192\t147962580\tNM_005997_cds_0_0_chr1_147962193_r\t0\t-")
 
 

--- a/test/unit/data/test_model_copy.py
+++ b/test/unit/data/test_model_copy.py
@@ -176,7 +176,7 @@ def _create_hda(
 
 def _check_metadata_file(hda):
     assert hda.metadata.bam_index.id
-    copied_index = hda.metadata.bam_index.file_name
+    copied_index = hda.metadata.bam_index.get_file_name()
     assert os.path.exists(copied_index)
     with open(copied_index) as f:
         assert f.read() == "moo"

--- a/test/unit/tool_util/data/test_tool_data_bundles.py
+++ b/test/unit/tool_util/data/test_tool_data_bundles.py
@@ -72,9 +72,12 @@ def test_parsing_mothur() -> None:
 
 @dataclass
 class OutputDataset:
-    file_name: str
+    file_name_: str
     extra_files_path: str
     ext: str = "data_manager_json"
+
+    def get_file_name(self) -> str:
+        return self.file_name_
 
     def extra_files_path_exists(self) -> bool:
         return os.path.exists(self.extra_files_path)

--- a/tools/data_source/microbial_import_code.py
+++ b/tools/data_source/microbial_import_code.py
@@ -159,7 +159,7 @@ def exec_after_process(app, inp_data, out_data, param_dict, tool, stdout, stderr
             app.model.context.add(history)
             app.model.context.flush()
             try:
-                copyfile(filepath, newdata.file_name)
+                copyfile(filepath, newdata.get_file_name())
                 newdata.info = newdata.name
                 newdata.state = newdata.states.OK
             except Exception:

--- a/tools/data_source/upload.xml
+++ b/tools/data_source/upload.xml
@@ -14,7 +14,7 @@
     #while $varExists('output%i' % $outnum):
         #set $output = $getVar('output%i' % $outnum)
         #set $outnum += 1
-        #set $file_name = $output.file_name
+        #set $file_name = $output.get_file_name()
         ## FIXME: This is not future-proof for other uses of external_filename (other than for use by the library upload's "link data" feature)
         #if $output.dataset.dataset.external_filename:
             #set $file_name = "None"

--- a/tools/filters/lav_to_bed_code.py
+++ b/tools/filters/lav_to_bed_code.py
@@ -11,7 +11,7 @@ def exec_after_process(app, inp_data, out_data, param_dict, tool, stdout, stderr
     for data in out_data.values():
         try:
             data.info = "%s\n%s" % (new_stdout, stderr)
-            data.dbkey = filename_to_build[data.file_name]
+            data.dbkey = filename_to_build[data.get_file_name()]
             data.name = "%s (%s)" % (data.name, data.dbkey)
             app.model.context.add(data)
             app.model.context.flush()


### PR DESCRIPTION
Following discussions in https://github.com/galaxyproject/galaxy/pull/16702, this PR replaces `.file_name` property with `get_file_name` function so that later on we could pass parameters to this function (control pulling from an object store, pass user object for authentication, ... ). No functionality changes in this PR. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
