### PR TITLE
Update API tool_panels route conditions

### DIFF
--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -367,8 +367,10 @@ def populate_api_routes(webapp, app):
     # ====== TOOLS API ======
     # =======================
 
-    webapp.mapper.connect("/api/tool_panels", action="panel_views", controller="tools")
-    webapp.mapper.connect("/api/tool_panels/{view}", action="panel_view", controller="tools")
+    webapp.mapper.connect("/api/tool_panels", action="panel_views", controller="tools", conditions=dict(method=["GET"]))
+    webapp.mapper.connect(
+        "/api/tool_panels/{view}", action="panel_view", controller="tools", conditions=dict(method=["GET"])
+    )
 
     webapp.mapper.connect("/api/tools/all_requirements", action="all_requirements", controller="tools")
     webapp.mapper.connect("/api/tools/error_stack", action="error_stack", controller="tools")


### PR DESCRIPTION
explicitly specify operation so tool_panels are included in apispec & thus docs

Without any specified conditions, the APIspec doesn't know what actions the endpoint supports and lists no actions, even though it's a valid endpoint. 

Do we ever deviate from the action being GET in the situation where it's a custom action name/function (i.e. -- not one of the default resource names 'index', 'create', 'show', etc)?  If we do not, then we could update build_apispec to *assume* GET if not specified, but we'd really want to double check that.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
