### PR TITLE
SA2.0 updates: handling "object is being merged into a Session along the backref cascade path"

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -35,7 +35,6 @@ from sqlalchemy import (
 from sqlalchemy.orm import (
     aliased,
     joinedload,
-    object_session,
     Query,
     subqueryload,
 )
@@ -67,6 +66,7 @@ from galaxy.model import (
     WorkflowInvocationStep,
 )
 from galaxy.model.base import transaction
+from galaxy.model.database_utils import ensure_object_added_to_session
 from galaxy.model.index_filter_util import (
     append_user_filter,
     raw_text_column_filter,
@@ -822,8 +822,7 @@ class WorkflowContentsManager(UsesAnnotations):
         # Safeguard: workflow was implicitly merged into this Session prior to SQLAlchemy 2.0.
         # when AT LEAST ONE step in steps belonged to a session.
         for step in steps:
-            if step and object_session(step):
-                object_session(step).add(workflow)
+            if ensure_object_added_to_session(workflow, object_in_session=step):
                 break
 
         comments: List[model.WorkflowComment] = []

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -65,8 +65,10 @@ from galaxy.model import (
     WorkflowInvocation,
     WorkflowInvocationStep,
 )
-from galaxy.model.base import transaction
-from galaxy.model.database_utils import ensure_object_added_to_session
+from galaxy.model.base import (
+    ensure_object_added_to_session,
+    transaction,
+)
 from galaxy.model.index_filter_util import (
     append_user_filter,
     raw_text_column_filter,

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8873,7 +8873,9 @@ class WorkflowInvocationStep(Base, Dictifiable, Serializable):
     job = relationship("Job", back_populates="workflow_invocation_step", uselist=False)
     implicit_collection_jobs = relationship("ImplicitCollectionJobs", uselist=False)
     output_dataset_collections = relationship(
-        "WorkflowInvocationStepOutputDatasetCollectionAssociation", back_populates="workflow_invocation_step"
+        "WorkflowInvocationStepOutputDatasetCollectionAssociation",
+        back_populates="workflow_invocation_step",
+        cascade_backrefs=False,
     )
     output_datasets = relationship(
         "WorkflowInvocationStepOutputDatasetAssociation",
@@ -8942,6 +8944,9 @@ class WorkflowInvocationStep(Base, Dictifiable, Serializable):
         elif output_object.history_content_type == "dataset_collection":
             output_assoc = WorkflowInvocationStepOutputDatasetCollectionAssociation()
             output_assoc.workflow_invocation_step = self
+            # Safeguard: output_assoc was implicitly merged into this Session prior to SQLAlchemy 2.0.
+            if object_session(self):
+                object_session(self).add(output_assoc)
             output_assoc.dataset_collection = output_object
             output_assoc.output_name = output_name
             self.output_dataset_collections.append(output_assoc)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3712,6 +3712,9 @@ class LibraryPermissions(Base, RepresentById):
         self.action = action
         if isinstance(library_item, Library):
             self.library = library_item
+            # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
+            if object_session(library_item):
+                object_session(library_item).add(self)
         else:
             raise Exception(f"Invalid Library specified: {library_item.__class__.__name__}")
         self.role = role
@@ -3733,6 +3736,9 @@ class LibraryFolderPermissions(Base, RepresentById):
         self.action = action
         if isinstance(library_item, LibraryFolder):
             self.folder = library_item
+            # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
+            if object_session(library_item):
+                object_session(library_item).add(self)
         else:
             raise Exception(f"Invalid LibraryFolder specified: {library_item.__class__.__name__}")
         self.role = role
@@ -5376,7 +5382,7 @@ class Library(Base, Dictifiable, HasName, Serializable):
     description = Column(TEXT)
     synopsis = Column(TEXT)
     root_folder = relationship("LibraryFolder", back_populates="library_root")
-    actions = relationship("LibraryPermissions", back_populates="library")
+    actions = relationship("LibraryPermissions", back_populates="library", cascade_backrefs=False)
 
     permitted_actions = get_permitted_actions(filter="LIBRARY")
     dict_collection_visible_keys = ["id", "name"]

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -689,7 +689,9 @@ class User(Base, Dictifiable, RepresentById):
     active = Column(Boolean, index=True, default=True, nullable=False)
     activation_token = Column(TrimmedString(64), nullable=True, index=True)
 
-    addresses = relationship("UserAddress", back_populates="user", order_by=lambda: desc(UserAddress.update_time))
+    addresses = relationship(
+        "UserAddress", back_populates="user", order_by=lambda: desc(UserAddress.update_time), cascade_backrefs=False
+    )
     cloudauthz = relationship("CloudAuthz", back_populates="user")
     custos_auth = relationship("CustosAuthnzToken", back_populates="user")
     default_permissions = relationship("DefaultUserPermissions", back_populates="user")

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8237,7 +8237,9 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
     output_datasets = relationship(
         "WorkflowInvocationOutputDatasetAssociation", back_populates="workflow_invocation", cascade_backrefs=False
     )
-    output_values = relationship("WorkflowInvocationOutputValue", back_populates="workflow_invocation")
+    output_values = relationship(
+        "WorkflowInvocationOutputValue", back_populates="workflow_invocation", cascade_backrefs=False
+    )
     messages = relationship("WorkflowInvocationMessage", back_populates="workflow_invocation")
 
     dict_collection_visible_keys = [
@@ -8446,6 +8448,9 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
             # dispatch on actual object and not step type.
             output_assoc = WorkflowInvocationOutputValue()
             output_assoc.workflow_invocation = self
+            # Safeguard: output_assoc was implicitly merged into this Session prior to SQLAlchemy 2.0.
+            if object_session(self):
+                object_session(self).add(output_assoc)
             output_assoc.workflow_output = workflow_output
             output_assoc.workflow_step = step
             output_assoc.value = output_object

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7234,7 +7234,7 @@ class GalaxySession(Base, RepresentById):
     disk_usage = Column(Numeric(15, 0), index=True)
     last_action = Column(DateTime)
     current_history = relationship("History")
-    histories = relationship("GalaxySessionToHistoryAssociation", back_populates="galaxy_session")
+    histories = relationship("GalaxySessionToHistoryAssociation", back_populates="galaxy_session", cascade_backrefs=False)
     user = relationship("User", back_populates="galaxy_sessions")
 
     def __init__(self, is_valid=False, **kwd):
@@ -7271,6 +7271,9 @@ class GalaxySessionToHistoryAssociation(Base, RepresentById):
 
     def __init__(self, galaxy_session, history):
         self.galaxy_session = galaxy_session
+        # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
+        if object_session(galaxy_session):
+            object_session(galaxy_session).add(self)
         add_object_to_object_session(self, history)
         self.history = history
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9937,6 +9937,7 @@ class Visualization(Base, HasTags, Dictifiable, RepresentById):
         back_populates="visualization",
         cascade="all, delete-orphan",
         primaryjoin=(lambda: Visualization.id == VisualizationRevision.visualization_id),
+        cascade_backrefs=False,
     )
     latest_revision = relationship(
         "VisualizationRevision",

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2999,7 +2999,7 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
     galaxy_sessions = relationship("GalaxySessionToHistoryAssociation", back_populates="history")
     workflow_invocations = relationship("WorkflowInvocation", back_populates="history", cascade_backrefs=False)
     user = relationship("User", back_populates="histories")
-    jobs = relationship("Job", back_populates="history")
+    jobs = relationship("Job", back_populates="history", cascade_backrefs=False)
 
     update_time = column_property(
         select(func.max(HistoryAudit.update_time)).where(HistoryAudit.history_id == id).scalar_subquery(),

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -739,7 +739,10 @@ class User(Base, Dictifiable, RepresentById):
     data_manager_histories = relationship("DataManagerHistoryAssociation", back_populates="user")
     roles = relationship("UserRoleAssociation", back_populates="user")
     stored_workflows = relationship(
-        "StoredWorkflow", back_populates="user", primaryjoin=(lambda: User.id == StoredWorkflow.user_id)  # type: ignore[has-type]
+        "StoredWorkflow",
+        back_populates="user",
+        primaryjoin=(lambda: User.id == StoredWorkflow.user_id),  # type: ignore[has-type]
+        cascade_backrefs=False,
     )
     all_notifications = relationship("UserNotificationAssociation", back_populates="user")
     non_private_roles = relationship(

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2466,7 +2466,7 @@ class PostJobAction(Base, RepresentById):
         self.action_arguments = action_arguments
         self.workflow_step = workflow_step
         # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-        if object_session(workflow_step):
+        if workflow_step and object_session(workflow_step):
             object_session(workflow_step).add(self)
 
 
@@ -2483,7 +2483,7 @@ class PostJobActionAssociation(Base, RepresentById):
         if job is not None:
             self.job = job
             # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-            if object_session(job):
+            if job and object_session(job):
                 object_session(job).add(self)
         elif job_id is not None:
             self.job_id = job_id
@@ -2856,7 +2856,7 @@ class UserNotificationAssociation(Base, RepresentById):
     def __init__(self, user, notification):
         self.user = user
         # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-        if object_session(user):
+        if user and object_session(user):
             object_session(user).add(self)
         self.notification = notification
 
@@ -3512,7 +3512,7 @@ class GroupRoleAssociation(Base, RepresentById):
     def __init__(self, group, role):
         self.group = group
         # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-        if object_session(group):
+        if group and object_session(group):
             object_session(group).add(self)
         self.role = role
 
@@ -3685,7 +3685,7 @@ class DefaultQuotaAssociation(Base, Dictifiable, RepresentById):
         self.type = type
         self.quota = quota
         # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-        if object_session(quota):
+        if quota and object_session(quota):
             object_session(quota).add(self)
 
 
@@ -3728,7 +3728,7 @@ class LibraryPermissions(Base, RepresentById):
         if isinstance(library_item, Library):
             self.library = library_item
             # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-            if object_session(library_item):
+            if library_item and object_session(library_item):
                 object_session(library_item).add(self)
         else:
             raise Exception(f"Invalid Library specified: {library_item.__class__.__name__}")
@@ -3752,7 +3752,7 @@ class LibraryFolderPermissions(Base, RepresentById):
         if isinstance(library_item, LibraryFolder):
             self.folder = library_item
             # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-            if object_session(library_item):
+            if library_item and object_session(library_item):
                 object_session(library_item).add(self)
         else:
             raise Exception(f"Invalid LibraryFolder specified: {library_item.__class__.__name__}")
@@ -3776,7 +3776,7 @@ class LibraryDatasetPermissions(Base, RepresentById):
         if isinstance(library_item, LibraryDataset):
             self.library_dataset = library_item
             # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-            if object_session(library_item):
+            if library_item and object_session(library_item):
                 object_session(library_item).add(self)
         else:
             raise Exception(f"Invalid LibraryDataset specified: {library_item.__class__.__name__}")
@@ -4401,7 +4401,7 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
         self.dataset = dataset
 
         # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-        if object_session(dataset):
+        if dataset and object_session(dataset):
             object_session(dataset).add(self)
 
         self.parent_id = parent_id
@@ -7274,7 +7274,7 @@ class GalaxySessionToHistoryAssociation(Base, RepresentById):
     def __init__(self, galaxy_session, history):
         self.galaxy_session = galaxy_session
         # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-        if object_session(galaxy_session):
+        if galaxy_session and object_session(galaxy_session):
             object_session(galaxy_session).add(self)
         add_object_to_object_session(self, history)
         self.history = history

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3892,6 +3892,7 @@ class Dataset(Base, StorableObject, Serializable):
         "LibraryDatasetDatasetAssociation",
         primaryjoin=(lambda: LibraryDatasetDatasetAssociation.table.c.dataset_id == Dataset.id),
         back_populates="dataset",
+        cascade_backrefs=False,
     )
 
     # failed_metadata is only valid as DatasetInstance state currently

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8218,6 +8218,7 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
         "WorkflowInvocationStep",
         back_populates="workflow_invocation",
         order_by=lambda: WorkflowInvocationStep.order_index,
+        cascade_backrefs=False,
     )
     workflow: Workflow = relationship("Workflow")
     output_dataset_collections = relationship(

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5526,7 +5526,7 @@ class LibraryFolder(Base, Dictifiable, HasName, Serializable):
     )
 
     library_root = relationship("Library", back_populates="root_folder")
-    actions = relationship("LibraryFolderPermissions", back_populates="folder")
+    actions = relationship("LibraryFolderPermissions", back_populates="folder", cascade_backrefs=False)
 
     dict_element_visible_keys = [
         "id",

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3873,7 +3873,7 @@ class Dataset(Base, StorableObject, Serializable):
         ),
         viewonly=True,
     )
-    hashes = relationship("DatasetHash", back_populates="dataset")
+    hashes = relationship("DatasetHash", back_populates="dataset", cascade_backrefs=False)
     sources = relationship("DatasetSource", back_populates="dataset")
     history_associations = relationship("HistoryDatasetAssociation", back_populates="dataset")
     library_associations = relationship(

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1344,7 +1344,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     numeric_metrics = relationship("JobMetricNumeric")
     interactivetool_entry_points = relationship("InteractiveToolEntryPoint", back_populates="job", uselist=True)
     implicit_collection_jobs_association = relationship(
-        "ImplicitCollectionJobsJobAssociation", back_populates="job", uselist=False
+        "ImplicitCollectionJobsJobAssociation", back_populates="job", uselist=False, cascade_backrefs=False
     )
     container = relationship("JobContainerAssociation", back_populates="job", uselist=False)
     data_manager_association = relationship(

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3878,7 +3878,7 @@ class Dataset(Base, StorableObject, Serializable):
     )
     hashes = relationship("DatasetHash", back_populates="dataset", cascade_backrefs=False)
     sources = relationship("DatasetSource", back_populates="dataset")
-    history_associations = relationship("HistoryDatasetAssociation", back_populates="dataset")
+    history_associations = relationship("HistoryDatasetAssociation", back_populates="dataset", cascade_backrefs=False)
     library_associations = relationship(
         "LibraryDatasetDatasetAssociation",
         primaryjoin=(lambda: LibraryDatasetDatasetAssociation.table.c.dataset_id == Dataset.id),
@@ -4374,6 +4374,11 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
         elif dataset:
             add_object_to_object_session(self, dataset)
         self.dataset = dataset
+
+        # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
+        if object_session(dataset):
+            object_session(dataset).add(self)
+
         self.parent_id = parent_id
 
     @property

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7693,7 +7693,10 @@ class WorkflowStep(Base, RepresentById):
         "WorkflowStepConnection", primaryjoin=(lambda: WorkflowStepConnection.output_step_id == WorkflowStep.id)
     )
     workflow = relationship(
-        "Workflow", primaryjoin=(lambda: Workflow.id == WorkflowStep.workflow_id), back_populates="steps"
+        "Workflow",
+        primaryjoin=(lambda: Workflow.id == WorkflowStep.workflow_id),
+        back_populates="steps",
+        cascade_backrefs=False,
     )
 
     # Injected attributes

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -119,7 +119,10 @@ import galaxy.model.metadata
 import galaxy.model.tags
 import galaxy.security.passwords
 import galaxy.util
-from galaxy.model.base import transaction
+from galaxy.model.base import (
+    ensure_object_added_to_session,
+    transaction,
+)
 from galaxy.model.custom_types import (
     DoubleEncodedJsonType,
     JSONType,
@@ -129,7 +132,6 @@ from galaxy.model.custom_types import (
     UUIDType,
 )
 from galaxy.model.database_object_names import NAMING_CONVENTION
-from galaxy.model.database_utils import ensure_object_added_to_session
 from galaxy.model.item_attrs import (
     get_item_annotation_str,
     UsesAnnotations,

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3775,6 +3775,9 @@ class LibraryDatasetPermissions(Base, RepresentById):
         self.action = action
         if isinstance(library_item, LibraryDataset):
             self.library_dataset = library_item
+            # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
+            if object_session(library_item):
+                object_session(library_item).add(self)
         else:
             raise Exception(f"Invalid LibraryDataset specified: {library_item.__class__.__name__}")
         self.role = role
@@ -5642,7 +5645,7 @@ class LibraryDataset(Base, Serializable):
         viewonly=True,
         uselist=True,
     )
-    actions = relationship("LibraryDatasetPermissions", back_populates="library_dataset")
+    actions = relationship("LibraryDatasetPermissions", back_populates="library_dataset", cascade_backrefs=False)
 
     # This class acts as a proxy to the currently selected LDDA
     upload_options = [

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8876,7 +8876,9 @@ class WorkflowInvocationStep(Base, Dictifiable, Serializable):
         "WorkflowInvocationStepOutputDatasetCollectionAssociation", back_populates="workflow_invocation_step"
     )
     output_datasets = relationship(
-        "WorkflowInvocationStepOutputDatasetAssociation", back_populates="workflow_invocation_step"
+        "WorkflowInvocationStepOutputDatasetAssociation",
+        back_populates="workflow_invocation_step",
+        cascade_backrefs=False,
     )
     workflow_invocation = relationship("WorkflowInvocation", back_populates="steps")
     output_value = relationship(
@@ -8931,6 +8933,9 @@ class WorkflowInvocationStep(Base, Dictifiable, Serializable):
         if output_object.history_content_type == "dataset":
             output_assoc = WorkflowInvocationStepOutputDatasetAssociation()
             output_assoc.workflow_invocation_step = self
+            # Safeguard: output_assoc was implicitly merged into this Session prior to SQLAlchemy 2.0.
+            if object_session(self):
+                object_session(self).add(output_assoc)
             output_assoc.dataset = output_object
             output_assoc.output_name = output_name
             self.output_datasets.append(output_assoc)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2465,6 +2465,9 @@ class PostJobAction(Base, RepresentById):
         self.output_name = output_name
         self.action_arguments = action_arguments
         self.workflow_step = workflow_step
+        # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
+        if object_session(workflow_step):
+            object_session(workflow_step).add(self)
 
 
 class PostJobActionAssociation(Base, RepresentById):
@@ -7658,7 +7661,7 @@ class WorkflowStep(Base, RepresentById):
         order_by=lambda: WorkflowStepAnnotationAssociation.id,
         back_populates="workflow_step",
     )
-    post_job_actions = relationship("PostJobAction", back_populates="workflow_step")
+    post_job_actions = relationship("PostJobAction", back_populates="workflow_step", cascade_backrefs=False)
     inputs = relationship("WorkflowStepInput", back_populates="workflow_step")
     workflow_outputs = relationship("WorkflowOutput", back_populates="workflow_step")
     output_connections = relationship(

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2774,7 +2774,7 @@ class Group(Base, Dictifiable, RepresentById):
     name = Column(String(255), index=True, unique=True)
     deleted = Column(Boolean, index=True, default=False)
     quotas = relationship("GroupQuotaAssociation", back_populates="group")
-    roles = relationship("GroupRoleAssociation", back_populates="group")
+    roles = relationship("GroupRoleAssociation", back_populates="group", cascade_backrefs=False)
     users = relationship("UserGroupAssociation", back_populates="group")
 
     dict_collection_visible_keys = ["id", "name"]
@@ -3502,6 +3502,9 @@ class GroupRoleAssociation(Base, RepresentById):
 
     def __init__(self, group, role):
         self.group = group
+        # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
+        if object_session(group):
+                object_session(group).add(self)
         self.role = role
 
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8234,7 +8234,9 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
         back_populates="workflow_invocation",
         cascade_backrefs=False,
     )
-    output_datasets = relationship("WorkflowInvocationOutputDatasetAssociation", back_populates="workflow_invocation")
+    output_datasets = relationship(
+        "WorkflowInvocationOutputDatasetAssociation", back_populates="workflow_invocation", cascade_backrefs=False
+    )
     output_values = relationship("WorkflowInvocationOutputValue", back_populates="workflow_invocation")
     messages = relationship("WorkflowInvocationMessage", back_populates="workflow_invocation")
 
@@ -8451,6 +8453,9 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
         elif output_object.history_content_type == "dataset":
             output_assoc = WorkflowInvocationOutputDatasetAssociation()
             output_assoc.workflow_invocation = self
+            # Safeguard: output_assoc was implicitly merged into this Session prior to SQLAlchemy 2.0.
+            if object_session(self):
+                object_session(self).add(output_assoc)
             output_assoc.workflow_output = workflow_output
             output_assoc.workflow_step = step
             output_assoc.dataset = output_object

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1331,7 +1331,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     )
     output_dataset_collection_instances = relationship("JobToOutputDatasetCollectionAssociation", back_populates="job")
     output_dataset_collections = relationship("JobToImplicitOutputDatasetCollectionAssociation", back_populates="job")
-    post_job_actions = relationship("PostJobActionAssociation", back_populates="job")
+    post_job_actions = relationship("PostJobActionAssociation", back_populates="job", cascade_backrefs=False)
     input_library_datasets = relationship("JobToInputLibraryDatasetAssociation", back_populates="job")
     output_library_datasets = relationship("JobToOutputLibraryDatasetAssociation", back_populates="job")
     external_output_metadata = relationship("JobExternalOutputMetadata", back_populates="job")
@@ -2482,6 +2482,9 @@ class PostJobActionAssociation(Base, RepresentById):
     def __init__(self, pja, job=None, job_id=None):
         if job is not None:
             self.job = job
+            # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
+            if object_session(job):
+                object_session(job).add(self)
         elif job_id is not None:
             self.job_id = job_id
         else:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7790,6 +7790,9 @@ class WorkflowStep(Base, RepresentById):
 
         conn = WorkflowStepConnection()
         conn.input_step_input = step_input
+        # Safeguard: conn was implicitly merged into this Session prior to SQLAlchemy 2.0.
+        if step_input and object_session(step_input):
+            object_session(step_input).add(conn)
         conn.output_name = output_name
         add_object_to_object_session(conn, output_step)
         conn.output_step = output_step
@@ -7979,6 +7982,7 @@ class WorkflowStepInput(Base, RepresentById):
         "WorkflowStepConnection",
         back_populates="input_step_input",
         primaryjoin=(lambda: WorkflowStepConnection.input_step_input_id == WorkflowStepInput.id),
+        cascade_backrefs=False,
     )
 
     def __init__(self, workflow_step):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7328,6 +7328,7 @@ class StoredWorkflow(Base, HasTags, Dictifiable, RepresentById):
         cascade="all, delete-orphan",
         primaryjoin=(lambda: StoredWorkflow.id == Workflow.stored_workflow_id),  # type: ignore[has-type]
         order_by=lambda: -Workflow.id,  # type: ignore[has-type]
+        cascade_backrefs=False,
     )
     latest_workflow = relationship(
         "Workflow",

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7688,7 +7688,7 @@ class WorkflowStep(Base, RepresentById):
     )
     post_job_actions = relationship("PostJobAction", back_populates="workflow_step", cascade_backrefs=False)
     inputs = relationship("WorkflowStepInput", back_populates="workflow_step")
-    workflow_outputs = relationship("WorkflowOutput", back_populates="workflow_step")
+    workflow_outputs = relationship("WorkflowOutput", back_populates="workflow_step", cascade_backrefs=False)
     output_connections = relationship(
         "WorkflowStepConnection", primaryjoin=(lambda: WorkflowStepConnection.output_step_id == WorkflowStep.id)
     )
@@ -8074,6 +8074,9 @@ class WorkflowOutput(Base, Serializable):
 
     def __init__(self, workflow_step, output_name=None, label=None, uuid=None):
         self.workflow_step = workflow_step
+        # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
+        if object_session(workflow_step):
+            object_session(workflow_step).add(self)
         self.output_name = output_name
         self.label = label
         self.uuid = get_uuid(uuid)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8210,7 +8210,9 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
         "WorkflowRequestToInputDatasetAssociation", back_populates="workflow_invocation", cascade_backrefs=False
     )
     input_dataset_collections = relationship(
-        "WorkflowRequestToInputDatasetCollectionAssociation", back_populates="workflow_invocation"
+        "WorkflowRequestToInputDatasetCollectionAssociation",
+        back_populates="workflow_invocation",
+        cascade_backrefs=False,
     )
     subworkflow_invocations = relationship(
         "WorkflowInvocationToSubworkflowInvocationAssociation",
@@ -8228,7 +8230,9 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
     )
     workflow: Workflow = relationship("Workflow")
     output_dataset_collections = relationship(
-        "WorkflowInvocationOutputDatasetCollectionAssociation", back_populates="workflow_invocation"
+        "WorkflowInvocationOutputDatasetCollectionAssociation",
+        back_populates="workflow_invocation",
+        cascade_backrefs=False,
     )
     output_datasets = relationship("WorkflowInvocationOutputDatasetAssociation", back_populates="workflow_invocation")
     output_values = relationship("WorkflowInvocationOutputValue", back_populates="workflow_invocation")
@@ -8454,6 +8458,8 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
         elif output_object.history_content_type == "dataset_collection":
             output_assoc = WorkflowInvocationOutputDatasetCollectionAssociation()
             output_assoc.workflow_invocation = self
+            if object_session(self):
+                object_session(self).add(output_assoc)
             output_assoc.workflow_output = workflow_output
             output_assoc.workflow_step = step
             output_assoc.dataset_collection = output_object

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7497,6 +7497,7 @@ class Workflow(Base, Dictifiable, RepresentById):
         "WorkflowStep",
         primaryjoin=(lambda: Workflow.id == WorkflowStep.subworkflow_id),  # type: ignore[has-type]
         back_populates="subworkflow",
+        cascade_backrefs=False,
     )
     stored_workflow = relationship(
         "StoredWorkflow",

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -129,6 +129,7 @@ from galaxy.model.custom_types import (
     UUIDType,
 )
 from galaxy.model.database_object_names import NAMING_CONVENTION
+from galaxy.model.database_utils import ensure_object_added_to_session
 from galaxy.model.item_attrs import (
     get_item_annotation_str,
     UsesAnnotations,
@@ -2471,9 +2472,7 @@ class PostJobAction(Base, RepresentById):
         self.output_name = output_name
         self.action_arguments = action_arguments
         self.workflow_step = workflow_step
-        # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-        if workflow_step and object_session(workflow_step):
-            object_session(workflow_step).add(self)
+        ensure_object_added_to_session(self, object_in_session=workflow_step)
 
 
 class PostJobActionAssociation(Base, RepresentById):
@@ -2488,9 +2487,7 @@ class PostJobActionAssociation(Base, RepresentById):
     def __init__(self, pja, job=None, job_id=None):
         if job is not None:
             self.job = job
-            # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-            if job and object_session(job):
-                object_session(job).add(self)
+            ensure_object_added_to_session(self, object_in_session=job)
         elif job_id is not None:
             self.job_id = job_id
         else:
@@ -2861,9 +2858,7 @@ class UserNotificationAssociation(Base, RepresentById):
 
     def __init__(self, user, notification):
         self.user = user
-        # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-        if user and object_session(user):
-            object_session(user).add(self)
+        ensure_object_added_to_session(self, object_in_session=user)
         self.notification = notification
 
 
@@ -3517,9 +3512,7 @@ class GroupRoleAssociation(Base, RepresentById):
 
     def __init__(self, group, role):
         self.group = group
-        # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-        if group and object_session(group):
-            object_session(group).add(self)
+        ensure_object_added_to_session(self, object_in_session=group)
         self.role = role
 
 
@@ -3690,9 +3683,7 @@ class DefaultQuotaAssociation(Base, Dictifiable, RepresentById):
         assert type in self.types.__members__.values(), "Invalid type"
         self.type = type
         self.quota = quota
-        # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-        if quota and object_session(quota):
-            object_session(quota).add(self)
+        ensure_object_added_to_session(self, object_in_session=quota)
 
 
 class DatasetPermissions(Base, RepresentById):
@@ -3733,9 +3724,7 @@ class LibraryPermissions(Base, RepresentById):
         self.action = action
         if isinstance(library_item, Library):
             self.library = library_item
-            # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-            if library_item and object_session(library_item):
-                object_session(library_item).add(self)
+            ensure_object_added_to_session(self, object_in_session=library_item)
         else:
             raise Exception(f"Invalid Library specified: {library_item.__class__.__name__}")
         self.role = role
@@ -3757,9 +3746,7 @@ class LibraryFolderPermissions(Base, RepresentById):
         self.action = action
         if isinstance(library_item, LibraryFolder):
             self.folder = library_item
-            # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-            if library_item and object_session(library_item):
-                object_session(library_item).add(self)
+            ensure_object_added_to_session(self, object_in_session=library_item)
         else:
             raise Exception(f"Invalid LibraryFolder specified: {library_item.__class__.__name__}")
         self.role = role
@@ -3781,9 +3768,7 @@ class LibraryDatasetPermissions(Base, RepresentById):
         self.action = action
         if isinstance(library_item, LibraryDataset):
             self.library_dataset = library_item
-            # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-            if library_item and object_session(library_item):
-                object_session(library_item).add(self)
+            ensure_object_added_to_session(self, object_in_session=library_item)
         else:
             raise Exception(f"Invalid LibraryDataset specified: {library_item.__class__.__name__}")
         self.role = role
@@ -4405,11 +4390,7 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
         elif dataset:
             add_object_to_object_session(self, dataset)
         self.dataset = dataset
-
-        # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-        if dataset and object_session(dataset):
-            object_session(dataset).add(self)
-
+        ensure_object_added_to_session(self, object_in_session=dataset)
         self.parent_id = parent_id
 
     @property
@@ -7279,9 +7260,7 @@ class GalaxySessionToHistoryAssociation(Base, RepresentById):
 
     def __init__(self, galaxy_session, history):
         self.galaxy_session = galaxy_session
-        # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-        if galaxy_session and object_session(galaxy_session):
-            object_session(galaxy_session).add(self)
+        ensure_object_added_to_session(self, object_in_session=galaxy_session)
         add_object_to_object_session(self, history)
         self.history = history
 
@@ -7793,9 +7772,7 @@ class WorkflowStep(Base, RepresentById):
 
         conn = WorkflowStepConnection()
         conn.input_step_input = step_input
-        # Safeguard: conn was implicitly merged into this Session prior to SQLAlchemy 2.0.
-        if step_input and object_session(step_input):
-            object_session(step_input).add(conn)
+        ensure_object_added_to_session(conn, object_in_session=step_input)
         conn.output_name = output_name
         add_object_to_object_session(conn, output_step)
         conn.output_step = output_step
@@ -8077,9 +8054,7 @@ class WorkflowOutput(Base, Serializable):
 
     def __init__(self, workflow_step, output_name=None, label=None, uuid=None):
         self.workflow_step = workflow_step
-        # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
-        if object_session(workflow_step):
-            object_session(workflow_step).add(self)
+        ensure_object_added_to_session(self, object_in_session=workflow_step)
         self.output_name = output_name
         self.label = label
         self.uuid = get_uuid(uuid)
@@ -8468,9 +8443,7 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
             # dispatch on actual object and not step type.
             output_assoc = WorkflowInvocationOutputValue()
             output_assoc.workflow_invocation = self
-            # Safeguard: output_assoc was implicitly merged into this Session prior to SQLAlchemy 2.0.
-            if object_session(self):
-                object_session(self).add(output_assoc)
+            ensure_object_added_to_session(output_assoc, object_in_session=self)
             output_assoc.workflow_output = workflow_output
             output_assoc.workflow_step = step
             output_assoc.value = output_object
@@ -8478,9 +8451,7 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
         elif output_object.history_content_type == "dataset":
             output_assoc = WorkflowInvocationOutputDatasetAssociation()
             output_assoc.workflow_invocation = self
-            # Safeguard: output_assoc was implicitly merged into this Session prior to SQLAlchemy 2.0.
-            if object_session(self):
-                object_session(self).add(output_assoc)
+            ensure_object_added_to_session(output_assoc, object_in_session=self)
             output_assoc.workflow_output = workflow_output
             output_assoc.workflow_step = step
             output_assoc.dataset = output_object
@@ -8488,8 +8459,7 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
         elif output_object.history_content_type == "dataset_collection":
             output_assoc = WorkflowInvocationOutputDatasetCollectionAssociation()
             output_assoc.workflow_invocation = self
-            if object_session(self):
-                object_session(self).add(output_assoc)
+            ensure_object_added_to_session(output_assoc, object_in_session=self)
             output_assoc.workflow_output = workflow_output
             output_assoc.workflow_step = step
             output_assoc.dataset_collection = output_object
@@ -8943,18 +8913,14 @@ class WorkflowInvocationStep(Base, Dictifiable, Serializable):
         if output_object.history_content_type == "dataset":
             output_assoc = WorkflowInvocationStepOutputDatasetAssociation()
             output_assoc.workflow_invocation_step = self
-            # Safeguard: output_assoc was implicitly merged into this Session prior to SQLAlchemy 2.0.
-            if object_session(self):
-                object_session(self).add(output_assoc)
+            ensure_object_added_to_session(output_assoc, object_in_session=self)
             output_assoc.dataset = output_object
             output_assoc.output_name = output_name
             self.output_datasets.append(output_assoc)
         elif output_object.history_content_type == "dataset_collection":
             output_assoc = WorkflowInvocationStepOutputDatasetCollectionAssociation()
             output_assoc.workflow_invocation_step = self
-            # Safeguard: output_assoc was implicitly merged into this Session prior to SQLAlchemy 2.0.
-            if object_session(self):
-                object_session(self).add(output_assoc)
+            ensure_object_added_to_session(output_assoc, object_in_session=self)
             output_assoc.dataset_collection = output_object
             output_assoc.output_name = output_name
             self.output_dataset_collections.append(output_assoc)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -704,7 +704,7 @@ class User(Base, Dictifiable, RepresentById):
         order_by=lambda: desc(History.update_time),  # type: ignore[has-type]
     )
     galaxy_sessions = relationship(
-        "GalaxySession", back_populates="user", order_by=lambda: desc(GalaxySession.update_time)  # type: ignore[has-type]
+        "GalaxySession", back_populates="user", order_by=lambda: desc(GalaxySession.update_time), cascade_backrefs=False  # type: ignore[has-type]
     )
     quotas = relationship("UserQuotaAssociation", back_populates="user")
     quota_source_usages = relationship("UserQuotaSourceUsage", back_populates="user")

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8220,7 +8220,9 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
         "WorkflowRequestInputParameter", back_populates="workflow_invocation", cascade_backrefs=False
     )
     step_states = relationship("WorkflowRequestStepState", back_populates="workflow_invocation", cascade_backrefs=False)
-    input_step_parameters = relationship("WorkflowRequestInputStepParameter", back_populates="workflow_invocation")
+    input_step_parameters = relationship(
+        "WorkflowRequestInputStepParameter", back_populates="workflow_invocation", cascade_backrefs=False
+    )
     input_datasets = relationship(
         "WorkflowRequestToInputDatasetAssociation", back_populates="workflow_invocation", cascade_backrefs=False
     )

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3513,7 +3513,7 @@ class GroupRoleAssociation(Base, RepresentById):
         self.group = group
         # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
         if object_session(group):
-                object_session(group).add(self)
+            object_session(group).add(self)
         self.role = role
 
 
@@ -7234,7 +7234,9 @@ class GalaxySession(Base, RepresentById):
     disk_usage = Column(Numeric(15, 0), index=True)
     last_action = Column(DateTime)
     current_history = relationship("History")
-    histories = relationship("GalaxySessionToHistoryAssociation", back_populates="galaxy_session", cascade_backrefs=False)
+    histories = relationship(
+        "GalaxySessionToHistoryAssociation", back_populates="galaxy_session", cascade_backrefs=False
+    )
     user = relationship("User", back_populates="galaxy_sessions")
 
     def __init__(self, is_valid=False, **kwd):
@@ -8199,7 +8201,9 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
     history_id = Column(Integer, ForeignKey("history.id"), index=True)
 
     history = relationship("History", back_populates="workflow_invocations")
-    input_parameters = relationship("WorkflowRequestInputParameter", back_populates="workflow_invocation")
+    input_parameters = relationship(
+        "WorkflowRequestInputParameter", back_populates="workflow_invocation", cascade_backrefs=False
+    )
     step_states = relationship("WorkflowRequestStepState", back_populates="workflow_invocation")
     input_step_parameters = relationship("WorkflowRequestInputStepParameter", back_populates="workflow_invocation")
     input_datasets = relationship("WorkflowRequestToInputDatasetAssociation", back_populates="workflow_invocation")

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2413,7 +2413,9 @@ class ImplicitCollectionJobs(Base, Serializable):
 
     id = Column(Integer, primary_key=True)
     populated_state = Column(TrimmedString(64), default="new", nullable=False)
-    jobs = relationship("ImplicitCollectionJobsJobAssociation", back_populates="implicit_collection_jobs")
+    jobs = relationship(
+        "ImplicitCollectionJobsJobAssociation", back_populates="implicit_collection_jobs", cascade_backrefs=False
+    )
 
     class populated_states(str, Enum):
         NEW = "new"  # New implicit jobs object, unpopulated job associations

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2991,7 +2991,7 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
     default_permissions = relationship("DefaultHistoryPermissions", back_populates="history")
     users_shared_with = relationship("HistoryUserShareAssociation", back_populates="history")
     galaxy_sessions = relationship("GalaxySessionToHistoryAssociation", back_populates="history")
-    workflow_invocations = relationship("WorkflowInvocation", back_populates="history")
+    workflow_invocations = relationship("WorkflowInvocation", back_populates="history", cascade_backrefs=False)
     user = relationship("User", back_populates="histories")
     jobs = relationship("Job", back_populates="history")
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8206,7 +8206,9 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
     )
     step_states = relationship("WorkflowRequestStepState", back_populates="workflow_invocation", cascade_backrefs=False)
     input_step_parameters = relationship("WorkflowRequestInputStepParameter", back_populates="workflow_invocation")
