### PR TITLE
Enhancement for drag and drop box

### DIFF
--- a/client/src/style/scss/upload.scss
+++ b/client/src/style/scss/upload.scss
@@ -32,7 +32,8 @@
 
 .upload-wrapper {
     .upload-box.highlight {
-        border-color: $border-color;
+        border-color: $brand-primary;
+        background-color: $workflow-editor-grid-color;
         border-width: 2px;
         padding: 7px !important;
         .upload-helper {


### PR DESCRIPTION
![github_16990_AFTER](https://github.com/galaxyproject/galaxy/assets/3672779/06d58fbe-4020-4bd2-b47c-4398bb2d4f58)

Addresses issue #16990 
_To better display the "drop zone" for the Drag-and-Drop file upload feature, replaced (1) the gray dashed line and white background with a (2) blue dashed line and light blue background._ 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
