### PR TITLE
Drop unused HistoryContentManager code and related tests

### DIFF
--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -98,24 +98,6 @@ class HistoryContentsManager(base.SortableManager):
         self.subcontainer_manager = app[self.subcontainer_class_manager_class]
 
     # ---- interface
-    def contained(self, container, filters=None, limit=None, offset=None, order_by=None, **kwargs):
-        """
-        Returns non-subcontainer objects within `container`.
-        """
-        filter_to_inside_container = self._get_filter_for_contained(container, self.contained_class)
-        filters = base.munge_lists(filter_to_inside_container, filters)
-        return self.contained_manager.list(filters=filters, limit=limit, offset=offset, order_by=order_by, **kwargs)
-
-    def subcontainers(self, container, filters=None, limit=None, offset=None, order_by=None, **kwargs):
-        """
-        Returns only the containers within `container`.
-        """
-        filter_to_inside_container = self._get_filter_for_contained(container, self.subcontainer_class)
-        filters = base.munge_lists(filter_to_inside_container, filters)
-        # TODO: collections.DatasetCollectionManager doesn't have the list
-        # return self.subcontainer_manager.list( filters=filters, limit=limit, offset=offset, order_by=order_by, **kwargs )
-        return self._session().query(self.subcontainer_class).filter(filters).all()
-
     def contents(self, container, filters=None, limit=None, offset=None, order_by=None, **kwargs):
         """
         Returns a list of both/all types of contents, filtered and in some order.
@@ -241,15 +223,6 @@ class HistoryContentsManager(base.SortableManager):
     # ---- private
     def _session(self):
         return self.app.model.context
-
-    def _filter_to_contents_query(self, container, content_class, **kwargs):
-        # TODO: use list (or by_history etc.)
-        container_filter = self._get_filter_for_contained(container, content_class)
-        query = self._session().query(content_class).filter(container_filter)
-        return query
-
-    def _get_filter_for_contained(self, container, content_class):
-        return content_class.history == container
 
     def _union_of_contents(self, container, expand_models=True, **kwargs):
         """

--- a/test/unit/app/managers/test_HistoryContentsManager.py
+++ b/test/unit/app/managers/test_HistoryContentsManager.py
@@ -73,19 +73,6 @@ class TestHistoryAsContainer(HistoryAsContainerBaseTestCase):
         all_contents = list(self.contents_manager.contents(history))
         assert all_contents == list(ordered_hda_contents) + [hdca]
 
-    def test_contained(self):
-        user2 = self.user_manager.create(**user2_data)
-        self.trans.set_user(user2)
-        history = self.history_manager.create(name="history", user=user2)
-
-        self.log("calling contained on an empty history should return an empty list")
-        assert [] == list(self.contents_manager.contained(history))
-
-        self.log("calling contained on an history with both hdas and collections should return only hdas")
-        hdas = [self.add_hda_to_history(history, name=("hda-" + str(x))) for x in range(3)]
-        self.add_list_collection_to_history(history, hdas)
-        assert list(self.contents_manager.contained(history)) == hdas
-
     def test_copy_elements_on_collection_creation(self):
         user2 = self.user_manager.create(**user2_data)
         self.trans.set_user(user2)
@@ -96,20 +83,6 @@ class TestHistoryAsContainer(HistoryAsContainerBaseTestCase):
 
         hdca = self.add_list_collection_to_history(history, hdas, copy_elements=True)
         assert hdas != hdca.dataset_instances
-
-    def test_subcontainers(self):
-        user2 = self.user_manager.create(**user2_data)
-        self.trans.set_user(user2)
-        history = self.history_manager.create(name="history", user=user2)
-
-        self.log("calling subcontainers on an empty history should return an empty list")
-        assert [] == list(self.contents_manager.subcontainers(history))
-
-        self.log("calling subcontainers on an history with both hdas and collections should return only collections")
-        hdas = [self.add_hda_to_history(history, name=("hda-" + str(x))) for x in range(3)]
-        hdca = self.add_list_collection_to_history(history, hdas)
-        subcontainers = list(self.contents_manager.subcontainers(history))
-        assert subcontainers == [hdca]
 
     def test_limit_and_offset(self):
         user2 = self.user_manager.create(**user2_data)
@@ -226,10 +199,6 @@ class TestHistoryAsContainer(HistoryAsContainerBaseTestCase):
         # find 'hda-4'
         assert [contents[4]] == self.contents_manager.contents(
             history, filters=[parsed_filter("orm", HDA.name.like("%-4"))]
-        )
-        # the collections added above have the default name 'test collection'
-        assert self.contents_manager.subcontainers(history) == self.contents_manager.contents(
-            history, filters=[parsed_filter("orm", HDA.name.like("%collect%"))]
         )
 
     def test_order_by(self):


### PR DESCRIPTION
Discovered while upgrading SQLAlchemy code.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
