### PR TITLE
Publish tool shed frontend to npm.

### DIFF
--- a/lib/tool_shed/webapp/frontend/package.json
+++ b/lib/tool_shed/webapp/frontend/package.json
@@ -1,7 +1,10 @@
 {
-  "name": "galaxy-tool-shed",
+  "name": "@galaxyproject/tool-shed-frontend",
   "license": "MIT",
-  "version": "0.2.0",
+  "version": "0.2.1",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "dev": "vite --port 4040 --strict-port",
     "build": "vue-tsc --noEmit && vite build",

--- a/lib/tool_shed/webapp/package.json
+++ b/lib/tool_shed/webapp/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@galaxyproject/tool-shed",
+  "version": "1.0.0",
+  "description": ".. figure:: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo.jpg    :alt: Galaxy Logo",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/galaxyproject/galaxy.git"
+  },
+  "author": "Galaxy Contributors",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/galaxyproject/galaxy/issues"
+  },
+  "homepage": "https://github.com/galaxyproject/galaxy#readme",
+  "dependencies": {
+    "@galaxyproject/tool-shed-frontend": "^0.2.1"
+  }
+}


### PR DESCRIPTION
https://www.npmjs.com/package/@galaxyproject/tool-shed-frontend

So if HMR is turned off the tool shed backend will check both for a built src packages like currently or for installed node modules published to npm using the new package. The structure is a lot simpler than Galaxy and it looks like we can get away with serving the assets directly from ``node_modules`` without the staging we do in the comparable Galaxy code.

Making the npm packages available to the backend I think is as simple as:

``cd lib/tool_shed/webapp && npm install``

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
