### PR TITLE
Remove record access handling for Invenio RDM plugin

### DIFF
--- a/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
+++ b/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
@@ -99,17 +99,13 @@ preferences:
         description: Your Invenio RDM Integration Settings
         inputs:
             - name: token
-              label: Personal Token to upload files to Invenio RDM
+              label: Personal Token used to create draft records and to upload files
               type: secret
               store: vault # Requires setting up vault_config_file in your galaxy.yml
               required: False
             - name: public_name
-              label: Creator name to associate with new records (formatted as "Last name, First name"). If left blank "Anonymous Galaxy User" will be used.
+              label: Creator name to associate with new records (formatted as "Last name, First name"). If left blank "Anonymous Galaxy User" will be used. You can always change this by editing your record directly.
               type: text
-              required: False
-            - name: public_records
-              label: Whether to make draft records publicly available or restricted.
-              type: boolean
               required: False
 
     # Used in file_sources_conf.yml

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -201,10 +201,7 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
     def create_draft_record(self, title: str, user_context: OptionalUserContext = None) -> RemoteDirectory:
         today = datetime.date.today().isoformat()
         creator = self._get_creator_from_user_context(user_context)
-        public = bool(self.get_user_preference_by_key("public_records", user_context))
-        access = "public" if public else "restricted"
         create_record_request = {
-            "access": {"record": access, "files": access},
             "files": {"enabled": True},
             "metadata": {
                 "title": title,


### PR DESCRIPTION
I was checking the compatibility of the Invenio RDM plugin, with the new version of `Zenodo`, and it seems it doesn't allow access handling through the API using your personal token. So when creating a new record and trying to set the access options it will return a `You don't have permissions to manage record access` error.

In any case, it's safer (and simpler) to always work with `draft` versions of records from Galaxy and leave the publication handling directly to the remote platform (Zenodo/Invenio frontend).

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - You can try this out with the Zenodo Sandbox which already uses the new Invenio-based API:

    ```yml
    # file_sources_conf.yml
    - type: inveniordm
      id: zenodo
      doc: Zenodo RDM Sandbox for testing
      label: Zenodo RDM Sandbox
      url: https://zenodo-rdm-qa.web.cern.ch
      token: ${user.preferences['zenodo|token']}
      public_name: ${user.preferences['zenodo|public_name']}
      writable: true
    
    # user_preferences_extra_conf.yml
        zenodo:
            description: Your Zenodo RDM Account
            inputs:
                - name: token
                  label: Personal Token to publish records to Zenodo RDM
                  type: secret
                  store: vault # Requires setting up vault_config_file in your galaxy.yml
                  required: False
                - name: public_name
                  label: Public name to publish records (formatted as "Lastname, Firstname")
                  type: text
                  required: False
    ```

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
