### PR TITLE
[23.2] Fix hid/elementindex for collection displays

### DIFF
--- a/client/src/components/History/Content/GenericElement.test.js
+++ b/client/src/components/History/Content/GenericElement.test.js
@@ -19,7 +19,7 @@ describe("GenericElement", () => {
                 dsc: {
                     elements: [
                         {
-                            element_index: 1,
+                            element_index: 0,
                             element_identifier: "element-1",
                             element_type: "hda",
                             object: {
@@ -27,17 +27,17 @@ describe("GenericElement", () => {
                             },
                         },
                         {
-                            element_index: 2,
+                            element_index: 1,
                             element_identifier: "element-2",
                             element_type: "hdca",
                             object: {
                                 id: "item-2",
                                 collection_type: "list",
-                                element_count: 2,
+                                element_count: 1,
                                 elements_datatypes: ["txt"],
                                 elements: [
                                     {
-                                        element_index: 3,
+                                        element_index: 2,
                                         element_identifier: "element-3",
                                         element_type: "hda",
                                         object: {
@@ -45,7 +45,7 @@ describe("GenericElement", () => {
                                         },
                                     },
                                     {
-                                        element_index: 4,
+                                        element_index: 3,
                                         element_identifier: "element-4",
                                         element_type: "hda",
                                         object: {

--- a/client/src/components/History/Content/GenericElement.vue
+++ b/client/src/components/History/Content/GenericElement.vue
@@ -25,7 +25,7 @@ function toggle(expansionMap: Record<string, boolean>, itemId: string) {
     <div>
         <div v-for="(item, index) in dsc.elements" :key="index">
             <ContentItem
-                :id="item.element_index"
+                :id="item.element_index + 1"
                 :item="item.object"
                 :name="item.element_identifier"
                 :is-dataset="item.element_type == 'hda'"


### PR DESCRIPTION
Fixes element index handling in job information display.  element_index is 0-based, but we always display starting at 1.  Below are screenshots from the job information page.


Before:
![image](https://github.com/galaxyproject/galaxy/assets/155398/d0eacb03-c5b7-447e-bbd1-4a73a2cac56a)


After:

![image](https://github.com/galaxyproject/galaxy/assets/155398/75017f4b-9463-4847-96eb-30392e7b7ac7)


Thanks for the report @abueg!

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
