### PR TITLE
Use eventbus to emit route request in grid list

### DIFF
--- a/client/src/components/Grid/GridList.test.js
+++ b/client/src/components/Grid/GridList.test.js
@@ -1,7 +1,6 @@
 import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { getLocalVue } from "tests/jest/helpers";
-import { useRouter } from "vue-router/composables";
 
 import Filtering from "@/utils/filtering";
 
@@ -10,9 +9,6 @@ import MountTarget from "./GridList.vue";
 const localVue = getLocalVue();
 
 jest.useFakeTimers();
-jest.mock("vue-router/composables");
-
-useRouter.mockImplementation(() => "router");
 
 const testGrid = {
     actions: [
@@ -147,10 +143,7 @@ describe("GridList", () => {
         await dropdownItems.at(0).trigger("click");
         const clickHandler = testGrid.fields[2].operations[0].handler;
         expect(clickHandler).toHaveBeenCalledTimes(1);
-        expect(clickHandler.mock.calls[0]).toEqual([
-            { id: "id-1", link: "link-1", operation: "operation-1" },
-            "router",
-        ]);
+        expect(clickHandler.mock.calls[0]).toEqual([{ id: "id-1", link: "link-1", operation: "operation-1" }]);
         await dropdownItems.at(1).trigger("click");
         await flushPromises();
         const alert = wrapper.find(".alert");

--- a/client/src/components/Grid/configs/types.ts
+++ b/client/src/components/Grid/configs/types.ts
@@ -1,12 +1,11 @@
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
-import type Router from "vue-router";
 
 import Filtering from "@/utils/filtering";
 
 export interface Action {
     title: string;
     icon?: IconDefinition;
-    handler: (router: Router) => void;
+    handler: () => void;
 }
 
 export type ActionArray = Array<Action>;
@@ -36,13 +35,13 @@ export interface FieldEntry {
     width?: number;
 }
 
-export type FieldHandler = (data: RowData, router?: Router) => void;
+export type FieldHandler = (data: RowData) => void;
 
 export interface Operation {
     title: string;
     icon: IconDefinition;
     condition?: (data: RowData) => boolean;
-    handler: (data: RowData, router: Router) => OperationHandlerReturn;
+    handler: (data: RowData) => OperationHandlerReturn;
 }
 
 interface OperationHandlerMessage {

--- a/client/src/components/Grid/configs/types.ts
+++ b/client/src/components/Grid/configs/types.ts
@@ -29,7 +29,7 @@ export interface FieldEntry {
     title: string;
     condition?: (data: RowData) => boolean;
     disabled?: boolean;
-    type: string;
+    type: validTypes;
     operations?: Array<Operation>;
     handler?: FieldHandler;
     width?: number;
@@ -52,3 +52,5 @@ interface OperationHandlerMessage {
 type OperationHandlerReturn = Promise<OperationHandlerMessage> | void;
 
 export type RowData = Record<string, unknown>;
+
+type validTypes = "date" | "link" | "operations" | "sharing" | "tags" | "text";

--- a/client/src/components/Grid/configs/visualizations.ts
+++ b/client/src/components/Grid/configs/visualizations.ts
@@ -1,6 +1,6 @@
 import { faCopy, faEdit, faEye, faPlus, faShareAlt, faTrash, faTrashRestore } from "@fortawesome/free-solid-svg-icons";
+import { useEventBus } from "@vueuse/core";
 import axios from "axios";
-import type Router from "vue-router";
 
 import { fetcher } from "@/api/schema";
 import { getGalaxyInstance } from "@/app";
@@ -9,6 +9,8 @@ import { withPrefix } from "@/utils/redirect";
 import { errorMessageAsString, rethrowSimple } from "@/utils/simple-error";
 
 import type { ActionArray, Config, FieldArray } from "./types";
+
+const { emit } = useEventBus<string>("grid-router-push");
 
 /**
  * Api endpoint handlers
@@ -52,8 +54,8 @@ const actions: ActionArray = [
     {
         title: "Create",
         icon: faPlus,
-        handler: (router: Router) => {
-            router.push(`/visualizations`);
+        handler: () => {
+            emit("/visualizations");
         },
     },
 ];
@@ -81,8 +83,8 @@ const fields: FieldArray = [
                 title: "Edit Attributes",
                 icon: faEdit,
                 condition: (data: VisualizationEntry) => !data.deleted,
-                handler: (data: VisualizationEntry, router: Router) => {
-                    router.push(`/visualizations/edit?id=${data.id}`);
+                handler: (data: VisualizationEntry) => {
+                    emit(`/visualizations/edit?id=${data.id}`);
                 },
             },
             {
@@ -115,8 +117,8 @@ const fields: FieldArray = [
                 title: "Share and Publish",
                 icon: faShareAlt,
                 condition: (data: VisualizationEntry) => !data.deleted,
-                handler: (data: VisualizationEntry, router: Router) => {
-                    router.push(`/visualizations/sharing?id=${data.id}`);
+                handler: (data: VisualizationEntry) => {
+                    emit(`/visualizations/sharing?id=${data.id}`);
                 },
             },
             {


### PR DESCRIPTION
Adjustment to the grid configuration. Instead of directly calling the `router`, the grid module `emits` a routing request using the `EventBus`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
