### PR TITLE
[23.1] Fix delete collection + elements

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -63,7 +63,7 @@
                     :state="state"
                     :item-urls="itemUrls"
                     :keyboard-selectable="expandDataset"
-                    @delete="$emit('delete')"
+                    @delete="onDelete"
                     @display="onDisplay"
                     @showCollectionInfo="onShowCollectionInfo"
                     @edit="onEdit"
@@ -233,6 +233,9 @@ export default {
             } else {
                 this.$router.push(this.itemUrls.display, { title: this.name });
             }
+        },
+        onDelete(recursive = false) {
+            this.$emit("delete", this.item, recursive);
         },
         onDragStart(evt) {
             setDrag(evt, this.item);

--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -1,5 +1,5 @@
 <template>
-    <span class="align-self-start btn-group">
+    <span class="align-self-start btn-group align-items-baseline">
         <!-- Special case for collections -->
         <b-button
             v-if="isCollection && canShowCollectionDetails"
@@ -43,8 +43,21 @@
             title="Delete"
             size="sm"
             variant="link"
-            @click.stop="$emit('delete')">
-            <icon icon="trash" />
+            @click.stop="onDelete($event)">
+            <icon v-if="isDataset" icon="trash" />
+            <b-dropdown v-else ref="deleteCollectionMenu" size="sm" variant="link" no-caret toggle-class="p-0 m-0">
+                <template v-slot:button-content>
+                    <icon icon="trash" />
+                </template>
+                <b-dropdown-item title="Delete collection Only" @click.prevent.stop="onDeleteItem">
+                    <icon icon="file" />
+                    Collection only
+                </b-dropdown-item>
+                <b-dropdown-item title="Delete collection and elements" @click.prevent.stop="onDeleteItemRecursively">
+                    <icon icon="copy" />
+                    Collection and elements
+                </b-dropdown-item>
+            </b-dropdown>
         </b-button>
         <b-button
             v-if="writable && isHistoryItem && isDeleted"
@@ -130,6 +143,26 @@ export default {
                 this.$emit("display");
             }
         },
+        onDelete() {
+            if (this.isCollection) {
+                this.$refs.deleteCollectionMenu.show();
+            } else {
+                this.onDeleteItem();
+            }
+        },
+        onDeleteItem() {
+            this.$emit("delete");
+        },
+        onDeleteItemRecursively() {
+            const recursive = true;
+            this.$emit("delete", recursive);
+        },
     },
 };
 </script>
