### PR TITLE
Change Broadcast Notifications Style

### DIFF
--- a/client/src/components/Notifications/Broadcasts/BroadcastContainer.vue
+++ b/client/src/components/Notifications/Broadcasts/BroadcastContainer.vue
@@ -10,7 +10,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton } from "bootstrap-vue";
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 
 import { type components } from "@/api/schema";
 import { useMarkdown } from "@/composables/markdown";
@@ -49,20 +49,24 @@ const multiple = computed(() => {
 });
 
 const page = ref(0);
+
 const currentPage = computed({
     get: () => {
         return page.value;
     },
     set: (newPage) => {
-        if (newPage < 0) {
-            page.value = sortedBroadcasts.value.length - 1;
-        } else if (newPage >= sortedBroadcasts.value.length) {
-            page.value = 0;
-        } else if (multiple.value) {
-            page.value = newPage;
-        }
+        page.value = newPage;
+        checkPageInBounds();
     },
 });
+
+function checkPageInBounds() {
+    if (page.value < 0) {
+        page.value = sortedBroadcasts.value.length - 1;
+    } else if (page.value >= sortedBroadcasts.value.length) {
+        page.value = 0;
+    }
+}
 
 const displayedBroadcast = computed(
     () => ensureDefined(sortedBroadcasts.value[currentPage.value]) as BroadcastNotification
@@ -82,6 +86,13 @@ const sortedBroadcasts = computed(() => {
         return sorted;
     }
 });
