### PR TITLE
[23.1] Fix short ids in tool panel views. 

### DIFF
--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -95,7 +95,8 @@ class ToolBoxRegistryImpl(ToolBoxRegistry):
         self.__toolbox = toolbox
 
     def has_tool(self, tool_id: str) -> bool:
-        return tool_id in self.__toolbox._tools_by_id
+        toolbox = self.__toolbox
+        return tool_id in toolbox._tools_by_id or tool_id in toolbox._tools_by_old_id
 
     def get_tool(self, tool_id: str):
         return self.__toolbox.get_tool(tool_id)
@@ -153,6 +154,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
         # so each will be present once in the above dictionary. The following
         # dictionary can instead hold multiple tools with different versions.
         self._tool_versions_by_id = {}
+        self._tools_by_old_id = {}
         self._workflows_by_id = {}
         # Cache for tool's to_dict calls specific to toolbox. Invalidates on toolbox reload.
         self._tool_to_dict_cache = {}
@@ -710,9 +712,8 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                         rval.append(lineage_tool)
             if not rval:
                 # still no tool, do a deeper search and try to match by old ids
-                for tool in self._tools_by_id.values():
-                    if tool.old_id == tool_id:
-                        rval.append(tool)
+                if tool_id in self._tools_by_old_id:
+                    rval.extend(self._tools_by_old_id[tool_id])
                 if get_all_versions and tool_id in self._tool_versions_by_id:
                     for tool in self._tool_versions_by_id[tool_id].values():
                         if tool not in rval:
@@ -1152,6 +1153,10 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                 self._tools_by_id[tool_id] = tool
         else:
             self._tools_by_id[tool_id] = tool
+        old_id = tool.old_id
+        if old_id not in self._tools_by_old_id:
+            self._tools_by_old_id[old_id] = []
+        self._tools_by_old_id[old_id].append(tool)
 
     def package_tool(self, trans, tool_id):
         """
@@ -1211,6 +1216,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
         else:
             tool = self._tools_by_id[tool_id]
             del self._tools_by_id[tool_id]
+            self._tools_by_old_id[tool.old_id].remove(tool)
             tool_cache = getattr(self.app, "tool_cache", None)
             if tool_cache:
                 tool_cache.expire_tool(tool_id)

--- a/test/integration/panel_views_1/custom_6.yml
+++ b/test/integration/panel_views_1/custom_6.yml
@@ -2,7 +2,7 @@ name: Custom Panel in a New Section
 type: generic
 items:
 - type: section
-  name: My Completely New Sectin
+  name: My Completely New Section
   items:
   - type: label
     text: The Start

--- a/test/integration/test_repository_operations.py
+++ b/test/integration/test_repository_operations.py
@@ -123,9 +123,7 @@ class TestRepositoryInstallIntegrationTestCase(integration_util.IntegrationTestC
         assert tool["version"] == "0.0.2"
         self.uninstall_repository(REPO.owner, REPO.name, REPO.changeset)
         response = self.get_tool(assert_ok=False)
-        assert (
-            "err_msg" in response
-        ), f"Expected an error message after tool install but response was {response.content}"
+        assert "err_msg" in response, f"Expected an error message after tool install but response was {response}"
         assert response["err_msg"]
         assert self.get_installed_repository_for(REPO.owner, REPO.name, REPO.changeset) is None
 


### PR DESCRIPTION
Fix using short ids in tool panel views. Use new data structure to optimize get_tool(exact=False) as well - should speed up certain kinds of toolbox related operations.

A redo of https://github.com/galaxyproject/galaxy/pull/16664 for main though. The tool shed repo uninstall tests caught a pretty serious bug here that I believe I have fixed now also.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
