### PR TITLE
[23.1] Fix web_apps dependencies

### DIFF
--- a/packages/web_apps/setup.cfg
+++ b/packages/web_apps/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     galaxy-data
     galaxy-job-execution
     galaxy-tool-util
-    galaxy-util
+    galaxy-util[jstree,template]
     galaxy-web-framework
     a2wsgi
     apispec


### PR DESCRIPTION
Fixes failing startup due to missing dictobj.
With this I can actually start a simple galaxy server, this might be the quickest way to just boot a server for test cases like in ephemeris.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

```
python -m venv /tmp/venv
source /tmp/venv/bin/activate
python -m pip install packages/web_apps
echo "{}" > galaxy.yml
GALAXY_CONFIG_OVERRIDE_CONDA_AUTO_INIT=false uvicorn --factory galaxy.webapps.galaxy.fast_factory:factory  -port 8080
```
galaxy should run and API is available at 8080

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
