### PR TITLE
SQLAlchemy 2.0 upgrades (part 4)

### DIFF
--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -323,17 +323,6 @@ class ModelManager(Generic[U]):
         except sqlalchemy.orm.exc.MultipleResultsFound:
             raise exceptions.InconsistentDatabase(f"found more than one {self.model_class.__name__}")
 
-    def _one_or_none(self, query):
-        """
-        Return the object if found, None if it's not.
-
-        :raises exceptions.InconsistentDatabase: if more than one model is found
-        """
-        try:
-            return self._one_with_recast_errors(query)
-        except exceptions.ObjectNotFound:
-            return None
-
     # NOTE: at this layer, all ids are expected to be decoded and in int form
     def by_id(self, id: int) -> Query:
         """

--- a/lib/galaxy/managers/context.py
+++ b/lib/galaxy/managers/context.py
@@ -44,6 +44,8 @@ from typing import (
     Optional,
 )
 
+from sqlalchemy import select
+
 from galaxy.exceptions import (
     AuthenticationRequired,
     UserActivationRequiredException,
@@ -307,15 +309,8 @@ class ProvidesHistoryContext(ProvidesUserContext):
             return None
         non_ready_or_ok = set(Dataset.non_ready_states)
         non_ready_or_ok.add(HistoryDatasetAssociation.states.OK)
-        datasets = (
-            self.sa_session.query(HistoryDatasetAssociation)
-            .filter_by(deleted=False, history_id=self.history.id, extension="len")
-            .filter(
-                HistoryDatasetAssociation.table.c._state.in_(non_ready_or_ok),
-            )
-        )
         valid_ds = None
-        for ds in datasets:
+        for ds in get_hdas(self.sa_session, self.history.id, non_ready_or_ok):
             if ds.dbkey == dbkey:
                 if ds.state == HistoryDatasetAssociation.states.OK:
                     return ds
@@ -330,3 +325,12 @@ class ProvidesHistoryContext(ProvidesUserContext):
         """
         # FIXME: This method should be removed
         return self.app.genome_builds.get_genome_build_names(trans=self)
+
+
+def get_hdas(session, history_id, states):
+    stmt = (
+        select(HistoryDatasetAssociation)
+        .filter_by(deleted=False, history_id=history_id, extension="len")
+        .where(HistoryDatasetAssociation._state.in_(states))
+    )
+    return session.scalars(stmt)

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -13,6 +13,8 @@ from typing import (
     TypeVar,
 )
 
