### PR TITLE
Upgrade axios to 1.6.2

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -43,7 +43,7 @@
     "@types/jest": "^29.5.6",
     "@vueuse/core": "^10.5.0",
     "assert": "^2.1.0",
-    "axios": "^1.5.1",
+    "axios": "^1.6.2",
     "babel-runtime": "^6.26.0",
     "backbone": "1.5.0",
     "bootstrap": "4.6",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3512,10 +3512,10 @@ axios-mock-adapter@^1.22.0:
     fast-deep-equal "^3.1.3"
     is-buffer "^2.0.5"
 
-axios@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.5.1.tgz#11fbaa11fc35f431193a9564109c88c1f27b585f"
-  integrity sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==
+axios@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
+  integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==
   dependencies:
     follow-redirects "^1.15.0"
     form-data "^4.0.0"


### PR DESCRIPTION
Upgrades past and supersedes https://github.com/galaxyproject/galaxy/pull/17012, addressing the CSRF vuln in axios.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
