### PR TITLE
[23.1] Increase `CustosAuthnzToken.external_user_id` column size

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9534,7 +9534,7 @@ class CustosAuthnzToken(Base, RepresentById):
 
     id = Column(Integer, primary_key=True)
     user_id = Column(Integer, ForeignKey("galaxy_user.id"))
-    external_user_id = Column(String(64))
+    external_user_id = Column(String(255))
     provider = Column(String(255))
     access_token = Column(Text)
     id_token = Column(Text)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/e93c5d0b47a9_alter_column_external_user_id.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/e93c5d0b47a9_alter_column_external_user_id.py
@@ -1,0 +1,30 @@
+"""alter column CustosAuthnzToken.external_user_id to increase length
+
+Revision ID: e93c5d0b47a9
+Revises: e0561d5fc8c7
+Create Date: 2023-10-08 12:11:02.024669
+
+"""
+import sqlalchemy as sa
+
+from galaxy.model.migrations.util import alter_column
+
+# revision identifiers, used by Alembic.
+revision = "e93c5d0b47a9"
+down_revision = "e0561d5fc8c7"
+branch_labels = None
+depends_on = None
+
+table_name = "custos_authnz_token"
+column_name = "external_user_id"
+
+LONGER_LENGTH = 255
+
+
+def upgrade():
+    alter_column(table_name, column_name, type_=sa.String(LONGER_LENGTH))
+
+
+def downgrade():
+    # No need to downgrade, this is a one-way migration. Otherwise, existing data would be truncated or lost.
+    pass

--- a/lib/galaxy/model/migrations/dbscript.py
+++ b/lib/galaxy/model/migrations/dbscript.py
@@ -36,8 +36,8 @@ REVISION_TAGS = {
     "22.05": "186d4835587b",
     "release_23.0": "caa7742f7bca",
     "23.0": "caa7742f7bca",
-    "release_23.1": "e0561d5fc8c7",
-    "23.1": "e0561d5fc8c7",
+    "release_23.1": "e93c5d0b47a9",
+    "23.1": "e93c5d0b47a9",
 }
 
 


### PR DESCRIPTION
Fixes #15294

A couple of comments:
- I'm not sure the `downgrade` strategy I used is the best here... I'll add an inline comment in the code for discussion.
- I targeted `23.1` as I think this could somewhat be considered a bug fix. But if it is not, just let me know and I'll target the `dev` branch.
  - I also updated the migration tags for the release.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
