### PR TITLE
[23.1] Fix History item deletion/undeletion reactivity with filter and `ToolForm` input field

### DIFF
--- a/client/src/components/Form/FormDisplay.vue
+++ b/client/src/components/Form/FormDisplay.vue
@@ -104,7 +104,7 @@ export default {
             visitInputs(this.formInputs, (input, name) => {
                 const newValue = newAttributes[name];
                 if (newValue != undefined) {
-                    input.attributes = newValue;
+                    Vue.set(input, "attributes", newValue);
                 }
             });
             this.onChangeForm();

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -320,13 +320,15 @@ export default {
         ...mapActions(useHistoryItemsStore, ["fetchHistoryItems"]),
         getHighlight(item) {
             const highlightsKey = FilterClass.getFilterValue(this.filterText, "related");
-            if (highlightsKey == item.hid) {
-                return "active";
-            } else if (highlightsKey) {
-                if (item.hid > highlightsKey) {
-                    return "output";
-                } else {
-                    return "input";
+            if (!this.loading) {
+                if (highlightsKey == item.hid) {
+                    return "active";
+                } else if (highlightsKey) {
+                    if (item.hid > highlightsKey) {
+                        return "output";
+                    } else {
+                        return "input";
+                    }
                 }
             } else {
                 return null;

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -206,7 +206,6 @@ export default {
             operationRunning: null,
             operationError: null,
             querySelectionBreak: false,
-            itemsLoaded: [],
         };
     },
     computed: {
@@ -234,6 +233,10 @@ export default {
         /** @returns {Boolean} */
         isProcessing() {
             return this.operationRunning >= this.history.update_time;
+        },
+        /** @returns {Array} */
+        itemsLoaded() {
+            return this.getHistoryItems(this.historyId, this.filterText);
         },
         /** @returns {Date} */
         lastChecked() {
@@ -307,6 +310,15 @@ export default {
         historyUpdateTime() {
             this.loadHistoryItems();
         },
+        itemsLoaded(newItems) {
+            if (this.invisible) {
+                newItems.forEach((item) => {
+                    if (this.invisible[item.hid]) {
+                        Vue.set(this.invisible, item.hid, false);
+                    }
+                });
+            }
+        },
     },
     async mounted() {
         // `filterable` here indicates if this is the current history panel
@@ -353,14 +365,6 @@ export default {
                     console.debug("HistoryPanel - Load items error.", error);
                 }
             } finally {
-                this.itemsLoaded = this.getHistoryItems(this.historyId, this.filterText);
-                if (this.invisible) {
-                    this.itemsLoaded.forEach((item) => {
-                        if (this.invisible[item.hid]) {
-                            Vue.set(this.invisible, item.hid, false);
-                        }
-                    });
-                }
                 this.loading = false;
             }
         },

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -206,6 +206,7 @@ export default {
             operationRunning: null,
             operationError: null,
             querySelectionBreak: false,
+            itemsLoaded: [],
         };
     },
     computed: {
@@ -233,10 +234,6 @@ export default {
         /** @returns {Boolean} */
         isProcessing() {
             return this.operationRunning >= this.history.update_time;
-        },
-        /** @returns {Array} */
-        itemsLoaded() {
-            return this.getHistoryItems(this.historyId, this.filterText);
         },
         /** @returns {Date} */
         lastChecked() {
@@ -346,13 +343,21 @@ export default {
             try {
                 await this.fetchHistoryItems(this.historyId, this.filterText, this.offset);
                 this.searchError = null;
-                this.loading = false;
             } catch (error) {
                 if (error.response && error.response.data && error.response.data.err_msg) {
                     console.debug("HistoryPanel - Load items error:", error.response.data.err_msg);
                     this.searchError = error.response.data;
                 } else {
                     console.debug("HistoryPanel - Load items error.", error);
+                }
+            } finally {
+                this.itemsLoaded = this.getHistoryItems(this.historyId, this.filterText);
+                if (this.invisible) {
+                    this.itemsLoaded.forEach((item) => {
+                        if (this.invisible[item.hid]) {
+                            Vue.set(this.invisible, item.hid, false);
+                        }
+                    });
                 }
                 this.loading = false;
             }


### PR DESCRIPTION
## Reactivity with History filter
If you apply the filter: `deleted:any`, your deleted items come into view along with other active items. But when you undelete an item, there is a bug where it is hidden even though the current filter is `deleted:any`

| Before (Bug)  | After (Fixed) |
| ------------- | ------------- |
| <video src="https://github.com/galaxyproject/galaxy/assets/78516064/77aa0645-1503-49f4-a84d-0695ded9c000"> | <video src="https://github.com/galaxyproject/galaxy/assets/78516064/bfb3e373-1cd0-415b-a92d-287c7ca826ef"> |
| Undeleted item goes away even though filter includes "deleted:any" | Undeleted item comes back into the panel as an active item |

## Reactivity with `FormDisplay` form input
If there is a change in the current history that doesn't affect currently selected item in the Tool form, we do not reflect the change in the select field. Fix:  Do `Vue.set(input, "attributes", newValue);` instead of just `input.attributes = newValue;`

| Before (Bug)  |
| ------------- |
| If you delete/undelete an item in the history that is not already selected in the select field, the field does not react to changes.
| <video src="https://github.com/galaxyproject/galaxy/assets/78516064/9ad78f3d-315e-46a7-9dad-d4cd4d45d3f4"> |

| After (Fixed) |
| ------------- |
| The field now reacts to a change in the current history |
| <video src="https://github.com/galaxyproject/galaxy/assets/78516064/aa1e1d98-4d8b-4f9d-bf18-a5b645a8ce8b"> |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
