### PR TITLE
Add history items display state for collections/lists with failed or new populated_state

### DIFF
--- a/client/src/components/History/Content/Collection/CollectionDescription.vue
+++ b/client/src/components/History/Content/Collection/CollectionDescription.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <span class="description mt-1 mb-1">
-            a {{ collectionLabel }} with {{ elementCount }}<b>{{ homogeneousDatatype }}</b> {{ pluralizedItem }}
+            a {{ collectionLabel }} with {{ elementCount || 0 }}<b>{{ homogeneousDatatype }}</b> {{ pluralizedItem }}
         </span>
         <CollectionProgress v-if="jobStateSummary.size != 0" :summary="jobStateSummary" />
     </div>

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -43,7 +43,11 @@
                         <FontAwesomeIcon class="text-info" icon="arrow-circle-down" />
                     </b-button>
                     <span v-if="hasStateIcon" class="state-icon">
-                        <icon fixed-width :icon="contentState.icon" :spin="contentState.spin" />
+                        <icon
+                            fixed-width
+                            :icon="contentState.icon"
+                            :spin="contentState.spin"
+                            :title="contentState.text" />
                     </span>
                     <span class="id hid">{{ id }}:</span>
                     <span class="content-title name font-weight-bold">{{ name }}</span>
@@ -169,6 +173,8 @@ export default {
         state() {
             if (this.isPlaceholder) {
                 return "placeholder";
+            } else if (this.item.element_count !== undefined && this.item.element_count === 0) {
+                return "emptyCollection";
             }
             if (this.item.job_state_summary) {
                 for (const state of HIERARCHICAL_COLLECTION_JOB_STATES) {

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -173,8 +173,11 @@ export default {
         state() {
             if (this.isPlaceholder) {
                 return "placeholder";
-            } else if (this.item.element_count !== undefined && this.item.element_count === 0) {
-                return "emptyCollection";
+            } else if (
+                this.item.history_content_type === "dataset_collection" &&
+                this.item.populated_state === "failed"
+            ) {
+                return "failed_populated_state";
             }
             if (this.item.job_state_summary) {
                 for (const state of HIERARCHICAL_COLLECTION_JOB_STATES) {

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -47,7 +47,7 @@
                             fixed-width
                             :icon="contentState.icon"
                             :spin="contentState.spin"
-                            :title="contentState.text" />
+                            :title="item.populated_state_message || contentState.text" />
                     </span>
                     <span class="id hid">{{ id }}:</span>
                     <span class="content-title name font-weight-bold">{{ name }}</span>

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -3,7 +3,7 @@
         :id="contentId"
         :class="['content-item m-1 p-0 rounded btn-transparent-background', contentCls]"
         :data-hid="id"
-        :data-state="state"
+        :data-state="dataState"
         tabindex="0"
         role="button"
         @keydown="onKeyDown">
@@ -173,11 +173,12 @@ export default {
         state() {
             if (this.isPlaceholder) {
                 return "placeholder";
-            } else if (
-                this.item.history_content_type === "dataset_collection" &&
-                this.item.populated_state === "failed"
-            ) {
+            }
+            if (this.item.populated_state === "failed") {
                 return "failed_populated_state";
+            }
+            if (this.item.populated_state === "new") {
+                return "new_populated_state";
             }
             if (this.item.job_state_summary) {
                 for (const state of HIERARCHICAL_COLLECTION_JOB_STATES) {
@@ -189,6 +190,9 @@ export default {
                 return this.item.state;
             }
             return "ok";
+        },
+        dataState() {
+            return this.state === "new_populated_state" ? "new" : this.state;
         },
         tags() {
             return this.item.tags;

--- a/client/src/components/History/Content/model/StatesInfo.vue
+++ b/client/src/components/History/Content/model/StatesInfo.vue
@@ -34,8 +34,11 @@ function onFilter(value: string) {
         <dl v-for="(state, key, index) in states" :key="index">
             <div :class="['alert', 'content-item', 'alert-' + state.status]" :data-state="key">
                 <dt>
-                    <a class="text-decoration-none" href="javascript:void(0)" @click="onFilter(key)"
+                    <a v-if="!state.nonDb" class="text-decoration-none" href="javascript:void(0)" @click="onFilter(key)"
                         ><code>{{ key }}</code></a
+                    >
+                    <span v-else
+                        ><code>{{ key }}</code></span
                     >
                     <icon v-if="state.icon" :icon="state.icon" />
                 </dt>

--- a/client/src/components/History/Content/model/StatesInfo.vue
+++ b/client/src/components/History/Content/model/StatesInfo.vue
@@ -22,6 +22,10 @@ if (props.excludeStates) {
     }
 }
 
+function dataState(state: string) {
+    return state === "new_populated_state" ? "new" : state;
+}
+
 function onFilter(value: string) {
     emit("set-filter", `state`, value);
 }
@@ -37,7 +41,7 @@ function onFilter(value: string) {
             </i>
         </p>
         <dl v-for="(state, key, index) in states" :key="index">
-            <div :class="['alert', 'content-item', 'alert-' + state.status]" :data-state="key">
+            <div :class="['alert', 'content-item', 'alert-' + state.status]" :data-state="dataState(key)">
                 <dt>
                     <a v-if="!state.nonDb" class="text-decoration-none" href="javascript:void(0)" @click="onFilter(key)"
                         ><code>{{ key }}</code></a

--- a/client/src/components/History/Content/model/StatesInfo.vue
+++ b/client/src/components/History/Content/model/StatesInfo.vue
@@ -30,7 +30,12 @@ function onFilter(value: string) {
 <template>
     <div>
         <p>Here are all available item states in Galaxy:</p>
-        <p><i>(Note that the colors for each state correspond to content item state colors in the history)</i></p>
+        <p>
+            <i>
+                (Note that the colors for each state correspond to content item state colors in the history, and if it
+                exists, hovering over the icon on a history item will display the state message.)
+            </i>
+        </p>
         <dl v-for="(state, key, index) in states" :key="index">
             <div :class="['alert', 'content-item', 'alert-' + state.status]" :data-state="key">
                 <dt>

--- a/client/src/components/History/Content/model/stateTypes.d.ts
+++ b/client/src/components/History/Content/model/stateTypes.d.ts
@@ -5,6 +5,7 @@ export type State = {
     text?: string;
     icon?: string;
     spin?: boolean;
+    nonDb?: boolean;
 };
 
 export type States = {

--- a/client/src/components/History/Content/model/states.ts
+++ b/client/src/components/History/Content/model/states.ts
@@ -2,13 +2,14 @@ import type { components } from "@/api/schema";
 
 type DatasetState = components["schemas"]["DatasetState"];
 // The 'failed' state is for the collection job state summary, not a dataset state.
-type State = DatasetState | "failed" | "placeholder";
+type State = DatasetState | "failed" | "placeholder" | "emptyCollection";
 
 interface StateRepresentation {
     status: "success" | "warning" | "info" | "danger" | "secondary";
     text?: string;
     icon?: string;
     spin?: boolean;
+    nonDb?: boolean;
 }
 
 type StateMap = {
@@ -103,6 +104,14 @@ export const STATES: StateMap = {
         text: "This dataset is being fetched.",
         icon: "spinner",
         spin: true,
+        nonDb: true,
+    },
+    /** the collection is empty. This state is only visual and transitional, it does not exist in the database. */
+    emptyCollection: {
+        status: "secondary",
+        text: "This is an empty list/collection.",
+        icon: "exclamation-triangle",
+        nonDb: true,
     },
 } as const satisfies StateMap;
 

--- a/client/src/components/History/Content/model/states.ts
+++ b/client/src/components/History/Content/model/states.ts
@@ -2,7 +2,7 @@ import type { components } from "@/api/schema";
 
 type DatasetState = components["schemas"]["DatasetState"];
 // The 'failed' state is for the collection job state summary, not a dataset state.
-type State = DatasetState | "failed" | "placeholder" | "failed_populated_state";
+type State = DatasetState | "failed" | "placeholder" | "failed_populated_state" | "new_populated_state";
 
 interface StateRepresentation {
     status: "success" | "warning" | "info" | "danger" | "secondary";
@@ -111,6 +111,13 @@ export const STATES: StateMap = {
         status: "danger",
         text: "Failed to populate the list/collection.",
         icon: "exclamation-triangle",
+        nonDb: true,
+    },
+    /** the `populated_state: new`. This state is only visual and transitional, it does not exist in the database. */
+    new_populated_state: {
+        status: "warning",
+        text: "This is a new collection and not all of its data are available yet.",
+        icon: "clock",
         nonDb: true,
     },
 } as const satisfies StateMap;

--- a/client/src/components/History/Content/model/states.ts
+++ b/client/src/components/History/Content/model/states.ts
@@ -109,7 +109,7 @@ export const STATES: StateMap = {
     /** the `populated_state: failed`. This state is only visual and transitional, it does not exist in the database. */
     failed_populated_state: {
         status: "danger",
-        text: "Failed to populate the list/collection.",
+        text: "Failed to populate the collection.",
         icon: "exclamation-triangle",
         nonDb: true,
     },

--- a/client/src/components/History/Content/model/states.ts
+++ b/client/src/components/History/Content/model/states.ts
@@ -2,7 +2,7 @@ import type { components } from "@/api/schema";
 
 type DatasetState = components["schemas"]["DatasetState"];
 // The 'failed' state is for the collection job state summary, not a dataset state.
-type State = DatasetState | "failed" | "placeholder" | "emptyCollection";
+type State = DatasetState | "failed" | "placeholder" | "failed_populated_state";
 
 interface StateRepresentation {
     status: "success" | "warning" | "info" | "danger" | "secondary";
@@ -106,10 +106,10 @@ export const STATES: StateMap = {
         spin: true,
         nonDb: true,
     },
-    /** the collection is empty. This state is only visual and transitional, it does not exist in the database. */
-    emptyCollection: {
-        status: "secondary",
-        text: "This is an empty list/collection.",
+    /** the `populated_state: failed`. This state is only visual and transitional, it does not exist in the database. */
+    failed_populated_state: {
+        status: "danger",
+        text: "Failed to populate the list/collection.",
         icon: "exclamation-triangle",
         nonDb: true,
     },

--- a/client/src/components/History/CurrentCollection/CollectionPanel.vue
+++ b/client/src/components/History/CurrentCollection/CollectionPanel.vue
@@ -123,7 +123,7 @@ watch(
                         class="m-2"
                         :variant="populatedStateMsg ? 'danger' : 'info'"
                         show>
-                        {{ populatedStateMsg || "This is an empty list/collection." }}
+                        {{ populatedStateMsg || "This is an empty collection." }}
                     </b-alert>
                     <ListingLayout
                         v-else

--- a/client/src/components/History/CurrentCollection/CollectionPanel.vue
+++ b/client/src/components/History/CurrentCollection/CollectionPanel.vue
@@ -115,7 +115,11 @@ watch(
             </section>
             <section class="position-relative flex-grow-1 scroller">
                 <div>
+                    <b-alert v-if="collectionElements.length === 0" class="m-2" variant="info" show>
+                        This is an empty list/collection.
+                    </b-alert>
                     <ListingLayout
+                        v-else
                         data-key="element_index"
                         :items="collectionElements"
                         :loading="loading"

--- a/client/src/components/History/CurrentCollection/CollectionPanel.vue
+++ b/client/src/components/History/CurrentCollection/CollectionPanel.vue
@@ -46,6 +46,9 @@ const dsc = computed(() => {
 const collectionElements = computed(() => collectionElementsStore.getCollectionElements(dsc.value, offset.value));
 const loading = computed(() => collectionElementsStore.isLoadingCollectionElements(dsc.value));
 const jobState = computed(() => ("job_state_summary" in dsc.value ? dsc.value.job_state_summary : undefined));
+const populatedStateMsg = computed(() =>
+    "populated_state_message" in dsc.value ? dsc.value.populated_state_message : undefined
+);
 const rootCollection = computed(() => {
     if (isHDCA(props.selectedCollections[0])) {
         return props.selectedCollections[0];
@@ -115,8 +118,12 @@ watch(
             </section>
             <section class="position-relative flex-grow-1 scroller">
                 <div>
-                    <b-alert v-if="collectionElements.length === 0" class="m-2" variant="info" show>
-                        This is an empty list/collection.
+                    <b-alert
+                        v-if="collectionElements.length === 0"
+                        class="m-2"
+                        :variant="populatedStateMsg ? 'danger' : 'info'"
+                        show>
+                        {{ populatedStateMsg || "This is an empty list/collection." }}
                     </b-alert>
                     <ListingLayout
                         v-else

--- a/client/src/components/History/HistoryFilters.js
+++ b/client/src/components/History/HistoryFilters.js
@@ -2,7 +2,7 @@ import { STATES } from "components/History/Content/model/states";
 import StatesInfo from "components/History/Content/model/StatesInfo";
 import Filtering, { compare, contains, equals, expandNameTag, toBool, toDate } from "utils/filtering";
 
-const excludeStates = ["empty", "failed", "upload", "placeholder", "emptyCollection"];
+const excludeStates = ["empty", "failed", "upload", "placeholder", "failed_populated_state"];
 const states = Object.keys(STATES).filter((state) => !excludeStates.includes(state));
 
 const validFilters = {

--- a/client/src/components/History/HistoryFilters.js
+++ b/client/src/components/History/HistoryFilters.js
@@ -2,7 +2,7 @@ import { STATES } from "components/History/Content/model/states";
 import StatesInfo from "components/History/Content/model/StatesInfo";
 import Filtering, { compare, contains, equals, expandNameTag, toBool, toDate } from "utils/filtering";
 
-const excludeStates = ["empty", "failed", "upload", "placeholder", "failed_populated_state"];
+const excludeStates = ["empty", "failed", "upload", "placeholder", "failed_populated_state", "new_populated_state"];
 const states = Object.keys(STATES).filter((state) => !excludeStates.includes(state));
 
 const validFilters = {

--- a/client/src/components/History/HistoryFilters.js
+++ b/client/src/components/History/HistoryFilters.js
@@ -2,7 +2,7 @@ import { STATES } from "components/History/Content/model/states";
 import StatesInfo from "components/History/Content/model/StatesInfo";
 import Filtering, { compare, contains, equals, expandNameTag, toBool, toDate } from "utils/filtering";
 
-const excludeStates = ["empty", "failed", "upload"];
+const excludeStates = ["empty", "failed", "upload", "placeholder", "emptyCollection"];
 const states = Object.keys(STATES).filter((state) => !excludeStates.includes(state));
 
 const validFilters = {

--- a/client/src/components/History/HistoryPublishedList.vue
+++ b/client/src/components/History/HistoryPublishedList.vue
@@ -179,7 +179,7 @@ async function load() {
 
 onMounted(async () => {
     if (props.fUsername) {
-        filterText.value = filters.getFilterText({ "user_eq:": props.fUsername });
+        filterText.value = filters.getFilterText({ user_eq: props.fUsername });
     }
     await load();
     useInfiniteScroll(scrollableDiv.value, () => load());


### PR DESCRIPTION
Add a non-DB, purely visual state for lists/collections that have `populated_state: failed` ( Fixes #17001 ) or `populated_state: new` ( Fixes #16858 ) in the `HistoryPanel`:

| In the History Panel | In the Collection Panel |
| -------------------- | ----------------------- |
| ![image](https://github.com/galaxyproject/galaxy/assets/78516064/012bd218-c42e-4a89-a707-85fccd7e696f) | ![image](https://github.com/galaxyproject/galaxy/assets/78516064/be6e6087-d93e-47a6-bfa2-abc8a6f22818) |

| In the `StatesInfo` modal found next to the State filter in the History filter menu |
| --------------------------------------------------------------------------------- |
| ![image](https://github.com/galaxyproject/galaxy/assets/78516064/98a91791-65bf-438a-9d30-1aa890eaa62b) |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
