### PR TITLE
Enhance Invenio RDM integration

### DIFF
--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -195,7 +195,7 @@ class RDMFilesSource(BaseFilesSource):
         for key, val in self._props.items():
             effective_props[key] = self._evaluate_prop(val, user_context=user_context)
         effective_props["url"] = self._repository_url
-        effective_props["token"] = self.get_authorization_token(user_context)
+        effective_props["token"] = self.safe_get_authorization_token(user_context)
         return cast(RDMFilesSourceProperties, effective_props)
 
     def get_authorization_token(self, user_context: OptionalUserContext) -> str:
@@ -206,3 +206,9 @@ class RDMFilesSource(BaseFilesSource):
         if token is None:
             raise AuthenticationRequired(f"No authorization token provided in user's settings for '{self.label}'")
         return token
+
+    def safe_get_authorization_token(self, user_context: OptionalUserContext) -> Optional[str]:
+        try:
+            return self.get_authorization_token(user_context)
+        except AuthenticationRequired:
+            return None

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -260,7 +260,10 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         user_context: OptionalUserContext = None,
     ):
         download_file_content_url = self._get_download_file_url(record_id, filename, user_context)
-        headers = self._get_request_headers(user_context)
+        headers = {}
+        if self._is_api_url(download_file_content_url):
+            # pass the token as a header only when using the API
+            headers = self._get_request_headers(user_context)
         req = urllib.request.Request(download_file_content_url, headers=headers)
         with urllib.request.urlopen(req, timeout=DEFAULT_SOCKET_TIMEOUT) as page:
             f = open(file_path, "wb")
@@ -274,10 +277,29 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         This method is used to download files from both published and draft records that are accessible by the user.
         """
         is_draft_record = self._is_draft_record(record_id, user_context)
-        download_file_content_url = f"{self.records_url}/{record_id}/files/{quote(filename)}/content"
+        file_details_url = f"{self.records_url}/{record_id}/files/{quote(filename)}"
+        download_file_content_url = f"{file_details_url}/content"
         if is_draft_record:
-            download_file_content_url = download_file_content_url.replace("/files/", "/draft/files/")
+            file_details_url = self._to_draft_url(file_details_url)
+            download_file_content_url = self._to_draft_url(download_file_content_url)
+        file_details = self._get_response(user_context, file_details_url)
+        if not self._can_download_from_api(file_details):
+            # TODO: This is a temporary workaround for the fact that the "content" API
+            # does not support downloading files from S3 or other remote storage classes.
+            # More info: https://inveniordm.docs.cern.ch/reference/file_storage/#remote-files-r
+            download_file_content_url = f"{file_details_url.replace('/api','')}?download=1"
         return download_file_content_url
+
+    def _is_api_url(self, url: str) -> bool:
+        return "/api/" in url
+
+    def _to_draft_url(self, url: str) -> str:
+        return url.replace("/files/", "/draft/files/")
+
+    def _can_download_from_api(self, file_details: dict) -> bool:
+        # Only files stored locally seems to be fully supported by the API for now
+        # More info: https://inveniordm.docs.cern.ch/reference/file_storage/
+        return file_details["storage_class"] == "L"
 
     def _is_draft_record(self, record_id: str, user_context: OptionalUserContext = None):
         request_url = self._get_draft_record_url(record_id)


### PR DESCRIPTION
- Avoid erroring out when serializing file sources without credentials
- Improve the error message when trying to download files from non-public records. This might be possible in the future but there is currently no way of accessing the user credentials when fetching the files.
- Workaround for Invenio instances that use a remote or external storage backend instead of local files. Those files cannot be downloaded using the Invenio API (there is no support yet) but we can directly use the front-end download link to download them from Galaxy.

## How to test the changes?
- [x] Instructions for manual testing are as follows:
   - You can try this out with the [DataPLANT Invenio instance[(https://invenio.nfdi4plants.org/) which uses S3 as the storage backend
   - Setup your file_sources configuration:

    ```yml
    # file_sources_conf.yml
    - type: inveniordm
      id: invenio
      doc: Invenio RDM The turn-key research data management repository
      label: Invenio RDM DataPLANT
      url: https://invenio.nfdi4plants.org
      token: ${user.preferences['invenio|token']}
      public_name: ${user.preferences['invenio|public_name']}
      writable: true
    
    # user_preferences_extra_conf.yml
    invenio:
        description: Your Invenio RDM Account
        inputs:
            - name: token
              label: Personal Token to publish records to Invenio RDM
              type: secret
              store: vault # Requires setting up vault_config_file in your galaxy.yml
              required: False
            - name: public_name
              label: Public name to publish records (formatted as "Lastname, Firstname")
              type: text
              required: False
    ```
    - Use the Upload tool to import a file from a public record using the remote file sources.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
