### PR TITLE
Fix link to mercurial tip in tool shed 2.0.

### DIFF
--- a/lib/tool_shed/webapp/frontend/src/components/RepositoryExplore.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/RepositoryExplore.vue
@@ -22,7 +22,7 @@ const props = withDefaults(defineProps<RepositoryExploreProps>(), {
 })
 
 const changelog = computed(() => `/repos/${props.repository.owner}/${[props.repository.name]}/shortlog`)
-const contents = computed(() => `/repos/${props.repository.owner}/${[props.repository.name]}/tip`)
+const contents = computed(() => `/repos/${props.repository.owner}/${[props.repository.name]}/rev/tip`)
 function navigate(location: string | null | undefined) {
     if (location) {
         window.location.href = location


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/16815 - thanks to @martenson for the diligence and wonderful bug report. 

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Deploy to test tool shed and verify link is no longer broken.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
