### PR TITLE
[23.2] Fix job destination extra params

### DIFF
--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -198,6 +198,9 @@ class JobDestinationParams(Model):
         None, title="Handler", description="Name of the process that handled the job.", alias="Handler"
     )
 
+    class Config:
+        extra = Extra.allow  # JobDestinationParams can have extra fields
+
 
 class JobOutput(Model):
     label: Any = Field(default=Required, title="Output label", description="The output label")  # check if this is true


### PR DESCRIPTION
Allow JobDestinationParams return to include extra fields instead of trimming to just the defined 3.  This is admin-only anyway, it's safe, and this was the previous (23.1) behavior.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
