### PR TITLE
[23.2] Add rerun and show details buttons in expanded collection

### DIFF
--- a/client/src/components/History/CurrentCollection/CollectionOperations.vue
+++ b/client/src/components/History/CurrentCollection/CollectionOperations.vue
@@ -1,3 +1,27 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useRouter } from "vue-router/composables";
+
+import { HDCADetailed } from "@/api";
+import { getAppRoot } from "@/onload/loadConfig";
+
+const router = useRouter();
+
+const props = defineProps<{
+    dsc: HDCADetailed;
+}>();
+
+const downloadUrl = computed(() => `${getAppRoot()}api/dataset_collections/${props.dsc.id}/download`);
+const rerunUrl = computed(() =>
+    props.dsc.job_source_type == "Job" ? `/root?job_id=${props.dsc.job_source_id}` : null
+);
+const showCollectionDetailsUrl = computed(() =>
+    props.dsc.job_source_type == "Job" ? `/jobs/${props.dsc.job_source_id}/view` : null
+);
+function onDownload() {
+    window.location.href = downloadUrl.value;
+}
+</script>
 <template>
     <section>
         <nav class="content-operations d-flex justify-content-between bg-secondary">
@@ -12,26 +36,29 @@
                     <Icon class="mr-1" icon="download" />
                     <span>Download</span>
                 </b-button>
+                <b-button
+                    v-if="showCollectionDetailsUrl"
+                    class="collection-job-details-btn px-1"
+                    title="Show Details"
+                    size="sm"
+                    variant="link"
+                    :href="showCollectionDetailsUrl"
+                    @click.prevent.stop="router.push(showCollectionDetailsUrl)">
+                    <icon icon="info-circle" />
+                    <span>Show Details</span>
+                </b-button>
+                <b-button
+                    v-if="rerunUrl"
+                    title="Rerun job"
+                    class="rounded-0 text-decoration-none"
+                    size="sm"
+                    variant="link"
+                    :href="rerunUrl"
+                    @click.prevent.stop="router.push(rerunUrl)">
+                    <Icon class="mr-1" icon="redo" />
+                    <span>Run Job Again</span>
+                </b-button>
             </b-button-group>
         </nav>
     </section>
 </template>
-
-<script>
-export default {
-    props: {
-        dsc: { type: Object, required: true },
-    },
-    computed: {
-        /** @return {String} */
-        downloadUrl() {
-            return `${this.dsc.url}/download`;
-        },
-    },
-    methods: {
-        onDownload() {
-            window.location.href = this.downloadUrl;
-        },
-    },
-};
-</script>


### PR DESCRIPTION
If the collection you're currently viewing has been produced by a job (and not a map over) we'll show the info and rerun buttons. (And if it's a map over job that contains jobs that produce a collection at least one of the inner collections will show the button).

![image](https://github.com/galaxyproject/galaxy/assets/6804901/9ccafbf7-c332-495f-a731-6d364fbce779)

Fixes https://github.com/galaxyproject/galaxy/issues/17121#issuecomment-1852618920 and I believe we've had more reports of this but not finding it right now.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
