### PR TITLE
[23.1] Fix workflow import losing tool_version

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7765,6 +7765,7 @@ class WorkflowStep(Base, RepresentById):
         copied_step.order_index = self.order_index
         copied_step.type = self.type
         copied_step.tool_id = self.tool_id
+        copied_step.tool_version = self.tool_version
         copied_step.tool_inputs = self.tool_inputs
         copied_step.tool_errors = self.tool_errors
         copied_step.position = self.position

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1161,6 +1161,14 @@ steps:
             self._assert_status_code_is(other_import_response, 200)
             self._assert_user_has_workflow_with_name("imported: test_import_published")
 
+    def test_import_published_api(self):
+        workflow_id = self.workflow_populator.simple_workflow("test_import_published", publish=True)
+        with self._different_user():
+            other_import_response = self.__import_workflow(workflow_id, deprecated_route=False)
+            self._assert_status_code_is(other_import_response, 200)
+            workflow = self._download_workflow(other_import_response.json()["id"])
+            assert workflow["steps"]["2"]["tool_version"] == "1.0.0"
+
     def test_export(self):
         uploaded_workflow_id = self.workflow_populator.simple_workflow("test_for_export")
         downloaded_workflow = self._download_workflow(uploaded_workflow_id)


### PR DESCRIPTION
Didn't have much of an impact on workflows using mostly tool shed tools, but this can be the difference between the workflow working fine for the author, but not for a user importing the workflow if the workflow uses a non-default built-in tool version.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
