### PR TITLE
[23.1] Fix unbound ``runner`` variable when there is an error in the job config

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -1216,12 +1216,16 @@ class DefaultJobDispatcher:
         except KeyError:
             log.error(f"({job_wrapper.job_id}) Invalid job runner: {runner_name}")
             job_wrapper.fail(DEFAULT_JOB_RUNNER_FAILURE_MESSAGE)
+            return None
         if get_task_runner and job_wrapper.can_split() and runner.runner_name != "PulsarJobRunner":
             return self.job_runners["tasks"]
         return runner
 
     def put(self, job_wrapper):
         runner = self.get_job_runner(job_wrapper, get_task_runner=True)
+        if runner is None:
+            # Something went wrong, we've already failed the job wrapper
+            return
         if isinstance(job_wrapper, TaskWrapper):
             # DBTODO Refactor
             log.debug(f"({job_wrapper.job_id}) Dispatching task {job_wrapper.task_id} to task runner")


### PR DESCRIPTION
Fixes
```
UnboundLocalError: local variable 'runner' referenced before assignment
  File "galaxy/jobs/handler.py", line 541, in __handle_waiting_jobs
    self.dispatcher.put(self.job_wrappers.pop(job.id))
  File "galaxy/jobs/handler.py", line 1224, in put
    runner = self.get_job_runner(job_wrapper, get_task_runner=True)
  File "galaxy/jobs/handler.py", line 1221, in get_job_runner
    return runner
```
from https://sentry.galaxyproject.org/share/issue/a0a0049feb53487f9c84ede3784624b0/ which followed `(53095435) Invalid job runner: bridges`.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
