### PR TITLE
Fixes for job metrics Galaxy markdown component.

### DIFF
--- a/client/src/components/JobMetrics/JobMetrics.vue
+++ b/client/src/components/JobMetrics/JobMetrics.vue
@@ -194,7 +194,7 @@ const estimatedServerInstance = computed(() => {
         </div>
 
         <AwsEstimate
-            v-if="jobRuntimeInSeconds && coresAllocated && ec2Instances"
+            v-if="jobRuntimeInSeconds && coresAllocated && ec2Instances && shouldShowAwsEstimate"
             :ec2-instances="ec2Instances"
             :should-show-aws-estimate="shouldShowAwsEstimate"
             :job-runtime-in-seconds="jobRuntimeInSeconds"

--- a/client/src/components/Markdown/Elements/JobMetrics.vue
+++ b/client/src/components/Markdown/Elements/JobMetrics.vue
@@ -1,6 +1,11 @@
 <template>
     <b-card nobody>
-        <JobMetrics class="job-metrics" :job-id="args.job_id" />
+        <JobMetrics
+            class="job-metrics"
+            :job-id="args.job_id"
+            :should-show-aws-estimate="false"
+            :should-show-carbon-emissions-estimates="false"
+            :include-title="false" />
     </b-card>
 </template>
 


### PR DESCRIPTION
So https://github.com/galaxyproject/galaxy/pull/10121 added back in the title header to the component which is only designed for the dataset details page for an individual dataset - the original Markdown implementation striped out the title of that for a good reason.

The target job might an interesting step of a workflow, a problematic tool, an interesting job - so trying to come up with a title atomically is challenging - the context defines why the data is interested. My thought was therefore to keep the component rendered as simply as possible - since the page or report writer will be the one that has the context for how the component should be titled. This component needs a prefix or preamble from the user to be intelligible and so the big h2 "Job Metrics" is not useful or wanted IMO.

https://github.com/galaxyproject/galaxy/pull/10121 did correctly preserve the removal of the title for the job parameters component - which was always striped out for an identical reason - so I think this getting added back in was just an oversight.

This PR also removes the AWS and Carbon footprint stuff from the component - they take up a ton of real estate. I think the report author should explicitly add those if they are of interest - but that should be a follow up PR.

Before:

<img width="1228" alt="Screenshot 2023-11-08 at 12 02 27 PM" src="https://github.com/galaxyproject/galaxy/assets/216771/67fbcded-2db2-4f48-8b6f-7b9c2141c8fc">

After:

<img width="1233" alt="Screenshot 2023-11-08 at 11 52 03 AM" src="https://github.com/galaxyproject/galaxy/assets/216771/20ce966c-e28e-4f0b-a9cf-66ecf2de36f7">

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Run a job. Create a page. Add the component and select the job. Render the page. See it looks better now.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
