### PR TITLE
[23.1] Load latest version only into panel views

### DIFF
--- a/lib/galaxy/tool_util/toolbox/views/interface.py
+++ b/lib/galaxy/tool_util/toolbox/views/interface.py
@@ -71,5 +71,5 @@ def walk_loaded_tools(tool_panel: ToolPanelElements, toolbox_registry: ToolBoxRe
             for section_key, section_item_type, section_val in val.panel_items_iter():
                 if section_item_type == panel_item_types.TOOL:
                     tool_id = section_key.replace("tool_", "", 1)
-                    if toolbox_registry.has_tool(tool_id):
+                    if toolbox_registry.has_tool(tool_id) and toolbox_registry.get_tool(tool_id).is_latest_version:
                         yield (tool_id, key, section_val, val.name)

--- a/lib/galaxy/tool_util/toolbox/views/static.py
+++ b/lib/galaxy/tool_util/toolbox/views/static.py
@@ -140,7 +140,8 @@ class StaticToolPanelView(ToolPanelView):
                         )
                         continue
                     tool = toolbox_registry.get_tool(tool_id)
-                    toolbox_registry.add_tool_to_tool_panel_view(tool, new_panel)
+                    if tool and tool.is_latest_version:
+                        toolbox_registry.add_tool_to_tool_panel_view(tool, new_panel)
                 elif element.content_type == "workflow":
                     workflow_def: Workflow = element
                     workflow = toolbox_registry.get_workflow(element.id)

