### PR TITLE
Allow partial matches in workflow name tag search and search all tags for unquoted query

### DIFF
--- a/client/src/components/Page/PageList.vue
+++ b/client/src/components/Page/PageList.vue
@@ -100,7 +100,7 @@ import StatelessTags from "components/TagsMultiselect/StatelessTags";
 import UtcDate from "components/UtcDate";
 import paginationMixin from "components/Workflow/paginationMixin";
 import { getAppRoot } from "onload/loadConfig";
-import Filtering, { contains, equals, expandNameTagWithQuotes, toBool } from "utils/filtering";
+import Filtering, { contains, equals, expandNameTag, toBool } from "utils/filtering";
 import _l from "utils/localization";
 import { useRouter } from "vue-router/composables";
 
@@ -155,7 +155,7 @@ const validFilters = {
     tag: {
         placeholder: "tag(s)",
         type: "MultiTags",
-        handler: contains("tag", "tag", expandNameTagWithQuotes),
+        handler: contains("tag", "tag", expandNameTag),
         menuItem: true,
     },
     published: {

--- a/client/src/components/Workflow/WorkflowFilters.js
+++ b/client/src/components/Workflow/WorkflowFilters.js
@@ -1,4 +1,4 @@
-import Filtering, { contains, equals, expandNameTagWithQuotes, toBool } from "utils/filtering";
+import Filtering, { contains, equals, expandNameTag, toBool } from "utils/filtering";
 
 export const helpHtml = `<div>
 <p>This input can be used to filter the workflows displayed.</p>
@@ -56,7 +56,7 @@ const validFilters = {
     tag: {
         placeholder: "tag(s)",
         type: "MultiTags",
-        handler: contains("tag", "tag", expandNameTagWithQuotes),
+        handler: contains("tag", "tag", expandNameTag),
         menuItem: true,
     },
     published: {

--- a/client/src/utils/filtering.ts
+++ b/client/src/utils/filtering.ts
@@ -553,7 +553,10 @@ export default class Filtering<T> {
         ) {
             const { converter } = this.validFilters[filterName]?.handler as HandlerReturn<T>;
             if (converter) {
-                if ((converter == toBool && filterValue == "any") || /^(['"]).*\1$/.test(filterValue as string)) {
+                if (
+                    (converter == toBool && filterValue == "any") ||
+                    (!backendFormatted && /^(['"]).*\1$/.test(filterValue as string))
+                ) {
                     return filterValue;
                 } else if (!backendFormatted && ([expandNameTag, toDate] as Converter<T>[]).includes(converter)) {
                     return toLower(filterValue) as T;

--- a/client/src/utils/filtering.ts
+++ b/client/src/utils/filtering.ts
@@ -553,7 +553,7 @@ export default class Filtering<T> {
         ) {
             const { converter } = this.validFilters[filterName]?.handler as HandlerReturn<T>;
             if (converter) {
-                if (converter == toBool && filterValue == "any") {
+                if ((converter == toBool && filterValue == "any") || /^(['"]).*\1$/.test(filterValue as string)) {
                     return filterValue;
                 } else if (!backendFormatted && ([expandNameTag, toDate] as Converter<T>[]).includes(converter)) {
                     return toLower(filterValue) as T;

--- a/client/src/utils/filtering.ts
+++ b/client/src/utils/filtering.ts
@@ -108,25 +108,13 @@ export function toLowerNoQuotes<T>(value: T): string {
  * */
 export function expandNameTag<T>(value: T): string {
     if (value && typeof value === "string") {
-        value = value.replace(/^#/, "name:") as T;
-    }
-    return toLower(value);
-}
-
-/** Converts name tags starting with "#" to "'name:...'"; forces quotation marks
- * and **is also case-sensitive**
- * @param value
- * @returns Lowercase value with 'name:' replaced with '#'
- */
-export function expandNameTagWithQuotes<T>(value: T): string {
-    if (value && typeof value === "string") {
-        if (value.startsWith("'#") && value.endsWith("'")) {
-            value = value.replace(/^'#/g, "'name:") as T;
-        } else if (value.startsWith("#")) {
-            value = `'name:${value.slice(1)}'` as T;
+        if ((value.startsWith("'#") || value.startsWith('"#')) && (value.endsWith('"') || value.endsWith("'"))) {
+            value = value.replace(/^['"]#/g, "'name:") as T;
+        } else {
+            value = value.replace(/^#/, "name:") as T;
         }
     }
-    return value as string;
+    return toLower(value);
 }
 
 /** Converts string alias to string operator, e.g.: 'gt' to '>'
@@ -569,8 +557,6 @@ export default class Filtering<T> {
                     return filterValue;
                 } else if (!backendFormatted && ([expandNameTag, toDate] as Converter<T>[]).includes(converter)) {
                     return toLower(filterValue) as T;
-                } else if (!backendFormatted && converter == expandNameTagWithQuotes) {
-                    return (filterValue as string).startsWith("#") ? (`'${filterValue}'` as T) : filterValue;
                 }
                 return converter(filterValue);
             } else {

--- a/lib/galaxy/model/index_filter_util.py
+++ b/lib/galaxy/model/index_filter_util.py
@@ -52,7 +52,13 @@ def tag_filter(assocation_model_class, term_text, quoted: bool = False):
             )
     else:
         if not quoted:
-            return assocation_model_class.user_tname.ilike(f"%{term_text}%")
+            return or_(
+                assocation_model_class.user_tname.ilike(f"%{term_text}%"),
+                and_(
+                    assocation_model_class.user_tname.ilike("name"),
+                    assocation_model_class.user_value.ilike(f"%{term_text}%"),
+                ),
+            )
         else:
             return assocation_model_class.user_tname == term_text
 

--- a/lib/galaxy/util/search.py
+++ b/lib/galaxy/util/search.py
@@ -36,7 +36,7 @@ def parse_filters_structured(
     search_space = search_term.replace('"', "'")
     filters = filters or {}
     filter_keys = "|".join(list(filters.keys()))
-    pattern = rf"({filter_keys}):(?:\s+)?([\w-]+|\'.*?\')"
+    pattern = rf"({filter_keys}):(?:\s+)?([\w-]+|'.*?')(:\w+)?"
     reserved = re.compile(pattern)
     parsed_search = ParsedSearch()
     while True:
@@ -52,8 +52,11 @@ def parse_filters_structured(
         else:
             first_group = match.groups()[0]
             if first_group in filters:
+                if match.groups()[0] == "tag" and match.groups()[1] == "name" and match.groups()[2] is not None:
+                    group = match.groups()[1] + match.groups()[2].strip()
+                else:
+                    group = match.groups()[1].strip()
                 filter_as = filters[first_group]
-                group = match.groups()[1].strip()
                 quoted = preserve_quotes and group.startswith("'")
                 parsed_search.add_keyed_term(filter_as, group.replace("'", ""), quoted)
             parsed_search.add_unfiltered_text_terms(search_space[0 : match.start()])

--- a/lib/galaxy_test/selenium/test_workflow_management.py
+++ b/lib/galaxy_test/selenium/test_workflow_management.py
@@ -207,10 +207,10 @@ class TestWorkflowManagement(SeleniumTestCase, TestsGalaxyPagers, UsesWorkflowAs
         self.components.workflows.advanced_search_toggle.wait_for_and_click()
         # search by 2 tags, one of which is not present
         self.components.workflows.advanced_search_tag_input.wait_for_and_click()
-        self.tagging_add(["mytag", "DNEtag"])
+        self.tagging_add(["'mytag'", "'DNEtag'"])
         self.components.workflows.advanced_search_submit.wait_for_and_click()
         curr_value = self.workflow_index_get_current_filter()
-        assert curr_value == "tag:mytag tag:DNEtag", curr_value
+        assert curr_value == "tag:'mytag' tag:'DNEtag'", curr_value
         self._assert_showing_n_workflows(0)
 
     @selenium_test


### PR DESCRIPTION
Changes made here:
- Allow partial matches for #name tags as well: therefore, also don't require quotations for name tags
   
    https://github.com/galaxyproject/galaxy/assets/78516064/7e118e86-a2f2-494d-9a5a-27f2823b5126


- Search all tags for unquoted (non-name tag) query. Fixes #16843 
   
   https://github.com/galaxyproject/galaxy/assets/78516064/19a028d7-e531-4ee1-b20e-26360d4b06b1


   

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
