### PR TITLE
Allow to permanently delete non-deleted items in Storage Dashboard Visualizations

### DIFF
--- a/client/src/components/User/DiskUsage/Visualizations/SelectedItemActions.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/SelectedItemActions.vue
@@ -81,7 +81,6 @@ function onPermanentlyDeleteItem() {
                 <FontAwesomeIcon icon="undo" />
             </BButton>
             <BButton
-                v-if="isRecoverable"
                 variant="outline-danger"
                 size="sm"
                 class="mx-2"


### PR DESCRIPTION
Closes #16699

You can now `permanently delete` histories or datasets from the Storage Dashboard visualization charts even if they have not been previously marked as deleted. Since you must confirm the action anyway, it should be secure enough.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Go to `http://127.0.0.1:8081/storage/histories`
  - Click any non-deleted history or go into the history details `http://127.0.0.1:8081/storage/history/{history_id}` and click any dataset
  - Check that you can permanently delete it from the card options.
  
![AllowDashboardVizDelete](https://github.com/galaxyproject/galaxy/assets/46503462/4abae099-c53b-4735-a545-0474ec2e2a41)



## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