--- a/lib/galaxy_test/base/uses_shed_api.py
+++ b/lib/galaxy_test/base/uses_shed_api.py
@@ -34,15 +34,28 @@ class UsesShedApi:
         )
 
     def repository_operation(
-        self, operation: OperationT, owner: str, name: str, changeset: str, tool_shed_url: str = DEFAULT_TOOL_SHED_URL
+        self,
+        operation: OperationT,
+        owner: str,
+        name: str,
+        changeset: str,
+        tool_shed_url: str = DEFAULT_TOOL_SHED_URL,
+        tool_panel_section_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         payload = {"tool_shed_url": tool_shed_url, "name": name, "owner": owner, "changeset_revision": changeset}
+        if tool_panel_section_id:
+            payload["tool_panel_section_id"] = tool_panel_section_id
         create_response = operation(payload)
         assert_status_code_is(create_response, 200)
         return create_response.json()
 
     def install_repository(
-        self, owner: str, name: str, changeset: str, tool_shed_url: str = DEFAULT_TOOL_SHED_URL
+        self,
+        owner: str,
+        name: str,
+        changeset: str,
+        tool_shed_url: str = DEFAULT_TOOL_SHED_URL,
+        tool_panel_section_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         try:
             return self.repository_operation(
@@ -51,6 +64,7 @@ class UsesShedApi:
                 name=name,
                 changeset=changeset,
                 tool_shed_url=tool_shed_url,
+                tool_panel_section_id=tool_panel_section_id,
             )
         except AssertionError as e:
             if "Error attempting to retrieve installation information from tool shed" in unicodify(e):

--- a/run.sh
+++ b/run.sh
@@ -41,6 +41,7 @@ then
     export GALAXY_CONFIG_OVERRIDE_ENABLE_BETA_TOOL_FORMATS="true"
     export GALAXY_CONFIG_INTERACTIVETOOLS_ENABLE="true"
     export GALAXY_CONFIG_OVERRIDE_WEBHOOKS_DIR="test/functional/webhooks"
+    export GALAXY_CONFIG_OVERRIDE_PANEL_VIEWS_DIR="$(pwd)/test/integration/panel_views_1/"
 fi
 
 set_galaxy_config_file_var

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -220,6 +220,12 @@
   <tool file="multiple_versions_v01.xml" />
   <tool file="multiple_versions_v01galaxy6.xml" />
   <tool file="multiple_versions_v02.xml" />
+  <section id="test_section_multi" name="Test Section with Multiple Versions">
+    <tool file="multiple_versions_v01.xml" />
+    <tool file="multiple_versions_v01galaxy6.xml" />
+    <tool file="multiple_versions_v02.xml" />
+  </section>
+
   <tool file="multiple_versions_changes_v01.xml" />
   <tool file="multiple_versions_changes_v02.xml" />
 

--- a/test/integration/panel_views_1/custom_13.yml
+++ b/test/integration/panel_views_1/custom_13.yml
@@ -1,0 +1,4 @@
+name: Filtered Test Section w/multiple versions
+type: activity
+items:
+- sections: [test_section_multi]

--- a/test/integration/test_panel_views.py
+++ b/test/integration/test_panel_views.py
@@ -110,6 +110,18 @@ class TestPanelViewsFromDirectoryIntegration(integration_util.IntegrationTestCas
         tools = section["elems"]
         assert len(tools) == 2, len(tools)
 
+    def test_only_latest_version_in_panel(self):
+        index = self.galaxy_interactor.get("tools", data=dict(in_panel=True, view="custom_13"))
+        index.raise_for_status()
+        index_as_list = index.json()
+        sections = [x for x in index_as_list if x["model_class"] == "ToolSection"]
+        assert len(sections) == 1
+        section = sections[0]
+        assert section["id"] == "test_section_multi"
+        tools = section["elems"]
+        assert len(tools) == 1, len(tools)
+        assert tools[0]["version"] == "0.2"
+
 
 class TestPanelViewsFromConfigIntegration(integration_util.IntegrationTestCase):
     framework_tool_and_types = True

--- a/test/integration/test_panel_views.py
+++ b/test/integration/test_panel_views.py
@@ -1,6 +1,8 @@
 import os
+import time
 
 from galaxy_test.driver import integration_util
+from galaxy_test.driver.uses_shed import UsesShed
 
 THIS_DIR = os.path.dirname(__file__)
 PANEL_VIEWS_DIR_1 = os.path.join(THIS_DIR, "panel_views_1")
@@ -121,6 +123,38 @@ class TestPanelViewsFromDirectoryIntegration(integration_util.IntegrationTestCas
         tools = section["elems"]
         assert len(tools) == 1, len(tools)
         assert tools[0]["version"] == "0.2"
+
+
+class TestPanelViewsWithShedTools(integration_util.IntegrationTestCase, UsesShed):
+    framework_tool_and_types = True
+    allow_tool_conf_override = False
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        config["panel_views_dir"] = PANEL_VIEWS_DIR_1
+
+    def test_only_latest_version_in_panel_fastp(self):
+        FASTP_REPO = {"name": "fastp", "owner": "iuc", "tool_panel_section_id": "test_section_multi"}
+        OLD_CHANGESET = "1d8fe9bc4cb0"
+        NEW_CHANGESET = "dbf9c561ef29"
+        self.install_repository(**FASTP_REPO, changeset=OLD_CHANGESET)
+        self.install_repository(**FASTP_REPO, changeset=NEW_CHANGESET)
+
+        # give the toolbox a moment to reload after repo installation
+        time.sleep(5)
+        index = self.galaxy_interactor.get("tools", data=dict(in_panel=True, view="custom_13"))
+        index.raise_for_status()
+        index_as_list = index.json()
+        sections = [x for x in index_as_list if x["model_class"] == "ToolSection"]
+        assert len(sections) == 1
+        section = sections[0]
+        assert section["id"] == "test_section_multi"
+        tools = section["elems"]
+        assert len(tools) == 2, len(tools)
+        fastp = tools[0]
+        assert fastp["id"] == "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.20.1+galaxy0"
+        assert fastp["tool_shed_repository"]["changeset_revision"] == NEW_CHANGESET
 
 
 class TestPanelViewsFromConfigIntegration(integration_util.IntegrationTestCase):


### PR DESCRIPTION
Might be a quick and dirty fix for

![image](https://github.com/galaxyproject/galaxy/assets/6804901/e4893fd4-03db-4ddc-b3d1-fe73f476eef0)

seen at vgp.usegalaxy.org. Need to figure out how I can test this.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
