### PR TITLE
[23.1] Provide error message instead of internal server error

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -488,6 +488,10 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             history_is_current = history_to_view == trans.history
         else:
             history_to_view = trans.history
+            if not history_to_view:
+                raise exceptions.RequestParameterMissingException(
+                    "No 'id' parameter provided for history, and user does not have a current history."
+                )
             user_is_owner = True
             history_is_current = True
 


### PR DESCRIPTION
This is a route pretty much exclusively triggered by bots when hitting usegalaxy.org/history.
The controller route itself is probably something we should get rid of sooner than later, I think this might still be used by the history switcher grid.

Fixes:
```
AttributeError: 'NoneType' object has no attribute 'id'
  File "galaxy/web/framework/decorators.py", line 337, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/controllers/history.py", line 495, in view
    history_dictionary = self.history_serializer.serialize_to_view(
  File "galaxy/managers/base.py", line 816, in serialize_to_view
    return self.serialize(item, all_keys, **context)
  File "galaxy/managers/base.py", line 729, in serialize
    returned[key] = self.serializers[key](item, key, **context)
  File "galaxy/managers/histories.py", line 718, in <lambda>
    "history_contents", history_id=self.app.security.encode_id(item.id), context=context
```
from https://sentry.galaxyproject.org/share/issue/a6a2c1283f514d2f8651784a3a4215a9/

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