+from sqlalchemy import select
+
 from galaxy import (
     exceptions,
     model,
@@ -24,6 +26,10 @@ from galaxy.managers import (
     rbac_secured,
     secured,
     users,
+)
+from galaxy.model import (
+    Dataset,
+    DatasetHash,
 )
 from galaxy.model.base import transaction
 from galaxy.schema.tasks import (
@@ -103,7 +109,7 @@ class DatasetManager(base.ModelManager[model.Dataset], secured.AccessibleManager
         self.error_unless_dataset_purge_allowed()
         with self.session().begin():
             for dataset_id in request.dataset_ids:
-                dataset: model.Dataset = self.session().query(model.Dataset).get(dataset_id)
+                dataset: Dataset = self.session().get(Dataset, dataset_id)
                 if dataset.user_can_purge:
                     try:
                         dataset.full_delete()
@@ -158,15 +164,7 @@ class DatasetManager(base.ModelManager[model.Dataset], secured.AccessibleManager
         # TODO: replace/update if the combination of dataset_id/hash_function has already
         # been stored.
         sa_session = self.session()
-        hash = (
-            sa_session.query(model.DatasetHash)
-            .filter(
-                model.DatasetHash.dataset_id == dataset.id,
-                model.DatasetHash.hash_function == hash_function,
-                model.DatasetHash.extra_files_path == extra_files_path,
-            )
-            .one_or_none()
-        )
+        hash = get_dataset_hash(sa_session, dataset.id, hash_function, extra_files_path)
         if hash is None:
             sa_session.add(dataset_hash)
             with transaction(sa_session):
@@ -477,7 +475,7 @@ class DatasetAssociationManager(
 
     def detect_datatype(self, trans, dataset_assoc):
         """Sniff and assign the datatype to a given dataset association (ldda or hda)"""
-        data = trans.sa_session.query(self.model_class).get(dataset_assoc.id)
+        data = trans.sa_session.get(self.model_class, dataset_assoc.id)
         self.ensure_can_change_datatype(data)
         self.ensure_can_set_metadata(data)
         path = data.dataset.get_file_name()
@@ -489,7 +487,7 @@ class DatasetAssociationManager(
 
     def set_metadata(self, trans, dataset_assoc, overwrite=False, validate=True):
         """Trigger a job that detects and sets metadata on a given dataset association (ldda or hda)"""
-        data = trans.sa_session.query(self.model_class).get(dataset_assoc.id)
+        data = trans.sa_session.get(self.model_class, dataset_assoc.id)
         self.ensure_can_set_metadata(data)
         if overwrite:
             self.overwrite_metadata(data)
@@ -874,3 +872,13 @@ class DatasetAssociationFilterParser(base.ModelFilterParser, deletable.PurgableF
             if datatype_class:
                 comparison_classes.append(datatype_class)
         return comparison_classes and isinstance(dataset_assoc.datatype, tuple(comparison_classes))
+
+
+def get_dataset_hash(session, dataset_id, hash_function, extra_files_path):
+    stmt = (
+        select(DatasetHash)
+        .where(DatasetHash.dataset_id == dataset_id)
+        .where(DatasetHash.hash_function == hash_function)
+        .where(DatasetHash.extra_files_path == extra_files_path)
+    )
+    return session.scalars(stmt).one_or_none()

--- a/lib/galaxy/managers/folders.py
+++ b/lib/galaxy/managers/folders.py
@@ -12,10 +12,12 @@ from typing import (
 
 from sqlalchemy import (
     and_,
+    exists,
     false,
     func,
     not_,
     or_,
+    select,
 )
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm.exc import (
@@ -35,6 +37,15 @@ from galaxy.exceptions import (
     ItemAccessibilityException,
     MalformedId,
     RequestParameterInvalidException,
+)
+from galaxy.model import (
+    Dataset,
+    DatasetPermissions,
+    LibraryDataset,
+    LibraryDatasetDatasetAssociation,
+    LibraryDatasetPermissions,
+    LibraryFolder,
+    LibraryFolderPermissions,
 )
 from galaxy.model.base import transaction
 from galaxy.model.scoped_session import galaxy_scoped_session
@@ -89,11 +100,7 @@ class FolderManager:
         :raises: InconsistentDatabase, RequestParameterInvalidException, InternalServerError
         """
         try:
-            folder = (
-                trans.sa_session.query(trans.app.model.LibraryFolder)
-                .filter(trans.app.model.LibraryFolder.table.c.id == decoded_folder_id)
-                .one()
-            )
+            folder = get_folder(trans.sa_session, decoded_folder_id)
         except MultipleResultsFound:
             raise InconsistentDatabase("Multiple folders found with the same id.")
         except NoResultFound:
@@ -210,7 +217,7 @@ class FolderManager:
             raise InsufficientPermissionsException(
                 "You do not have proper permission to create folders under given folder."
             )
-        new_folder = trans.app.model.LibraryFolder(name=new_folder_name, description=new_folder_description)
+        new_folder = LibraryFolder(name=new_folder_name, description=new_folder_description)
         # We are associating the last used genome build with folders, so we will always
         # initialize a new folder with the first dbkey in genome builds list which is currently
         # ?    unspecified (?)
@@ -386,9 +393,9 @@ class FolderManager:
     def get_contents(
         self,
         trans,
-        folder: model.LibraryFolder,
+        folder: LibraryFolder,
         payload: LibraryFolderContentsIndexQueryPayload,
-    ) -> Tuple[List[Union[model.LibraryFolder, model.LibraryDataset]], int]:
+    ) -> Tuple[List[Union[LibraryFolder, LibraryDataset]], int]:
         """Retrieves the contents of the given folder that match the provided filters and pagination parameters.
         Returns a tuple with the list of paginated contents and the total number of items contained in the folder."""
         limit = payload.limit
@@ -400,19 +407,19 @@ class FolderManager:
             is_admin=trans.user_is_admin,
         )
 
-        content_items: List[Union[model.LibraryFolder, model.LibraryDataset]] = []
-        sub_folders_query = self._get_sub_folders_query(sa_session, folder, security_params, payload)
-        total_sub_folders: int = sub_folders_query.count()
+        content_items: List[Union[LibraryFolder, LibraryDataset]] = []
+        sub_folders_stmt = self._get_sub_folders_statement(sa_session, folder, security_params, payload)
+        total_sub_folders = get_count(sa_session, sub_folders_stmt)
         if payload.order_by in FOLDER_SORT_COLUMN_MAP:
-            sort_column = FOLDER_SORT_COLUMN_MAP[payload.order_by](model.LibraryFolder)
-            sub_folders_query = sub_folders_query.order_by(sort_column.desc() if payload.sort_desc else sort_column)
+            sort_column = FOLDER_SORT_COLUMN_MAP[payload.order_by](LibraryFolder)
+            sub_folders_stmt = sub_folders_stmt.order_by(sort_column.desc() if payload.sort_desc else sort_column)
         else:  # Sort by name alphabetically by default
-            sub_folders_query = sub_folders_query.order_by(model.LibraryFolder.name)
+            sub_folders_stmt = sub_folders_stmt.order_by(LibraryFolder.name)
         if limit is not None and limit > 0:
-            sub_folders_query = sub_folders_query.limit(limit)
+            sub_folders_stmt = sub_folders_stmt.limit(limit)
         if offset is not None:
-            sub_folders_query = sub_folders_query.offset(offset)
-        folders = sub_folders_query.all()
+            sub_folders_stmt = sub_folders_stmt.offset(offset)
+        folders = sa_session.scalars(sub_folders_stmt).all()
         content_items.extend(folders)
 
         # Update pagination
@@ -424,77 +431,69 @@ class FolderManager:
             offset -= num_folders_skipped
             offset = max(0, offset)
 
-        datasets_query = self._get_contained_datasets_query(sa_session, folder, security_params, payload)
-        total_datasets = datasets_query.count()
+        datasets_stmt = self._get_contained_datasets_statement(sa_session, folder, security_params, payload)
+        total_datasets = get_count(sa_session, datasets_stmt)
         if limit is not None and limit > 0:
-            datasets_query = datasets_query.limit(limit)
+            datasets_stmt = datasets_stmt.limit(limit)
         if offset is not None:
-            datasets_query = datasets_query.offset(offset)
-        datasets = datasets_query.all()
+            datasets_stmt = datasets_stmt.offset(offset)
+        datasets = sa_session.scalars(datasets_stmt).all()
         content_items.extend(datasets)
         return (content_items, total_sub_folders + total_datasets)
 
-    def _get_sub_folders_query(
+    def _get_sub_folders_statement(
         self,
         sa_session: galaxy_scoped_session,
-        folder: model.LibraryFolder,
+        folder: LibraryFolder,
         security: SecurityParams,
         payload: LibraryFolderContentsIndexQueryPayload,
     ):
         """Builds a query to retrieve all the sub-folders contained in the given folder applying filters."""
-        item_model = model.LibraryFolder
-        item_permission_model = model.LibraryFolderPermissions
         search_text = payload.search_text
-        query = sa_session.query(item_model)
-        query = query.filter(item_model.parent_id == folder.id)
-        query = self._filter_by_include_deleted(
-            query, item_model, item_permission_model, payload.include_deleted, security
+        stmt = select(LibraryFolder).where(LibraryFolder.parent_id == folder.id)
+        stmt = self._filter_by_include_deleted(
+            stmt, LibraryFolder, LibraryFolderPermissions, payload.include_deleted, security
         )
         if search_text:
             search_text = search_text.lower()
-            query = query.filter(
+            stmt = stmt.where(
                 or_(
-                    func.lower(item_model.name).contains(search_text, autoescape=True),
-                    func.lower(item_model.description).contains(search_text, autoescape=True),
+                    func.lower(LibraryFolder.name).contains(search_text, autoescape=True),
+                    func.lower(LibraryFolder.description).contains(search_text, autoescape=True),
                 )
             )
-        query = query.group_by(item_model.id)
-        return query
+        stmt = stmt.group_by(LibraryFolder.id)
+        return stmt
 
-    def _get_contained_datasets_query(
+    def _get_contained_datasets_statement(
         self,
         sa_session: galaxy_scoped_session,
-        folder: model.LibraryFolder,
+        folder: LibraryFolder,
         security: SecurityParams,
         payload: LibraryFolderContentsIndexQueryPayload,
     ):
         """Builds a query to retrieve all the datasets contained in the given folder applying filters."""
         search_text = payload.search_text
-        item_model = model.LibraryDataset
-        item_permission_model = model.LibraryDatasetPermissions
         access_action = security.security_agent.permitted_actions.DATASET_ACCESS.action
-        query = sa_session.query(item_model)
-        query = query.filter(item_model.folder_id == folder.id)
-        query = self._filter_by_include_deleted(
-            query, item_model, item_permission_model, payload.include_deleted, security
+
+        stmt = select(LibraryDataset).where(LibraryDataset.folder_id == folder.id)
+        stmt = self._filter_by_include_deleted(
+            stmt, LibraryDataset, LibraryDatasetPermissions, payload.include_deleted, security
         )
-        ldda = aliased(model.LibraryDatasetDatasetAssociation)
-        associated_dataset = aliased(model.Dataset)
-        query = query.outerjoin(item_model.library_dataset_dataset_association.of_type(ldda))
+        ldda = aliased(LibraryDatasetDatasetAssociation)
+        associated_dataset = aliased(Dataset)
+        stmt = stmt.outerjoin(LibraryDataset.library_dataset_dataset_association.of_type(ldda))
         if not security.is_admin:  # Non-admin users require ACCESS permission
             # We check against the actual dataset and not the ldda (for now?)
-            dataset_permission = aliased(model.DatasetPermissions)
+            dataset_permission = aliased(DatasetPermissions)
             is_public_dataset = not_(
-                sa_session.query(model.DatasetPermissions)
-                .filter(
-                    model.DatasetPermissions.dataset_id == associated_dataset.id,
-                    model.DatasetPermissions.action == access_action,
-                )
-                .exists()
+                exists()
+                .where(DatasetPermissions.dataset_id == associated_dataset.id)
+                .where(DatasetPermissions.action == access_action)
             )
-            query = query.outerjoin(ldda.dataset.of_type(associated_dataset))
-            query = query.outerjoin(associated_dataset.actions.of_type(dataset_permission))
-            query = query.filter(
+            stmt = stmt.outerjoin(ldda.dataset.of_type(associated_dataset))
+            stmt = stmt.outerjoin(associated_dataset.actions.of_type(dataset_permission))
+            stmt = stmt.where(
                 or_(
                     # The dataset is public
                     is_public_dataset,
@@ -505,30 +504,27 @@ class FolderManager:
                     ),
                 )
             )
-
         if search_text:
             search_text = search_text.lower()
-            query = query.filter(
+            stmt = stmt.where(
                 or_(
                     func.lower(ldda.name).contains(search_text, autoescape=True),
                     func.lower(ldda.message).contains(search_text, autoescape=True),
                 )
             )
         sort_column = LDDA_SORT_COLUMN_MAP[payload.order_by](ldda, associated_dataset)
-        query = query.order_by(sort_column.desc() if payload.sort_desc else sort_column)
-
-        query = query.group_by(item_model.id, sort_column)
-
-        return query
+        stmt = stmt.order_by(sort_column.desc() if payload.sort_desc else sort_column)
+        stmt = stmt.group_by(LibraryDataset.id, sort_column)
+        return stmt
 
     def _filter_by_include_deleted(
-        self, query, item_model, item_permissions_model, include_deleted: Optional[bool], security: SecurityParams
+        self, stmt, item_model, item_permissions_model, include_deleted: Optional[bool], security: SecurityParams
     ):
         if include_deleted:  # Admins or users with MODIFY permissions can see deleted contents
             if not security.is_admin:
                 item_permission = aliased(item_permissions_model)
-                query = query.outerjoin(item_model.actions.of_type(item_permission))
-                query = query.filter(
+                stmt = stmt.outerjoin(item_model.actions.of_type(item_permission))
+                stmt = stmt.where(
                     or_(
                         item_model.deleted == false(),  # Is not deleted
                         # User has MODIFY permission
@@ -539,8 +535,8 @@ class FolderManager:
                     )
                 )
         else:
-            query = query.filter(item_model.deleted == false())
-        return query
+            stmt = stmt.where(item_model.deleted == false())
+        return stmt
 
     def build_folder_path(
         self, sa_session: galaxy_scoped_session, folder: model.LibraryFolder
@@ -553,7 +549,17 @@ class FolderManager:
         current_folder = folder
         path_to_root = [(LibraryFolderDatabaseIdField.encode(current_folder.id), current_folder.name)]
         while current_folder.parent_id is not None:
-            parent_folder = sa_session.query(model.LibraryFolder).get(current_folder.parent_id)
+            parent_folder = sa_session.get(LibraryFolder, current_folder.parent_id)
             current_folder = parent_folder
             path_to_root.insert(0, (LibraryFolderDatabaseIdField.encode(current_folder.id), current_folder.name))
         return path_to_root
+
+
+def get_folder(session, folder_id):
+    stmt = select(LibraryFolder).where(LibraryFolder.id == folder_id)
+    return session.execute(stmt).scalar_one()
+
+
+def get_count(session, statement):
+    stmt = select(func.count()).select_from(statement)
+    return session.scalar(stmt)

--- a/lib/galaxy/managers/forms.py
+++ b/lib/galaxy/managers/forms.py
@@ -1,0 +1,21 @@
+from sqlalchemy import select
+
+from galaxy.model import (
+    FormDefinition,
+    FormDefinitionCurrent,
+)
+
+
+def get_form_definitions(session):
+    stmt = select(FormDefinition)
+    return session.scalars(stmt)
+
+
+def get_form_definitions_current(session):
+    stmt = select(FormDefinitionCurrent)
+    return session.scalars(stmt)
+
+
+def get_filtered_form_definitions_current(session, filter):
+    stmt = select(FormDefinitionCurrent).filter_by(**filter)
+    return session.scalars(stmt)

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -16,7 +16,6 @@ from typing import (
 )
 
 from sqlalchemy import (
-    and_,
     asc,
     desc,
     false,
@@ -44,6 +43,11 @@ from galaxy.managers.base import (
     StorageCleanerManager,
 )
 from galaxy.managers.export_tracker import StoreExportTracker
+from galaxy.model import (
+    History,
+    HistoryUserShareAssociation,
+    Job,
+)
 from galaxy.model.base import transaction
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
@@ -126,7 +130,7 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         return super().is_owner(item, user)
 
     # TODO: possibly to sharable or base
-    def most_recent(self, user, filters=None, current_history=None, **kwargs):
+    def most_recent(self, user, filters=None, current_history=None):
         """
         Return the most recently update history for the user.
 
@@ -135,10 +139,9 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         """
         if self.user_manager.is_anonymous(user):
             return None if (not current_history or current_history.deleted) else current_history
-        desc_update_time = desc(self.model_class.update_time)
-        filters = combine_lists(filters, self.model_class.user_id == user.id)
-        # TODO: normalize this return value
-        return self.query(filters=filters, order_by=desc_update_time, limit=1, **kwargs).first()
+        filters = combine_lists(filters, History.user_id == user.id)
+        stmt = select(History).where(*filters).order_by(History.update_time.desc()).limit(1)
+        return self.session().scalars(stmt).first()
 
     # .... purgable
     def purge(self, history, flush=True, **kwargs):
@@ -218,13 +221,8 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         """
         # TODO: defer to jobModelManager (if there was one)
         # TODO: genericize the params to allow other filters
-        jobs = (
-            self.session()
-            .query(model.Job)
-            .filter(model.Job.history == history)
-            .filter(model.Job.state.in_(model.Job.non_ready_states))
-        )
-        return jobs
+        stmt = select(Job).where(Job.history == history).where(Job.state.in_(Job.non_ready_states))
+        return self.session().scalars(stmt)
 
     def queue_history_import(self, trans, archive_type, archive_source):
         # Run job to do import.
@@ -342,17 +340,13 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         return extra
 
     def is_history_shared_with(self, history: model.History, user: model.User) -> bool:
-        return bool(
-            self.session()
-            .query(self.user_share_model)
-            .filter(
-                and_(
-                    self.user_share_model.table.c.user_id == user.id,
-                    self.user_share_model.table.c.history_id == history.id,
-                )
-            )
-            .first()
+        stmt = (
+            select(HistoryUserShareAssociation.id)
+            .where(HistoryUserShareAssociation.user_id == user.id)
+            .where(HistoryUserShareAssociation.history_id == history.id)
+            .limit(1)
         )
+        return bool(self.session().execute(stmt).first())
 
     def make_members_public(self, trans, item):
         """Make the non-purged datasets in history public.

--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -407,31 +407,31 @@ class HistoryContentsManager(base.SortableManager):
         if not id_list:
             return []
         component_class = self.contained_class
-        query = (
-            self._session()
-            .query(component_class)
-            .filter(component_class.id.in_(id_list))  # type: ignore[attr-defined]
+        stmt = (
+            select(component_class)
+            .where(component_class.id.in_(id_list))  # type: ignore[attr-defined]
             .options(undefer(component_class._metadata))
             .options(joinedload(component_class.dataset).joinedload(model.Dataset.actions))
             .options(joinedload(component_class.tags))
             .options(joinedload(component_class.annotations))  # type: ignore[attr-defined]
         )
-        return {row.id: row for row in query.all()}
+        result = self._session().scalars(stmt).unique()
+        return {row.id: row for row in result}
 
     def _subcontainer_id_map(self, id_list, serialization_params=None):
         """Return an id to model map of all subcontainer-type models in the id_list."""
         if not id_list:
             return []
         component_class = self.subcontainer_class
-        query = (
-            self._session()
-            .query(component_class)
-            .filter(component_class.id.in_(id_list))
+        stmt = (
+            select(component_class)
+            .where(component_class.id.in_(id_list))
             .options(joinedload(component_class.collection))
             .options(joinedload(component_class.tags))
             .options(joinedload(component_class.annotations))
         )
-        return {row.id: row for row in query.all()}
+        result = self._session().scalars(stmt).unique()
+        return {row.id: row for row in result}
 
 
 class HistoryContentsSerializer(base.ModelSerializer, deletable.PurgableSerializerMixin):

--- a/lib/galaxy/managers/notification.py
+++ b/lib/galaxy/managers/notification.py
@@ -412,8 +412,8 @@ class DefaultStrategy(NotificationRecipientResolverStrategy):
         user_ids_from_groups_and_roles = set([id for id, in self.sa_session.execute(union_stmt)])
         unique_user_ids.update(user_ids_from_groups_and_roles)
 
-        unique_recipient_users = self.sa_session.query(User).filter(User.id.in_(unique_user_ids)).all()
-        return unique_recipient_users
+        stmt = select(User).where(User.id.in_(unique_user_ids))
+        return self.sa_session.scalars(stmt).all()
 
     def _get_all_user_ids_from_roles_query(self, role_ids: Set[int]) -> Select:
         stmt = (

--- a/lib/galaxy/managers/ratable.py
+++ b/lib/galaxy/managers/ratable.py
@@ -4,6 +4,7 @@ Mixins for Ratable model managers and serializers.
 import logging
 from typing import Type
 
+from sqlalchemy import select
 from sqlalchemy.sql.expression import func
 
 from galaxy.model import ItemRatingAssociation
@@ -35,13 +36,14 @@ class RatableManagerMixin:
     def ratings_avg(self, item):
         """Returns the average of all ratings given to this item."""
         foreign_key = self._foreign_key(self.rating_assoc)
-        avg = self.session().query(func.avg(self.rating_assoc.rating)).filter(foreign_key == item).scalar()
-        return avg or 0.0
+        stmt = select(func.avg(self.rating_assoc.rating)).where(foreign_key == item)
+        return self.session().scalar(stmt) or 0.0
 
     def ratings_count(self, item):
         """Returns the number of ratings given to this item."""
         foreign_key = self._foreign_key(self.rating_assoc)
-        return self.session().query(func.count(self.rating_assoc.rating)).filter(foreign_key == item).scalar()
+        stmt = select(func.count(self.rating_assoc.rating)).where(foreign_key == item)
+        return self.session().scalar(stmt)
 
     def rate(self, item, user, value, flush=True):
         """Updates or creates a rating for this item and user. Returns the rating"""

--- a/lib/galaxy/managers/session.py
+++ b/lib/galaxy/managers/session.py
@@ -1,7 +1,7 @@
 import logging
 
 from sqlalchemy import (
-    and_,
+    select,
     true,
 )
 from sqlalchemy.orm import joinedload
@@ -22,15 +22,11 @@ class GalaxySessionManager:
         """Returns GalaxySession if session_key is valid."""
         # going through self.model since this can be used by Galaxy or Toolshed despite
         # type annotations
-        galaxy_session = (
-            self.sa_session.query(self.model.GalaxySession)
-            .filter(
-                and_(
-                    self.model.GalaxySession.table.c.session_key == session_key,
-                    self.model.GalaxySession.table.c.is_valid == true(),
-                )
-            )
+        stmt = (
+            select(self.model.GalaxySession)
+            .where(self.model.GalaxySession.session_key == session_key)
+            .where(self.model.GalaxySession.is_valid == true())
             .options(joinedload(self.model.GalaxySession.user))
-            .first()
+            .limit(1)
         )
-        return galaxy_session
+        return self.sa_session.scalars(stmt).first()

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -349,9 +349,7 @@ class SharableModelManager(
         # add integer to end.
         new_slug = slug_base
         count = 1
-        while (
-            self.session().query(item.__class__).filter_by(user=item.user, slug=new_slug, importable=True).count() != 0
-        ):
+        while importable_item_slug_exists(self.session(), item.__class__, item.user, new_slug):
             # Slug taken; choose a new slug based on count. This approach can
             # handle numerous items with the same name gracefully.
             new_slug = "%s-%i" % (slug_base, count)
@@ -592,6 +590,13 @@ def slug_exists(session, model_class, user, slug, ignore_deleted=False):
     stmt = select(exists().where(model_class.user == user).where(model_class.slug == slug))
     if ignore_deleted:  # Only check items that are NOT marked as deleted
         stmt = stmt.where(model_class.deleted == false())
+    return session.scalar(stmt)
+
+
+def importable_item_slug_exists(session, model_class, user, slug):
+    stmt = select(
+        exists().where(model_class.user == user).where(model_class.slug == slug).where(model_class.importable == true())
+    )
     return session.scalar(stmt)
 
 

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -570,12 +570,7 @@ class SlugBuilder:
         count = 1
         # Ensure unique across model class and user and don't include this item
         # in the check in case it has previously been assigned a valid slug.
-        while (
-            sa_session.query(item.__class__)
-            .filter(item.__class__.user == item.user, item.__class__.slug == new_slug, item.__class__.id != item.id)
-            .count()
-            != 0
-        ):
+        while another_slug_exists(sa_session, item.__class__, item.user, new_slug, item.id):
             # Slug taken; choose a new slug based on count. This approach can
             # handle numerous items with the same name gracefully.
             new_slug = f"{slug_base}-{count}"
@@ -597,6 +592,11 @@ def importable_item_slug_exists(session, model_class, user, slug):
     stmt = select(
         exists().where(model_class.user == user).where(model_class.slug == slug).where(model_class.importable == true())
     )
+    return session.scalar(stmt)
+
+
+def another_slug_exists(session, model_class, user, slug, id):
+    stmt = select(exists().where(model_class.user == user).where(model_class.slug == slug).where(model_class.id != id))
     return session.scalar(stmt)
 
 

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -150,14 +150,6 @@ class SharableModelManager(
         """
         return self._session_setattr(item, "published", False, flush=flush)
 
-    def _query_published(self, filters=None, **kwargs):
-        """
-        Return a query for all published items.
-        """
-        published_filter = self.model_class.table.c.published == true()
-        filters = combine_lists(published_filter, filters)
-        return self.query(filters=filters, **kwargs)
-
     def list_published(self, filters=None, **kwargs):
         """
         Return a list of all published items.

--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -62,5 +62,4 @@ class TagsManager:
         """
         item_class_name = str(payload.item_class)
         item_class = tag_handler.item_tag_assoc_info[item_class_name].item_class
-        item = tag_handler.sa_session.query(item_class).filter(item_class.id == payload.item_id).first()
-        return item
+        return tag_handler.sa_session.get(item_class, payload.item_id)

--- a/lib/galaxy/managers/tools.py
+++ b/lib/galaxy/managers/tools.py
@@ -6,13 +6,17 @@ from typing import (
 )
 from uuid import UUID
 
-from sqlalchemy import sql
+from sqlalchemy import (
+    select,
+    sql,
+)
 
 from galaxy import (
     exceptions,
     model,
 )
 from galaxy.exceptions import DuplicatedIdentifierException
+from galaxy.model import DynamicTool
 from galaxy.tool_util.cwl import tool_proxy
 from .base import (
     ModelManager,
@@ -32,16 +36,16 @@ class DynamicToolManager(ModelManager):
     model_class = model.DynamicTool
 
     def get_tool_by_uuid(self, uuid: Optional[Union[UUID, str]]):
-        dynamic_tool = self._one_or_none(self.query().filter(self.model_class.uuid == uuid))
-        return dynamic_tool
+        stmt = select(DynamicTool).where(DynamicTool.uuid == uuid)
+        return self.session().scalars(stmt).one_or_none()
 
     def get_tool_by_tool_id(self, tool_id):
-        dynamic_tool = self._one_or_none(self.query().filter(self.model_class.tool_id == tool_id))
-        return dynamic_tool
+        stmt = select(DynamicTool).where(DynamicTool.tool_id == tool_id)
+        return self.session().scalars(stmt).one_or_none()
 
     def get_tool_by_id(self, object_id):
-        dynamic_tool = self._one_or_none(self.query().filter(self.model_class.id == object_id))
-        return dynamic_tool
+        stmt = select(DynamicTool).where(DynamicTool.id == object_id)
+        return self.session().scalars(stmt).one_or_none()
 
     def create_tool(self, trans, tool_payload, allow_load=True):
         if not getattr(self.app.config, "enable_beta_tool_formats", False):
@@ -112,7 +116,8 @@ class DynamicToolManager(ModelManager):
         return dynamic_tool
 
     def list_tools(self, active=True):
-        return self.query().filter(self.model_class.active == active)
+        stmt = select(DynamicTool).where(DynamicTool.active == active)
+        return self.session().scalars(stmt)
 
     def deactivate(self, dynamic_tool):
         self.update(dynamic_tool, {"active": False})

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -415,19 +415,20 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         # get all the taggable model TagAssociations
         if not tag_models:
             tag_models = [v.tag_assoc_class for v in self.app.tag_handler.item_tag_assoc_info.values()]
-        # create a union of subqueries for each for this user - getting only the tname and user_value
-        all_tags_query = None
-        for tag_model in tag_models:
-            subq = self.session().query(tag_model.user_tname, tag_model.user_value).filter(tag_model.user == user)
-            all_tags_query = subq if all_tags_query is None else all_tags_query.union(subq)
 
-        # if nothing init'd the query, bail
-        if all_tags_query is None:
+        if not tag_models:
             return []
 
+        # create a union of select statements for each tag model for this user - getting only the tname and user_value
+        all_tags_stmt = None
+        for tag_model in tag_models:
+            stmt = select(tag_model.user_tname, tag_model.user_value).where(tag_model.user == user)
+            all_tags_stmt = stmt if all_tags_stmt is None else stmt.union(all_tags_stmt.union)
+
         # boil the tag tuples down into a sorted list of DISTINCT name:val strings
-        tags = all_tags_query.distinct().all()
-        tags = [(f"{name}:{val}" if val else name) for name, val in tags]
+        all_tags_stmt = all_tags_stmt.distinct()
+        tag_tuples = self.session().exectute(all_tags_stmt)
+        tags = [(f"{name}:{val}" if val else name) for name, val in tag_tuples]
         # consider named tags while sorting
         return sorted(tags, key=lambda str: re.sub("^name:", "#", str))
 

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -1316,7 +1316,7 @@ class SharableMixin:
         item = self.get_item(trans, id)
         if item:
             # Only update slug if slug is not already in use.
-            if trans.sa_session.query(item.__class__).filter_by(user=item.user, slug=new_slug).count() == 0:
+            if not slug_exists(trans.sa_session, item.__class__, item.user, new_slug):
                 item.slug = new_slug
                 with transaction(trans.sa_session):
                     trans.sa_session.commit()

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -32,7 +32,15 @@ from galaxy.managers import (
     users,
     workflows,
 )
-from galaxy.managers.sharable import SlugBuilder
+from galaxy.managers.forms import (
+    get_filtered_form_definitions_current,
+    get_form_definitions,
+    get_form_definitions_current,
+)
+from galaxy.managers.sharable import (
+    slug_exists,
+    SlugBuilder,
+)
 from galaxy.model import (
     ExtendedMetadata,
     ExtendedMetadataIndex,
@@ -1066,10 +1074,7 @@ class UsesVisualizationMixin(UsesLibraryMixinItems):
             title_err = "visualization name is required"
         elif slug and not managers_base.is_valid_slug(slug):
             slug_err = "visualization identifier must consist of only lowercase letters, numbers, and the '-' character"
-        elif (
-            slug
-            and trans.sa_session.query(trans.model.Visualization).filter_by(user=user, slug=slug, deleted=False).first()
-        ):
+        elif slug and slug_exists(trans.sa_session, trans.model.Visualization, user, slug, ignore_deleted=True):
             slug_err = "visualization identifier must be unique"
 
         if title_err or slug_err:

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -1238,11 +1238,11 @@ class UsesFormDefinitionsMixin:
         of all the forms from the form_definition table.
         """
         if all_versions:
-            return trans.sa_session.query(trans.app.model.FormDefinition)
+            return get_form_definitions(trans.sa_session)
         if filter:
-            fdc_list = trans.sa_session.query(trans.app.model.FormDefinitionCurrent).filter_by(**filter)
+            fdc_list = get_filtered_form_definitions_current(trans.sa_session, filter)
         else:
-            fdc_list = trans.sa_session.query(trans.app.model.FormDefinitionCurrent)
+            fdc_list = get_form_definitions_current(trans.sa_session)
         if form_type == "All":
             return [fdc.latest_form for fdc in fdc_list]
         else:


### PR DESCRIPTION
SQLAlchemy 2.0 compatibility upgrades. Ref #12541.

This covers the `managers/` directory, with just a few cases left out (in `base`, `history_contents` and `sharable` - those involve query-building abstractions which may require more refactoring; I'll have a separate PR for those). All commits are atomic; most are straightforward syntactical edits. If there is a notable refactoring present, I noted that in the commit description. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
