### PR TITLE
Use debounce instead of timeout utility

### DIFF
--- a/client/src/components/Grid/GridList.vue
+++ b/client/src/components/Grid/GridList.vue
@@ -2,11 +2,10 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCaretDown, faCaretUp } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { useDebounceFn } from "@vueuse/core";
 import { BAlert, BButton, BLink, BPagination } from "bootstrap-vue";
 import { computed, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router/composables";
-
-import { timeout } from "@/utils/timeout";
 
 import { Config, FieldHandler, Operation, RowData } from "./configs/types";
 
@@ -25,11 +24,14 @@ const router = useRouter();
 interface Props {
     // provide a grid configuration
     config: Config;
+    // debounce delay
+    delay?: number;
     // rows per page to be shown
     limit?: number;
 }
 
 const props = withDefaults(defineProps<Props>(), {
+    delay: 5000,
     limit: 25,
 });
 
@@ -59,6 +61,11 @@ const sortDesc = ref(props.config ? props.config.sortDesc : false);
 const filterText = ref("");
 const searchTerm = ref("");
 const showAdvanced = ref(false);
+
+// hide message helper
+const hideMessage = useDebounceFn(() => {
+    operationMessage.value = "";
+}, props.delay);
 
 /**
  * Manually set filter value, used for tags and `SharingIndicators`
@@ -156,9 +163,7 @@ watch([currentPage, searchTerm, sortDesc, sortBy], () => getGridData());
  * Operation message timeout handler
  */
 watch(operationMessage, () => {
-    timeout(() => {
-        operationMessage.value = "";
-    });
+    hideMessage();
 });
 </script>
 

--- a/client/src/utils/timeout.ts
+++ b/client/src/utils/timeout.ts
@@ -1,7 +1,0 @@
-let timeoutHandler: ReturnType<typeof setTimeout> | null = null;
-export const timeout = (callback: () => void, delay = 5000) => {
-    if (timeoutHandler) {
-        clearTimeout(timeoutHandler);
-    }
-    timeoutHandler = setTimeout(callback, delay);
-};


### PR DESCRIPTION
The timeout utility is unnecessary, instead the vue-core `useDebounceFn`  function can be called.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