+
+watch(
+    () => sortedBroadcasts.value,
+    () => {
+        checkPageInBounds();
+    }
+);
 
 function actionLinkBind(link: string) {
     if (link.startsWith("/")) {

--- a/client/src/components/Notifications/Broadcasts/BroadcastContainer.vue
+++ b/client/src/components/Notifications/Broadcasts/BroadcastContainer.vue
@@ -152,7 +152,7 @@ function dismiss() {
             <FontAwesomeIcon fixed-width icon="fa-chevron-right" />
         </BButton>
 
-        <BButton class="cross inline-icon-button area-x" title="Dismiss" @click="dismiss">
+        <BButton class="dismiss-button inline-icon-button area-x" title="Dismiss" @click="dismiss">
             <FontAwesomeIcon fixed-width icon="fa-times" />
         </BButton>
     </div>
@@ -227,7 +227,7 @@ $margin: 1rem;
         }
     }
 
-    .cross {
+    .dismiss-button {
         font-size: 1.5rem;
         color: $border-color;
 

--- a/client/src/components/Notifications/Broadcasts/BroadcastContainer.vue
+++ b/client/src/components/Notifications/Broadcasts/BroadcastContainer.vue
@@ -72,9 +72,14 @@ const displayedBroadcast = computed(
     () => ensureDefined(sortedBroadcasts.value[currentPage.value]) as BroadcastNotification
 );
 
-// newest first
-function sortByPublicationTime(a: BroadcastNotification, b: BroadcastNotification) {
-    return new Date(b.publication_time).getTime() - new Date(a.publication_time).getTime();
+function sortByImportanceAndPublicationTime(a: BroadcastNotification, b: BroadcastNotification) {
+    if (a.variant === "urgent" && b.variant !== "urgent") {
+        return -1;
+    } else if (a.variant === "warning" && b.variant === "info") {
+        return -1;
+    } else {
+        return new Date(b.publication_time).getTime() - new Date(a.publication_time).getTime();
+    }
 }
 
 const sortedBroadcasts = computed(() => {
@@ -82,7 +87,7 @@ const sortedBroadcasts = computed(() => {
         return [props.options.broadcast];
     } else {
         const sorted = [...props.options.broadcasts];
-        sorted.sort(sortByPublicationTime);
+        sorted.sort(sortByImportanceAndPublicationTime);
         return sorted;
     }
 });
@@ -148,8 +153,8 @@ function dismiss() {
                 <div class="action-links">
                     <BButton
                         v-for="(actionLink, index) in displayedBroadcast.content.action_links"
-                        :key="index"
-                        variant="primary"
+                        :key="`${displayedBroadcast.id}-${index}`"
+                        :variant="displayedBroadcast.variant === 'urgent' ? 'danger' : 'primary'"
                         v-bind="actionLinkBind(actionLink.link)">
                         {{ actionLink.action_name }}
                     </BButton>
@@ -220,8 +225,8 @@ $margin: 1rem;
     }
 
     &.urgent {
-        border-color: $brand-info;
-        background: linear-gradient(to top, lighten($brand-info, 50%), $white 120px);
+        border-color: $brand-danger;
+        background: linear-gradient(to top, lighten($brand-warning, 35%), $white 120px);
     }
 
     .arrow {
@@ -258,7 +263,7 @@ $margin: 1rem;
         font-size: 1.5rem;
 
         .urgent {
-            color: $brand-info;
+            color: $brand-danger;
         }
 
         .warning {
@@ -283,6 +288,7 @@ $margin: 1rem;
 
             .action-links {
                 display: flex;
+                flex-wrap: wrap;
                 gap: 0.5rem;
             }
 

--- a/client/src/components/Notifications/Broadcasts/BroadcastContainer.vue
+++ b/client/src/components/Notifications/Broadcasts/BroadcastContainer.vue
@@ -1,26 +1,32 @@
 <script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faInfoCircle, faTimes } from "@fortawesome/free-solid-svg-icons";
+import {
+    faChevronLeft,
+    faChevronRight,
+    faExclamationCircle,
+    faExclamationTriangle,
+    faInfoCircle,
+    faTimes,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton, BCol, BRow } from "bootstrap-vue";
-import { storeToRefs } from "pinia";
-import { computed } from "vue";
-import { useRouter } from "vue-router/composables";
+import { BButton } from "bootstrap-vue";
+import { computed, ref } from "vue";
 
 import { type components } from "@/api/schema";
 import { useMarkdown } from "@/composables/markdown";
 import { type BroadcastNotification, useBroadcastsStore } from "@/stores/broadcastsStore";
+import { ensureDefined } from "@/utils/assertions";
 
 import Heading from "@/components/Common/Heading.vue";
 
-library.add(faInfoCircle, faTimes);
+library.add(faInfoCircle, faTimes, faChevronRight, faChevronLeft, faExclamationTriangle, faExclamationCircle);
 
 type BroadcastNotificationCreateRequest = components["schemas"]["BroadcastNotificationCreateRequest"];
 
 type Options =
     | {
           previewMode?: false;
-          broadcast: BroadcastNotification;
+          broadcasts: BroadcastNotification[];
       }
     | {
           previewMode: true;
@@ -31,125 +37,249 @@ const props = defineProps<{
     options: Options;
 }>();
 
-const router = useRouter();
 const broadcastsStore = useBroadcastsStore();
-const { activeBroadcasts } = storeToRefs(broadcastsStore);
 const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true });
 
-const remainingBroadcastsCountText = computed(() => {
-    const count = activeBroadcasts.value.length - 1;
-    return count > 0 ? `${count} more` : "";
+const multiple = computed(() => {
+    if (props.options.previewMode) {
+        return false;
+    } else {
+        return props.options.broadcasts.length > 1;
+    }
 });
 
-function getBroadcastVariant(item: { variant: string }) {
-    switch (item.variant) {
-        case "urgent":
-            return "danger";
-        default:
-            return item.variant;
-    }
+const page = ref(0);
+const currentPage = computed({
+    get: () => {
+        return page.value;
+    },
+    set: (newPage) => {
+        if (newPage < 0) {
+            page.value = sortedBroadcasts.value.length - 1;
+        } else if (newPage >= sortedBroadcasts.value.length) {
+            page.value = 0;
+        } else if (multiple.value) {
+            page.value = newPage;
+        }
+    },
+});
+
+const displayedBroadcast = computed(
+    () => ensureDefined(sortedBroadcasts.value[currentPage.value]) as BroadcastNotification
+);
+
+// newest first
+function sortByPublicationTime(a: BroadcastNotification, b: BroadcastNotification) {
+    return new Date(b.publication_time).getTime() - new Date(a.publication_time).getTime();
 }
 
-function onActionClick(item: BroadcastNotification, link: string) {
-    if (link.startsWith("/")) {
-        router.push(link);
+const sortedBroadcasts = computed(() => {
+    if (props.options.previewMode) {
+        return [props.options.broadcast];
     } else {
-        window.open(link, "_blank");
+        const sorted = [...props.options.broadcasts];
+        sorted.sort(sortByPublicationTime);
+        return sorted;
     }
+});
 
-    if (!props.options.previewMode) {
-        onDismiss(item);
+function actionLinkBind(link: string) {
+    if (link.startsWith("/")) {
+        return {
+            to: link,
+        };
+    } else {
+        return {
+            href: link,
+        };
     }
 }
 
-function onDismiss(item: BroadcastNotification) {
-    broadcastsStore.dismissBroadcast(item);
+function dismiss() {
+    if (!props.options.previewMode) {
+        broadcastsStore.dismissBroadcast(displayedBroadcast.value);
+    }
 }
 </script>
 
 <template>
-    <BRow
-        align-v="center"
-        class="broadcast-banner"
+    <div
+        class="broadcast-container shadow"
         :class="{
-            'non-urgent': props.options.broadcast.variant !== 'urgent',
-            'fixed-position': !props.options.previewMode,
-        }"
-        no-gutters>
-        <BCol cols="auto">
+            single: !multiple,
+            preview: props.options.previewMode,
+            warning: displayedBroadcast.variant === 'warning',
+            urgent: displayedBroadcast.variant === 'urgent',
+        }">
+        <BButton
+            v-if="multiple"
+            class="arrow left inline-icon-button area-l"
+            title="Previous"
+            @click="currentPage -= 1">
+            <FontAwesomeIcon fixed-width icon="fa-chevron-left" />
+        </BButton>
+
+        <div class="info-icon area-i">
             <FontAwesomeIcon
-                class="mx-2"
-                size="2xl"
-                :class="`text-${getBroadcastVariant(props.options.broadcast)}`"
-                :icon="faInfoCircle" />
-        </BCol>
+                v-if="displayedBroadcast.variant === 'warning'"
+                class="warning"
+                icon="fa-exclamation-triangle" />
+            <FontAwesomeIcon
+                v-if="displayedBroadcast.variant === 'urgent'"
+                class="urgent"
+                icon="fa-exclamation-circle" />
+        </div>
 
-        <BCol>
-            <BRow align-v="center" no-gutters>
-                <Heading size="md" bold>
-                    {{ props.options.broadcast.content.subject }}
-                </Heading>
-            </BRow>
-
-            <BRow align-v="center" no-gutters>
-                <span class="broadcast-message" v-html="renderMarkdown(props.options.broadcast.content.message)" />
-            </BRow>
-
-            <BRow no-gutters>
-                <div v-if="props.options.broadcast.content.action_links">
+        <section class="main-content area-m">
+            <Heading h2>{{ displayedBroadcast.content.subject }}</Heading>
+            <div class="message mb-1" v-html="renderMarkdown(displayedBroadcast.content.message)"></div>
+            <div class="bottom-row">
+                <div class="action-links">
                     <BButton
-                        v-for="actionLink in props.options.broadcast.content.action_links"
-                        :key="actionLink.action_name"
-                        class="mx-1"
-                        :title="actionLink.action_name"
+                        v-for="(actionLink, index) in displayedBroadcast.content.action_links"
+                        :key="index"
                         variant="primary"
-                        @click="onActionClick(props.options.broadcast, actionLink.link)">
+                        v-bind="actionLinkBind(actionLink.link)">
                         {{ actionLink.action_name }}
                     </BButton>
                 </div>
-            </BRow>
-        </BCol>
 
-        <BCol v-if="!props.options.previewMode" cols="auto" align-self="center" class="p-0">
-            <BButton
-                id="dismiss-button"
-                variant="light"
-                class="align-items-center d-flex"
-                @click="broadcastsStore.dismissBroadcast(props.options.broadcast)">
-                <FontAwesomeIcon class="mx-1" :icon="faTimes" />
-                Dismiss
-            </BButton>
-
-            <div v-if="remainingBroadcastsCountText" class="text-center mt-2">
-                {{ remainingBroadcastsCountText }}...
+                <div v-if="multiple" class="page-indicator">{{ currentPage + 1 }} / {{ sortedBroadcasts.length }}</div>
             </div>
-        </BCol>
-    </BRow>
+        </section>
+
+        <BButton v-if="multiple" class="arrow right inline-icon-button area-r" title="Next" @click="currentPage += 1">
+            <FontAwesomeIcon fixed-width icon="fa-chevron-right" />
+        </BButton>
+
+        <BButton class="cross inline-icon-button area-x" title="Dismiss" @click="dismiss">
+            <FontAwesomeIcon fixed-width icon="fa-times" />
+        </BButton>
+    </div>
 </template>
 
 <style lang="scss" scoped>
-.broadcast-banner {
-    width: 100%;
-    color: white;
-    display: flex;
-    z-index: 9999;
-    padding: 1rem;
-    min-height: 6rem;
-    backdrop-filter: blur(0.2rem);
-    justify-content: space-between;
-    background-color: rgb(0, 0, 0, 0.7);
-    box-shadow: 0 0 1rem 0 rgba(0, 0, 0, 0.5);
+@import "theme/blue.scss";
 
-    .broadcast-message {
-        font-size: large;
-    }
-}
+$margin: 1rem;
 
-.fixed-position {
+.broadcast-container {
     position: fixed;
-}
+    bottom: $margin;
+    left: 50%;
+    transform: translate(-50%, 0);
+    height: 200px;
+    width: min(calc(100% - $margin - $margin), 1200px);
+    background: $white;
+    border-color: $border-color;
+    border-width: 1px;
+    border-style: solid;
+    border-radius: 0.5rem;
+    display: grid;
+    grid-template-columns: 50px 1fr 50px;
+    grid-template-rows: 50px 1fr 50px;
+    grid-template-areas:
+        "i m x"
+        "l m r"
+        ". m .";
 
-.non-urgent {
-    bottom: 0;
+    .area-l {
+        grid-area: l;
+    }
+    .area-m {
+        grid-area: m;
+    }
+    .area-x {
+        grid-area: x;
+    }
+    .area-r {
+        grid-area: r;
+    }
+    .area-i {
+        grid-area: i;
+    }
+
+    &.preview {
+        position: relative;
+        bottom: 0;
+    }
+
+    &.warning {
+        border-color: $brand-warning;
+    }
+
+    &.urgent {
+        border-color: $brand-info;
+        background: linear-gradient(to top, lighten($brand-info, 50%), $white 120px);
+    }
+
+    .arrow {
+        font-size: 2rem;
+
+        &.left {
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+        }
+
+        &.right {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+        }
+    }
+
+    .cross {
+        font-size: 1.5rem;
+        color: $border-color;
+
+        &:hover {
+            background: none;
+            color: $brand-danger;
+        }
+
+        &:focus {
+            color: $brand-primary;
+        }
+    }
+
+    .info-icon {
+        display: grid;
+        place-items: center;
+        font-size: 1.5rem;
+
+        .urgent {
+            color: $brand-info;
+        }
+
+        .warning {
+            color: $brand-warning;
+        }
+    }
+
+    .main-content {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        padding: 0.75rem 0.25rem;
+
+        .message {
+            flex: 1;
+            overflow-y: scroll;
+        }
+
+        .bottom-row {
+            display: grid;
+            grid-template-columns: 1fr auto 1fr;
+
+            .action-links {
+                display: flex;
+                gap: 0.5rem;
+            }
+
+            .page-indicator {
+                align-self: end;
+                justify-self: center;
+            }
+        }
+    }
 }
 </style>

--- a/client/src/components/Notifications/Broadcasts/BroadcastsOverlay.test.ts
+++ b/client/src/components/Notifications/Broadcasts/BroadcastsOverlay.test.ts
@@ -58,6 +58,8 @@ async function mountBroadcastsOverlayWith(broadcasts: BroadcastNotification[] = 
     return wrapper;
 }
 
+const messageCssSelector = ".broadcast-container .message";
+
 describe("BroadcastsOverlay.vue", () => {
     it("should not render anything when there is no broadcast", async () => {
         const wrapper = await mountBroadcastsOverlayWith();
@@ -68,19 +70,19 @@ describe("BroadcastsOverlay.vue", () => {
 
     it("should render only one broadcast at a time", async () => {
         const wrapper = await mountBroadcastsOverlayWith(FAKE_BROADCASTS);
-        expect(wrapper.findAll(".broadcast-message")).toHaveLength(1);
-        expect(wrapper.find(".broadcast-message").text()).toContain("Test message 1");
+        expect(wrapper.findAll(messageCssSelector)).toHaveLength(1);
+        expect(wrapper.find(messageCssSelector).text()).toContain("Test message 1");
     });
 
     it("should render the next broadcast when the current one is dismissed", async () => {
         const wrapper = await mountBroadcastsOverlayWith(FAKE_BROADCASTS);
-        expect(wrapper.findAll(".broadcast-message")).toHaveLength(1);
-        expect(wrapper.find(".broadcast-message").text()).toContain("Test message 1");
+        expect(wrapper.findAll(messageCssSelector)).toHaveLength(1);
+        expect(wrapper.find(messageCssSelector).text()).toContain("Test message 1");
 
-        const dismissButton = wrapper.find("#dismiss-button");
+        const dismissButton = wrapper.find(".dismiss-button");
         await dismissButton.trigger("click");
 
-        expect(wrapper.findAll(".broadcast-message")).toHaveLength(1);
-        expect(wrapper.find(".broadcast-message").text()).toContain("Test message 2");
+        expect(wrapper.findAll(messageCssSelector)).toHaveLength(1);
+        expect(wrapper.find(messageCssSelector).text()).toContain("Test message 2");
     });
 });

--- a/client/src/components/Notifications/Broadcasts/BroadcastsOverlay.test.ts
+++ b/client/src/components/Notifications/Broadcasts/BroadcastsOverlay.test.ts
@@ -13,7 +13,11 @@ const localVue = getLocalVue(true);
 const now = new Date();
 const inTwoMonths = new Date(now.setMonth(now.getMonth() + 2));
 
-function generateBroadcastNotification(id: string): BroadcastNotification {
+let idCounter = 0;
+
+function generateBroadcastNotification(overwrites: Partial<BroadcastNotification> = {}): BroadcastNotification {
+    const id = `${idCounter++}`;
+
     return {
         id: id,
         create_time: now.toISOString(),
@@ -23,15 +27,16 @@ function generateBroadcastNotification(id: string): BroadcastNotification {
         source: "testing",
         variant: "info",
         content: {
-            subject: `Test subject ${id}`,
-            message: `Test message ${id}`,
+            subject: `Test subject ${overwrites.id ?? id}`,
+            message: `Test message ${overwrites.id ?? id}`,
         },
+        ...overwrites,
     };
 }
 
 const FAKE_BROADCASTS: BroadcastNotification[] = [
-    generateBroadcastNotification("1"),
-    generateBroadcastNotification("2"),
+    generateBroadcastNotification({ id: "1" }),
+    generateBroadcastNotification({ id: "2" }),
 ];
 
 async function mountBroadcastsOverlayWith(broadcasts: BroadcastNotification[] = []) {
@@ -83,6 +88,53 @@ describe("BroadcastsOverlay.vue", () => {
         await dismissButton.trigger("click");
 
         expect(wrapper.findAll(messageCssSelector)).toHaveLength(1);
+        expect(wrapper.find(messageCssSelector).text()).toContain("Test message 2");
+    });
+
+    it("should show more important broadcasts first", async () => {
+        const broadcasts = [
+            generateBroadcastNotification({ id: "warning", variant: "warning" }),
+            generateBroadcastNotification({ id: "info", variant: "info" }),
+            generateBroadcastNotification({ id: "urgent", variant: "urgent" }),
+        ];
+
+        const wrapper = await mountBroadcastsOverlayWith(broadcasts);
+        expect(wrapper.find(messageCssSelector).text()).toContain("Test message urgent");
+
+        const dismissButton = wrapper.find(".dismiss-button");
+        await dismissButton.trigger("click");
+        expect(wrapper.find(messageCssSelector).text()).toContain("Test message warning");
+
+        await dismissButton.trigger("click");
+        expect(wrapper.find(messageCssSelector).text()).toContain("Test message info");
+    });
+
+    it("should allow cycling through broadcasts", async () => {
+        const broadcasts = [
+            generateBroadcastNotification({ id: "1" }),
+            generateBroadcastNotification({ id: "2" }),
+            generateBroadcastNotification({ id: "3" }),
+        ];
+
+        const wrapper = await mountBroadcastsOverlayWith(broadcasts);
+        expect(wrapper.findAll(messageCssSelector)).toHaveLength(1);
+        expect(wrapper.find(messageCssSelector).text()).toContain("Test message 1");
+
+        const rightButton = wrapper.find("button.right");
+        await rightButton.trigger("click");
+        expect(wrapper.find(messageCssSelector).text()).toContain("Test message 2");
+
+        await rightButton.trigger("click");
+        expect(wrapper.find(messageCssSelector).text()).toContain("Test message 3");
+
+        await rightButton.trigger("click");
+        expect(wrapper.find(messageCssSelector).text()).toContain("Test message 1");
+
+        const leftButton = wrapper.find("button.left");
+        await leftButton.trigger("click");
+        expect(wrapper.find(messageCssSelector).text()).toContain("Test message 3");
+
+        await leftButton.trigger("click");
         expect(wrapper.find(messageCssSelector).text()).toContain("Test message 2");
     });
 });

--- a/client/src/components/Notifications/Broadcasts/BroadcastsOverlay.vue
+++ b/client/src/components/Notifications/Broadcasts/BroadcastsOverlay.vue
@@ -1,26 +1,15 @@
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
-import { computed } from "vue";
 
-import { type BroadcastNotification, useBroadcastsStore } from "@/stores/broadcastsStore";
+import { useBroadcastsStore } from "@/stores/broadcastsStore";
 
 import BroadcastContainer from "@/components/Notifications/Broadcasts/BroadcastContainer.vue";
 
 const { activeBroadcasts } = storeToRefs(useBroadcastsStore());
-
-const currentBroadcast = computed(() => getNextActiveBroadcast());
-
-function sortByPublicationTime(a: BroadcastNotification, b: BroadcastNotification) {
-    return new Date(a.publication_time).getTime() - new Date(b.publication_time).getTime();
-}
-
-function getNextActiveBroadcast(): BroadcastNotification | undefined {
-    return activeBroadcasts.value.sort(sortByPublicationTime).at(0);
-}
 </script>
 
 <template>
-    <div v-if="currentBroadcast">
-        <BroadcastContainer :options="{ broadcast: currentBroadcast }" />
+    <div v-if="activeBroadcasts.length > 0">
+        <BroadcastContainer :options="{ broadcasts: activeBroadcasts }" />
     </div>
 </template>

--- a/client/src/stores/broadcastsStore.ts
+++ b/client/src/stores/broadcastsStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import Vue, { computed, ref } from "vue";
+import { computed, ref, set } from "vue";
 
 import { fetchAllBroadcasts } from "@/api/notifications.broadcast";
 import type { components } from "@/api/schema";
@@ -37,7 +37,7 @@ export const useBroadcastsStore = defineStore("broadcastsStore", () => {
     }
 
     function dismissBroadcast(broadcast: BroadcastNotification) {
-        Vue.set(dismissedBroadcasts.value, broadcast.id, { expiration_time: broadcast.expiration_time });
+        set(dismissedBroadcasts.value, broadcast.id, { expiration_time: broadcast.expiration_time });
     }
 
     function hasExpired(expirationTimeStr?: string) {


### PR DESCRIPTION
Changes the style of broadcast notifications to be easier readable and less intrusive.
Also fixes issue of urgent broadcast notification close button being unclickable on some screen sizes.

Related issue: #16623

![Screen Shot 2023-11-15 at 14 46 06](https://github.com/galaxyproject/galaxy/assets/44241786/2449cc17-b2ff-4bae-818f-fb99ec0fdd7e)
*new notification look*

![image](https://github.com/galaxyproject/galaxy/assets/44241786/36fa4159-8dc0-4568-83d3-9431fd57be0d)
![image](https://github.com/galaxyproject/galaxy/assets/44241786/ecc7ef5a-0a86-4c48-8637-2f38b922d41c)
*Multiple active broadcasts now render a carousel*

![image](https://github.com/galaxyproject/galaxy/assets/44241786/09ea68cc-7080-4be5-b2e4-d20add8eb60f)
![image](https://github.com/galaxyproject/galaxy/assets/44241786/cf557887-1a36-4a43-ac20-940bed005678)
*New look of warning variant*

![image](https://github.com/galaxyproject/galaxy/assets/44241786/39690e9c-3e2c-462d-a520-7b2ec479add6)
*New look of urgent broadcast*

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
