### PR TITLE
Fix for fits_image_viewer visualization plugin

### DIFF
--- a/config/plugins/visualizations/fits_image_viewer/package.json
+++ b/config/plugins/visualizations/fits_image_viewer/package.json
@@ -11,6 +11,6 @@
         "parcel-bundler": "^1.4.1"
     },
     "scripts": {
-        "build": "cp -r node_modules/aladin-lite-galaxy static/dist && parcel build src/script.js -d static"
+        "build": "cp -r node_modules/aladin-lite-galaxy/. static/dist/aladin-lite-galaxy && parcel build src/script.js -d static"
     }
 }

--- a/config/plugins/visualizations/fits_image_viewer/package.json
+++ b/config/plugins/visualizations/fits_image_viewer/package.json
@@ -11,6 +11,6 @@
         "parcel-bundler": "^1.4.1"
     },
     "scripts": {
-        "build": "cp -r node_modules/aladin-lite-galaxy/. static/dist/aladin-lite-galaxy && parcel build src/script.js -d static"
+        "build": "mkdir -p static/dist; cp -r node_modules/aladin-lite-galaxy static/dist/. && parcel build src/script.js -d static"
     }
 }

--- a/config/plugins/visualizations/fits_image_viewer/package.json
+++ b/config/plugins/visualizations/fits_image_viewer/package.json
@@ -8,9 +8,10 @@
     "license": "AFL-3.0",
     "dependencies": {
         "aladin-lite-galaxy": "^1.0.0",
-        "parcel-bundler": "^1.4.1"
+        "parcel-bundler": "^1.4.1",
+        "cpy-cli": "^5.0.0"
     },
     "scripts": {
-        "build": "mkdir -p static/dist; cp -r node_modules/aladin-lite-galaxy static/dist/. && parcel build src/script.js -d static"
+        "build": "cpy --flat node_modules/aladin-lite-galaxy static/dist/aladin-lite-galaxy && parcel build src/script.js -d static"
     }
 }

--- a/config/plugins/visualizations/fits_image_viewer/src/script.js
+++ b/config/plugins/visualizations/fits_image_viewer/src/script.js
@@ -1,7 +1,31 @@
-let aladin;
+var aladin;
 
-A.init.then(() => {
-    aladin = A.aladin('#aladin-lite-div', {showCooGridControl: true});
-    aladin.displayFITS(file_url)
-    aladin.showCooGrid(true);
-});
+function initializeAladinLite() {
+    A.init.then(() => {
+        aladin = A.aladin('#aladin-lite-div', {showCooGridControl: true});
+        aladin.displayFITS(fileUrl)
+        aladin.showCooGrid(true);
+    });
+}
+
+function localScriptLoadingError() {
+    addScriptToHead(appRoot+aladinLiteScriptAlternativeLocation);
+}
+
+function cdnLoadingError() {
+    addScriptToHead(appRoot+aladinLiteScriptLocation, localScriptLoadingError);
+}
+
+function addScriptToHead(url, onerrorFunction) {
+    const scriptToAdd = document.createElement("script");
+    scriptToAdd.onload = initializeAladinLite;
+
+    if(onerrorFunction) {
+        scriptToAdd.onerror = onerrorFunction
+    }
+
+    document.head.appendChild(scriptToAdd);
+    scriptToAdd.src = url;
+}
+
+addScriptToHead(aladinLiteCDNUrl, cdnLoadingError);

--- a/config/plugins/visualizations/fits_image_viewer/templates/fits_image_viewer.mako
+++ b/config/plugins/visualizations/fits_image_viewer/templates/fits_image_viewer.mako
@@ -13,15 +13,19 @@
 <html>
     <head>
         ${h.stylesheet_link( app_root + 'style.css' )}
-        ${h.javascript_link( app_root + 'dist/aladin-lite-galaxy/aladin.js' )}
     </head>
     <body>
         <div id="div_title"><span id="span_plugin_name">FITS aladin viewer</span> : <span id="span_file_name">${hda.name | h}</span></div>
         <div id="aladin-lite-div"></div>
 
         <script>
-            let file_url = '${file_url}';
+            const fileUrl = '${file_url}';
+            const appRoot = '${app_root}'
+            const aladinLiteCDNUrl = "https://aladin.cds.unistra.fr/AladinLite/api/v3/latest/aladin.js"
+            const aladinLiteScriptLocation = "dist/aladin-lite-galaxy/aladin.js"
+            const aladinLiteScriptAlternativeLocation = "dist/aladin.js"
         </script>
+
         ${h.javascript_link( app_root + 'script.js' )}
     </body>
 </html>


### PR DESCRIPTION
The fits_image_viewer (used for visualization of FITS file) has been unusable on usegalaxy.eu and on some local instances.

Two differents bugs are causing this issue (more details can be found in this issue https://github.com/usegalaxy-eu/galaxy/issues/194) :

- The first one is only related to the usegalaxy.eu server that doesn't serve the correct mime type for web assembly file
- The second one is caused by the aladin lite js files not being copied to the correct location.

This fix makes the plugin relies on the university of strasbourg CDN (which should be a workaround for the server mime type issue) with a fallback to local aladin lite js files if the cdn were not to be available.

The second fix is to force the creation of the aladin lite folder directly on the build script in order to resolve the issue that on some instances the folder was not created correctly which caused some missing js files error 

@bgruening since the plugin is not usable right now on galaxy.eu we were wondering what kind of timeframe we should expect for the fix to be pushed to galaxy.eu prod, thanks

## How to test the changes?
- [X] Instructions for manual testing are as follows:
  1. Upload a fits file to galaxy (one should be present on the test-data folder)
  2. Use the visualization plugin to open the fits file (after a few second a map of space should be displayed with the content of the file in the middle) 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
