### PR TITLE
Remove sentry.py from mypy exclusions.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -311,8 +311,6 @@ check_untyped_defs = False
 check_untyped_defs = False
 [mypy-galaxy.tools.parameters.dataset_matcher]
 check_untyped_defs = False
-[mypy-galaxy.tools.error_reports.plugins.sentry]
-check_untyped_defs = False
 [mypy-galaxy.tool_util.verify.script]
 check_untyped_defs = False
 [mypy-galaxy.tool_util.deps.resolvers.unlinked_tool_shed_packages]


### PR DESCRIPTION
Seems like typing has been fixed 

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
