### PR TITLE
Dataset Display : force reload on subsequent clicks.

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -240,7 +240,13 @@ export default {
                 const url = entryPointsForHda[0].target;
                 window.open(url, "_blank");
             } else {
-                this.$router.push(this.itemUrls.display, { title: this.name });
+                // vue-router 4 supports a force push, but we work around it here until then.
+                // upon update, we can use `force` and avoid the full reload.
+                if (this.$router.currentRoute.path === this.itemUrls.display) {
+                    this.$router.go();
+                } else {
+                    this.$router.push(this.itemUrls.display, { title: this.name });
+                }
             }
         },
         onDelete(recursive = false) {

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -240,10 +240,11 @@ export default {
                 const url = entryPointsForHda[0].target;
                 window.open(url, "_blank");
             } else {
-                // vue-router 4 supports a force push, but we work around it here until then.
-                // upon update, we can use `force` and avoid the full reload.
+                // vue-router 4 supports a native force push with clean URLs,
+                // but we're using a workaround with a __vkey__ bit as a workaround
+                // Only conditionally force to keep urls clean most of the time.
                 if (this.$router.currentRoute.path === this.itemUrls.display) {
-                    this.$router.go();
+                    this.$router.push(this.itemUrls.display, { title: this.name, force: true });
                 } else {
                     this.$router.push(this.itemUrls.display, { title: this.name });
                 }


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/16972

I considered generalizing the only-force-when-needed check and adding it to our monkeypatched router push, but I think it's alright to just focus on getting to vue-router-4 where we can make it all cleaner by default.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Click display on same dataset twice in a row, observe a component reload w/ __vkey__ in address bar.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
