### PR TITLE
Make flex panel drag handle more obvious

### DIFF
--- a/client/src/components/Panels/FlexPanel.vue
+++ b/client/src/components/Panels/FlexPanel.vue
@@ -1,10 +1,11 @@
-<script setup>
+<script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faChevronLeft, faChevronRight, faGripLinesVertical } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { useDraggable } from "@vueuse/core";
-import { LastQueue } from "utils/promise-queue";
 import { computed, ref, watch } from "vue";
+
+import { LastQueue } from "@/utils/lastQueue";
 
 import { determineWidth } from "./utilities";
 
@@ -121,14 +122,17 @@ watch(position, () => {
     </div>
 </template>
 
-<style>
+<style scoped lang="scss">
 @import "theme/blue.scss";
+
 .cursor-grab {
     cursor: grab;
 }
+
 .cursor-grabbing {
     cursor: grabbing;
 }
+
 .flex-panel-expand {
     background: $panel-footer-bg-color;
     border: $border-default;
@@ -136,31 +140,38 @@ watch(position, () => {
     position: absolute;
     z-index: 1;
 }
+
 .flex-panel-footer {
     background: $panel-footer-bg-color;
 }
+
 .flex-panel-left {
     border-right: $border-default;
 }
+
 .flex-panel-right {
     border-left: $border-default;
 }
+
 .flex-panel-left-expand {
     @extend .flex-panel-expand;
     border-top-right-radius: $border-radius-base;
     left: 0;
 }
+
 .flex-panel-right-expand {
     @extend .flex-panel-expand;
     border-top-left-radius: $border-radius-base;
     right: 0;
 }
+
 .interaction-area {
     margin: -1.5rem;
     padding: 1.5rem;
     position: absolute;
     z-index: 2;
 }
+
 .interaction-overlay {
     height: 100%;
     position: fixed;

--- a/client/src/components/Panels/FlexPanel.vue
+++ b/client/src/components/Panels/FlexPanel.vue
@@ -170,6 +170,7 @@ const sideClasses = computed(() => ({
 @import "theme/blue.scss";
 
 .flex-panel {
+    z-index: 100;
     flex-shrink: 0;
     display: flex;
     width: var(--width);
@@ -225,6 +226,7 @@ const sideClasses = computed(() => ({
 
 .collapse-button {
     position: absolute;
+    z-index: 100;
 
     --width: 0px;
 
@@ -260,8 +262,17 @@ const sideClasses = computed(() => ({
     }
 
     &.closed {
-        --width: 1.5rem;
+        --width: 0.75rem;
         border-style: solid;
+
+        > * {
+            transform: translateX(-0.15rem);
+        }
+
+        &:hover,
+        &:focus {
+            --width: 1.5rem;
+        }
 
         &.right {
             left: unset;

--- a/client/src/components/Panels/FlexPanel.vue
+++ b/client/src/components/Panels/FlexPanel.vue
@@ -9,7 +9,7 @@ import { LastQueue } from "@/utils/lastQueue";
 
 import { determineWidth } from "./utilities";
 
-const lastQueue = new LastQueue(10);
+const lastQueue = new LastQueue<() => void>(10);
 
 library.add({
     faChevronLeft,
@@ -30,8 +30,8 @@ const props = defineProps({
 
 const draggable = ref();
 const root = ref();
-const rangeWidth = [200, 300, 600];
-const panelWidth = ref(rangeWidth[1]);
+const rangeWidth = [200, 300, 600] as const;
+const panelWidth = ref(rangeWidth[1] as number);
 const show = ref(true);
 
 const { position, isDragging } = useDraggable(draggable, {
@@ -40,7 +40,7 @@ const { position, isDragging } = useDraggable(draggable, {
 });
 
 const style = computed(() => {
-    return show.value ? { width: `${panelWidth.value}px` } : null;
+    return show.value ? { width: `${panelWidth.value}px` } : {};
 });
 
 function toggle() {
@@ -60,7 +60,7 @@ watch(position, () => {
             props.side,
             position.value.x
         );
-    });
+    }, []);
 });
 </script>
 

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -177,7 +177,7 @@ import { provideScopedWorkflowStores } from "@/composables/workflowStores";
 import { hide_modal } from "@/layout/modal";
 import { getAppRoot } from "@/onload/loadConfig";
 import { useScopePointerStore } from "@/stores/scopePointerStore";
-import { LastQueue } from "@/utils/promise-queue";
+import { LastQueue } from "@/utils/lastQueue";
 
 import { defaultPosition } from "./composables/useDefaultStepPosition";
 import { fromSimple, toSimple } from "./modules/model";
@@ -846,3 +846,4 @@ export default {
     width: 100%;
 }
 </style>
+@/utils/lastQueue

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -846,4 +846,3 @@ export default {
     width: 100%;
 }
 </style>
-@/utils/lastQueue

--- a/client/src/components/providers/SingleQueryProvider.js
+++ b/client/src/components/providers/SingleQueryProvider.js
@@ -1,5 +1,5 @@
 import hash from "object-hash";
-import { LastQueue } from "utils/promise-queue";
+import { LastQueue } from "utils/lastQueue";
 
 import { HasAttributesMixin } from "./utils";
 

--- a/client/src/composables/throttle.ts
+++ b/client/src/composables/throttle.ts
@@ -18,3 +18,40 @@ export function useAnimationFrameThrottle(animationFramePriority = 0) {
         throttle,
     };
 }
+
+type TimeoutThrottleCallback = (() => void) | (() => Promise<void>);
+
+/**
+ * Throttles a function with a timeout in milliseconds.
+ * Will call the provided function immediately, and subsequent throttle calls
+ * only after provided timeout period. Unlike the equivalent function from VueUse,
+ * this will always call the last provided callback eventually.
+ */
+export function useTimeoutThrottle(timeout = 100) {
+    let lastCallback: TimeoutThrottleCallback | null = null;
+    let pendingTimeout = false;
+
+    const throttle = (callback: TimeoutThrottleCallback) => {
+        lastCallback = callback;
+        run();
+    };
+
+    const run = async () => {
+        const nextCallback = lastCallback;
+
+        if (!pendingTimeout && nextCallback) {
+            pendingTimeout = true;
+            lastCallback = null;
+            await nextCallback();
+
+            setTimeout(() => {
+                pendingTimeout = false;
+                run();
+            }, timeout);
+        }
+    };
+
+    return {
+        throttle,
+    };
+}

--- a/client/src/stores/historyItemsStore.ts
+++ b/client/src/stores/historyItemsStore.ts
@@ -11,7 +11,7 @@ import Vue, { computed, ref } from "vue";
 import type { DatasetSummary, HDCASummary } from "@/api";
 import { HistoryFilters } from "@/components/History/HistoryFilters";
 import { mergeArray } from "@/store/historyStore/model/utilities";
-import { LastQueue } from "@/utils/promise-queue";
+import { LastQueue } from "@/utils/lastQueue";
 import { urlData } from "@/utils/url";
 
 type HistoryItem = DatasetSummary | HDCASummary;

--- a/client/src/stores/historyItemsStore.ts
+++ b/client/src/stores/historyItemsStore.ts
@@ -17,12 +17,14 @@ import { urlData } from "@/utils/url";
 type HistoryItem = DatasetSummary | HDCASummary;
 
 const limit = 100;
-const queue = new LastQueue();
+
+type ExpectedReturn = { stats: { total_matches: number }; contents: HistoryItem[] };
+const queue = new LastQueue<typeof urlData>();
 
 export const useHistoryItemsStore = defineStore("historyItemsStore", () => {
     const items = ref<Record<string, HistoryItem[]>>({});
     const itemKey = ref("hid");
-    const totalMatchesCount = ref(undefined);
+    const totalMatchesCount = ref<number | undefined>(undefined);
     const lastCheckedTime = ref(new Date());
     const lastUpdateTime = ref(new Date());
     const relatedItems = ref<Record<string, boolean>>({});
@@ -58,9 +60,9 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", () => {
         const url = `/api/histories/${historyId}/contents?${params}&${queryString}`;
         const headers = { accept: "application/vnd.galaxy.history.contents.stats+json" };
         return await queue.enqueue(urlData, { url, headers, errorSimplify: false }, historyId).then((data) => {
-            const stats = data.stats;
+            const stats = (data as ExpectedReturn).stats;
             totalMatchesCount.value = stats.total_matches;
-            const payload = data.contents;
+            const payload = (data as ExpectedReturn).contents;
             const relatedHid = HistoryFilters.getFilterValue(filterText, "related");
             saveHistoryItems(historyId, payload, relatedHid);
         });

--- a/client/src/utils/lastQueue.test.js
+++ b/client/src/utils/lastQueue.test.js
@@ -1,4 +1,4 @@
-import { LastQueue } from "./promise-queue";
+import { LastQueue } from "./lastQueue";
 
 const x = 10;
 const lastQueue = new LastQueue(x);

--- a/client/src/utils/lastQueue.ts
+++ b/client/src/utils/lastQueue.ts
@@ -1,38 +1,48 @@
+type QueuedAction<T extends (...args: any) => R, R = unknown> = {
+    action: T;
+    args: Parameters<T>;
+    resolve: (value: R) => void;
+    reject: (e: Error) => void;
+};
+
 /**
  * This queue waits until the current promise is resolved and only executes the last enqueued
  * promise. Promises added between the last and the currently executing promise are skipped.
  * This is useful when promises earlier enqueued become obsolete.
  * See also: https://stackoverflow.com/questions/53540348/js-async-await-tasks-queue
  */
-export class LastQueue {
+export class LastQueue<T extends (...args: any) => R, R = unknown> {
+    throttlePeriod: number;
+    private queuedPromises: Record<string, QueuedAction<T, R>> = {};
+    private pendingPromise = false;
+
     constructor(throttlePeriod = 1000) {
         this.throttlePeriod = throttlePeriod;
-        this.nextPromise = {};
-        this.pendingPromise = false;
     }
 
     /**
      * @param {String | Number} key
      */
-    async enqueue(action, args = undefined, key = 0) {
+    async enqueue(action: T, args: Parameters<T>, key = 0) {
         return new Promise((resolve, reject) => {
-            this.nextPromise[key] = { action, args, resolve, reject };
+            this.queuedPromises[key] = { action, args, resolve, reject };
             this.dequeue();
         });
     }
 
     async dequeue() {
-        const keys = Object.keys(this.nextPromise);
+        const keys = Object.keys(this.queuedPromises);
         if (!this.pendingPromise && keys.length > 0) {
-            const nextKey = keys[0];
-            const item = this.nextPromise[nextKey];
-            delete this.nextPromise[nextKey];
+            const nextKey = keys[0] as string;
+            const item = this.queuedPromises[nextKey] as QueuedAction<T, R>;
+            delete this.queuedPromises[nextKey];
             this.pendingPromise = true;
+
             try {
                 const payload = await item.action(item.args);
                 item.resolve(payload);
             } catch (e) {
-                item.reject(e);
+                item.reject(e as Error);
             } finally {
                 setTimeout(() => {
                     this.pendingPromise = false;

--- a/client/src/utils/lastQueue.ts
+++ b/client/src/utils/lastQueue.ts
@@ -20,9 +20,6 @@ export class LastQueue<T extends (...args: any) => R, R = unknown> {
         this.throttlePeriod = throttlePeriod;
     }
 
-    /**
-     * @param {String | Number} key
-     */
     async enqueue(action: T, args: Parameters<T> | Parameters<T>[0], key: string | number = 0) {
         return new Promise((resolve, reject) => {
             this.queuedPromises[key] = { action, args, resolve, reject };

--- a/client/src/utils/lastQueue.ts
+++ b/client/src/utils/lastQueue.ts
@@ -14,7 +14,7 @@ export class LastQueue {
     /**
      * @param {String | Number} key
      */
-    async enqueue(action, args, key = 0) {
+    async enqueue(action, args = undefined, key = 0) {
         return new Promise((resolve, reject) => {
             this.nextPromise[key] = { action, args, resolve, reject };
             this.dequeue();

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -12,10 +12,10 @@ _:  # global stuff
     editable_text: '.editable-text'
     tooltip_balloon: '.tooltip'
     tooltip_inner: .tooltip-inner
-    left_panel_drag: '#left-drag'
-    left_panel_collapse: '#left-collapse'
-    right_panel_drag: '#right-drag'
-    right_panel_collapse: '#right-collapse'
+    left_panel_drag: '.flex-panel.left .drag-handle'
+    left_panel_collapse: '.collapse-button.left'
+    right_panel_drag: '.flex-panel.right .drag-handle'
+    right_panel_collapse: '.collapse-button.right'
     by_attribute: '${scope} [${name}="${value}"]'
 
   messages:

--- a/client/src/utils/url.ts
+++ b/client/src/utils/url.ts
@@ -1,13 +1,21 @@
 import axios from "axios";
-import { withPrefix } from "utils/redirect";
-import { rethrowSimple } from "utils/simple-error";
 
-export async function urlData({ url, headers, params, errorSimplify = true }) {
+import { withPrefix } from "@/utils/redirect";
+import { rethrowSimple } from "@/utils/simple-error";
+
+export interface UrlDataOptions {
+    url: string;
+    headers: Record<string, string>;
+    params?: Record<string, string>;
+    errorSimplify?: boolean;
+}
+
+export async function urlData<R>({ url, headers, params, errorSimplify = true }: UrlDataOptions): Promise<R> {
     try {
         headers = headers || {};
         params = params || {};
         const { data } = await axios.get(withPrefix(url), { headers, params });
-        return data;
+        return data as R;
     } catch (e) {
         if (errorSimplify) {
             rethrowSimple(e);
@@ -20,11 +28,11 @@ export async function urlData({ url, headers, params, errorSimplify = true }) {
 /**
  * Adds search parameters to url.
  *
- * @param {String} original url
- * @param {Object} params which will be added to the url
+ * @param original url
+ * @param params which will be added to the url
  * @returns
  */
-export function addSearchParams(url, params) {
+export function addSearchParams(url: string, params: Record<string, string>) {
     const placeholder = url.indexOf("?") == -1 ? "?" : "&";
     const searchParams = new URLSearchParams(params);
     const searchString = searchParams.toString();

--- a/config/plugins/tours/core.galaxy_ui.yaml
+++ b/config/plugins/tours/core.galaxy_ui.yaml
@@ -117,26 +117,6 @@ steps:
       element: "#current-history-panel div.content-item .rerun-btn"
       intro: "By clicking the reload button, you can re-run your tool again (e.g. with different parameters or on another dataset)."
 
-    - title: "Panel collapse"
-      element: ".flex-panel.left .collapse-button.open"
-      intro: "To extend the view for your main Galaxy page in the middle, you can collapse the tool panel on the left hand side."
-      postclick: true
-
-    - title: "Panel expand"
-      element: ".collapse-button.closed"
-      intro: "Click on the expansion icon to restore the panel."
-      postclick: true
-
-    - title: "Panel collapse"
-      element: ".flex-panel.right .collapse-button.open"
-      intro: "Clicking the panel arrow on the right hand side, collapses the history."
-      postclick: true
-
-    - title: "Panel expand"
-      element: ".collapse-button.closed"
-      intro: "Click on the expansion icon to restore the panel."
-      postclick: true
-
     - title: "Top panel"
       element: "#masthead"
       intro: "The top panel will give you access to a lot of useful things."

--- a/config/plugins/tours/core.galaxy_ui.yaml
+++ b/config/plugins/tours/core.galaxy_ui.yaml
@@ -118,22 +118,22 @@ steps:
       intro: "By clicking the reload button, you can re-run your tool again (e.g. with different parameters or on another dataset)."
 
     - title: "Panel collapse"
-      element: "#left-collapse"
+      element: ".flex-panel.left .collapse-button.open"
       intro: "To extend the view for your main Galaxy page in the middle, you can collapse the tool panel on the left hand side."
       postclick: true
 
     - title: "Panel expand"
-      element: "#left-expand"
+      element: ".collapse-button.closed"
       intro: "Click on the expansion icon to restore the panel."
       postclick: true
 
     - title: "Panel collapse"
-      element: "#right-collapse"
+      element: ".flex-panel.right .collapse-button.open"
       intro: "Clicking the panel arrow on the right hand side, collapses the history."
       postclick: true
 
     - title: "Panel expand"
-      element: "#right-expand"
+      element: ".collapse-button.closed"
       intro: "Click on the expansion icon to restore the panel."
       postclick: true
 

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -51,14 +51,14 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows):
 
         self.screenshot("workflow_editor_blank")
 
-        self.components._.left_panel_drag.wait_for_visible()
+        self.hover_over(self.components._.left_panel_drag.wait_for_visible())
         self.components._.left_panel_collapse.wait_for_and_click()
 
         self.sleep_for(self.wait_types.UX_RENDER)
 
         self.screenshot("workflow_editor_left_collapsed")
 
-        self.components._.right_panel_drag.wait_for_visible()
+        self.hover_over(self.components._.right_panel_drag.wait_for_visible())
         self.components._.right_panel_collapse.wait_for_and_click()
 
         self.sleep_for(self.wait_types.UX_RENDER)

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -1300,8 +1300,10 @@ steps:
 
     def workflow_editor_maximize_center_pane(self, collapse_left=True, collapse_right=True):
         if collapse_left:
+            self.hover_over(self.components._.left_panel_drag.wait_for_visible())
             self.components._.left_panel_collapse.wait_for_and_click()
         if collapse_right:
+            self.hover_over(self.components._.right_panel_drag.wait_for_visible())
             self.components._.right_panel_collapse.wait_for_and_click()
         self.sleep_for(self.wait_types.UX_RENDER)
 


### PR DESCRIPTION
Changes the flex side panels to be resizable and collapsible at their edges.

The intent is to make this feature more obvious to users, as many do not know that resizing the side panels is an option.


https://github.com/galaxyproject/galaxy/assets/44241786/80b0ff7d-e0d4-48af-ae03-e7dddb327813



Also refactors a bunch of related code to typescript.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
