### PR TITLE
Upgrade job manager's index_query method to SA2.0

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -41,9 +41,13 @@ from galaxy.managers.datasets import DatasetManager
 from galaxy.managers.hdas import HDAManager
 from galaxy.managers.lddas import LDDAManager
 from galaxy.model import (
+    ImplicitCollectionJobsJobAssociation,
     Job,
     JobParameter,
     User,
+    Workflow,
+    WorkflowInvocation,
+    WorkflowInvocationStep,
     YIELD_PER_ROWS,
 )
 from galaxy.model.base import transaction
@@ -113,13 +117,13 @@ class JobManager:
 
         if is_admin:
             if decoded_user_id is not None:
-                query = trans.sa_session.query(model.Job).filter(model.Job.user_id == decoded_user_id)
+                query = trans.sa_session.query(Job).filter(Job.user_id == decoded_user_id)
             else:
-                query = trans.sa_session.query(model.Job)
+                query = trans.sa_session.query(Job)
             if user_details:
-                query = query.outerjoin(model.Job.user)
+                query = query.outerjoin(Job.user)
         else:
-            query = trans.sa_session.query(model.Job).filter(model.Job.user_id == trans.user.id)
+            query = trans.sa_session.query(Job).filter(Job.user_id == trans.user.id)
 
         def build_and_apply_filters(query, objects, filter_func):
             if objects is not None:
@@ -132,38 +136,38 @@ class JobManager:
                     query = query.filter(or_(*t))
             return query
 
-        query = build_and_apply_filters(query, payload.states, lambda s: model.Job.state == s)
-        query = build_and_apply_filters(query, payload.tool_ids, lambda t: model.Job.tool_id == t)
-        query = build_and_apply_filters(query, payload.tool_ids_like, lambda t: model.Job.tool_id.like(t))
-        query = build_and_apply_filters(query, payload.date_range_min, lambda dmin: model.Job.update_time >= dmin)
-        query = build_and_apply_filters(query, payload.date_range_max, lambda dmax: model.Job.update_time <= dmax)
+        query = build_and_apply_filters(query, payload.states, lambda s: Job.state == s)
+        query = build_and_apply_filters(query, payload.tool_ids, lambda t: Job.tool_id == t)
+        query = build_and_apply_filters(query, payload.tool_ids_like, lambda t: Job.tool_id.like(t))
+        query = build_and_apply_filters(query, payload.date_range_min, lambda dmin: Job.update_time >= dmin)
+        query = build_and_apply_filters(query, payload.date_range_max, lambda dmax: Job.update_time <= dmax)
 
         history_id = payload.history_id
         workflow_id = payload.workflow_id
         invocation_id = payload.invocation_id
         if history_id is not None:
-            query = query.filter(model.Job.history_id == history_id)
+            query = query.filter(Job.history_id == history_id)
         if workflow_id or invocation_id:
             if workflow_id is not None:
                 wfi_step = (
-                    trans.sa_session.query(model.WorkflowInvocationStep)
-                    .join(model.WorkflowInvocation)
-                    .join(model.Workflow)
+                    trans.sa_session.query(WorkflowInvocationStep)
+                    .join(WorkflowInvocation)
+                    .join(Workflow)
                     .filter(
-                        model.Workflow.stored_workflow_id == workflow_id,
+                        Workflow.stored_workflow_id == workflow_id,
                     )
                     .subquery()
                 )
             elif invocation_id is not None:
                 wfi_step = (
-                    trans.sa_session.query(model.WorkflowInvocationStep)
-                    .filter(model.WorkflowInvocationStep.workflow_invocation_id == invocation_id)
+                    trans.sa_session.query(WorkflowInvocationStep)
+                    .filter(WorkflowInvocationStep.workflow_invocation_id == invocation_id)
                     .subquery()
                 )
             query1 = query.join(wfi_step)
-            query2 = query.join(model.ImplicitCollectionJobsJobAssociation).join(
+            query2 = query.join(ImplicitCollectionJobsJobAssociation).join(
                 wfi_step,
-                model.ImplicitCollectionJobsJobAssociation.implicit_collection_jobs_id
+                ImplicitCollectionJobsJobAssociation.implicit_collection_jobs_id
                 == wfi_step.c.implicit_collection_jobs_id,
             )
             query = query1.union(query2)
@@ -196,26 +200,26 @@ class JobManager:
                 if isinstance(term, FilteredTerm):
                     key = term.filter
                     if key == "user":
-                        query = query.filter(text_column_filter(model.User.email, term))
+                        query = query.filter(text_column_filter(User.email, term))
                     elif key == "tool":
-                        query = query.filter(text_column_filter(model.Job.tool_id, term))
+                        query = query.filter(text_column_filter(Job.tool_id, term))
                     elif key == "handler":
-                        query = query.filter(text_column_filter(model.Job.handler, term))
+                        query = query.filter(text_column_filter(Job.handler, term))
                     elif key == "runner":
-                        query = query.filter(text_column_filter(model.Job.job_runner_name, term))
+                        query = query.filter(text_column_filter(Job.job_runner_name, term))
                 elif isinstance(term, RawTextTerm):
-                    columns = [model.Job.tool_id]
+                    columns = [Job.tool_id]
                     if user_details:
-                        columns.append(model.User.email)
+                        columns.append(User.email)
                     if is_admin:
-                        columns.append(model.Job.handler)
-                        columns.append(model.Job.job_runner_name)
+                        columns.append(Job.handler)
+                        columns.append(Job.job_runner_name)
                     query = query.filter(raw_text_column_filter(columns, term))
 
         if payload.order_by == JobIndexSortByEnum.create_time:
-            order_by = model.Job.create_time.desc()
+            order_by = Job.create_time.desc()
         else:
-            order_by = model.Job.update_time.desc()
+            order_by = Job.update_time.desc()
         query = query.order_by(order_by)
 
         query = query.offset(payload.offset)

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -169,6 +169,7 @@ class JobManager:
                         "h": "handler",
                     }
                 )
