### PR TITLE
Create pydantic model for the return of show operation -  get: `/api/jobs/{job_id}` 

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -4218,7 +4218,7 @@ export interface components {
              * @description The (major) version of Galaxy used to create this job.
              * @example 21.05
              */
-            galaxy_version: string;
+            galaxy_version?: string;
             /**
              * History ID
              * @description The encoded ID of the history associated with this item.
@@ -6631,7 +6631,7 @@ export interface components {
              * @description The (major) version of Galaxy used to create this job.
              * @example 21.05
              */
-            galaxy_version: string;
+            galaxy_version?: string;
             /**
              * History ID
              * @description The encoded ID of the history associated with this item.
@@ -9057,7 +9057,7 @@ export interface components {
              * Job dependencies
              * @description The dependencies of the job.
              */
-            dependencies: Record<string, never>[];
+            dependencies?: Record<string, never>[];
             /**
              * Exit Code
              * @description The exit code returned by the tool. Can be unset if the job is not completed yet.
@@ -9073,7 +9073,7 @@ export interface components {
              * @description The (major) version of Galaxy used to create this job.
              * @example 21.05
              */
-            galaxy_version: string;
+            galaxy_version?: string;
             /**
              * History ID
              * @description The encoded ID of the history associated with this item.
@@ -9098,7 +9098,7 @@ export interface components {
              * Job Messages
              * @description List with additional information and possible reasons for a failed job.
              */
-            job_messages: Record<string, never>[];
+            job_messages?: Record<string, never>[];
             /**
              * Job Metrics
              * @description Collections of metrics provided by `JobInstrumenter` plugins on a particular job. Only administrators can see these metrics.
@@ -9108,12 +9108,12 @@ export interface components {
              * Job Standard Error
              * @description The captured standard error of the job execution.
              */
-            job_stderr: string;
+            job_stderr?: string;
             /**
              * Job Standard Output
              * @description The captured standard output of the job execution.
              */
-            job_stdout: string;
+            job_stdout?: string;
             /**
              * Model class
              * @description The name of the database model class.
@@ -9150,12 +9150,12 @@ export interface components {
              * Standard Error
              * @description Combined tool and job standard error streams.
              */
-            stderr: string;
+            stderr?: string;
             /**
              * Standard Output
              * @description Combined tool and job standard output streams.
              */
-            stdout: string;
+            stdout?: string;
             /**
              * Tool ID
              * @description Identifier of the tool that generated this job.
@@ -9165,12 +9165,12 @@ export interface components {
              * Tool Standard Error
              * @description The captured standard error of the tool executed by the job.
              */
-            tool_stderr: string;
+            tool_stderr?: string;
             /**
              * Tool Standard Output
              * @description The captured standard output of the tool executed by the job.
              */
-            tool_stdout: string;
+            tool_stdout?: string;
             /**
              * Update Time
              * Format: date-time

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -4196,7 +4196,7 @@ export interface components {
              * @description Reference to cached job if job execution was cached.
              * @example 0123456789ABCDEF
              */
-            copied_from_job_id?: string;
+            copied_from_job_id: string;
             /**
              * Create Time
              * Format: date-time
@@ -9027,10 +9027,10 @@ export interface components {
             short_term_storage_request_id: string;
         };
         /**
-         * ShowJobResponse
+         * ShowFullJobResponse
          * @description Basic information about a job.
          */
-        ShowJobResponse: {
+        ShowFullJobResponse: {
             /**
              * Command Line
              * @description The command line produced by the job. Users can see this value if allowed in the configuration, administrator can always see this value.
@@ -9046,7 +9046,7 @@ export interface components {
              * @description Reference to cached job if job execution was cached.
              * @example 0123456789ABCDEF
              */
-            copied_from_job_id?: string;
+            copied_from_job_id: string;
             /**
              * Create Time
              * Format: date-time
@@ -9057,7 +9057,7 @@ export interface components {
              * Job dependencies
              * @description The dependencies of the job.
              */
-            dependencies?: Record<string, never>[];
+            dependencies: Record<string, never>[];
             /**
              * Exit Code
              * @description The exit code returned by the tool. Can be unset if the job is not completed yet.
@@ -9098,7 +9098,7 @@ export interface components {
              * Job Messages
              * @description List with additional information and possible reasons for a failed job.
              */
-            job_messages?: Record<string, never>[];
+            job_messages: Record<string, never>[];
             /**
              * Job Metrics
              * @description Collections of metrics provided by `JobInstrumenter` plugins on a particular job. Only administrators can see these metrics.
@@ -9108,12 +9108,12 @@ export interface components {
              * Job Standard Error
              * @description The captured standard error of the job execution.
              */
-            job_stderr?: string;
+            job_stderr: string;
             /**
              * Job Standard Output
              * @description The captured standard output of the job execution.
              */
-            job_stdout?: string;
+            job_stdout: string;
             /**
              * Model class
              * @description The name of the database model class.
@@ -9150,12 +9150,12 @@ export interface components {
              * Standard Error
              * @description Combined tool and job standard error streams.
              */
-            stderr?: string;
+            stderr: string;
             /**
              * Standard Output
              * @description Combined tool and job standard output streams.
              */
-            stdout?: string;
+            stdout: string;
             /**
              * Tool ID
              * @description Identifier of the tool that generated this job.
@@ -9165,12 +9165,12 @@ export interface components {
              * Tool Standard Error
              * @description The captured standard error of the tool executed by the job.
              */
-            tool_stderr?: string;
+            tool_stderr: string;
             /**
              * Tool Standard Output
              * @description The captured standard output of the tool executed by the job.
              */
-            tool_stdout?: string;
+            tool_stdout: string;
             /**
              * Update Time
              * Format: date-time
@@ -15955,7 +15955,9 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["ShowJobResponse"];
+                    "application/json":
+                        | components["schemas"]["EncodedJobDetails"]
+                        | components["schemas"]["ShowFullJobResponse"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -9098,7 +9098,7 @@ export interface components {
              * Job Messages
              * @description List with additional information and possible reasons for a failed job.
              */
-            job_messages?: string[];
+            job_messages?: Record<string, never>[];
             /**
              * Job Metrics
              * @description Collections of metrics provided by `JobInstrumenter` plugins on a particular job. Only administrators can see these metrics.

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6756,6 +6756,12 @@ export interface components {
              */
             value: string;
         };
+        /**
+         * JobMetricCollection
+         * @description Collections of metrics provided by `JobInstrumenter` plugins on a particular job.
+         * @default []
+         */
+        JobMetricCollection: components["schemas"]["JobMetric"][];
         /** JobOutput */
         JobOutput: {
             /**
@@ -9019,6 +9025,163 @@ export interface components {
              * Format: uuid
              */
             short_term_storage_request_id: string;
+        };
+        /**
+         * ShowJobResponse
+         * @description Basic information about a job.
+         */
+        ShowJobResponse: {
+            /**
+             * Command Line
+             * @description The command line produced by the job. Users can see this value if allowed in the configuration, administrator can always see this value.
+             */
+            command_line?: string;
+            /**
+             * Command Version
+             * @description Tool version indicated during job execution.
+             */
+            command_version: string;
+            /**
+             * Copied from Job-ID
+             * @description Reference to cached job if job execution was cached.
+             * @example 0123456789ABCDEF
+             */
+            copied_from_job_id?: string;
+            /**
+             * Create Time
+             * Format: date-time
+             * @description The time and date this item was created.
+             */
+            create_time: string;
+            /**
+             * Job dependencies
+             * @description The dependencies of the job.
+             */
+            dependencies?: Record<string, never>[];
+            /**
+             * Exit Code
+             * @description The exit code returned by the tool. Can be unset if the job is not completed yet.
+             */
+            exit_code?: number;
+            /**
+             * External ID
+             * @description The job id used by the external job runner (Condor, Pulsar, etc.)Only administrator can see this value.
+             */
+            external_id?: string;
+            /**
+             * Galaxy Version
+             * @description The (major) version of Galaxy used to create this job.
+             * @example 21.05
+             */
+            galaxy_version: string;
+            /**
+             * History ID
+             * @description The encoded ID of the history associated with this item.
+             * @example 0123456789ABCDEF
+             */
+            history_id?: string;
+            /**
+             * ID
+             * @description The encoded ID of this entity.
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /**
+             * Inputs
+             * @description Dictionary mapping all the tool inputs (by name) to the corresponding data references.
+             * @default {}
+             */
+            inputs?: {
+                [key: string]: components["schemas"]["EncodedDatasetJobInfo"] | undefined;
+            };
+            /**
+             * Job Messages
+             * @description List with additional information and possible reasons for a failed job.
+             */
+            job_messages?: string[];
+            /**
+             * Job Metrics
+             * @description Collections of metrics provided by `JobInstrumenter` plugins on a particular job. Only administrators can see these metrics.
+             */
+            job_metrics?: components["schemas"]["JobMetricCollection"];
+            /**
+             * Job Standard Error
+             * @description The captured standard error of the job execution.
+             */
+            job_stderr?: string;
+            /**
+             * Job Standard Output
+             * @description The captured standard output of the job execution.
+             */
+            job_stdout?: string;
+            /**
+             * Model class
+             * @description The name of the database model class.
+             * @default Job
+             * @enum {string}
+             */
+            model_class: "Job";
+            /**
+             * Output collections
+             * @default {}
+             */
+            output_collections?: {
+                [key: string]: components["schemas"]["EncodedHdcaSourceId"] | undefined;
+            };
+            /**
+             * Outputs
+             * @description Dictionary mapping all the tool outputs (by name) to the corresponding data references.
+             * @default {}
+             */
+            outputs?: {
+                [key: string]: components["schemas"]["EncodedDatasetJobInfo"] | undefined;
+            };
+            /**
+             * Parameters
+             * @description Object containing all the parameters of the tool associated with this job. The specific parameters depend on the tool itself.
+             */
+            params: Record<string, never>;
+            /**
+             * State
+             * @description Current state of the job.
+             */
+            state: components["schemas"]["JobState"];
+            /**
+             * Standard Error
+             * @description Combined tool and job standard error streams.
+             */
+            stderr?: string;
+            /**
+             * Standard Output
+             * @description Combined tool and job standard output streams.
+             */
+            stdout?: string;
+            /**
+             * Tool ID
+             * @description Identifier of the tool that generated this job.
+             */
+            tool_id: string;
+            /**
+             * Tool Standard Error
+             * @description The captured standard error of the tool executed by the job.
+             */
+            tool_stderr?: string;
+            /**
+             * Tool Standard Output
+             * @description The captured standard output of the tool executed by the job.
+             */
+            tool_stdout?: string;
+            /**
+             * Update Time
+             * Format: date-time
+             * @description The last time and date this item was updated.
+             */
+            update_time: string;
+            /**
+             * User Email
+             * @description The email of the user that owns this job. Only the owner of the job and administrators can see this value.
+             */
+            user_email?: string;
         };
         /**
          * Src
@@ -15792,7 +15955,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["ShowJobResponse"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -15956,8 +15956,8 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["EncodedJobDetails"]
-                        | components["schemas"]["ShowFullJobResponse"];
+                        | components["schemas"]["ShowFullJobResponse"]
+                        | components["schemas"]["EncodedJobDetails"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -4190,13 +4190,13 @@ export interface components {
              * Command Version
              * @description Tool version indicated during job execution.
              */
-            command_version: string;
+            command_version?: string;
             /**
              * Copied from Job-ID
              * @description Reference to cached job if job execution was cached.
              * @example 0123456789ABCDEF
              */
-            copied_from_job_id: string;
+            copied_from_job_id?: string;
             /**
              * Create Time
              * Format: date-time
@@ -9040,13 +9040,13 @@ export interface components {
              * Command Version
              * @description Tool version indicated during job execution.
              */
-            command_version: string;
+            command_version?: string;
             /**
              * Copied from Job-ID
              * @description Reference to cached job if job execution was cached.
              * @example 0123456789ABCDEF
              */
-            copied_from_job_id: string;
+            copied_from_job_id?: string;
             /**
              * Create Time
              * Format: date-time

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1550,6 +1550,7 @@ class BaseDirectoryImportModelStore(ModelImportStore):
             "tool_stderr",
             "job_stdout",
             "job_stderr",
+            "galaxy_version",
         )
         for attribute in ATTRIBUTES:
             value = job_attrs.get(attribute)

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -159,7 +159,7 @@ class EncodedDatasetJobInfo(EncodedDataItemSourceId):
 
 class EncodedJobDetails(JobSummary):
     command_version: Optional[str] = Field(
-        ...,
+        default=None,
         title="Command Version",
         description="Tool version indicated during job execution.",
     )
@@ -182,7 +182,7 @@ class EncodedJobDetails(JobSummary):
         description="Dictionary mapping all the tool outputs (by name) to the corresponding data references.",
     )
     copied_from_job_id: Optional[EncodedDatabaseIdField] = Field(
-        default=Required,
+        default=None,
         title="Copied from Job-ID",
         description="Reference to cached job if job execution was cached.",
     )

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -245,42 +245,42 @@ class JobDisplayParametersSummary(Model):
 
 class ShowFullJobResponse(EncodedJobDetails):
     tool_stdout: Optional[str] = Field(
-        default=Required,
+        default=None,
         title="Tool Standard Output",
         description="The captured standard output of the tool executed by the job.",
     )
     tool_stderr: Optional[str] = Field(
-        default=Required,
+        default=None,
         title="Tool Standard Error",
         description="The captured standard error of the tool executed by the job.",
     )
     job_stdout: Optional[str] = Field(
-        default=Required,
+        default=None,
         title="Job Standard Output",
         description="The captured standard output of the job execution.",
     )
     job_stderr: Optional[str] = Field(
-        default=Required,
+        default=None,
         title="Job Standard Error",
         description="The captured standard error of the job execution.",
     )
     stdout: Optional[str] = Field(  # Redundant? it seems to be (tool_stdout + "\n" + job_stdout)
-        default=Required,
+        default=None,
         title="Standard Output",
         description="Combined tool and job standard output streams.",
     )
     stderr: Optional[str] = Field(  # Redundant? it seems to be (tool_stderr + "\n" + job_stderr)
-        default=Required,
+        default=None,
         title="Standard Error",
         description="Combined tool and job standard error streams.",
     )
     job_messages: Optional[List[Any]] = Field(
-        default=Required,
+        default=None,
         title="Job Messages",
         description="List with additional information and possible reasons for a failed job.",
     )
     dependencies: Optional[List[Any]] = Field(
-        default=Required,
+        default=None,
         title="Job dependencies",
         description="The dependencies of the job.",
     )

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -274,7 +274,7 @@ class ShowJobResponse(EncodedJobDetails):
         title="Standard Error",
         description="Combined tool and job standard error streams.",
     )
-    job_messages: Optional[List[str]] = Field(
+    job_messages: Optional[List[Any]] = Field(
         default=None,
         title="Job Messages",
         description="List with additional information and possible reasons for a failed job.",

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -182,7 +182,7 @@ class EncodedJobDetails(JobSummary):
         description="Dictionary mapping all the tool outputs (by name) to the corresponding data references.",
     )
     copied_from_job_id: Optional[EncodedDatabaseIdField] = Field(
-        default=None,
+        default=Required,
         title="Copied from Job-ID",
         description="Reference to cached job if job execution was cached.",
     )
@@ -243,41 +243,46 @@ class JobDisplayParametersSummary(Model):
     )
 
 
-class ShowJobResponse(EncodedJobDetails):
+class ShowFullJobResponse(EncodedJobDetails):
     tool_stdout: Optional[str] = Field(
-        default=None,
+        default=Required,
         title="Tool Standard Output",
         description="The captured standard output of the tool executed by the job.",
     )
     tool_stderr: Optional[str] = Field(
-        default=None,
+        default=Required,
         title="Tool Standard Error",
         description="The captured standard error of the tool executed by the job.",
     )
     job_stdout: Optional[str] = Field(
-        default=None,
+        default=Required,
         title="Job Standard Output",
         description="The captured standard output of the job execution.",
     )
     job_stderr: Optional[str] = Field(
-        default=None,
+        default=Required,
         title="Job Standard Error",
         description="The captured standard error of the job execution.",
     )
     stdout: Optional[str] = Field(  # Redundant? it seems to be (tool_stdout + "\n" + job_stdout)
-        default=None,
+        default=Required,
         title="Standard Output",
         description="Combined tool and job standard output streams.",
     )
     stderr: Optional[str] = Field(  # Redundant? it seems to be (tool_stderr + "\n" + job_stderr)
-        default=None,
+        default=Required,
         title="Standard Error",
         description="Combined tool and job standard error streams.",
     )
     job_messages: Optional[List[Any]] = Field(
-        default=None,
+        default=Required,
         title="Job Messages",
         description="List with additional information and possible reasons for a failed job.",
+    )
+    dependencies: Optional[List[Any]] = Field(
+        default=Required,
+        title="Job dependencies",
+        description="The dependencies of the job.",
     )
     job_metrics: Optional[JobMetricCollection] = Field(
         default=None,
@@ -286,9 +291,4 @@ class ShowJobResponse(EncodedJobDetails):
             "Collections of metrics provided by `JobInstrumenter` plugins on a particular job. "
             "Only administrators can see these metrics."
         ),
-    )
-    dependencies: Optional[List[Any]] = Field(
-        default=None,
-        title="Job dependencies",
-        description="The dependencies of the job.",
     )

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -23,6 +23,7 @@ from galaxy.schema.schema import (
     DataItemSourceType,
     EncodedDataItemSourceId,
     EntityIdField,
+    JobMetricCollection,
     JobState,
     JobSummary,
     Model,
@@ -181,9 +182,15 @@ class EncodedJobDetails(JobSummary):
         description="Dictionary mapping all the tool outputs (by name) to the corresponding data references.",
     )
     copied_from_job_id: Optional[EncodedDatabaseIdField] = Field(
-        default=None, title="Copied from Job-ID", description="Reference to cached job if job execution was cached."
+        default=None,
+        title="Copied from Job-ID",
+        description="Reference to cached job if job execution was cached.",
     )
-    output_collections: Dict[str, EncodedHdcaSourceId] = Field(default={}, title="Output collections", description="")
+    output_collections: Dict[str, EncodedHdcaSourceId] = Field(
+        default={},
+        title="Output collections",
+        description="",
+    )
 
 
 class JobDestinationParams(Model):
@@ -233,4 +240,55 @@ class JobDisplayParametersSummary(Model):
         default=Required,
         title="Outputs",
         description="Dictionary mapping all the tool outputs (by name) with the corresponding dataset information in a nested format.",
+    )
+
+
+class ShowJobResponse(EncodedJobDetails):
+    tool_stdout: Optional[str] = Field(
+        default=None,
+        title="Tool Standard Output",
+        description="The captured standard output of the tool executed by the job.",
+    )
+    tool_stderr: Optional[str] = Field(
+        default=None,
+        title="Tool Standard Error",
+        description="The captured standard error of the tool executed by the job.",
+    )
+    job_stdout: Optional[str] = Field(
+        default=None,
+        title="Job Standard Output",
+        description="The captured standard output of the job execution.",
+    )
+    job_stderr: Optional[str] = Field(
+        default=None,
+        title="Job Standard Error",
+        description="The captured standard error of the job execution.",
+    )
+    stdout: Optional[str] = Field(  # Redundant? it seems to be (tool_stdout + "\n" + job_stdout)
+        default=None,
+        title="Standard Output",
+        description="Combined tool and job standard output streams.",
+    )
+    stderr: Optional[str] = Field(  # Redundant? it seems to be (tool_stderr + "\n" + job_stderr)
+        default=None,
+        title="Standard Error",
+        description="Combined tool and job standard error streams.",
+    )
+    job_messages: Optional[List[str]] = Field(
+        default=None,
+        title="Job Messages",
+        description="List with additional information and possible reasons for a failed job.",
+    )
+    job_metrics: Optional[JobMetricCollection] = Field(
+        default=None,
+        title="Job Metrics",
+        description=(
+            "Collections of metrics provided by `JobInstrumenter` plugins on a particular job. "
+            "Only administrators can see these metrics."
+        ),
+    )
+    dependencies: Optional[List[Any]] = Field(
+        default=None,
+        title="Job dependencies",
+        description="The dependencies of the job.",
     )

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1852,7 +1852,7 @@ class JobBaseModel(Model):
     create_time: datetime = CreateTimeField
     update_time: datetime = UpdateTimeField
     galaxy_version: Optional[str] = Field(
-        ...,
+        default=None,
         title="Galaxy Version",
         description="The (major) version of Galaxy used to create this job.",
         example="21.05",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1851,7 +1851,7 @@ class JobBaseModel(Model):
     )
     create_time: datetime = CreateTimeField
     update_time: datetime = UpdateTimeField
-    galaxy_version: str = Field(
+    galaxy_version: Optional[str] = Field(
         ...,
         title="Galaxy Version",
         description="The (major) version of Galaxy used to create this job.",

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -49,7 +49,7 @@ from galaxy.schema.jobs import (
     JobOutputAssociation,
     ReportJobErrorPayload,
     SearchJobsPayload,
-    ShowJobResponse,
+    ShowFullJobResponse,
 )
 from galaxy.schema.schema import (
     DatasetSourceType,
@@ -495,16 +495,17 @@ class FastAPIJobs:
         "/api/jobs/{job_id}",
         name="show_job",
         summary="Return dictionary containing description of job data.",
-        response_model=ShowJobResponse,
-        response_model_exclude_unset=True,
     )
     def show(
         self,
         job_id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
         full: Annotated[Optional[bool], FullShowQueryParam] = False,
         trans: ProvidesUserContext = DependsOnTrans,
-    ):
-        return self.service.show(trans, job_id, bool(full))
+    ) -> Union[EncodedJobDetails, ShowFullJobResponse]:
+        if full:
+            return ShowFullJobResponse(**self.service.show(trans, job_id, bool(full)))
+        else:
+            return EncodedJobDetails(**self.service.show(trans, job_id, bool(full)))
 
     @router.delete(
         "/api/jobs/{job_id}",

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -501,7 +501,7 @@ class FastAPIJobs:
         job_id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
         full: Annotated[Optional[bool], FullShowQueryParam] = False,
         trans: ProvidesUserContext = DependsOnTrans,
-    ) -> Union[EncodedJobDetails, ShowFullJobResponse]:
+    ) -> Union[ShowFullJobResponse, EncodedJobDetails]:
         if full:
             return ShowFullJobResponse(**self.service.show(trans, job_id, bool(full)))
         else:

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -49,6 +49,7 @@ from galaxy.schema.jobs import (
     JobOutputAssociation,
     ReportJobErrorPayload,
     SearchJobsPayload,
+    ShowJobResponse,
 )
 from galaxy.schema.schema import (
     DatasetSourceType,
@@ -494,13 +495,15 @@ class FastAPIJobs:
         "/api/jobs/{job_id}",
         name="show_job",
         summary="Return dictionary containing description of job data.",
+        response_model=ShowJobResponse,
+        response_model_exclude_unset=True,
     )
     def show(
         self,
         job_id: Annotated[DecodedDatabaseIdField, JobIdPathParam],
         full: Annotated[Optional[bool], FullShowQueryParam] = False,
         trans: ProvidesUserContext = DependsOnTrans,
-    ) -> Dict[str, Any]:
+    ):
         return self.service.show(trans, job_id, bool(full))
 
     @router.delete(

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -353,7 +353,7 @@ steps:
         assert not job_lock_response.json()["active"]
 
         show_jobs_response = self._get(f"jobs/{job_id}", admin=False)
-        self._assert_not_has_keys(show_jobs_response.json(), "external_id")
+        assert show_jobs_response.json()["external_id"] is None
 
         # TODO: Re-activate test case when API accepts privacy settings
         # with self._different_user():
@@ -361,7 +361,8 @@ steps:
         #    self._assert_status_code_is( show_jobs_response, 200 )
 
         show_jobs_response = self._get(f"jobs/{job_id}", admin=True)
-        self._assert_has_keys(show_jobs_response.json(), "command_line", "external_id")
+        assert show_jobs_response.json()["external_id"] is not None
+        assert show_jobs_response.json()["command_line"] is not None
 
     def _run_detect_errors(self, history_id, inputs):
         payload = self.dataset_populator.run_tool_payload(


### PR DESCRIPTION
This extends the work done in #16778

## Summary
- [x] Operation now returns pydantic model

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
You can find the interactive API documentation here: [http://127.0.0.1:8080/api/docs#/jobs/show_job_api_jobs__job_id__get](https://github.com/galaxyproject/galaxy/pull/url)


![image](https://github.com/galaxyproject/galaxy/assets/117033448/17dfeea9-497e-4adf-bc8e-c5aabb555fe0)




## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
