### PR TITLE
Prevent excessive `api/tool_panels` calls by keeping views in store

### DIFF
--- a/client/src/components/Panels/ToolPanel.vue
+++ b/client/src/components/Panels/ToolPanel.vue
@@ -2,12 +2,10 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCaretDown } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import axios from "axios";
 import { storeToRefs } from "pinia";
 import { computed, onMounted, ref, watch } from "vue";
 
-import { getAppRoot } from "@/onload";
-import { type PanelView, useToolStore } from "@/stores/toolStore";
+import { useToolStore } from "@/stores/toolStore";
 import localize from "@/utils/localization";
 
 import { types_to_icons } from "./utilities";
@@ -35,21 +33,16 @@ const emit = defineEmits<{
 }>();
 
 const arePanelsFetched = ref(false);
-const defaultPanelView = ref("");
 const toolStore = useToolStore();
-const { currentPanelView, isPanelPopulated } = storeToRefs(toolStore);
+const { currentPanelView, defaultPanelView, isPanelPopulated, panelViews } = storeToRefs(toolStore);
 
 const query = ref("");
-const panelViews = ref<Record<string, PanelView> | null>(null);
 const showAdvanced = ref(false);
 
 onMounted(async () => {
-    await axios
-        .get(`${getAppRoot()}api/tool_panels`)
-        .then(async ({ data }) => {
-            const { default_panel_view, views } = data;
-            defaultPanelView.value = default_panel_view;
-            panelViews.value = views;
+    await toolStore
+        .fetchPanelViews()
+        .then(async () => {
             await initializeTools();
         })
         .catch((error) => {

--- a/client/src/components/Panels/ToolPanel.vue
+++ b/client/src/components/Panels/ToolPanel.vue
@@ -40,17 +40,14 @@ const query = ref("");
 const showAdvanced = ref(false);
 
 onMounted(async () => {
-    await toolStore
-        .fetchPanelViews()
-        .then(async () => {
-            await initializeTools();
-        })
-        .catch((error) => {
-            console.error(error);
-        })
-        .finally(() => {
-            arePanelsFetched.value = true;
-        });
+    try {
+        await toolStore.fetchPanelViews();
+        await initializeTools();
+    } catch (error) {
+        console.error(error);
+    } finally {
+        arePanelsFetched.value = true;
+    }
 });
 
 watch(

--- a/client/src/stores/toolStore.ts
+++ b/client/src/stores/toolStore.ts
@@ -181,9 +181,10 @@ export const useToolStore = defineStore("toolStore", () => {
     }
 
     async function fetchPanelViews() {
-        if (defaultPanelView.value && Object.keys(panelViews.value).length > 0) {
+        if (loading.value || (defaultPanelView.value && Object.keys(panelViews.value).length > 0)) {
             return;
         }
+        loading.value = true;
         try {
             const { data } = await axios.get(`${getAppRoot()}api/tool_panels`);
             const { default_panel_view, views } = data;
@@ -191,6 +192,8 @@ export const useToolStore = defineStore("toolStore", () => {
             panelViews.value = views;
         } catch (e) {
             rethrowSimple(e);
+        } finally {
+            loading.value = false;
         }
     }
 


### PR DESCRIPTION
Also remove extra api call added by mistake in #17021

The call `api/tool_panels` is used to get the dict of panel views for the `ToolPanel` when mounted, but this meant collapsing and expanding the tool panel over and over would produce multiple, needless calls. Instead, store the `views` and `default_panel_view` from this call in the `toolStore` and only fetch them once.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
