### PR TITLE
SQLAlchemy 2.0 upgrades (part 5)

### DIFF
--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -18,6 +18,7 @@ from typing import (
 from sqlalchemy import (
     asc,
     desc,
+    exists,
     false,
     func,
     select,
@@ -340,13 +341,12 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         return extra
 
     def is_history_shared_with(self, history: model.History, user: model.User) -> bool:
-        stmt = (
-            select(HistoryUserShareAssociation.id)
+        stmt = select(
+            exists()
             .where(HistoryUserShareAssociation.user_id == user.id)
             .where(HistoryUserShareAssociation.history_id == history.id)
-            .limit(1)
         )
-        return bool(self.session().execute(stmt).first())
+        return self.session().scalar(stmt)
 
     def make_members_public(self, trans, item):
         """Make the non-purged datasets in history public.

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6358,7 +6358,8 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
         db_session = object_session(self)
         if db_session and self.id:
             stmt = self._build_nested_collection_attributes_stmt(return_entities=(HistoryDatasetAssociation,))
-            return db_session.scalars(stmt).all()
+            tuples = db_session.execute(stmt).all()
+            return [tuple[0] for tuple in tuples]
         else:
             # Sessionless context
             instances = []

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6212,11 +6212,11 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
             stmt = self._build_nested_collection_attributes_stmt(
                 hda_attributes=("extension",), dataset_attributes=("state",)
             )
-            col_attrs = object_session(self).execute(stmt)
+            tuples = object_session(self).execute(stmt)
 
             extensions = set()
             states = set()
-            for extension, state in col_attrs:
+            for extension, state, *_ in tuples:
                 states.add(state)
                 extensions.add(extension)
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6376,7 +6376,8 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
         db_session = object_session(self)
         if db_session and self.id:
             stmt = self._build_nested_collection_attributes_stmt(return_entities=(DatasetCollectionElement,))
-            return db_session.scalars(stmt).all()
+            tuples = db_session.execute(stmt).all()
+            return [tuple[0] for tuple in tuples]
         elements = []
         for element in self.elements:
             if element.is_collection:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6465,8 +6465,9 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
         stmt = self._build_nested_collection_attributes_stmt(
             return_entities=[DatasetCollectionElement], hda_attributes=["id"]
         )
-        col_attrs = object_session(self).execute(stmt).all()
-        hda_id_to_element = dict(col_attrs)
+        tuples = object_session(self).execute(stmt).all()
+        tuples = [(element, id) for element, id, *_ in tuples]
+        hda_id_to_element = dict(tuples)
         for failed, replacement in replacements.items():
             element = hda_id_to_element.get(failed.id)
             if element:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6200,7 +6200,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
             .add_columns(*attribute_columns(DatasetPermissions, dataset_permission_attributes))
         )
         for entity in return_entities:
-            q = q.add_entity(entity)
+            q = q.add_columns(entity)
             if entity == DatasetCollectionElement:
                 q = q.filter(entity.id == dce.c.id)
         return q.distinct().order_by(*order_by_columns)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6733,11 +6733,11 @@ class HistoryDatasetCollectionAssociation(
     def dataset_dbkeys_and_extensions_summary(self):
         if not hasattr(self, "_dataset_dbkeys_and_extensions_summary"):
             stmt = self.collection._build_nested_collection_attributes_stmt(hda_attributes=("_metadata", "extension"))
-            col_attrs = object_session(self).execute(stmt)
+            tuples = object_session(self).execute(stmt)
 
             extensions = set()
             dbkeys = set()
-            for row in col_attrs:
+            for row in tuples:
                 if row is not None:
                     dbkey_field = row._metadata.get("dbkey")
                     if isinstance(dbkey_field, list):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6231,9 +6231,9 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
             if object_session(self):
                 # TODO: Optimize by just querying without returning the states...
                 stmt = self._build_nested_collection_attributes_stmt(dataset_attributes=("state",))
-                col_attrs = object_session(self).execute(stmt)
+                tuples = object_session(self).execute(stmt)
 
-                for (state,) in col_attrs:
+                for state, *_ in tuples:
                     if state == Dataset.states.DEFERRED:
                         has_deferred_data = True
                         break

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6204,6 +6204,8 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
                 q = q.filter(entity.id == dce.c.id)
 
         q = q.distinct().order_by(*order_by_columns)
+        # With DISTINCT, all columns that appear in the ORDER BY clause must appear in the SELECT clause.
+        q = q.add_columns(*order_by_columns)
         return q
 
     @property

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6285,14 +6285,6 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
         return self._dataset_action_tuples
 
     @property
-    def element_identifiers_extensions_and_paths(self):
-        stmt = self._build_nested_collection_attributes_stmt(
-            element_attributes=("element_identifier",), hda_attributes=("extension",), return_entities=(Dataset,)
-        )
-        col_attrs = object_session(self).execute(stmt)
-        return [(row[:-2], row.extension, row.Dataset.get_file_name()) for row in col_attrs]
-
-    @property
     def element_identifiers_extensions_paths_and_metadata_files(
         self,
     ) -> List[List[Any]]:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6280,16 +6280,8 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
     def dataset_action_tuples(self):
         if not hasattr(self, "_dataset_action_tuples"):
             stmt = self._build_nested_collection_attributes_stmt(dataset_permission_attributes=("action", "role_id"))
-            col_attrs = object_session(self).execute(stmt)
-
-            _dataset_action_tuples = []
-            for _dataset_action_tuple in col_attrs:
-                if _dataset_action_tuple[0] is None:
-                    continue
-                _dataset_action_tuples.append(_dataset_action_tuple)
-
-            self._dataset_action_tuples = _dataset_action_tuples
-
+            tuples = object_session(self).execute(stmt)
+            self._dataset_action_tuples = [(action, role_id) for action, role_id, *_ in tuples if action is not None]
         return self._dataset_action_tuples
 
     @property

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6203,9 +6203,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
             if entity == DatasetCollectionElement:
                 q = q.filter(entity.id == dce.c.id)
 
-        q = q.distinct().order_by(*order_by_columns)
-        # With DISTINCT, all columns that appear in the ORDER BY clause must appear in the SELECT clause.
-        q = q.add_columns(*order_by_columns)
+        q = q.order_by(*order_by_columns)
         return q
 
     @property
@@ -6214,11 +6212,15 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
             stmt = self._build_nested_collection_attributes_stmt(
                 hda_attributes=("extension",), dataset_attributes=("state",)
             )
+            # With DISTINCT, all columns that appear in the ORDER BY clause must appear in the SELECT clause.
+            stmt = stmt.add_columns(*stmt._order_by_clauses)
+            stmt = stmt.distinct()
+
             tuples = object_session(self).execute(stmt)
 
             extensions = set()
             states = set()
-            for extension, state, *_ in tuples:
+            for extension, state, *_ in tuples:  # we discard the added columns from the order-by clause
                 states.add(state)
                 extensions.add(extension)
 
@@ -6234,8 +6236,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
                 # TODO: Optimize by just querying without returning the states...
                 stmt = self._build_nested_collection_attributes_stmt(dataset_attributes=("state",))
                 tuples = object_session(self).execute(stmt)
-
-                for state, *_ in tuples:
+                for (state,) in tuples:
                     if state == Dataset.states.DEFERRED:
                         has_deferred_data = True
                         break
@@ -6283,28 +6284,13 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
         if not hasattr(self, "_dataset_action_tuples"):
             stmt = self._build_nested_collection_attributes_stmt(dataset_permission_attributes=("action", "role_id"))
             tuples = object_session(self).execute(stmt)
-            self._dataset_action_tuples = [(action, role_id) for action, role_id, *_ in tuples if action is not None]
+            self._dataset_action_tuples = [(action, role_id) for action, role_id in tuples if action is not None]
         return self._dataset_action_tuples
 
     @property
     def element_identifiers_extensions_paths_and_metadata_files(
         self,
     ) -> List[List[Any]]:
-        def find_identifiers(row):
-            # Assume row has this structure: [id1, id2, ..., idn, extension, model, anything];
-            # model is an instance of a Dataset or a HistoryDatasetAssociation;
-            # extension is a string that always preceeds the model;
-            # we look for the first model, then pick the preceeding items minus the extention.
-            identifiers = []
-            i = 0
-            while i + 1 < len(row):
-                item, next_item = row[i], row[i + 1]
-                if isinstance(next_item, HistoryDatasetAssociation) or isinstance(next_item, Dataset):
-                    break
-                identifiers.append(item)
-                i += 1
-            return tuple(identifiers)
-
         results = []
         if object_session(self):
             stmt = self._build_nested_collection_attributes_stmt(
@@ -6315,7 +6301,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
             tuples = object_session(self).execute(stmt)
             # element_identifiers, extension, path
             for row in tuples:
-                result = [find_identifiers(row), row.extension, row.Dataset.get_file_name()]
+                result = [row[:-3], row.extension, row.Dataset.get_file_name()]
                 hda = row.HistoryDatasetAssociation
                 result.append(hda.get_metadata_file_paths_and_extensions())
                 results.append(result)
@@ -6468,7 +6454,6 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
             return_entities=[DatasetCollectionElement], hda_attributes=["id"]
         )
         tuples = object_session(self).execute(stmt).all()
-        tuples = [(element, id) for element, id, *_ in tuples]
         hda_id_to_element = dict(tuples)
         for failed, replacement in replacements.items():
             element = hda_id_to_element.get(failed.id)

--- a/scripts/check_model.py
+++ b/scripts/check_model.py
@@ -47,8 +47,9 @@ def find_missing_indexes():
 
     # create EMPTY metadata, then load from database
     db_url = get_config(sys.argv)["db_url"]
-    metadata = MetaData(bind=create_engine(db_url))
-    metadata.reflect()
+    metadata = MetaData()
+    engine = create_engine(db_url)
+    metadata.reflect(bind=engine)
     indexes_in_db = load_indexes(metadata)
 
     all_indexes = set(mapping_indexes.keys()) | set(tsi_mapping_indexes.keys())

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -414,25 +414,25 @@ class TestMappings(BaseModelTestCase):
         )
         result = self.model.session.execute(stmt).all()
         assert [(r._fields) for r in result] == [
-            ("element_identifier_0", "element_identifier_1", "extension", "state", "element_index", "element_index_1"),
-            ("element_identifier_0", "element_identifier_1", "extension", "state", "element_index", "element_index_1"),
+            ("element_identifier_0", "element_identifier_1", "extension", "state"),
+            ("element_identifier_0", "element_identifier_1", "extension", "state"),
         ]
 
         stmt = c2._build_nested_collection_attributes_stmt(
             element_attributes=("element_identifier",), hda_attributes=("extension",), dataset_attributes=("state",)
         )
         result = self.model.session.execute(stmt).all()
-        assert result == [("inner_list", "forward", "bam", "new", 0, 0), ("inner_list", "reverse", "txt", "new", 0, 1)]
+        assert result == [("inner_list", "forward", "bam", "new"), ("inner_list", "reverse", "txt", "new")]
 
         stmt = c2._build_nested_collection_attributes_stmt(return_entities=(model.HistoryDatasetAssociation,))
         result = self.model.session.execute(stmt).all()
-        assert result == [(d1, 0, 0), (d2, 0, 1)]
+        assert result == [(d1,), (d2,)]
 
         stmt = c2._build_nested_collection_attributes_stmt(
             return_entities=(model.HistoryDatasetAssociation, model.Dataset)
         )
         result = self.model.session.execute(stmt).all()
-        assert result == [(d1, d1.dataset, 0, 0), (d2, d2.dataset, 0, 1)]
+        assert result == [(d1, d1.dataset), (d2, d2.dataset)]
         # Assert properties that use _get_nested_collection_attributes return correct content
         assert c2.dataset_instances == [d1, d2]
         assert c2.dataset_elements == [dce1, dce2]
@@ -455,8 +455,8 @@ class TestMappings(BaseModelTestCase):
         stmt = c4._build_nested_collection_attributes_stmt(element_attributes=("element_identifier",))
         result = self.model.session.execute(stmt).all()
         assert result == [
-            ("outer_list", "inner_list", "forward", 0, 0, 0),
-            ("outer_list", "inner_list", "reverse", 0, 0, 1),
+            ("outer_list", "inner_list", "forward"),
+            ("outer_list", "inner_list", "reverse"),
         ]
         assert c4.dataset_elements == [dce1, dce2]
 


### PR DESCRIPTION
Builds on #16852 (34 commits).
SQLAlchemy 2.0 compatibility upgrades. Ref https://github.com/galaxyproject/galaxy/issues/12541.

The main part of this PR is the `_get_nested_collection_attributes` method. It is dynamic and the structure of the result depends on the input. The method uses a `Query` object which must be replaced with a `Select`. 

There are 2 main challenges here:
1. Unlike `Query`, which may return tuples of items or mapped objects, a `Select` always returns tuples ([ref](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#orm-query-unified-with-core-select)). The usual workaround is to call `scalars()`, which will simply return the  first item from each tuple, turning `[(model,), ...]` into `[model, ...]`. However, this method, depending on input, may return tuples of items, tuples of items and mapped objects, and mapped objects. Therefore, the burden of restructuring the result has to be shifted to the caller. 
2. The usage of DISTINCT requires that all columns appearing in the ORDER BY clause must also appear in the SELECT clause (see more details in commit description: c0f6b1d2c8eba5657f6c4d154551810bbeeb531e). We can easily add the missing columns to the select statement; however, that alters the structure of the returned values. Removing the added columns (without breaking some of the calls) is a surprisingly hard problem (the [suggested approach](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#using-distinct-with-additional-columns-but-only-select-the-entity) doesn't work with a complex statement with joins and the `metadata` attribute which we handle differently, but which still appears in the select clause (I didn't find a way to do it using SA's public API). The alternative is to leave the added columns in the select clause - that works for the most part. The exception is the case when the columns are added dynamically and there is no way to determine how many of them will be added (depends on collection nesting): that, coupled with accessing items in the result by relative position (like [here](8ece42025b4f496c51fcb808b7b6bfd403da11bd)) poses the following challenge: with code like `row[:-3]` we intend to chop-off the last 3 elements, because we don't know how many precede them. However, with adding columns from the order by clause, we no longer know how many columns have been appended (added to the right of the list). Thus, we have a list that is dynamic "on both ends", so accessing items by relative position doesn't work. The workaround is the `find_identifiers` helper.
For the rest of the cases, we use a throwaway variable `*_` when destructuring the result.

Of course, this reduces the number of SA's RemovedIn20 warnings.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
