### PR TITLE
[23.1] Fix and prevent persisting null file_size

### DIFF
--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -91,7 +91,7 @@ class PermissionProvider(AbstractPermissionProvider):
             self._security_agent.set_all_dataset_permissions(primary_data.dataset, permissions, new=True, flush=False)
 
     def copy_dataset_permissions(self, init_from, primary_data):
-        self._security_agent.copy_dataset_permissions(init_from.dataset, primary_data.dataset)
+        self._security_agent.copy_dataset_permissions(init_from.dataset, primary_data.dataset, flush=False)
 
 
 class MetadataSourceProvider(AbstractMetadataSourceProvider):

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1430,8 +1430,6 @@ class MinimalJobWrapper(HasResourceParameters):
                 dataset.state = dataset.states.ERROR
                 dataset.blurb = "tool error"
                 dataset.info = message
-                dataset.set_size()
-                dataset.dataset.set_total_size()
                 dataset.mark_unhidden()
                 if dataset.ext == "auto":
                     dataset.extension = "data"
@@ -1738,7 +1736,6 @@ class MinimalJobWrapper(HasResourceParameters):
             # Ensure white space between entries
             dataset.info = f"{dataset.info.rstrip()}\n{context['stderr'].strip()}"
         dataset.tool_version = self.version_string
-        dataset.set_size()
         if "uuid" in context:
             dataset.dataset.uuid = context["uuid"]
         self.__update_output(job, dataset)
