### PR TITLE
Visually indicate currently viewed/edited dataset

### DIFF
--- a/client/src/components/History/Content/ContentItem.test.js
+++ b/client/src/components/History/Content/ContentItem.test.js
@@ -3,13 +3,16 @@ import { mount } from "@vue/test-utils";
 import { updateContentFields } from "components/History/model/queries";
 import { PiniaVuePlugin } from "pinia";
 import { getLocalVue } from "tests/jest/helpers";
+import VueRouter from "vue-router";
 
 import ContentItem from "./ContentItem";
 
 jest.mock("components/History/model/queries");
 
 const localVue = getLocalVue();
+localVue.use(VueRouter);
 localVue.use(PiniaVuePlugin);
+const router = new VueRouter();
 
 // mock queries
 updateContentFields.mockImplementation(async () => {});
@@ -48,6 +51,7 @@ describe("ContentItem", () => {
                 },
             },
             pinia: createTestingPinia(),
+            router,
         });
     });
 

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -289,9 +289,13 @@ export default {
     }
 
     // improve focus visibility
-    &:deep(.btn:focus),
-    &.being-used {
+    &:deep(.btn:focus) {
         box-shadow: 0 0 0 0.2rem transparentize($brand-primary, 0.75);
+    }
+
+    &.being-used {
+        border-left: 0.25rem solid $brand-primary;
+        margin-left: 0rem !important;
     }
 }
 </style>

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         :id="contentId"
-        :class="['content-item m-1 p-0 rounded btn-transparent-background', contentCls]"
+        :class="['content-item m-1 p-0 rounded btn-transparent-background', contentCls, isBeingUsed]"
         :data-hid="id"
         :data-state="state"
         tabindex="0"
@@ -211,6 +211,9 @@ export default {
                 visualize: `/visualizations?dataset_id=${id}`,
             };
         },
