### PR TITLE
Add test and doc showing how dynamic selects are used

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4118,10 +4118,12 @@ dataset for the contained input of the type specified using the ``type`` tag.
   <xs:complexType name="ParamOptions">
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
+This tag set is optionally contained within the ``<param>`` tag when the
+``type`` attribute value is ``select`` or ``data`` and used to dynamically
+generated lists of options.
 See [/tools/extract/liftOver_wrapper.xml](https://github.com/galaxyproject/galaxy/blob/dev/tools/extract/liftOver_wrapper.xml)
-for an example of how to use this tag set. This tag set is optionally contained
-within the ``<param>`` tag when the ``type`` attribute value is ``select`` or
-``data`` and used to dynamically generated lists of options.
+and [test/functional/tools/select_dynamic.xml](https://github.com/galaxyproject/galaxy/blob/dev/test/functional/tools/select_dynamic.xml)
+for an examples of how to use this tag set.
 
 For data parameters this tag can be used to restrict possible input datasets to datasets that match the ``dbkey`` of another data input by including a ``data_meta`` filter. See for
 instance here: [/tools/maf/interval2maf.xml](https://github.com/galaxyproject/galaxy/blob/dev/tools/maf/interval2maf.xml)

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -135,6 +135,7 @@
   <tool file="column_param_list.xml" />
   <tool file="column_multi_param.xml" />
   <tool file="select_optional.xml"/>
+  <tool file="select_dynamic.xml"/>
   <tool file="hidden_param.xml" />
   <tool file="special_params.xml" />
   <tool file="section.xml" />

--- a/test/functional/tools/select_dynamic.xml
+++ b/test/functional/tools/select_dynamic.xml
@@ -1,0 +1,53 @@
+<!-- test how dynamic selects are used in the command section -->
+<tool id="select_dynamic" name="Dynamic select" version="1.0.0" profile="22.05">
+    <command><![CDATA[
+        echo "select $select" >> '$output1' &&
+        echo "select path $select.fields.path" >> '$output1' &&
+
+        echo "select_mult $select_mult" >> '$output1'
+        #for i, o in enumerate($select_mult)
+            && echo "select_mult $i $o" >> '$output1'
+        #end for 
+    ]]></command>
+    <inputs>
+        <param name="select" type="select" optional="true">
+            <options from_data_table="test_fasta_indexes">
+            </options>
+        </param>
+        <param name="select_mult" type="select" optional="true" multiple="true">
+            <options from_data_table="test_fasta_indexes">
+                <column name="name" index="2"/>
+                <column name="value" index="3"/>
+            </options>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="output1" format="tabular" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="select" value="hg19_name"/>
+            <param name="select_mult" value="hg19_name,hg18_name"/>
+            <output name="output1">
+                <assert_contents>
+                    <has_line line="select hg19_value" />
+                    <has_line line="select path hg19_path" />
+                    <has_line line="select_mult hg19_path,hg18_path" />
+                    <has_line line="select_mult 0 hg19_path" />
+                    <has_line line="select_mult 1 hg18_path" />
+                    <has_n_lines n="5"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <output name="output1">
+                <assert_contents>
+                    <has_line line="select None" />
+                    <has_line line="select path " />
+                    <has_line line="select_mult None" />
+                    <has_n_lines n="3" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/select_dynamic.xml
+++ b/test/functional/tools/select_dynamic.xml
@@ -4,10 +4,19 @@
         echo "select $select" >> '$output1' &&
         echo "select path $select.fields.path" >> '$output1' &&
 
+        ## direct access to the select parameter gives a comma sepated list of the `value`s
         echo "select_mult $select_mult" >> '$output1'
+        ## looping over the select parameter gives the `value`s
         #for i, o in enumerate($select_mult)
             && echo "select_mult $i $o" >> '$output1'
-        #end for 
+        #end for
+        ## acessing fields gives comma separated properties
+        ## and in case nothing is selected empty string
+        && echo "select_mult real_value $select_mult.fields.real_value" >> '$output1' 
+        && echo "select_mult dbkey $select_mult.fields.dbkey" >> '$output1' 
+        && echo "select_mult name $select_mult.fields.name" >> '$output1' 
+        && echo "select_mult path $select_mult.fields.path"  >> '$output1'
+        && echo "select_mult value $select_mult.fields.value" >> '$output1' 
     ]]></command>
     <inputs>
         <param name="select" type="select" optional="true">
@@ -16,8 +25,15 @@
         </param>
         <param name="select_mult" type="select" optional="true" multiple="true">
             <options from_data_table="test_fasta_indexes">
+                <!-- all columns that should be accessible via the fields attribute need to be included
+                since the for loop should iterate over the paths column 3 is names value here
+                and the actual value column (0) is "renamed" to real_value  -->
+                <column name="real_value" index="0"/>
+                <column name="dbkey" index="1"/>
                 <column name="name" index="2"/>
                 <column name="value" index="3"/>
+                <!-- same column can be accessible via multiple names-->
+                <column name="path" index="3"/>
             </options>
         </param>
     </inputs>
@@ -35,7 +51,12 @@
                     <has_line line="select_mult hg19_path,hg18_path" />
                     <has_line line="select_mult 0 hg19_path" />
                     <has_line line="select_mult 1 hg18_path" />
-                    <has_n_lines n="5"/>
+                    <has_line line="select_mult real_value hg19_value,hg18_value" />
+                    <has_line line="select_mult dbkey hg19,hg18" />
+                    <has_line line="select_mult name hg19_name,hg18_name" />
+                    <has_line line="select_mult path hg19_path,hg18_path" />
+                    <has_line line="select_mult value hg19_path,hg18_path" />
+                    <has_n_lines n="10"/>
                 </assert_contents>
             </output>
         </test>
@@ -45,7 +66,12 @@
                     <has_line line="select None" />
                     <has_line line="select path " />
                     <has_line line="select_mult None" />
-                    <has_n_lines n="3" />
+                    <has_line line="select_mult real_value " />
+                    <has_line line="select_mult dbkey " />
+                    <has_line line="select_mult name " />
+                    <has_line line="select_mult path " />
+                    <has_line line="select_mult value " />
+                    <has_n_lines n="8" />
                 </assert_contents>
             </output>
         </test>


### PR DESCRIPTION
I struggled to get dynamic selects with `multiple="true"` to work. The problem is that when iterating over the select in the command section one can not access the `fields` property (e.g., `.fields.path`). 

Q: Do we want consistent access to select options for `multiple="true"` and `multiple="false"`. A potential problem is that we can access only the value of one column in the `true` case (whereas we can access all via `fields` in the `false` case).

Docs would also be nice. Where should I put it? https://docs.galaxyproject.org/en/master/dev/schema.html#tool-inputs-param-options? 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
