### PR TITLE
add a "get more workflows" button to the bottom of the workflow list

### DIFF
--- a/client/src/components/Workflow/Import/TrsSearch.vue
+++ b/client/src/components/Workflow/Import/TrsSearch.vue
@@ -34,7 +34,7 @@ const fields = [
     { key: "organization", label: "Organization" },
 ];
 
-const query = ref("");
+const query = ref(props.search ?? "");
 const results: Ref<TrsSearchData[]> = ref([]);
 const trsServer = ref("");
 const loading = ref(false);
@@ -56,29 +56,37 @@ const searchHelp = computed(() => {
 
 const services = new Services();
 
+const router = useRouter();
+
 watch(query, async () => {
     if (query.value == "") {
         results.value = [];
     } else {
-        loading.value = true;
-
-        try {
-            const response = await axios.get(
-                withPrefix(`/api/trs_search?query=${query.value}&trs_server=${trsServer.value}`)
-            );
-            results.value = response.data;
-        } catch (e) {
-            errorMessage.value = e as string;
-        }
-
-        loading.value = false;
+        await searchWorkflows();
     }
 });
 
-function onTrsSelection(selection: TrsSelection) {
+async function searchWorkflows() {
+    loading.value = true;
+
+    try {
+        const response = await axios.get(
+            withPrefix(`/api/trs_search?query=${query.value}&trs_server=${trsServer.value}`)
+        );
+        results.value = response.data;
+    } catch (e) {
+        errorMessage.value = e as string;
+    }
+
+    loading.value = false;
+}
+
+async function onTrsSelection(selection: TrsSelection) {
     trsSelection.value = selection;
     trsServer.value = selection.id;
-    query.value = props.search ? props.search : "";
+    if (query.value) {
+        await searchWorkflows();
+    }
 }
 
 function onTrsSelectionError(message: string) {
@@ -102,8 +110,6 @@ function computeItems(items: TrsSearchData[]) {
         };
     });
 }
-
-const router = useRouter();
 
 async function importVersion(trsId?: string, toolIdToImport?: string, version?: string, isRunFormRedirect = false) {
     if (!trsId || !toolIdToImport) {

--- a/client/src/components/Workflow/Import/TrsSearch.vue
+++ b/client/src/components/Workflow/Import/TrsSearch.vue
@@ -14,6 +14,13 @@ import TrsServerSelection from "./TrsServerSelection.vue";
 import TrsTool from "./TrsTool.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
+const props = defineProps({
+    search: {
+        type: String,
+        default: null,
+    },
+});
+
 type TrsSearchData = {
     id: string;
     name: string;
@@ -71,7 +78,7 @@ watch(query, async () => {
 function onTrsSelection(selection: TrsSelection) {
     trsSelection.value = selection;
     trsServer.value = selection.id;
-    query.value = "";
+    query.value = props.search ? props.search : "";
 }
 
 function onTrsSelectionError(message: string) {

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -78,6 +78,17 @@
                 </b-card>
             </template>
         </b-table>
+        <b-alert class="search-more-workflows" variant="info" show>
+            <div>
+                <b-button
+                    class="px-1"
+                    title="Search workflows from other sources"
+                    variant="link"
+                    @click.prevent.stop="onSearchMore">
+                    Get more workflows
+                </b-button>
+            </div>
+        </b-alert>
         <b-pagination
             v-show="rows >= perPage"
             v-model="currentPage"
@@ -303,6 +314,12 @@ export default {
         },
         normalizeTag: function (tag) {
             return tag.replace(/(tag:')#/g, "$1name:");
+        },
+        onSearchMore: function () {
+            const query = this.filter;
+            const path = "/workflows/trs_search";
+            const routerParams = query ? { path, query: { query } } : { path };
+            this.$router.push(routerParams);
         },
     },
 };

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -536,6 +536,9 @@ export function getRouter(Galaxy) {
                     {
                         path: "workflows/trs_search",
                         component: TrsSearch,
+                        props: (route) => ({
+                            search: route.query.query,
+                        }),
                     },
                     {
                         path: "workflows/:storedWorkflowId/invocations",


### PR DESCRIPTION
Brings you to trs search with the query prefilled and results fetched from the default store. Looking for ideas on where to put it and how it should look like. Current button is just a placeholder.

<img width="697" alt="Galaxy___martenson" src="https://github.com/galaxyproject/galaxy/assets/1814954/fe6948ca-9239-4f4b-bd9c-3ebeda479473">

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
