### PR TITLE
xsd: reorder choices for permissive boolean

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -7328,14 +7328,14 @@ and ``contains``. In addition there is ``sim_size`` which is discouraged in favo
       </xs:simpleType>
       <xs:simpleType>
         <xs:restriction base="xs:string">
-          <xs:enumeration value="0"/>
-          <xs:enumeration value="1"/>
           <xs:enumeration value="true"/>
           <xs:enumeration value="false"/>
           <xs:enumeration value="True"/>
           <xs:enumeration value="False"/>
           <xs:enumeration value="yes"/>
           <xs:enumeration value="no"/>
+          <xs:enumeration value="0"/>
+          <xs:enumeration value="1"/>
         </xs:restriction>
       </xs:simpleType>
     </xs:union>


### PR DESCRIPTION
in order of preference. language server seems to take the suggested values from this list using this ordering.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
