### PR TITLE
[23.1] Fix safe update version handling in run form

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -301,6 +301,21 @@ WORKFLOW_SAFE_TOOL_VERSION_UPDATES = {
 }
 
 
+def get_safe_version(tool: "Tool", requested_tool_version: str) -> Optional[str]:
+    if tool.id:
+        safe_version = WORKFLOW_SAFE_TOOL_VERSION_UPDATES.get(tool.id)
+        if (
+            safe_version
+            and tool.lineage
+            and safe_version.current_version >= parse_version(requested_tool_version) >= safe_version.min_version
+        ):
+            # tool versions are sorted from old to new, so check newest version first
+            for lineage_version in reversed(tool.lineage.tool_versions):
+                if safe_version.current_version >= parse_version(lineage_version) >= safe_version.min_version:
+                    return lineage_version
+    return None
+
+
 class ToolNotFoundException(Exception):
     pass
 

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1706,9 +1706,9 @@ class ToolModule(WorkflowModule):
             )
         if self.tool:
             current_tool_version = str(self.tool.version)
-            if tool_version and exact_tools and self.tool_version and self.tool_version != current_tool_version:
+            if exact_tools and self.tool_version and self.tool_version != current_tool_version:
                 safe_version = get_safe_version(self.tool, self.tool_version)
-                if safe_version and self.tool.lineage:
+                if safe_version:
                     self.tool = trans.app.toolbox.get_tool(
                         tool_id, tool_version=safe_version, exact=True, tool_uuid=tool_uuid
                     )

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -47,11 +47,10 @@ from galaxy.schema.invocation import (
 )
 from galaxy.tool_util.cwl.util import set_basename_and_derived_properties
 from galaxy.tool_util.parser.output_objects import ToolExpressionOutput
-from galaxy.tool_util.version import parse_version
 from galaxy.tools import (
     DatabaseOperationTool,
     DefaultToolState,
-    WORKFLOW_SAFE_TOOL_VERSION_UPDATES,
+    get_safe_version,
 )
 from galaxy.tools.actions import filter_output
 from galaxy.tools.execute import (
@@ -1706,21 +1705,14 @@ class ToolModule(WorkflowModule):
                 tool_id, tool_version=tool_version, exact=exact_tools, tool_uuid=tool_uuid
             )
         if self.tool:
-            current_tool_id = self.tool.id
             current_tool_version = str(self.tool.version)
-            if tool_version and exact_tools and self.tool_version != current_tool_version:
-                safe_version = WORKFLOW_SAFE_TOOL_VERSION_UPDATES.get(current_tool_id)
-                safe_version_found = False
+            if tool_version and exact_tools and self.tool_version and self.tool_version != current_tool_version:
+                safe_version = get_safe_version(self.tool, self.tool_version)
                 if safe_version and self.tool.lineage:
-                    # tool versions are sorted from old to new, so check newest version first
-                    for lineage_version in reversed(self.tool.lineage.tool_versions):
-                        if safe_version.current_version >= parse_version(lineage_version) >= safe_version.min_version:
-                            self.tool = trans.app.toolbox.get_tool(
-                                tool_id, tool_version=lineage_version, exact=True, tool_uuid=tool_uuid
-                            )
-                            safe_version_found = True
-                            break
-                if not safe_version_found:
+                    self.tool = trans.app.toolbox.get_tool(
+                        tool_id, tool_version=safe_version, exact=True, tool_uuid=tool_uuid
+                    )
+                else:
                     log.info(
                         f"Exact tool specified during workflow module creation for [{tool_id}] but couldn't find correct version [{tool_version}]."
                     )
@@ -1799,7 +1791,9 @@ class ToolModule(WorkflowModule):
                     new_tool_shed_url = new_url.split("/view")[0]
                     message += f'The tool \'{module.tool.name}\', version {tool_version} by the owner {module.tool.repository_owner} installed from <a href="{old_url}" target="_blank">{old_tool_shed_url}</a> is not available. '
                     message += f'A derivation of this tool installed from <a href="{new_url}" target="_blank">{new_tool_shed_url}</a> will be used instead. '
-            if step.tool_version and (step.tool_version != module.tool.version):
+            if step.tool_version and (
+                step.tool_version != module.tool.version and not get_safe_version(module.tool, step.tool_version)
+            ):
                 message += f"<span title=\"tool id '{step.tool_id}'\">Using version '{module.tool.version}' instead of version '{step.tool_version}' specified in this workflow. "
             if message:
                 log.debug(message)


### PR DESCRIPTION
That was the intention when we first added WORKFLOW_SAFE_TOOL_VERSION_UPDATES ... there's no reason to bother users with tool updates to built-in tools that don't alter the structure of the workflow.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
