### PR TITLE
[23.1] Add HEAD route to job_files endpoint

### DIFF
--- a/lib/galaxy/web/framework/base.py
+++ b/lib/galaxy/web/framework/base.py
@@ -548,6 +548,9 @@ def send_file(start_response, trans, body):
         trans.response.headers["accept-ranges"] = "bytes"
         start = None
         end = None
+        if trans.request.method == "HEAD":
+            trans.response.headers["content-length"] = os.path.getsize(body.name)
+            body = b""
         if trans.request.range:
             start = int(trans.request.range.start)
             file_size = int(trans.response.headers["content-length"])
@@ -555,7 +558,8 @@ def send_file(start_response, trans, body):
             trans.response.headers["content-length"] = str(end - start)
             trans.response.headers["content-range"] = f"bytes {start}-{end - 1}/{file_size}"
             trans.response.status = 206
-        body = iterate_file(body, start, end)
+        if body:
+            body = iterate_file(body, start, end)
     start_response(trans.response.wsgi_status(), trans.response.wsgi_headeritems())
     return body
 

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -1061,6 +1061,14 @@ def populate_api_routes(webapp, app):
         parent_resources=dict(member_name="job", collection_name="jobs"),
     )
 
+    webapp.mapper.connect(
+        "index",
+        "/api/jobs/{job_id}/files",
+        controller="job_files",
+        action="index",
+        conditions=dict(method=["HEAD"]),
+    )
+
     webapp.mapper.resource(
         "port",
         "ports",

--- a/test/integration/test_job_files.py
+++ b/test/integration/test_job_files.py
@@ -61,6 +61,10 @@ class TestJobFilesIntegration(integration_util.IntegrationTestCase):
         job_id, job_key = self._api_job_keys(job)
         data = {"path": self.input_hda.file_name, "job_key": job_key}
         get_url = self._api_url(f"jobs/{job_id}/files", use_key=True)
+        head_response = requests.head(get_url, params=data)
+        api_asserts.assert_status_code_is_ok(head_response)
+        assert head_response.text == ""
+        assert head_response.headers["content-length"] == str(len(TEST_INPUT_TEXT))
         response = requests.get(get_url, params=data)
         api_asserts.assert_status_code_is_ok(response)
         assert response.text == TEST_INPUT_TEXT


### PR DESCRIPTION
This is to make sure resuming downloads works out of the box (it should already work if `nginx_x_accel_redirect_base` or `apache_xsendfile` is set up).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
