### PR TITLE
[23.2] Disable admin notifications management if notifications are disabled in config

### DIFF
--- a/client/src/components/admin/Notifications/NotificationsManagement.test.ts
+++ b/client/src/components/admin/Notifications/NotificationsManagement.test.ts
@@ -1,0 +1,55 @@
+import { createTestingPinia } from "@pinia/testing";
+import { getLocalVue } from "@tests/jest/helpers";
+import { shallowMount } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import { setActivePinia } from "pinia";
+
+import { mockFetcher } from "@/api/schema/__mocks__";
+
+import NotificationsManagement from "./NotificationsManagement.vue";
+
+jest.mock("@/api/schema");
+
+const localVue = getLocalVue(true);
+
+const selectors = {
+    sendNotificationButton: "#send-notification-button",
+    createBroadcastButton: "#create-broadcast-button",
+} as const;
+
+async function mountNotificationsManagement(config: any = {}) {
+    const pinia = createTestingPinia();
+    setActivePinia(pinia);
+
+    mockFetcher.path("/api/configuration").method("get").mock({ data: config });
+
+    const wrapper = shallowMount(NotificationsManagement as object, {
+        localVue,
+        pinia,
+        stubs: {
+            FontAwesomeIcon: true,
+        },
+    });
+
+    await flushPromises();
+
+    return wrapper;
+}
+
+describe("NotificationsManagement.vue", () => {
+    it("should render the create notification buttons if the notification system is enabled", async () => {
+        const config = { enable_notification_system: true };
+        const wrapper = await mountNotificationsManagement(config);
+
+        expect(wrapper.find(selectors.sendNotificationButton).exists()).toBe(true);
+        expect(wrapper.find(selectors.createBroadcastButton).exists()).toBe(true);
+    });
+
+    it("should not render the create notification buttons if the notification system is disabled", async () => {
+        const config = { enable_notification_system: false };
+        const wrapper = await mountNotificationsManagement(config);
+
+        expect(wrapper.find(selectors.sendNotificationButton).exists()).toBe(false);
+        expect(wrapper.find(selectors.createBroadcastButton).exists()).toBe(false);
+    });
+});

--- a/client/src/components/admin/Notifications/NotificationsManagement.vue
+++ b/client/src/components/admin/Notifications/NotificationsManagement.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton } from "bootstrap-vue";
+import { BAlert, BButton } from "bootstrap-vue";
 import { useRouter } from "vue-router/composables";
+
+import { useConfig } from "@/composables/config";
 
 import BroadcastsList from "@/components/admin/Notifications/BroadcastsList.vue";
 import Heading from "@/components/Common/Heading.vue";
 
 const router = useRouter();
+const { config, isConfigLoaded } = useConfig();
 
 function goToCreateNewNotification() {
     router.push("/admin/notifications/create_new_notification");
@@ -28,18 +31,32 @@ function goToCreateNewBroadcast() {
             <i>broadcast notifications</i> to all users (even anonymous users).
         </p>
 
-        <div>
-            <BButton class="mb-2" variant="outline-primary" @click="goToCreateNewNotification">
-                <FontAwesomeIcon icon="plus" />
-                Send new notification
-            </BButton>
+        <div v-if="isConfigLoaded && config.enable_notification_system">
+            <div>
+                <BButton
+                    id="send-notification-button"
+                    class="mb-2"
+                    variant="outline-primary"
+                    @click="goToCreateNewNotification">
+                    <FontAwesomeIcon icon="plus" />
+                    Send new notification
+                </BButton>
 
-            <BButton class="mb-2" variant="outline-primary" @click="goToCreateNewBroadcast">
-                <FontAwesomeIcon icon="plus" />
-                Create new broadcast
-            </BButton>
+                <BButton
+                    id="create-broadcast-button"
+                    class="mb-2"
+                    variant="outline-primary"
+                    @click="goToCreateNewBroadcast">
+                    <FontAwesomeIcon icon="plus" />
+                    Create new broadcast
+                </BButton>
+            </div>
+
+            <BroadcastsList class="mt-2" />
         </div>
-
-        <BroadcastsList class="mt-2" />
+        <BAlert v-else variant="warning" show>
+            The notification system is disabled. To enable it, set the
+            <code>enable_notification_system</code> option to <code>true</code> in the Galaxy configuration file.
+        </BAlert>
     </div>
 </template>


### PR DESCRIPTION
Fixes #17108

When the notification system is disabled in the configuration you now get the following message:

![Screenshot from 2023-11-30 15-33-29](https://github.com/galaxyproject/galaxy/assets/46503462/e1bed209-5e13-45de-a9f3-91ae9b1a8bc8)



## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
