### PR TITLE
[23.1] Fix parameter display in job info page for tools with sections

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -965,8 +965,6 @@ def summarize_job_parameters(trans, job):
                 # Get parameter label.
                 if input.type == "conditional":
                     label = input.test_param.label
-                elif input.type == "repeat":
-                    label = input.label()
                 else:
                     label = input.label or input.name
                 rval.append(

--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -102,6 +102,7 @@ class Repeat(Group):
     def title_plural(self):
         return inflector.pluralize(self.title)
 
+    @property
     def label(self):
         return f"Repeat ({self.title})"
 
@@ -183,6 +184,7 @@ class Section(Group):
     def title_plural(self):
         return inflector.pluralize(self.title)
 
+    @property
     def label(self):
         return f"Section ({self.title})"
 


### PR DESCRIPTION
Fixes:

```
Message
Uncaught exception in exposed API method:
Stack Trace(most recent call first)

TypeError: Object of type method is not JSON serializable
  File "galaxy/util/json.py", line 74, in safe_dumps
    dumped = json.dumps(obj, allow_nan=False, **kwargs)
  File "__init__.py", line 234, in dumps
    return cls(
  File "json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type method is not JSON serializable
  File "galaxy/web/framework/decorators.py", line 341, in decorator
    rval = format_return_as_json(rval, jsonp_callback, pretty=trans.debug)
  File "galaxy/web/framework/decorators.py", line 378, in format_return_as_json
    json = safe_dumps(rval, **dumps_kwargs)
  File "galaxy/util/json.py", line 77, in safe_dumps
    dumped = json.dumps(obj, allow_nan=False, **kwargs)
  File "__init__.py", line 234, in dumps
    return cls(
  File "json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
```

from https://sentry.galaxyproject.org/share/issue/665556bc240f4a04978f7c81c2be629c/

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
