### PR TITLE
[23.1] Prevent Singular external auth users from disconnecting identity

### DIFF
--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -49,7 +49,7 @@
             to="/user/cloud_auth" />
         <ConfigProvider v-slot="{ config }">
             <user-preferences-element
-                v-if="config.enable_oidc"
+                v-if="config.enable_oidc && !config.fixed_delegated_auth"
                 id="manage-third-party-identities"
                 icon="fa-id-card-o"
                 title="Manage Third-Party Identities"

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -397,7 +397,7 @@ export function getRouter(Galaxy) {
                     {
                         path: "user/external_ids",
                         component: ExternalIdentities,
-                        redirect: redirectAnon(),
+                        redirect: redirectIf(Galaxy.config.fixed_delegated_auth, "/") || redirectAnon(),
                     },
                     {
                         path: "user/notifications",

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -709,6 +709,13 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
                 self, self.config.oidc_config_file, self.config.oidc_backends_config_file
             )
 
+            # If there is only a single external authentication provider in use
+            # TODO: Future work will expand on this and provide an interface for
+            # multiple auth providers allowing explicit authenticated association.
+            self.config.fixed_delegated_auth = (
+                len(list(self.config.oidc)) == 1 and len(list(self.auth_manager.authenticators)) == 0
+            )
+
         if not self.config.enable_celery_tasks and self.config.history_audit_table_prune_interval > 0:
             self.prune_history_audit_task = IntervalTask(
                 func=lambda: galaxy.model.HistoryAudit.prune(self.model.session),

--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -189,21 +189,9 @@ class CustosAuthnz(IdentityProvider):
         if custos_authnz_token is None:
             user = trans.user
             existing_user = trans.sa_session.query(User).filter_by(email=email).first()
-            # If there is only a single external authentication
-            # provider in use, trust the user provided and
-            # automatically associate.
-            # Equivalent to `fixed_delegated_auth` from `ConfigSerializer`
-            # TODO: Future work will expand on this and provide an
-            # interface for when there are multiple auth providers
-            # allowing explicit authenticated association.
-            fixed_delegated_auth = (
-                trans.app.config.enable_oidc
-                and len(trans.app.config.oidc) == 1
-                and len(trans.app.auth_manager.authenticators) == 0
-            )
             if not user:
                 if existing_user:
-                    if fixed_delegated_auth:
+                    if trans.app.config.fixed_delegated_auth:
                         user = existing_user
                     else:
                         message = f"There already exists a user with email {email}.  To associate this external login, you must first be logged in as that existing account."
@@ -235,7 +223,7 @@ class CustosAuthnz(IdentityProvider):
                 refresh_expiration_time=refresh_expiration_time,
             )
             label = self.config["label"]
-            if fixed_delegated_auth:
+            if trans.app.config.fixed_delegated_auth:
                 redirect_url = login_redirect_url
             elif existing_user and existing_user != user:
                 redirect_url = (

--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -189,19 +189,21 @@ class CustosAuthnz(IdentityProvider):
         if custos_authnz_token is None:
             user = trans.user
             existing_user = trans.sa_session.query(User).filter_by(email=email).first()
+            # If there is only a single external authentication
+            # provider in use, trust the user provided and
+            # automatically associate.
+            # Equivalent to `fixed_delegated_auth` from `ConfigSerializer`
+            # TODO: Future work will expand on this and provide an
+            # interface for when there are multiple auth providers
+            # allowing explicit authenticated association.
+            fixed_delegated_auth = (
+                trans.app.config.enable_oidc
+                and len(trans.app.config.oidc) == 1
+                and len(trans.app.auth_manager.authenticators) == 0
+            )
             if not user:
                 if existing_user:
-                    # If there is only a single external authentication
-                    # provider in use, trust the user provided and
-                    # automatically associate.
-                    # TODO: Future work will expand on this and provide an
-                    # interface for when there are multiple auth providers
-                    # allowing explicit authenticated association.
-                    if (
-                        trans.app.config.enable_oidc
-                        and len(trans.app.config.oidc) == 1
-                        and len(trans.app.auth_manager.authenticators) == 0
-                    ):
+                    if fixed_delegated_auth:
                         user = existing_user
                     else:
                         message = f"There already exists a user with email {email}.  To associate this external login, you must first be logged in as that existing account."
@@ -233,7 +235,9 @@ class CustosAuthnz(IdentityProvider):
                 refresh_expiration_time=refresh_expiration_time,
             )
             label = self.config["label"]
-            if existing_user and existing_user != user:
+            if fixed_delegated_auth:
+                redirect_url = login_redirect_url
+            elif existing_user and existing_user != user:
                 redirect_url = (
                     f"{login_redirect_url}user/external_ids"
                     f"?email_exists={email}"

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -857,6 +857,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         self.builds_file_path = os.path.join(self.tool_data_path, self.builds_file_path)
         self.len_file_path = os.path.join(self.tool_data_path, self.len_file_path)
         self.oidc: Dict[str, Dict] = {}
+        self.fixed_delegated_auth: bool = False
         self.integrated_tool_panel_config = self._in_managed_config_dir(self.integrated_tool_panel_config)
         integrated_tool_panel_tracking_directory = kwargs.get("integrated_tool_panel_tracking_directory")
         if integrated_tool_panel_tracking_directory:

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -113,7 +113,6 @@ class ConfigSerializer(base.ModelSerializer):
             return True if item.get(key) else False
 
         object_store = self.app.object_store
-        auth_manager = self.app.auth_manager
         self.serializers: Dict[str, base.Serializer] = {
             # TODO: this is available from user data, remove
             "is_admin_user": lambda *a, **c: False,
@@ -209,11 +208,7 @@ class ConfigSerializer(base.ModelSerializer):
             "tool_training_recommendations_link": _use_config,
             "tool_training_recommendations_api_url": _use_config,
             "enable_notification_system": _use_config,
-            "fixed_delegated_auth": lambda item, key, **context: (
-                bool(item.get("enable_oidc"))
-                and len(list(_use_config(item, "oidc", **context))) == 1
-                and len(list(auth_manager.authenticators)) == 0
-            ),
+            "fixed_delegated_auth": _defaults_to(False),
         }
 
 

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -113,6 +113,7 @@ class ConfigSerializer(base.ModelSerializer):
             return True if item.get(key) else False
 
         object_store = self.app.object_store
+        auth_manager = self.app.auth_manager
         self.serializers: Dict[str, base.Serializer] = {
             # TODO: this is available from user data, remove
             "is_admin_user": lambda *a, **c: False,
@@ -208,6 +209,11 @@ class ConfigSerializer(base.ModelSerializer):
             "tool_training_recommendations_link": _use_config,
             "tool_training_recommendations_api_url": _use_config,
             "enable_notification_system": _use_config,
+            "fixed_delegated_auth": lambda item, key, **context: (
+                bool(item.get("enable_oidc"))
+                and len(list(_use_config(item, "oidc", **context))) == 1
+                and len(list(auth_manager.authenticators)) == 0
+            ),
         }
 
 

--- a/test/unit/app/authnz/test_custos_authnz.py
+++ b/test/unit/app/authnz/test_custos_authnz.py
@@ -97,6 +97,7 @@ class TestCustosAuthnz(TestCase):
         self.trans.app.config.enable_oidc = True
         self.trans.app.config.oidc = []
         self.trans.app.auth_manager.authenticators = []
+        self.trans.app.config.fixed_delegated_auth = False
 
     @property
     def test_id_token(self):


### PR DESCRIPTION
Added a `fixed_delegated_auth` variable to `Galaxy.config` that lets us reroute users to home if we have a Galaxy set up with:
```
	config.enable_oidc
	and len(config.oidc) == 1
	and len(auth_manager.authenticators) == 0
```

as in; we only have 1 external auth and no local authenticator, hence, we don't want users to be able to disconnect the only external provider, i.e.: the only way for them to login.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
