### PR TITLE
[PROCEDURES] Add Ahmed as a committer

### DIFF
--- a/doc/source/project/organization.rst
+++ b/doc/source/project/organization.rst
@@ -42,6 +42,7 @@ Members
 -------
 
 - Enis Afgan (@afgane)
+- Ahmed Awan (@ahmedhamidawan)
 - Dannon Baker (@dannon)
 - Matthias Bernt (@bernt-matthias)
 - Daniel Blankenberg (@blankenberg)


### PR DESCRIPTION
Ahmed has made many fantastic contributions since joining (https://github.com/galaxyproject/galaxy/pulls?page=1&q=is%3Apr+author%3Aahmedhamidawan), has done some great work especially on the UI/UX side while also making an impact on Galaxy's authentication handling and other backend code.

Quick to help others and communicate, proactively reaching out about design choices and issues, and fast to follow up in communication, he will be a valuable addition to the committers group.


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
