### PR TITLE
Allow switching histories from Storage Dashboard Visualizations

### DIFF
--- a/client/src/components/User/DiskUsage/Visualizations/HistoriesStorageOverview.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/HistoriesStorageOverview.vue
@@ -4,6 +4,7 @@ import { useRouter } from "vue-router/composables";
 
 import { useConfirmDialog } from "@/composables/confirmDialog";
 import { useToast } from "@/composables/toast";
+import { useHistoryStore } from "@/stores/historyStore";
 import localize from "@/utils/localization";
 
 import type { DataValuePoint } from "./Charts";
@@ -16,6 +17,7 @@ import SelectedItemActions from "./SelectedItemActions.vue";
 import Heading from "@/components/Common/Heading.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
+const historyStore = useHistoryStore();
 const router = useRouter();
 const { success: successToast, error: errorToast } = useToast();
 const { confirm } = useConfirmDialog();
@@ -96,6 +98,11 @@ function isArchivedDataPoint(dataPoint: DataValuePoint): boolean {
         return historiesSizeSummary?.archived || false;
     }
     return false;
+}
+
+async function onSetCurrentHistory(historyId: string) {
+    await historyStore.setCurrentHistory(historyId);
+    router.push({ path: "/" });
 }
 
 function onViewHistory(historyId: string) {
@@ -197,6 +204,7 @@ async function onPermanentlyDeleteHistory(historyId: string) {
                         item-type="history"
                         :is-recoverable="isRecoverableDataPoint(data)"
                         :is-archived="isArchivedDataPoint(data)"
+                        @set-current-history="onSetCurrentHistory"
                         @view-item="onViewHistory"
                         @undelete-item="onUndeleteHistory"
                         @permanently-delete-item="onPermanentlyDeleteHistory" />

--- a/client/src/components/User/DiskUsage/Visualizations/HistoriesStorageOverview.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/HistoriesStorageOverview.vue
@@ -194,6 +194,7 @@ async function onPermanentlyDeleteHistory(historyId: string) {
                 </template>
                 <template v-slot:tooltip="{ data }">
                     <RecoverableItemSizeTooltip
+                        v-if="data"
                         :data="data"
                         :is-recoverable="isRecoverableDataPoint(data)"
                         :is-archived="isArchivedDataPoint(data)" />
@@ -222,7 +223,10 @@ async function onPermanentlyDeleteHistory(historyId: string) {
                 :label-formatter="bytesLabelFormatter"
                 :value-formatter="bytesValueFormatter">
                 <template v-slot:tooltip="{ data }">
-                    <RecoverableItemSizeTooltip :data="data" :is-recoverable="isRecoverableDataPoint(data)" />
+                    <RecoverableItemSizeTooltip
+                        v-if="data"
+                        :data="data"
+                        :is-recoverable="isRecoverableDataPoint(data)" />
                 </template>
             </BarChart>
         </div>

--- a/client/src/components/User/DiskUsage/Visualizations/HistoryStorageOverview.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/HistoryStorageOverview.vue
@@ -196,7 +196,10 @@ async function onPermanentlyDeleteDataset(datasetId: string) {
                     </b-form-select>
                 </template>
                 <template v-slot:tooltip="{ data }">
-                    <RecoverableItemSizeTooltip :data="data" :is-recoverable="isRecoverableDataPoint(data)" />
+                    <RecoverableItemSizeTooltip
+                        v-if="data"
+                        :data="data"
+                        :is-recoverable="isRecoverableDataPoint(data)" />
                 </template>
                 <template v-slot:selection="{ data }">
                     <SelectedItemActions
@@ -221,7 +224,10 @@ async function onPermanentlyDeleteDataset(datasetId: string) {
                 :label-formatter="bytesLabelFormatter"
                 :value-formatter="bytesValueFormatter">
                 <template v-slot:tooltip="{ data }">
-                    <RecoverableItemSizeTooltip :data="data" :is-recoverable="isRecoverableDataPoint(data)" />
+                    <RecoverableItemSizeTooltip
+                        v-if="data"
+                        :data="data"
+                        :is-recoverable="isRecoverableDataPoint(data)" />
                 </template>
             </BarChart>
         </div>

--- a/client/src/components/User/DiskUsage/Visualizations/SelectedItemActions.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/SelectedItemActions.vue
@@ -1,10 +1,18 @@
 <script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faArchive, faChartBar, faInfoCircle, faTrash, faUndo } from "@fortawesome/free-solid-svg-icons";
+import {
+    faArchive,
+    faChartBar,
+    faInfoCircle,
+    faLocationArrow,
+    faTrash,
+    faUndo,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton } from "bootstrap-vue";
 import { computed } from "vue";
 
+import { useHistoryStore } from "@/stores/historyStore";
 import localize from "@/utils/localization";
 import { bytesToString } from "@/utils/utils";
 
@@ -19,17 +27,23 @@ interface SelectedItemActionsProps {
     isArchived?: boolean;
 }
 
+const { currentHistoryId } = useHistoryStore();
+
 const props = withDefaults(defineProps<SelectedItemActionsProps>(), {
     isArchived: false,
 });
 
-library.add(faChartBar, faUndo, faTrash, faInfoCircle, faArchive);
+library.add(faArchive, faChartBar, faInfoCircle, faLocationArrow, faTrash, faUndo);
 
 const label = computed(() => props.data?.label ?? "No data");
 const prettySize = computed(() => bytesToString(props.data?.value ?? 0));
 const viewDetailsIcon = computed(() => (props.itemType === "history" ? "chart-bar" : "info-circle"));
+const canSetAsCurrent = computed(
+    () => props.itemType === "history" && !props.isArchived && props.data.id !== currentHistoryId
+);
 
 const emit = defineEmits<{
+    (e: "set-current-history", historyId: string): void;
     (e: "view-item", itemId: string): void;
     (e: "undelete-item", itemId: string): void;
     (e: "permanently-delete-item", itemId: string): void;
@@ -37,6 +51,10 @@ const emit = defineEmits<{
 
 function onUndeleteItem() {
     emit("undelete-item", props.data.id);
+}
+
+function onSetCurrentHistory() {
+    emit("set-current-history", props.data.id);
 }
 
 function onViewItem() {
@@ -63,6 +81,15 @@ function onPermanentlyDeleteItem() {
         </div>
 
         <div class="my-2">
+            <BButton
+                v-if="canSetAsCurrent"
+                variant="outline-primary"
+                size="sm"
+                class="mx-2"
+                :title="localize('Set this history as current')"
+                @click="onSetCurrentHistory">
+                <FontAwesomeIcon icon="location-arrow" />
+            </BButton>
             <BButton
                 variant="outline-primary"
                 size="sm"


### PR DESCRIPTION
Adds a new button in the `Histories Storage Overview` when you select a history to switch to that history.

https://github.com/galaxyproject/galaxy/assets/46503462/8c8739d5-da72-4d66-9e22-abbf0fb2392a

Closes #16899

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Go to http://127.0.0.1:8081/storage/histories
  - Select a history (that is not the current history) and click on "set as current" button

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