+        isBeingUsed() {
+            return Object.values(this.itemUrls).includes(this.$route.path) ? "being-used" : "";
+        },
     },
     methods: {
         onKeyDown(event) {
@@ -286,7 +289,8 @@ export default {
     }
 
     // improve focus visibility
-    &:deep(.btn:focus) {
+    &:deep(.btn:focus),
+    &.being-used {
         box-shadow: 0 0 0 0.2rem transparentize($brand-primary, 0.75);
     }
 }

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -89,7 +89,7 @@
         <!-- collections are not expandable, so we only need the DatasetDetails component here -->
         <b-collapse :visible="expandDataset">
             <DatasetDetails
-                v-if="expandDataset"
+                v-if="expandDataset && item.id"
                 :id="item.id"
                 :writable="writable"
                 :show-highlight="(isHistoryItem && filterable) || addHighlightBtn"

--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -1,11 +1,8 @@
 <script setup lang="ts">
 import { BDropdown } from "bootstrap-vue";
 import { computed, type Ref, ref } from "vue";
-import { useRoute } from "vue-router/composables";
 
 import { prependPath } from "@/utils/redirect";
-
-const route = useRoute();
 
 const props = defineProps({
     writable: { type: Boolean, default: true },
@@ -49,12 +46,6 @@ const canShowCollectionDetails = computed(() => props.itemUrls.showDetails);
 
 const showCollectionDetailsUrl = computed(() => prependPath(props.itemUrls.showDetails));
 
-const isDisplaying = computed(() => route.path === displayUrl.value);
-
-const isEditing = computed(() => route.path === editUrl.value);
-
-const isShowingDetails = computed(() => route.path === showCollectionDetailsUrl.value);
-
 const tabindex = computed(() => (props.keyboardSelectable ? "0" : "-1"));
 
 function onDelete($event: MouseEvent) {
@@ -93,7 +84,7 @@ function onDisplay($event: MouseEvent) {
             class="collection-job-details-btn px-1"
             title="Show Details"
             size="sm"
-            :variant="!isShowingDetails ? 'link' : 'primary'"
+            variant="link"
             :href="showCollectionDetailsUrl"
             @click.prevent.stop="emit('showCollectionInfo')">
             <icon icon="info-circle" />
@@ -106,7 +97,7 @@ function onDisplay($event: MouseEvent) {
             :tabindex="tabindex"
             class="display-btn px-1"
             size="sm"
-            :variant="!isDisplaying ? 'link' : 'primary'"
+            variant="link"
             :href="displayUrl"
             @click.prevent.stop="onDisplay($event)">
             <icon icon="eye" />
@@ -118,7 +109,7 @@ function onDisplay($event: MouseEvent) {
             :tabindex="tabindex"
             class="edit-btn px-1"
             size="sm"
-            :variant="!isEditing ? 'link' : 'primary'"
+            variant="link"
             :href="editUrl"
             @click.prevent.stop="emit('edit')">
             <icon icon="pen" />

--- a/client/src/components/History/Content/GenericElement.test.js
+++ b/client/src/components/History/Content/GenericElement.test.js
@@ -1,9 +1,14 @@
 import { mount } from "@vue/test-utils";
 import { getLocalVue } from "tests/jest/helpers";
+import VueRouter from "vue-router";
 
 import GenericElement from "./GenericElement";
 
+jest.mock("components/History/model/queries");
+
 const localVue = getLocalVue();
+localVue.use(VueRouter);
+const router = new VueRouter();
 
 describe("GenericElement", () => {
     let wrapper;
@@ -54,6 +59,7 @@ describe("GenericElement", () => {
                 },
             },
             localVue,
+            router,
         });
     });
 

--- a/client/src/components/History/HistoryView.test.js
+++ b/client/src/components/History/HistoryView.test.js
@@ -67,6 +67,7 @@ async function createWrapper(localVue, currentUserId, history) {
         localVue,
         stubs: {
             icon: { template: "<div></div>" },
+            ContentItem: true,
         },
         provide: {
             store: {
@@ -119,14 +120,13 @@ describe("History center panel View", () => {
         // parts of the layout that should be similar for all cases
         expectCorrectLayout(wrapper);
 
-        // all history items, make sure all show up with hids and names
-        const historyItems = wrapper.findAll(".content-item");
+        // make sure all history items show up
+        const historyItems = wrapper.findAll("contentitem-stub");
         expect(historyItems.length).toBe(10);
         for (let i = 0; i < historyItems.length; i++) {
             const hid = historyItems.length - i;
-            const itemHeader = historyItems.at(i).find("[data-description='content item header info']");
-            const headerText = `${hid}: Dataset ${hid}`;
-            expect(itemHeader.text()).toBe(headerText);
+            expect(historyItems.at(i).attributes("id")).toBe(`${hid}`);
+            expect(historyItems.at(i).attributes("name")).toBe(`Dataset ${hid}`);
         }
     });
 

--- a/client/src/components/JobParameters/JobParameters.test.ts
+++ b/client/src/components/JobParameters/JobParameters.test.ts
@@ -46,6 +46,7 @@ describe("JobParameters/JobParameters.vue", () => {
             propsData,
             stubs: {
                 DatasetProvider: DatasetProvider,
+                ContentItem: true,
             },
             pinia,
         });
@@ -54,12 +55,18 @@ describe("JobParameters/JobParameters.vue", () => {
         const checkTableParameter = (
             element: Wrapper<any>,
             expectedTitle: string,
-            expectedValue: string,
+            expectedValue: string | { hid: number; name: string },
             link?: string
         ) => {
             const tds = element.findAll("td");
             expect(tds.at(0).text()).toBe(expectedTitle);
-            expect(tds.at(1).text()).toContain(expectedValue);
+            if (typeof expectedValue === "string") {
+                expect(tds.at(1).text()).toContain(expectedValue);
+            } else {
+                const contentItem = tds.at(1).find("contentitem-stub");
+                expect(contentItem.attributes("id")).toBe(`${expectedValue.hid}`);
+                expect(contentItem.attributes("name")).toBe(expectedValue.name);
+            }
             if (link) {
                 const a_element = tds.at(1).find("a");
                 expect(a_element.attributes("href")).toBe(link);
@@ -74,7 +81,7 @@ describe("JobParameters/JobParameters.vue", () => {
         expect(elements.length).toBe(3);
 
         checkTableParameter(elements.at(0), "Add this value", "22", undefined);
-        checkTableParameter(elements.at(1), linkParam.text, `${raw.hid}: ${raw.name}`, undefined);
+        checkTableParameter(elements.at(1), linkParam.text, { hid: raw.hid, name: raw.name }, undefined);
         checkTableParameter(elements.at(2), "Iterate?", "NO", undefined);
     });
 
@@ -89,6 +96,7 @@ describe("JobParameters/JobParameters.vue", () => {
                 propsData,
                 stubs: {
                     DatasetProvider: DatasetProvider,
+                    ContentItem: true,
                 },
                 pinia,
             });


### PR DESCRIPTION
Fixes #16784 

Indicates which dataset is currently being viewed/edited in `ContentItem` using a left-border:

https://github.com/galaxyproject/galaxy/assets/78516064/e3c4919d-a4d4-4c73-b5e5-159d25f2a1cc


https://github.com/galaxyproject/galaxy/assets/78516064/03f53655-6235-4889-aedd-6b5fd4407430


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
