### PR TITLE
[23.1] Disable button in `CopyModal` for histories when copying history

### DIFF
--- a/client/src/components/History/Modals/CopyModal.vue
+++ b/client/src/components/History/Modals/CopyModal.vue
@@ -36,7 +36,7 @@
         <div slot="modal-footer" slot-scope="{ ok, cancel }">
             <div>
                 <b-button class="mr-3" @click="cancel()"> Cancel </b-button>
-                <b-button :variant="saveVariant" :disabled="!formValid" @click="copy(ok)">
+                <b-button :variant="saveVariant" :disabled="loading || !formValid" @click="copy(ok)">
                     {{ saveTitle | localize }}
                 </b-button>
             </div>


### PR DESCRIPTION
Disable the `Copy History | Saving...` button in the copy history modal. If not disabled, it allows you to click the `Saving...` button repeatedly, copying the history multiple times.

Bug:

https://github.com/galaxyproject/galaxy/assets/78516064/c14669fc-4e67-435e-8d2b-395c778d2f7a


You end up with the same history many times...
## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
