### PR TITLE
[22.05] Reload built-in converters on toolbox reload

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -650,9 +650,6 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
         self.datatypes_registry.load_external_metadata_tool(self.toolbox)
         # Load history import/export tools.
         load_lib_tools(self.toolbox)
-        # Load built-in converters
-        if self.config.display_builtin_converters:
-            self.toolbox.load_builtin_converters()
         self.toolbox.persist_cache(register_postfork=True)
         # visualizations registry: associates resources with visualizations, controls how to render
         self.visualizations_registry = self._register_singleton(

--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -205,6 +205,7 @@ class MockAppConfig(GalaxyDataTestConfig, CommonConfigurationMixin):
         self.integrated_tool_panel_config = None
         self.vault_config_file = kwargs.get("vault_config_file")
         self.max_discovered_files = 10000
+        self.display_builtin_converters = True
 
     @property
     def config_dict(self):

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -183,6 +183,9 @@ def _get_new_toolbox(app, save_integrated_tool_panel=True):
     app.datatypes_registry.load_datatype_converters(new_toolbox, use_cached=True)
     app.datatypes_registry.load_external_metadata_tool(new_toolbox)
     load_lib_tools(new_toolbox)
+    # Load built-in converters
+    if app.config.display_builtin_converters:
+        new_toolbox.load_builtin_converters()
     [new_toolbox.register_tool(tool) for tool in new_toolbox.data_manager_tools.values()]
     app.toolbox = new_toolbox
     app.toolbox.persist_cache()

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -183,9 +183,6 @@ def _get_new_toolbox(app, save_integrated_tool_panel=True):
     app.datatypes_registry.load_datatype_converters(new_toolbox, use_cached=True)
     app.datatypes_registry.load_external_metadata_tool(new_toolbox)
     load_lib_tools(new_toolbox)
-    # Load built-in converters
-    if app.config.display_builtin_converters:
-        new_toolbox.load_builtin_converters()
     [new_toolbox.register_tool(tool) for tool in new_toolbox.data_manager_tools.values()]
     app.toolbox = new_toolbox
     app.toolbox.persist_cache()

--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -32,7 +32,6 @@ from galaxy.util import (
     string_as_bool,
     unicodify,
 )
-
 from galaxy.util.bunch import Bunch
 from galaxy.util.dictifiable import Dictifiable
 from .filters import FilterFactory

--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -32,6 +32,7 @@ from galaxy.util import (
     string_as_bool,
     unicodify,
 )
+
 from galaxy.util.bunch import Bunch
 from galaxy.util.dictifiable import Dictifiable
 from .filters import FilterFactory
@@ -1411,6 +1412,9 @@ class BaseGalaxyToolBox(AbstractToolBox):
         super().__init__(
             config_filenames, tool_root_dir, app, view_sources, default_panel_view, save_integrated_tool_panel
         )
+        # Load built-in converters
+        if app.config.display_builtin_converters:
+            self.load_builtin_converters()
         old_toolbox = getattr(app, "toolbox", None)
         if old_toolbox:
             self.dependency_manager = old_toolbox.dependency_manager

--- a/test/unit/app/tools/test_toolbox.py
+++ b/test/unit/app/tools/test_toolbox.py
@@ -412,14 +412,15 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
         self._setup_two_versions()
         self.__verify_two_test_tools()
 
-        # Assert tools merged in tool panel.
-        assert len(self.toolbox._tool_panel) == 1
+        # Assert tools merged in tool panel (2nd element is the built in converters section loaded per default)
+        assert len(self.toolbox._tool_panel) == 2
 
     def test_get_section_by_label(self):
         self._add_config(
             """<toolbox><section id="tid" name="Completely unrelated"><label id="lab1" text="Label 1" /><label id="lab2" text="Label 2" /></section></toolbox>"""
         )
-        assert len(self.toolbox._tool_panel) == 1
+        # assert len of 2: the section + the builtin converters that are loaded per default
+        assert len(self.toolbox._tool_panel) == 2
         section = self.toolbox._tool_panel["tid"]
         tool_panel_section_key, section_by_label = self.toolbox.get_section(
             section_id="nope", new_label="Completely unrelated", create_if_needed=True
@@ -466,7 +467,8 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
         stored_workflow = self.__test_workflow()
         encoded_id = self.app.security.encode_id(stored_workflow.id)
         self._add_config("""<toolbox><workflow id="%s" /></toolbox>""" % encoded_id)
-        assert len(self.toolbox._tool_panel) == 1
+        # assert len of 2: the workflow + the builtin converters that are loaded per default
+        assert len(self.toolbox._tool_panel) == 2
         panel_workflow = next(iter(self.toolbox._tool_panel.values()))
         assert panel_workflow == stored_workflow.latest_workflow
         # TODO: test to_dict with workflows
@@ -477,7 +479,8 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
         self._add_config(
             """<toolbox><section id="tid" name="TID"><workflow id="%s" /></section></toolbox>""" % encoded_id
         )
-        assert len(self.toolbox._tool_panel) == 1
+        # assert len of 2: the section + the builtin converters that are loaded per default
+        assert len(self.toolbox._tool_panel) == 2
         section = self.toolbox._tool_panel["tid"]
         assert len(section.elems) == 1
         panel_workflow = next(iter(section.elems.values()))
@@ -485,14 +488,17 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
 
     def test_label_in_panel(self):
         self._add_config("""<toolbox><label id="lab1" text="Label 1" /><label id="lab2" text="Label 2" /></toolbox>""")
-        assert len(self.toolbox._tool_panel) == 2
+
+        # assert len of 3: 2 labels + the builtin converters that are loaded per default
+        assert len(self.toolbox._tool_panel) == 3
         self.__check_test_labels(self.toolbox._tool_panel)
 
     def test_label_in_section(self):
         self._add_config(
             """<toolbox><section id="tid" name="TID"><label id="lab1" text="Label 1" /><label id="lab2" text="Label 2" /></section></toolbox>"""
         )
-        assert len(self.toolbox._tool_panel) == 1
+        # assert len of 2: section + the builtin converters that are loaded per default
+        assert len(self.toolbox._tool_panel) == 2
         section = self.toolbox._tool_panel["tid"]
         self.__check_test_labels(section.elems)
 
@@ -510,7 +516,12 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
             self._add_config({"items": [section]}, name="tool_conf.json")
 
     def __check_test_labels(self, panel_dict):
-        assert list(panel_dict.keys()) == ["label_lab1", "label_lab2"]
+        # if panel_dict is the complete panel it will contain builtin_converters
+        # if its a section then not
+        assert list(panel_dict.keys()) in (
+            ["label_lab1", "label_lab2", "builtin_converters"],
+            ["label_lab1", "label_lab2"],
+        )
         label1 = next(iter(panel_dict.values()))
         assert label1.id == "lab1"
         assert label1.text == "Label 1"
@@ -584,7 +595,8 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
         self._init_tool(filename="tool_v02.xml", version="0.2")
 
     def __verify_tool_panel_for_default_lineage(self):
-        assert len(self.toolbox._tool_panel) == 1
+        # assert len of 2: the section + the builtin converters that are loaded per default
+        assert len(self.toolbox._tool_panel) == 2
         tool = self.toolbox._tool_panel["tool_test_tool"]
         assert tool.version == "0.2", tool.version
         assert tool.id == "test_tool"

--- a/test/unit/shed_unit/test_tool_panel_manager.py
+++ b/test/unit/shed_unit/test_tool_panel_manager.py
@@ -25,20 +25,23 @@ class ToolPanelManagerTestCase(BaseToolBoxTestCase):
         assert section_id == "tid"
         assert len(section.elems) == 1  # tool.xml
         assert section.id == "tid"
-        assert len(toolbox._tool_panel) == 1
+        # assert len of 2: the section + the builtin converters that are loaded per default
+        assert len(toolbox._tool_panel) == 2
 
         section_id, section = tpm.handle_tool_panel_section(toolbox, new_tool_panel_section_label="tid2")
         assert section_id == "tid2"
         assert len(section.elems) == 0  # new section
         assert section.id == "tid2"
-        assert len(toolbox._tool_panel) == 2
+        # assert len of 3: tid, tid2 + the builtin converters that are loaded per default
+        assert len(toolbox._tool_panel) == 3
 
         # Test re-fetch new section by same id.
         section_id, section = tpm.handle_tool_panel_section(toolbox, new_tool_panel_section_label="tid2")
         assert section_id == "tid2"
         assert len(section.elems) == 0  # new section
         assert section.id == "tid2"
-        assert len(toolbox._tool_panel) == 2
+        # assert len of 3: tid, tid2 + the builtin converters that are loaded per default
+        assert len(toolbox._tool_panel) == 3
 
     def test_add_tool_to_panel(self):
         self._init_ts_tool(guid=DEFAULT_GUID)


### PR DESCRIPTION
Hopefully fixes https://github.com/galaxyproject/galaxy/issues/16947 

Maybe `load_builtin_converters` should be included in the `load_lib_tools` or `Toolbox` init function?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
