### PR TITLE
Add ClientSearchMiss Sentry Capture

### DIFF
--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -180,7 +180,15 @@ export default {
             this.queryPending = true;
         },
         onResults(results, closestTerm = null) {
+            const Galaxy = getGalaxyInstance();
             this.results = results;
+            if (!this.hasResults) {
+                Galaxy.Sentry.captureMessage("ClientSearchMiss", {
+                    extra: {
+                        query: this.query,
+                    },
+                });
+            }
             this.closestTerm = closestTerm;
             this.queryFilter = this.hasResults ? this.query : null;
             this.setButtonText();

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -183,7 +183,7 @@ export default {
             const Galaxy = getGalaxyInstance();
             this.results = results;
             if (!this.hasResults) {
-                Galaxy.Sentry.captureMessage("ClientSearchMiss", {
+                Galaxy.Sentry?.captureMessage("ClientSearchMiss", {
                     extra: {
                         query: this.query,
                     },


### PR DESCRIPTION
Might be better as a custom event for aggregation?  The idea was to capture tools searched for but unavailble.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
