### PR TITLE
Allow relative URLs in broadcasts action links

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1722,7 +1722,7 @@ export interface components {
              * Link
              * @description The link to be opened when the button is clicked.
              */
-            link: string | string;
+            link: string;
         };
         /**
          * AnonUserModel

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1720,10 +1720,9 @@ export interface components {
             action_name: string;
             /**
              * Link
-             * Format: uri
              * @description The link to be opened when the button is clicked.
              */
-            link: string;
+            link: string | string;
         };
         /**
          * AnonUserModel

--- a/lib/galaxy/schema/notifications.py
+++ b/lib/galaxy/schema/notifications.py
@@ -8,7 +8,6 @@ from typing import (
 )
 
 from pydantic import (
-    AnyUrl,
     Field,
     Required,
 )
@@ -22,6 +21,7 @@ from galaxy.schema.fields import (
     EncodedDatabaseIdField,
 )
 from galaxy.schema.schema import Model
+from galaxy.schema.types import AbsoluteOrRelativeUrl
 
 
 class NotificationVariant(str, Enum):
@@ -72,7 +72,9 @@ class ActionLink(Model):
     action_name: str = Field(
         Required, title="Action name", description="The name of the action, will be the button title."
     )
-    link: AnyUrl = Field(Required, title="Link", description="The link to be opened when the button is clicked.")
+    link: AbsoluteOrRelativeUrl = Field(
+        Required, title="Link", description="The link to be opened when the button is clicked."
+    )
 
 
 # Create the corresponding model for the registered category below and

--- a/lib/galaxy/schema/types.py
+++ b/lib/galaxy/schema/types.py
@@ -1,7 +1,5 @@
 from datetime import datetime
-from typing import Union
 
-from pydantic import AnyUrl
 from pydantic.datetime_parse import parse_datetime
 from typing_extensions import Literal
 
@@ -9,7 +7,8 @@ from typing_extensions import Literal
 # Making them an alias of `str` for now
 RelativeUrl = str
 
-AbsoluteOrRelativeUrl = Union[AnyUrl, RelativeUrl]
+# TODO: we may want to add a custom validator for this and for RelativeUrl
+AbsoluteOrRelativeUrl = RelativeUrl
 
 LatestLiteral = Literal["latest"]
 

--- a/lib/galaxy/schema/types.py
+++ b/lib/galaxy/schema/types.py
@@ -1,11 +1,15 @@
 from datetime import datetime
+from typing import Union
 
+from pydantic import AnyUrl
 from pydantic.datetime_parse import parse_datetime
 from typing_extensions import Literal
 
 # Relative URLs cannot be validated with AnyUrl, they need a scheme.
 # Making them an alias of `str` for now
 RelativeUrl = str
+
+AbsoluteOrRelativeUrl = Union[AnyUrl, RelativeUrl]
 
 LatestLiteral = Literal["latest"]
 

--- a/test/integration/test_notifications.py
+++ b/test/integration/test_notifications.py
@@ -7,6 +7,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
 )
 from uuid import uuid4
 
@@ -268,6 +269,25 @@ class TestNotificationsIntegration(IntegrationTestCase):
         assert "Scheduled" in subjects
         assert "Expired" in subjects
 
+    def test_broadcast_notification_action_links(self):
+        # Broadcast notifications can have relative and absolute links
+        response = self._send_broadcast_notification(
+            action_links=[("View Workflows", "/workflows/list"), ("Go to GTN", "https://training.galaxyproject.org")]
+        )
+        notification_id = response["notification"]["id"]
+        response = self._get(f"notifications/broadcast/{notification_id}")
+        self._assert_status_code_is_ok(response)
+        notification = response.json()
+        assert "content" in notification
+        assert "action_links" in notification["content"]
+        assert len(notification["content"]["action_links"]) == 2
+        action_link = notification["content"]["action_links"][0]
+        assert action_link["action_name"] == "View Workflows"
+        assert action_link["link"] == "/workflows/list"
+        action_link = notification["content"]["action_links"][1]
+        assert action_link["action_name"] == "Go to GTN"
+        assert action_link["link"] == "https://training.galaxyproject.org"
+
     def test_sharing_items_creates_notifications_when_expected(self):
         user1 = self._create_test_user()
         user2 = self._create_test_user()
@@ -349,12 +369,17 @@ class TestNotificationsIntegration(IntegrationTestCase):
         message: Optional[str] = None,
         publication_time: Optional[datetime] = None,
         expiration_time: Optional[datetime] = None,
+        action_links: Optional[List[Tuple[str, str]]] = None,
     ):
         payload = notification_broadcast_test_data()
         if subject is not None:
             payload["content"]["subject"] = subject
         if message is not None:
             payload["content"]["message"] = message
+        if action_links is not None:
+            payload["content"]["action_links"] = [
+                {"action_name": action_name, "link": link} for action_name, link in action_links
+            ]
         if publication_time is not None:
             payload["publication_time"] = publication_time.isoformat()
         if expiration_time is not None:


### PR DESCRIPTION
Fixes #17033

It relaxes the schema typing in notifications a bit to support relative URLs. The pydantic type `AnyUrl` always confuses me and makes me think it supports both absolute and relative URLs but it's not the case.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
