### PR TITLE
Fix selenium selector for Workflow Run warnings

### DIFF
--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -648,7 +648,7 @@ trs_import:
 
 workflow_run:
   selectors:
-    warning: ".ui-form-composite .alert-warning"
+    warning: ".ui-form-composite-messages .alert-warning"
     input_div: "[step-label='${label}']"
     input_data_div: "[step-label='${label}'] .multiselect"
     # TODO: put step labels in the DOM ideally


### PR DESCRIPTION
It looks like the selenium test `test_run_form_safe_upgrade_handling` is failing consistently in dev because the new `No options available` is considered a top component warning... I hope this is the correct fix.

![image](https://github.com/galaxyproject/galaxy/assets/46503462/030f7945-7c28-4bc5-8674-0268fbdf7851)


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
