### PR TITLE
[23.1] Exclude on_opened and on_closed from watcher events

### DIFF
--- a/lib/galaxy/util/watcher.py
+++ b/lib/galaxy/util/watcher.py
@@ -130,7 +130,17 @@ class EventHandler(FileSystemEventHandler):
     def __init__(self, watcher):
         self.watcher = watcher
 
-    def on_any_event(self, event):
+    # this effectively excludes on_opened and on_closed
+    def on_moved(self, event):
+        self._handle(event)
+
+    def on_created(self, event):
+        self._handle(event)
+
+    def on_deleted(self, event):
+        self._handle(event)
+
+    def on_modified(self, event):
         self._handle(event)
 
     def _extension_check(self, key, path):


### PR DESCRIPTION
We're not interested in these. `on_opened` in particular was introduced in https://github.com/gorakhargosh/watchdog/pull/941 and then partially reverted in
https://github.com/gorakhargosh/watchdog/commit/25a2d1fec55fc32f97055ba827c8ce7b959acb34, but that doesn't work for us.

Should fix https://github.com/galaxyproject/galaxy/issues/16840

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