+            assert search
             parsed_search = parse_filters_structured(search, search_filters)
             for term in parsed_search.terms:
                 if isinstance(term, FilteredTerm):

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -108,6 +108,11 @@ class JobManager:
         is_admin = trans.user_is_admin
         user_details = payload.user_details
         decoded_user_id = payload.user_id
+        history_id = payload.history_id
+        workflow_id = payload.workflow_id
+        invocation_id = payload.invocation_id
+        search = payload.search
+        order_by = payload.order_by
 
         if not is_admin:
             if user_details:
@@ -142,9 +147,6 @@ class JobManager:
         query = build_and_apply_filters(query, payload.date_range_min, lambda dmin: Job.update_time >= dmin)
         query = build_and_apply_filters(query, payload.date_range_max, lambda dmax: Job.update_time <= dmax)
 
-        history_id = payload.history_id
-        workflow_id = payload.workflow_id
-        invocation_id = payload.invocation_id
         if history_id is not None:
             query = query.filter(Job.history_id == history_id)
         if workflow_id or invocation_id:
@@ -172,7 +174,6 @@ class JobManager:
             )
             query = query1.union(query2)
 
-        search = payload.search
         if search:
             search_filters = {
                 "tool": "tool",
@@ -216,11 +217,11 @@ class JobManager:
                         columns.append(Job.job_runner_name)
                     query = query.filter(raw_text_column_filter(columns, term))
 
-        if payload.order_by == JobIndexSortByEnum.create_time:
-            order_by = Job.create_time.desc()
+        if order_by == JobIndexSortByEnum.create_time:
+            _order_by = Job.create_time.desc()
         else:
-            order_by = Job.update_time.desc()
-        query = query.order_by(order_by)
+            _order_by = Job.update_time.desc()
+        query = query.order_by(_order_by)
 
         query = query.offset(payload.offset)
         query = query.limit(payload.limit)

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -166,7 +166,8 @@ class JobManager:
                 ImplicitCollectionJobsJobAssociation.implicit_collection_jobs_id
                 == wfi_step.c.implicit_collection_jobs_id,
             )
-            stmt = stmt1.union(stmt2)
+            # Ensure the result is models, not tuples
+            stmt = select(aliased(Job, stmt1.union(stmt2).subquery()))
 
         if search:
             search_filters = {

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import (
     Any,
     Dict,
+    Optional,
 )
 
 from galaxy import (
@@ -59,15 +60,18 @@ class JobsService:
     ):
         security = trans.security
         is_admin = trans.user_is_admin
-        if payload.view == JobIndexViewEnum.admin_job_list:
+        view = payload.view
+        if view == JobIndexViewEnum.admin_job_list:
             payload.user_details = True
         user_details = payload.user_details
-        if payload.view == JobIndexViewEnum.admin_job_list and not is_admin:
-            raise exceptions.AdminRequiredException("Only admins can use the admin_job_list view")
-        query = self.job_manager.index_query(trans, payload)
+        decoded_user_id = payload.user_id
+
+        if not is_admin:
+            self._check_nonadmin_access(view, user_details, decoded_user_id, trans.user.id)
+
+        jobs = self.job_manager.index_query(trans, payload)
         out = []
-        view = payload.view
-        for job in query.yield_per(model.YIELD_PER_ROWS):
+        for job in jobs.yield_per(model.YIELD_PER_ROWS):
             job_dict = job.to_dict(view, system_details=is_admin)
             j = security.encode_all_ids(job_dict, True)
             if view == JobIndexViewEnum.admin_job_list:
@@ -77,3 +81,14 @@ class JobsService:
             out.append(j)
 
         return out
+
+    def _check_nonadmin_access(
+        self, view: str, user_details: bool, decoded_user_id: Optional[DecodedDatabaseIdField], trans_user_id: int
+    ):
+        """Verify admin-only resources are not being accessed."""
+        if view == JobIndexViewEnum.admin_job_list:
+            raise exceptions.AdminRequiredException("Only admins can use the admin_job_list view")
+        if user_details:
+            raise exceptions.AdminRequiredException("Only admins can index the jobs with user details enabled")
+        if decoded_user_id is not None and decoded_user_id != trans_user_id:
+            raise exceptions.AdminRequiredException("Only admins can index the jobs of others")


### PR DESCRIPTION
SQLAlchemy 2.0 compatibility upgrades. Ref #12541. Extracted from #16852. 

Two notable edits: 
1. Calling union() on a `Select` statement creates a `CompoundSelect` object; executing it will return tuples of column values, not models. This causes a problem because the method is expected to return models in all cases. To ensure the method always returns models (regardless of whether the union is called or not), I used `aliased()` to map the `Job` model to the `CompoundSelect` object.
2.  The combination of `UNION` and `ORDER BY` causes problems in SQLite. More details here: https://github.com/galaxyproject/galaxy/pull/16852#issuecomment-1804676322. Solution: instead of using the `Job` class to access the column collection, use `Job` only if workflow jobs have not been added to the statement (and `UNION` has not been applied). Otherwise use the subquery produced by the union.

I've restructured the method - I think it's easier to follow its query-building logic this way. But if that's not the case, I'll drop the last commit.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
