### PR TITLE
[23.2] Make payload optional again for create tag API

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6392,7 +6392,7 @@ export interface components {
          */
         ItemTagsCreatePayload: {
             /** value of the item tag */
-            value: string;
+            value?: string;
         };
         /**
          * ItemTagsListResponse
@@ -13796,7 +13796,7 @@ export interface operations {
                 history_id: string;
             };
         };
-        requestBody: {
+        requestBody?: {
             content: {
                 "application/json": components["schemas"]["ItemTagsCreatePayload"];
             };
@@ -15103,7 +15103,7 @@ export interface operations {
                 tag_name: string;
             };
         };
-        requestBody: {
+        requestBody?: {
             content: {
                 "application/json": components["schemas"]["ItemTagsCreatePayload"];
             };
@@ -19862,7 +19862,7 @@ export interface operations {
                 tag_name: string;
             };
         };
-        requestBody: {
+        requestBody?: {
             content: {
                 "application/json": components["schemas"]["ItemTagsCreatePayload"];
             };

--- a/lib/galaxy/schema/item_tags.py
+++ b/lib/galaxy/schema/item_tags.py
@@ -42,7 +42,7 @@ class ItemTagsListResponse(Model):
 class ItemTagsCreatePayload(Model):
     """Payload schema for creating an item tag."""
 
-    value: str = Field(
-        Required,
+    value: Optional[str] = Field(
+        None,
         title="value of the item tag",
     )

--- a/lib/galaxy/webapps/galaxy/api/item_tags.py
+++ b/lib/galaxy/webapps/galaxy/api/item_tags.py
@@ -72,8 +72,10 @@ class FastAPIItemTags:
                 trans: ProvidesAppContext = DependsOnTrans,
                 item_id: DecodedDatabaseIdField = Path(..., title="Item ID", alias=tagged_item_id),
                 tag_name: str = Path(..., title="Tag Name"),
-                payload: ItemTagsCreatePayload = Body(...),
+                payload: ItemTagsCreatePayload = Body(None),
             ) -> ItemTagsResponse:
+                if payload is None:
+                    payload = ItemTagsCreatePayload()
                 return self.manager.create(trans, tagged_item_class, item_id, tag_name, payload)
 
             @router.put(

--- a/lib/galaxy_test/api/test_item_tags.py
+++ b/lib/galaxy_test/api/test_item_tags.py
@@ -6,7 +6,7 @@ from galaxy_test.base.populators import (
 from galaxy_test.driver import integration_util
 
 
-class TestHistoriesApi(integration_util.IntegrationTestCase):
+class TestItemTagsApi(integration_util.IntegrationTestCase):
     dataset_populator: DatasetPopulator
 
     @classmethod
@@ -20,75 +20,77 @@ class TestHistoriesApi(integration_util.IntegrationTestCase):
         self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
 
     def test_get_tags_workflows(self):
-        response = self._test_get_tags(self._create_prefixes()["workflows"])
+        response = self._test_get_tags(self._create_prefix("workflows"))
         self._assert_status_code_is(response, 200)
 
     def test_create_tag_workflows(self):
-        response = self._test_create_tag(self._create_prefixes()["workflows"])
+        response = self._test_create_tag(self._create_prefix("workflows"))
         self._assert_status_code_is(response, 200)
 
     def test_update_tag_workflows(self):
-        response = self._test_update_tag(self._create_prefixes()["workflows"])
+        response = self._test_update_tag(self._create_prefix("workflows"))
         self._assert_status_code_is(response, 200)
 
     def test_get_tag_workflows(self):
-        response = self._test_get_tag(self._create_prefixes()["workflows"])
+        response = self._test_get_tag(self._create_prefix("workflows"))
         self._assert_status_code_is(response, 200)
 
     def test_delete_tag_workflows(self):
-        response = self._test_delete_tag(self._create_prefixes()["workflows"])
+        response = self._test_delete_tag(self._create_prefix("workflows"))
         self._assert_status_code_is(response, 200)
 
     def test_get_tags_histories(self):
-        response = self._test_get_tags(self._create_prefixes()["histories"])
+        response = self._test_get_tags(self._create_prefix("histories"))
         self._assert_status_code_is(response, 200)
 
     def test_create_tag_histories(self):
-        response = self._test_create_tag(self._create_prefixes()["histories"])
+        response = self._test_create_tag(self._create_prefix("histories"))
         self._assert_status_code_is(response, 200)
 
     def test_update_tag_histories(self):
-        response = self._test_update_tag(self._create_prefixes()["histories"])
+        response = self._test_update_tag(self._create_prefix("histories"))
         self._assert_status_code_is(response, 200)
 
     def test_get_tag_histories(self):
-        response = self._test_get_tag(self._create_prefixes()["histories"])
+        response = self._test_get_tag(self._create_prefix("histories"))
         self._assert_status_code_is(response, 200)
 
     def test_delete_tag_histories(self):
-        response = self._test_delete_tag(self._create_prefixes()["histories"])
+        response = self._test_delete_tag(self._create_prefix("histories"))
         self._assert_status_code_is(response, 200)
 
     def test_get_tags_histories_content(self):
-        response = self._test_get_tags(self._create_prefixes()["histories_content"])
+        response = self._test_get_tags(self._create_prefix("histories_content"))
         self._assert_status_code_is(response, 200)
 
     def test_create_tag_histories_content(self):
-        response = self._test_create_tag(self._create_prefixes()["histories_content"])
+        response = self._test_create_tag(self._create_prefix("histories_content"))
         self._assert_status_code_is(response, 200)
 
     def test_update_tag_histories_content(self):
-        response = self._test_update_tag(self._create_prefixes()["histories_content"])
+        response = self._test_update_tag(self._create_prefix("histories_content"))
         self._assert_status_code_is(response, 200)
 
     def test_get_tag_histories_content(self):
-        response = self._test_get_tag(self._create_prefixes()["histories_content"])
+        response = self._test_get_tag(self._create_prefix("histories_content"))
         self._assert_status_code_is(response, 200)
 
     def test_delete_tag_histories_content(self):
-        response = self._test_delete_tag(self._create_prefixes()["histories_content"])
+        response = self._test_delete_tag(self._create_prefix("histories_content"))
         self._assert_status_code_is(response, 200)
 
-    def _create_prefixes(self):
-        workflow_id = self._create_workflow()
+    def _create_prefix(self, type_: str) -> str:
+        if type_ == "workflows":
+            workflow_id = self._create_workflow()
+            return f"workflows/{workflow_id}"
         history_id = self._create_history()
-        history_content_id = self._create_history_contents(history_id)
-        prefixs = {
-            "workflows": f"workflows/{workflow_id}",
-            "histories": f"histories/{history_id}",
-            "histories_content": f"histories/{history_id}/contents/{history_content_id}",
-        }
-        return prefixs
+        if type_ == "histories":
+            return f"histories/{history_id}"
+        elif type_ == "histories_content":
+            history_content_id = self._create_history_contents(history_id)
+            return f"histories/{history_id}/contents/{history_content_id}"
+        else:
+            raise ValueError(f"Unrecognized type_ {type_}")
 
     def _test_get_tags(self, prefix):
         url = f"{prefix}/tags"

--- a/lib/galaxy_test/api/test_item_tags.py
+++ b/lib/galaxy_test/api/test_item_tags.py
@@ -1,3 +1,8 @@
+from typing import (
+    Any,
+    Dict,
+)
+
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
@@ -125,7 +130,7 @@ class TestItemTagsApi(integration_util.IntegrationTestCase):
 
     def _create_valid_tag(self, prefix: str):
         url = f"{prefix}/tags/awesometagname"
-        tag_data = dict(value="awesometagvalue")
+        tag_data: Dict[str, Any] = {}  # Can also be dict(value="awesometagvalue")
         response = self._post(url, data=tag_data, json=True)
         return response
 


### PR DESCRIPTION
Also:
- Refactor item tag API tests to create only necessary items.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
