### PR TITLE
Require name for workflows on save, set default to Unnamed Workflow

### DIFF
--- a/client/src/components/Workflow/Editor/Options.vue
+++ b/client/src/components/Workflow/Editor/Options.vue
@@ -77,7 +77,7 @@ async function onSave() {
             @click="$emit('onAttributes')">
             <span class="fa fa-pencil-alt" />
         </BButton>
-        <b-button-group v-b-tooltip class="editor-button-save-group" :title="saveHover">
+        <b-button-group v-b-tooltip.hover.noninteractive class="editor-button-save-group" :title="saveHover">
             <BButton
                 id="workflow-save-button"
                 role="button"

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -712,6 +712,8 @@ class WorkflowContentsManager(UsesAnnotations):
             update_dict = raw_workflow_description.as_dict
             if "name" in update_dict:
                 sanitized_name = sanitize_html(update_dict["name"])
+                if not sanitized_name:
+                    raise exceptions.RequestParameterInvalidException("Workflow must have a valid name")
                 workflow.name = sanitized_name
                 stored_workflow.name = sanitized_name
             if update_dict.get("annotation") is not None:

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -475,6 +475,8 @@ class WorkflowsAPIController(
             steps_updated = "steps" in workflow_dict
             if name_updated and not steps_updated:
                 sanitized_name = sanitize_html(new_workflow_name or old_workflow.name)
+                if not sanitized_name:
+                    raise exceptions.MessageException("Workflow must have a valid name.")
                 workflow = old_workflow.copy(user=trans.user)
                 workflow.stored_workflow = stored_workflow
                 workflow.name = sanitized_name

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -849,6 +849,24 @@ class TestWorkflowsApi(BaseWorkflowsApiTestCase, ChangeDatatypeTests):
         workflow_dict = self.workflow_populator.download_workflow(workflow_id)
         assert workflow_dict["license"] == "AAL"
 
+    def test_update_name_empty(self):
+        # Update doesn't allow empty names.
+
+        # Load a workflow with a given name.
+        original_name = "test update name"
+        workflow_object = self.workflow_populator.load_workflow(name=original_name)
+        upload_response = self.__test_upload(workflow=workflow_object, name=original_name)
+        workflow = upload_response.json()
+        assert workflow["name"] == original_name
+
+        # Try to update the name to an empty string (also change steps to force an update).
+        data = {"name": "", "steps": {}}
+        update_response = self._update_workflow(workflow["id"], data)
+        assert update_response.json()["err_msg"] == "Workflow must have a valid name"
+        self._assert_status_code_is(update_response, 400)
+        workflow_dict = self.workflow_populator.download_workflow(workflow["id"])
+        assert workflow_dict["name"] == original_name
+
     def test_refactor(self):
         workflow_id = self.workflow_populator.upload_yaml_workflow(
             """


### PR DESCRIPTION
Also, use `Toast` instead of modal for empty name, as well as `Toast.success` on newly created workflow
Fixes #16998 
Fixes #16997 

| Before |
| ------ |
| <video src="https://github.com/galaxyproject/galaxy/assets/78516064/ebea7385-cda0-4bed-b4a8-e723e10d8476"> |

| After |
| ------ |
| <video src="https://github.com/galaxyproject/galaxy/assets/78516064/d4068e2f-ca0d-4bbd-b33c-144961caaf4b"> |

~~_To Do:_
_- Also require name for Workflow `update` method (`PUT /api/workflows/{id}`) like we do for the `create` method (`PUT /api/workflow/create`) already._~~ Done ✅ 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
