### PR TITLE
Migrate ItemTags API to FastAPI

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -626,6 +626,20 @@ export interface paths {
         /** Returns the metadata file associated with this history item. */
         get: operations["history_contents__get_metadata_file"];
     };
+    "/api/histories/{history_id}/contents/{history_content_id}/tags": {
+        /** Show tags based on history_content_id */
+        get: operations["index_api_histories__history_id__contents__history_content_id__tags_get"];
+    };
+    "/api/histories/{history_id}/contents/{history_content_id}/tags/{tag_name}": {
+        /** Show tag based on history_content_id */
+        get: operations["show_api_histories__history_id__contents__history_content_id__tags__tag_name__get"];
+        /** Update tag based on history_content_id */
+        put: operations["update_api_histories__history_id__contents__history_content_id__tags__tag_name__put"];
+        /** Create tag based on history_content_id */
+        post: operations["create_api_histories__history_id__contents__history_content_id__tags__tag_name__post"];
+        /** Delete tag based on history_content_id */
+        delete: operations["delete_api_histories__history_id__contents__history_content_id__tags__tag_name__delete"];
+    };
     "/api/histories/{history_id}/contents/{id}": {
         /**
          * Return detailed information about an HDA within a history. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.
@@ -648,20 +662,6 @@ export interface paths {
          * **Note**: Currently does not stop any active jobs for which this dataset is an output.
          */
         delete: operations["history_contents__delete_legacy"];
-    };
-    "/api/histories/{history_id}/contents/{id}/tags": {
-        /** Show tags based on history_content_id */
-        get: operations["index_api_histories__history_id__contents__id__tags_get"];
-    };
-    "/api/histories/{history_id}/contents/{id}/tags/{tag_name}": {
-        /** Show tag based on history_content_id */
-        get: operations["show_api_histories__history_id__contents__id__tags__tag_name__get"];
-        /** Update tag based on history_content_id */
-        put: operations["update_api_histories__history_id__contents__id__tags__tag_name__put"];
-        /** Create tag based on history_content_id */
-        post: operations["create_api_histories__history_id__contents__id__tags__tag_name__post"];
-        /** Delete tag based on history_content_id */
-        delete: operations["delete_api_histories__history_id__contents__id__tags__tag_name__delete"];
     };
     "/api/histories/{history_id}/contents/{id}/validate": {
         /**
@@ -843,6 +843,20 @@ export interface paths {
          */
         put: operations["set_slug_api_histories__history_id__slug_put"];
     };
+    "/api/histories/{history_id}/tags": {
+        /** Show tags based on history_id */
+        get: operations["index_api_histories__history_id__tags_get"];
+    };
+    "/api/histories/{history_id}/tags/{tag_name}": {
+        /** Show tag based on history_id */
+        get: operations["show_api_histories__history_id__tags__tag_name__get"];
+        /** Update tag based on history_id */
+        put: operations["update_api_histories__history_id__tags__tag_name__put"];
+        /** Create tag based on history_id */
+        post: operations["create_api_histories__history_id__tags__tag_name__post"];
+        /** Delete tag based on history_id */
+        delete: operations["delete_api_histories__history_id__tags__tag_name__delete"];
+    };
     "/api/histories/{history_id}/unpublish": {
         /**
          * Removes this item from the published list.
@@ -853,20 +867,6 @@ export interface paths {
     "/api/histories/{history_id}/write_store": {
         /** Prepare history for export-style download and write to supplied URI. */
         post: operations["write_store_api_histories__history_id__write_store_post"];
-    };
-    "/api/histories/{id}/tags": {
-        /** Show tags based on history_id */
-        get: operations["index_api_histories__id__tags_get"];
-    };
-    "/api/histories/{id}/tags/{tag_name}": {
-        /** Show tag based on history_id */
-        get: operations["show_api_histories__id__tags__tag_name__get"];
-        /** Update tag based on history_id */
-        put: operations["update_api_histories__id__tags__tag_name__put"];
-        /** Create tag based on history_id */
-        post: operations["create_api_histories__id__tags__tag_name__post"];
-        /** Delete tag based on history_id */
-        delete: operations["delete_api_histories__id__tags__tag_name__delete"];
     };
     "/api/invocations/{invocation_id}/biocompute": {
         /**
@@ -1703,20 +1703,6 @@ export interface paths {
          */
         put: operations["set_slug_api_workflows__id__slug_put"];
     };
-    "/api/workflows/{id}/tags": {
-        /** Show tags based on workflow_id */
-        get: operations["index_api_workflows__id__tags_get"];
-    };
-    "/api/workflows/{id}/tags/{tag_name}": {
-        /** Show tag based on workflow_id */
-        get: operations["show_api_workflows__id__tags__tag_name__get"];
-        /** Update tag based on workflow_id */
-        put: operations["update_api_workflows__id__tags__tag_name__put"];
-        /** Create tag based on workflow_id */
-        post: operations["create_api_workflows__id__tags__tag_name__post"];
-        /** Delete tag based on workflow_id */
-        delete: operations["delete_api_workflows__id__tags__tag_name__delete"];
-    };
     "/api/workflows/{id}/unpublish": {
         /**
          * Removes this item from the published list.
@@ -1727,6 +1713,20 @@ export interface paths {
     "/api/workflows/{workflow_id}": {
         /** Add the deleted flag to a workflow. */
         delete: operations["delete_workflow_api_workflows__workflow_id__delete"];
+    };
+    "/api/workflows/{workflow_id}/tags": {
+        /** Show tags based on workflow_id */
+        get: operations["index_api_workflows__workflow_id__tags_get"];
+    };
+    "/api/workflows/{workflow_id}/tags/{tag_name}": {
+        /** Show tag based on workflow_id */
+        get: operations["show_api_workflows__workflow_id__tags__tag_name__get"];
+        /** Update tag based on workflow_id */
+        put: operations["update_api_workflows__workflow_id__tags__tag_name__put"];
+        /** Create tag based on workflow_id */
+        post: operations["create_api_workflows__workflow_id__tags__tag_name__post"];
+        /** Delete tag based on workflow_id */
+        delete: operations["delete_api_workflows__workflow_id__tags__tag_name__delete"];
     };
     "/api/workflows/{workflow_id}/undelete": {
         /** Remove the deleted flag from a workflow. */
@@ -13251,6 +13251,155 @@ export interface operations {
             };
         };
     };
