### PR TITLE
Add select parameter with options from remote resources

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4227,8 +4227,8 @@ For data parameters this tag can be used to restrict possible input datasets to 
 instance here: [/tools/maf/interval2maf.xml](https://github.com/galaxyproject/galaxy/blob/dev/tools/maf/interval2maf.xml)
 
 For select parameters this tag set dynamically creates a list of options whose
-values can be obtained from a predefined file stored locally or a dataset
-selected from the current history.
+values can be obtained from a predefined file stored locally, a dataset
+selected from the current history or data fetched from a URL.
 
 There are at least five basic ways to use this tag - four of these correspond to
 a ``from_XXX`` attribute on the ``options`` directive and the other is to
@@ -4237,6 +4237,7 @@ exclusively use ``filter``s to populate options.
 * ``from_data_table`` - The options for the select list are dynamically obtained
   from a file specified in the Galaxy configuration file
   ``tool_data_table_conf.xml`` or from a Tool Shed installed data manager.
+* `from_url` - Fetches a list of available options from a remote server.
 * ``from_dataset`` - The options for the select list are dynamically obtained
   from input dataset selected for the tool from the current history.
 * ``from_file`` - The options for the select list are dynamically obtained from
@@ -4390,7 +4391,7 @@ used to generate dynamic options.
 </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:group ref="OptionsElement" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:group ref="OptionsElement" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
     <xs:attribute name="from_dataset" type="xs:string">
       <xs:annotation>
@@ -4405,6 +4406,11 @@ used to generate dynamic options.
     <xs:attribute name="from_data_table" type="xs:string">
       <xs:annotation>
         <xs:documentation xml:lang="en">Determine options from a data table. </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="from_url" type="xs:string">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Determine options from data hosted at specified URL. </xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="from_parameter" type="xs:string">

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4039,6 +4039,16 @@ of "type" specified for this expression block.
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:simpleType name="RequestMethodType">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">Select a request method, defaults to GET if unspecified</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="GET" />
+      <xs:enumeration value="POST" />
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:complexType name="ParamSelectOption">
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
@@ -4413,6 +4423,11 @@ used to generate dynamic options.
         <xs:documentation xml:lang="en">Determine options from data hosted at specified URL. </xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="request_method" type="RequestMethodType">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Set the request method to use for options provided using from_url. </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="from_parameter" type="xs:string">
       <xs:annotation>
         <xs:documentation xml:lang="en">Deprecated.</xs:documentation>
@@ -4446,10 +4461,12 @@ used to generate dynamic options.
   </xs:complexType>
   <xs:group name="OptionsElement">
     <xs:choice>
-      <xs:element name="filter" type="Filter" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="column" type="Column" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="validator" type="Validator" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="postprocess_expression" type="Expression" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="filter" type="Filter" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="column" type="Column" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="validator" type="Validator" minOccurs="0" maxOccurs="1" />
+      <xs:element name="postprocess_expression" type="Expression" minOccurs="0" maxOccurs="1" />
+      <xs:element name="request_body" type="RequestBody" minOccurs="0" maxOccurs="1" />
+      <xs:element name="request_headers" type="RequestHeaders" minOccurs="0" maxOccurs="1" />
       <xs:element name="file" type="xs:string" minOccurs="0" maxOccurs="unbounded">
         <xs:annotation>
           <xs:documentation xml:lang="en">Documentation for file</xs:documentation>
@@ -4458,6 +4475,20 @@ used to generate dynamic options.
       <xs:element name="option" type="ParamDrillDownOption" minOccurs="0" maxOccurs="unbounded"/>
     </xs:choice>
   </xs:group>
+  <xs:complexType name="RequestBody">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="type" type="xs:string"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="RequestHeaders">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="type" type="xs:string"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
   <xs:complexType name="Column">
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[Optionally contained within an

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4361,6 +4361,62 @@ example below demonstrates (many more examples are present in the
 </param>
 ```
 
+### ``from_url``
+
+The following example demonstrates getting options from a third-party server
+with server side requests.
+
+```xml
+<param name="url_param_value" type="select">
+    <options from_url="https://usegalaxy.org/api/genomes">
+    </options>
+</param>
+```
+
+Here a GET request is made to [https://usegalaxy.org/api/genomes](https://usegalaxy.org/api/genomes), which returns
+an array of arrays, such as
+
+```json
+[
+    ["unspecified (?)", "?"],
+    ["A. ceylanicum Mar. 2014 (WS243/Acey_2013.11.30.genDNA/ancCey1) (ancCey1)", "ancCey1"],
+    ...
+]
+```
+Each inner array is a user-selectable option, where the first item in the inner array
+is the `name` of the option (as shown in the select field in the user interface), and
+the second option is the `value` that is passed on to the tool. An optional third
+element can be added to the inner array which corresponds to the `selected` state.
+If the third item is `true` then this particular option is pre-selected.
+
+A more complicated example is shown below, where a POST request is made with a templated
+request header and body. The upstream response is then also transformed using an ecma 5.1
+expression:
+
+```xml
+<param name="url_param_value_header_and_body" type="select">
+    <options from_url="https://postman-echo.com/post" request_method="POST">
+        <!-- Example for accessing user secrets via extra preferences -->
+        <request_headers type="json">
+            {"x-api-key": "${__user__.extra_preferences.fake_api_key if $__user__ else "anon"}"}
+        </request_headers>
+        <request_body type="json">
+            {"name": "value"}
+        </request_body>
+        <!-- https://postman-echo.com/post echos values sent to it, so here we list the response headers -->
+        <postprocess_expression type="ecma5.1"><![CDATA[${
+            return Object.keys(inputs.headers).map((header) => [header, header])
+        }]]]]><![CDATA[></postprocess_expression>
+    </options>
+</param>
+```
+
+The header and body templating mechanism can be used to access protected resources,
+and the `postprocess_expression` can be used to transform arbitrary JSON responses
+to arrays of `name` and `value`, or arrays of `name`, `value` and `selected`.
+
+For an example tool see [select_from_url.xml](https://github.com/galaxyproject/galaxy/tree/dev/test/functional/tools/select_from_url.xml).
+
 ### ``from_file``
 
 The following example is for Blast databases. In this example users maybe select
@@ -4425,7 +4481,7 @@ used to generate dynamic options.
     </xs:attribute>
     <xs:attribute name="request_method" type="RequestMethodType">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Set the request method to use for options provided using from_url. </xs:documentation>
+        <xs:documentation xml:lang="en">Set the request method to use for options provided using 'from_url'. </xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="from_parameter" type="xs:string">

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4449,6 +4449,7 @@ used to generate dynamic options.
       <xs:element name="filter" type="Filter" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="column" type="Column" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="validator" type="Validator" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="postprocess_expression" type="Expression" minOccurs="0" maxOccurs="1"/>
       <xs:element name="file" type="xs:string" minOccurs="0" maxOccurs="unbounded">
         <xs:annotation>
           <xs:documentation xml:lang="en">Documentation for file</xs:documentation>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3938,8 +3938,8 @@ Name | Description
 ``$__tool_data_path__`` | ``config/galaxy.ini``'s tool_data_path value
 ``$__root_dir__`` | Top-level Galaxy source directory made absolute via ``os.path.abspath()``
 ``$__datatypes_config__`` | ``config/galaxy.ini``'s datatypes_config value
-``$__user_id__`` | Email's numeric ID (id column of ``galaxy_user`` table in the database)
-``$__user_email__`` | User's email address
+``$__user_id__`` | Numeric ID of user (id column of ``galaxy_user`` table in the database)
+``$__user_email__`` | Email address of user
 ``$__app__`` | The ``galaxy.app.UniverseApplication`` instance, gives access to all other configuration file variables (e.g. $__app__.config.output_size_limit). Should be used as a last resort, may go away in future releases.
 ``$__target_datatype__`` | Only available in converter tools when run internally by Galaxy. Contains the target datatype of the conversion
 

--- a/lib/galaxy/tools/expressions/__init__.py
+++ b/lib/galaxy/tools/expressions/__init__.py
@@ -1,4 +1,7 @@
-from .evaluation import evaluate
+from .evaluation import (
+    do_eval,
+    evaluate,
+)
 from .script import (
     EXPRESSION_SCRIPT_CALL,
     EXPRESSION_SCRIPT_NAME,
@@ -7,6 +10,7 @@ from .script import (
 from .util import find_engine
 
 __all__ = (
+    "do_eval",
     "evaluate",
     "EXPRESSION_SCRIPT_CALL",
     "EXPRESSION_SCRIPT_NAME",

--- a/lib/galaxy/tools/expressions/evaluation.py
+++ b/lib/galaxy/tools/expressions/evaluation.py
@@ -1,11 +1,26 @@
 import json
 import os
 import subprocess
+from typing import MutableMapping
+
+from cwl_utils.expression import do_eval as _do_eval
 
 from .util import find_engine
 
 FILE_DIRECTORY = os.path.normpath(os.path.dirname(os.path.join(__file__)))
 NODE_ENGINE = os.path.join(FILE_DIRECTORY, "cwlNodeEngine.js")
+
+
+def do_eval(expression: str, context: MutableMapping):
+    return _do_eval(
+        expression,
+        context,
+        [{"class": "InlineJavascriptRequirement"}],
+        None,
+        None,
+        {},
+        cwlVersion="v1.2.1",
+    )
 
 
 def evaluate(config, input):

--- a/lib/galaxy/tools/parameters/cancelable_request.py
+++ b/lib/galaxy/tools/parameters/cancelable_request.py
@@ -1,0 +1,73 @@
+import asyncio
+import logging
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
+
+import aiohttp
+from typing_extensions import Literal
+
+log = logging.getLogger()
+
+REQUEST_METHOD = Literal["GET", "POST", "HEAD"]
+
+
+async def fetch_url(
+    session: aiohttp.ClientSession,
+    url: str,
+    params: Optional[Dict[str, Any]] = None,
+    data: Optional[Dict[str, Any]] = None,
+    headers: Optional[Dict[str, Any]] = None,
+    method: REQUEST_METHOD = "GET",
+):
+    async with session.request(method=method, url=url, params=params, data=data, headers=headers) as response:
+        return await response.json()
+
+
+async def async_request_with_timeout(
+    url: str,
+    params: Optional[Dict[str, Any]] = None,
+    data: Optional[Dict[str, Any]] = None,
+    headers: Optional[Dict[str, Any]] = None,
+    method: REQUEST_METHOD = "GET",
+    timeout: float = 1.0,
+):
+    async with aiohttp.ClientSession() as session:
+        try:
+            # Wait for the async request, with a user-defined timeout
+            result = await asyncio.wait_for(
+                fetch_url(session=session, url=url, params=params, data=data, headers=headers, method=method),
+                timeout=timeout,
+            )
+            return result
+        except asyncio.TimeoutError:
+            log.debug("Request timed out after %s second", timeout)
+            return None
+
+
+def request(
+    url: str,
+    params: Optional[Dict[str, Any]] = None,
+    data: Optional[Dict[str, Any]] = None,
+    headers: Optional[Dict[str, Any]] = None,
+    method: REQUEST_METHOD = "GET",
+    timeout: float = 1.0,
+):
+    loop = asyncio.new_event_loop()
+
+    # Run the event loop until the future is done or cancelled
+    try:
+        result = loop.run_until_complete(
+            async_request_with_timeout(
+                url=url, params=params, data=data, headers=headers, method=method, timeout=timeout
+            )
+        )
+    except asyncio.CancelledError:
+        log.debug("Request cancelled")
+        result = None
+
+    loop.close()
+
+    return result

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -9,8 +9,6 @@ import os
 import re
 from io import StringIO
 
-from cwl_utils.expression import do_eval
-
 from galaxy.model import (
     DatasetCollectionElement,
     HistoryDatasetAssociation,
@@ -18,6 +16,7 @@ from galaxy.model import (
     MetadataFile,
     User,
 )
+from galaxy.tools.expressions import do_eval
 from galaxy.util import string_as_bool
 from galaxy.util.template import fill_template
 from . import validation
@@ -792,11 +791,6 @@ class DynamicOptions:
                 data = do_eval(
                     self.from_url_postprocess,
                     data,
-                    [{"class": "InlineJavascriptRequirement"}],
-                    None,
-                    None,
-                    {},
-                    cwlVersion="v1.2.1",
                 )
 
             # We only support the very specific ["name", "value", "selected"] format for now.

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -17,6 +17,7 @@ from galaxy.model import (
     User,
 )
 from galaxy.util import string_as_bool
+from galaxy.util.template import fill_template
 from . import validation
 
 log = logging.getLogger(__name__)
@@ -777,7 +778,10 @@ class DynamicOptions:
         if self.from_url:
             import requests
 
-            data = requests.get(self.from_url).json()
+            context = User.user_template_environment(trans.user)
+            url = fill_template(self.from_url, context)
+            data = requests.get(url).json()
+
             # We only support the very specific ["name", "value", "selected"] format for now.
             return [to_triple(d) for d in data]
         rval = []

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -565,6 +565,7 @@ class DynamicOptions:
         dataset_file = elem.get("from_dataset", None)
         from_parameter = elem.get("from_parameter", None)
         self.tool_data_table_name = elem.get("from_data_table", None)
+        self.from_url = elem.get("from_url", None)
         # Options are defined from a data table loaded by the app
         self._tool_data_table = None
         self.elem = elem
@@ -767,6 +768,18 @@ class DynamicOptions:
         return rval
 
     def get_options(self, trans, other_values):
+        def to_triple(values):
+            if len(values) == 2:
+                return [str(values[0]), str(values[1]), False]
+            else:
+                return [str(values[0]), str(values[1]), bool(values[2])]
+
+        if self.from_url:
+            import requests
+
+            data = requests.get(self.from_url).json()
+            # We only support the very specific ["name", "value", "selected"] format for now.
+            return [to_triple(d) for d in data]
         rval = []
         if (
             self.file_fields is not None

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -788,16 +788,20 @@ class DynamicOptions:
             try:
                 response = requests.get(url)
                 response.raise_for_status()
+                data = response.json()
             except Exception as e:
                 log.warning("Fetching from url '%s' failed: %s", url, str(e))
-                return []
-            data = response.json()
+                data = None
 
             if self.from_url_postprocess:
-                data = do_eval(
-                    self.from_url_postprocess,
-                    data,
-                )
+                try:
+                    data = do_eval(
+                        self.from_url_postprocess,
+                        data,
+                    )
+                except Exception as eval_error:
+                    log.warning("Failed to evaluate postprocess_expression: %s", str(eval_error))
+                    data = []
 
             # We only support the very specific ["name", "value", "selected"] format for now.
             return [to_triple(d) for d in data]

--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -1,5 +1,7 @@
 import abc
 from typing import (
+    Any,
+    Dict,
     List,
     Optional,
 )
@@ -42,8 +44,15 @@ class WorkRequestContext(ProvidesHistoryContext):
         self.__user_current_roles: Optional[List[Role]] = None
         self.__history = history
         self._url_builder = url_builder
+        self._short_term_cache: Dict[str, Any] = {}
         self.workflow_building_mode = workflow_building_mode
         self.galaxy_session = galaxy_session
+
+    def set_cache_value(self, key: str, value: Any):
+        self._short_term_cache[key] = value
+
+    def get_cache_value(self, key: str, default: Any = None) -> Any:
+        return self._short_term_cache.get(key, default)
 
     @property
     def app(self):

--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -4,6 +4,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
 )
 
 from typing_extensions import Literal
@@ -44,15 +45,15 @@ class WorkRequestContext(ProvidesHistoryContext):
         self.__user_current_roles: Optional[List[Role]] = None
         self.__history = history
         self._url_builder = url_builder
-        self._short_term_cache: Dict[str, Any] = {}
+        self._short_term_cache: Dict[Tuple[str, ...], Any] = {}
         self.workflow_building_mode = workflow_building_mode
         self.galaxy_session = galaxy_session
 
-    def set_cache_value(self, key: str, value: Any):
-        self._short_term_cache[key] = value
+    def set_cache_value(self, args: Tuple[str, ...], value: Any):
+        self._short_term_cache[args] = value
 
-    def get_cache_value(self, key: str, default: Any = None) -> Any:
-        return self._short_term_cache.get(key, default)
+    def get_cache_value(self, args: Tuple[str, ...], default: Any = None) -> Any:
+        return self._short_term_cache.get(args, default)
 
     @property
     def app(self):

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -18,7 +18,6 @@ from typing import (
     Union,
 )
 
-from cwl_utils.expression import do_eval
 from typing_extensions import TypedDict
 
 from galaxy import (
@@ -59,6 +58,7 @@ from galaxy.tools.execute import (
     MappingParameters,
     PartialJobExecution,
 )
+from galaxy.tools.expressions import do_eval
 from galaxy.tools.parameters import (
     check_param,
     params_to_incoming,
@@ -226,10 +226,6 @@ def evaluate_value_from_expressions(progress, step, execution_state, extra_step_
             as_cwl_value = do_eval(
                 when_expression,
                 step_state,
-                [{"class": "InlineJavascriptRequirement"}],
-                None,
-                None,
-                {},
             )
         except Exception:
             # Exception contains script and traceback, which could be helpful for debugging workflows,

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -23,6 +23,7 @@
   <tool file="multi_repeats.xml" />
   <tool file="remove_value.xml" />
   <tool file="bibtex.xml" />
+  <tool file="select_from_url.xml" />
   <tool file="multi_select.xml" />
   <tool file="multi_output.xml" />
   <tool file="multi_output_configured.xml" />

--- a/test/functional/tools/select_from_url.xml
+++ b/test/functional/tools/select_from_url.xml
@@ -16,7 +16,7 @@ echo '$url_param_value_postprocessed' > '$param_value_postprocessed'
         -->
         <param name="url_param_value_postprocessed" type="select">
             <options from_url="https://usegalaxy.org/api/genomes/dm6">
-                <postprocess_expression><![CDATA[
+                <postprocess_expression type="ecma5.1"><![CDATA[
                     $( Object.values(inputs.chrom_info).map((v) => [v.chrom, v.len]) )
                 ]]></postprocess_expression>
             </options>

--- a/test/functional/tools/select_from_url.xml
+++ b/test/functional/tools/select_from_url.xml
@@ -1,0 +1,14 @@
+<tool id="select_from_url" name="select_from_url" version="0.1.0" profile="23.1">
+    <command>
+echo '$url_param_value' > '$the_value'
+    </command>
+    <inputs>
+        <param name="url_param_value" type="select">
+            <options from_url="http://localhost:8000/data">
+            </options>
+        </param>
+    </inputs>
+    <outputs>
+        <data format="txt" name="the_value"></data>
+    </outputs>
+</tool>

--- a/test/functional/tools/select_from_url.xml
+++ b/test/functional/tools/select_from_url.xml
@@ -1,25 +1,45 @@
 <tool id="select_from_url" name="select_from_url" version="0.1.0" profile="23.1">
-    <command>
-echo '$url_param_value' > '$the_value'
-    </command>
+    <command><![CDATA[
+echo '$url_param_value' > '$param_value' &&
+echo '$url_param_value_postprocessed' > '$param_value_postprocessed'
+    ]]></command>
     <inputs>
         <param name="url_param_value" type="select">
-            <options from_url="http://localhost:8000/data">
+            <options from_url="https://usegalaxy.org/api/genomes">
             </options>
         </param>
+        <!--
         <param name="url_param_value_templated" type="select">
             <options from_url="http://localhost:8000/data?user=$__user_id__">
             </options>
         </param>
-        <param name="url_param_value_templated_and_postprocessed" type="select">
-            <options from_url="http://localhost:8000/data_paginated?user=$__user_id__">
+        -->
+        <param name="url_param_value_postprocessed" type="select">
+            <options from_url="https://usegalaxy.org/api/genomes/dm6">
                 <postprocess_expression><![CDATA[
-                    $( inputs.map((v) => [`name: ${v[0]}`, `value: ${v[1]}`]) )
+                    $( Object.values(inputs.chrom_info).map((v) => [v.chrom, v.len]) )
                 ]]></postprocess_expression>
             </options>
         </param>
     </inputs>
     <outputs>
-        <data format="txt" name="the_value"></data>
+        <data format="txt" label="url param value" name="param_value"></data>
+        <data format="txt" label="url param value postprocessed" name="param_value_postprocessed"></data>
     </outputs>
+    <tests>
+        <test>
+            <param name="url_param_value" value="dm6" />
+            <param name="url_param_value_postprocessed" value="chr2L" />
+            <output name="param_value">
+                <assert_contents>
+                    <has_text text="dm6"></has_text>
+                </assert_contents>
+            </output>
+            <output name="param_value_postprocessed">
+                <assert_contents>
+                    <has_text text="23513712"></has_text>
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/select_from_url.xml
+++ b/test/functional/tools/select_from_url.xml
@@ -7,6 +7,10 @@ echo '$url_param_value' > '$the_value'
             <options from_url="http://localhost:8000/data">
             </options>
         </param>
+        <param name="url_param_value_templated" type="select">
+            <options from_url="http://localhost:8000/data?user=$__user_id__">
+            </options>
+        </param>
     </inputs>
     <outputs>
         <data format="txt" name="the_value"></data>

--- a/test/functional/tools/select_from_url.xml
+++ b/test/functional/tools/select_from_url.xml
@@ -11,6 +11,13 @@ echo '$url_param_value' > '$the_value'
             <options from_url="http://localhost:8000/data?user=$__user_id__">
             </options>
         </param>
+        <param name="url_param_value_templated_and_postprocessed" type="select">
+            <options from_url="http://localhost:8000/data_paginated?user=$__user_id__">
+                <postprocess_expression><![CDATA[
+                    $( inputs.map((v) => [`name: ${v[0]}`, `value: ${v[1]}`]) )
+                ]]></postprocess_expression>
+            </options>
+        </param>
     </inputs>
     <outputs>
         <data format="txt" name="the_value"></data>

--- a/test/functional/tools/select_from_url.xml
+++ b/test/functional/tools/select_from_url.xml
@@ -1,7 +1,8 @@
 <tool id="select_from_url" name="select_from_url" version="0.1.0" profile="23.1">
     <command><![CDATA[
 echo '$url_param_value' > '$param_value' &&
-echo '$url_param_value_postprocessed' > '$param_value_postprocessed'
+echo '$url_param_value_postprocessed' > '$param_value_postprocessed' &&
+echo '$invalid_url_param_value_postprocessed' > '$invalid_param_value_postprocessed'
     ]]></command>
     <inputs>
         <param name="url_param_value" type="select">
@@ -21,15 +22,28 @@ echo '$url_param_value_postprocessed' > '$param_value_postprocessed'
                 ]]></postprocess_expression>
             </options>
         </param>
+        <param name="invalid_url_param_value_postprocessed" type="select">
+            <options from_url="https://usegalaxy.or/api/genomes/dm6">
+                <postprocess_expression type="ecma5.1"><![CDATA[${
+                    if (inputs) {
+                        return Object.values(inputs.chrom_info).map((v) => [v.chrom, v.len])
+                    } else {
+                        return [["The fallback value", "default"]]
+                    }
+                }]]></postprocess_expression>
+            </options>
+        </param>
     </inputs>
     <outputs>
         <data format="txt" label="url param value" name="param_value"></data>
         <data format="txt" label="url param value postprocessed" name="param_value_postprocessed"></data>
+        <data format="txt" label="invalid url param value postprocessed" name="invalid_param_value_postprocessed"></data>
     </outputs>
     <tests>
         <test>
             <param name="url_param_value" value="dm6" />
             <param name="url_param_value_postprocessed" value="chr2L" />
+            <param name="invalid_url_param_value_postprocessed" value="default" />
             <output name="param_value">
                 <assert_contents>
                     <has_text text="dm6"></has_text>
@@ -38,6 +52,11 @@ echo '$url_param_value_postprocessed' > '$param_value_postprocessed'
             <output name="param_value_postprocessed">
                 <assert_contents>
                     <has_text text="23513712"></has_text>
+                </assert_contents>
+            </output>
+            <output name="invalid_param_value_postprocessed">
+                <assert_contents>
+                    <has_text text="default"></has_text>
                 </assert_contents>
             </output>
         </test>

--- a/test/functional/tools/select_from_url.xml
+++ b/test/functional/tools/select_from_url.xml
@@ -2,7 +2,8 @@
     <command><![CDATA[
 echo '$url_param_value' > '$param_value' &&
 echo '$url_param_value_postprocessed' > '$param_value_postprocessed' &&
-echo '$invalid_url_param_value_postprocessed' > '$invalid_param_value_postprocessed'
+echo '$invalid_url_param_value_postprocessed' > '$invalid_param_value_postprocessed' &&
+echo '$url_param_value_header_and_body' > '$param_value_header_and_body'
     ]]></command>
     <inputs>
         <param name="url_param_value" type="select">
@@ -33,17 +34,34 @@ echo '$invalid_url_param_value_postprocessed' > '$invalid_param_value_postproces
                 }]]></postprocess_expression>
             </options>
         </param>
+        <param name="url_param_value_header_and_body" type="select">
+            <options from_url="https://postman-echo.com/post" request_method="POST">
+                <!-- Example for accessing user secrets via extra preferences -->
+                <request_headers type="json">
+                    {"x-api-key": "${__user__.extra_preferences.fake_api_key if $__user__ else "anon"}"}
+                </request_headers>
+                <request_body type="json">
+                    {"name": "value"}
+                </request_body>
+                <!-- https://postman-echo.com/post echos values sent to it, so here's we're listing the response headers -->
+                <postprocess_expression type="ecma5.1"><![CDATA[${
+                    return Object.keys(inputs.headers).map((header) => [header, header])
+                }]]></postprocess_expression>
+            </options>
+        </param>
     </inputs>
     <outputs>
         <data format="txt" label="url param value" name="param_value"></data>
         <data format="txt" label="url param value postprocessed" name="param_value_postprocessed"></data>
         <data format="txt" label="invalid url param value postprocessed" name="invalid_param_value_postprocessed"></data>
+        <data format="txt" label="param value for header and body request" name="param_value_header_and_body"></data>
     </outputs>
     <tests>
         <test>
             <param name="url_param_value" value="dm6" />
             <param name="url_param_value_postprocessed" value="chr2L" />
             <param name="invalid_url_param_value_postprocessed" value="default" />
+            <param name="url_param_value_header_and_body" value="x-api-key" />
             <output name="param_value">
                 <assert_contents>
                     <has_text text="dm6"></has_text>
@@ -57,6 +75,11 @@ echo '$invalid_url_param_value_postprocessed' > '$invalid_param_value_postproces
             <output name="invalid_param_value_postprocessed">
                 <assert_contents>
                     <has_text text="default"></has_text>
+                </assert_contents>
+            </output>
+            <output name="param_value_header_and_body">
+                <assert_contents>
+                    <has_text text="x-api-key"></has_text>
                 </assert_contents>
             </output>
         </test>

--- a/test/unit/app/tools/test_dynamic_options.py
+++ b/test/unit/app/tools/test_dynamic_options.py
@@ -1,0 +1,57 @@
+from galaxy.app_unittest_utils.galaxy_mock import MockApp
+from galaxy.tools.parameters.dynamic_options import DynamicOptions
+from galaxy.util import XML
+from galaxy.util.bunch import Bunch
+from galaxy.work.context import WorkRequestContext
+
+
+def get_from_url_option():
+    return DynamicOptions(
+        XML(
+            """
+<options from_url="https://usegalaxy.org/api/genomes/dm6" request_method="POST">
+    <request_headers type="json">
+        {"x-api-key": "${__user__.extra_preferences.resource_api_key if $__user__ else "anon"}"}
+    </request_headers>
+    <request_body type="json">
+        {"some_key": "some_value"}
+    </request_body>
+    <postprocess_expression type="ecma5.1"><![CDATA[${
+        if (inputs) {
+            return Object.values(inputs.chrom_info).map((v) => [v.chrom, v.len])
+        } else {
+            return [["The fallback value", "default"]]
+        }
+    }]]></postprocess_expression>
+</options>
+"""
+        ),
+        Bunch(),
+    )
+
+
+def test_dynamic_option_parsing():
+    from_url_option = get_from_url_option()
+    assert from_url_option.from_url_options
+    assert from_url_option.from_url_options.from_url == "https://usegalaxy.org/api/genomes/dm6"
+
+
+def test_dynamic_option_cache():
+    app = MockApp()
+    trans = WorkRequestContext(app=app)
+    from_url_option = get_from_url_option()
+    options = from_url_option.from_url_options
+    assert options
+    args = (options.from_url, options.request_method, options.request_body, '{"x-api-key": "anon"}')
+    trans.set_cache_value(
+        args,
+        {
+            "id": "dm6",
+            "reference": True,
+            "chrom_info": [{"chrom": "chr2L", "len": 23513712}],
+            "prev_chroms": False,
+            "next_chroms": False,
+            "start_index": 0,
+        },
+    )
+    assert from_url_option.get_options(trans, {}) == [["chr2L", "23513712", False]]


### PR DESCRIPTION
Updating regular tool data tables for frequently changing data is a little tricky, and it was requested that we allow loading options dynamically from a URL. The eventual goals of this work is to enable exploring resources with great APIs (NCBI datasets is a good example) from within Galaxy tools.

Includes a little mini-language for manipulating arbitrary JSON responses using ECMAScript expressions.

From the schema:

### ``from_url``

The following example demonstrates getting options from a third-party server
with server side requests.

```xml
<param name="url_param_value" type="select">
    <options from_url="https://usegalaxy.org/api/genomes">
    </options>
</param>
```

Here a GET request is made to https://usegalaxy.org/api/genomes, which returns
an array of arrays, such as

```json
[
    ["unspecified (?)", "?"],
    ["A. ceylanicum Mar. 2014 (WS243/Acey_2013.11.30.genDNA/ancCey1) (ancCey1)", "ancCey1"],
    ...
]
```
Each inner array is a user-selectable option, where the first item in the inner array
is the `name` of the option (as shown in the select field in the user interface), and
the second option is the `value` that is passed on to the tool. An optional third
element can be added to the inner array which corresponds to the `selected` state.
If the third item is `true` then this particular option is pre-selected.

A more complicated example is shown below, where a POST request is made with a templated
request header and body. The upstream response is then also transformed using an ecma 5.1
expression:

```xml
<param name="url_param_value_header_and_body" type="select">
    <options from_url="https://postman-echo.com/post" request_method="POST">
        <!-- Example for accessing user secrets via extra preferences -->
        <request_headers type="json">
            {"x-api-key": "${__user__.extra_preferences.fake_api_key if $__user__ else "anon"}"}
        </request_headers>
        <request_body type="json">
            {"name": "value"}
        </request_body>
        <!-- https://postman-echo.com/post echos values sent to it, so here we list the response headers -->
        <postprocess_expression type="ecma5.1"><![CDATA[${
            return Object.keys(inputs.headers).map((header) => [header, header])
        }]]></postprocess_expression>
    </options>
</param>
```

The header and body templating mechanism can be used to access protected resources,
and the `postprocess_expression` can be used to transform arbitrary JSON responses
to arrays of `name` and `value`, or arrays of `name`, `value` and `selected`.

For an example tool see [select_from_url.xml](https://github.com/galaxyproject/galaxy/tree/dev/test/functional/tools/select_from_url.xml).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
