### PR TITLE
[23.1] Let job handler work queue call job wrapper fail

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -2,6 +2,7 @@
 Galaxy job handler, prepares, runs, tracks, and finishes Galaxy jobs
 """
 import datetime
+import functools
 import os
 import time
 from collections import defaultdict
@@ -1268,7 +1269,7 @@ class DefaultJobDispatcher:
         except ObjectNotFound:
             msg = "Could not recover job working directory after Galaxy restart"
             log.exception(f"recover(): ({job_wrapper.job_id}) {msg}")
-            job_wrapper.fail(msg)
+            runner.work_queue.put(functools.partial(job_wrapper.fail, msg))
 
     def shutdown(self):
         failures = []

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -106,6 +106,7 @@ class BaseJobRunner:
         self.runner_params = RunnerParams(specs=runner_param_specs, params=kwargs)
         self.runner_state_handlers = build_state_handlers()
         self._should_stop = False
+        self.work_queue = Queue()
 
     def start(self):
         for start_method in self.start_methods:
@@ -113,7 +114,6 @@ class BaseJobRunner:
 
     def _init_worker_threads(self):
         """Start ``nworkers`` worker threads."""
-        self.work_queue = Queue()
         self.work_threads = []
         log.debug(f"Starting {self.nworkers} {self.runner_name} workers")
         for i in range(self.nworkers):


### PR DESCRIPTION
This avoids committing the transaction and then have it fail on the next iteration. Should fix the app startup failing in https://github.com/galaxyproject/galaxy/issues/17079

There's more places though where we commit in the startup case. I wonder if all that's even necessary, the job handler should probably handle all of the error conditions ?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
