### PR TITLE
Open `HistoryStorageOverview` in center panel from `HistoryPanel`

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -57,7 +57,7 @@ onMounted(() => {
 });
 
 function onDashboard() {
-    router.push({ name: "HistoryOverview", params: { historyId: props.history.id } });
+    router.push({ name: "HistoryOverviewInAnalysis", params: { historyId: props.history.id } });
 }
 
 function setFilter(filter: string) {

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -68,6 +68,7 @@ import HistoryArchive from "@/components/History/Archiving/HistoryArchive.vue";
 import HistoryArchiveWizard from "@/components/History/Archiving/HistoryArchiveWizard.vue";
 import NotificationsList from "@/components/Notifications/NotificationsList.vue";
 import Sharing from "@/components/Sharing/SharingPage.vue";
+import HistoryStorageOverview from "@/components/User/DiskUsage/Visualizations/HistoryStorageOverview.vue";
 import WorkflowPublished from "@/components/Workflow/Published/WorkflowPublished.vue";
 
 Vue.use(VueRouter);
@@ -365,6 +366,12 @@ export function getRouter(Galaxy) {
                         props: (route) => ({
                             published: route.params.actionId == "list_published" ? true : false,
                         }),
+                    },
+                    {
+                        path: "storage/history/:historyId",
+                        name: "HistoryOverviewInAnalysis",
+                        component: HistoryStorageOverview,
+                        props: true,
                     },
                     {
                         path: "tours",


### PR DESCRIPTION
Previously, if we clicked the History storage button for the current history in the `HistoryPanel`, it took over the whole screen because the `StorageDashboardRoutes` are not children of the `Analysis` route.

Changed it so the `HistoryStorageOverview` route opens in the center panel as an `Analysis` route (only from the `HistoryPanel`, otherwise, it is still opened as one of the `StorageDashboardRoutes`)

Fixes https://github.com/galaxyproject/galaxy/issues/17026

https://github.com/galaxyproject/galaxy/assets/78516064/68882c30-b86f-4f3f-b458-468ce2977bab

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
