### PR TITLE
Enhance Notification Broadcasts Admin Panel

### DIFF
--- a/client/src/components/admin/Notifications/BroadcastCard.vue
+++ b/client/src/components/admin/Notifications/BroadcastCard.vue
@@ -1,0 +1,202 @@
+<script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import {
+    faBroadcastTower,
+    faClock,
+    faEdit,
+    faHourglassHalf,
+    faInfoCircle,
+    faTrash,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BButton, BCol, BInputGroup, BRow } from "bootstrap-vue";
+import { computed } from "vue";
+
+import { useConfirmDialog } from "@/composables/confirmDialog";
+import { useMarkdown } from "@/composables/markdown";
+import { BroadcastNotification } from "@/stores/broadcastsStore";
+
+import Heading from "@/components/Common/Heading.vue";
+import UtcDate from "@/components/UtcDate.vue";
+
+library.add(faBroadcastTower, faClock, faEdit, faHourglassHalf, faInfoCircle, faTrash);
+
+const { confirm } = useConfirmDialog();
+const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true });
+
+interface Props {
+    broadcastNotification: BroadcastNotification;
+}
+
+const props = defineProps<Props>();
+
+const emit = defineEmits<{
+    (e: "edit", broadcastNotification: BroadcastNotification): void;
+    (e: "expire", broadcastNotification: BroadcastNotification): void;
+    (e: "go-to-link", link: string): void;
+}>();
+
+const notification = computed(() => props.broadcastNotification);
+
+const hasExpired = computed(() => {
+    return notification.value.expiration_time && new Date(notification.value.expiration_time) < new Date();
+});
+
+const hasBeenPublished = computed(() => {
+    return new Date(notification.value.publication_time) < new Date();
+});
+
+const notificationVariant = computed(() => {
+    switch (notification.value.variant) {
+        case "urgent":
+            return "danger";
+        default:
+            return notification.value.variant;
+    }
+});
+
+function onEditClick() {
+    emit("edit", notification.value);
+}
+
+async function onForceExpirationClick() {
+    const confirmed = await confirm(
+        "Are you sure you want to expire this broadcast? It will be automatically deleted on the next cleanup cycle.",
+        "Expire broadcast"
+    );
+    if (confirmed) {
+        emit("expire", notification.value);
+    }
+}
+
+function onActionClick(link: string) {
+    emit("go-to-link", link);
+}
+
+function getBroadcastPublicity(item: BroadcastNotification) {
+    if (hasBeenPublished.value) {
+        return `Published on ${new Date(item.publication_time + "Z").toLocaleString()}`;
+    } else {
+        return `Scheduled to publish on ${new Date(item.publication_time + "Z").toLocaleString()}`;
+    }
+}
+
+function getBroadcastExpiry(item: BroadcastNotification) {
+    if (item.expiration_time) {
+        if (hasExpired.value) {
+            return `Expired on ${new Date(item.expiration_time + "Z").toLocaleString()}`;
+        }
+        return `Expires on ${new Date(item.expiration_time + "Z").toLocaleString()}`;
+    } else {
+        return "Does not expire";
+    }
+}
+</script>
+
+<template>
+    <div class="broadcast-card mb-2">
+        <BRow align-v="center" align-h="between" no-gutters>
+            <Heading size="md" class="mb-0" :class="hasExpired ? 'expired-broadcast' : ''">
+                <FontAwesomeIcon :class="`text-${notificationVariant}`" :icon="faInfoCircle" />
+                {{ notification.content.subject }}
+            </Heading>
+
+            <BRow align-h="end" align-v="center" no-gutters>
+                <span>
+                    created
+                    <UtcDate class="mr-2" :date="notification.create_time" mode="elapsed" />
+                </span>
+
+                <BInputGroup v-if="!hasExpired">
+                    <BButton
+                        id="edit-broadcast-button"
+                        v-b-tooltip.hover
+                        variant="link"
+                        title="Edit broadcast"
+                        @click="onEditClick">
+                        <FontAwesomeIcon :icon="faEdit" />
+                    </BButton>
+
+                    <BButton
+                        id="delete-button"
+                        v-b-tooltip.hover
+                        variant="link"
+                        title="Delete broadcast"
+                        @click="onForceExpirationClick">
+                        <FontAwesomeIcon :icon="faTrash" />
+                    </BButton>
+                </BInputGroup>
+            </BRow>
+        </BRow>
+
+        <BRow align-v="center" align-h="between" no-gutters>
+            <BCol cols="auto">
+                <BRow align-v="center" no-gutters>
+                    <span
+                        :class="hasExpired ? 'expired-broadcast' : ''"
+                        v-html="renderMarkdown(notification.content.message)" />
+                </BRow>
+
+                <BRow no-gutters>
+                    <BButton
+                        v-for="actionLink in notification.content.action_links"
+                        :key="actionLink.action_name"
+                        class="mr-1"
+                        :title="actionLink.action_name"
+                        variant="primary"
+                        @click="onActionClick(actionLink.link)">
+                        {{ actionLink.action_name }}
+                    </BButton>
+                </BRow>
+            </BCol>
+
+            <BCol>
+                <BRow align-v="center" align-h="end" no-gutters>
+                    <FontAwesomeIcon
+                        :icon="hasBeenPublished ? faBroadcastTower : faClock"
+                        :class="hasBeenPublished ? 'published' : 'scheduled'"
+                        class="mx-1" />
+                    {{ getBroadcastPublicity(notification) }}
+                </BRow>
+
+                <BRow align-v="center" align-h="end" no-gutters>
+                    <FontAwesomeIcon
+                        variant="danger"
+                        :icon="hasExpired ? faTrash : faHourglassHalf"
+                        :class="hasExpired ? 'expired' : 'expires'"
+                        class="mx-1" />
+                    {{ getBroadcastExpiry(notification) }}
+                </BRow>
+            </BCol>
+        </BRow>
+    </div>
+</template>
+
+<style scoped lang="scss">
+@import "scss/theme/blue.scss";
+.broadcast-card {
+    border-radius: 0.25rem;
+    border: 1px solid $gray-300;
+    padding: 1rem;
+
+    .expired-broadcast {
+        text-decoration: line-through;
+    }
+
+    .published {
+        color: $brand-primary;
+    }
+
+    .scheduled {
+        color: $brand-warning;
+    }
+
+    .expires {
+        color: $brand-info;
+    }
+
+    .expired {
+        color: $brand-danger;
+    }
+}
+</style>