+    index_api_histories__history_id__contents__history_content_id__tags_get: {
+        /** Show tags based on history_content_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                history_content_id: string;
+                history_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    show_api_histories__history_id__contents__history_content_id__tags__tag_name__get: {
+        /** Show tag based on history_content_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                history_content_id: string;
+                tag_name: string;
+                history_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_api_histories__history_id__contents__history_content_id__tags__tag_name__put: {
+        /** Update tag based on history_content_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                history_content_id: string;
+                tag_name: string;
+                history_id: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ItemTagsCreatePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_api_histories__history_id__contents__history_content_id__tags__tag_name__post: {
+        /** Create tag based on history_content_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                history_content_id: string;
+                tag_name: string;
+                history_id: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ItemTagsCreatePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_api_histories__history_id__contents__history_content_id__tags__tag_name__delete: {
+        /** Delete tag based on history_content_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                history_content_id: string;
+                tag_name: string;
+                history_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": boolean;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     history_contents__show_legacy: {
         /**
          * Return detailed information about an HDA within a history. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.
@@ -13419,155 +13568,6 @@ export interface operations {
             202: {
                 content: {
                     "application/json": components["schemas"]["DeleteHistoryContentResult"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    index_api_histories__history_id__contents__id__tags_get: {
-        /** Show tags based on history_content_id */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description history_content_id */
-            path: {
-                id: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    show_api_histories__history_id__contents__id__tags__tag_name__get: {
-        /** Show tag based on history_content_id */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description history_content_id */
-            path: {
-                id: string;
-                tag_name: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_api_histories__history_id__contents__id__tags__tag_name__put: {
-        /** Update tag based on history_content_id */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description history_content_id */
-            path: {
-                id: string;
-                tag_name: string;
-            };
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ItemTagsCreatePayload"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_api_histories__history_id__contents__id__tags__tag_name__post: {
-        /** Create tag based on history_content_id */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description history_content_id */
-            path: {
-                id: string;
-                tag_name: string;
-            };
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ItemTagsCreatePayload"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_api_histories__history_id__contents__id__tags__tag_name__delete: {
-        /** Delete tag based on history_content_id */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description history_content_id */
-            path: {
-                id: string;
-                tag_name: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": boolean;
                 };
             };
             /** @description Validation Error */
@@ -14562,6 +14562,150 @@ export interface operations {
             };
         };
     };
+    index_api_histories__history_id__tags_get: {
+        /** Show tags based on history_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                history_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    show_api_histories__history_id__tags__tag_name__get: {
+        /** Show tag based on history_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                history_id: string;
+                tag_name: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_api_histories__history_id__tags__tag_name__put: {
+        /** Update tag based on history_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                history_id: string;
+                tag_name: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ItemTagsCreatePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_api_histories__history_id__tags__tag_name__post: {
+        /** Create tag based on history_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                history_id: string;
+                tag_name: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ItemTagsCreatePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_api_histories__history_id__tags__tag_name__delete: {
+        /** Delete tag based on history_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                history_id: string;
+                tag_name: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": boolean;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     unpublish_api_histories__history_id__unpublish_put: {
         /**
          * Removes this item from the published list.
@@ -14614,155 +14758,6 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["AsyncTaskResultSummary"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    index_api_histories__id__tags_get: {
-        /** Show tags based on history_id */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description history_id */
-            path: {
-                id: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    show_api_histories__id__tags__tag_name__get: {
-        /** Show tag based on history_id */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description history_id */
-            path: {
-                id: string;
-                tag_name: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_api_histories__id__tags__tag_name__put: {
-        /** Update tag based on history_id */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description history_id */
-            path: {
-                id: string;
-                tag_name: string;
-            };
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ItemTagsCreatePayload"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_api_histories__id__tags__tag_name__post: {
-        /** Create tag based on history_id */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description history_id */
-            path: {
-                id: string;
-                tag_name: string;
-            };
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ItemTagsCreatePayload"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_api_histories__id__tags__tag_name__delete: {
-        /** Delete tag based on history_id */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description history_id */
-            path: {
-                id: string;
-                tag_name: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": boolean;
                 };
             };
             /** @description Validation Error */
@@ -19269,155 +19264,6 @@ export interface operations {
             };
         };
     };
-    index_api_workflows__id__tags_get: {
-        /** Show tags based on workflow_id */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description workflow_id */
-            path: {
-                id: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    show_api_workflows__id__tags__tag_name__get: {
-        /** Show tag based on workflow_id */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description workflow_id */
-            path: {
-                id: string;
-                tag_name: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_api_workflows__id__tags__tag_name__put: {
-        /** Update tag based on workflow_id */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description workflow_id */
-            path: {
-                id: string;
-                tag_name: string;
-            };
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ItemTagsCreatePayload"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_api_workflows__id__tags__tag_name__post: {
-        /** Create tag based on workflow_id */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description workflow_id */
-            path: {
-                id: string;
-                tag_name: string;
-            };
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ItemTagsCreatePayload"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_api_workflows__id__tags__tag_name__delete: {
-        /** Delete tag based on workflow_id */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description workflow_id */
-            path: {
-                id: string;
-                tag_name: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": boolean;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     unpublish_api_workflows__id__unpublish_put: {
         /**
          * Removes this item from the published list.
@@ -19465,6 +19311,150 @@ export interface operations {
             200: {
                 content: {
                     "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    index_api_workflows__workflow_id__tags_get: {
+        /** Show tags based on workflow_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                workflow_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    show_api_workflows__workflow_id__tags__tag_name__get: {
+        /** Show tag based on workflow_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                workflow_id: string;
+                tag_name: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_api_workflows__workflow_id__tags__tag_name__put: {
+        /** Update tag based on workflow_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                workflow_id: string;
+                tag_name: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ItemTagsCreatePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_api_workflows__workflow_id__tags__tag_name__post: {
+        /** Create tag based on workflow_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                workflow_id: string;
+                tag_name: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ItemTagsCreatePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_api_workflows__workflow_id__tags__tag_name__delete: {
+        /** Delete tag based on workflow_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                workflow_id: string;
+                tag_name: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": boolean;
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -656,6 +656,20 @@ export interface paths {
          */
         put: operations["validate_api_histories__history_id__contents__id__validate_put"];
     };
+    "/api/histories/{history_id}/contents/{tagged_item_id}/tags": {
+        /** Index */
+        get: operations["index_api_histories__history_id__contents__tagged_item_id__tags_get"];
+    };
+    "/api/histories/{history_id}/contents/{tagged_item_id}/tags/{tag_name}": {
+        /** Show */
+        get: operations["show_api_histories__history_id__contents__tagged_item_id__tags__tag_name__get"];
+        /** Update */
+        put: operations["update_api_histories__history_id__contents__tagged_item_id__tags__tag_name__put"];
+        /** Create */
+        post: operations["create_api_histories__history_id__contents__tagged_item_id__tags__tag_name__post"];
+        /** Delete */
+        delete: operations["delete_api_histories__history_id__contents__tagged_item_id__tags__tag_name__delete"];
+    };
     "/api/histories/{history_id}/contents/{type}s": {
         /**
          * Returns the contents of the given history filtered by type.
@@ -839,6 +853,20 @@ export interface paths {
     "/api/histories/{history_id}/write_store": {
         /** Prepare history for export-style download and write to supplied URI. */
         post: operations["write_store_api_histories__history_id__write_store_post"];
+    };
+    "/api/histories/{tagged_item_id}/tags": {
+        /** Index */
+        get: operations["index_api_histories__tagged_item_id__tags_get"];
+    };
+    "/api/histories/{tagged_item_id}/tags/{tag_name}": {
+        /** Show */
+        get: operations["show_api_histories__tagged_item_id__tags__tag_name__get"];
+        /** Update */
+        put: operations["update_api_histories__tagged_item_id__tags__tag_name__put"];
+        /** Create */
+        post: operations["create_api_histories__tagged_item_id__tags__tag_name__post"];
+        /** Delete */
+        delete: operations["delete_api_histories__tagged_item_id__tags__tag_name__delete"];
     };
     "/api/invocations/{invocation_id}/biocompute": {
         /**
@@ -1681,6 +1709,20 @@ export interface paths {
          * @description Removes this item from the published list and return the current sharing status.
          */
         put: operations["unpublish_api_workflows__id__unpublish_put"];
+    };
+    "/api/workflows/{tagged_item_id}/tags": {
+        /** Index */
+        get: operations["index_api_workflows__tagged_item_id__tags_get"];
+    };
+    "/api/workflows/{tagged_item_id}/tags/{tag_name}": {
+        /** Show */
+        get: operations["show_api_workflows__tagged_item_id__tags__tag_name__get"];
+        /** Update */
+        put: operations["update_api_workflows__tagged_item_id__tags__tag_name__put"];
+        /** Create */
+        post: operations["create_api_workflows__tagged_item_id__tags__tag_name__post"];
+        /** Delete */
+        delete: operations["delete_api_workflows__tagged_item_id__tags__tag_name__delete"];
     };
     "/api/workflows/{workflow_id}": {
         /** Add the deleted flag to a workflow. */
@@ -6046,6 +6088,19 @@ export interface components {
             /** Uninstalled */
             uninstalled: boolean;
         };
+        /**
+         * ItemTagsCreatePayload
+         * @description Payload schema for creating an item tag.
+         */
+        ItemTagsCreatePayload: {
+            /** value of the item tag */
+            value: string;
+        };
+        /**
+         * ItemTagsListResponse
+         * @description Response schema for listing item tags.
+         */
+        ItemTagsListResponse: components["schemas"]["ItemTagsResponse"][];
         /** ItemTagsPayload */
         ItemTagsPayload: {
             /**
@@ -6064,6 +6119,23 @@ export interface components {
              * @description The list of tags that will replace the current tags associated with the item.
              */
             item_tags?: components["schemas"]["TagCollection"];
+        };
+        /**
+         * ItemTagsResponse
+         * @description Response schema for showing an item tag.
+         */
+        ItemTagsResponse: {
+            /**
+             * item tag ID
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /** model class */
+            model_class: string;
+            /** name of the item tag */
+            user_tname: string;
+            /** value of the item tag */
+            user_value?: string;
         };
         /**
          * ItemsFromSrc
@@ -13389,6 +13461,150 @@ export interface operations {
             };
         };
     };
+    index_api_histories__history_id__contents__tagged_item_id__tags_get: {
+        /** Index */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                tagged_item_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    show_api_histories__history_id__contents__tagged_item_id__tags__tag_name__get: {
+        /** Show */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                tagged_item_id: string;
+                tag_name: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_api_histories__history_id__contents__tagged_item_id__tags__tag_name__put: {
+        /** Update */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                tagged_item_id: string;
+                tag_name: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ItemTagsCreatePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_api_histories__history_id__contents__tagged_item_id__tags__tag_name__post: {
+        /** Create */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                tagged_item_id: string;
+                tag_name: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ItemTagsCreatePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_api_histories__history_id__contents__tagged_item_id__tags__tag_name__delete: {
+        /** Delete */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                tagged_item_id: string;
+                tag_name: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": boolean;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     history_contents__index_typed: {
         /**
          * Returns the contents of the given history filtered by type.
@@ -14393,6 +14609,150 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["AsyncTaskResultSummary"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    index_api_histories__tagged_item_id__tags_get: {
+        /** Index */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                tagged_item_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    show_api_histories__tagged_item_id__tags__tag_name__get: {
+        /** Show */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                tagged_item_id: string;
+                tag_name: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_api_histories__tagged_item_id__tags__tag_name__put: {
+        /** Update */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                tagged_item_id: string;
+                tag_name: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ItemTagsCreatePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_api_histories__tagged_item_id__tags__tag_name__post: {
+        /** Create */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                tagged_item_id: string;
+                tag_name: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ItemTagsCreatePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_api_histories__tagged_item_id__tags__tag_name__delete: {
+        /** Delete */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                tagged_item_id: string;
+                tag_name: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": boolean;
                 };
             };
             /** @description Validation Error */
@@ -18919,6 +19279,150 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["SharingStatus"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    index_api_workflows__tagged_item_id__tags_get: {
+        /** Index */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                tagged_item_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    show_api_workflows__tagged_item_id__tags__tag_name__get: {
+        /** Show */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                tagged_item_id: string;
+                tag_name: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_api_workflows__tagged_item_id__tags__tag_name__put: {
+        /** Update */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                tagged_item_id: string;
+                tag_name: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ItemTagsCreatePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_api_workflows__tagged_item_id__tags__tag_name__post: {
+        /** Create */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                tagged_item_id: string;
+                tag_name: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ItemTagsCreatePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_api_workflows__tagged_item_id__tags__tag_name__delete: {
+        /** Delete */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                tagged_item_id: string;
+                tag_name: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": boolean;
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -649,26 +649,26 @@ export interface paths {
          */
         delete: operations["history_contents__delete_legacy"];
     };
+    "/api/histories/{history_id}/contents/{id}/tags": {
+        /** Show tags based on history_content_id */
+        get: operations["index_api_histories__history_id__contents__id__tags_get"];
+    };
+    "/api/histories/{history_id}/contents/{id}/tags/{tag_name}": {
+        /** Show tag based on history_content_id */
+        get: operations["show_api_histories__history_id__contents__id__tags__tag_name__get"];
+        /** Update tag based on history_content_id */
+        put: operations["update_api_histories__history_id__contents__id__tags__tag_name__put"];
+        /** Create tag based on history_content_id */
+        post: operations["create_api_histories__history_id__contents__id__tags__tag_name__post"];
+        /** Delete tag based on history_content_id */
+        delete: operations["delete_api_histories__history_id__contents__id__tags__tag_name__delete"];
+    };
     "/api/histories/{history_id}/contents/{id}/validate": {
         /**
          * Validates the metadata associated with a dataset within a History.
          * @description Validates the metadata associated with a dataset within a History.
          */
         put: operations["validate_api_histories__history_id__contents__id__validate_put"];
-    };
-    "/api/histories/{history_id}/contents/{tagged_item_id}/tags": {
-        /** Index */
-        get: operations["index_api_histories__history_id__contents__tagged_item_id__tags_get"];
-    };
-    "/api/histories/{history_id}/contents/{tagged_item_id}/tags/{tag_name}": {
-        /** Show */
-        get: operations["show_api_histories__history_id__contents__tagged_item_id__tags__tag_name__get"];
-        /** Update */
-        put: operations["update_api_histories__history_id__contents__tagged_item_id__tags__tag_name__put"];
-        /** Create */
-        post: operations["create_api_histories__history_id__contents__tagged_item_id__tags__tag_name__post"];
-        /** Delete */
-        delete: operations["delete_api_histories__history_id__contents__tagged_item_id__tags__tag_name__delete"];
     };
     "/api/histories/{history_id}/contents/{type}s": {
         /**
@@ -854,19 +854,19 @@ export interface paths {
         /** Prepare history for export-style download and write to supplied URI. */
         post: operations["write_store_api_histories__history_id__write_store_post"];
     };
-    "/api/histories/{tagged_item_id}/tags": {
-        /** Index */
-        get: operations["index_api_histories__tagged_item_id__tags_get"];
+    "/api/histories/{id}/tags": {
+        /** Show tags based on history_id */
+        get: operations["index_api_histories__id__tags_get"];
     };
-    "/api/histories/{tagged_item_id}/tags/{tag_name}": {
-        /** Show */
-        get: operations["show_api_histories__tagged_item_id__tags__tag_name__get"];
-        /** Update */
-        put: operations["update_api_histories__tagged_item_id__tags__tag_name__put"];
-        /** Create */
-        post: operations["create_api_histories__tagged_item_id__tags__tag_name__post"];
-        /** Delete */
-        delete: operations["delete_api_histories__tagged_item_id__tags__tag_name__delete"];
+    "/api/histories/{id}/tags/{tag_name}": {
+        /** Show tag based on history_id */
+        get: operations["show_api_histories__id__tags__tag_name__get"];
+        /** Update tag based on history_id */
+        put: operations["update_api_histories__id__tags__tag_name__put"];
+        /** Create tag based on history_id */
+        post: operations["create_api_histories__id__tags__tag_name__post"];
+        /** Delete tag based on history_id */
+        delete: operations["delete_api_histories__id__tags__tag_name__delete"];
     };
     "/api/invocations/{invocation_id}/biocompute": {
         /**
@@ -1703,26 +1703,26 @@ export interface paths {
          */
         put: operations["set_slug_api_workflows__id__slug_put"];
     };
+    "/api/workflows/{id}/tags": {
+        /** Show tags based on workflow_id */
+        get: operations["index_api_workflows__id__tags_get"];
+    };
+    "/api/workflows/{id}/tags/{tag_name}": {
+        /** Show tag based on workflow_id */
+        get: operations["show_api_workflows__id__tags__tag_name__get"];
+        /** Update tag based on workflow_id */
+        put: operations["update_api_workflows__id__tags__tag_name__put"];
+        /** Create tag based on workflow_id */
+        post: operations["create_api_workflows__id__tags__tag_name__post"];
+        /** Delete tag based on workflow_id */
+        delete: operations["delete_api_workflows__id__tags__tag_name__delete"];
+    };
     "/api/workflows/{id}/unpublish": {
         /**
          * Removes this item from the published list.
          * @description Removes this item from the published list and return the current sharing status.
          */
         put: operations["unpublish_api_workflows__id__unpublish_put"];
-    };
-    "/api/workflows/{tagged_item_id}/tags": {
-        /** Index */
-        get: operations["index_api_workflows__tagged_item_id__tags_get"];
-    };
-    "/api/workflows/{tagged_item_id}/tags/{tag_name}": {
-        /** Show */
-        get: operations["show_api_workflows__tagged_item_id__tags__tag_name__get"];
-        /** Update */
-        put: operations["update_api_workflows__tagged_item_id__tags__tag_name__put"];
-        /** Create */
-        post: operations["create_api_workflows__tagged_item_id__tags__tag_name__post"];
-        /** Delete */
-        delete: operations["delete_api_workflows__tagged_item_id__tags__tag_name__delete"];
     };
     "/api/workflows/{workflow_id}": {
         /** Add the deleted flag to a workflow. */
@@ -13429,6 +13429,155 @@ export interface operations {
             };
         };
     };
+    index_api_histories__history_id__contents__id__tags_get: {
+        /** Show tags based on history_content_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description history_content_id */
+            path: {
+                id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    show_api_histories__history_id__contents__id__tags__tag_name__get: {
+        /** Show tag based on history_content_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description history_content_id */
+            path: {
+                id: string;
+                tag_name: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_api_histories__history_id__contents__id__tags__tag_name__put: {
+        /** Update tag based on history_content_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description history_content_id */
+            path: {
+                id: string;
+                tag_name: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ItemTagsCreatePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_api_histories__history_id__contents__id__tags__tag_name__post: {
+        /** Create tag based on history_content_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description history_content_id */
+            path: {
+                id: string;
+                tag_name: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ItemTagsCreatePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_api_histories__history_id__contents__id__tags__tag_name__delete: {
+        /** Delete tag based on history_content_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description history_content_id */
+            path: {
+                id: string;
+                tag_name: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": boolean;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     validate_api_histories__history_id__contents__id__validate_put: {
         /**
          * Validates the metadata associated with a dataset within a History.
@@ -13451,150 +13600,6 @@ export interface operations {
             200: {
                 content: {
                     "application/json": Record<string, never>;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    index_api_histories__history_id__contents__tagged_item_id__tags_get: {
-        /** Index */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            path: {
-                tagged_item_id: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    show_api_histories__history_id__contents__tagged_item_id__tags__tag_name__get: {
-        /** Show */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            path: {
-                tagged_item_id: string;
-                tag_name: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_api_histories__history_id__contents__tagged_item_id__tags__tag_name__put: {
-        /** Update */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            path: {
-                tagged_item_id: string;
-                tag_name: string;
-            };
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ItemTagsCreatePayload"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_api_histories__history_id__contents__tagged_item_id__tags__tag_name__post: {
-        /** Create */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            path: {
-                tagged_item_id: string;
-                tag_name: string;
-            };
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ItemTagsCreatePayload"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_api_histories__history_id__contents__tagged_item_id__tags__tag_name__delete: {
-        /** Delete */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            path: {
-                tagged_item_id: string;
-                tag_name: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": boolean;
                 };
             };
             /** @description Validation Error */
@@ -14619,15 +14624,16 @@ export interface operations {
             };
         };
     };
-    index_api_histories__tagged_item_id__tags_get: {
-        /** Index */
+    index_api_histories__id__tags_get: {
+        /** Show tags based on history_id */
         parameters: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
                 "run-as"?: string;
             };
+            /** @description history_id */
             path: {
-                tagged_item_id: string;
+                id: string;
             };
         };
         responses: {
@@ -14645,15 +14651,16 @@ export interface operations {
             };
         };
     };
-    show_api_histories__tagged_item_id__tags__tag_name__get: {
-        /** Show */
+    show_api_histories__id__tags__tag_name__get: {
+        /** Show tag based on history_id */
         parameters: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
                 "run-as"?: string;
             };
+            /** @description history_id */
             path: {
-                tagged_item_id: string;
+                id: string;
                 tag_name: string;
             };
         };
@@ -14672,47 +14679,16 @@ export interface operations {
             };
         };
     };
-    update_api_histories__tagged_item_id__tags__tag_name__put: {
-        /** Update */
+    update_api_histories__id__tags__tag_name__put: {
+        /** Update tag based on history_id */
         parameters: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
                 "run-as"?: string;
             };
+            /** @description history_id */
             path: {
-                tagged_item_id: string;
-                tag_name: string;
-            };
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ItemTagsCreatePayload"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_api_histories__tagged_item_id__tags__tag_name__post: {
-        /** Create */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            path: {
-                tagged_item_id: string;
+                id: string;
                 tag_name: string;
             };
         };
@@ -14736,15 +14712,49 @@ export interface operations {
             };
         };
     };
-    delete_api_histories__tagged_item_id__tags__tag_name__delete: {
-        /** Delete */
+    create_api_histories__id__tags__tag_name__post: {
+        /** Create tag based on history_id */
         parameters: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
                 "run-as"?: string;
             };
+            /** @description history_id */
             path: {
-                tagged_item_id: string;
+                id: string;
+                tag_name: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ItemTagsCreatePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_api_histories__id__tags__tag_name__delete: {
+        /** Delete tag based on history_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description history_id */
+            path: {
+                id: string;
                 tag_name: string;
             };
         };
@@ -19259,6 +19269,155 @@ export interface operations {
             };
         };
     };
+    index_api_workflows__id__tags_get: {
+        /** Show tags based on workflow_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description workflow_id */
+            path: {
+                id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    show_api_workflows__id__tags__tag_name__get: {
+        /** Show tag based on workflow_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description workflow_id */
+            path: {
+                id: string;
+                tag_name: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_api_workflows__id__tags__tag_name__put: {
+        /** Update tag based on workflow_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description workflow_id */
+            path: {
+                id: string;
+                tag_name: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ItemTagsCreatePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_api_workflows__id__tags__tag_name__post: {
+        /** Create tag based on workflow_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description workflow_id */
+            path: {
+                id: string;
+                tag_name: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ItemTagsCreatePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ItemTagsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_api_workflows__id__tags__tag_name__delete: {
+        /** Delete tag based on workflow_id */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description workflow_id */
+            path: {
+                id: string;
+                tag_name: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": boolean;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     unpublish_api_workflows__id__unpublish_put: {
         /**
          * Removes this item from the published list.
@@ -19279,150 +19438,6 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["SharingStatus"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    index_api_workflows__tagged_item_id__tags_get: {
-        /** Index */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            path: {
-                tagged_item_id: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    show_api_workflows__tagged_item_id__tags__tag_name__get: {
-        /** Show */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            path: {
-                tagged_item_id: string;
-                tag_name: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_api_workflows__tagged_item_id__tags__tag_name__put: {
-        /** Update */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            path: {
-                tagged_item_id: string;
-                tag_name: string;
-            };
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ItemTagsCreatePayload"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_api_workflows__tagged_item_id__tags__tag_name__post: {
-        /** Create */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            path: {
-                tagged_item_id: string;
-                tag_name: string;
-            };
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ItemTagsCreatePayload"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["ItemTagsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_api_workflows__tagged_item_id__tags__tag_name__delete: {
-        /** Delete */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            path: {
-                tagged_item_id: string;
-                tag_name: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": boolean;
                 };
             };
             /** @description Validation Error */

--- a/lib/galaxy/managers/item_tags.py
+++ b/lib/galaxy/managers/item_tags.py
@@ -1,0 +1,89 @@
+from galaxy.exceptions import (
+    NoContentException,
+    ObjectNotFound,
+)
+from galaxy.managers import base
+from galaxy.managers.context import ProvidesAppContext
+from galaxy.model.base import transaction
+from galaxy.schema.fields import DecodedDatabaseIdField
+from galaxy.schema.item_tags import ItemTagsCreatePayload
+from galaxy.structured_app import MinimalManagerApp
+
+
+class ItemTagsManager:
+    """Interface/service object shared by controllers for interacting with item-tags."""
+
+    def __init__(self, app: MinimalManagerApp) -> None:
+        self._app = app
+        self._tag_handler = app.tag_handler
+
+    def index(self, trans: ProvidesAppContext, tagged_item_class: str, tagged_item_id: DecodedDatabaseIdField):
+        """Displays a collection (list) of tags associated with an item."""
+        tags = self._get_user_tags(trans, tagged_item_class, tagged_item_id)
+        return [self._api_value(tag, trans, view="collection") for tag in tags]
+
+    def show(
+        self, trans: ProvidesAppContext, tagged_item_class: str, tagged_item_id: DecodedDatabaseIdField, tag_name: str
+    ):
+        """Displays information about a tag associated with an item."""
+        tag = self._get_item_tag_assoc(trans, tagged_item_class, tagged_item_id, tag_name)
+        if not tag:
+            raise ObjectNotFound("Failed to retrieve specified tag.")
+        return self._api_value(tag, trans)
+
+    def create(
+        self,
+        trans: ProvidesAppContext,
+        tagged_item_class: str,
+        tagged_item_id: DecodedDatabaseIdField,
+        tag_name: str,
+        payload: ItemTagsCreatePayload,
+    ):
+        """Apply a new set of tags to an item."""
+        value = payload.value
+        tag = self._apply_item_tag(trans, tagged_item_class, tagged_item_id, tag_name, value)
+        return self._api_value(tag, trans)
+
+    def delete(
+        self, trans: ProvidesAppContext, tagged_item_class: str, tagged_item_id: DecodedDatabaseIdField, tag_name: str
+    ):
+        """Remove a tag from an item."""
+        deleted = self._remove_items_tag(trans, tagged_item_class, tagged_item_id, tag_name)
+        if not deleted:
+            raise NoContentException("Failed to delete specified tag.")
+        return deleted
+
+    def _get_tagged_item(self, trans, item_class_name, id, check_ownership=True):
+        tagged_item = base.get_object(
+            trans, id, item_class_name, check_ownership=check_ownership, check_accessible=True
+        )
+        return tagged_item
+
+    def _get_user_tags(self, trans, item_class_name, id):
+        user = trans.user
+        tagged_item = self._get_tagged_item(trans, item_class_name, id)
+        return [tag for tag in tagged_item.tags if tag.user == user]
+
+    def _remove_items_tag(self, trans, item_class_name, id, tag_name):
+        user = trans.user
+        tagged_item = self._get_tagged_item(trans, item_class_name, id)
+        deleted = tagged_item and self._tag_handler.remove_item_tag(user, tagged_item, tag_name)
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
+        return deleted
+
+    def _apply_item_tag(self, trans, item_class_name, id, tag_name, tag_value=None):
+        user = trans.user
+        tagged_item = self._get_tagged_item(trans, item_class_name, id)
+        tag_assoc = self._tag_handler.apply_item_tag(user, tagged_item, tag_name, tag_value)
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
+        return tag_assoc
+
+    def _get_item_tag_assoc(self, trans, item_class_name, id, tag_name):
+        user = trans.user
+        tagged_item = self._get_tagged_item(trans, item_class_name, id)
+        return self._tag_handler._get_item_tag_assoc(user, tagged_item, tag_name)
+
+    def _api_value(self, tag, trans, view="element"):
+        return tag.to_dict(view=view, value_mapper={"id": trans.security.encode_id})

--- a/lib/galaxy/schema/item_tags.py
+++ b/lib/galaxy/schema/item_tags.py
@@ -1,0 +1,48 @@
+from typing import (
+    List,
+    Optional,
+)
+
+from pydantic import (
+    Field,
+    Required,
+)
+
+from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.schema import Model
+
+
+class ItemTagsResponse(Model):
+    """Response schema for showing an item tag."""
+
+    model_class: str = Field(
+        Required,
+        title="model class",
+    )
+    id: EncodedDatabaseIdField = Field(
+        Required,
+        title="item tag ID",
+    )
+    user_tname: str = Field(
+        Required,
+        title="name of the item tag",
+    )
+    user_value: Optional[str] = Field(
+        None,
+        title="value of the item tag",
+    )
+
+
+class ItemTagsListResponse(Model):
+    """Response schema for listing item tags."""
+
+    __root__: List[ItemTagsResponse]
+
+
+class ItemTagsCreatePayload(Model):
+    """Payload schema for creating an item tag."""
+
+    value: str = Field(
+        Required,
+        title="value of the item tag",
+    )

--- a/lib/galaxy/webapps/galaxy/api/item_tags.py
+++ b/lib/galaxy/webapps/galaxy/api/item_tags.py
@@ -24,7 +24,7 @@ from galaxy.webapps.galaxy.api import (
 
 log = logging.getLogger(__name__)
 
-router = Router(tags=["item_tags"])
+router = Router()
 
 
 @router.cbv
@@ -32,64 +32,83 @@ class FastAPIItemTags:
     manager: ItemTagsManager = depends(ItemTagsManager)
 
     @classmethod
-    def create_class(cls, prefix, tagged_item_class):
+    def create_class(cls, prefix, tagged_item_class, tagged_item_id, tagged_item_tag):
         class Temp(cls):
-            @router.get(f"/api/{prefix}/{{tagged_item_id}}/tags")
+            @router.get(
+                f"/api/{prefix}/{{id}}/tags", tags=[tagged_item_tag], summary=f"Show tags based on {tagged_item_id}"
+            )
             def index(
                 self,
                 trans: ProvidesAppContext = DependsOnTrans,
-                tagged_item_id: DecodedDatabaseIdField = Path(..., title="Item ID"),
+                id: DecodedDatabaseIdField = Path(..., title="Item ID", description=f"{tagged_item_id}"),
             ) -> ItemTagsListResponse:
-                return self.manager.index(trans, tagged_item_class, tagged_item_id)
+                return self.manager.index(trans, tagged_item_class, id)
 
-            @router.get(f"/api/{prefix}/{{tagged_item_id}}/tags/{{tag_name}}")
+            @router.get(
+                f"/api/{prefix}/{{id}}/tags/{{tag_name}}",
+                tags=[tagged_item_tag],
+                summary=f"Show tag based on {tagged_item_id}",
+            )
             def show(
                 self,
                 trans: ProvidesAppContext = DependsOnTrans,
-                tagged_item_id: DecodedDatabaseIdField = Path(..., title="Item ID"),
+                id: DecodedDatabaseIdField = Path(..., title="Item ID", description=f"{tagged_item_id}"),
                 tag_name: str = Path(..., title="Tag Name"),
             ) -> ItemTagsResponse:
-                return self.manager.show(trans, tagged_item_class, tagged_item_id, tag_name)
+                return self.manager.show(trans, tagged_item_class, id, tag_name)
 
-            @router.post(f"/api/{prefix}/{{tagged_item_id}}/tags/{{tag_name}}")
+            @router.post(
+                f"/api/{prefix}/{{id}}/tags/{{tag_name}}",
+                tags=[tagged_item_tag],
+                summary=f"Create tag based on {tagged_item_id}",
+            )
             def create(
                 self,
                 trans: ProvidesAppContext = DependsOnTrans,
-                tagged_item_id: DecodedDatabaseIdField = Path(..., title="Item ID"),
+                id: DecodedDatabaseIdField = Path(..., title="Item ID", description=f"{tagged_item_id}"),
                 tag_name: str = Path(..., title="Tag Name"),
                 payload: ItemTagsCreatePayload = Body(...),
             ) -> ItemTagsResponse:
-                return self.manager.create(trans, tagged_item_class, tagged_item_id, tag_name, payload)
+                return self.manager.create(trans, tagged_item_class, id, tag_name, payload)
 
-            @router.put(f"/api/{prefix}/{{tagged_item_id}}/tags/{{tag_name}}")
+            @router.put(
+                f"/api/{prefix}/{{id}}/tags/{{tag_name}}",
+                tags=[tagged_item_tag],
+                summary=f"Update tag based on {tagged_item_id}",
+            )
             def update(
                 self,
                 trans: ProvidesAppContext = DependsOnTrans,
-                tagged_item_id: DecodedDatabaseIdField = Path(..., title="Item ID"),
+                id: DecodedDatabaseIdField = Path(..., title="Item ID", description=f"{tagged_item_id}"),
                 tag_name: str = Path(..., title="Tag Name"),
                 payload: ItemTagsCreatePayload = Body(...),
             ) -> ItemTagsResponse:
-                return self.manager.create(trans, tagged_item_class, tagged_item_id, tag_name, payload)
+                return self.manager.create(trans, tagged_item_class, id, tag_name, payload)
 
-            @router.delete(f"/api/{prefix}/{{tagged_item_id}}/tags/{{tag_name}}")
+            @router.delete(
+                f"/api/{prefix}/{{id}}/tags/{{tag_name}}",
+                tags=[tagged_item_tag],
+                summary=f"Delete tag based on {tagged_item_id}",
+            )
             def delete(
                 self,
                 trans: ProvidesAppContext = DependsOnTrans,
-                tagged_item_id: DecodedDatabaseIdField = Path(..., title="Item ID"),
+                id: DecodedDatabaseIdField = Path(..., title="Item ID", description=f"{tagged_item_id}"),
                 tag_name: str = Path(..., title="Tag Name"),
             ) -> bool:
-                return self.manager.delete(trans, tagged_item_class, tagged_item_id, tag_name)
+                return self.manager.delete(trans, tagged_item_class, id, tag_name)
 
         return Temp
 
 
 prefixs = {
-    "histories": "History",
-    "histories/{history_id}/contents": "HistoryDatasetAssociation",
-    "workflows": "StoredWorkflow",
+    "histories": ["History", "history_id", "histories"],
+    "histories/{history_id}/contents": ["HistoryDatasetAssociation", "history_content_id", "histories"],
+    "workflows": ["StoredWorkflow", "workflow_id", "workflows"],
 }
-for prefix, tagged_item_class in prefixs.items():
-    router.cbv(FastAPIItemTags.create_class(prefix, tagged_item_class))
+for prefix, tagged_item in prefixs.items():
+    tagged_item_class, tagged_item_id, tagged_item_tag = tagged_item
+    router.cbv(FastAPIItemTags.create_class(prefix, tagged_item_class, tagged_item_id, tagged_item_tag))
 
 
 # TODO: Visualization and Pages once APIs for those are available

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -308,12 +308,6 @@ def postfork_setup():
 def populate_api_routes(webapp, app):
     webapp.add_api_controllers("galaxy.webapps.galaxy.api", app)
 
-    _add_item_tags_controller(
-        webapp, name_prefix="history_content_", path_prefix="/api/histories/{history_id}/contents/{history_content_id}"
-    )
-
-    _add_item_tags_controller(webapp, name_prefix="history_", path_prefix="/api/histories/{history_id}")
-    _add_item_tags_controller(webapp, name_prefix="workflow_", path_prefix="/api/workflows/{workflow_id}")
     _add_item_annotation_controller(
         webapp, name_prefix="history_content_", path_prefix="/api/histories/{history_id}/contents/{history_content_id}"
     )
@@ -1047,48 +1041,6 @@ def populate_api_routes(webapp, app):
     # Connect logger from app
     if app.trace_logger:
         webapp.trace_logger = app.trace_logger
-
-
-def _add_item_tags_controller(webapp, name_prefix, path_prefix, **kwd):
-    # Not just using map.resources because actions should be based on name not id
-    controller = f"{name_prefix}tags"
-    name = f"{name_prefix}tag"
-    path = f"{path_prefix}/tags"
-    map = webapp.mapper
-    # Allow view items' tags.
-    map.connect(name, path, controller=controller, action="index", conditions=dict(method=["GET"]))
-    # Allow remove tag from item
-    map.connect(
-        f"{name}_delete",
-        "%s/tags/{tag_name}" % path_prefix,
-        controller=controller,
-        action="delete",
-        conditions=dict(method=["DELETE"]),
-    )
-    # Allow create a new tag with from name
-    map.connect(
-        f"{name}_create",
-        "%s/tags/{tag_name}" % path_prefix,
-        controller=controller,
-        action="create",
-        conditions=dict(method=["POST"]),
-    )
-    # Allow update tag value
-    map.connect(
-        f"{name}_update",
-        "%s/tags/{tag_name}" % path_prefix,
-        controller=controller,
-        action="update",
-        conditions=dict(method=["PUT"]),
-    )
-    # Allow show tag by name
-    map.connect(
-        f"{name}_show",
-        "%s/tags/{tag_name}" % path_prefix,
-        controller=controller,
-        action="show",
-        conditions=dict(method=["GET"]),
-    )
 
 
 def _add_item_extended_metadata_controller(webapp, name_prefix, path_prefix, **kwd):

--- a/lib/galaxy_test/api/test_item_tags.py
+++ b/lib/galaxy_test/api/test_item_tags.py
@@ -20,66 +20,66 @@ class TestHistoriesApi(integration_util.IntegrationTestCase):
         self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
 
     def test_get_tags_workflows(self):
-        response = self._test_get_tags(self._create_prefixs()["workflows"])
+        response = self._test_get_tags(self._create_prefixes()["workflows"])
         self._assert_status_code_is(response, 200)
 
     def test_create_tag_workflows(self):
-        response = self._test_create_tag(self._create_prefixs()["workflows"])
+        response = self._test_create_tag(self._create_prefixes()["workflows"])
         self._assert_status_code_is(response, 200)
 
     def test_update_tag_workflows(self):
-        response = self._test_update_tag(self._create_prefixs()["workflows"])
+        response = self._test_update_tag(self._create_prefixes()["workflows"])
         self._assert_status_code_is(response, 200)
 
     def test_get_tag_workflows(self):
-        response = self._test_get_tag(self._create_prefixs()["workflows"])
+        response = self._test_get_tag(self._create_prefixes()["workflows"])
         self._assert_status_code_is(response, 200)
 
     def test_delete_tag_workflows(self):
-        response = self._test_delete_tag(self._create_prefixs()["workflows"])
+        response = self._test_delete_tag(self._create_prefixes()["workflows"])
         self._assert_status_code_is(response, 200)
 
     def test_get_tags_histories(self):
-        response = self._test_get_tags(self._create_prefixs()["histories"])
+        response = self._test_get_tags(self._create_prefixes()["histories"])
         self._assert_status_code_is(response, 200)
 
     def test_create_tag_histories(self):
-        response = self._test_create_tag(self._create_prefixs()["histories"])
+        response = self._test_create_tag(self._create_prefixes()["histories"])
         self._assert_status_code_is(response, 200)
 
     def test_update_tag_histories(self):
-        response = self._test_update_tag(self._create_prefixs()["histories"])
+        response = self._test_update_tag(self._create_prefixes()["histories"])
         self._assert_status_code_is(response, 200)
 
     def test_get_tag_histories(self):
-        response = self._test_get_tag(self._create_prefixs()["histories"])
+        response = self._test_get_tag(self._create_prefixes()["histories"])
         self._assert_status_code_is(response, 200)
 
     def test_delete_tag_histories(self):
-        response = self._test_delete_tag(self._create_prefixs()["histories"])
+        response = self._test_delete_tag(self._create_prefixes()["histories"])
         self._assert_status_code_is(response, 200)
 
     def test_get_tags_histories_content(self):
-        response = self._test_get_tags(self._create_prefixs()["histories_content"])
+        response = self._test_get_tags(self._create_prefixes()["histories_content"])
         self._assert_status_code_is(response, 200)
 
     def test_create_tag_histories_content(self):
-        response = self._test_create_tag(self._create_prefixs()["histories_content"])
+        response = self._test_create_tag(self._create_prefixes()["histories_content"])
         self._assert_status_code_is(response, 200)
 
     def test_update_tag_histories_content(self):
-        response = self._test_update_tag(self._create_prefixs()["histories_content"])
+        response = self._test_update_tag(self._create_prefixes()["histories_content"])
         self._assert_status_code_is(response, 200)
 
     def test_get_tag_histories_content(self):
-        response = self._test_get_tag(self._create_prefixs()["histories_content"])
+        response = self._test_get_tag(self._create_prefixes()["histories_content"])
         self._assert_status_code_is(response, 200)
 
     def test_delete_tag_histories_content(self):
-        response = self._test_delete_tag(self._create_prefixs()["histories_content"])
+        response = self._test_delete_tag(self._create_prefixes()["histories_content"])
         self._assert_status_code_is(response, 200)
 
-    def _create_prefixs(self):
+    def _create_prefixes(self):
         workflow_id = self._create_workflow()
         history_id = self._create_history()
         history_content_id = self._create_history_contents(history_id)

--- a/lib/galaxy_test/api/test_item_tags.py
+++ b/lib/galaxy_test/api/test_item_tags.py
@@ -84,9 +84,9 @@ class TestHistoriesApi(integration_util.IntegrationTestCase):
         history_id = self._create_history()
         history_content_id = self._create_history_contents(history_id)
         prefixs = {
-            "workflows": "workflows/" + workflow_id,
-            "histories": "histories/" + history_id,
-            "histories_content": "histories/" + history_id + "/contents/" + history_content_id,
+            "workflows": f"workflows/{workflow_id}",
+            "histories": f"histories/{history_id}",
+            "histories_content": f"histories/{history_id}/contents/{history_content_id}",
         }
         return prefixs
 

--- a/test/integration/test_item_tags.py
+++ b/test/integration/test_item_tags.py
@@ -1,0 +1,143 @@
+from galaxy_test.base.populators import (
+    DatasetCollectionPopulator,
+    DatasetPopulator,
+    WorkflowPopulator,
+)
+from galaxy_test.driver import integration_util
+
+
+class TestHistoriesApi(integration_util.IntegrationTestCase):
+    dataset_populator: DatasetPopulator
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+
+    def setUp(self):
+        super().setUp()
+        self.workflow_populator = WorkflowPopulator(self.galaxy_interactor)
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
+
+    def test_get_tags_workflows(self):
+        response = self._test_get_tags(self._create_prefixs()["workflows"])
+        self._assert_status_code_is(response, 200)
+
+    def test_create_tag_workflows(self):
+        response = self._test_create_tag(self._create_prefixs()["workflows"])
+        self._assert_status_code_is(response, 200)
+
+    def test_update_tag_workflows(self):
+        response = self._test_update_tag(self._create_prefixs()["workflows"])
+        self._assert_status_code_is(response, 200)
+
+    def test_get_tag_workflows(self):
+        response = self._test_get_tag(self._create_prefixs()["workflows"])
+        self._assert_status_code_is(response, 200)
+
+    def test_delete_tag_workflows(self):
+        response = self._test_delete_tag(self._create_prefixs()["workflows"])
+        self._assert_status_code_is(response, 200)
+
+    def test_get_tags_histories(self):
+        response = self._test_get_tags(self._create_prefixs()["histories"])
+        self._assert_status_code_is(response, 200)
+
+    def test_create_tag_histories(self):
+        response = self._test_create_tag(self._create_prefixs()["histories"])
+        self._assert_status_code_is(response, 200)
+
+    def test_update_tag_histories(self):
+        response = self._test_update_tag(self._create_prefixs()["histories"])
+        self._assert_status_code_is(response, 200)
+
+    def test_get_tag_histories(self):
+        response = self._test_get_tag(self._create_prefixs()["histories"])
+        self._assert_status_code_is(response, 200)
+
+    def test_delete_tag_histories(self):
+        response = self._test_delete_tag(self._create_prefixs()["histories"])
+        self._assert_status_code_is(response, 200)
+
+    def test_get_tags_histories_content(self):
+        response = self._test_get_tags(self._create_prefixs()["histories_content"])
+        self._assert_status_code_is(response, 200)
+
+    def test_create_tag_histories_content(self):
+        response = self._test_create_tag(self._create_prefixs()["histories_content"])
+        self._assert_status_code_is(response, 200)
+
+    def test_update_tag_histories_content(self):
+        response = self._test_update_tag(self._create_prefixs()["histories_content"])
+        self._assert_status_code_is(response, 200)
+
+    def test_get_tag_histories_content(self):
+        response = self._test_get_tag(self._create_prefixs()["histories_content"])
+        self._assert_status_code_is(response, 200)
+
+    def test_delete_tag_histories_content(self):
+        response = self._test_delete_tag(self._create_prefixs()["histories_content"])
+        self._assert_status_code_is(response, 200)
+
+    def _create_prefixs(self):
+        workflow_id = self._create_workflow()
+        history_id = self._create_history()
+        history_content_id = self._create_history_contents(history_id)
+        prefixs = {
+            "workflows": "workflows/" + workflow_id,
+            "histories": "histories/" + history_id,
+            "histories_content": "histories/" + history_id + "/contents/" + history_content_id,
+        }
+        return prefixs
+
+    def _test_get_tags(self, prefix):
+        url = f"{prefix}/tags"
+        response = self._get(url)
+        return response
+
+    def _test_create_tag(self, prefix):
+        response = self._create_valid_tag(prefix)
+        return response
+
+    def _test_update_tag(self, prefix):
+        response = self._create_valid_tag(prefix)
+        tag_name = response.json()["user_tname"]
+        url = f"{prefix}/tags/{tag_name}"
+        tag_data = dict(value="updatedtagvalue")
+        response = self._put(url, data=tag_data, json=True)
+        return response
+
+    def _test_get_tag(self, prefix):
+        response = self._create_valid_tag(prefix)
+        tag_name = response.json()["user_tname"]
+        url = f"{prefix}/tags/{tag_name}"
+        response = self._get(url)
+        return response
+
+    def _test_delete_tag(self, prefix):
+        response = self._create_valid_tag(prefix)
+        tag_name = response.json()["user_tname"]
+        url = f"{prefix}/tags/{tag_name}"
+        response = self._delete(url)
+        return response
+
+    def _create_valid_tag(self, prefix: str):
+        url = f"{prefix}/tags/awesometagname"
+        tag_data = dict(value="awesometagvalue")
+        response = self._post(url, data=tag_data, json=True)
+        return response
+
+    def _create_history_contents(self, history_id):
+        history_content_id = self.dataset_collection_populator.create_list_in_history(
+            history_id, contents=["test_dataset"], direct_upload=True, wait=True
+        ).json()["outputs"][0]["id"]
+        return history_content_id
+
+    def _create_history(self):
+        history_id = self.dataset_populator.new_history()
+        return history_id
+
+    def _create_workflow(self):
+        workflow = self.workflow_populator.load_workflow_from_resource(name="test_workflow_with_input_tags")
+        workflow_id = self.workflow_populator.create_workflow(workflow)
+        return workflow_id


### PR DESCRIPTION
## What did you do?

- Include an API test under `lib/galaxy_test/api/`
- Refactor the legacy `ItemTags` API logic so all the logic is contained in the `ItemTagsManager` class
- Create pydantic models for the responses and payloads
- Create the FastAPI routes that will replace the old ones

related to https://github.com/galaxyproject/galaxy/issues/10889

## Why did you make this change?
This is part of the efforts to migrate the full Galaxy API to FastAPI see #10889.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
