### PR TITLE
Remove "Create Workflow" form and allow workflow creation in editor

### DIFF
--- a/client/src/components/Panels/WorkflowBox.vue
+++ b/client/src/components/Panels/WorkflowBox.vue
@@ -47,7 +47,7 @@ function userTitle(title: string) {
                             variant="link"
                             :title="userTitle('Create new workflow')"
                             :disabled="isAnonymous"
-                            @click="$router.push('/workflows/create')">
+                            @click="$router.push('/workflows/edit')">
                             <Icon fixed-width icon="plus" />
                         </b-button>
                         <b-button

--- a/client/src/components/Workflow/Editor/Attributes.test.js
+++ b/client/src/components/Workflow/Editor/Attributes.test.js
@@ -33,6 +33,7 @@ describe("Attributes", () => {
                 name: TEST_NAME,
                 tags: ["workflow_tag_0", "workflow_tag_1"],
                 parameters: untypedParameters,
+                version: 0,
                 versions: TEST_VERSIONS,
                 annotation: TEST_ANNOTATION,
             },

--- a/client/src/components/Workflow/Editor/Attributes.vue
+++ b/client/src/components/Workflow/Editor/Attributes.vue
@@ -12,7 +12,7 @@
                 :state="!nameCurrent ? false : null"
                 @keyup="$emit('update:nameCurrent', nameCurrent)" />
         </div>
-        <div v-if="versionCurrent !== null" id="workflow-version-area" class="mt-2">
+        <div v-if="versionOptions.length > 0" id="workflow-version-area" class="mt-2">
             <b>Version</b>
             <b-form-select v-model="versionCurrent" @change="onVersion">
                 <b-form-select-option v-for="v in versionOptions" :key="v.version" :value="v.version">

--- a/client/src/components/Workflow/Editor/Attributes.vue
+++ b/client/src/components/Workflow/Editor/Attributes.vue
@@ -12,7 +12,7 @@
                 :state="!nameCurrent ? false : null"
                 @keyup="$emit('update:nameCurrent', nameCurrent)" />
         </div>
-        <div id="workflow-version-area" class="mt-2">
+        <div v-if="versionCurrent !== null" id="workflow-version-area" class="mt-2">
             <b>Version</b>
             <b-form-select v-model="versionCurrent" @change="onVersion">
                 <b-form-select-option v-for="v in versionOptions" :key="v.version" :value="v.version">

--- a/client/src/components/Workflow/Editor/Attributes.vue
+++ b/client/src/components/Workflow/Editor/Attributes.vue
@@ -6,7 +6,11 @@
         <div id="workflow-name-area">
             <b>Name</b>
             <meta itemprop="name" :content="name" />
-            <b-input id="workflow-name" v-model="nameCurrent" @keyup="$emit('update:nameCurrent', nameCurrent)" />
+            <b-input
+                id="workflow-name"
+                v-model="nameCurrent"
+                :state="!nameCurrent ? false : null"
+                @keyup="$emit('update:nameCurrent', nameCurrent)" />
         </div>
         <div id="workflow-version-area" class="mt-2">
             <b>Version</b>
@@ -30,6 +34,7 @@
             <b-textarea
                 id="workflow-annotation"
                 v-model="annotationCurrent"
+                :state="!annotationCurrent ? false : null"
                 @keyup="$emit('update:annotationCurrent', annotationCurrent)" />
             <div class="form-text text-muted">These notes will be visible when this workflow is viewed.</div>
         </div>
@@ -184,7 +189,7 @@ export default {
         onTags(tags) {
             this.tagsCurrent = tags;
             this.onAttributes({ tags });
-            this.$emit("input", this.tagsCurrent);
+            this.$emit("onTags", this.tagsCurrent);
         },
         onVersion() {
             this.$emit("onVersion", this.versionCurrent);
@@ -200,9 +205,11 @@ export default {
             this.messageVariant = "danger";
         },
         onAttributes(data) {
-            this.services.updateWorkflow(this.id, data).catch((error) => {
-                this.onError(error);
-            });
+            if (this.id !== "new_temp_workflow") {
+                this.services.updateWorkflow(this.id, data).catch((error) => {
+                    this.onError(error);
+                });
+            }
         },
     },
 };

--- a/client/src/components/Workflow/Editor/Attributes.vue
+++ b/client/src/components/Workflow/Editor/Attributes.vue
@@ -34,7 +34,6 @@
             <b-textarea
                 id="workflow-annotation"
                 v-model="annotationCurrent"
-                :state="!annotationCurrent ? false : null"
                 @keyup="$emit('update:annotationCurrent', annotationCurrent)" />
             <div class="form-text text-muted">These notes will be visible when this workflow is viewed.</div>
         </div>

--- a/client/src/components/Workflow/Editor/Attributes.vue
+++ b/client/src/components/Workflow/Editor/Attributes.vue
@@ -204,7 +204,7 @@ export default {
             this.messageVariant = "danger";
         },
         onAttributes(data) {
-            if (this.id !== "new_temp_workflow") {
+            if (!this.id.includes("workflow-editor")) {
                 this.services.updateWorkflow(this.id, data).catch((error) => {
                     this.onError(error);
                 });

--- a/client/src/components/Workflow/Editor/Index.test.ts
+++ b/client/src/components/Workflow/Editor/Index.test.ts
@@ -47,9 +47,9 @@ describe("Index", () => {
         });
         wrapper = shallowMount(Index, {
             propsData: {
-                id: "workflow_id",
+                workflowId: "workflow_id",
                 initialVersion: 1,
-                tags: ["moo", "cow"],
+                workflowTags: ["moo", "cow"],
                 moduleSections: [],
                 dataManagers: [],
                 workflows: [],

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -243,7 +243,7 @@ export default {
         const uid = unref(useUid("workflow-editor-"));
         const id = ref(props.workflowId || uid);
 
-        const { connectionStore, stepStore, stateStore, commentStore } = provideScopedWorkflowStores(id.value);
+        const { connectionStore, stepStore, stateStore, commentStore } = provideScopedWorkflowStores(id);
 
         const { comments } = storeToRefs(commentStore);
         const { getStepIndex, steps } = storeToRefs(stepStore);

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -368,9 +368,9 @@ export default {
             this.$emit("update:confirmation", this.hasChanges);
         },
     },
-    created() {
+    async created() {
         this.lastQueue = new LastQueue();
-        this._loadCurrent(this.id, this.version);
+        await this._loadCurrent(this.id, this.version);
         hide_modal();
     },
     methods: {
@@ -730,19 +730,18 @@ export default {
             await Vue.nextTick();
             this.hasChanges = has_changes;
         },
-        _loadCurrent(id, version) {
+        async _loadCurrent(id, version) {
             if (!this.isNewTempWorkflow) {
                 this.resetStores();
                 this.onWorkflowMessage("Loading workflow...", "progress");
-                this.lastQueue
-                    .enqueue(loadWorkflow, { id, version })
-                    .then((data) => {
-                        fromSimple(id, data);
-                        this._loadEditorData(data);
-                    })
-                    .catch((response) => {
-                        this.onWorkflowError("Loading workflow failed...", response);
-                    });
+
+                try {
+                    const data = await this.lastQueue.enqueue(loadWorkflow, { id, version });
+                    await fromSimple(id, data);
+                    await this._loadEditorData(data);
+                } catch (e) {
+                    this.onWorkflowError("Loading workflow failed...", e);
+                }
             }
         },
         onTags(tags) {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -175,6 +175,7 @@ import { useUid } from "@/composables/utils/uid";
 import { provideScopedWorkflowStores } from "@/composables/workflowStores";
 import { hide_modal } from "@/layout/modal";
 import { getAppRoot } from "@/onload/loadConfig";
+import { useScopePointerStore } from "@/stores/scopePointerStore";
 import { LastQueue } from "@/utils/promise-queue";
 
 import { defaultPosition } from "./composables/useDefaultStepPosition";
@@ -534,10 +535,13 @@ export default {
                 .then((response) => {
                     this.onWorkflowMessage("Workflow saved as", "success");
                     this.hideModal();
+                    this.onNavigate(`${getAppRoot()}workflows/edit?id=${response.data}`);
+
                     if (create) {
-                        window.location = `${getAppRoot()}workflows/edit?id=${response.data}`;
-                    } else {
-                        this.onNavigate(`${getAppRoot()}workflows/edit?id=${response.data}`);
+                        const { addScopePointer } = useScopePointerStore();
+                        // map scoped stores to existing stores, before updating the id
+                        addScopePointer(response.data, this.id);
+                        this.id = response.data;
                     }
                 })
                 .catch((response) => {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -546,6 +546,12 @@ export default {
                 const response = await axios.post(`${getAppRoot()}workflow/save_workflow_as`, formData);
                 const newId = response.data;
 
+                if (!create) {
+                    this.name = rename_name;
+                    this.annotation = rename_annotation;
+                }
+
+                this.hasChanges = false;
                 await this.routeToWorkflow(newId);
             } catch (e) {
                 this.onWorkflowError("Saving workflow failed, please contact an administrator.");
@@ -575,18 +581,9 @@ export default {
             this.onUpdateStep(step);
         },
         async routeToWorkflow(id) {
-            const { addScopePointer, scope } = useScopePointerStore();
-
-            let pointedTo;
-            // the current workflow id might be pointing to existing stores
-            const originalPointed = scope(this.id);
-            if (originalPointed !== this.id) {
-                pointedTo = originalPointed;
-            } else {
-                pointedTo = this.id;
-            }
             // map scoped stores to existing stores, before updating the id
-            addScopePointer(id, pointedTo);
+            const { addScopePointer } = useScopePointerStore();
+            addScopePointer(id, this.id);
 
             this.id = id;
             await this.onSave();
@@ -618,7 +615,6 @@ export default {
                     await this.routeToWorkflow(id);
                 } else {
                     // otherwise, use `save_as` endpoint to include steps, etc.
-                    this.hasChanges = false;
                     await this.doSaveAs(true);
                 }
             } catch (e) {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -565,7 +565,7 @@ export default {
             this.onUpdateStep(step);
         },
         async onCreate() {
-            if (!this.name || !this.annotation) {
+            if (!this.name) {
                 const response = "Please provide a name for your workflow.";
                 this.onWorkflowError("Creating workflow failed", response, {
                     Ok: () => {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -86,7 +86,7 @@
                     </div>
                 </div>
                 <div ref="right-panel" class="unified-panel-body workflow-right p-2">
-                    <div>
+                    <div v-if="!initialLoading">
                         <FormTool
                             v-if="hasActiveNodeTool"
                             :key="activeStep.id"
@@ -279,6 +279,8 @@ export default {
             emit("update:confirmation", false);
         });
 
+        const initialLoading = ref(true);
+
         return {
             id,
             connectionStore,
@@ -295,6 +297,7 @@ export default {
             datatypesMapperLoading,
             stateStore,
             resetStores,
+            initialLoading,
         };
     },
     data() {
@@ -372,6 +375,7 @@ export default {
         this.lastQueue = new LastQueue();
         await this._loadCurrent(this.id, this.version);
         hide_modal();
+        this.initialLoading = false;
     },
     methods: {
         onUpdateStep(step) {

--- a/client/src/components/Workflow/Editor/Options.vue
+++ b/client/src/components/Workflow/Editor/Options.vue
@@ -84,7 +84,7 @@ async function onSave() {
                 variant="link"
                 aria-label="Save Workflow"
                 class="editor-button-save"
-                :disabled="!hasChanges"
+                :disabled="!isNewTempWorkflow && !hasChanges"
                 @click="onSave">
                 <span class="fa fa-floppy-o" />
             </BButton>

--- a/client/src/components/Workflow/Editor/Options.vue
+++ b/client/src/components/Workflow/Editor/Options.vue
@@ -7,6 +7,7 @@ import { useConfirmDialog } from "@/composables/confirmDialog";
 const emit = defineEmits<{
     (e: "onAttributes"): void;
     (e: "onSave"): void;
+    (e: "onCreate"): void;
     (e: "onReport"): void;
     (e: "onSaveAs"): void;
     (e: "onLayout"): void;
@@ -17,6 +18,7 @@ const emit = defineEmits<{
 }>();
 
 const props = defineProps<{
+    isNewTempWorkflow?: boolean;
     hasChanges?: boolean;
     hasInvalidConnections?: boolean;
     requiredReindex?: boolean;
@@ -25,7 +27,9 @@ const props = defineProps<{
 const { confirm } = useConfirmDialog();
 
 const saveHover = computed(() => {
-    if (!props.hasChanges) {
+    if (props.isNewTempWorkflow) {
+        return "Create a new workflow";
+    } else if (!props.hasChanges) {
         return "Workflow has no changes";
     } else if (props.hasInvalidConnections) {
         return "Workflow has invalid connections, review and remove invalid connections";
@@ -33,6 +37,14 @@ const saveHover = computed(() => {
         return "Save Workflow";
     }
 });
+
+function emitSaveOrCreate() {
+    if (props.isNewTempWorkflow) {
+        emit("onCreate");
+    } else {
+        emit("onSave");
+    }
+}
 
 async function onSave() {
     if (props.hasInvalidConnections) {
@@ -45,10 +57,10 @@ async function onSave() {
             }
         );
         if (confirmed) {
-            emit("onSave");
+            emitSaveOrCreate();
         }
     } else {
-        emit("onSave");
+        emitSaveOrCreate();
     }
 }
 </script>
@@ -56,7 +68,7 @@ async function onSave() {
     <div class="panel-header-buttons">
         <BButton
             id="workflow-home-button"
-            v-b-tooltip.hover
+            v-b-tooltip.hover.noninteractive
             role="button"
             title="Edit Attributes"
             variant="link"
@@ -79,25 +91,27 @@ async function onSave() {
         </b-button-group>
         <BButton
             id="workflow-report-button"
-            v-b-tooltip.hover
+            v-b-tooltip.hover.noninteractive
             role="button"
             title="Edit Report"
             variant="link"
             aria-label="Edit Report"
             class="editor-button-report"
+            :disabled="isNewTempWorkflow"
             @click="$emit('onReport')">
             <span class="fa fa-edit" />
         </BButton>
         <BDropdown
             id="workflow-options-button"
-            v-b-tooltip.hover
+            v-b-tooltip.hover.noninteractive
             no-caret
             right
             role="button"
             title="Workflow Options"
             variant="link"
             aria-label="Workflow Options"
-            class="editor-button-options">
+            class="editor-button-options"
+            :disabled="isNewTempWorkflow">
             <template v-slot:button-content>
                 <span class="fa fa-cog" />
             </template>
@@ -113,12 +127,13 @@ async function onSave() {
         </BDropdown>
         <BButton
             id="workflow-run-button"
-            v-b-tooltip.hover
+            v-b-tooltip.hover.noninteractive
             role="button"
             title="Run Workflow"
             variant="link"
             aria-label="Run Workflow"
             class="editor-button-run"
+            :disabled="isNewTempWorkflow"
             @click="$emit('onRun')">
             <span class="fa fa-play" />
         </BButton>

--- a/client/src/components/Workflow/Editor/modules/model.ts
+++ b/client/src/components/Workflow/Editor/modules/model.ts
@@ -10,6 +10,7 @@ interface Workflow {
     report: any;
     steps: Steps;
     comments: WorkflowComment[];
+    tags: string[];
 }
 
 /**
@@ -80,6 +81,7 @@ export function toSimple(id: string, workflow: Workflow): Omit<Workflow, "versio
     const creator = workflow.creator;
     const annotation = workflow.annotation;
     const name = workflow.name;
+    const tags = workflow.tags;
 
     const commentStore = useWorkflowCommentStore(id);
     commentStore.resolveCommentsInFrames();
@@ -87,5 +89,5 @@ export function toSimple(id: string, workflow: Workflow): Omit<Workflow, "versio
 
     const comments = workflow.comments.filter((comment) => !(comment.type === "text" && comment.data.text === ""));
 
-    return { steps, report, license, creator, annotation, name, comments };
+    return { steps, report, license, creator, annotation, name, comments, tags };
 }

--- a/client/src/components/Workflow/Editor/modules/services.js
+++ b/client/src/components/Workflow/Editor/modules/services.js
@@ -54,13 +54,19 @@ export async function loadWorkflow({ id, version = null }) {
 export async function saveWorkflow(workflow) {
     if (workflow.hasChanges) {
         try {
-            const requestData = { workflow: toSimple(workflow.id, workflow), from_tool_form: true, tags: workflow.tags };
+            const requestData = {
+                workflow: toSimple(workflow.id, workflow),
+                from_tool_form: true,
+                tags: workflow.tags,
+            };
             const { data } = await axios.put(`${getAppRoot()}api/workflows/${workflow.id}`, requestData);
             workflow.name = data.name;
             workflow.hasChanges = false;
             workflow.stored = true;
             workflow.version = data.version;
-            workflow.annotation = data.annotation;
+            if (workflow.annotation || data.annotation) {
+                workflow.annotation = data.annotation;
+            }
             return data;
         } catch (e) {
             rethrowSimple(e);

--- a/client/src/components/Workflow/Editor/modules/services.js
+++ b/client/src/components/Workflow/Editor/modules/services.js
@@ -54,11 +54,7 @@ export async function loadWorkflow({ id, version = null }) {
 export async function saveWorkflow(workflow) {
     if (workflow.hasChanges) {
         try {
-            const requestData = {
-                workflow: toSimple(workflow.id, workflow),
-                from_tool_form: true,
-                tags: workflow.tags,
-            };
+            const requestData = { workflow: toSimple(workflow.id, workflow), from_tool_form: true };
             const { data } = await axios.put(`${getAppRoot()}api/workflows/${workflow.id}`, requestData);
             workflow.name = data.name;
             workflow.hasChanges = false;

--- a/client/src/components/Workflow/Editor/modules/services.js
+++ b/client/src/components/Workflow/Editor/modules/services.js
@@ -54,7 +54,7 @@ export async function loadWorkflow({ id, version = null }) {
 export async function saveWorkflow(workflow) {
     if (workflow.hasChanges) {
         try {
-            const requestData = { workflow: toSimple(workflow.id, workflow), from_tool_form: true };
+            const requestData = { workflow: toSimple(workflow.id, workflow), from_tool_form: true, tags: workflow.tags };
             const { data } = await axios.put(`${getAppRoot()}api/workflows/${workflow.id}`, requestData);
             workflow.name = data.name;
             workflow.hasChanges = false;

--- a/client/src/components/Workflow/InvocationsList.test.js
+++ b/client/src/components/Workflow/InvocationsList.test.js
@@ -6,16 +6,20 @@ import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import { formatDistanceToNow, parseISO } from "date-fns";
 import { getLocalVue } from "tests/jest/helpers";
+import VueRouter from "vue-router";
 
 import InvocationsList from "./InvocationsList";
 import mockInvocationData from "./test/json/invocation.json";
 
 const localVue = getLocalVue();
+localVue.use(VueRouter);
+const router = new VueRouter();
 
 const pinia = createTestingPinia();
 describe("InvocationsList.vue", () => {
     let axiosMock;
     let wrapper;
+    let $router;
 
     beforeEach(async () => {
         axiosMock = new MockAdapter(axios);
@@ -158,7 +162,9 @@ describe("InvocationsList.vue", () => {
                 },
                 localVue,
                 pinia,
+                router,
             });
+            $router = wrapper.vm.$router;
         });
 
         it("renders one row", async () => {
@@ -194,8 +200,10 @@ describe("InvocationsList.vue", () => {
         });
 
         it("calls executeWorkflow", async () => {
+            const mockMethod = jest.fn();
+            $router.push = mockMethod;
             await wrapper.find(".workflow-run").trigger("click");
-            expect(window.location).toBeAt("workflows/run?id=workflowId");
+            expect(mockMethod).toHaveBeenCalledWith("/workflows/run?id=workflowId");
         });
 
         it("should not render pager", async () => {

--- a/client/src/components/Workflow/Published/WorkflowPublished.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublished.vue
@@ -46,7 +46,7 @@ const errorMessage = ref("");
 
 const { datatypesMapper } = useDatatypesMapper();
 
-const { stateStore } = provideScopedWorkflowStores(ref(props.id));
+const { stateStore } = provideScopedWorkflowStores(props.id);
 
 stateStore.setScale(0.75);
 

--- a/client/src/components/Workflow/Published/WorkflowPublished.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublished.vue
@@ -46,7 +46,7 @@ const errorMessage = ref("");
 
 const { datatypesMapper } = useDatatypesMapper();
 
-const { stateStore } = provideScopedWorkflowStores(props.id);
+const { stateStore } = provideScopedWorkflowStores(ref(props.id));
 
 stateStore.setScale(0.75);
 

--- a/client/src/components/Workflow/WorkflowIndexActions.test.js
+++ b/client/src/components/Workflow/WorkflowIndexActions.test.js
@@ -35,7 +35,7 @@ describe("WorkflowIndexActions", () => {
     describe("naviation", () => {
         it("should create a workflow when create is clicked", async () => {
             await wrapper.find(ROOT_COMPONENT.workflows.new_button.selector).trigger("click");
-            expect(getCurrentPath($router)).toBe("/workflows/create");
+            expect(getCurrentPath($router)).toBe("/workflows/edit");
         });
 
         it("should import a workflow when create is clicked", async () => {

--- a/client/src/components/Workflow/WorkflowIndexActions.vue
+++ b/client/src/components/Workflow/WorkflowIndexActions.vue
@@ -54,7 +54,7 @@ export default {
     },
     methods: {
         navigateToCreate: function () {
-            this.$router.push("/workflows/create");
+            this.$router.push("/workflows/edit");
         },
         navigateToImport: function () {
             this.$router.push("/workflows/import");

--- a/client/src/components/Workflow/WorkflowRunButton.vue
+++ b/client/src/components/Workflow/WorkflowRunButton.vue
@@ -34,7 +34,7 @@ export default {
     },
     methods: {
         executeWorkflow() {
-            window.location.assign(`${this.root}workflows/run?id=${this.id}`);
+            this.$router.push(`/workflows/run?id=${this.id}`);
         },
     },
 };

--- a/client/src/composables/workflowStores.ts
+++ b/client/src/composables/workflowStores.ts
@@ -1,4 +1,4 @@
-import { inject, onScopeDispose, provide } from "vue";
+import { inject, onScopeDispose, provide, type Ref } from "vue";
 
 import { useConnectionStore } from "@/stores/workflowConnectionStore";
 import { useWorkflowCommentStore } from "@/stores/workflowEditorCommentStore";
@@ -15,14 +15,14 @@ import { useWorkflowStepStore } from "@/stores/workflowStepStore";
  * @param workflowId the workflow to scope to
  * @returns workflow Stores
  */
-export function provideScopedWorkflowStores(workflowId: string) {
+export function provideScopedWorkflowStores(workflowId: Ref<string>) {
     provide("workflowId", workflowId);
 
-    const connectionStore = useConnectionStore(workflowId);
-    const stateStore = useWorkflowStateStore(workflowId);
-    const stepStore = useWorkflowStepStore(workflowId);
-    const commentStore = useWorkflowCommentStore(workflowId);
-    const toolbarStore = useWorkflowEditorToolbarStore(workflowId);
+    const connectionStore = useConnectionStore(workflowId.value);
+    const stateStore = useWorkflowStateStore(workflowId.value);
+    const stepStore = useWorkflowStepStore(workflowId.value);
+    const commentStore = useWorkflowCommentStore(workflowId.value);
+    const toolbarStore = useWorkflowEditorToolbarStore(workflowId.value);
 
     onScopeDispose(() => {
         connectionStore.$dispose();
@@ -51,19 +51,19 @@ export function provideScopedWorkflowStores(workflowId: string) {
  * @returns workflow stores
  */
 export function useWorkflowStores() {
-    const workflowId = inject("workflowId");
+    const workflowId = inject("workflowId") as Ref<string>;
 
-    if (typeof workflowId !== "string") {
+    if (typeof workflowId?.value !== "string") {
         throw new Error(
             "Workflow ID not provided by parent component. Use `provideScopedWorkflowStores` on a parent component."
         );
     }
 
-    const connectionStore = useConnectionStore(workflowId);
-    const stateStore = useWorkflowStateStore(workflowId);
-    const stepStore = useWorkflowStepStore(workflowId);
-    const commentStore = useWorkflowCommentStore(workflowId);
-    const toolbarStore = useWorkflowEditorToolbarStore(workflowId);
+    const connectionStore = useConnectionStore(workflowId.value);
+    const stateStore = useWorkflowStateStore(workflowId.value);
+    const stepStore = useWorkflowStepStore(workflowId.value);
+    const commentStore = useWorkflowCommentStore(workflowId.value);
+    const toolbarStore = useWorkflowEditorToolbarStore(workflowId.value);
 
     return {
         connectionStore,

--- a/client/src/composables/workflowStores.ts
+++ b/client/src/composables/workflowStores.ts
@@ -1,4 +1,4 @@
-import { inject, onScopeDispose, provide, type Ref } from "vue";
+import { inject, onScopeDispose, provide, type Ref, ref } from "vue";
 
 import { useConnectionStore } from "@/stores/workflowConnectionStore";
 import { useWorkflowCommentStore } from "@/stores/workflowEditorCommentStore";
@@ -15,7 +15,11 @@ import { useWorkflowStepStore } from "@/stores/workflowStepStore";
  * @param workflowId the workflow to scope to
  * @returns workflow Stores
  */
-export function provideScopedWorkflowStores(workflowId: Ref<string>) {
+export function provideScopedWorkflowStores(workflowId: Ref<string> | string) {
+    if (typeof workflowId === "string") {
+        workflowId = ref(workflowId);
+    }
+
     provide("workflowId", workflowId);
 
     const connectionStore = useConnectionStore(workflowId.value);

--- a/client/src/composables/workflowStores.ts
+++ b/client/src/composables/workflowStores.ts
@@ -1,4 +1,4 @@
-import { inject, onScopeDispose, provide, type Ref, ref } from "vue";
+import { inject, onScopeDispose, provide, type Ref, ref, unref } from "vue";
 
 import { useConnectionStore } from "@/stores/workflowConnectionStore";
 import { useWorkflowCommentStore } from "@/stores/workflowEditorCommentStore";
@@ -55,19 +55,20 @@ export function provideScopedWorkflowStores(workflowId: Ref<string> | string) {
  * @returns workflow stores
  */
 export function useWorkflowStores() {
-    const workflowId = inject("workflowId") as Ref<string>;
+    const workflowId = inject("workflowId") as Ref<string> | string;
+    const id = unref(workflowId);
 
-    if (typeof workflowId?.value !== "string") {
+    if (typeof id !== "string") {
         throw new Error(
             "Workflow ID not provided by parent component. Use `provideScopedWorkflowStores` on a parent component."
         );
     }
 
-    const connectionStore = useConnectionStore(workflowId.value);
-    const stateStore = useWorkflowStateStore(workflowId.value);
-    const stepStore = useWorkflowStepStore(workflowId.value);
-    const commentStore = useWorkflowCommentStore(workflowId.value);
-    const toolbarStore = useWorkflowEditorToolbarStore(workflowId.value);
+    const connectionStore = useConnectionStore(id);
+    const stateStore = useWorkflowStateStore(id);
+    const stepStore = useWorkflowStepStore(id);
+    const commentStore = useWorkflowCommentStore(id);
+    const toolbarStore = useWorkflowEditorToolbarStore(id);
 
     return {
         connectionStore,

--- a/client/src/entry/analysis/modules/WorkflowEditor.vue
+++ b/client/src/entry/analysis/modules/WorkflowEditor.vue
@@ -1,11 +1,11 @@
 <template>
     <Editor
         v-if="editorConfig"
-        :id="editorConfig.id"
+        :workflow-id="editorConfig.id"
         :data-managers="editorConfig.dataManagers"
         :initial-version="editorConfig.initialVersion"
         :module-sections="editorConfig.moduleSections"
-        :tags="editorConfig.tags"
+        :workflow-tags="editorConfig.tags"
         :workflows="editorConfig.workflows"
         @update:confirmation="$emit('update:confirmation', $event)" />
 </template>

--- a/client/src/stores/scopePointerStore.ts
+++ b/client/src/stores/scopePointerStore.ts
@@ -11,7 +11,7 @@ export const useScopePointerStore = defineStore("scopePointerStore", () => {
     const scopePointers = ref<Record<FromScopeId, ToScopeId | undefined>>({});
 
     function addScopePointer(from: FromScopeId, to: ToScopeId) {
-        scopePointers.value[from] = to;
+        scopePointers.value[from] = scope.value(to);
     }
 
     const scope = computed(() => (scopeId: string) => scopePointers.value[scopeId] ?? scopeId);

--- a/client/src/stores/scopePointerStore.ts
+++ b/client/src/stores/scopePointerStore.ts
@@ -1,0 +1,28 @@
+import { defineStore } from "pinia";
+import { computed, ref } from "vue";
+
+/**
+ * This store allows for pointing scoped stores to other scoped stores
+ */
+export const useScopePointerStore = defineStore("scopePointerStore", () => {
+    type FromScopeId = string;
+    type ToScopeId = string;
+
+    const scopePointers = ref<Record<FromScopeId, ToScopeId | undefined>>({});
+
+    function addScopePointer(from: FromScopeId, to: ToScopeId) {
+        scopePointers.value[from] = to;
+    }
+
+    const scope = computed(() => (scopeId: string) => scopePointers.value[scopeId] ?? scopeId);
+
+    function removeScopePointer(id: FromScopeId) {
+        scopePointers.value[id] = undefined;
+    }
+
+    return {
+        addScopePointer,
+        removeScopePointer,
+        scope,
+    };
+});

--- a/client/src/stores/workflowConnectionStore.ts
+++ b/client/src/stores/workflowConnectionStore.ts
@@ -4,6 +4,8 @@ import Vue from "vue";
 import { useWorkflowStepStore } from "@/stores/workflowStepStore";
 import { pushOrSet } from "@/utils/pushOrSet";
 
+import { useScopePointerStore } from "./scopePointerStore";
+
 interface InvalidConnections {
     [index: ConnectionId]: string | undefined;
 }
@@ -43,11 +45,9 @@ interface TerminalToOutputTerminals {
 }
 
 export const useConnectionStore = (workflowId: string) => {
-    if (!workflowId) {
-        throw new Error("WorkflowId is undefined");
-    }
+    const { scope } = useScopePointerStore();
 
-    return defineStore(`workflowConnectionStore${workflowId}`, {
+    return defineStore(`workflowConnectionStore${scope(workflowId)}`, {
         state: (): State => ({
             connections: [] as Array<Readonly<Connection>>,
             invalidConnections: {} as InvalidConnections,

--- a/client/src/stores/workflowEditorCommentStore.ts
+++ b/client/src/stores/workflowEditorCommentStore.ts
@@ -15,6 +15,7 @@ import {
 import { assertDefined } from "@/utils/assertions";
 import { hasKeys, match } from "@/utils/utils";
 
+import { useScopePointerStore } from "./scopePointerStore";
 import { useWorkflowStateStore } from "./workflowEditorStateStore";
 import { Step, useWorkflowStepStore } from "./workflowStepStore";
 
@@ -92,7 +93,9 @@ function assertCommentDataValid(
 export type WorkflowCommentStore = ReturnType<typeof useWorkflowCommentStore>;
 
 export const useWorkflowCommentStore = (workflowId: string) => {
-    return defineStore(`workflowCommentStore${workflowId}`, () => {
+    const { scope } = useScopePointerStore();
+
+    return defineStore(`workflowCommentStore${scope(workflowId)}`, () => {
         const commentsRecord = ref<Record<number, WorkflowComment>>({});
         const localCommentsMetadata = ref<Record<number, CommentsMetadata>>({});
 

--- a/client/src/stores/workflowEditorStateStore.ts
+++ b/client/src/stores/workflowEditorStateStore.ts
@@ -5,6 +5,8 @@ import Vue, { reactive } from "vue";
 
 import type { OutputTerminals } from "@/components/Workflow/Editor/modules/terminals";
 
+import { useScopePointerStore } from "./scopePointerStore";
+
 export interface InputTerminalPosition {
     endX: number;
     endY: number;
@@ -34,7 +36,9 @@ interface State {
 }
 
 export const useWorkflowStateStore = (workflowId: string) => {
-    return defineStore(`workflowStateStore${workflowId}`, {
+    const { scope } = useScopePointerStore();
+
+    return defineStore(`workflowStateStore${scope(workflowId)}`, {
         state: (): State => ({
             inputTerminals: {},
             outputTerminals: {},

--- a/client/src/stores/workflowEditorToolbarStore.ts
+++ b/client/src/stores/workflowEditorToolbarStore.ts
@@ -4,6 +4,7 @@ import { computed, onScopeDispose, reactive, ref, watch } from "vue";
 
 import { useUserLocalStorage } from "@/composables/userLocalStorage";
 
+import { useScopePointerStore } from "./scopePointerStore";
 import { WorkflowCommentColor } from "./workflowEditorCommentStore";
 
 export type CommentTool = "textComment" | "markdownComment" | "frameComment" | "freehandComment" | "freehandEraser";
@@ -28,7 +29,9 @@ export interface InputCatcherEvent {
 export type WorkflowEditorToolbarStore = ReturnType<typeof useWorkflowEditorToolbarStore>;
 
 export const useWorkflowEditorToolbarStore = (workflowId: string) => {
-    return defineStore(`workflowEditorToolbarStore${workflowId}`, () => {
+    const { scope } = useScopePointerStore();
+
+    return defineStore(`workflowEditorToolbarStore${scope(workflowId)}`, () => {
         const snapActive = useUserLocalStorage("workflow-editor-toolbar-snap-active", false);
         const currentTool = ref<EditorTool>("pointer");
         const inputCatcherActive = ref<boolean>(false);

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -5,6 +5,8 @@ import type { CollectionTypeDescriptor } from "@/components/Workflow/Editor/modu
 import { type Connection, getConnectionId, useConnectionStore } from "@/stores/workflowConnectionStore";
 import { assertDefined } from "@/utils/assertions";
 
+import { useScopePointerStore } from "./scopePointerStore";
+
 interface State {
     steps: { [index: string]: Step };
     stepIndex: number;
@@ -145,7 +147,9 @@ interface StepInputMapOver {
 }
 
 export const useWorkflowStepStore = (workflowId: string) => {
-    return defineStore(`workflowStepStore${workflowId}`, {
+    const { scope } = useScopePointerStore();
+
+    return defineStore(`workflowStepStore${scope(workflowId)}`, {
         state: (): State => ({
             steps: {} as Steps,
             stepMapOver: {} as { [index: number]: CollectionTypeDescriptor },

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -687,6 +687,16 @@ class WorkflowContentsManager(UsesAnnotations):
             stored_workflow.latest_workflow = workflow
             workflow.stored_workflow = stored_workflow
 
+        data = raw_workflow_description.as_dict
+        if isinstance(data, str):
+            data = json.loads(data)
+        if "tags" in data:
+            trans.tag_handler.set_tags_from_list(
+                trans.user,
+                stored_workflow,
+                data.get("tags", []),
+            )
+
         if workflow_update_options.update_stored_workflow_attributes:
             update_dict = raw_workflow_description.as_dict
             if "name" in update_dict:

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -693,7 +693,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 sanitized_name = sanitize_html(update_dict["name"])
                 workflow.name = sanitized_name
                 stored_workflow.name = sanitized_name
-            if "annotation" in update_dict:
+            if update_dict.get("annotation") is not None:
                 newAnnotation = sanitize_html(update_dict["annotation"])
                 sa_session = None if dry_run else trans.sa_session
                 self.add_item_annotation(sa_session, stored_workflow.user, stored_workflow, newAnnotation)

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1526,6 +1526,7 @@ class NavigatesGalaxy(HasDriver):
         save_button.wait_for_visible()
         assert not save_button.has_class("disabled")
         save_button.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
         return name
 
     def invocation_index_table_elements(self):

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1516,13 +1516,16 @@ class NavigatesGalaxy(HasDriver):
         self.click_button_new_workflow()
         self.sleep_for(self.wait_types.UX_RENDER)
         name = self._get_random_name()
-        name_component = self.components.workflows.create.name
+        name_component = self.components.workflow_editor.edit_name
         if clear_placeholder:
             name_component.wait_for_visible().clear()
         name_component.wait_for_and_send_keys(name)
         annotation = annotation or self._get_random_name()
-        self.components.workflows.create.annotation.wait_for_and_send_keys(annotation)
-        self.components.workflows.create.submit.wait_for_and_click()
+        self.components.workflow_editor.edit_annotation.wait_for_and_send_keys(annotation)
+        save_button = self.components.workflow_editor.save_button
+        save_button.wait_for_visible()
+        assert not save_button.has_class("disabled")
+        save_button.wait_for_and_click()
         return name
 
     def invocation_index_table_elements(self):

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -364,6 +364,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
             user = trans.get_user()
             workflow_name = payload.get("workflow_name")
             workflow_annotation = payload.get("workflow_annotation")
+            workflow_tags = payload.get("workflow_tags", [])
             if not workflow_name:
                 return self.message_exception(trans, "Please provide a workflow name.")
             # Create the new stored workflow
@@ -379,6 +380,12 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
             # Add annotation.
             workflow_annotation = sanitize_html(workflow_annotation)
             self.add_item_annotation(trans.sa_session, trans.get_user(), stored_workflow, workflow_annotation)
+            # Add tags
+            trans.tag_handler.set_tags_from_list(
+                trans.user,
+                stored_workflow,
+                workflow_tags,
+            )
             # Persist
             session = trans.sa_session
             session.add(stored_workflow)

--- a/test/integration/test_workflow_refactoring.py
+++ b/test/integration/test_workflow_refactoring.py
@@ -898,6 +898,7 @@ class MockTrans(ProvidesAppContext):
         self.user = user
         self.history = None
         self.workflow_building_mode = workflow_building_modes.ENABLED
+        self.tag_handler = app.tag_handler
 
     @property
     def galaxy_session(self):


### PR DESCRIPTION
Skip the step of Creating a workflow, and instead go straight into an empty editor, add nodes, tags, connections...; workflow will only be created once you Save and provide the worfklow a name. Fixes https://github.com/galaxyproject/galaxy/issues/16912

https://github.com/galaxyproject/galaxy/assets/78516064/90df5d03-e77f-4434-b3f0-db2a9c5b30b7

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
