### PR TITLE
Enhancement to Tool Form page, Repeating form fields implement parameter instructions

### DIFF
--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -25,6 +25,22 @@ const maxRepeats = computed(() => {
     return typeof props.input.max === "number" ? props.input.cache?.length >= props.input.max : false;
 });
 
+const minRepeats = computed(() => {
+    return typeof props.input.min === "number" ? props.input.cache?.length > props.input.min : true;
+});
+
+const buttonTooltip = computed(() => {
+    return maxRepeats.value
+        ? `Maximum number of ${props.input.title || "Repeat"} fields reached`
+        : `Click to add ${props.input.title || "Repeat"} fields`;
+});
+
+const deleteTooltip = computed(() => {
+    return !minRepeats.value
+        ? `Minimum number of ${props.input.title || "Repeat"} not reached`
+        : `Click to delete ${props.input.title || "Repeat"} fields`;
+});
+
 const props = defineProps({
     input: {
         type: Object as PropType<Input>,
@@ -136,17 +152,18 @@ const { keyObject } = useKeyedObjects();
                         </b-button>
                     </b-button-group>
 
-                    <b-button
-                        v-if="cacheId >= props.input.min"
-                        v-b-tooltip.hover.bottom
-                        title="delete"
-                        role="button"
-                        variant="link"
-                        size="sm"
-                        class="ml-0"
-                        @click="() => onDelete(cacheId)">
-                        <FontAwesomeIcon icon="trash-alt" />
-                    </b-button>
+                    <span v-b-tooltip.hover.bottom :title="deleteTooltip">
+                        <b-button
+                            :disabled="!minRepeats"
+                            title="delete"
+                            role="button"
+                            variant="link"
+                            size="sm"
+                            class="ml-0"
+                            @click="() => onDelete(cacheId)">
+                            <FontAwesomeIcon icon="trash-alt" />
+                        </b-button>
+                    </span>
                 </span>
             </template>
 
@@ -155,10 +172,11 @@ const { keyObject } = useKeyedObjects();
             </template>
         </FormCard>
 
-        <b-button v-if="!props.sustainRepeats && !maxRepeats" @click="onInsert">
-            <FontAwesomeIcon icon="plus" class="mr-1" />
-            <span data-description="repeat insert">Insert {{ props.input.title || "Repeat" }}</span>
-        </b-button>
-        <div v-if="maxRepeats">Maximum number of {{ props.input.title || "Repeat" }} fields reached</div>
+        <span v-b-tooltip.hover :title="buttonTooltip">
+            <b-button v-if="!props.sustainRepeats" :disabled="maxRepeats" @click="onInsert">
+                <FontAwesomeIcon icon="plus" class="mr-1" />
+                <span data-description="repeat insert">Insert {{ props.input.title || "Repeat" }}</span>
+            </b-button>
+        </span>
     </div>
 </template>

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -16,13 +16,13 @@ interface Input {
     title: string;
     min: number;
     default: number;
-    max: number|string;
+    max: number | string;
     help?: string;
     cache: Array<Record<string, unknown>>;
 }
 
 const maxRepeats = computed(() => {
-    return (typeof props.input.max === "number") ? props.input.cache?.length >= props.input.max : false;
+    return typeof props.input.max === "number" ? props.input.cache?.length >= props.input.max : false;
 });
 
 const props = defineProps({
@@ -159,8 +159,6 @@ const { keyObject } = useKeyedObjects();
             <FontAwesomeIcon icon="plus" class="mr-1" />
             <span data-description="repeat insert">Insert {{ props.input.title || "Repeat" }}</span>
         </b-button>
-        <div v-if="maxRepeats">
-            Maximum number of {{ props.input.title || "Repeat" }} fields reached
-        </div>
+        <div v-if="maxRepeats">Maximum number of {{ props.input.title || "Repeat" }} fields reached</div>
     </div>
 </template>

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -146,9 +146,12 @@ const { keyObject } = useKeyedObjects();
             </template>
         </FormCard>
 
-        <b-button v-if="!props.sustainRepeats" @click="onInsert">
+        <b-button v-if="!props.sustainRepeats && props.input.cache.length < props.input.max" @click="onInsert">
             <FontAwesomeIcon icon="plus" class="mr-1" />
             <span data-description="repeat insert">Insert {{ props.input.title || "Repeat" }}</span>
         </b-button>
+        <div v-if="props.input.cache.length >= props.input.max">
+            Maximum of {{ props.input.cache.length }} {{ props.input.title || "Repeat" }} fields reached
+        </div>
     </div>
 </template>

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -129,6 +129,7 @@ const { keyObject } = useKeyedObjects();
                     </b-button-group>
 
                     <b-button
+                        v-if="cacheId >= props.input.min"
                         v-b-tooltip.hover.bottom
                         title="delete"
                         role="button"

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -38,7 +38,7 @@ const buttonTooltip = computed(() => {
 
 const deleteTooltip = computed(() => {
     return !minRepeats.value
-        ? localize(`Minimum number of ${props.input.title || "Repeat"} not reached`)
+        ? localize(`Minimum number of ${props.input.title || "Repeat"} fields reached`)
         : localize(`Click to delete ${props.input.title || "Repeat"} fields`);
 });
 

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -14,6 +14,8 @@ const FormNode = defineAsyncComponent(() => import("./FormInputs.vue"));
 interface Input {
     name: string;
     title: string;
+    min: number;
+    default: number;
     max: number|string;
     help?: string;
     cache: Array<Record<string, unknown>>;
@@ -108,7 +110,7 @@ const { keyObject } = useKeyedObjects();
             class="card"
             :title="getTitle(cacheId)">
             <template v-slot:operations>
-                                <span v-if="!props.sustainRepeats" class="float-right">
+                <span v-if="!props.sustainRepeats" class="float-right">
                     <b-button-group>
                         <b-button
                             :id="getButtonId(cacheId, 'up')"

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -3,6 +3,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCaretDown, faCaretUp, faPlus, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { defineAsyncComponent, nextTick, type PropType } from "vue";
+import { computed } from "vue";
 
 import { useKeyedObjects } from "@/composables/keyedObjects";
 
@@ -13,9 +14,14 @@ const FormNode = defineAsyncComponent(() => import("./FormInputs.vue"));
 interface Input {
     name: string;
     title: string;
+    max: number|string;
     help?: string;
     cache: Array<Record<string, unknown>>;
 }
+
+const maxRepeats = computed(() => {
+    return (typeof props.input.max === "number") ? props.input.cache?.length >= props.input.max : false;
+});
 
 const props = defineProps({
     input: {
@@ -102,7 +108,7 @@ const { keyObject } = useKeyedObjects();
             class="card"
             :title="getTitle(cacheId)">
             <template v-slot:operations>
-                <span v-if="!props.sustainRepeats" class="float-right">
+                                <span v-if="!props.sustainRepeats" class="float-right">
                     <b-button-group>
                         <b-button
                             :id="getButtonId(cacheId, 'up')"
@@ -147,12 +153,12 @@ const { keyObject } = useKeyedObjects();
             </template>
         </FormCard>
 
-        <b-button v-if="!props.sustainRepeats && props.input.cache.length < props.input.max" @click="onInsert">
+        <b-button v-if="!props.sustainRepeats && !maxRepeats" @click="onInsert">
             <FontAwesomeIcon icon="plus" class="mr-1" />
             <span data-description="repeat insert">Insert {{ props.input.title || "Repeat" }}</span>
         </b-button>
-        <div v-if="props.input.cache.length >= props.input.max">
-            Maximum of {{ props.input.cache.length }} {{ props.input.title || "Repeat" }} fields reached
+        <div v-if="maxRepeats">
+            Maximum number of {{ props.input.title || "Repeat" }} fields reached
         </div>
     </div>
 </template>

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -6,6 +6,7 @@ import { defineAsyncComponent, nextTick, type PropType } from "vue";
 import { computed } from "vue";
 
 import { useKeyedObjects } from "@/composables/keyedObjects";
+import localize from "@/utils/localization";
 
 import FormCard from "./FormCard.vue";
 
@@ -31,14 +32,14 @@ const minRepeats = computed(() => {
 
 const buttonTooltip = computed(() => {
     return maxRepeats.value
-        ? `Maximum number of ${props.input.title || "Repeat"} fields reached`
-        : `Click to add ${props.input.title || "Repeat"} fields`;
+        ? localize(`Maximum number of ${props.input.title || "Repeat"} fields reached`)
+        : localize(`Click to add ${props.input.title || "Repeat"} fields`);
 });
 
 const deleteTooltip = computed(() => {
     return !minRepeats.value
-        ? `Minimum number of ${props.input.title || "Repeat"} not reached`
-        : `Click to delete ${props.input.title || "Repeat"} fields`;
+        ? localize(`Minimum number of ${props.input.title || "Repeat"} not reached`)
+        : localize(`Click to delete ${props.input.title || "Repeat"} fields`);
 });
 
 const props = defineProps({

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -526,9 +526,10 @@ def _populate_state_legacy(
             del group_state[:]
             while True:
                 rep_prefix = "%s_%d" % (key, rep_index)
+                repeat_min_default = input.default if input.default > input.min else input.min
                 if (
                     not any(incoming_key.startswith(rep_prefix) for incoming_key in incoming.keys())
-                    and rep_index >= input.min
+                    and rep_index >= repeat_min_default
                 ):
                     break
                 if rep_index < input.max:

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -526,10 +526,10 @@ def _populate_state_legacy(
             del group_state[:]
             while True:
                 rep_prefix = "%s_%d" % (key, rep_index)
-                repeat_min_default = input.default if input.default > input.min else input.min
+                rep_min_default = input.default if input.default > input.min else input.min
                 if (
                     not any(incoming_key.startswith(rep_prefix) for incoming_key in incoming.keys())
-                    and rep_index >= repeat_min_default
+                    and rep_index >= rep_min_default
                 ):
                     break
                 if rep_index < input.max:


### PR DESCRIPTION
![demo_Enhance_Tool_Form_16487](https://github.com/galaxyproject/galaxy/assets/3672779/5f1f1417-556c-4721-899a-e83800e9e23d)
Addresses #16487 
_Changes: (1) "max" number repeating fields is controlled on front-end Button DOM (but also backwards compatible for users who already exceeded number of fields on prior runs) (2) "min" number repeating fields is controlled on the front-end Trash-Icon DOM (3) "default" number of repeating fields now works and if is larger number than "min", will load with the "default" number of fields which is controlled on the back-end Init file._

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
