### PR TITLE
Vueify Admin Groups Grid

### DIFF
--- a/client/src/api/groups.ts
+++ b/client/src/api/groups.ts
@@ -8,6 +8,6 @@ export async function getAllGroups(): Promise<GroupModel[]> {
     return data;
 }
 
-export const deleteGroup = fetcher.path("/api/groups/{id}").method("delete").create();
-export const purgeGroup = fetcher.path("/api/groups/{id}/purge").method("post").create();
-export const undeleteGroup = fetcher.path("/api/groups/{id}/undelete").method("post").create();
+export const deleteGroup = fetcher.path("/api/groups/{group_id}").method("delete").create();
+export const purgeGroup = fetcher.path("/api/groups/{group_id}/purge").method("post").create();
+export const undeleteGroup = fetcher.path("/api/groups/{group_id}/undelete").method("post").create();

--- a/client/src/api/groups.ts
+++ b/client/src/api/groups.ts
@@ -1,9 +1,13 @@
 import axios from "axios";
 
-import { components } from "@/api/schema";
+import { components, fetcher } from "@/api/schema";
 
 type GroupModel = components["schemas"]["GroupModel"];
 export async function getAllGroups(): Promise<GroupModel[]> {
     const { data } = await axios.get("/api/groups");
     return data;
 }
+
+export const deleteGroup = fetcher.path("/api/groups/{id}").method("delete").create();
+export const purgeGroup = fetcher.path("/api/groups/{id}/purge").method("post").create();
+export const undeleteGroup = fetcher.path("/api/groups/{id}/undelete").method("post").create();

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -451,6 +451,18 @@ export interface paths {
          */
         delete: operations["delete_api_groups__group_id__users__user_id__delete"];
     };
