### PR TITLE
[23.1] Include owner's annotation when exporting workflow

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1337,7 +1337,12 @@ class WorkflowContentsManager(UsesAnnotations):
         tag_str = ""
         if stored is not None:
             if stored.id:
-                annotation_str = self.get_item_annotation_str(trans.sa_session, trans.user, stored) or ""
+                # if the active user doesn't have an annotation on the workflow, default to the owner's annotation.
+                annotation_str = (
+                    self.get_item_annotation_str(trans.sa_session, trans.user, stored)
+                    or self.get_item_annotation_str(trans.sa_session, stored.user, stored)
+                    or ""
+                )
                 tag_str = stored.make_tag_string_list()
             else:
                 # dry run with flushed workflow objects, just use the annotation


### PR DESCRIPTION
…g user doesn't have an overriding one.

I don't know *when* a user would have annotated someone else's workflow, but I was hesitant to wholesale swap this to the owner's annotation.  Anyone recall the particulars here?  It looks like the same applies for WorkflowSteps, ~~though that isn't reflected here (yet, though I can add it after this is discussed)~~.  My guess is most people expect annotations to operate like a simple property of workflows/steps, and not some user-tethered remark.

Fixes #16886 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
