### PR TITLE
[23.2] Tool panel views overflow bug

### DIFF
--- a/client/src/components/Panels/Menus/PanelViewMenu.vue
+++ b/client/src/components/Panels/Menus/PanelViewMenu.vue
@@ -4,7 +4,8 @@
         right
         block
         no-caret
-        title="Show panel options"
+        :disabled="storeLoading"
+        :title="!storeLoading ? 'Show panel options' : 'Loading panel view'"
         variant="link"
         toggle-class="text-decoration-none"
         role="menu"
@@ -57,6 +58,10 @@ export default {
         },
         currentPanelView: {
             type: String,
+        },
+        storeLoading: {
+            type: Boolean,
+            default: false,
         },
     },
     computed: {

--- a/client/src/components/Panels/Menus/PanelViewMenu.vue
+++ b/client/src/components/Panels/Menus/PanelViewMenu.vue
@@ -99,3 +99,11 @@ export default {
     },
 };
 </script>
+
+<style lang="scss">
+.dropdown-menu {
+    overflow: auto;
+    max-height: 50vh;
+    min-width: 100%;
+}
+</style>

--- a/client/src/components/Panels/ToolPanel.vue
+++ b/client/src/components/Panels/ToolPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faCaretDown } from "@fortawesome/free-solid-svg-icons";
+import { faCaretDown, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { storeToRefs } from "pinia";
 import { computed, onMounted, ref, watch } from "vue";
@@ -16,7 +16,7 @@ import PanelViewMenu from "./Menus/PanelViewMenu.vue";
 import ToolBox from "./ToolBox.vue";
 import Heading from "@/components/Common/Heading.vue";
 
-library.add(faCaretDown);
+library.add(faCaretDown, faSpinner);
 
 const props = defineProps({
     workflow: { type: Boolean, default: false },
@@ -34,7 +34,7 @@ const emit = defineEmits<{
 
 const arePanelsFetched = ref(false);
 const toolStore = useToolStore();
-const { currentPanelView, defaultPanelView, isPanelPopulated, panelViews } = storeToRefs(toolStore);
+const { currentPanelView, defaultPanelView, isPanelPopulated, loading, panelViews } = storeToRefs(toolStore);
 
 const query = ref("");
 const showAdvanced = ref(false);
@@ -134,12 +134,14 @@ function onInsertWorkflowSteps(workflowId: string, workflowStepCount: number | u
                     v-if="panelViews && Object.keys(panelViews).length > 1"
                     :panel-views="panelViews"
                     :current-panel-view="currentPanelView"
+                    :store-loading="loading"
                     @updatePanelView="updatePanelView">
                     <template v-slot:panel-view-selector>
                         <div class="d-flex justify-content-between panel-view-selector">
                             <div>
+                                <FontAwesomeIcon v-if="loading" icon="spinner" spin />
                                 <span
-                                    v-if="viewIcon"
+                                    v-else-if="viewIcon"
                                     :class="['fas', `fa-${viewIcon}`, 'mr-1']"
                                     data-description="panel view header icon" />
                                 <Heading


### PR DESCRIPTION
If we have a long list of tool panel views (like on Test right now), the views at the bottom are hidden and unreachable. Added an `overflow: auto` property to deal with this.

Also added indicators that a panel view is currently loading, which was previously missing.

| Before 😠  | After 😃  |
| ------ | ------ |
| <video src="https://github.com/galaxyproject/galaxy/assets/78516064/90897413-80ad-45c3-b52b-047fd86ed40a" /> | <video src="https://github.com/galaxyproject/galaxy/assets/78516064/6ea6b6b4-7f05-43ee-98b8-456a06d21e79" /> |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
