### PR TITLE
[23.1] Workaround issue in Routes

### DIFF
--- a/lib/galaxy/web/framework/base.py
+++ b/lib/galaxy/web/framework/base.py
@@ -222,6 +222,12 @@ class WebApplication:
         rc = routes.request_config()
         rc.mapper = self.mapper
         rc.mapper_dict = map_match
+        server_port = environ["SERVER_PORT"]
+        if isinstance(server_port, int):
+            # Workaround bug in the routes package, which would concatenate this
+            # without casting to str in
+            # https://github.com/bbangert/routes/blob/c4d5a5fb693ce8dc7cf5dbc591861acfc49d5c23/routes/__init__.py#L73
+            environ["SERVER_PORT"] = str(server_port)
         rc.environ = environ
         # Setup the transaction
         trans = self.transaction_factory(environ)


### PR DESCRIPTION
Fix the following traceback:

```
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: uvicorn.access INFO 2023-06-30 10:28:03,573 [pN:main.1,p:3528860,tN:MainThread] 193.156.42.8:0 - "HEAD /root/login HTTP/1.0" 500
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: Exception in supplement:
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: Traceback (most recent call last):
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: File "/cluster/galaxy-test/srv/galaxy/server/lib/galaxy/web/framework/middleware/error.py", line 165, in __call__
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: app_iter = self.application(environ, sr_checker)
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: File "/cluster/galaxy-test/srv/galaxy/venv/lib64/python3.11/site-packages/paste/recursive.py", line 85, in __call__
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: return self.application(environ, start_response)
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: File "/cluster/galaxy-test/srv/galaxy/venv/lib64/python3.11/site-packages/paste/httpexceptions.py", line 640, in __call__
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: return self.application(environ, start_response)
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: File "/cluster/galaxy-test/srv/galaxy/server/lib/galaxy/web/framework/base.py", line 167, in __call__
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: return self.handle_request(environ, start_response)
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: File "/cluster/galaxy-test/srv/galaxy/server/lib/galaxy/web/framework/base.py", line 221, in handle_request
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: rc.environ = environ
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: ^^^^^^^^^^
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: File "/cluster/galaxy-test/srv/galaxy/venv/lib64/python3.11/site-packages/routes/__init__.py", line 23, in __setattr__
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: self.load_wsgi_environ(value)
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: File "/cluster/galaxy-test/srv/galaxy/venv/lib64/python3.11/site-packages/routes/__init__.py", line 73, in load_wsgi_environ
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: self.__shared_state.host += ':' + environ['SERVER_PORT']
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: ~~~~^~~~~~~~~~~~~~~~~~~~~~~~
Jun 30 10:28:03 galaxy01-test.educloud.no galaxyctl[3528286]: TypeError: can only concatenate str (not "int") to str
```

Reported by @vazovn : https://matrix.to/#/!rfLDbcWEWZapZrujix:gitter.im/$McOyd5Kmp-w-Z-bYbRUV42K30YhVvwRJtrCaxru-yf4?via=gitter.im&via=matrix.org

Longer term we should drop our use of [Routes](https://pypi.org/project/Routes/) as it looks unmaintained (last release 2020-10-14).

## How to test the changes?
(Select all options that apply)
- This was manually tested by @vazovn on his server.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
