### PR TITLE
Quote singularity env parameters

### DIFF
--- a/lib/galaxy/tool_util/deps/singularity_util.py
+++ b/lib/galaxy/tool_util/deps/singularity_util.py
@@ -81,7 +81,7 @@ def build_singularity_run_command(
     for key, value in env:
         if key == "HOME":
             home = value
-        command_parts.extend([f"SINGULARITYENV_{key}={value}"])
+        command_parts.extend([f'SINGULARITYENV_{key}="{value}"'])
     command_parts += _singularity_prefix(
         singularity_cmd=singularity_cmd,
         sudo=sudo,


### PR DESCRIPTION
destination parameters that contain spaces, e.g. `<param id="singularity_env__JAVA_OPTIONS">-Xmx61g -Xms256m</param>` need quoting. Not sure if there is a better implementation which covers eg the case of already quoted variables.

Of course admins could add them `<param id="singularity_env__JAVA_OPTIONS">"-Xmx61g -Xms256m"</param>`  but this might be inconsistent to what the corresponding docker env variables need. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
