### PR TITLE
[23.1] Fix library import from path linking files

### DIFF
--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -448,7 +448,7 @@ def set_metadata_portable(
                     object_store_update_actions.append(
                         partial(push_if_necessary, object_store, dataset, external_filename)
                     )
-                object_store_update_actions.append(partial(reset_external_filename, dataset))
+                    object_store_update_actions.append(partial(reset_external_filename, dataset))
                 object_store_update_actions.append(partial(dataset.set_total_size))
                 object_store_update_actions.append(partial(export_store.add_dataset, dataset))
                 if dataset_instance_id not in unnamed_id_to_path:


### PR DESCRIPTION
This fixes #16909 by reverting 8ae0b9241ea5a4aa4298855605057340d90b9639. 

However, I'm not fully aware of the consequences of this change or the motivation of 8ae0b9241ea5a4aa4298855605057340d90b9639.

@mvdbeek feel free to suggest or directly push additional changes

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Follow the steps in #16909
  - Make sure your Galaxy config has the following setup:
    ```yml
    metadata_strategy: extended # or  extended_celery
    library_import_dir: <some local directory>
    allow_path_paste: true
    ```
  - Login as an Admin user
  - Go to Shared Data > Data Libraries
  - In any Library folder choose `+ Datasets > from path`
  - In the dialog, make sure `Link files instead of copying` is enabled
  - Paste a directory with files you want to import into the library
  - Click Import
  - Wait a few seconds for the set_metadata job or task to finish
  - Refresh the page or navigate back and forth to your library files
  - Observe the size of the files doesn't turn to 0 bytes

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
