### PR TITLE
[23.1] Client publication

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galaxyproject/galaxy-client",
-  "version": "23.0.0",
+  "version": "23.1.0",
   "description": "Galaxy client application build system",
   "keywords": [
     "galaxy"

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galaxyproject/galaxy-client",
-  "version": "23.1.0",
+  "version": "23.1.1",
   "description": "Galaxy client application build system",
   "keywords": [
     "galaxy"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "homepage": "https://github.com/galaxyproject/galaxy#readme",
   "dependencies": {
     "@galaxyproject/galaxy-client": "^23.1.1",
-    "cpy-cli": "^4.2.0"
+    "cpy-cli": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/galaxyproject/galaxy#readme",
   "dependencies": {
-    "@galaxyproject/galaxy-client": "^23.0.0",
+    "@galaxyproject/galaxy-client": "^23.1.0",
     "cpy-cli": "^4.2.0",
     "vuedraggable": "^2.24.3"
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "homepage": "https://github.com/galaxyproject/galaxy#readme",
   "dependencies": {
     "@galaxyproject/galaxy-client": "^23.1.0",
-    "cpy-cli": "^4.2.0",
-    "vuedraggable": "^2.24.3"
+    "cpy-cli": "^4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/galaxyproject/galaxy#readme",
   "dependencies": {
-    "@galaxyproject/galaxy-client": "^23.1.0",
+    "@galaxyproject/galaxy-client": "^23.1.1",
     "cpy-cli": "^4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galaxyproject/galaxy",
-  "version": "1.0.0",
+  "version": "23.1.0",
   "description": ".. figure:: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo.jpg    :alt: Galaxy Logo",
   "main": "index.js",
   "devDependencies": {},


### PR DESCRIPTION
Publishes prebuilt client for 23.1.  Following up separately with updates to release process so this doesn't get skipped next time.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `make install-client`


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
