### PR TITLE
Remove legacy tool versions list from admin panel

### DIFF
--- a/client/src/components/admin/AdminPanel.vue
+++ b/client/src/components/admin/AdminPanel.vue
@@ -142,11 +142,6 @@ export default {
                             route: "/admin/toolbox_dependencies",
                         },
                         {
-                            id: "admin-link-tool-versions",
-                            title: "View Lineage",
-                            route: "/admin/tool_versions",
-                        },
-                        {
                             id: "admin-link-error-stack",
                             title: "View Error Logs",
                             route: "/admin/error_stack",

--- a/client/src/components/admin/Home.vue
+++ b/client/src/components/admin/Home.vue
@@ -114,12 +114,6 @@
                 </strong>
                 - Select on which repositories you want to reset metadata.
             </li>
-            <li>
-                <strong>
-                    <router-link to="/admin/tool_versions">View Lineage</router-link>
-                </strong>
-                - A view of a version lineages for all installed tools. Useful for debugging.
-            </li>
         </ul>
     </div>
 </template>

--- a/client/src/entry/analysis/routes/admin-routes.js
+++ b/client/src/entry/analysis/routes/admin-routes.js
@@ -23,7 +23,6 @@ import adminGroupsGridConfig from "components/Grid/configs/adminGroups";
 import adminQuotasGridConfig from "components/Grid/configs/adminQuotas";
 import adminRolesGridConfig from "components/Grid/configs/adminRoles";
 import adminUsersGridConfig from "components/Grid/configs/adminUsers";
-import Grid from "components/Grid/Grid";
 import GridList from "components/Grid/GridList";
 import RegisterForm from "components/Login/RegisterForm";
 import Toolshed from "components/Toolshed/Index";

--- a/client/src/entry/analysis/routes/admin-routes.js
+++ b/client/src/entry/analysis/routes/admin-routes.js
@@ -169,13 +169,6 @@ export default [
                     gridMessage: route.query.message,
                 }),
             },
-            {
-                path: "tool_versions",
-                component: Grid,
-                props: {
-                    urlBase: "admin/tool_versions_list",
-                },
-            },
             // forms
             {
                 path: "form/reset_user_password",

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -355,52 +355,6 @@ class QuotaListGrid(grids.GridData):
         return query
 
 
-class ToolVersionListGrid(grids.Grid):
-    class ToolIdColumn(grids.TextColumn):
-        def get_value(self, trans, grid, tool_version):
-            toolbox = trans.app.toolbox
-            if toolbox.has_tool(tool_version.tool_id, exact=True):
-                link = url_for(controller="tool_runner", tool_id=tool_version.tool_id)
-                link_str = f'<a target="_blank" href="{link}">'
-                return f'<div class="count-box state-color-ok">{link_str}{tool_version.tool_id}</a></div>'
-            return tool_version.tool_id
-
-    class ToolVersionsColumn(grids.TextColumn):
-        def get_value(self, trans, grid, tool_version):
-            tool_ids_str = ""
-            toolbox = trans.app.toolbox
-            if tool := toolbox._tools_by_id.get(tool_version.tool_id):
-                for tool_id in tool.lineage.tool_ids:
-                    if toolbox.has_tool(tool_id, exact=True):
-                        link = url_for(controller="tool_runner", tool_id=tool_id)
-                        link_str = f'<a target="_blank" href="{link}">'
-                        tool_ids_str += f'<div class="count-box state-color-ok">{link_str}{tool_id}</a></div><br/>'
-                    else:
-                        tool_ids_str += f"{tool_version.tool_id}<br/>"
-            else:
-                tool_ids_str += f"{tool_version.tool_id}<br/>"
-            return tool_ids_str
-
-    # Grid definition
-    title = "Tool versions"
-    model_class = install_model.ToolVersion
-    default_sort_key = "tool_id"
-    columns = [
-        ToolIdColumn("Tool id", key="tool_id", attach_popup=False),
-        ToolVersionsColumn("Version lineage by tool id (parent/child ordered)"),
-    ]
-    columns.append(
-        grids.MulticolFilterColumn(
-            "Search tool id", cols_to_filter=[columns[0]], key="free-text-search", visible=False, filterable="standard"
-        )
-    )
-    num_rows_per_page = 50
-    use_paging = True
-
-    def build_initial_query(self, trans, **kwd):
-        return trans.install_model.context.query(self.model_class)
-
-
 # TODO: Convert admin UI to use the API and drop this.
 class DatatypesEntryT(TypedDict):
     status: str
@@ -414,7 +368,6 @@ class AdminGalaxy(controller.JSAppLauncher):
     role_list_grid = RoleListGrid()
     group_list_grid = GroupListGrid()
     quota_list_grid = QuotaListGrid()
-    tool_version_list_grid = ToolVersionListGrid()
 
     def __init__(self, app: StructuredApp):
         super().__init__(app)
@@ -687,11 +640,6 @@ class AdminGalaxy(controller.JSAppLauncher):
         return trans.response.send_redirect(
             web.url_for(controller="admin", action="users", message="Invalid user selected", status="error")
         )
-
-    @web.legacy_expose_api
-    @web.require_admin
-    def tool_versions_list(self, trans, **kwd):
-        return self.tool_version_list_grid(trans, **kwd)
 
     @web.expose
     @web.json

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -15,7 +15,6 @@ from galaxy import (
 )
 from galaxy.exceptions import ActionInputError
 from galaxy.managers.quotas import QuotaManager
-from galaxy.model import tool_shed_install as install_model
 from galaxy.model.base import transaction
 from galaxy.model.index_filter_util import (
     raw_text_column_filter,


### PR DESCRIPTION
This PR removes the tool versions list. To my knowledge this list is not used and/or useful anymore. Please comment if you have a different opinion on this. We could easily Vueify this list if needed.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
