### PR TITLE
Refactor workflow step display stuff toward TS & reuse.

### DIFF
--- a/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
+++ b/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
@@ -7,6 +7,8 @@ import { isEmpty } from "@/utils/utils";
 
 import WorkflowTree from "./WorkflowTree.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
+import WorkflowStepIcon from "@/components/WorkflowInvocationState/WorkflowStepIcon.vue";
+import WorkflowStepTitle from "@/components/WorkflowInvocationState/WorkflowStepTitle.vue";
 
 interface WorkflowDisplayProps {
     workflowId: string;
@@ -94,7 +96,13 @@ onMounted(async () => {
                 </b-alert>
                 <div v-if="itemContent !== null">
                     <div v-for="step in itemContent?.steps" :key="step.order_index" class="mb-2">
-                        <div>Step {{ step.order_index + 1 }}: {{ step.label }}</div>
+                        <WorkflowStepIcon v-if="step.type" :step-type="step.type" />
+                        <WorkflowStepTitle
+                            :step-tool-id="step.tool_id"
+                            :step-subworkflow-id="step.subworkflow_id"
+                            :step-label="step.label"
+                            :step-type="step.type"
+                            :step-index="step.order_index" />
                         <WorkflowTree :input="step" :skip-head="true" />
                     </div>
                 </div>

--- a/client/src/components/Workflow/icons.js
+++ b/client/src/components/Workflow/icons.js
@@ -1,8 +1,14 @@
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faFile } from "@fortawesome/free-regular-svg-icons";
+import { faFolderOpen, faPause, faPencilAlt, faSitemap, faWrench } from "@fortawesome/free-solid-svg-icons";
+
+library.add(faWrench, faFile, faSitemap, faPencilAlt, faPause, faFolderOpen);
+
 export default {
     tool: "fa-wrench",
-    data_input: "fa-file-o",
-    data_collection_input: "fa-folder-o",
+    data_input: "fa-file-o fa-file", // fa-file-o for older FontAwesome, fa-file is the only thing I could find newer font awesome
+    data_collection_input: "fa-folder-o fa-folder-open",
     subworkflow: "fa-sitemap fa-rotate-270",
-    parameter_input: "fa-pencil",
+    parameter_input: "fa-pencil-alt", // fa-pencil for older FontAwesome, fa-pencil-alt for newer
     pause: "fa-pause",
 };

--- a/client/src/components/WorkflowInvocationState/WorkflowStepIcon.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowStepIcon.vue
@@ -1,0 +1,22 @@
+<script lang="ts" setup>
+import { computed } from "vue";
+
+import WorkflowIcons from "@/components/Workflow/icons";
+
+interface WorkflowStepIconProps {
+    stepType: "tool" | "data_input" | "data_collection_input" | "subworkflow" | "parameter_input" | "pause";
+}
+
+const props = defineProps<WorkflowStepIconProps>();
+
+const stepIcon = computed(() => {
+    return WorkflowIcons[props.stepType];
+});
+const cssClasses = computed(() => {
+    return ["fa", "mr-1", stepIcon.value];
+});
+</script>
+
+<template>
+    <i :class="cssClasses"></i>
+</template>

--- a/client/src/components/WorkflowInvocationState/WorkflowStepIcon.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowStepIcon.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed } from "vue";
 
 import WorkflowIcons from "@/components/Workflow/icons";
@@ -12,11 +13,8 @@ const props = defineProps<WorkflowStepIconProps>();
 const stepIcon = computed(() => {
     return WorkflowIcons[props.stepType];
 });
-const cssClasses = computed(() => {
-    return ["fa", "mr-1", stepIcon.value];
-});
 </script>
 
 <template>
-    <i :class="cssClasses"></i>
+    <FontAwesomeIcon class="mr-1" :icon="stepIcon" />
 </template>

--- a/client/src/components/WorkflowInvocationState/WorkflowStepTitle.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowStepTitle.vue
@@ -65,10 +65,13 @@ function initStores() {
     }
 }
 
-watch(props, () => {
-    initStores();
-});
-initStores();
+watch(
+    props,
+    () => {
+        initStores();
+    },
+    { immediate: true }
+);
 </script>
 
 <template>

--- a/client/src/components/WorkflowInvocationState/WorkflowStepTitle.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowStepTitle.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { computed, watch } from "vue";
+
+import { useToolStore } from "@/stores/toolStore";
+import { useWorkflowStore } from "@/stores/workflowStore";
+
+interface WorkflowInvocationStepTitleProps {
+    stepIndex: number;
+    stepLabel?: string;
+    stepType: string;
+    stepToolId?: string;
+    stepSubworkflowId?: string;
+}
+
+const props = defineProps<WorkflowInvocationStepTitleProps>();
+
+const workflowStore = useWorkflowStore();
+const toolStore = useToolStore();
+
+const subWorkflow = computed(() => {
+    if (props.stepSubworkflowId) {
+        return workflowStore.getStoredWorkflowByInstanceId(props.stepSubworkflowId);
+    }
+    return null;
+});
+const toolName = computed(() => {
+    if (props.stepToolId) {
+        return toolStore.getToolNameById(props.stepToolId);
+    }
+    return "";
+});
+
+const title = computed(() => {
+    const oneBasedStepIndex = props.stepIndex + 1;
+    if (props.stepLabel) {
+        return `Step ${oneBasedStepIndex}: ${props.stepLabel}`;
+    }
+    const workflowStepType = props.stepType;
+    switch (workflowStepType) {
+        case "tool":
+            return `Step ${oneBasedStepIndex}: ${toolName.value}`;
+        case "subworkflow": {
+            const subworkflow = subWorkflow.value;
+            const label = subworkflow ? subworkflow.name : "Subworkflow";
+            return `Step ${oneBasedStepIndex}: ${label}`;
+        }
+        case "parameter_input":
+            return `Step ${oneBasedStepIndex}: Parameter input`;
+        case "data_input":
+            return `Step ${oneBasedStepIndex}: Data input`;
+        case "data_collection_input":
+            return `Step ${oneBasedStepIndex}: Data collection input`;
+        default:
+            return `Step ${oneBasedStepIndex}: Unknown step type '${workflowStepType}'`;
+    }
+});
+
+function initStores() {
+    if (props.stepToolId && !toolStore.getToolForId(props.stepToolId)) {
+        toolStore.fetchToolForId(props.stepToolId);
+    }
+
+    if (props.stepSubworkflowId) {
+        workflowStore.fetchWorkflowForInstanceId(props.stepSubworkflowId);
+    }
+}
+
+watch(props, () => {
+    initStores();
+});
+initStores();
+</script>
+
+<template>
+    <span>{{ title }}</span>
+</template>

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1122,6 +1122,7 @@ class WorkflowContentsManager(UsesAnnotations):
         for step in workflow.steps:
             step_dict = {}
             step_dict["order_index"] = step.order_index
+            step_dict["type"] = step.type
             if step.annotations:
                 step_dict["annotation"] = step.annotations[0].annotation
             try:


### PR DESCRIPTION
- Bring the workflow preview step list more inline with the invocation step list (reuse naming steps logic, add icons).
- Migrate refactored bits of ``WorkflowInvocationStep.vue`` to Typescript.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
