### PR TITLE
[23.1] Adds `biii` as supported xref reference type

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -7275,7 +7275,6 @@ A tool can refer multiple reference IDs.
    <xrefs>
        <xref type="bio.tools">dada2</xref>
        <xref type="bioconductor">dada2</xref>
-       <xref type="biii">dada2</xref>
    </xrefs>
    <!-- https://bio.tools/dada2 -->
 ```

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -7275,6 +7275,7 @@ A tool can refer multiple reference IDs.
    <xrefs>
        <xref type="bio.tools">dada2</xref>
        <xref type="bioconductor">dada2</xref>
+       <xref type="biii">dada2</xref>
    </xrefs>
    <!-- https://bio.tools/dada2 -->
 ```
@@ -7295,7 +7296,7 @@ information according to a catalog.</xs:documentation>
       <xs:extension base="xs:string">
         <xs:attribute name="type" type="xrefType" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">Type of reference - currently ``bio.tools`` and ``bioconductor`` are
+            <xs:documentation xml:lang="en">Type of reference - currently ``bio.tools``, ``bioconductor``, and ``biii`` are
 the only supported options.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
@@ -7309,6 +7310,7 @@ the only supported options.</xs:documentation>
     <xs:restriction base="xs:string">
       <xs:enumeration value="bio.tools"/>
       <xs:enumeration value="bioconductor"/>
+      <xs:enumeration value="biii"/>
       <!--xs:enumeration value="whatelse"/-->
     </xs:restriction>
   </xs:simpleType>


### PR DESCRIPTION
Adds `biii` to the list of supported xref references. This enables annotating tools using the [biii.eu](https://biii.eu) ontology:
```
<xrefs>
  <xref type="biii">scikit-image</xref>
</xrefs>
```

Essentia

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
