### PR TITLE
Refactor dataset services

### DIFF
--- a/client/src/components/Dataset/DatasetLink/DatasetLink.vue
+++ b/client/src/components/Dataset/DatasetLink/DatasetLink.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script>
-import { getCompositeDatasetInfo } from "components/Dataset/services";
+import { getDatasetDetails } from "components/Dataset/services";
 import { mapCacheActions } from "vuex-cache";
 
 export default {
@@ -57,7 +57,7 @@ export default {
             });
         } else {
             // download whole dataset
-            getCompositeDatasetInfo(this.history_dataset_id).then((response) => {
+            getDatasetDetails(this.history_dataset_id).then((response) => {
                 this.pathDestination = { fileLink: `${response.download_url}?to_ext=${response.file_ext}` };
             });
         }

--- a/client/src/components/Dataset/DatasetLink/DatasetLink.vue
+++ b/client/src/components/Dataset/DatasetLink/DatasetLink.vue
@@ -5,8 +5,9 @@
 </template>
 
 <script>
-import { getDatasetDetails } from "components/Dataset/services";
 import { mapCacheActions } from "vuex-cache";
+
+import { fetchDatasetDetails } from "@/stores/services/dataset.service";
 
 export default {
     props: {
@@ -57,7 +58,7 @@ export default {
             });
         } else {
             // download whole dataset
-            getDatasetDetails(this.history_dataset_id).then((response) => {
+            fetchDatasetDetails({ id: this.history_dataset_id }).then((response) => {
                 this.pathDestination = { fileLink: `${response.download_url}?to_ext=${response.file_ext}` };
             });
         }

--- a/client/src/components/Dataset/services.ts
+++ b/client/src/components/Dataset/services.ts
@@ -69,9 +69,3 @@ export async function updateTags(
 export function getCompositeDatasetLink(historyDatasetId: string, path: string) {
     return withPrefix(`/api/datasets/${historyDatasetId}/display?filename=${path}`);
 }
-
-const getDataset = fetcher.path("/api/datasets/{dataset_id}").method("get").create();
-export async function getDatasetDetails(id: string) {
-    const { data } = await getDataset({ dataset_id: id });
-    return data;
-}

--- a/client/src/components/Dataset/services.ts
+++ b/client/src/components/Dataset/services.ts
@@ -71,7 +71,7 @@ export function getCompositeDatasetLink(historyDatasetId: string, path: string) 
 }
 
 const getDataset = fetcher.path("/api/datasets/{dataset_id}").method("get").create();
-export async function getCompositeDatasetInfo(id: string) {
+export async function getDatasetDetails(id: string) {
     const { data } = await getDataset({ dataset_id: id });
     return data;
 }

--- a/client/src/components/Dataset/services.ts
+++ b/client/src/components/Dataset/services.ts
@@ -67,13 +67,11 @@ export async function updateTags(
 }
 
 export function getCompositeDatasetLink(historyDatasetId: string, path: string) {
-    // TODO: historyDatasetId is wrong here, we should expose the route without forcing to provide a history id
-    return withPrefix(`/api/histories/${historyDatasetId}/contents/${historyDatasetId}/display?filename=${path}`);
+    return withPrefix(`/api/datasets/${historyDatasetId}/display?filename=${path}`);
 }
 
-const getDataset = fetcher.path("/api/histories/{history_id}/contents/{id}").method("get").create();
+const getDataset = fetcher.path("/api/datasets/{dataset_id}").method("get").create();
 export async function getCompositeDatasetInfo(id: string) {
-    // TODO: ${id} as history id is wrong here, we should expose the route without forcing to provide a history id
-    const { data } = await getDataset({ history_id: id, id });
+    const { data } = await getDataset({ dataset_id: id });
     return data;
 }


### PR DESCRIPTION
Small refactoring to get rid of having to pass a (wrong) history ID when we just need the Dataset ID in some client API calls.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
