### PR TITLE
Persistent toggle sections of job info

### DIFF
--- a/client/src/components/Common/Heading.vue
+++ b/client/src/components/Common/Heading.vue
@@ -65,7 +65,7 @@ const element = computed(() => {
             sizeClass,
             props.bold ? 'font-weight-bold' : '',
             props.inline ? 'inline' : '',
-            props.collapsible ? 'collapsible' : '',
+            collapsible ? 'collapsible' : '',
         ]"
         @click="$emit('click')">
         <FontAwesomeIcon v-if="props.icon" :icon="props.icon" />

--- a/client/src/components/Common/Heading.vue
+++ b/client/src/components/Common/Heading.vue
@@ -39,7 +39,10 @@ const element = computed(() => {
 <template>
     <div v-if="props.separator" class="separator heading">
         <div class="stripe"></div>
-        <component :is="element" :class="[sizeClass, props.bold ? 'font-weight-bold' : '']" @click="$emit('click')">
+        <component
+            :is="element"
+            :class="[sizeClass, props.bold ? 'font-weight-bold' : '', props.collapsible ? 'collapsible' : '']"
+            @click="$emit('click')">
             <slot />
             <FontAwesomeIcon v-if="collapsible" :icon="collapsed ? 'chevron-down' : 'chevron-up'" />
         </component>
@@ -49,7 +52,12 @@ const element = computed(() => {
         :is="element"
         v-else
         class="heading"
-        :class="[sizeClass, props.bold ? 'font-weight-bold' : '', props.inline ? 'inline' : '']"
+        :class="[
+            sizeClass,
+            props.bold ? 'font-weight-bold' : '',
+            props.inline ? 'inline' : '',
+            props.collapsible ? 'collapsible' : '',
+        ]"
         @click="$emit('click')">
         <FontAwesomeIcon v-if="props.icon" :icon="props.icon" />
         <slot />
@@ -74,6 +82,10 @@ h1, h2, h3, h4, h5, h6 {
         display: inline-flex;
         margin-bottom: 0;
     }
+}
+
+.collapsible {
+    cursor: pointer;
 }
 
 .separator {

--- a/client/src/components/Common/Heading.vue
+++ b/client/src/components/Common/Heading.vue
@@ -14,16 +14,25 @@ interface Props {
     inline?: boolean;
     size?: "xl" | "lg" | "md" | "sm" | "text";
     icon?: string | [string, string];
-    collapsible?: boolean;
-    collapsed?: boolean;
+    collapse?: "open" | "closed" | "none";
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+    collapse: "none",
+});
 
 defineEmits(["click"]);
 
 const sizeClass = computed(() => {
     return `h-${props.size ?? "lg"}`;
+});
+
+const collapsible = computed(() => {
+    return props.collapse !== "none";
+});
+
+const collapsed = computed(() => {
+    return props.collapse === "closed";
 });
 
 const element = computed(() => {
@@ -41,7 +50,7 @@ const element = computed(() => {
         <div class="stripe"></div>
         <component
             :is="element"
-            :class="[sizeClass, props.bold ? 'font-weight-bold' : '', props.collapsible ? 'collapsible' : '']"
+            :class="[sizeClass, props.bold ? 'font-weight-bold' : '', collapsible ? 'collapsible' : '']"
             @click="$emit('click')">
             <slot />
             <FontAwesomeIcon v-if="collapsible" :icon="collapsed ? 'chevron-down' : 'chevron-up'" />

--- a/client/src/components/Common/Heading.vue
+++ b/client/src/components/Common/Heading.vue
@@ -48,8 +48,8 @@ const element = computed(() => {
 <template>
     <div v-if="props.separator" class="separator heading">
         <b-button v-if="collapsible" variant="link" size="sm" @click="$emit('click')">
-            <icon v-if="collapsed" fixed-width icon="angle-double-down" />
-            <icon v-else fixed-width icon="angle-double-up" />
+            <FontAwesomeIcon v-if="collapsed" fixed-width :icon="faAngleDoubleDown" />
+            <FontAwesomeIcon v-else fixed-width :icon="faAngleDoubleUp" />
         </b-button>
         <div v-else class="stripe"></div>
         <component

--- a/client/src/components/Common/Heading.vue
+++ b/client/src/components/Common/Heading.vue
@@ -39,12 +39,9 @@ const element = computed(() => {
 <template>
     <div v-if="props.separator" class="separator heading">
         <div class="stripe"></div>
-        <component :is="element" :class="[sizeClass, props.bold ? 'font-weight-bold' : '']">
+        <component :is="element" :class="[sizeClass, props.bold ? 'font-weight-bold' : '']" @click="$emit('click')">
             <slot />
-            <FontAwesomeIcon
-                v-if="collapsible"
-                :icon="collapsed ? 'chevron-down' : 'chevron-up'"
-                @click="$emit('click')" />
+            <FontAwesomeIcon v-if="collapsible" :icon="collapsed ? 'chevron-down' : 'chevron-up'" />
         </component>
         <div class="stripe"></div>
     </div>
@@ -52,10 +49,11 @@ const element = computed(() => {
         :is="element"
         v-else
         class="heading"
-        :class="[sizeClass, props.bold ? 'font-weight-bold' : '', props.inline ? 'inline' : '']">
+        :class="[sizeClass, props.bold ? 'font-weight-bold' : '', props.inline ? 'inline' : '']"
+        @click="$emit('click')">
         <FontAwesomeIcon v-if="props.icon" :icon="props.icon" />
         <slot />
-        <FontAwesomeIcon v-if="collapsible" :icon="collapsed ? 'chevron-down' : 'chevron-up'" @click="$emit('click')" />
+        <FontAwesomeIcon v-if="collapsible" :icon="collapsed ? 'chevron-down' : 'chevron-up'" />
     </component>
 </template>
 

--- a/client/src/components/Common/Heading.vue
+++ b/client/src/components/Common/Heading.vue
@@ -52,8 +52,8 @@ const element = computed(() => {
             :is="element"
             :class="[sizeClass, props.bold ? 'font-weight-bold' : '', collapsible ? 'collapsible' : '']"
             @click="$emit('click')">
-            <slot />
             <FontAwesomeIcon v-if="collapsible" :icon="collapsed ? 'chevron-down' : 'chevron-up'" />
+            <slot />
         </component>
         <div class="stripe"></div>
     </div>
@@ -69,8 +69,8 @@ const element = computed(() => {
         ]"
         @click="$emit('click')">
         <FontAwesomeIcon v-if="props.icon" :icon="props.icon" />
-        <slot />
         <FontAwesomeIcon v-if="collapsible" :icon="collapsed ? 'chevron-down' : 'chevron-up'" />
+        <slot />
     </component>
 </template>
 

--- a/client/src/components/Common/Heading.vue
+++ b/client/src/components/Common/Heading.vue
@@ -47,15 +47,15 @@ const element = computed(() => {
 
 <template>
     <div v-if="props.separator" class="separator heading">
-        <div class="stripe"></div>
+        <b-button v-if="collapsible" variant="link" size="sm" @click="$emit('click')">
+            <icon v-if="collapsed" fixed-width icon="angle-double-down" />
+            <icon v-else fixed-width icon="angle-double-up" />
+        </b-button>
+        <div v-else class="stripe"></div>
         <component
             :is="element"
             :class="[sizeClass, props.bold ? 'font-weight-bold' : '', collapsible ? 'collapsible' : '']"
             @click="$emit('click')">
-            <b-button v-if="collapsible" variant="link" size="sm">
-                <icon v-if="collapsed" fixed-width icon="angle-double-down" />
-                <icon v-else fixed-width icon="angle-double-up" />
-            </b-button>
             <slot />
         </component>
         <div class="stripe"></div>

--- a/client/src/components/Common/Heading.vue
+++ b/client/src/components/Common/Heading.vue
@@ -52,7 +52,10 @@ const element = computed(() => {
             :is="element"
             :class="[sizeClass, props.bold ? 'font-weight-bold' : '', collapsible ? 'collapsible' : '']"
             @click="$emit('click')">
-            <FontAwesomeIcon v-if="collapsible" :icon="collapsed ? 'chevron-down' : 'chevron-up'" />
+            <b-button v-if="collapsible" variant="link" size="sm">
+                <icon v-if="collapsed" fixed-width icon="angle-double-down" />
+                <icon v-else fixed-width icon="angle-double-up" />
+            </b-button>
             <slot />
         </component>
         <div class="stripe"></div>
@@ -68,8 +71,11 @@ const element = computed(() => {
             collapsible ? 'collapsible' : '',
         ]"
         @click="$emit('click')">
+        <b-button v-if="collapsible" variant="link" size="sm">
+            <icon v-if="collapsed" fixed-width icon="angle-double-down" />
+            <icon v-else fixed-width icon="angle-double-up" />
+        </b-button>
         <FontAwesomeIcon v-if="props.icon" :icon="props.icon" />
-        <FontAwesomeIcon v-if="collapsible" :icon="collapsed ? 'chevron-down' : 'chevron-up'" />
         <slot />
     </component>
 </template>

--- a/client/src/components/Common/Heading.vue
+++ b/client/src/components/Common/Heading.vue
@@ -14,9 +14,13 @@ interface Props {
     inline?: boolean;
     size?: "xl" | "lg" | "md" | "sm" | "text";
     icon?: string | [string, string];
+    collapsible?: boolean;
+    collapsed?: boolean;
 }
 
 const props = defineProps<Props>();
+
+defineEmits(["click"]);
 
 const sizeClass = computed(() => {
     return `h-${props.size ?? "lg"}`;
@@ -37,6 +41,10 @@ const element = computed(() => {
         <div class="stripe"></div>
         <component :is="element" :class="[sizeClass, props.bold ? 'font-weight-bold' : '']">
             <slot />
+            <FontAwesomeIcon
+                v-if="collapsible"
+                :icon="collapsed ? 'chevron-down' : 'chevron-up'"
+                @click="$emit('click')" />
         </component>
         <div class="stripe"></div>
     </div>
@@ -47,6 +55,7 @@ const element = computed(() => {
         :class="[sizeClass, props.bold ? 'font-weight-bold' : '', props.inline ? 'inline' : '']">
         <FontAwesomeIcon v-if="props.icon" :icon="props.icon" />
         <slot />
+        <FontAwesomeIcon v-if="collapsible" :icon="collapsed ? 'chevron-down' : 'chevron-up'" @click="$emit('click')" />
     </component>
 </template>
 

--- a/client/src/components/JobMetrics/AwsEstimate.vue
+++ b/client/src/components/JobMetrics/AwsEstimate.vue
@@ -56,7 +56,9 @@ const computedAwsEstimate = computed(() => {
 
 <template>
     <div v-if="computedAwsEstimate" id="aws-estimate" class="mt-4">
-        <Heading h2 size="md" separator collapsible :collapsed="toggled" @click="toggle()">AWS estimate</Heading>
+        <Heading h2 size="md" separator :collapse="toggled ? 'closed' : 'open'" @click="toggle()">
+            AWS estimate
+        </Heading>
 
         <template v-if="!toggled">
             <strong id="aws-cost">{{ computedAwsEstimate.price }} USD</strong>

--- a/client/src/components/JobMetrics/AwsEstimate.vue
+++ b/client/src/components/JobMetrics/AwsEstimate.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
+import { usePersistentToggle } from "@/composables/persistentToggle";
+
+import Heading from "@/components/Common/Heading.vue";
+
 const props = defineProps<{
     jobRuntimeInSeconds: number;
     coresAllocated: number;
@@ -19,6 +23,8 @@ const props = defineProps<{
         }[];
     }[];
 }>();
+
+const { toggled, toggle } = usePersistentToggle("aws-estimate");
 
 const computedAwsEstimate = computed(() => {
     const { coresAllocated, jobRuntimeInSeconds, memoryAllocatedInMebibyte } = props;
@@ -50,24 +56,26 @@ const computedAwsEstimate = computed(() => {
 
 <template>
     <div v-if="computedAwsEstimate" id="aws-estimate" class="mt-4">
-        <h2>AWS estimate</h2>
+        <Heading h2 size="md" separator collapsible :collapsed="toggled" @click="toggle()">AWS estimate</Heading>
 
-        <strong id="aws-cost">{{ computedAwsEstimate.price }} USD</strong>
+        <template v-if="!toggled">
+            <strong id="aws-cost">{{ computedAwsEstimate.price }} USD</strong>
 
-        <br />
+            <br />
 
-        This job requested {{ computedAwsEstimate.requestedVCpuCount }} core(s) and
-        {{ computedAwsEstimate.memory.toFixed(3) }} GiB of memory. Given this information, the smallest EC2 machine we
-        could find is:
+            This job requested {{ computedAwsEstimate.requestedVCpuCount }} core(s) and
+            {{ computedAwsEstimate.memory.toFixed(3) }} GiB of memory. Given this information, the smallest EC2 machine
+            we could find is:
 
-        <span id="aws-name">{{ computedAwsEstimate.instance.name }}</span>
-        (<span id="aws-mem">{{ computedAwsEstimate.instance.mem }}</span> GB /
-        <span id="aws-vcpus">{{ computedAwsEstimate.instance.vCpuCount }}</span> vCPUs /
-        <span id="aws-cpu">{{ computedAwsEstimate.instance.cpu.map(({ cpuModel }) => cpuModel).join(", ") }}</span
-        >). This instance is priced at {{ computedAwsEstimate.instance.price }} USD/hour.
+            <span id="aws-name">{{ computedAwsEstimate.instance.name }}</span>
+            (<span id="aws-mem">{{ computedAwsEstimate.instance.mem }}</span> GB /
+            <span id="aws-vcpus">{{ computedAwsEstimate.instance.vCpuCount }}</span> vCPUs /
+            <span id="aws-cpu">{{ computedAwsEstimate.instance.cpu.map(({ cpuModel }) => cpuModel).join(", ") }}</span
+            >). This instance is priced at {{ computedAwsEstimate.instance.price }} USD/hour.
 
-        <br />
+            <br />
 
-        &ast;Please note, that these numbers are only estimates, all jobs are always free of charge for all users.
+            &ast;Please note, that these numbers are only estimates, all jobs are always free of charge for all users.
+        </template>
     </div>
 </template>

--- a/client/src/components/JobMetrics/CarbonEmissions/CarbonEmissions.vue
+++ b/client/src/components/JobMetrics/CarbonEmissions/CarbonEmissions.vue
@@ -274,7 +274,7 @@ function getEnergyNeededText(energyNeededInKiloWattHours: number) {
 
 <template v-if="carbonEmissions && carbonEmissionsComparisons">
     <div class="mt-4">
-        <Heading h2 separator size="md" inline collapsible :collapsed="toggled" @click="toggle()">
+        <Heading h2 separator size="md" inline :collapse="toggled ? 'closed' : 'open'" @click="toggle()">
             Carbon Footprint
         </Heading>
 

--- a/client/src/components/JobMetrics/CarbonEmissions/CarbonEmissions.vue
+++ b/client/src/components/JobMetrics/CarbonEmissions/CarbonEmissions.vue
@@ -5,6 +5,8 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import type { GetComponentPropTypes } from "types/utilityTypes";
 import { computed, unref } from "vue";
 
+import { usePersistentToggle } from "@/composables/persistentToggle";
+
 import * as carbonEmissionsConstants from "./carbonEmissionConstants.js";
 
 import BarChart from "./BarChart.vue";
@@ -33,6 +35,8 @@ interface CarbonEmissionsProps {
 const props = withDefaults(defineProps<CarbonEmissionsProps>(), {
     memoryAllocatedInMebibyte: 0,
 });
+
+const { toggled, toggle } = usePersistentToggle("carbonEmissions");
 
 const carbonEmissions = computed(() => {
     const memoryPowerUsed = carbonEmissionsConstants.memoryPowerUsage;
@@ -270,9 +274,11 @@ function getEnergyNeededText(energyNeededInKiloWattHours: number) {
 
 <template v-if="carbonEmissions && carbonEmissionsComparisons">
     <div class="mt-4">
-        <Heading h2 separator size="md" inline> Carbon Footprint </Heading>
+        <Heading h2 separator size="md" inline collapsible :collapsed="toggled" @click="toggle()">
+            Carbon Footprint
+        </Heading>
 
-        <section class="carbon-emission-values my-4">
+        <section v-if="!toggled" class="carbon-emission-values my-4">
             <div class="emissions-grid">
                 <!-- Carbon Footprint Totals -->
                 <CarbonEmissionsCard

--- a/client/src/components/JobMetrics/CarbonEmissions/CarbonEmissions.vue
+++ b/client/src/components/JobMetrics/CarbonEmissions/CarbonEmissions.vue
@@ -270,7 +270,7 @@ function getEnergyNeededText(energyNeededInKiloWattHours: number) {
 
 <template v-if="carbonEmissions && carbonEmissionsComparisons">
     <div class="mt-4">
-        <Heading h2 separator inline bold> Carbon Footprint </Heading>
+        <Heading h2 separator size="md" inline> Carbon Footprint </Heading>
 
         <section class="carbon-emission-values my-4">
             <div class="emissions-grid">

--- a/client/src/components/JobMetrics/JobMetrics.vue
+++ b/client/src/components/JobMetrics/JobMetrics.vue
@@ -203,7 +203,6 @@ const estimatedServerInstance = computed(() => {
         <AwsEstimate
             v-if="jobRuntimeInSeconds && coresAllocated && ec2Instances && shouldShowAwsEstimate"
             :ec2-instances="ec2Instances"
-            :should-show-aws-estimate="shouldShowAwsEstimate"
             :job-runtime-in-seconds="jobRuntimeInSeconds"
             :cores-allocated="coresAllocated"
             :memory-allocated-in-mebibyte="memoryAllocatedInMebibyte" />

--- a/client/src/composables/persistentToggle.ts
+++ b/client/src/composables/persistentToggle.ts
@@ -1,0 +1,28 @@
+import { type Ref, ref, watch } from "vue";
+
+interface ToggleStateInterface {
+    toggled: Ref<boolean>;
+    toggle: () => void;
+}
+
+export function usePersistentToggle(uniqueId: string): ToggleStateInterface{
+    const localStorageKey = `toggle-state-${uniqueId}`;
+
+    // Retrieve the toggled state from localStorage if available, otherwise default to false
+    const toggled = ref<boolean>(localStorage.getItem(localStorageKey) === "true");
+
+    // Watch for changes in the toggled state and persist them to localStorage
+    watch(toggled, (newVal: boolean) => {
+        localStorage.setItem(localStorageKey, String(newVal));
+    });
+
+    // Expose a function for toggling state
+    const toggle = () => {
+        toggled.value = !toggled.value;
+    };
+
+    return {
+        toggled,
+        toggle,
+    };
+}

--- a/client/src/composables/persistentToggle.ts
+++ b/client/src/composables/persistentToggle.ts
@@ -9,7 +9,7 @@ interface ToggleStateInterface {
 
 export function usePersistentToggle(uniqueId: string): ToggleStateInterface {
     const localStorageKey = `toggle-state-${uniqueId}`;
-    const toggled = useUserLocalStorage(localStorageKey, true);
+    const toggled = useUserLocalStorage(localStorageKey, false);
 
     // Expose a function for toggling state
     const toggle = () => {

--- a/client/src/composables/persistentToggle.ts
+++ b/client/src/composables/persistentToggle.ts
@@ -1,4 +1,6 @@
-import { type Ref, ref, watch } from "vue";
+import { type Ref } from "vue";
+
+import { useUserLocalStorage } from "./userLocalStorage";
 
 interface ToggleStateInterface {
     toggled: Ref<boolean>;
@@ -7,14 +9,7 @@ interface ToggleStateInterface {
 
 export function usePersistentToggle(uniqueId: string): ToggleStateInterface {
     const localStorageKey = `toggle-state-${uniqueId}`;
-
-    // Retrieve the toggled state from localStorage if available, otherwise default to false
-    const toggled = ref<boolean>(localStorage.getItem(localStorageKey) === "true");
-
-    // Watch for changes in the toggled state and persist them to localStorage
-    watch(toggled, (newVal: boolean) => {
-        localStorage.setItem(localStorageKey, String(newVal));
-    });
+    const toggled = useUserLocalStorage(localStorageKey, true);
 
     // Expose a function for toggling state
     const toggle = () => {

--- a/client/src/composables/persistentToggle.ts
+++ b/client/src/composables/persistentToggle.ts
@@ -5,7 +5,7 @@ interface ToggleStateInterface {
     toggle: () => void;
 }
 
-export function usePersistentToggle(uniqueId: string): ToggleStateInterface{
+export function usePersistentToggle(uniqueId: string): ToggleStateInterface {
     const localStorageKey = `toggle-state-${uniqueId}`;
 
     // Retrieve the toggled state from localStorage if available, otherwise default to false


### PR DESCRIPTION
Persistent section toggles to address https://github.com/galaxyproject/galaxy/issues/16441.  Adds a basic keyed persistent toggle composable, integrates it with our Heading component (though you could use it wherever), and sets two sections to use it as a test.

Considering dropping the caret and just having the header be clickable as the toggle in this case, with an appropriate tooltip.

![image](https://github.com/galaxyproject/galaxy/assets/155398/5fc3e42f-a4b7-4bfd-9fd7-31daedbe6326)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
