### PR TITLE
Drop fastapi-utils.InferringRouter in favor of fastapi.APIRouter 

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -22,6 +22,7 @@ from urllib.parse import (
 
 from a2wsgi.wsgi import build_environ
 from fastapi import (
+    APIRouter,
     Form,
     Header,
     Query,
@@ -38,7 +39,6 @@ from fastapi.security import (
     APIKeyQuery,
 )
 from fastapi_utils.cbv import cbv
-from fastapi_utils.inferring_router import InferringRouter
 from pydantic import ValidationError
 from pydantic.main import BaseModel
 from starlette.datastructures import Headers
@@ -353,8 +353,8 @@ class RestVerb(str, Enum):
     options = "OPTIONS"
 
 
-class FrameworkRouter(InferringRouter):
-    """A FastAPI Inferring Router tailored to Galaxy."""
+class FrameworkRouter(APIRouter):
+    """A FastAPI Router tailored to Galaxy."""
 
     admin_user_dependency: Any
 


### PR DESCRIPTION
As per fastapi-utils: `"InferringRouter is deprecated, as its functionality is now provided in fastapi.APIRouter", DeprecationWarning` (ref https://github.com/dmontagu/fastapi-utils/blob/master/fastapi_utils/inferring_router.py).  

I think `fastapi.APIRouter` is all we need.

Note: this is also part of solving the issue of fastapi-utils requiring SQLAlchemy < 2, which prevents us from upgrading to SA 2.0.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
