### PR TITLE
[23.1] Allow referring to steps by label only in markdown editor

### DIFF
--- a/client/src/components/Markdown/MarkdownToolBox.vue
+++ b/client/src/components/Markdown/MarkdownToolBox.vue
@@ -258,8 +258,8 @@ export default {
             const steps = [];
             this.steps &&
                 Object.values(this.steps).forEach((step) => {
-                    if (step.label || step.content_id) {
-                        steps.push(step.label || step.content_id);
+                    if (step.label) {
+                        steps.push(step.label);
                     }
                 });
             return steps;

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -749,7 +749,8 @@ history_dataset_collection_display(input={})
             target_match = step_match
             name = find_non_empty_group(target_match)
             ref_object_type = "job"
-            ref_object = invocation.step_invocation_for_label(name).job
+            invocation_step = invocation.step_invocation_for_label(name)
+            ref_object = invocation_step and invocation_step.job
         else:
             target_match = None
             ref_object = None


### PR DESCRIPTION
It does not make sense to use content_id (this is typically the tool id): it's not unique, and it changes when you update tools in a workflow. This has caused:

```
AttributeError: 'NoneType' object has no attribute 'job'
  File "galaxy/web/framework/decorators.py", line 337, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/api/workflows.py", line 926, in show_invocation_report
    return self.workflow_manager.get_invocation_report(trans, invocation_id, **kwd)
  File "galaxy/managers/workflows.py", line 399, in get_invocation_report
    return generate_report(
  File "galaxy/workflow/reports/__init__.py", line 14, in generate_report
    return plugin.generate_report_json(trans, invocation, runtime_report_config_json=runtime_report_config_json)
  File "galaxy/workflow/reports/generators/__init__.py", line 42, in generate_report_json
    internal_markdown = self._generate_internal_markdown(
  File "galaxy/workflow/reports/generators/__init__.py", line 72, in _generate_internal_markdown
    internal_markdown = resolve_invocation_markdown(trans, invocation, workflow_markdown)
  File "galaxy/managers/markdown_util.py", line 770, in resolve_invocation_markdown
    galaxy_markdown = _remap_galaxy_markdown_calls(_remap, workflow_markdown)
  File "galaxy/managers/markdown_util.py", line 815, in _remap_galaxy_markdown_calls
    return _remap_galaxy_markdown_containers(_remap_container, markdown)
  File "galaxy/managers/markdown_util.py", line 783, in _remap_galaxy_markdown_containers
    (replacement, whole_block) = func(replace)
  File "galaxy/managers/markdown_util.py", line 811, in _remap_container
    return func(match.group(1), f"{matching_line}\n")
  File "galaxy/managers/markdown_util.py", line 752, in _remap
    ref_object = invocation.step_invocation_for_label(name).job
```
from https://sentry.galaxyproject.org/organizations/galaxy/issues/128004/?project=3&query=is%3Aunresolved&referrer=issue-stream

and I don't think this has ever worked.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
