### PR TITLE
[23.0] Assert that tus uploader instance has URL

### DIFF
--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -989,6 +989,7 @@ class TestToolsUpload(ApiTestCase):
             # Upload a file to a tus server.
             uploader = my_client.uploader(path, metadata=metadata)
             uploader.upload()
+            assert uploader.url
             return uploader.url.rsplit("/", 1)[1]
 
         with self.dataset_populator.test_history() as history_id:


### PR DESCRIPTION
Newer tusclient package allows passing in client in which case url can be None.

Fixes package tests.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
