### PR TITLE
[23.1] move history and tool panel tooltips out of the way

### DIFF
--- a/client/src/components/Common/DelayedInput.vue
+++ b/client/src/components/Common/DelayedInput.vue
@@ -13,7 +13,7 @@
         <b-input-group-append>
             <b-button
                 v-if="enableAdvanced"
-                v-b-tooltip.hover.noninteractive
+                v-b-tooltip.hover.bottom.noninteractive
                 aria-haspopup="true"
                 size="sm"
                 :pressed="showAdvanced"
@@ -25,7 +25,7 @@
                 <icon v-else fixed-width icon="angle-double-down" />
             </b-button>
             <b-button
-                v-b-tooltip.hover.noninteractive
+                v-b-tooltip.hover.bottom.noninteractive
                 aria-haspopup="true"
                 class="search-clear"
                 size="sm"

--- a/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
@@ -13,7 +13,7 @@
             </DebouncedInput>
             <b-input-group-append>
                 <b-button
-                    v-b-tooltip.hover
+                    v-b-tooltip.hover.bottom.noninteractive
                     aria-haspopup="true"
                     size="sm"
                     :pressed="showAdvanced"
@@ -26,7 +26,7 @@
                     <icon v-else fixed-width icon="angle-double-down" />
                 </b-button>
                 <b-button
-                    v-b-tooltip.hover
+                    v-b-tooltip.hover.bottom.noninteractive
                     aria-haspopup="true"
                     size="sm"
                     title="Clear Filters (esc)"

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -7,7 +7,7 @@
             <h2 class="m-1 h-sm">History</h2>
             <b-button-group>
                 <b-button
-                    v-b-tooltip.bottom.hover
+                    v-b-tooltip.top.hover.noninteractive
                     class="create-hist-btn"
                     data-description="create new history"
                     size="sm"
@@ -19,7 +19,7 @@
                 </b-button>
 
                 <b-button
-                    v-b-tooltip.bottom.hover
+                    v-b-tooltip.top.hover.noninteractive
                     data-description="switch to another history"
                     size="sm"
                     variant="link"
@@ -30,7 +30,7 @@
                 </b-button>
 
                 <b-dropdown
-                    v-b-tooltip.bottom.hover
+                    v-b-tooltip.top.hover.noninteractive
                     size="sm"
                     variant="link"
                     toggle-class="text-decoration-none"

--- a/client/src/components/Panels/Buttons/FavoritesButton.vue
+++ b/client/src/components/Panels/Buttons/FavoritesButton.vue
@@ -1,6 +1,6 @@
 <template>
     <b-button
-        v-b-tooltip.hover.noninteractive
+        v-b-tooltip.hover.top.noninteractive
         class="panel-header-button-toolbox"
         size="sm"
         variant="link"

--- a/client/src/components/Panels/Buttons/PanelViewButton.vue
+++ b/client/src/components/Panels/Buttons/PanelViewButton.vue
@@ -1,6 +1,6 @@
 <template>
     <b-dropdown
-        v-b-tooltip.hover.noninteractive
+        v-b-tooltip.hover.top.noninteractive
         right
         title="Show panel options"
         variant="link"


### PR DESCRIPTION
also make them noninteractive so they don't stay in the way once cursor moves away


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. navigate your cursor between the icons at the top of the history and tool panels
  2. observe that they are not blocking the view of other icons and they disappear after cursor leaves the icon
## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