-    input_datasets = relationship("WorkflowRequestToInputDatasetAssociation", back_populates="workflow_invocation")
+    input_datasets = relationship(
+        "WorkflowRequestToInputDatasetAssociation", back_populates="workflow_invocation", cascade_backrefs=False
+    )
     input_dataset_collections = relationship(
         "WorkflowRequestToInputDatasetCollectionAssociation", back_populates="workflow_invocation"
     )

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -697,7 +697,7 @@ class User(Base, Dictifiable, RepresentById):
     default_permissions = relationship("DefaultUserPermissions", back_populates="user")
     groups = relationship("UserGroupAssociation", back_populates="user")
     histories = relationship(
-        "History", back_populates="user", order_by=lambda: desc(History.update_time)  # type: ignore[has-type]
+        "History", back_populates="user", order_by=lambda: desc(History.update_time), cascade_backrefs=False  # type: ignore[has-type]
     )
     active_histories = relationship(
         "History",

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8204,7 +8204,7 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
     input_parameters = relationship(
         "WorkflowRequestInputParameter", back_populates="workflow_invocation", cascade_backrefs=False
     )
-    step_states = relationship("WorkflowRequestStepState", back_populates="workflow_invocation")
+    step_states = relationship("WorkflowRequestStepState", back_populates="workflow_invocation", cascade_backrefs=False)
     input_step_parameters = relationship("WorkflowRequestInputStepParameter", back_populates="workflow_invocation")
     input_datasets = relationship("WorkflowRequestToInputDatasetAssociation", back_populates="workflow_invocation")
     input_dataset_collections = relationship(

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -744,7 +744,7 @@ class User(Base, Dictifiable, RepresentById):
         primaryjoin=(lambda: User.id == StoredWorkflow.user_id),  # type: ignore[has-type]
         cascade_backrefs=False,
     )
-    all_notifications = relationship("UserNotificationAssociation", back_populates="user")
+    all_notifications = relationship("UserNotificationAssociation", back_populates="user", cascade_backrefs=False)
     non_private_roles = relationship(
         "UserRoleAssociation",
         viewonly=True,
@@ -2855,6 +2855,9 @@ class UserNotificationAssociation(Base, RepresentById):
 
     def __init__(self, user, notification):
         self.user = user
+        # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
+        if object_session(user):
+            object_session(user).add(self)
         self.notification = notification
 
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3614,7 +3614,7 @@ class Quota(Base, Dictifiable, RepresentById):
     operation = Column(String(8))
     deleted = Column(Boolean, index=True, default=False)
     quota_source_label = Column(String(32), default=None)
-    default = relationship("DefaultQuotaAssociation", back_populates="quota")
+    default = relationship("DefaultQuotaAssociation", back_populates="quota", cascade_backrefs=False)
     groups = relationship("GroupQuotaAssociation", back_populates="quota")
     users = relationship("UserQuotaAssociation", back_populates="quota")
 
@@ -3684,6 +3684,9 @@ class DefaultQuotaAssociation(Base, Dictifiable, RepresentById):
         assert type in self.types.__members__.values(), "Invalid type"
         self.type = type
         self.quota = quota
+        # Safeguard: self was implicitly merged into this Session prior to SQLAlchemy 2.0.
+        if object_session(quota):
+            object_session(quota).add(self)
 
 
 class DatasetPermissions(Base, RepresentById):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1345,7 +1345,9 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
         "ImplicitCollectionJobsJobAssociation", back_populates="job", uselist=False
     )
     container = relationship("JobContainerAssociation", back_populates="job", uselist=False)
-    data_manager_association = relationship("DataManagerJobAssociation", back_populates="job", uselist=False)
+    data_manager_association = relationship(
+        "DataManagerJobAssociation", back_populates="job", uselist=False, cascade_backrefs=False
+    )
     history_dataset_collection_associations = relationship("HistoryDatasetCollectionAssociation", back_populates="job")
     workflow_invocation_step = relationship("WorkflowInvocationStep", back_populates="job", uselist=False)
 

--- a/lib/galaxy/model/database_utils.py
+++ b/lib/galaxy/model/database_utils.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.engine import Engine
 from sqlalchemy.engine.url import make_url
+from sqlalchemy.orm import object_session
 from sqlalchemy.sql.compiler import IdentifierPreparer
 from sqlalchemy.sql.expression import (
     ClauseElement,
@@ -175,3 +176,22 @@ def _statement_executed_without_error(statement: ClauseElement, engine: Engine) 
 
 def is_postgres(url: DbUrl) -> bool:
     return url.startswith("postgres")
+
+
+def ensure_object_added_to_session(object_to_add, *, object_in_session=None, session=None) -> bool:
+    """
+    This function is intended as a safeguard to mimic pre-SQLAlchemy 2.0 behavior.
+    `object_to_add` was implicitly merged into a Session prior to SQLAlchemy 2.0, which was indicated
+    by `RemovedIn20Warning` warnings logged while running Galaxy's tests. (See https://github.com/galaxyproject/galaxy/issues/12541)
+    As part of the upgrade to 2.0, the `cascade_backrefs=False` argument was added to the relevant relationships that turned off this behavior.
+    This function is called from the code that triggered these warnings, thus emulating the cascading behavior.
+    The intention is to remove all such calls, as well as this function definition, after the move to SQLAlchemy 2.0.
+    # Ref: https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#cascade-backrefs-behavior-deprecated-for-removal-in-2-0
+    """
+    if session:
+        session.add(object_to_add)
+        return True
+    if object_in_session and object_session(object_in_session):
+        object_session(object_in_session).add(object_to_add)
+        return True
+    return False

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1028,7 +1028,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
             imported_invocation.user = self.user
             imported_invocation.history = history
             # Safeguard: imported_invocation was implicitly merged into this Session prior to SQLAlchemy 2.0.
-            if object_session(history):
+            if history and object_session(history):
                 object_session(history).add(imported_invocation)
             workflow_key = invocation_attrs["workflow"]
             if workflow_key not in object_import_tracker.workflows_by_key:
@@ -1052,7 +1052,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 imported_invocation_step = model.WorkflowInvocationStep()
                 imported_invocation_step.workflow_invocation = imported_invocation
                 # Safeguard: imported_invocation_step was implicitly merged into this Session prior to SQLAlchemy 2.0.
-                if object_session(imported_invocation):
+                if imported_invocation and object_session(imported_invocation):
                     object_session(imported_invocation).add(imported_invocation_step)
                 attach_workflow_step(imported_invocation_step, step_attrs)
                 restore_times(imported_invocation_step, step_attrs)
@@ -1109,7 +1109,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 input_parameter.type = input_parameter_attrs["type"]
                 input_parameter.workflow_invocation = imported_invocation
                 # Safeguard: input_parameter was implicitly merged into this Session prior to SQLAlchemy 2.0.
-                if object_session(imported_invocation):
+                if imported_invocation and object_session(imported_invocation):
                     object_session(imported_invocation).add(input_parameter)
                 self._session_add(input_parameter)
                 input_parameters.append(input_parameter)

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1122,6 +1122,8 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 step_state.value = step_state_attrs["value"]
                 attach_workflow_step(step_state, step_state_attrs)
                 step_state.workflow_invocation = imported_invocation
+                # Safeguard: step_state was implicitly merged into this Session prior to SQLAlchemy 2.0.
+                self.sa_session.add(step_state)
                 self._session_add(step_state)
                 step_states.append(step_state)
 

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1199,6 +1199,8 @@ class ModelImportStore(metaclass=abc.ABCMeta):
             for output_value_attrs in invocation_attrs["output_values"]:
                 output_value = model.WorkflowInvocationOutputValue()
                 output_value.workflow_invocation = imported_invocation
+                # Safeguard: output_value was implicitly merged into this Session prior to SQLAlchemy 2.0.
+                self.sa_session.add(output_value)
                 output_value.value = output_value_attrs["value"]
                 attach_workflow_step(output_value, output_value_attrs)
                 workflow_output = output_value_attrs["workflow_output"]

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1052,8 +1052,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 imported_invocation_step = model.WorkflowInvocationStep()
                 imported_invocation_step.workflow_invocation = imported_invocation
                 # Safeguard: imported_invocation_step was implicitly merged into this Session prior to SQLAlchemy 2.0.
-                if imported_invocation and object_session(imported_invocation):
-                    object_session(imported_invocation).add(imported_invocation_step)
+                self.sa_session.add(imported_invocation_step)
                 attach_workflow_step(imported_invocation_step, step_attrs)
                 restore_times(imported_invocation_step, step_attrs)
                 imported_invocation_step.action = step_attrs["action"]
@@ -1109,8 +1108,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 input_parameter.type = input_parameter_attrs["type"]
                 input_parameter.workflow_invocation = imported_invocation
                 # Safeguard: input_parameter was implicitly merged into this Session prior to SQLAlchemy 2.0.
-                if imported_invocation and object_session(imported_invocation):
-                    object_session(imported_invocation).add(input_parameter)
+                self.sa_session.add(input_parameter)
                 self._session_add(input_parameter)
                 input_parameters.append(input_parameter)
 

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1141,6 +1141,8 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 input_dataset = model.WorkflowRequestToInputDatasetAssociation()
                 attach_workflow_step(input_dataset, input_dataset_attrs)
                 input_dataset.workflow_invocation = imported_invocation
+                # Safeguard: input_dataset was implicitly merged into this Session prior to SQLAlchemy 2.0.
+                self.sa_session.add(input_dataset)
                 input_dataset.name = input_dataset_attrs["name"]
                 dataset_link_attrs = input_dataset_attrs["dataset"]
                 if dataset_link_attrs:

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1048,6 +1048,9 @@ class ModelImportStore(metaclass=abc.ABCMeta):
             for step_attrs in invocation_attrs["steps"]:
                 imported_invocation_step = model.WorkflowInvocationStep()
                 imported_invocation_step.workflow_invocation = imported_invocation
+                # Safeguard: imported_invocation_step was implicitly merged into this Session prior to SQLAlchemy 2.0.
+                if object_session(imported_invocation):
+                    object_session(imported_invocation).add(imported_invocation_step)
                 attach_workflow_step(imported_invocation_step, step_attrs)
                 restore_times(imported_invocation_step, step_attrs)
                 imported_invocation_step.action = step_attrs["action"]

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1185,6 +1185,8 @@ class ModelImportStore(metaclass=abc.ABCMeta):
             for output_dataset_attrs in invocation_attrs["output_datasets"]:
                 output_dataset = model.WorkflowInvocationOutputDatasetAssociation()
                 output_dataset.workflow_invocation = imported_invocation
+                # Safeguard: output_dataset was implicitly merged into this Session prior to SQLAlchemy 2.0.
+                self.sa_session.add(output_dataset)
                 attach_workflow_step(output_dataset, output_dataset_attrs)
                 workflow_output = output_dataset_attrs["workflow_output"]
                 label = workflow_output.get("label")

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -56,8 +56,10 @@ from galaxy.files import (
     ProvidesUserFileSourcesUserContext,
 )
 from galaxy.files.uris import stream_url_to_file
-from galaxy.model.base import transaction
-from galaxy.model.database_utils import ensure_object_added_to_session
+from galaxy.model.base import (
+    ensure_object_added_to_session,
+    transaction,
+)
 from galaxy.model.mapping import GalaxyModelMapping
 from galaxy.model.metadata import MetadataCollection
 from galaxy.model.orm.util import (

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -40,7 +40,10 @@ from rocrate.model.computationalworkflow import (
 )
 from rocrate.rocrate import ROCrate
 from sqlalchemy import select
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import (
+    joinedload,
+    object_session,
+)
 from sqlalchemy.orm.scoping import scoped_session
 from sqlalchemy.sql import expression
 from typing_extensions import Protocol
@@ -1105,6 +1108,9 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 input_parameter.name = input_parameter_attrs["name"]
                 input_parameter.type = input_parameter_attrs["type"]
                 input_parameter.workflow_invocation = imported_invocation
+                # Safeguard: input_parameter was implicitly merged into this Session prior to SQLAlchemy 2.0.
+                if object_session(imported_invocation):
+                    object_session(imported_invocation).add(input_parameter)
                 self._session_add(input_parameter)
                 input_parameters.append(input_parameter)
 

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1155,6 +1155,8 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 input_dataset_collection = model.WorkflowRequestToInputDatasetCollectionAssociation()
                 attach_workflow_step(input_dataset_collection, input_dataset_collection_attrs)
                 input_dataset_collection.workflow_invocation = imported_invocation
+                # Safeguard: input_dataset_collection was implicitly merged into this Session prior to SQLAlchemy 2.0.
+                self.sa_session.add(input_dataset_collection)
                 input_dataset_collection.name = input_dataset_collection_attrs["name"]
                 dataset_collection_link_attrs = input_dataset_collection_attrs["dataset_collection"]
                 if dataset_collection_link_attrs:
@@ -1169,6 +1171,8 @@ class ModelImportStore(metaclass=abc.ABCMeta):
             for output_dataset_collection_attrs in invocation_attrs["output_dataset_collections"]:
                 output_dataset_collection = model.WorkflowInvocationOutputDatasetCollectionAssociation()
                 output_dataset_collection.workflow_invocation = imported_invocation
+                # Safeguard: output_dataset_collection was implicitly merged into this Session prior to SQLAlchemy 2.0.
+                self.sa_session.add(output_dataset_collection)
                 attach_workflow_step(output_dataset_collection, output_dataset_collection_attrs)
                 workflow_output = output_dataset_collection_attrs["workflow_output"]
                 label = workflow_output.get("label")

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1107,8 +1107,6 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 input_parameter.name = input_parameter_attrs["name"]
                 input_parameter.type = input_parameter_attrs["type"]
                 input_parameter.workflow_invocation = imported_invocation
-                # Safeguard: input_parameter was implicitly merged into this Session prior to SQLAlchemy 2.0.
-                self.sa_session.add(input_parameter)
                 self._session_add(input_parameter)
                 input_parameters.append(input_parameter)
 
@@ -1120,8 +1118,6 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 step_state.value = step_state_attrs["value"]
                 attach_workflow_step(step_state, step_state_attrs)
                 step_state.workflow_invocation = imported_invocation
-                # Safeguard: step_state was implicitly merged into this Session prior to SQLAlchemy 2.0.
-                self.sa_session.add(step_state)
                 self._session_add(step_state)
                 step_states.append(step_state)
 
@@ -1139,8 +1135,6 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 input_dataset = model.WorkflowRequestToInputDatasetAssociation()
                 attach_workflow_step(input_dataset, input_dataset_attrs)
                 input_dataset.workflow_invocation = imported_invocation
-                # Safeguard: input_dataset was implicitly merged into this Session prior to SQLAlchemy 2.0.
-                self.sa_session.add(input_dataset)
                 input_dataset.name = input_dataset_attrs["name"]
                 dataset_link_attrs = input_dataset_attrs["dataset"]
                 if dataset_link_attrs:
@@ -1155,8 +1149,6 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 input_dataset_collection = model.WorkflowRequestToInputDatasetCollectionAssociation()
                 attach_workflow_step(input_dataset_collection, input_dataset_collection_attrs)
                 input_dataset_collection.workflow_invocation = imported_invocation
-                # Safeguard: input_dataset_collection was implicitly merged into this Session prior to SQLAlchemy 2.0.
-                self.sa_session.add(input_dataset_collection)
                 input_dataset_collection.name = input_dataset_collection_attrs["name"]
                 dataset_collection_link_attrs = input_dataset_collection_attrs["dataset_collection"]
                 if dataset_collection_link_attrs:
@@ -1171,8 +1163,6 @@ class ModelImportStore(metaclass=abc.ABCMeta):
             for output_dataset_collection_attrs in invocation_attrs["output_dataset_collections"]:
                 output_dataset_collection = model.WorkflowInvocationOutputDatasetCollectionAssociation()
                 output_dataset_collection.workflow_invocation = imported_invocation
-                # Safeguard: output_dataset_collection was implicitly merged into this Session prior to SQLAlchemy 2.0.
-                self.sa_session.add(output_dataset_collection)
                 attach_workflow_step(output_dataset_collection, output_dataset_collection_attrs)
                 workflow_output = output_dataset_collection_attrs["workflow_output"]
                 label = workflow_output.get("label")
@@ -1185,8 +1175,6 @@ class ModelImportStore(metaclass=abc.ABCMeta):
             for output_dataset_attrs in invocation_attrs["output_datasets"]:
                 output_dataset = model.WorkflowInvocationOutputDatasetAssociation()
                 output_dataset.workflow_invocation = imported_invocation
-                # Safeguard: output_dataset was implicitly merged into this Session prior to SQLAlchemy 2.0.
-                self.sa_session.add(output_dataset)
                 attach_workflow_step(output_dataset, output_dataset_attrs)
                 workflow_output = output_dataset_attrs["workflow_output"]
                 label = workflow_output.get("label")
@@ -1199,8 +1187,6 @@ class ModelImportStore(metaclass=abc.ABCMeta):
             for output_value_attrs in invocation_attrs["output_values"]:
                 output_value = model.WorkflowInvocationOutputValue()
                 output_value.workflow_invocation = imported_invocation
-                # Safeguard: output_value was implicitly merged into this Session prior to SQLAlchemy 2.0.
-                self.sa_session.add(output_value)
                 output_value.value = output_value_attrs["value"]
                 attach_workflow_step(output_value, output_value_attrs)
                 workflow_output = output_value_attrs["workflow_output"]

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1024,6 +1024,9 @@ class ModelImportStore(metaclass=abc.ABCMeta):
             imported_invocation = model.WorkflowInvocation()
             imported_invocation.user = self.user
             imported_invocation.history = history
+            # Safeguard: imported_invocation was implicitly merged into this Session prior to SQLAlchemy 2.0.
+            if object_session(history):
+                object_session(history).add(imported_invocation)
             workflow_key = invocation_attrs["workflow"]
             if workflow_key not in object_import_tracker.workflows_by_key:
                 raise Exception(f"Failed to find key {workflow_key} in {object_import_tracker.workflows_by_key.keys()}")

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -24,7 +24,6 @@ from sqlalchemy import (
     select,
     true,
 )
-from sqlalchemy.orm import object_session
 from sqlalchemy.orm.exc import NoResultFound
 
 from galaxy import util
@@ -39,6 +38,7 @@ from galaxy.managers import context
 from galaxy.managers.session import GalaxySessionManager
 from galaxy.managers.users import UserManager
 from galaxy.model.base import transaction
+from galaxy.model.database_utils import ensure_object_added_to_session
 from galaxy.structured_app import (
     BasicSharedApp,
     MinimalApp,
@@ -1120,9 +1120,7 @@ def create_new_session(trans, prev_galaxy_session=None, user_for_new_session=Non
     if user_for_new_session:
         # The new session should be associated with the user
         galaxy_session.user = user_for_new_session
-        # Safeguard: galaxy_session was implicitly merged into this Session prior to SQLAlchemy 2.0.
-        if user_for_new_session and object_session(user_for_new_session):
-            object_session(user_for_new_session).add(galaxy_session)
+        ensure_object_added_to_session(galaxy_session, object_in_session=user_for_new_session)
     return galaxy_session
 
 

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -24,6 +24,7 @@ from sqlalchemy import (
     select,
     true,
 )
+from sqlalchemy.orm import object_session
 from sqlalchemy.orm.exc import NoResultFound
 
 from galaxy import util
@@ -1119,6 +1120,9 @@ def create_new_session(trans, prev_galaxy_session=None, user_for_new_session=Non
     if user_for_new_session:
         # The new session should be associated with the user
         galaxy_session.user = user_for_new_session
+        # Safeguard: galaxy_session was implicitly merged into this Session prior to SQLAlchemy 2.0.
+        if user_for_new_session and object_session(user_for_new_session):
+            object_session(user_for_new_session).add(galaxy_session)
     return galaxy_session
 
 

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -37,8 +37,10 @@ from galaxy.exceptions import (
 from galaxy.managers import context
 from galaxy.managers.session import GalaxySessionManager
 from galaxy.managers.users import UserManager
-from galaxy.model.base import transaction
-from galaxy.model.database_utils import ensure_object_added_to_session
+from galaxy.model.base import (
+    ensure_object_added_to_session,
+    transaction,
+)
 from galaxy.structured_app import (
     BasicSharedApp,
     MinimalApp,

--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -9,6 +9,7 @@ from galaxy import (
     model,
 )
 from galaxy.model.base import transaction
+from galaxy.model.database_utils import ensure_object_added_to_session
 from galaxy.tool_util.parser import ToolOutputCollectionPart
 from galaxy.tools.parameters.basic import (
     DataCollectionToolParameter,
@@ -71,8 +72,7 @@ def extract_workflow(
     workflow.stored_workflow = stored
     stored.latest_workflow = workflow
     trans.sa_session.add(stored)
-    # Safeguard: workflow was implicitly merged into this Session prior to SQLAlchemy 2.0.
-    trans.sa_session.add(workflow)
+    ensure_object_added_to_session(workflow, session=trans.sa_session)
     with transaction(trans.sa_session):
         trans.sa_session.commit()
     return stored

--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -71,6 +71,8 @@ def extract_workflow(
     workflow.stored_workflow = stored
     stored.latest_workflow = workflow
     trans.sa_session.add(stored)
+    # Safeguard: workflow was implicitly merged into this Session prior to SQLAlchemy 2.0.
+    trans.sa_session.add(workflow)
     with transaction(trans.sa_session):
         trans.sa_session.commit()
     return stored

--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -8,8 +8,10 @@ from galaxy import (
     exceptions,
     model,
 )
-from galaxy.model.base import transaction
-from galaxy.model.database_utils import ensure_object_added_to_session
+from galaxy.model.base import (
+    ensure_object_added_to_session,
+    transaction,
+)
 from galaxy.tool_util.parser import ToolOutputCollectionPart
 from galaxy.tools.parameters.basic import (
     DataCollectionToolParameter,

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -18,7 +18,6 @@ from typing import (
 )
 
 from cwl_utils.expression import do_eval
-from sqlalchemy.orm import object_session
 from typing_extensions import TypedDict
 
 from galaxy import (
@@ -36,6 +35,7 @@ from galaxy.model import (
     WorkflowStep,
     WorkflowStepConnection,
 )
+from galaxy.model.database_utils import ensure_object_added_to_session
 from galaxy.model.dataset_collections import matching
 from galaxy.schema.invocation import (
     CancelReason,
@@ -645,9 +645,7 @@ class SubWorkflowModule(WorkflowModule):
     def save_to_step(self, step, **kwd):
         step.type = self.type
         step.subworkflow = self.subworkflow
-        # Safeguard: step was implicitly merged into this Session prior to SQLAlchemy 2.0.
-        if self.subworkflow and object_session(self.subworkflow):
-            object_session(self.subworkflow).add(step)
+        ensure_object_added_to_session(step, object_in_session=self.subworkflow)
 
     def get_name(self):
         if hasattr(self.subworkflow, "name"):

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -18,6 +18,7 @@ from typing import (
 )
 
 from cwl_utils.expression import do_eval
+from sqlalchemy.orm import object_session
 from typing_extensions import TypedDict
 
 from galaxy import (
@@ -644,6 +645,9 @@ class SubWorkflowModule(WorkflowModule):
     def save_to_step(self, step, **kwd):
         step.type = self.type
         step.subworkflow = self.subworkflow
+        # Safeguard: step was implicitly merged into this Session prior to SQLAlchemy 2.0.
+        if self.subworkflow and object_session(self.subworkflow):
+            object_session(self.subworkflow).add(step)
 
     def get_name(self):
         if hasattr(self.subworkflow, "name"):

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -35,7 +35,7 @@ from galaxy.model import (
     WorkflowStep,
     WorkflowStepConnection,
 )
-from galaxy.model.database_utils import ensure_object_added_to_session
+from galaxy.model.base import ensure_object_added_to_session
 from galaxy.model.dataset_collections import matching
 from galaxy.schema.invocation import (
     CancelReason,

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -18,8 +18,10 @@ from galaxy.model import (
     WorkflowInvocation,
     WorkflowInvocationStep,
 )
-from galaxy.model.base import transaction
-from galaxy.model.database_utils import ensure_object_added_to_session
+from galaxy.model.base import (
+    ensure_object_added_to_session,
+    transaction,
+)
 from galaxy.schema.invocation import (
     CancelReason,
     FailureReason,

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -10,6 +10,7 @@ from typing import (
     Union,
 )
 
+from sqlalchemy.orm import object_session
 from typing_extensions import Protocol
 
 from galaxy import model
@@ -225,6 +226,9 @@ class WorkflowInvoker:
                     workflow_invocation_step = WorkflowInvocationStep()
                     assert workflow_invocation_step
                     workflow_invocation_step.workflow_invocation = workflow_invocation
+                    # Safeguard: workflow_invocation_step was implicitly merged into this Session prior to SQLAlchemy 2.0.
+                    if workflow_invocation and object_session(workflow_invocation):
+                        object_session(workflow_invocation).add(workflow_invocation_step)
                     workflow_invocation_step.workflow_step = step
                     workflow_invocation_step.state = "new"
 

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -10,7 +10,6 @@ from typing import (
     Union,
 )
 
-from sqlalchemy.orm import object_session
 from typing_extensions import Protocol
 
 from galaxy import model
@@ -20,6 +19,7 @@ from galaxy.model import (
     WorkflowInvocationStep,
 )
 from galaxy.model.base import transaction
+from galaxy.model.database_utils import ensure_object_added_to_session
 from galaxy.schema.invocation import (
     CancelReason,
     FailureReason,
@@ -226,9 +226,7 @@ class WorkflowInvoker:
                     workflow_invocation_step = WorkflowInvocationStep()
                     assert workflow_invocation_step
                     workflow_invocation_step.workflow_invocation = workflow_invocation
-                    # Safeguard: workflow_invocation_step was implicitly merged into this Session prior to SQLAlchemy 2.0.
-                    if workflow_invocation and object_session(workflow_invocation):
-                        object_session(workflow_invocation).add(workflow_invocation_step)
+                    ensure_object_added_to_session(workflow_invocation_step, object_in_session=workflow_invocation)
                     workflow_invocation_step.workflow_step = step
                     workflow_invocation_step.state = "new"
 

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -21,8 +21,10 @@ from galaxy.model import (
     WorkflowRequestInputParameter,
     WorkflowRequestStepState,
 )
-from galaxy.model.base import transaction
-from galaxy.model.database_utils import ensure_object_added_to_session
+from galaxy.model.base import (
+    ensure_object_added_to_session,
+    transaction,
+)
 from galaxy.tools.parameters.meta import expand_workflow_inputs
 from galaxy.workflow.resources import get_resource_mapper_function
 

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -9,6 +9,8 @@ from typing import (
     TYPE_CHECKING,
 )
 
+from sqlalchemy.orm import object_session
+
 from galaxy import exceptions
 from galaxy.model import (
     EffectiveOutput,
@@ -486,6 +488,9 @@ def workflow_run_config_to_request(
     workflow_invocation = WorkflowInvocation()
     workflow_invocation.uuid = uuid.uuid1()
     workflow_invocation.history = run_config.target_history
+    # Safeguard: workflow_invocation was implicitly merged into this Session prior to SQLAlchemy 2.0.
+    if run_config.target_history and object_session(run_config.target_history):
+        object_session(run_config.target_history).add(workflow_invocation)
 
     def add_parameter(name: str, value: str, type: WorkflowRequestInputParameter.types) -> None:
         parameter = WorkflowRequestInputParameter(

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -9,8 +9,6 @@ from typing import (
     TYPE_CHECKING,
 )
 
-from sqlalchemy.orm import object_session
-
 from galaxy import exceptions
 from galaxy.model import (
     EffectiveOutput,
@@ -24,6 +22,7 @@ from galaxy.model import (
     WorkflowRequestStepState,
 )
 from galaxy.model.base import transaction
+from galaxy.model.database_utils import ensure_object_added_to_session
 from galaxy.tools.parameters.meta import expand_workflow_inputs
 from galaxy.workflow.resources import get_resource_mapper_function
 
@@ -488,9 +487,7 @@ def workflow_run_config_to_request(
     workflow_invocation = WorkflowInvocation()
     workflow_invocation.uuid = uuid.uuid1()
     workflow_invocation.history = run_config.target_history
-    # Safeguard: workflow_invocation was implicitly merged into this Session prior to SQLAlchemy 2.0.
-    if run_config.target_history and object_session(run_config.target_history):
-        object_session(run_config.target_history).add(workflow_invocation)
+    ensure_object_added_to_session(workflow_invocation, object_in_session=run_config.target_history)
 
     def add_parameter(name: str, value: str, type: WorkflowRequestInputParameter.types) -> None:
         parameter = WorkflowRequestInputParameter(

--- a/test/integration/test_job_files.py
+++ b/test/integration/test_job_files.py
@@ -22,8 +22,10 @@ import requests
 from sqlalchemy import select
 
 from galaxy import model
-from galaxy.model.base import transaction
-from galaxy.model.database_utils import ensure_object_added_to_session
+from galaxy.model.base import (
+    ensure_object_added_to_session,
+    transaction,
+)
 from galaxy_test.base import api_asserts
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util

--- a/test/integration/test_job_files.py
+++ b/test/integration/test_job_files.py
@@ -20,6 +20,7 @@ import tempfile
 
 import requests
 from sqlalchemy import select
+from sqlalchemy.orm import object_session
 
 from galaxy import model
 from galaxy.model.base import transaction
@@ -138,6 +139,8 @@ class TestJobFilesIntegration(integration_util.IntegrationTestCase):
             sa_session.commit()
         job = model.Job()
         job.history = history
+        # Safeguard: job was implicitly merged into this Session prior to SQLAlchemy 2.0.
+        object_session(history).add(job)
         job.user = user
         job.handler = "unknown-handler"
         job.state = state

--- a/test/integration/test_job_files.py
+++ b/test/integration/test_job_files.py
@@ -20,10 +20,10 @@ import tempfile
 
 import requests
 from sqlalchemy import select
-from sqlalchemy.orm import object_session
 
 from galaxy import model
 from galaxy.model.base import transaction
+from galaxy.model.database_utils import ensure_object_added_to_session
 from galaxy_test.base import api_asserts
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
@@ -139,8 +139,7 @@ class TestJobFilesIntegration(integration_util.IntegrationTestCase):
             sa_session.commit()
         job = model.Job()
         job.history = history
-        # Safeguard: job was implicitly merged into this Session prior to SQLAlchemy 2.0.
-        object_session(history).add(job)
+        ensure_object_added_to_session(job, object_in_session=history)
         job.user = user
         job.handler = "unknown-handler"
         job.state = state


### PR DESCRIPTION
Ref: #12541  
(SA documentation refs: [1](https://docs.sqlalchemy.org/en/14/errors.html#object-is-being-merged-into-a-session-along-the-backref-cascade), [2](https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#cascade-backrefs-behavior-deprecated-for-removal-in-2-0), [3](https://docs.sqlalchemy.org/en/14/orm/cascades.html#controlling-cascade-on-backrefs))

See the referenced documentation for a detailed description of the issue. This should eliminate 200+ SA2.0 warnings.

Notes:
if a `cascade_backrefs=False` clause is added to the relationship definition without any additional edits, that means that the addition is, most likely, inconsequential - i.e., the object is explicitly added to the appropriate session within the same block of code. Additional safeguard code in the same commit implies that we have to mimic the current behavior to ensure that turning off automated cascading via backref on the relationship will not lead to an object not being added to the session. (I doubt this would happen: judging by our code, we've been careful to add objects to the session explicitly; still, it's not impossible, so adding the safeguard seems a safe temporary step - we can remove it once we're running under SA2.0).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
