### PR TITLE
[23.1] Fix discarded dataset ordering in Storage Dashboard

### DIFF
--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -21,6 +21,8 @@ from sqlalchemy import (
     desc,
     false,
     func,
+    nulls_first,
+    nulls_last,
     select,
     true,
 )
@@ -347,8 +349,8 @@ class HDAStorageCleanerManager(base.StorageCleanerManager):
         self.sort_map = {
             StoredItemOrderBy.NAME_ASC: asc(model.HistoryDatasetAssociation.name),
             StoredItemOrderBy.NAME_DSC: desc(model.HistoryDatasetAssociation.name),
-            StoredItemOrderBy.SIZE_ASC: asc(model.Dataset.total_size),
-            StoredItemOrderBy.SIZE_DSC: desc(model.Dataset.total_size),
+            StoredItemOrderBy.SIZE_ASC: nulls_first(asc(model.Dataset.total_size)),
+            StoredItemOrderBy.SIZE_DSC: nulls_last(desc(model.Dataset.total_size)),
             StoredItemOrderBy.UPDATE_TIME_ASC: asc(model.HistoryDatasetAssociation.update_time),
             StoredItemOrderBy.UPDATE_TIME_DSC: desc(model.HistoryDatasetAssociation.update_time),
         }


### PR DESCRIPTION
Fixes #16898

When you delete an output of a tool the HDA size is null, by default, Postgresql seems to sort null values first. This change uses the correct null sorting for the size attribute in each case.

## Before
![Screenshot from 2023-10-26 10-50-33](https://github.com/galaxyproject/galaxy/assets/46503462/535a43bb-92fe-4ea6-9eb1-4e6bb583f5b6)


## After
![Screenshot from 2023-10-26 10-56-09](https://github.com/galaxyproject/galaxy/assets/46503462/6bdc4b69-c9bb-40fa-ab98-21db42ddc9a6)


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
