### PR TITLE
Make notification message input multi-line

### DIFF
--- a/client/src/components/admin/Notifications/BroadcastForm.vue
+++ b/client/src/components/admin/Notifications/BroadcastForm.vue
@@ -175,7 +175,8 @@ if (props.id) {
                 :optional="false"
                 help="The message can be written in markdown."
                 placeholder="Enter message"
-                required />
+                required
+                area />
 
             <BFormGroup id="broadcast-action-link-group" label="Action Links" label-for="broadcast-action-link">
                 <BRow v-for="(actionLink, index) in broadcastData.content.action_links" :key="index" class="my-2">


### PR DESCRIPTION
This is a very minor change, but the single-line text input was messing with the markdown format if you updated an existing notification message from the Notifications Admin Panel.

## Before
![image](https://github.com/galaxyproject/galaxy/assets/46503462/c6827369-9883-4384-b823-143f76cd1593)


## After

![image](https://github.com/galaxyproject/galaxy/assets/46503462/db5ca2ba-133b-424b-97cb-4b043a4c30ee)


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
