### PR TITLE
[23.1] Fix input dates in notifications: consider timezone offset

### DIFF
--- a/lib/galaxy/schema/notifications.py
+++ b/lib/galaxy/schema/notifications.py
@@ -22,6 +22,7 @@ from galaxy.schema.fields import (
     EncodedDatabaseIdField,
 )
 from galaxy.schema.schema import Model
+from galaxy.schema.types import OffsetNaiveDatetime
 
 
 class NotificationVariant(str, Enum):
@@ -244,12 +245,12 @@ class NotificationCreateData(Model):
     category: NotificationCategory = NotificationCategoryField
     variant: NotificationVariant = NotificationVariantField
     content: AnyNotificationContent
-    publication_time: Optional[datetime] = Field(
+    publication_time: Optional[OffsetNaiveDatetime] = Field(
         None,
         title="Publication time",
         description="The time when the notification should be published. Notifications can be created and then scheduled to be published at a later time.",
     )
-    expiration_time: Optional[datetime] = Field(
+    expiration_time: Optional[OffsetNaiveDatetime] = Field(
         None,
         title="Expiration time",
         description="The time when the notification should expire. By default it will expire after 6 months. Expired notifications will be permanently deleted.",
@@ -349,12 +350,12 @@ class NotificationBroadcastUpdateRequest(NotificationUpdateRequest):
         title="Variant",
         description="The variant of the notification. Used to express the importance of the notification.",
     )
-    publication_time: Optional[datetime] = Field(
+    publication_time: Optional[OffsetNaiveDatetime] = Field(
         None,
         title="Publication time",
         description="The time when the notification should be published. Notifications can be created and then scheduled to be published at a later time.",
     )
-    expiration_time: Optional[datetime] = Field(
+    expiration_time: Optional[OffsetNaiveDatetime] = Field(
         None,
         title="Expiration time",
         description="The time when the notification should expire. By default it will expire after 6 months. Expired notifications will be permanently deleted.",

--- a/lib/galaxy/webapps/galaxy/api/notifications.py
+++ b/lib/galaxy/webapps/galaxy/api/notifications.py
@@ -3,7 +3,6 @@ API operations on Notification objects.
 """
 
 import logging
-from datetime import datetime
 from typing import Optional
 
 from fastapi import (
@@ -33,6 +32,7 @@ from galaxy.schema.notifications import (
     UserNotificationsBatchUpdateRequest,
     UserNotificationUpdateRequest,
 )
+from galaxy.schema.types import OffsetNaiveDatetime
 from galaxy.webapps.galaxy.services.notifications import NotificationService
 from . import (
     depends,
@@ -56,7 +56,7 @@ class FastAPINotifications:
     def get_notifications_status(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        since: datetime = Query(),
+        since: OffsetNaiveDatetime = Query(),
     ) -> NotificationStatusSummary:
         """Anonymous users cannot receive personal notifications, only broadcasted notifications."""
         return self.service.get_notifications_status(trans, since)

--- a/test/integration/test_notifications.py
+++ b/test/integration/test_notifications.py
@@ -268,6 +268,16 @@ class TestNotificationsIntegration(IntegrationTestCase):
         assert "Scheduled" in subjects
         assert "Expired" in subjects
 
+    def test_notification_input_dates_consider_timezone(self):
+        payload = notification_broadcast_test_data(subject="Test", message="Test")
+        payload["publication_time"] = "2021-01-01T12:00:00+02:00"
+        payload["expiration_time"] = "2021-01-01T12:00:00Z"
+        response = self._post("notifications/broadcast", data=payload, admin=True, json=True)
+        self._assert_status_code_is_ok(response)
+        notification = response.json()["notification"]
+        assert notification["publication_time"] == "2021-01-01T10:00:00"
+        assert notification["expiration_time"] == "2021-01-01T12:00:00"
+
     def test_sharing_items_creates_notifications_when_expected(self):
         user1 = self._create_test_user()
         user2 = self._create_test_user()


### PR DESCRIPTION
Fixes part of #17010

This was an issue indeed. Now you can pass timezone offsets in ISO 8601 and they should be converted to UTC internally.

I will follow up on the `dev` branch with the other enhancements in the UI described in #17010 and the API responses with datetime to include the timezone `Z` indicator.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