+    "/api/groups/{id}": {
+        /** Delete */
+        delete: operations["delete_api_groups__id__delete"];
+    };
+    "/api/groups/{id}/purge": {
+        /** Purge */
+        post: operations["purge_api_groups__id__purge_post"];
+    };
+    "/api/groups/{id}/undelete": {
+        /** Undelete */
+        post: operations["undelete_api_groups__id__undelete_post"];
+    };
     "/api/help/forum/search": {
         /**
          * Search the Galaxy Help forum.
@@ -12375,6 +12387,84 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["GroupUserResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_api_groups__id__delete: {
+        /** Delete */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    purge_api_groups__id__purge_post: {
+        /** Purge */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    undelete_api_groups__id__undelete_post: {
+        /** Undelete */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -392,6 +392,12 @@ export interface paths {
         get: operations["show_group_api_groups__group_id__get"];
         /** Modifies a group. */
         put: operations["update_api_groups__group_id__put"];
+        /** Delete */
+        delete: operations["delete_api_groups__group_id__delete"];
+    };
+    "/api/groups/{group_id}/purge": {
+        /** Purge */
+        post: operations["purge_api_groups__group_id__purge_post"];
     };
     "/api/groups/{group_id}/roles": {
         /** Displays a collection (list) of groups. */
@@ -404,6 +410,10 @@ export interface paths {
         put: operations["update_api_groups__group_id__roles__role_id__put"];
         /** Removes a role from a group */
         delete: operations["delete_api_groups__group_id__roles__role_id__delete"];
+    };
+    "/api/groups/{group_id}/undelete": {
+        /** Undelete */
+        post: operations["undelete_api_groups__group_id__undelete_post"];
     };
     "/api/groups/{group_id}/user/{user_id}": {
         /**
@@ -450,18 +460,6 @@ export interface paths {
          * Removes a user from a group
          */
         delete: operations["delete_api_groups__group_id__users__user_id__delete"];
-    };
-    "/api/groups/{id}": {
-        /** Delete */
-        delete: operations["delete_api_groups__id__delete"];
-    };
-    "/api/groups/{id}/purge": {
-        /** Purge */
-        post: operations["purge_api_groups__id__purge_post"];
-    };
-    "/api/groups/{id}/undelete": {
-        /** Undelete */
-        post: operations["undelete_api_groups__id__undelete_post"];
     };
     "/api/help/forum/search": {
         /**
@@ -12056,6 +12054,58 @@ export interface operations {
             };
         };
     };
+    delete_api_groups__group_id__delete: {
+        /** Delete */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                group_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    purge_api_groups__group_id__purge_post: {
+        /** Purge */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                group_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     group_roles_api_groups__group_id__roles_get: {
         /** Displays a collection (list) of groups. */
         parameters: {
@@ -12160,6 +12210,32 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["GroupRoleResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    undelete_api_groups__group_id__undelete_post: {
+        /** Undelete */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            path: {
+                group_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -12387,84 +12463,6 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["GroupUserResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_api_groups__id__delete: {
-        /** Delete */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            path: {
-                id: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": Record<string, never>;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    purge_api_groups__id__purge_post: {
-        /** Purge */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            path: {
-                id: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": Record<string, never>;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    undelete_api_groups__id__undelete_post: {
-        /** Undelete */
-        parameters: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            path: {
-                id: string;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */

--- a/client/src/components/Grid/GridList.vue
+++ b/client/src/components/Grid/GridList.vue
@@ -27,6 +27,8 @@ library.add(faCaretDown, faCaretUp, faShieldAlt);
 interface Props {
     // provide a grid configuration
     gridConfig: GridConfig;
+    // incoming initial message
+    gridMessage?: string;
     // debounce delay
     delay?: number;
     // rows per page to be shown
@@ -78,6 +80,16 @@ function applyFilter(filter: string, value: string | boolean, quoted = false) {
     const quotedValue = quoted ? `'${value}'` : value;
     if (filtering) {
         filterText.value = filtering.setFilterValue(filterText.value, filter, quotedValue.toString()) || "";
+    }
+}
+
+/**
+ * Display initial message parsed through route query
+ */
+function displayInitialMessage() {
+    if (props.gridMessage) {
+        operationMessage.value = props.gridMessage;
+        operationStatus.value = "success";
     }
 }
 
@@ -164,6 +176,7 @@ function onFilter(filter?: string) {
 onMounted(() => {
     getGridData();
     eventBus.on(onRouterPush);
+    displayInitialMessage();
 });
 
 onUnmounted(() => {

--- a/client/src/components/Grid/configs/adminGroups.ts
+++ b/client/src/components/Grid/configs/adminGroups.ts
@@ -4,6 +4,7 @@ import axios from "axios";
 
 import { deleteGroup, purgeGroup, undeleteGroup } from "@/api/groups";
 import Filtering, { contains, equals, toBool, type ValidFilter } from "@/utils/filtering";
+import _l from "@/utils/localization";
 import { withPrefix } from "@/utils/redirect";
 import { errorMessageAsString } from "@/utils/simple-error";
 
@@ -75,17 +76,19 @@ const fields: FieldArray = [
                 icon: faTrash,
                 condition: (data: GroupEntry) => !data.deleted,
                 handler: async (data: GroupEntry) => {
-                    try {
-                        await deleteGroup({ group_id: String(data.id) });
-                        return {
-                            status: "success",
-                            message: `'${data.name}' has been deleted.`,
-                        };
-                    } catch (e) {
-                        return {
-                            status: "danger",
-                            message: `Failed to delete '${data.name}': ${errorMessageAsString(e)}`,
-                        };
+                    if (confirm(_l("Are you sure that you want to delete this group?"))) {
+                        try {
+                            await deleteGroup({ group_id: String(data.id) });
+                            return {
+                                status: "success",
+                                message: `'${data.name}' has been deleted.`,
+                            };
+                        } catch (e) {
+                            return {
+                                status: "danger",
+                                message: `Failed to delete '${data.name}': ${errorMessageAsString(e)}`,
+                            };
+                        }
                     }
                 },
             },
@@ -94,17 +97,19 @@ const fields: FieldArray = [
                 icon: faTrash,
                 condition: (data: GroupEntry) => !!data.deleted,
                 handler: async (data: GroupEntry) => {
-                    try {
-                        await purgeGroup({ group_id: String(data.id) });
-                        return {
-                            status: "success",
-                            message: `'${data.name}' has been purged.`,
-                        };
-                    } catch (e) {
-                        return {
-                            status: "danger",
-                            message: `Failed to purge '${data.name}': ${errorMessageAsString(e)}`,
-                        };
+                    if (confirm(_l("Are you sure that you want to purge this group?"))) {
+                        try {
+                            await purgeGroup({ group_id: String(data.id) });
+                            return {
+                                status: "success",
+                                message: `'${data.name}' has been purged.`,
+                            };
+                        } catch (e) {
+                            return {
+                                status: "danger",
+                                message: `Failed to purge '${data.name}': ${errorMessageAsString(e)}`,
+                            };
+                        }
                     }
                 },
             },

--- a/client/src/components/Grid/configs/adminGroups.ts
+++ b/client/src/components/Grid/configs/adminGroups.ts
@@ -76,7 +76,7 @@ const fields: FieldArray = [
                 condition: (data: GroupEntry) => !data.deleted,
                 handler: async (data: GroupEntry) => {
                     try {
-                        await deleteGroup({ id: String(data.id) });
+                        await deleteGroup({ group_id: String(data.id) });
                         return {
                             status: "success",
                             message: `'${data.name}' has been deleted.`,
@@ -95,7 +95,7 @@ const fields: FieldArray = [
                 condition: (data: GroupEntry) => !!data.deleted,
                 handler: async (data: GroupEntry) => {
                     try {
-                        await purgeGroup({ id: String(data.id) });
+                        await purgeGroup({ group_id: String(data.id) });
                         return {
                             status: "success",
                             message: `'${data.name}' has been purged.`,
@@ -114,7 +114,7 @@ const fields: FieldArray = [
                 condition: (data: GroupEntry) => !!data.deleted,
                 handler: async (data: GroupEntry) => {
                     try {
-                        await undeleteGroup({ id: String(data.id) });
+                        await undeleteGroup({ group_id: String(data.id) });
                         return {
                             status: "success",
                             message: `'${data.name}' has been restored.`,

--- a/client/src/components/Grid/configs/adminGroups.ts
+++ b/client/src/components/Grid/configs/adminGroups.ts
@@ -1,0 +1,176 @@
+import { faEdit, faKey, faPlus, faTrash, faTrashRestore } from "@fortawesome/free-solid-svg-icons";
+import { useEventBus } from "@vueuse/core";
+import axios from "axios";
+
+import { deleteGroup, purgeGroup, undeleteGroup } from "@/api/groups";
+import Filtering, { contains, equals, toBool, type ValidFilter } from "@/utils/filtering";
+import { withPrefix } from "@/utils/redirect";
+import { errorMessageAsString } from "@/utils/simple-error";
+
+import type { ActionArray, FieldArray, GridConfig } from "./types";
+
+const { emit } = useEventBus<string>("grid-router-push");
+
+/**
+ * Local types
+ */
+type GroupEntry = Record<string, unknown>;
+
+/**
+ * Request and return data from server
+ */
+async function getData(offset: number, limit: number, search: string, sort_by: string, sort_desc: boolean) {
+    const query = {
+        limit: String(limit),
+        offset: String(offset),
+        search: search,
+        sort_by: sort_by,
+        sort_desc: String(sort_desc),
+    };
+    const queryString = new URLSearchParams(query).toString();
+    const { data } = await axios.get(withPrefix(`/admin/groups_list?${queryString}`));
+    return [data.rows, data.rows_total];
+}
+
+/**
+ * Actions are grid-wide operations
+ */
+const actions: ActionArray = [
+    {
+        title: "Create New Group",
+        icon: faPlus,
+        handler: () => {
+            emit("/admin/form/create_group");
+        },
+    },
+];
+
+/**
+ * Declare columns to be displayed
+ */
+const fields: FieldArray = [
+    {
+        key: "name",
+        title: "Name",
+        type: "operations",
+        operations: [
+            {
+                title: "Edit Name/Description",
+                icon: faEdit,
+                condition: (data: GroupEntry) => !data.deleted,
+                handler: (data: GroupEntry) => {
+                    emit(`/admin/form/rename_group?id=${data.id}`);
+                },
+            },
+            {
+                title: "Edit Permissions",
+                icon: faKey,
+                condition: (data: GroupEntry) => !data.deleted,
+                handler: (data: GroupEntry) => {
+                    emit(`/admin/form/manage_users_and_groups_for_role?id=${data.id}`);
+                },
+            },
+            {
+                title: "Delete",
+                icon: faTrash,
+                condition: (data: GroupEntry) => !data.deleted,
+                handler: async (data: GroupEntry) => {
+                    try {
+                        await deleteGroup({ id: String(data.id) });
+                        return {
+                            status: "success",
+                            message: `'${data.name}' has been deleted.`,
+                        };
+                    } catch (e) {
+                        return {
+                            status: "danger",
+                            message: `Failed to delete '${data.name}': ${errorMessageAsString(e)}`,
+                        };
+                    }
+                },
+            },
+            {
+                title: "Purge",
+                icon: faTrash,
+                condition: (data: GroupEntry) => !!data.deleted,
+                handler: async (data: GroupEntry) => {
+                    try {
+                        await purgeGroup({ id: String(data.id) });
+                        return {
+                            status: "success",
+                            message: `'${data.name}' has been purged.`,
+                        };
+                    } catch (e) {
+                        return {
+                            status: "danger",
+                            message: `Failed to purge '${data.name}': ${errorMessageAsString(e)}`,
+                        };
+                    }
+                },
+            },
+            {
+                title: "Restore",
+                icon: faTrashRestore,
+                condition: (data: GroupEntry) => !!data.deleted,
+                handler: async (data: GroupEntry) => {
+                    try {
+                        await undeleteGroup({ id: String(data.id) });
+                        return {
+                            status: "success",
+                            message: `'${data.name}' has been restored.`,
+                        };
+                    } catch (e) {
+                        return {
+                            status: "danger",
+                            message: `Failed to restore '${data.name}': ${errorMessageAsString(e)}`,
+                        };
+                    }
+                },
+            },
+        ],
+    },
+    {
+        key: "roles",
+        title: "Roles",
+        type: "text",
+    },
+    {
+        key: "users",
+        title: "Users",
+        type: "text",
+    },
+    {
+        key: "update_time",
+        title: "Updated",
+        type: "date",
+    },
+];
+
+const validFilters: Record<string, ValidFilter<string | boolean | undefined>> = {
+    name: { placeholder: "name", type: String, handler: contains("name"), menuItem: true },
+    deleted: {
+        placeholder: "Filter on deleted entries",
+        type: Boolean,
+        boolType: "is",
+        handler: equals("deleted", "deleted", toBool),
+        menuItem: true,
+    },
+};
+
+/**
+ * Grid configuration
+ */
+const gridConfig: GridConfig = {
+    id: "groups-grid",
+    actions: actions,
+    fields: fields,
+    filtering: new Filtering(validFilters, undefined, false, false),
+    getData: getData,
+    plural: "Groups",
+    sortBy: "name",
+    sortDesc: true,
+    sortKeys: ["name", "update_time"],
+    title: "Groups",
+};
+
+export default gridConfig;

--- a/client/src/components/Grid/configs/adminGroups.ts
+++ b/client/src/components/Grid/configs/adminGroups.ts
@@ -55,7 +55,7 @@ const fields: FieldArray = [
         type: "operations",
         operations: [
             {
-                title: "Edit Name/Description",
+                title: "Edit Name",
                 icon: faEdit,
                 condition: (data: GroupEntry) => !data.deleted,
                 handler: (data: GroupEntry) => {
@@ -67,7 +67,7 @@ const fields: FieldArray = [
                 icon: faKey,
                 condition: (data: GroupEntry) => !data.deleted,
                 handler: (data: GroupEntry) => {
-                    emit(`/admin/form/manage_users_and_groups_for_role?id=${data.id}`);
+                    emit(`/admin/form/manage_users_and_roles_for_group?id=${data.id}`);
                 },
             },
             {

--- a/client/src/components/Grid/configs/adminRoles.ts
+++ b/client/src/components/Grid/configs/adminRoles.ts
@@ -4,6 +4,7 @@ import axios from "axios";
 
 import { deleteRole, purgeRole, undeleteRole } from "@/api/roles";
 import Filtering, { contains, equals, toBool, type ValidFilter } from "@/utils/filtering";
+import _l from "@/utils/localization";
 import { withPrefix } from "@/utils/redirect";
 import { errorMessageAsString } from "@/utils/simple-error";
 
@@ -75,17 +76,19 @@ const fields: FieldArray = [
                 icon: faTrash,
                 condition: (data: RoleEntry) => !data.deleted,
                 handler: async (data: RoleEntry) => {
-                    try {
-                        await deleteRole({ id: String(data.id) });
-                        return {
-                            status: "success",
-                            message: `'${data.name}' has been deleted.`,
-                        };
-                    } catch (e) {
-                        return {
-                            status: "danger",
-                            message: `Failed to delete '${data.name}': ${errorMessageAsString(e)}`,
-                        };
+                    if (confirm(_l("Are you sure that you want to delete this role?"))) {
+                        try {
+                            await deleteRole({ id: String(data.id) });
+                            return {
+                                status: "success",
+                                message: `'${data.name}' has been deleted.`,
+                            };
+                        } catch (e) {
+                            return {
+                                status: "danger",
+                                message: `Failed to delete '${data.name}': ${errorMessageAsString(e)}`,
+                            };
+                        }
                     }
                 },
             },
@@ -94,17 +97,19 @@ const fields: FieldArray = [
                 icon: faTrash,
                 condition: (data: RoleEntry) => !!data.deleted,
                 handler: async (data: RoleEntry) => {
-                    try {
-                        await purgeRole({ id: String(data.id) });
-                        return {
-                            status: "success",
-                            message: `'${data.name}' has been purged.`,
-                        };
-                    } catch (e) {
-                        return {
-                            status: "danger",
-                            message: `Failed to purge '${data.name}': ${errorMessageAsString(e)}`,
-                        };
+                    if (confirm(_l("Are you sure that you want to purge this role?"))) {
+                        try {
+                            await purgeRole({ id: String(data.id) });
+                            return {
+                                status: "success",
+                                message: `'${data.name}' has been purged.`,
+                            };
+                        } catch (e) {
+                            return {
+                                status: "danger",
+                                message: `Failed to purge '${data.name}': ${errorMessageAsString(e)}`,
+                            };
+                        }
                     }
                 },
             },

--- a/client/src/entry/analysis/routes/admin-routes.js
+++ b/client/src/entry/analysis/routes/admin-routes.js
@@ -137,9 +137,10 @@ export default [
             {
                 path: "groups",
                 component: GridList,
-                props: {
+                props: (route) => ({
                     gridConfig: adminGroupsGridConfig,
-                },
+                    gridMessage: route.query.message,
+                }),
             },
             {
                 path: "quotas",
@@ -151,16 +152,18 @@ export default [
             {
                 path: "roles",
                 component: GridList,
-                props: {
+                props: (route) => ({
                     gridConfig: adminRolesGridConfig,
-                },
+                    gridMessage: route.query.message,
+                }),
             },
             {
                 path: "users",
                 component: GridList,
-                props: {
+                props: (route) => ({
                     gridConfig: adminUsersGridConfig,
-                },
+                    gridMessage: route.query.message,
+                }),
             },
             {
                 path: "tool_versions",

--- a/client/src/entry/analysis/routes/admin-routes.js
+++ b/client/src/entry/analysis/routes/admin-routes.js
@@ -18,6 +18,7 @@ import NotificationsManagement from "components/admin/Notifications/Notification
 import ResetMetadata from "components/admin/ResetMetadata";
 import SanitizeAllow from "components/admin/SanitizeAllow";
 import FormGeneric from "components/Form/FormGeneric";
+import adminGroupsGridConfig from "components/Grid/configs/adminGroups";
 import adminRolesGridConfig from "components/Grid/configs/adminRoles";
 import adminUsersGridConfig from "components/Grid/configs/adminUsers";
 import Grid from "components/Grid/Grid";
@@ -135,9 +136,9 @@ export default [
             },
             {
                 path: "groups",
-                component: Grid,
+                component: GridList,
                 props: {
-                    urlBase: "admin/groups_list",
+                    gridConfig: adminGroupsGridConfig,
                 },
             },
             {

--- a/client/src/entry/analysis/routes/admin-routes.js
+++ b/client/src/entry/analysis/routes/admin-routes.js
@@ -195,7 +195,7 @@ export default [
                 component: FormGeneric,
                 props: (route) => ({
                     url: `/admin/manage_users_and_groups_for_role?id=${route.query.id}`,
-                    redirect: "/admin/users",
+                    redirect: "/admin/roles",
                 }),
             },
             {
@@ -203,7 +203,7 @@ export default [
                 component: FormGeneric,
                 props: (route) => ({
                     url: `/admin/manage_users_and_roles_for_group?id=${route.query.id}`,
-                    redirect: "/admin/users",
+                    redirect: "/admin/groups",
                 }),
             },
             {

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -956,7 +956,7 @@ admin:
     dm_table_card: '#data-table-card'
     users_grid: '#users-grid'
     users_grid_create_button: '[data-description="grid action create new user"]'
-    groups_grid_create_button: '.manage-table-actions .action-button'
+    groups_grid_create_button: '[data-description="grid action create new group"]'
     registration_form: 'form#registration'
     groups_grid: '#groups-grid'
     roles_grid: '#roles-grid'

--- a/lib/galaxy/managers/groups.py
+++ b/lib/galaxy/managers/groups.py
@@ -9,6 +9,7 @@ from galaxy.exceptions import (
     Conflict,
     ObjectAttributeMissingException,
     ObjectNotFound,
+    RequestParameterInvalidException,
 )
 from galaxy.managers.context import ProvidesAppContext
 from galaxy.managers.roles import get_roles_by_ids
@@ -111,8 +112,8 @@ class GroupsManager:
     def purge(self, trans: ProvidesAppContext, group_id: int):
         group = self._get_group(trans.sa_session, group_id)
         if not group.deleted:
-            raise galaxy.exceptions.RequestParameterInvalidException(
-                f"Group '{groups.name}' has not been deleted, so it cannot be purged."
+            raise RequestParameterInvalidException(
+                f"Group '{group.name}' has not been deleted, so it cannot be purged."
             )
         # Delete UserGroupAssociations
         for uga in group.users:
@@ -126,8 +127,8 @@ class GroupsManager:
     def undelete(self, trans: ProvidesAppContext, group_id: int):
         group = self._get_group(trans.sa_session, group_id)
         if not group.deleted:
-            raise galaxy.exceptions.RequestParameterInvalidException(
-                f"Group '{groups.name}' has not been deleted, so it cannot be undeleted."
+            raise RequestParameterInvalidException(
+                f"Group '{group.name}' has not been deleted, so it cannot be undeleted."
             )
         group.deleted = False
         trans.sa_session.add(group)

--- a/lib/galaxy/web/framework/helpers/grids.py
+++ b/lib/galaxy/web/framework/helpers/grids.py
@@ -1114,9 +1114,3 @@ class GridData:
 
     def build_initial_query(self, trans, **kwargs):
         return trans.sa_session.query(self.model_class)
-
-    def apply_query_filter(self, trans, query, **kwargs):
-        # Applies a database filter that holds for all items in the grid.
-        # (gvk) Is this method necessary?  Why not simply build the entire query,
-        # including applying filters in the build_initial_query() method?
-        return query

--- a/lib/galaxy/webapps/galaxy/api/groups.py
+++ b/lib/galaxy/webapps/galaxy/api/groups.py
@@ -85,15 +85,12 @@ class FastAPIGroups:
 
     @router.delete("/api/groups/{id}", require_admin=True)
     def delete(self, id: DecodedDatabaseIdField, trans: ProvidesAppContext = DependsOnTrans):
-        group = self.manager.get(trans, id)
-        self.manager.delete(trans, group)
+        self.manager.delete(trans, id)
 
     @router.post("/api/groups/{id}/purge", require_admin=True)
     def purge(self, id: DecodedDatabaseIdField, trans: ProvidesAppContext = DependsOnTrans):
-        group = self.manager.get(trans, id)
-        self.manager.purge(trans, group)
+        self.manager.purge(trans, id)
 
     @router.post("/api/groups/{id}/undelete", require_admin=True)
     def undelete(self, id: DecodedDatabaseIdField, trans: ProvidesAppContext = DependsOnTrans):
-        group = self.manager.get(trans, id)
-        self.manager.undelete(trans, group)
+        self.manager.undelete(trans, id)

--- a/lib/galaxy/webapps/galaxy/api/groups.py
+++ b/lib/galaxy/webapps/galaxy/api/groups.py
@@ -85,12 +85,12 @@ class FastAPIGroups:
 
     @router.delete("/api/groups/{group_id}", require_admin=True)
     def delete(self, group_id: DecodedDatabaseIdField, trans: ProvidesAppContext = DependsOnTrans):
-        self.manager.delete(trans, id)
+        self.manager.delete(trans, group_id)
 
     @router.post("/api/groups/{group_id}/purge", require_admin=True)
     def purge(self, group_id: DecodedDatabaseIdField, trans: ProvidesAppContext = DependsOnTrans):
-        self.manager.purge(trans, id)
+        self.manager.purge(trans, group_id)
 
     @router.post("/api/groups/{group_id}/undelete", require_admin=True)
     def undelete(self, group_id: DecodedDatabaseIdField, trans: ProvidesAppContext = DependsOnTrans):
-        self.manager.undelete(trans, id)
+        self.manager.undelete(trans, group_id)

--- a/lib/galaxy/webapps/galaxy/api/groups.py
+++ b/lib/galaxy/webapps/galaxy/api/groups.py
@@ -82,3 +82,18 @@ class FastAPIGroups:
         payload: GroupCreatePayload = Body(...),
     ) -> GroupResponse:
         return self.manager.update(trans, group_id, payload)
+
+    @router.delete("/api/groups/{id}", require_admin=True)
+    def delete(self, id: DecodedDatabaseIdField, trans: ProvidesAppContext = DependsOnTrans):
+        group = self.manager.get(trans, id)
+        self.manager.delete(trans, group)
+
+    @router.post("/api/groups/{id}/purge", require_admin=True)
+    def purge(self, id: DecodedDatabaseIdField, trans: ProvidesAppContext = DependsOnTrans):
+        group = self.manager.get(trans, id)
+        self.manager.purge(trans, group)
+
+    @router.post("/api/groups/{id}/undelete", require_admin=True)
+    def undelete(self, id: DecodedDatabaseIdField, trans: ProvidesAppContext = DependsOnTrans):
+        group = self.manager.get(trans, id)
+        self.manager.undelete(trans, group)

--- a/lib/galaxy/webapps/galaxy/api/groups.py
+++ b/lib/galaxy/webapps/galaxy/api/groups.py
@@ -83,14 +83,14 @@ class FastAPIGroups:
     ) -> GroupResponse:
         return self.manager.update(trans, group_id, payload)
 
-    @router.delete("/api/groups/{id}", require_admin=True)
-    def delete(self, id: DecodedDatabaseIdField, trans: ProvidesAppContext = DependsOnTrans):
+    @router.delete("/api/groups/{group_id}", require_admin=True)
+    def delete(self, group_id: DecodedDatabaseIdField, trans: ProvidesAppContext = DependsOnTrans):
         self.manager.delete(trans, id)
 
-    @router.post("/api/groups/{id}/purge", require_admin=True)
-    def purge(self, id: DecodedDatabaseIdField, trans: ProvidesAppContext = DependsOnTrans):
+    @router.post("/api/groups/{group_id}/purge", require_admin=True)
+    def purge(self, group_id: DecodedDatabaseIdField, trans: ProvidesAppContext = DependsOnTrans):
         self.manager.purge(trans, id)
 
-    @router.post("/api/groups/{id}/undelete", require_admin=True)
-    def undelete(self, id: DecodedDatabaseIdField, trans: ProvidesAppContext = DependsOnTrans):
+    @router.post("/api/groups/{group_id}/undelete", require_admin=True)
+    def undelete(self, group_id: DecodedDatabaseIdField, trans: ProvidesAppContext = DependsOnTrans):
         self.manager.undelete(trans, id)

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -247,7 +247,7 @@ class GroupListGrid(grids.GridData):
         UsersColumn("Users", key="users"),
         RolesColumn("Roles", key="roles"),
         grids.DeletedColumn("Deleted", key="deleted", escape=False),
-        grids.GridColumn("Last Updated", key="update_time", format=pretty_print_time_interval),
+        grids.GridColumn("Last Updated", key="update_time"),
     ]
 
     def apply_query_filter(self, query, **kwargs):

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -26,7 +26,6 @@ from galaxy.model.index_filter_util import (
 )
 from galaxy.security.validate_user_input import validate_password
 from galaxy.structured_app import StructuredApp
-from galaxy.util import pretty_print_time_interval
 from galaxy.util.search import (
     FilteredTerm,
     parse_filters_structured,


### PR DESCRIPTION
Requires #17118. This PR replaces the legacy groups grid in the admin panel with a GridList module. Operation handlers from the admin controller have been moved to the groups manager and api.

<img width="831" alt="image" src="https://github.com/galaxyproject/galaxy/assets/2105447/3c92ea7c-e3d1-4bc5-b3f6-b9ec9913badc">

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