+<style lang="css">
+.dropdown-menu .dropdown-item {
+    font-weight: normal;
+}
+</style>
+```

--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -49,7 +49,7 @@
                 <template v-slot:button-content>
                     <icon icon="trash" />
                 </template>
-                <b-dropdown-item title="Delete collection Only" @click.prevent.stop="onDeleteItem">
+                <b-dropdown-item title="Delete collection only" @click.prevent.stop="onDeleteItem">
                     <icon icon="file" />
                     Collection only
                 </b-dropdown-item>

--- a/client/src/components/History/Content/GenericItem.vue
+++ b/client/src/components/History/Content/GenericItem.vue
@@ -12,7 +12,7 @@
                 :is-dataset="item.history_content_type == 'dataset' || item.element_type == 'hda'"
                 @update:expand-dataset="expandDataset = $event"
                 @view-collection="viewCollection = !viewCollection"
-                @delete="onDelete(item)"
+                @delete="onDelete"
                 @toggleHighlights="onHighlight(item)"
                 @undelete="onUndelete(item)"
                 @unhide="onUnhide(item)" />
@@ -74,8 +74,8 @@ export default {
     },
     methods: {
         ...mapActions(useHistoryStore, ["applyFilters"]),
-        onDelete(item) {
-            deleteContent(item);
+        onDelete(item, recursive = false) {
+            deleteContent(item, { recursive: recursive });
         },
         onUndelete(item) {
             updateContentFields(item, { deleted: false });

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -127,7 +127,7 @@
                                     @update:expand-dataset="setExpanded(item, $event)"
                                     @update:selected="setSelected(item, $event)"
                                     @view-collection="$emit('view-collection', item, currentOffset)"
-                                    @delete="onDelete(item)"
+                                    @delete="onDelete"
                                     @undelete="onUndelete(item)"
                                     @unhide="onUnhide(item)" />
                             </template>
@@ -357,9 +357,9 @@ export default {
                 this.loading = false;
             }
         },
-        onDelete(item) {
+        onDelete(item, recursive = false) {
             this.setInvisible(item);
-            deleteContent(item);
+            deleteContent(item, { recursive: recursive });
         },
         onHideSelection(selectedItems) {
             selectedItems.forEach((item) => {

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -7,12 +7,6 @@ history.
 import logging
 from typing import Dict
 
-from sqlalchemy import (
-    false,
-    func,
-    select,
-)
-
 from galaxy import model
 from galaxy.managers import (
     annotatable,
@@ -108,32 +102,6 @@ class HDCAManager(
     def update_attributes(self, content, payload: Dict):
         # pre-requisite checked that attributes are valid
         self.map_datasets(content, fn=lambda item, *args: set_collection_attributes(item, payload.items()))
-
-    def delete(self, item, flush=True, **kwargs):
-        super().delete(item, flush=flush, **kwargs)
-        self.map_datasets(item, fn=self._delete_hda_if_orphaned_and_hidden)
-
-    def _delete_hda_if_orphaned_and_hidden(self, dataset, *parents):
-        if isinstance(dataset, model.HistoryDatasetAssociation):
-            if not dataset.deleted and not dataset.purged and not dataset.visible:
-                if not self._is_hda_used_in_multiple_active_collections(dataset):
-                    super().delete(dataset, flush=False)
-
-    def _is_hda_used_in_multiple_active_collections(self, dataset: model.HistoryDatasetAssociation):
-        stmt = (
-            select(func.count(model.DatasetCollectionElement.id))
-            .join(
-                model.HistoryDatasetCollectionAssociation,
-                model.DatasetCollectionElement.dataset_collection_id
-                == model.HistoryDatasetCollectionAssociation.collection_id,
-            )
-            .where(
-                model.DatasetCollectionElement.hda_id == dataset.id,
-                model.HistoryDatasetCollectionAssociation.deleted == false(),
-            )
-        )
-        usage_count = self.session().execute(stmt).scalar()
-        return usage_count > 1
 
 
 # serializers

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1416,10 +1416,6 @@ class HistoryItemOperator:
         item.visible = True
 
     def _delete(self, item: HistoryItemModel, trans: ProvidesHistoryContext):
-        if getattr(item, "deleted", False):
-            # TODO: remove this `update` when we can properly track the operation results to notify the history
-            item.update()
-            return
         if isinstance(item, HistoryDatasetCollectionAssociation):
             return self.dataset_collection_manager.delete(trans, "history", item.id, recursive=True, purge=False)
         return self.hda_manager.delete(item, flush=self.flush)

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1384,7 +1384,7 @@ class HistoryItemOperator:
         self._operation_map: Dict[HistoryContentItemOperation, ItemOperation] = {
             HistoryContentItemOperation.hide: lambda item, params, trans: self._hide(item),
             HistoryContentItemOperation.unhide: lambda item, params, trans: self._unhide(item),
-            HistoryContentItemOperation.delete: lambda item, params, trans: self._delete(item),
+            HistoryContentItemOperation.delete: lambda item, params, trans: self._delete(item, trans),
             HistoryContentItemOperation.undelete: lambda item, params, trans: self._undelete(item),
             HistoryContentItemOperation.purge: lambda item, params, trans: self._purge(item, trans),
             HistoryContentItemOperation.change_datatype: lambda item, params, trans: self._change_datatype(
@@ -1415,9 +1415,14 @@ class HistoryItemOperator:
     def _unhide(self, item: HistoryItemModel):
         item.visible = True
 
-    def _delete(self, item: HistoryItemModel):
-        manager = self._get_item_manager(item)
-        manager.delete(item, flush=self.flush)
+    def _delete(self, item: HistoryItemModel, trans: ProvidesHistoryContext):
+        if getattr(item, "deleted", False):
+            # TODO: remove this `update` when we can properly track the operation results to notify the history
+            item.update()
+            return
+        if isinstance(item, HistoryDatasetCollectionAssociation):
+            return self.dataset_collection_manager.delete(trans, "history", item.id, recursive=True, purge=False)
+        return self.hda_manager.delete(item, flush=self.flush)
 
     def _undelete(self, item: HistoryItemModel):
         if getattr(item, "purged", False):

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -1028,9 +1028,10 @@ class TestHistoryContentsApiBulkOperation(ApiTestCase):
 
     def test_deleting_collection_should_delete_contents_only_if_orphaned(self):
         with self.dataset_populator.test_history() as history_id:
-            num_expected_collections = 1
+            num_expected_collections = 2
             num_expected_datasets = 2
-            collection_ids = self._create_collection_in_history(history_id, num_expected_collections)
+            # Create original collections and datasets
+            collection_ids = self._create_collection_in_history(history_id, num_collections=1)
             original_collection_id = collection_ids[0]
             # Check datasets are hidden and not deleted
             history_contents = self._get_history_contents(history_id)
@@ -1069,8 +1070,12 @@ class TestHistoryContentsApiBulkOperation(ApiTestCase):
             bulk_operation_result = self._apply_bulk_operation(history_id, payload)
             self._assert_bulk_success(bulk_operation_result, 1)
 
-            # Check datasets are still not deleted
+            # We expect the original collection, the new collection and the datasets shared by both
+            num_expected_history_contents = num_expected_datasets + num_expected_collections
+
             history_contents = self._get_history_contents(history_id)
+            assert len(history_contents) == num_expected_history_contents
+            # Check datasets are still not deleted
             for item in history_contents:
                 if item["history_content_type"] == "dataset":
                     assert item["deleted"] is False
@@ -1090,6 +1095,7 @@ class TestHistoryContentsApiBulkOperation(ApiTestCase):
 
             # Check datasets are deleted (and collections too)
             history_contents = self._get_history_contents(history_id)
+            assert len(history_contents) == num_expected_history_contents
             for item in history_contents:
                 assert item["deleted"] is True
 


### PR DESCRIPTION
Fixes #16866

Before this fix, deleting a collection will only mark the HDCA as deleted but not the contained elements. There are currently 2 ways of deleting collections from the History Panel:

### Using the "Trash" icon in a collection

  We used to display (in the old history) a menu when deleting a single collection to choose to also delete its contents, this menu is now back to help mitigate this issue https://github.com/galaxyproject/galaxy/issues/16866#issuecomment-1768097231
    ![image](https://github.com/galaxyproject/galaxy/assets/46503462/5c2e1155-8360-4e94-8687-610d30b486c6)

### Using the "bulk delete" operation and including collections in the selection

  When deleting collections in bulk, we cannot present this choice for the user, we need to decide the default behavior (delete elements too vs only HCDA). Since using the "bulk purge" when there are collections in the selection will also purge its items, for consistency, using the "bulk delete" will now also mark elements as deleted in the same way.
    ![DeleteCollectionBulk](https://github.com/galaxyproject/galaxy/assets/46503462/a6893ef6-e366-4fdf-b52a-b3ee66d1c000)


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  - Follow the instructions in #16866

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