--- a/client/src/components/admin/Notifications/BroadcastCard.vue
+++ b/client/src/components/admin/Notifications/BroadcastCard.vue
@@ -55,6 +55,23 @@ const notificationVariant = computed(() => {
     }
 });
 
+const publicationTimePrefix = computed(() => {
+    if (hasBeenPublished.value) {
+        return "Published";
+    }
+    return "Scheduled to be published";
+});
+
+const expirationTimePrefix = computed(() => {
+    if (notification.value.expiration_time) {
+        if (hasExpired.value) {
+            return "Expired";
+        }
+        return "Expires";
+    }
+    return "Does not expire";
+});
+
 function onEditClick() {
     emit("edit", notification.value);
 }
@@ -71,25 +88,6 @@ async function onForceExpirationClick() {
 
 function onActionClick(link: string) {
     emit("go-to-link", link);
-}
-
-function getBroadcastPublicity(item: BroadcastNotification) {
-    if (hasBeenPublished.value) {
-        return `Published on ${new Date(item.publication_time + "Z").toLocaleString()}`;
-    } else {
-        return `Scheduled to publish on ${new Date(item.publication_time + "Z").toLocaleString()}`;
-    }
-}
-
-function getBroadcastExpiry(item: BroadcastNotification) {
-    if (item.expiration_time) {
-        if (hasExpired.value) {
-            return `Expired on ${new Date(item.expiration_time + "Z").toLocaleString()}`;
-        }
-        return `Expires on ${new Date(item.expiration_time + "Z").toLocaleString()}`;
-    } else {
-        return "Does not expire";
-    }
 }
 </script>
 
@@ -156,16 +154,22 @@ function getBroadcastExpiry(item: BroadcastNotification) {
                         :icon="hasBeenPublished ? faBroadcastTower : faClock"
                         :class="hasBeenPublished ? 'published' : 'scheduled'"
                         class="mx-1" />
-                    {{ getBroadcastPublicity(notification) }}
+                    {{ publicationTimePrefix }}
+                    <UtcDate class="ml-1" :date="notification.publication_time" mode="elapsed" />
                 </BRow>
 
                 <BRow align-v="center" align-h="end" no-gutters>
                     <FontAwesomeIcon
                         variant="danger"
-                        :icon="hasExpired ? faTrash : faHourglassHalf"
+                        :icon="faHourglassHalf"
                         :class="hasExpired ? 'expired' : 'expires'"
                         class="mx-1" />
-                    {{ getBroadcastExpiry(notification) }}
+                    {{ expirationTimePrefix }}
+                    <UtcDate
+                        v-if="notification.expiration_time"
+                        class="ml-1"
+                        :date="notification.expiration_time"
+                        mode="elapsed" />
                 </BRow>
             </BCol>
         </BRow>

--- a/client/src/components/admin/Notifications/BroadcastsList.test.ts
+++ b/client/src/components/admin/Notifications/BroadcastsList.test.ts
@@ -20,7 +20,7 @@ const selectors = {
     showActiveFilterButton: "#show-active-filter-button",
     showScheduledFilterButton: "#show-scheduled-filter-button",
     showExpiredFilterButton: "#show-expired-filter-button",
-    broadcastCard: ".broadcast-card",
+    broadcastItem: "[data-test-id='broadcast-item']",
 } as const;
 
 async function mountBroadcastsList(broadcasts?: BroadcastNotification[]) {
@@ -49,7 +49,7 @@ describe("BroadcastsList.vue", () => {
     it("should render empty list message when there are no broadcasts", async () => {
         const wrapper = await mountBroadcastsList();
 
-        expect(wrapper.findAll(selectors.broadcastCard).length).toBe(0);
+        expect(wrapper.findAll(selectors.broadcastItem).length).toBe(0);
         expect(wrapper.find(selectors.emptyBroadcastsListAlert).exists()).toBeTruthy();
     });
 
@@ -77,25 +77,25 @@ describe("BroadcastsList.vue", () => {
         const wrapper = await mountBroadcastsList([activeBroadcast, scheduledBroadcast, expiredBroadcast]);
 
         // All broadcasts are shown by default
-        expect(wrapper.findAll(selectors.broadcastCard).length).toBe(3);
+        expect(wrapper.findAll(selectors.broadcastItem).length).toBe(3);
 
         // Disable all filters
         await wrapper.find(selectors.showActiveFilterButton).trigger("click");
         await wrapper.find(selectors.showScheduledFilterButton).trigger("click");
         await wrapper.find(selectors.showExpiredFilterButton).trigger("click");
-        expect(wrapper.findAll(selectors.broadcastCard).length).toBe(0);
+        expect(wrapper.findAll(selectors.broadcastItem).length).toBe(0);
         expect(wrapper.find(selectors.emptyBroadcastsListAlert).exists()).toBeTruthy();
 
         // Enable active broadcasts filter
         await wrapper.find(selectors.showActiveFilterButton).trigger("click");
-        expect(wrapper.findAll(selectors.broadcastCard).length).toBe(1);
+        expect(wrapper.findAll(selectors.broadcastItem).length).toBe(1);
 
         // Enable scheduled broadcasts filter
         await wrapper.find(selectors.showScheduledFilterButton).trigger("click");
-        expect(wrapper.findAll(selectors.broadcastCard).length).toBe(2);
+        expect(wrapper.findAll(selectors.broadcastItem).length).toBe(2);
 
         // Enable expired broadcasts filter
         await wrapper.find(selectors.showExpiredFilterButton).trigger("click");
-        expect(wrapper.findAll(selectors.broadcastCard).length).toBe(3);
+        expect(wrapper.findAll(selectors.broadcastItem).length).toBe(3);
     });
 });

--- a/client/src/components/admin/Notifications/BroadcastsList.test.ts
+++ b/client/src/components/admin/Notifications/BroadcastsList.test.ts
@@ -1,0 +1,101 @@
+import { createTestingPinia } from "@pinia/testing";
+import { getLocalVue } from "@tests/jest/helpers";
+import { shallowMount } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import { setActivePinia } from "pinia";
+
+import { mockFetcher } from "@/api/schema/__mocks__";
+import { BroadcastNotification } from "@/stores/broadcastsStore";
+
+import { generateNewBroadcast } from "./test.utils";
+
+import BroadcastsList from "./BroadcastsList.vue";
+
+jest.mock("@/api/schema");
+
+const localVue = getLocalVue(true);
+
+const selectors = {
+    emptyBroadcastsListAlert: "#empty-broadcast-list-alert",
+    showActiveFilterButton: "#show-active-filter-button",
+    showScheduledFilterButton: "#show-scheduled-filter-button",
+    showExpiredFilterButton: "#show-expired-filter-button",
+    broadcastCard: ".broadcast-card",
+} as const;
+
+async function mountBroadcastsList(broadcasts?: BroadcastNotification[]) {
+    const pinia = createTestingPinia();
+    setActivePinia(pinia);
+
+    mockFetcher
+        .path("/api/notifications/broadcast")
+        .method("get")
+        .mock({ data: broadcasts ?? [] });
+
+    const wrapper = shallowMount(BroadcastsList as object, {
+        localVue,
+        pinia,
+        stubs: {
+            FontAwesomeIcon: true,
+        },
+    });
+
+    await flushPromises();
+
+    return wrapper;
+}
+
+describe("BroadcastsList.vue", () => {
+    it("should render empty list message when there are no broadcasts", async () => {
+        const wrapper = await mountBroadcastsList();
+
+        expect(wrapper.findAll(selectors.broadcastCard).length).toBe(0);
+        expect(wrapper.find(selectors.emptyBroadcastsListAlert).exists()).toBeTruthy();
+    });
+
+    it("should filter broadcasts by active, scheduled and expired", async () => {
+        const now = Date.now();
+
+        const activeBroadcast = {
+            ...generateNewBroadcast({}),
+            publication_time: new Date(now - 1000).toISOString(),
+            expiration_time: new Date(now + 1000).toISOString(),
+        };
+
+        const scheduledBroadcast = {
+            ...generateNewBroadcast({}),
+            publication_time: new Date(now + 1000).toISOString(),
+            expiration_time: new Date(now + 2000).toISOString(),
+        };
+
+        const expiredBroadcast = {
+            ...generateNewBroadcast({}),
+            publication_time: new Date(now - 2000).toISOString(),
+            expiration_time: new Date(now - 1000).toISOString(),
+        };
+
+        const wrapper = await mountBroadcastsList([activeBroadcast, scheduledBroadcast, expiredBroadcast]);
+
+        // All broadcasts are shown by default
+        expect(wrapper.findAll(selectors.broadcastCard).length).toBe(3);
+
+        // Disable all filters
+        await wrapper.find(selectors.showActiveFilterButton).trigger("click");
+        await wrapper.find(selectors.showScheduledFilterButton).trigger("click");
+        await wrapper.find(selectors.showExpiredFilterButton).trigger("click");
+        expect(wrapper.findAll(selectors.broadcastCard).length).toBe(0);
+        expect(wrapper.find(selectors.emptyBroadcastsListAlert).exists()).toBeTruthy();
+
+        // Enable active broadcasts filter
+        await wrapper.find(selectors.showActiveFilterButton).trigger("click");
+        expect(wrapper.findAll(selectors.broadcastCard).length).toBe(1);
+
+        // Enable scheduled broadcasts filter
+        await wrapper.find(selectors.showScheduledFilterButton).trigger("click");
+        expect(wrapper.findAll(selectors.broadcastCard).length).toBe(2);
+
+        // Enable expired broadcasts filter
+        await wrapper.find(selectors.showExpiredFilterButton).trigger("click");
+        expect(wrapper.findAll(selectors.broadcastCard).length).toBe(3);
+    });
+});

--- a/client/src/components/admin/Notifications/BroadcastsList.vue
+++ b/client/src/components/admin/Notifications/BroadcastsList.vue
@@ -1,34 +1,22 @@
 <script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
-import {
-    faBroadcastTower,
-    faClock,
-    faEdit,
-    faHourglassHalf,
-    faInfoCircle,
-    faRedo,
-    faTrash,
-} from "@fortawesome/free-solid-svg-icons";
+import { faCheck, faClock, faHourglassHalf, faRedo } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BButton, BCol, BInputGroup, BRow } from "bootstrap-vue";
+import { BAlert, BButton, BCol, BRow } from "bootstrap-vue";
 import { computed, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { fetchAllBroadcasts, updateBroadcast } from "@/api/notifications.broadcast";
-import { useConfirmDialog } from "@/composables/confirmDialog";
-import { useMarkdown } from "@/composables/markdown";
 import { Toast } from "@/composables/toast";
 import { BroadcastNotification } from "@/stores/broadcastsStore";
 
+import BroadcastCard from "./BroadcastCard.vue";
 import Heading from "@/components/Common/Heading.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
-import UtcDate from "@/components/UtcDate.vue";
 
-library.add(faBroadcastTower, faClock, faEdit, faHourglassHalf, faInfoCircle, faRedo, faTrash);
+library.add(faCheck, faClock, faHourglassHalf, faRedo);
 
 const router = useRouter();
-const { confirm } = useConfirmDialog();
-const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true });
 
 const overlay = ref(false);
 const loading = ref(false);
@@ -54,52 +42,21 @@ function filterBroadcasts(item: BroadcastNotification) {
     return showScheduled.value;
 }
 
-function getBroadcastVariant(item: BroadcastNotification) {
-    switch (item.variant) {
-        case "urgent":
-            return "danger";
-        default:
-            return item.variant;
-    }
-}
-
 function broadcastPublished(item: BroadcastNotification) {
     return new Date(item.publication_time) < new Date();
 }
 
-function onEditClick(item: BroadcastNotification) {
+function onEdit(item: BroadcastNotification) {
     router.push(`/admin/notifications/edit_broadcast/${item.id}`);
 }
 
-async function deleteBroadcast(item: BroadcastNotification) {
-    const confirmed = await confirm("Are you sure you want to delete this broadcast?", "Delete broadcast");
-    if (confirmed) {
-        await updateBroadcast(item.id, { expiration_time: new Date().toISOString().slice(0, 23) });
-        await loadBroadcastsList(true);
-        Toast.info("Broadcast marked as expired and will be removed from the database");
-    }
+async function onForceExpire(item: BroadcastNotification) {
+    await updateBroadcast(item.id, { expiration_time: new Date().toISOString().slice(0, 23) });
+    await loadBroadcastsList(true);
+    Toast.info("Broadcast marked as expired and will be removed from the database in the next cleanup cycle.");
 }
 
-function getBroadcastPublicity(item: BroadcastNotification) {
-    if (broadcastPublished(item)) {
-        return `Published on ${new Date(item.publication_time + "Z").toLocaleString()}`;
-    } else {
-        return `Scheduled to publish on ${new Date(item.publication_time + "Z").toLocaleString()}`;
-    }
-}
-
-function getBroadcastExpiry(item: BroadcastNotification) {
-    if (item.expiration_time) {
-        if (broadcastExpired(item)) {
-            return `Expired on ${new Date(item.expiration_time + "Z").toLocaleString()}`;
-        }
-        return `Expires on ${new Date(item.expiration_time + "Z").toLocaleString()}`;
-    } else {
-        return "Does not expire";
-    }
-}
-
-function onActionClick(item: BroadcastNotification, link: string) {
+function onGoToLink(link: string) {
     if (link.startsWith("/")) {
         router.push(link);
     } else {
@@ -153,7 +110,7 @@ loadBroadcastsList();
                                 title="Show active broadcasts"
                                 variant="outline-primary"
                                 @click="showActive = !showActive">
-                                <FontAwesomeIcon icon="check" />
+                                <FontAwesomeIcon :icon="faCheck" />
                                 Active
                             </BButton>
                             <BButton
@@ -163,7 +120,7 @@ loadBroadcastsList();
                                 title="Show scheduled broadcasts"
                                 variant="outline-primary"
                                 @click="showScheduled = !showScheduled">
-                                <FontAwesomeIcon icon="clock" />
+                                <FontAwesomeIcon :icon="faClock" />
                                 Scheduled
                             </BButton>
                             <BButton
@@ -173,7 +130,7 @@ loadBroadcastsList();
                                 title="Show expired broadcasts"
                                 variant="outline-primary"
                                 @click="showExpired = !showExpired">
-                                <FontAwesomeIcon icon="hourglass-half" />
+                                <FontAwesomeIcon :icon="faHourglassHalf" />
                                 Expired
                             </BButton>
                         </BButtonGroup>
@@ -200,86 +157,18 @@ loadBroadcastsList();
         </BAlert>
 
         <BAlert v-else-if="filteredBroadcasts.length === 0" id="empty-broadcast-list-alert" variant="info" show>
-            No broadcasts to show. Use the button above to create a new broadcast. Or change the filters.
+            There are no broadcast notifications to show. Use the button above to create a new broadcast notification or
+            change the filters.
         </BAlert>
-
         <BOverlay v-else :show="overlay" rounded="sm">
-            <div v-for="broadcast in filteredBroadcasts" :key="broadcast.id" class="broadcast-card mb-2">
-                <BRow align-v="center" align-h="between" no-gutters>
-                    <Heading size="md" class="mb-0" :class="broadcastExpired(broadcast) ? 'expired-broadcast' : ''">
-                        <FontAwesomeIcon :class="`text-${getBroadcastVariant(broadcast)}`" :icon="faInfoCircle" />
-                        {{ broadcast.content.subject }}
-                    </Heading>
-
-                    <BRow align-h="end" align-v="center" no-gutters>
-                        <span>
-                            created
-                            <UtcDate class="mr-2" :date="broadcast.create_time" mode="elapsed" />
-                        </span>
-
-                        <BInputGroup v-if="!broadcastExpired(broadcast)">
-                            <BButton
-                                id="edit-broadcast-button"
-                                v-b-tooltip.hover
-                                variant="link"
-                                title="Edit broadcast"
-                                @click="onEditClick(broadcast)">
-                                <FontAwesomeIcon :icon="faEdit" />
-                            </BButton>
-
-                            <BButton
-                                id="delete-button"
-                                v-b-tooltip.hover
-                                variant="link"
-                                title="Delete broadcast"
-                                @click="() => deleteBroadcast(broadcast)">
-                                <FontAwesomeIcon icon="trash" />
-                            </BButton>
-                        </BInputGroup>
-                    </BRow>
-                </BRow>
-
-                <BRow align-v="center" align-h="between" no-gutters>
-                    <BCol cols="auto">
-                        <BRow align-v="center" no-gutters>
-                            <span
-                                :class="broadcastExpired(broadcast) ? 'expired-broadcast' : ''"
-                                v-html="renderMarkdown(broadcast.content.message)" />
-                        </BRow>
-
-                        <BRow no-gutters>
-                            <BButton
-                                v-for="actionLink in broadcast.content.action_links"
-                                :key="actionLink.action_name"
-                                class="mr-1"
-                                :title="actionLink.action_name"
-                                variant="primary"
-                                @click="onActionClick(broadcast, actionLink.link)">
-                                {{ actionLink.action_name }}
-                            </BButton>
-                        </BRow>
-                    </BCol>
-
-                    <BCol>
-                        <BRow align-v="center" align-h="end" no-gutters>
-                            <FontAwesomeIcon
-                                :icon="broadcastPublished(broadcast) ? faBroadcastTower : faClock"
-                                :class="broadcastPublished(broadcast) ? 'published' : 'scheduled'"
-                                class="mx-1" />
-                            {{ getBroadcastPublicity(broadcast) }}
-                        </BRow>
-
-                        <BRow align-v="center" align-h="end" no-gutters>
-                            <FontAwesomeIcon
-                                variant="danger"
-                                :icon="broadcastExpired(broadcast) ? faTrash : faHourglassHalf"
-                                :class="broadcastExpired(broadcast) ? 'expired' : 'expires'"
-                                class="mx-1" />
-                            {{ getBroadcastExpiry(broadcast) }}
-                        </BRow>
-                    </BCol>
-                </BRow>
-            </div>
+            <BroadcastCard
+                v-for="notification in filteredBroadcasts"
+                :key="notification.id"
+                :broadcast-notification="notification"
+                data-test-id="broadcast-item"
+                @edit="onEdit"
+                @expire="onForceExpire"
+                @go-to-link="onGoToLink" />
         </BOverlay>
     </div>
 </template>
@@ -291,31 +180,5 @@ loadBroadcastsList();
     border-radius: 0.5rem;
     border: 1px solid $gray-400;
     padding: 0.5rem;
-}
-
-.broadcast-card {
-    border-radius: 0.25rem;
-    border: 1px solid $gray-300;
-    padding: 1rem;
-
-    .expired-broadcast {
-        text-decoration: line-through;
-    }
-
-    .published {
-        color: $brand-primary;
-    }
-
-    .scheduled {
-        color: $brand-warning;
-    }
-
-    .expires {
-        color: $brand-info;
-    }
-
-    .expired {
-        color: $brand-danger;
-    }
 }
 </style>

--- a/client/src/components/admin/Notifications/BroadcastsList.vue
+++ b/client/src/components/admin/Notifications/BroadcastsList.vue
@@ -150,7 +150,7 @@ loadBroadcastsList();
                         <span class="mx-2"> Filters: </span>
                         <BButtonGroup>
                             <BButton
-                                id="show-active-filter"
+                                id="show-active-filter-button"
                                 size="sm"
                                 :pressed="showActive"
                                 title="Show active broadcasts"
@@ -160,7 +160,7 @@ loadBroadcastsList();
                                 Active
                             </BButton>
                             <BButton
-                                id="show-scheduled-filter"
+                                id="show-scheduled-filter-button"
                                 size="sm"
                                 :pressed="showScheduled"
                                 title="Show scheduled broadcasts"
@@ -170,7 +170,7 @@ loadBroadcastsList();
                                 Scheduled
                             </BButton>
                             <BButton
-                                id="show-expired-filter"
+                                id="show-expired-filter-button"
                                 size="sm"
                                 :pressed="showExpired"
                                 title="Show expired broadcasts"
@@ -202,7 +202,7 @@ loadBroadcastsList();
             <LoadingSpan message="Loading broadcasts" />
         </BAlert>
 
-        <BAlert v-else-if="filteredBroadcasts.length === 0" variant="info" show>
+        <BAlert v-else-if="filteredBroadcasts.length === 0" id="empty-broadcast-list-alert" variant="info" show>
             No broadcasts to show. Use the button above to create a new broadcast. Or change the filters.
         </BAlert>
 

--- a/client/src/components/admin/Notifications/BroadcastsList.vue
+++ b/client/src/components/admin/Notifications/BroadcastsList.vue
@@ -115,6 +115,16 @@ loadBroadcastsList();
 <template>
     <div>
         <Heading h2 class="mb-2"> Broadcasts list </Heading>
+        <p v-localize class="mb-2">
+            Broadcasts are notifications that are displayed to all users. They can be scheduled to be published at a
+            specific time and can be set to expire at a specific time. They can also be marked as urgent to make them
+            stand out.
+        </p>
+        <p class="mb-2">
+            <b>NOTE:</b> Expired broadcasts are completely removed from the database in a periodic cleanup process. The
+            cleanup interval is defined in the Galaxy configuration file under the
+            <code>expired_notifications_cleanup_interval</code> key.
+        </p>
 
         <div class="list-operations mb-2">
             <BRow class="align-items-center" no-gutters>

--- a/client/src/components/admin/Notifications/BroadcastsList.vue
+++ b/client/src/components/admin/Notifications/BroadcastsList.vue
@@ -15,7 +15,6 @@ import { computed, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { fetchAllBroadcasts, updateBroadcast } from "@/api/notifications.broadcast";
-import { type components } from "@/api/schema";
 import { useConfirmDialog } from "@/composables/confirmDialog";
 import { useMarkdown } from "@/composables/markdown";
 import { Toast } from "@/composables/toast";
@@ -27,8 +26,6 @@ import UtcDate from "@/components/UtcDate.vue";
 
 library.add(faBroadcastTower, faClock, faEdit, faHourglassHalf, faInfoCircle, faRedo, faTrash);
 
-type BroadcastNotificationResponse = components["schemas"]["BroadcastNotificationResponse"];
-
 const router = useRouter();
 const { confirm } = useConfirmDialog();
 const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true });
@@ -38,7 +35,7 @@ const loading = ref(false);
 const showActive = ref(true);
 const showExpired = ref(true);
 const showScheduled = ref(true);
-const broadcasts = ref<BroadcastNotificationResponse[]>([]);
+const broadcasts = ref<BroadcastNotification[]>([]);
 
 const filteredBroadcasts = computed(() => {
     return broadcasts.value.filter(filterBroadcasts);

--- a/client/src/components/admin/Notifications/NotificationsManagement.vue
+++ b/client/src/components/admin/Notifications/NotificationsManagement.vue
@@ -19,24 +19,27 @@ function goToCreateNewBroadcast() {
 
 <template>
     <div aria-labelledby="notifications-managements">
-        <div class="d-flex justify-content-between">
-            <Heading id="notifications-title" h1 separator inline class="flex-grow-1">
-                Notifications and Broadcasts
-            </Heading>
+        <Heading id="notifications-title" h1 separator inline class="flex-grow-1">
+            Notifications and Broadcasts
+        </Heading>
 
-            <div>
-                <BButton class="mb-2" variant="outline-primary" @click="goToCreateNewNotification">
-                    <FontAwesomeIcon icon="plus" />
-                    Send new notification
-                </BButton>
+        <p>
+            As an admin, you can send individual notifications to users (groups or roles), or display
+            <i>broadcast notifications</i> to all users (even anonymous users).
+        </p>
 
-                <BButton class="mb-2" variant="outline-primary" @click="goToCreateNewBroadcast">
-                    <FontAwesomeIcon icon="plus" />
-                    Create new broadcast
-                </BButton>
-            </div>
+        <div>
+            <BButton class="mb-2" variant="outline-primary" @click="goToCreateNewNotification">
+                <FontAwesomeIcon icon="plus" />
+                Send new notification
+            </BButton>
+
+            <BButton class="mb-2" variant="outline-primary" @click="goToCreateNewBroadcast">
+                <FontAwesomeIcon icon="plus" />
+                Create new broadcast
+            </BButton>
         </div>
 
-        <BroadcastsList />
+        <BroadcastsList class="mt-2" />
     </div>
 </template>


### PR DESCRIPTION
Fixes #17010

- Includes some explanation texts for notification management.
- Allows to filter broadcast notifications by status
- Clarifies/simplifies the language around dates and times
- Refactors some components and includes some tests

![AdminBroadcastNotificationsEnhancements](https://github.com/galaxyproject/galaxy/assets/46503462/ac48cbcd-ca6a-4360-95d9-aac7ee08f23d)


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
