### PR TITLE
[23.2] Enhance xsd schema and allow simpler assertion lists

### DIFF
--- a/lib/galaxy/tool_util/parser/yaml.py
+++ b/lib/galaxy/tool_util/parser/yaml.py
@@ -267,7 +267,7 @@ def _parse_test(i, test_dict) -> ToolSourceTest:
     return test_dict
 
 
-def __to_test_assert_list(assertions) -> AssertionList:
+def to_test_assert_list(assertions) -> AssertionList:
     def expand_dict_form(item):
         key, value = item
         new_value = value.copy()
@@ -281,6 +281,12 @@ def __to_test_assert_list(assertions) -> AssertionList:
     for assertion in assertions:
         # TODO: not handling nested assertions correctly,
         # not sure these are used though.
+        if "that" not in assertion:
+            new_assertion = {}
+            for assertion_key, assertion_value in assertion.items():
+                new_assertion["that"] = assertion_key
+                new_assertion.update(assertion_value)
+            assertion = new_assertion
         children = []
         if "children" in assertion:
             children = assertion["children"]
@@ -293,6 +299,9 @@ def __to_test_assert_list(assertions) -> AssertionList:
         assert_list.append(assert_dict)
 
     return assert_list or None  # XML variant is None if no assertions made
+
+
+__to_test_assert_list = to_test_assert_list
 
 
 class YamlPageSource(PageSource):

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -7322,24 +7322,39 @@ and ``contains``. In addition there is ``sim_size`` which is discouraged in favo
     <xs:annotation>
       <xs:documentation xml:lang="en">Documentation for PermissiveBoolean</xs:documentation>
     </xs:annotation>
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="0"/>
-      <xs:enumeration value="1"/>
-      <xs:enumeration value="true"/>
-      <xs:enumeration value="false"/>
-      <xs:enumeration value="True"/>
-      <xs:enumeration value="False"/>
-      <xs:enumeration value="yes"/>
-      <xs:enumeration value="no"/>
-    </xs:restriction>
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:boolean"/>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="0"/>
+          <xs:enumeration value="1"/>
+          <xs:enumeration value="true"/>
+          <xs:enumeration value="false"/>
+          <xs:enumeration value="True"/>
+          <xs:enumeration value="False"/>
+          <xs:enumeration value="yes"/>
+          <xs:enumeration value="no"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
   </xs:simpleType>
   <xs:simpleType name="Bytes">
     <xs:annotation>
       <xs:documentation xml:lang="en">Number of bytes allowing for suffix (k|K|M|G|P|E)i? </xs:documentation>
     </xs:annotation>
-    <xs:restriction base="xs:string">
-      <xs:pattern value="(0|[1-9][0-9]*)([kKMGTPE]i?)?"></xs:pattern>
-    </xs:restriction>
+    <xs:union>
+       <xs:simpleType>
+         <xs:restriction base="xs:integer">
+         </xs:restriction>
+       </xs:simpleType>
+       <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:pattern value="(0|[1-9][0-9]*)([kKMGTPE]i?)?"></xs:pattern>
+         </xs:restriction>
+       </xs:simpleType>
+    </xs:union>
   </xs:simpleType>
   <xs:complexType name="EdamTopics">
     <xs:annotation>

--- a/test/unit/tool_util/test_test_parsing.py
+++ b/test/unit/tool_util/test_test_parsing.py
@@ -1,0 +1,40 @@
+import yaml
+
+from galaxy.tool_util.parser.yaml import to_test_assert_list
+
+# Legacy style
+ASSERT_THAT_LIST = yaml.safe_load(
+    """
+- that: "has_text"
+  text: "Number of input reads |\t1051466"
+- that: "has_text"
+  text: "Uniquely mapped reads number |\t871202"
+"""
+)
+# New list of assertion style
+ASSERT_LIST = yaml.safe_load(
+    """
+- has_text:
+    text: "Number of input reads |\t1051466"
+- has_text:
+    text: "Uniquely mapped reads number |\t871202"
+"""
+)
+# Singleton assertion
+SIMPLE_ASSERT = {"has_text": {"text": "Number of input reads |\t1051466"}}
+
+
+def test_assert_that_list_to_test_assert_list():
+    to_test_assert_list(ASSERT_THAT_LIST)
+
+
+def test_assert_list_to_test_assert_list():
+    to_test_assert_list(ASSERT_LIST)
+
+
+def test_simple_assert_to_test_assert_list():
+    to_test_assert_list(SIMPLE_ASSERT)
+
+
+def test_assert_legacy_same_as_new_list_style():
+    assert to_test_assert_list(ASSERT_THAT_LIST) == to_test_assert_list(ASSERT_THAT_LIST)


### PR DESCRIPTION
These are two minor changes needed in order to generate useful and usable dataclass / pydantic models for our tool and workflow test language via xsdata. We'll need pydantic 2 for that, so I'm thinking that while we can't use pydantic 2 yet, I can generate the schema externally via galaxy-tool-util. I do want to eventually have the schema inside tool-util so that we can use the generated dataclasses for loading, typing, validation and version lifting.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
