### PR TITLE
[23.1] Shorten job_to_output_dataset_assocation.name for discovered outputs

### DIFF
--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -543,7 +543,7 @@ def collect_primary_datasets(job_context: Union[JobContext, SessionlessJobContex
                 storage_callbacks=storage_callbacks,
             )
             # Associate new dataset with job
-            job_context.add_output_dataset_association(f"__new_primary_file_{name}|{designation}__", primary_data)
+            job_context.add_output_dataset_association(f"__new_primary_file_{name}|{filename_index}__", primary_data)
             job_context.add_datasets_to_history([primary_data], for_output_dataset=outdata)
             # Add dataset to return dict
             primary_datasets[name][designation] = primary_data

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -369,15 +369,16 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
             element_datasets["paths"].append(filename)
 
         self.add_tags_to_datasets(datasets=element_datasets["datasets"], tag_lists=element_datasets["tag_lists"])
-        for element_identifiers, dataset in zip(element_datasets["element_identifiers"], element_datasets["datasets"]):
+        for i, (element_identifiers, dataset) in enumerate(
+            zip(element_datasets["element_identifiers"], element_datasets["datasets"])
+        ):
             current_builder = root_collection_builder
             for element_identifier in element_identifiers[:-1]:
                 current_builder = current_builder.get_level(element_identifier)
             current_builder.add_dataset(element_identifiers[-1], dataset)
 
             # Associate new dataset with job
-            element_identifier_str = ":".join(element_identifiers)
-            association_name = f"__new_primary_file_{name}|{element_identifier_str}__"
+            association_name = f"__new_primary_file_{name}|{i}__"
             self.add_output_dataset_association(association_name, dataset)
 
         add_datasets_timer = ExecutionTimer()

--- a/test/unit/app/tools/test_collect_primary_datasets.py
+++ b/test/unit/app/tools/test_collect_primary_datasets.py
@@ -234,7 +234,7 @@ class TestCollectPrimaryDatasets(TestCase, tools_support.UsesTools):
         self._collect_default_extra()
         assert len(self.job.output_datasets) == 2
         extra_job_assoc = [job_assoc for job_assoc in self.job.output_datasets if job_assoc.name.startswith("__")][0]
-        assert extra_job_assoc.name == "__new_primary_file_out1|test1__"
+        assert extra_job_assoc.name == "__new_primary_file_out1|0__"
 
     def test_pattern_override_designation(self):
         self._replace_output_collectors(


### PR DESCRIPTION
by using an index instead of an arbitrary name.

These outputs don't exist in the tool like output datasets, so I don't think the association name attribute matters.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
