### PR TITLE
Use vue modal instead of global backbone modal in user preferences

### DIFF
--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -106,7 +106,15 @@
             icon="fa-sign-out"
             title="Sign Out"
             description="Click here to sign out of all sessions."
-            @click="signOut" />
+            @click="toggleLogout = !toggleLogout" />
+        <b-modal
+            v-model="toggleLogout"
+            title="Sign out"
+            title-class="font-weight-bold"
+            ok-title="Sign out"
+            @ok="signOut">
+            <span v-localize> Do you want to continue and sign out of all active sessions? </span>
+        </b-modal>
     </b-container>
 </template>
 
@@ -166,6 +174,7 @@ export default {
             messageVariant: null,
             message: null,
             toggleActivityBar: false,
+            toggleLogout: false,
             toggleTheme: false,
         };
     },
@@ -232,17 +241,7 @@ export default {
             }
         },
         signOut() {
-            const Galaxy = getGalaxyInstance();
-            Galaxy.modal.show({
-                title: _l("Sign out"),
-                body: "Do you want to continue and sign out of all active sessions?",
-                buttons: {
-                    Cancel: function () {
-                        Galaxy.modal.hide();
-                    },
-                    "Sign out": userLogoutAll,
-                },
-            });
+            userLogoutAll();
         },
     },
 };

--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -106,9 +106,17 @@
             icon="fa-sign-out"
             title="Sign Out"
             description="Click here to sign out of all sessions."
-            @click="toggleLogout = !toggleLogout" />
+            @click="showLogoutModal = true" />
+        <b-modal v-model="showDataPrivateModal" title="Datasets are now private" title-class="font-weight-bold" ok-only>
+            <span v-localize>
+                All of your histories and datasets have been made private. If you'd like to make all *future* histories
+                private please use the
+            </span>
+            <a :href="userPermissionsUrl">User Permissions</a>
+            <span v-localize>interface</span>.
+        </b-modal>
         <b-modal
-            v-model="toggleLogout"
+            v-model="showLogoutModal"
             title="Sign out"
             title-class="font-weight-bold"
             ok-title="Sign out"
@@ -173,8 +181,9 @@ export default {
             diskQuota: "",
             messageVariant: null,
             message: null,
+            showLogoutModal: false,
+            showDataPrivateModal: false,
             toggleActivityBar: false,
-            toggleLogout: false,
             toggleTheme: false,
         };
     },
@@ -195,6 +204,9 @@ export default {
             const themes = Object.keys(this.config.themes);
             return themes?.length > 1 ?? false;
         },
+        userPermissionsUrl() {
+            return withPrefix("/user/permissions");
+        },
     },
     created() {
         const message = QueryStringParsing.get("message");
@@ -211,7 +223,6 @@ export default {
     },
     methods: {
         makeDataPrivate() {
-            const Galaxy = getGalaxyInstance();
             if (
                 confirm(
                     _l(
@@ -225,18 +236,8 @@ export default {
                     )
                 )
             ) {
-                axios.post(withPrefix(`/history/make_private?all_histories=true`)).then((response) => {
-                    Galaxy.modal.show({
-                        title: _l("Datasets are now private"),
-                        body: `All of your histories and datasets have been made private.  If you'd like to make all *future* histories private please use the <a href="${withPrefix(
-                            "/user/permissions"
-                        )}">User Permissions</a> interface.`,
-                        buttons: {
-                            Close: () => {
-                                Galaxy.modal.hide();
-                            },
-                        },
-                    });
+                axios.post(withPrefix(`/history/make_private?all_histories=true`)).then(() => {
+                    this.showDataPrivateModal = true;
                 });
             }
         },

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -122,8 +122,8 @@ change_user_address:
 
 sign_out:
   selectors:
-    cancel_button: '.modal-footer .buttons #button-0'
-    sign_out_button: '.modal-footer .buttons #button-1'
+    cancel_button: '.modal-footer .btn-secondary'
+    sign_out_button: '.modal-footer .btn-primary'
 
 dataset_details:
   selectors:


### PR DESCRIPTION
This PR switches the modal used in the user preferences from backbone to Vue.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
