### PR TITLE
Workflow  Run Button Disabling after Single Clicks

### DIFF
--- a/client/src/components/Workflow/WorkflowRunButton.vue
+++ b/client/src/components/Workflow/WorkflowRunButton.vue
@@ -18,11 +18,6 @@ export default {
     directives: {
         VBTooltip,
     },
-    data() {
-        return{
-            clicked: false,
-        }
-    },
     props: {
         id: {
             type: String,
@@ -32,6 +27,11 @@ export default {
             type: String,
             required: true,
         },
+    },
+    data() {
+        return{
+            clicked: false,
+        }
     },
     computed: {
         title() {

--- a/client/src/components/Workflow/WorkflowRunButton.vue
+++ b/client/src/components/Workflow/WorkflowRunButton.vue
@@ -3,6 +3,7 @@
         v-b-tooltip.hover.bottom
         :title="title | localize"
         :data-workflow-run="id"
+        :disabled="clicked"
         class="workflow-run btn-sm btn-primary fa fa-play"
         @click.stop="executeWorkflow" />
 </template>
@@ -16,6 +17,11 @@ export default {
     },
     directives: {
         VBTooltip,
+    },
+    data() {
+        return{
+            clicked: false,
+        }
     },
     props: {
         id: {
@@ -34,6 +40,7 @@ export default {
     },
     methods: {
         executeWorkflow() {
+            this.clicked = true;
             this.$router.push(`/workflows/run?id=${this.id}`);
         },
     },


### PR DESCRIPTION
This PR addresses issue #16986 . 

This PR forces workflow buttons to use disabled attribute of bbuttons after they are clicked a single time. This prevents multiple submissions of a workflow by someone rapidly clicking the workflow run button. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
