### PR TITLE
[23.1] Remove duplicates when copying sections for tool panel view

### DIFF
--- a/lib/galaxy/tool_util/toolbox/views/static.py
+++ b/lib/galaxy/tool_util/toolbox/views/static.py
@@ -105,7 +105,7 @@ class StaticToolPanelView(ToolPanelView):
                                 f"Failed to find matching section for (id, name) = ({section_def.id}, {section_def.name})"
                             )
                             continue
-                        section = closest_section.copy()
+                        section = closest_section.copy(merge_tools=True)
                         if section_def.id is not None:
                             section.id = section_def.id
                         if section_def.name is not None:


### PR DESCRIPTION
In my tool panels I still see duplicated elements which go away by this fix. 

For instance a section like this:

```
- type: section
  id: sequence_analysis_(blast)
  name: Sequence Analysis - BLAST
```

Question: what is a `section_alias` and how/when is it supposed to be used? 

Follow up on: https://github.com/galaxyproject/galaxy/pull/17036/

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  - define a tool panel view containing a section from the main tool panel. 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
