### PR TITLE
Fix collection drilling

### DIFF
--- a/client/src/components/History/CurrentCollection/CollectionPanel.vue
+++ b/client/src/components/History/CurrentCollection/CollectionPanel.vue
@@ -7,7 +7,7 @@ import ExpandedItems from "@/components/History/Content/ExpandedItems";
 import { updateContentFields } from "@/components/History/model/queries";
 import { useCollectionElementsStore } from "@/stores/collectionElementsStore";
 import { HistorySummary } from "@/stores/historyStore";
-import { CollectionEntry, DCESummary, DCObject, HDCASummary } from "@/stores/services";
+import { CollectionEntry, DCESummary, DCObject, HDCASummary, SubCollection } from "@/stores/services";
 
 import CollectionDetails from "./CollectionDetails.vue";
 import CollectionNavigation from "./CollectionNavigation.vue";
@@ -60,13 +60,13 @@ function onScroll(newOffset: number) {
 }
 
 async function onViewSubCollection(itemObject: DCObject, name: string) {
-    // We need to convert the DCO to a CollectionEntry in order
-    // to be able to fetch the contents of a nested collection.
-    const collectionEntry: CollectionEntry = {
-        id: rootCollection.value.id,
+    // We need to convert the DCO to a SubCollection by providing
+    // some more context to represent the collection in the UI and
+    // fetch the elements of the collection in a consistent way.
+    const collectionEntry: SubCollection = {
+        ...itemObject,
         name,
-        collection_id: itemObject.id,
-        collection_type: itemObject.collection_type,
+        hdca_id: rootCollection.value.id,
     };
     emit("view-collection", collectionEntry);
 }

--- a/client/src/stores/collectionElementsStore.test.ts
+++ b/client/src/stores/collectionElementsStore.test.ts
@@ -46,7 +46,8 @@ describe("useCollectionElementsStore", () => {
         expect(store.isLoadingCollectionElements(collection1)).toEqual(false);
         expect(fetchCollectionElements).toHaveBeenCalled();
 
-        const elements = store.storedCollectionElements[collection1.id];
+        const collection1Key = store.getCollectionKey(collection1);
+        const elements = store.storedCollectionElements[collection1Key];
         expect(elements).toBeDefined();
         expect(elements).toHaveLength(limit);
     });
@@ -55,8 +56,9 @@ describe("useCollectionElementsStore", () => {
         const store = useCollectionElementsStore();
         const storedCount = 5;
         const expectedStoredElements = Array.from({ length: storedCount }, (_, i) => mockElement(collection1.id, i));
-        store.storedCollectionElements[collection1.id] = expectedStoredElements;
-        expect(store.storedCollectionElements[collection1.id]).toHaveLength(storedCount);
+        const collection1Key = store.getCollectionKey(collection1);
+        store.storedCollectionElements[collection1Key] = expectedStoredElements;
+        expect(store.storedCollectionElements[collection1Key]).toHaveLength(storedCount);
 
         const offset = 0;
         const limit = 5;
@@ -70,8 +72,9 @@ describe("useCollectionElementsStore", () => {
         const store = useCollectionElementsStore();
         const storedCount = 3;
         const expectedStoredElements = Array.from({ length: storedCount }, (_, i) => mockElement(collection1.id, i));
-        store.storedCollectionElements[collection1.id] = expectedStoredElements;
-        expect(store.storedCollectionElements[collection1.id]).toHaveLength(storedCount);
+        const collection1Key = store.getCollectionKey(collection1);
+        store.storedCollectionElements[collection1Key] = expectedStoredElements;
+        expect(store.storedCollectionElements[collection1Key]).toHaveLength(storedCount);
 
         const offset = 2;
         const limit = 5;
@@ -82,7 +85,7 @@ describe("useCollectionElementsStore", () => {
         expect(store.isLoadingCollectionElements(collection1)).toEqual(false);
         expect(fetchCollectionElements).toHaveBeenCalled();
 
-        const elements = store.storedCollectionElements[collection1.id];
+        const elements = store.storedCollectionElements[collection1Key];
         expect(elements).toBeDefined();
         // The offset was overlapping with the stored elements, so it was increased by the number of stored elements
         // so it fetches the next "limit" number of elements

--- a/client/src/stores/collectionElementsStore.ts
+++ b/client/src/stores/collectionElementsStore.ts
@@ -22,7 +22,7 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
     }
 
     const getCollectionElements = computed(() => {
-        return (collection: HDCASummary, offset = 0, limit = 50) => {
+        return (collection: CollectionEntry, offset = 0, limit = 50) => {
             const elements = storedCollectionElements.value[getCollectionKey(collection)] ?? [];
             fetchMissingElements({ collection, offset, limit });
             return elements ?? null;
@@ -30,12 +30,12 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
     });
 
     const isLoadingCollectionElements = computed(() => {
-        return (collection: HDCASummary) => {
+        return (collection: CollectionEntry) => {
             return loadingCollectionElements.value[getCollectionKey(collection)] ?? false;
         };
     });
 
-    async function fetchMissingElements(params: { collection: HDCASummary; offset: number; limit: number }) {
+    async function fetchMissingElements(params: { collection: CollectionEntry; offset: number; limit: number }) {
         const collectionKey = getCollectionKey(params.collection);
         try {
             const maxElementCountInCollection = params.collection.element_count ?? 0;
@@ -64,7 +64,7 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
         }
     }
 
-    async function loadCollectionElements(collection: HDCASummary) {
+    async function loadCollectionElements(collection: CollectionEntry) {
         const elements = await Service.fetchElementsFromCollection({ entry: collection });
         Vue.set(storedCollectionElements.value, getCollectionKey(collection), elements);
     }

--- a/client/src/stores/collectionElementsStore.ts
+++ b/client/src/stores/collectionElementsStore.ts
@@ -12,8 +12,8 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
     /**
      * Returns a key that can be used to store or retrieve the elements of a collection in the store.
      */
-    function getCollectionKey(collection: HDCASummary) {
-        return `${collection.id}-${collection.collection_id}`;
+    function getCollectionKey(collection: HDCASummary): string {
+        return collection.collection_id;
     }
 
     const getCollectionElements = computed(() => {

--- a/client/src/stores/collectionElementsStore.ts
+++ b/client/src/stores/collectionElementsStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
 import Vue, { computed, ref } from "vue";
 
-import { DCESummary, HDCASummary, HistoryContentItemBase } from "./services";
+import { CollectionEntry, DCESummary, HDCASummary, HistoryContentItemBase, isHDCA } from "./services";
 import * as Service from "./services/datasetCollection.service";
 
 export const useCollectionElementsStore = defineStore("collectionElementsStore", () => {
@@ -11,9 +11,14 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
 
     /**
      * Returns a key that can be used to store or retrieve the elements of a collection in the store.
+     *
+     * It consistently returns a DatasetCollection ID for (top level) HDCAs or sub-collections.
      */
-    function getCollectionKey(collection: HDCASummary): string {
-        return collection.collection_id;
+    function getCollectionKey(collection: CollectionEntry): string {
+        if (isHDCA(collection)) {
+            return collection.collection_id;
+        }
+        return collection.id;
     }
 
     const getCollectionElements = computed(() => {
@@ -47,8 +52,8 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
             }
 
             Vue.set(loadingCollectionElements.value, collectionKey, true);
-            const fetchedElements = await Service.fetchElementsFromHDCA({
-                hdca: params.collection,
+            const fetchedElements = await Service.fetchElementsFromCollection({
+                entry: params.collection,
                 offset: params.offset,
                 limit: params.limit,
             });
@@ -60,7 +65,7 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
     }
 
     async function loadCollectionElements(collection: HDCASummary) {
-        const elements = await Service.fetchElementsFromHDCA({ hdca: collection });
+        const elements = await Service.fetchElementsFromCollection({ entry: collection });
         Vue.set(storedCollectionElements.value, getCollectionKey(collection), elements);
     }
 

--- a/client/src/stores/services/datasetCollection.service.ts
+++ b/client/src/stores/services/datasetCollection.service.ts
@@ -1,6 +1,6 @@
 import { fetcher } from "@/schema";
 
-import { CollectionEntry, DCESummary, HDCADetailed } from ".";
+import { CollectionEntry, DCESummary, HDCADetailed, isHDCA } from ".";
 
 const DEFAULT_LIMIT = 50;
 
@@ -17,9 +17,13 @@ const getCollectionContents = fetcher
     .create();
 
 export async function fetchCollectionElements(params: {
+    /** The ID of the top level HDCA that associates this collection with the History it belongs to. */
     hdcaId: string;
+    /** The ID of the collection itself. */
     collectionId: string;
+    /** The offset to start fetching elements from. */
     offset?: number;
+    /** The maximum number of elements to fetch. */
     limit?: number;
 }): Promise<DCESummary[]> {
     const { data } = await getCollectionContents({
@@ -32,14 +36,19 @@ export async function fetchCollectionElements(params: {
     return data;
 }
 
-export async function fetchElementsFromHDCA(params: {
-    hdca: CollectionEntry;
+export async function fetchElementsFromCollection(params: {
+    /** The HDCA or sub-collection to fetch elements from. */
+    entry: CollectionEntry;
+    /** The offset to start fetching elements from. */
     offset?: number;
+    /** The maximum number of elements to fetch. */
     limit?: number;
 }): Promise<DCESummary[]> {
+    const hdcaId = isHDCA(params.entry) ? params.entry.id : params.entry.hdca_id;
+    const collectionId = isHDCA(params.entry) ? params.entry.collection_id : params.entry.id;
     return fetchCollectionElements({
-        hdcaId: params.hdca.id,
-        collectionId: params.hdca.collection_id,
+        hdcaId: hdcaId,
+        collectionId: collectionId,
         offset: params.offset ?? 0,
         limit: params.limit ?? DEFAULT_LIMIT,
     });

--- a/client/src/stores/services/datasetCollection.service.ts
+++ b/client/src/stores/services/datasetCollection.service.ts
@@ -1,6 +1,6 @@
 import { fetcher } from "@/schema";
 
-import { DCESummary, HDCADetailed, HDCASummary } from ".";
+import { CollectionEntry, DCESummary, HDCADetailed } from ".";
 
 const DEFAULT_LIMIT = 50;
 
@@ -33,7 +33,7 @@ export async function fetchCollectionElements(params: {
 }
 
 export async function fetchElementsFromHDCA(params: {
-    hdca: HDCASummary;
+    hdca: CollectionEntry;
     offset?: number;
     limit?: number;
 }): Promise<DCESummary[]> {

--- a/client/src/stores/services/index.ts
+++ b/client/src/stores/services/index.ts
@@ -31,6 +31,14 @@ export type DatasetEntry = DatasetSummary | DatasetDetails;
 export type DCESummary = components["schemas"]["DCESummary"];
 
 /**
+ * DatasetCollectionElement specific type for collections.
+ */
+export interface DCECollection extends DCESummary {
+    element_type: "dataset_collection";
+    object: DCObject;
+}
+
+/**
  * Contains summary information about a HDCA (HistoryDatasetCollectionAssociation).
  *
  * HDCAs are (top level only) history items that contains information about the association
@@ -51,7 +59,8 @@ export type HDCADetailed = components["schemas"]["HDCADetailed"];
 export type DCObject = components["schemas"]["DCObject"];
 
 /**
- * Represents a SubCollection as a DatasetCollection with additional information to simplify its handling.
+ * A SubCollection is a DatasetCollectionElement of type `dataset_collection`
+ * with additional information to simplify its handling.
  *
  * This is used to be able to distinguish between top level HDCAs and sub-collections.
  * It helps simplify both, the representation of sub-collections in the UI, and fetching of elements.
@@ -71,6 +80,15 @@ export type CollectionEntry = HDCASummary | SubCollection;
 /**
  * Returns true if the given entry is a top level HDCA and false for sub-collections.
  */
-export function isHDCA(entry: CollectionEntry): entry is HDCASummary {
-    return "history_content_type" in entry && entry.history_content_type === "dataset_collection";
+export function isHDCA(entry?: CollectionEntry): entry is HDCASummary {
+    return (
+        entry !== undefined && "history_content_type" in entry && entry.history_content_type === "dataset_collection"
+    );
+}
+
+/**
+ * Returns true if the given element of a collection is a DatasetCollection.
+ */
+export function isCollectionElement(element: DCESummary): element is DCECollection {
+    return element.element_type === "dataset_collection";
 }

--- a/client/src/stores/services/index.ts
+++ b/client/src/stores/services/index.ts
@@ -1,31 +1,76 @@
 import { components } from "@/schema";
 
-/** Minimal representation of a collection that can contain datasets or other collections.
- *
- * This is used as a common interface to be able to fetch the contents of a collection regardless
- * of whether it is an HDCA (top level) or a nested collection (DCO).
- *
- * To convert a DCO to a CollectionEntry we need the parent HDCA ID and the name of the
- * collection (DCE identifier). The collection_id is the ID of the DCO and collection_type as well.
+/**
+ * Contains minimal information about a HistoryContentItem.
  */
-export interface CollectionEntry {
-    /**HDCA ID */
-    id: string;
-    /**DCO ID */
-    collection_id: string;
-    /**Name of the HDCA or DatasetCollectionElement identifier */
-    name: string;
-    /**Type of the collection */
-    collection_type: string;
-}
-
-export type DatasetSummary = components["schemas"]["HDASummary"];
-export type DatasetDetails = components["schemas"]["HDADetailed"];
-export type DCESummary = components["schemas"]["DCESummary"];
-export type HDCASummary = components["schemas"]["HDCASummary"] & CollectionEntry;
-export type HDCADetailed = components["schemas"]["HDCADetailed"];
-export type DCObject = components["schemas"]["DCObject"];
-
 export type HistoryContentItemBase = components["schemas"]["EncodedHistoryContentItem"];
 
+/**
+ * Contains summary information about a HistoryDatasetAssociation.
+ */
+export type DatasetSummary = components["schemas"]["HDASummary"];
+
+/**
+ * Contains additional details about a HistoryDatasetAssociation.
+ */
+export type DatasetDetails = components["schemas"]["HDADetailed"];
+
+/**
+ * Represents a HistoryDatasetAssociation with either summary or detailed information.
+ */
 export type DatasetEntry = DatasetSummary | DatasetDetails;
+
+/**
+ * Contains summary information about a DCE (DatasetCollectionElement).
+ *
+ * DCEs associate a parent collection to its elements. Those elements can be either
+ * HDAs or other DCs (DatasetCollections).
+ * The type of the element is indicated by the `element_type` field and the element
+ * itself is contained in the `object` field.
+ */
+export type DCESummary = components["schemas"]["DCESummary"];
+
+/**
+ * Contains summary information about a HDCA (HistoryDatasetCollectionAssociation).
+ *
+ * HDCAs are (top level only) history items that contains information about the association
+ * between a History and a DatasetCollection.
+ */
+export type HDCASummary = components["schemas"]["HDCASummary"];
+
+/**
+ * Contains additional details about a HistoryDatasetCollectionAssociation.
+ */
+export type HDCADetailed = components["schemas"]["HDCADetailed"];
+
+/**
+ * Contains information about a DatasetCollection.
+ *
+ * DatasetCollections are immutable and contain one or more DCEs.
+ */
+export type DCObject = components["schemas"]["DCObject"];
+
+/**
+ * Represents a SubCollection as a DatasetCollection with additional information to simplify its handling.
+ *
+ * This is used to be able to distinguish between top level HDCAs and sub-collections.
+ * It helps simplify both, the representation of sub-collections in the UI, and fetching of elements.
+ */
+export interface SubCollection extends DCObject {
+    /** The name of the collection. Usually corresponds to the DCE identifier. */
+    name: string;
+    /** The ID of the top level HDCA that associates this collection with the History it belongs to. */
+    hdca_id: string;
+}
+
+/**
+ * Represents either a top level HDCASummary or a sub-collection.
+ */
+export type CollectionEntry = HDCASummary | SubCollection;
+
+/**
+ * Returns true if the given entry is a top level HDCA and false for sub-collections.
+ */
+export function isHDCA(entry: CollectionEntry): entry is HDCASummary {
+    return "history_content_type" in entry && entry.history_content_type === "dataset_collection";
+}

--- a/client/src/stores/services/index.ts
+++ b/client/src/stores/services/index.ts
@@ -1,9 +1,28 @@
 import { components } from "@/schema";
 
+/** Minimal representation of a collection that can contain datasets or other collections.
+ *
+ * This is used as a common interface to be able to fetch the contents of a collection regardless
+ * of whether it is an HDCA (top level) or a nested collection (DCO).
+ *
+ * To convert a DCO to a CollectionEntry we need the parent HDCA ID and the name of the
+ * collection (DCE identifier). The collection_id is the ID of the DCO and collection_type as well.
+ */
+export interface CollectionEntry {
+    /**HDCA ID */
+    id: string;
+    /**DCO ID */
+    collection_id: string;
+    /**Name of the HDCA or DatasetCollectionElement identifier */
+    name: string;
+    /**Type of the collection */
+    collection_type: string;
+}
+
 export type DatasetSummary = components["schemas"]["HDASummary"];
 export type DatasetDetails = components["schemas"]["HDADetailed"];
 export type DCESummary = components["schemas"]["DCESummary"];
-export type HDCASummary = components["schemas"]["HDCASummary"];
+export type HDCASummary = components["schemas"]["HDCASummary"] & CollectionEntry;
 export type HDCADetailed = components["schemas"]["HDCADetailed"];
 export type DCObject = components["schemas"]["DCObject"];
 


### PR DESCRIPTION
Fixes #16785

This should fix the selenium test failure:

```
FAILED lib/galaxy_test/selenium/test_history_multi_view.py::TestHistoryMultiView::test_list_list_display - selenium.common.exceptions.TimeoutException: Message: Failed waiting on history item 3 to become visible, visible datasets include [#dataset-f06d708dacad69d8,#dataset-da92407cb46a61f3]. Timeout waiting on CSS selector [.multi-history-panel .content-item[data-hid="3"]] to become visible.
```
The important stuff is in the function `onViewSubCollection` inside `CollectionPanel.vue`. I'm not 100% sure this is how we are supposed to query the elements of a sub-collection i.e. by calling `/api/dataset_collections/{hdca_id}/contents/{collection_id}` where `hdca_id` is the top HDCA in the history and `collection_id` is the `DatasetCollection` ID in DCObject, but it works on my tests... it is still a little fuzzy in my head how sub-collections work :sweat_smile: 

It also fixes the store by using a composed key `[hdca_id + collection_id]` to store and retrieve elements from a collection, since just using the collection ID can create collisions between HDCAs (top level) and sub-collections (DCOs).


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
