### PR TITLE
[23.1] Update tar_to_directory dependency

### DIFF
--- a/lib/galaxy/datatypes/converters/tar_to_directory.xml
+++ b/lib/galaxy/datatypes/converters/tar_to_directory.xml
@@ -1,7 +1,7 @@
 <tool id="CONVERTER_tar_to_directory" name="Convert tar to directory" version="1.0.1" profile="17.05">
     <!-- Don't use tar directly so we can verify safety of results - tar -xzf '$input1'; -->
     <requirements>
-        <requirement type="package" version="19.9">galaxy-util</requirement>
+        <requirement type="package" version="23.1">galaxy-util</requirement>
     </requirements>
     <command>
         mkdir '$output1.files_path';


### PR DESCRIPTION
Should fix:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.7/site-packages/galaxy/util/compression_utils.py", line 114, in extract
    common_prefix_dir = self.common_prefix_dir
  File "/usr/local/lib/python3.7/site-packages/galaxy/util/compression_utils.py", line 103, in common_prefix_dir
    if len(common_prefix) >= 1 and not common_prefix.endswith(os.sep) and self.isdir(self.getmember(common_prefix)) \
  File "/usr/local/lib/python3.7/site-packages/galaxy/util/compression_utils.py", line 186, in isdir
    return getattr(self, 'isdir_%s' % self.type)(member)
  File "/usr/local/lib/python3.7/site-packages/galaxy/util/compression_utils.py", line 189, in isdir_tar
    return member.isdir()
AttributeError: 'NoneType' object has no attribute 'isdir'

```

seen on usegalaxy.eu with https://www.ncbi.nlm.nih.gov/geo/download/?acc=GSE176031&format=file

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
