### PR TITLE
[23.2] Fix job search when ``command_version`` is None

### DIFF
--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -61,7 +61,7 @@ jobs:
           path: 'galaxy root/.venv'
           key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-toolshed
       - name: Install dependencies
-        run: ./scripts/common_startup.sh --skip-client-build
+        run: ./scripts/common_startup.sh --dev-wheels --skip-client-build
         working-directory: 'galaxy root'
       - name: Build Frontend
         run: |

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -157,7 +157,7 @@ class EncodedDatasetJobInfo(EncodedDataItemSourceId):
 
 
 class EncodedJobDetails(JobSummary):
-    command_version: str = Field(
+    command_version: Optional[str] = Field(
         ...,
         title="Command Version",
         description="Tool version indicated during job execution.",


### PR DESCRIPTION
Fix 500 response when searching jobs via API as seen in BioBlend tests on release_23.2 and dev, e.g.:

https://github.com/galaxyproject/bioblend/actions/runs/7090125691/job/19296402084#step:10:3256

Broken in https://github.com/galaxyproject/galaxy/pull/16778 .

Also:
- Install dev wheels in ToolShed tests. Fix ToolShed tests failing on release branches due to playwright not being installed, e.g. https://github.com/galaxyproject/galaxy/actions/runs/7090013789

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