@@ -2423,6 +2420,7 @@ class MinimalJobWrapper(HasResourceParameters):
         cleaned up if the dataset has been purged.
         """
         dataset = hda.dataset
+        dataset.set_total_size()
         if dataset not in job.output_library_datasets:
             purged = dataset.purged
             if not purged and not clean_only:

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -449,6 +449,7 @@ def set_metadata_portable(
                         partial(push_if_necessary, object_store, dataset, external_filename)
                     )
                 object_store_update_actions.append(partial(reset_external_filename, dataset))
+                object_store_update_actions.append(partial(dataset.set_total_size))
                 object_store_update_actions.append(partial(export_store.add_dataset, dataset))
                 if dataset_instance_id not in unnamed_id_to_path:
                     object_store_update_actions.append(partial(collect_extra_files, object_store, dataset, "."))

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3870,6 +3870,7 @@ class Dataset(Base, StorableObject, Serializable):
     non_ready_states = (states.NEW, states.UPLOAD, states.QUEUED, states.RUNNING, states.SETTING_METADATA)
     ready_states = tuple(set(states.__members__.values()) - set(non_ready_states))
     valid_input_states = tuple(set(states.__members__.values()) - {states.ERROR, states.DISCARDED})
+    no_data_states = (states.PAUSED, states.DEFERRED, states.DISCARDED, *non_ready_states)
     terminal_states = (
         states.OK,
         states.EMPTY,

--- a/lib/galaxy/model/base.py
+++ b/lib/galaxy/model/base.py
@@ -152,9 +152,13 @@ def versioned_objects_strict(iter):
                 # These should get some other type of permanent storage, perhaps UserDatasetAssociation ?
                 # Everything else needs to have a hid and a history
                 if not obj.history and not obj.history_id:
-                    raise Exception(f"HistoryDatsetAssociation {obj} without history detected, this is not valid")
+                    raise Exception(f"HistoryDatasetAssociation {obj} without history detected, this is not valid")
                 elif not obj.hid:
-                    raise Exception(f"HistoryDatsetAssociation {obj} without has no hid, this is not valid")
+                    raise Exception(f"HistoryDatasetAssociation {obj} without hid, this is not valid")
+                elif obj.dataset.file_size is None and obj.dataset.state not in obj.dataset.no_data_states:
+                    raise Exception(
+                        f"HistoryDatasetAssociation {obj} in state {obj.dataset.state} with null file size, this is not valid"
+                    )
             yield obj
 
 

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -998,12 +998,12 @@ class GalaxyRBACAgent(RBACAgent):
                 permissions[action] = [item_permission.role]
         return permissions
 
-    def copy_dataset_permissions(self, src, dst):
+    def copy_dataset_permissions(self, src, dst, flush=True):
         if not isinstance(src, self.model.Dataset):
             src = src.dataset
         if not isinstance(dst, self.model.Dataset):
             dst = dst.dataset
-        self.set_all_dataset_permissions(dst, self.get_permissions(src))
+        self.set_all_dataset_permissions(dst, self.get_permissions(src), flush=flush)
 
     def privately_share_dataset(self, dataset, users=None):
         dataset.ensure_shareable()

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -125,7 +125,7 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
 
                 if init_from:
                     self.permission_provider.copy_dataset_permissions(init_from, primary_data)
-                    primary_data.state = init_from.state
+                    primary_data.raw_set_dataset_state(init_from.state)
                 else:
                     self.permission_provider.set_default_hda_permissions(primary_data)
             else:

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -265,6 +265,8 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
             except Exception:
                 log.exception("Exception occured while setting dataset peek")
 
+            primary_data.set_total_size()
+
     def populate_collection_elements(
         self,
         collection,

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -675,6 +675,7 @@ class DefaultToolAction(ToolAction):
                 data.visible = False
                 with open(data.dataset.file_name, "w") as out:
                     out.write(json.dumps(None))
+                data.set_total_size()
         job.preferred_object_store_id = preferred_object_store_id
         self._record_inputs(trans, tool, job, incoming, inp_data, inp_dataset_collections)
         self._record_outputs(job, out_data, output_collections)

--- a/test/unit/app/tools/test_collect_primary_datasets.py
+++ b/test/unit/app/tools/test_collect_primary_datasets.py
@@ -447,6 +447,9 @@ class MockObjectStore:
     def __init__(self):
         self.created_datasets = {}
 
+    def get_store_by(self, obj, **kwargs):
+        return "uuid"
+
     def update_from_file(self, dataset, file_name, create):
         if create:
             self.created_datasets[dataset] = file_name
@@ -458,7 +461,7 @@ class MockObjectStore:
     def exists(self, *args, **kwargs):
         return True
 
-    def get_filename(self, dataset):
+    def get_filename(self, dataset, **kwargs):
         return self.created_datasets[dataset]
 
 


### PR DESCRIPTION
This can happen in extended metadata mode.
Fixes:
```
TypeError: float() argument must be a string or a number, not 'NoneType'
  File "galaxy/jobs/mapper.py", line 258, in __cache_job_destination
    self.cached_job_destination = self.__determine_job_destination(
  File "galaxy/jobs/mapper.py", line 242, in __determine_job_destination
    job_destination = self.__handle_dynamic_job_destination(raw_job_destination)
  File "galaxy/jobs/mapper.py", line 205, in __handle_dynamic_job_destination
    return self.__handle_rule(expand_function, destination)
  File "galaxy/jobs/mapper.py", line 220, in __handle_rule
    raise e
  File "galaxy/jobs/mapper.py", line 209, in __handle_rule
    job_destination = self.__invoke_expand_function(rule_function, destination)
  File "galaxy/jobs/mapper.py", line 125, in __invoke_expand_function
    return expand_function(**actual_args)
  File "tpv/rules/gateway.py", line 51, in map_tool_to_destination
    return ACTIVE_DESTINATION_MAPPER.map_to_destination(app, tool, user, job, job_wrapper, resource_params,
  File "tpv/core/mapper.py", line 168, in map_to_destination
    evaluated_entity = self.match_combine_evaluate_entities(context, tool, user)
  File "tpv/core/mapper.py", line 138, in match_combine_evaluate_entities
    evaluated_entity = combined_entity.evaluate_rules(context)
  File "tpv/core/entities.py", line 488, in evaluate_rules
    if rule.is_matching(context):
  File "tpv/core/entities.py", line 742, in is_matching
    if self.loader.eval_code_block(self.match, context):
  File "tpv/core/loader.py", line 49, in eval_code_block
    'input_size': helpers.input_size(context['job']) if 'input_size' in str(code) else 0
  File "tpv/core/helpers.py", line 32, in input_size
    return calculate_dataset_total(job.input_datasets)/GIGABYTES
  File "tpv/core/helpers.py", line 26, in calculate_dataset_total
    return reduce(sum_total, map(get_dataset_size, unique_datasets.values()), 0.0)
  File "tpv/core/helpers.py", line 16, in get_dataset_size
    return float(dataset.file_size)
```

from https://sentry.galaxyproject.org/share/issue/96123a088f554a8198b300989af27818/

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
