### PR TITLE
[23.2] Disable Workflow Report and Generate PDF buttons unless workflow is successful

### DIFF
--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationSummary.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationSummary.vue
@@ -148,9 +148,6 @@ export default {
                 this.invocationAndJobTerminal
             );
         },
-        displayTooltip: function () {
-            return this.invocationStateSuccess ? "" : this.disabledTooltip;
-        },
         stepCount: function () {
             return this.invocation?.steps.length;
         },

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationSummary.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationSummary.vue
@@ -13,7 +13,7 @@
                 </b-button>
                 <b-button
                     v-b-tooltip.hover
-                    :title="invocationStateSuccess ? generatePdfTooltip : disabledPdfTooltip"
+                    :title="invocationStateSuccess ? generatePdfTooltip : disabledReportTooltip"
                     :disabled="!invocationStateSuccess"
                     size="sm"
                     class="invocation-pdf-link"
@@ -119,10 +119,6 @@ export default {
             jobStatesInterval: null,
             reportTooltip: "View report for this workflow invocation",
             generatePdfTooltip: "Generate PDF report for this workflow invocation",
-            disabledReportTooltip:
-                "Unable to create report because this workflow invocation is not complete or was not successful.",
-            disabledPdfTooltip:
-                "Unable to generate PDF because this workflow invocation is not complete or was not successful.",
         };
     },
     computed: {
@@ -141,12 +137,26 @@ export default {
             return this.invocation?.state || "new";
         },
         invocationStateSuccess: function () {
-            return (
-                this.invocationState == "scheduled" &&
-                this.errorCount === 0 &&
-                this.runningCount === 0 &&
-                this.invocationAndJobTerminal
-            );
+            return this.invocationState == "scheduled" && this.runningCount === 0 && this.invocationAndJobTerminal;
+        },
+        disabledReportTooltip: function () {
+            const state = this.invocationState;
+            const runCount = this.runningCount;
+            if (this.invocationState != "scheduled") {
+                return (
+                    "This workflow is not currently scheduled. The current state is ",
+                    state,
+                    ". Once the workflow is fully scheduled and jobs have complete this option will become available."
+                );
+            } else if (runCount != 0) {
+                return (
+                    "The workflow invocation still contains ",
+                    runCount,
+                    " running job(s). Once these jobs have completed this option will become available. "
+                );
+            } else {
+                return "Steps for this workflow are still running. A report will be available once complete.";
+            }
         },
         stepCount: function () {
             return this.invocation?.steps.length;

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationSummary.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationSummary.vue
@@ -2,11 +2,19 @@
     <div class="mb-3 workflow-invocation-state-component">
         <div v-if="invocationAndJobTerminal">
             <span>
-                <b-button v-b-tooltip.hover size="sm" class="invocation-report-link" :href="invocationLink">
+                <b-button
+                    v-b-tooltip.hover
+                    :title="invocationStateSuccess ? reportTooltip : disabledReportTooltip"
+                    :disabled="!invocationStateSuccess"
+                    size="sm"
+                    class="invocation-report-link"
+                    :href="invocationLink">
                     View Report
                 </b-button>
                 <b-button
                     v-b-tooltip.hover
+                    :title="invocationStateSuccess ? generatePdfTooltip : disabledPdfTooltip"
+                    :disabled="!invocationStateSuccess"
                     size="sm"
                     class="invocation-pdf-link"
                     :href="invocationPdfLink"
@@ -109,6 +117,12 @@ export default {
         return {
             stepStatesInterval: null,
             jobStatesInterval: null,
+            reportTooltip: "View report for this workflow invocation",
+            generatePdfTooltip: "Generate PDF report for this workflow invocation",
+            disabledReportTooltip:
+                "Unable to create report because this workflow invocation is not complete or was not successful.",
+            disabledPdfTooltip:
+                "Unable to generate PDF because this workflow invocation is not complete or was not successful.",
         };
     },
     computed: {
@@ -125,6 +139,17 @@ export default {
         },
         invocationState: function () {
             return this.invocation?.state || "new";
+        },
+        invocationStateSuccess: function () {
+            return (
+                this.invocationState == "scheduled" &&
+                this.errorCount === 0 &&
+                this.runningCount === 0 &&
+                this.invocationAndJobTerminal
+            );
+        },
+        displayTooltip: function () {
+            return this.invocationStateSuccess ? "" : this.disabledTooltip;
         },
         stepCount: function () {
             return this.invocation?.steps.length;


### PR DESCRIPTION
~~Fix for #16922~~
XREF #17139

View Report or Generate Report buttons will be disabled if the workflow invocation and steps were unsucccessful
Simply added a conditional disabled class to those buttons and a method to checks invocation status and step status


## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. Navigate to User > Workflow Invocations
  2. Note that you can see & click "View Report" and "Generate PDF" for successful Workflows, but not for unsuccessful ones.
 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
