### PR TITLE
remote tests data: add test for multiple true

### DIFF
--- a/test/functional/tools/remote_test_data_location.xml
+++ b/test/functional/tools/remote_test_data_location.xml
@@ -1,9 +1,16 @@
 <tool id="remote_test_data_location" name="Remote test data location" version="1.0.0" profile="22.01">
     <command><![CDATA[
         cat '$input' > '$output'
+        #for $i, $f in enumerate($input_multiple)
+            #if $f
+                && echo -n "$i " 
+                && cat '$f'
+            #end if
+        #end for
     ]]></command>
     <inputs>
         <param name="input" type="data" format="txt" label="Input"/>
+        <param name="input_multiple" type="data" optional="true" multiple="true" format="txt" label="Input"/>
     </inputs>
     <outputs>
         <data name="output" format="txt"/>
@@ -13,11 +20,16 @@
             <!-- When only the `location` is defined, the name of the input file will be infered from the last component of the URL.
                 In this example, it will be equivalent to `value="hello.txt"`. -->
             <param name="input" location="https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt"/>
+            <param name="input_multiple" location="https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt,https://raw.githubusercontent.com/galaxyproject/planemo/b2135cb22a6974b595bc3579a99366972efcb802/tests/data/hello_truncated.txt"/>
             <output name="output">
                 <assert_contents>
                     <has_line line="Hello World!"/>
                 </assert_contents>
             </output>
+            <assert_stdout>
+                <has_line line="0 Hello World!"/>
+                <has_line line="1 Hello Wor"/>
+            </assert_stdout>
         </test>
         <test>
             <!-- When the `value` and the `location` are defined, if the local file is missing, the remote file pointed by location will be pre-downloaded


### PR DESCRIPTION
As suggested here https://github.com/galaxyproject/galaxy/pull/16495 but not used here https://github.com/galaxyproject/galaxy/pull/16542

.. even if it does not run (unfortunately) https://github.com/galaxyproject/galaxy/pull/16495#issuecomment-1658631173

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
