### PR TITLE
Fix for converter tests

### DIFF
--- a/lib/galaxy/datatypes/converters/interval_to_bgzip_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_bgzip_converter.xml
@@ -40,10 +40,7 @@
     <tests>
         <test>
             <param name="input1" ftype="bed" value="droPer1.bed"/>
-            <output name="output1" ftype="bgzip" value="droPer1.bgzip">
-                <expand macro="assert_size" value="131"/>
-            </output>
-            <output name="output1" ftype="bgzip" decompress="true">
+            <output name="output1" ftype="bgzip" value="droPer1.bgzip" decompress="true">
                 <expand macro="assert_size" value="120"/>
             </output>
             <assert_command>
@@ -52,9 +49,6 @@
         </test>
         <test>
             <param name="input1" ftype="encodepeak" value="encode.broad.peak"/>
-            <output name="output1" ftype="bgzip">
-                <expand macro="assert_size" value="141"/>
-            </output>
             <output name="output1" ftype="bgzip" decompress="true">
                 <expand macro="assert_size" value="143">
                     <has_text_matching expression="^#" negate="true"/>
@@ -66,9 +60,6 @@
         </test>
         <test>
             <param name="input1" ftype="gff" value="gff_filter_by_feature_count_out2.gff"/>
-            <output name="output1" ftype="bgzip">
-                <expand macro="assert_size" value="638"/>
-            </output>
             <output name="output1" ftype="bgzip" value="bgzip_filter_by_feature_count_out2.bgzip" decompress="true">
                 <expand macro="assert_size" value="3824"/>
             </output>
@@ -79,9 +70,6 @@
         </test>
         <test>
             <param name="input1" ftype="interval" value="2.interval"/>
-            <output name="output1" ftype="bgzip">
-                <expand macro="assert_size" value="208"/>
-            </output>
             <output name="output1" ftype="bgzip" value="2.bgzip" decompress="true">
                 <expand macro="assert_size" value="501"/>
             </output>
@@ -91,9 +79,6 @@
         </test>
         <test>
             <param name="input1" ftype="vcf" value="vcf_to_maf_in.vcf"/>
-            <output name="output1" ftype="bgzip">
-                <expand macro="assert_size" value="321"/>
-            </output>
             <output name="output1" ftype="bgzip" decompress="true">
                 <expand macro="assert_size" value="507">
                     <has_n_lines n="5"/>
@@ -106,11 +91,6 @@
         </test>
         <test>
             <param name="input1" ftype="gtf" value="cufflinks_out1.gtf"/>
-            <output name="output1" ftype="bgzip">
-                <assert_contents>
-                    <has_size value="270" delta="10"/>
-                </assert_contents>
-            </output>
             <output name="output1" ftype="bgzip" decompress="true">
                 <assert_contents>
                     <has_size value="887"/>

--- a/lib/galaxy/datatypes/converters/interval_to_bgzip_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_bgzip_converter.xml
@@ -40,8 +40,11 @@
     <tests>
         <test>
             <param name="input1" ftype="bed" value="droPer1.bed"/>
-            <output name="output1" ftype="bgzip" value="droPer1.bgzip" decompress="true">
+            <output name="output1" ftype="bgzip" value="droPer1.bgzip">
                 <expand macro="assert_size" value="131"/>
+            </output>
+            <output name="output1" ftype="bgzip" decompress="true">
+                <expand macro="assert_size" value="120"/>
             </output>
             <assert_command>
                 <has_text text="-k1,1 -k2,2n -k3,3n"/>
@@ -50,6 +53,9 @@
         <test>
             <param name="input1" ftype="encodepeak" value="encode.broad.peak"/>
             <output name="output1" ftype="bgzip">
+                <expand macro="assert_size" value="141"/>
+            </output>
+            <output name="output1" ftype="bgzip" decompress="true">
                 <expand macro="assert_size" value="143">
                     <has_text_matching expression="^#" negate="true"/>
                 </expand>
@@ -60,8 +66,11 @@
         </test>
         <test>
             <param name="input1" ftype="gff" value="gff_filter_by_feature_count_out2.gff"/>
-            <output name="output1" ftype="bgzip" value="bgzip_filter_by_feature_count_out2.bgzip" decompress="true">
+            <output name="output1" ftype="bgzip">
                 <expand macro="assert_size" value="638"/>
+            </output>
+            <output name="output1" ftype="bgzip" value="bgzip_filter_by_feature_count_out2.bgzip" decompress="true">
+                <expand macro="assert_size" value="3824"/>
             </output>
             <assert_command>
                 <has_text text="-k1,1 -k4,4n"/>
@@ -70,8 +79,11 @@
         </test>
         <test>
             <param name="input1" ftype="interval" value="2.interval"/>
-            <output name="output1" ftype="bgzip" value="2.bgzip" decompress="true">
+            <output name="output1" ftype="bgzip">
                 <expand macro="assert_size" value="208"/>
+            </output>
+            <output name="output1" ftype="bgzip" value="2.bgzip" decompress="true">
+                <expand macro="assert_size" value="501"/>
             </output>
             <assert_command>
                 <has_text text="-k1,1 -k2,2n -k3,3n"/>
@@ -79,11 +91,13 @@
         </test>
         <test>
             <param name="input1" ftype="vcf" value="vcf_to_maf_in.vcf"/>
+            <output name="output1" ftype="bgzip">
+                <expand macro="assert_size" value="321"/>
+            </output>
             <output name="output1" ftype="bgzip" decompress="true">
-                <expand macro="assert_size" value="322">
-                    <!-- will only work with https://github.com/galaxyproject/galaxy/pull/15085
-                        <has_n_lines n="3"/>
-                        <has_text_matching expression="^#" negate="true"/> -->
+                <expand macro="assert_size" value="507">
+                    <has_n_lines n="5"/>
+                    <has_text_matching expression="^#" negate="true"/>
                 </expand>
             </output>
             <assert_command>
@@ -92,9 +106,14 @@
         </test>
         <test>
             <param name="input1" ftype="gtf" value="cufflinks_out1.gtf"/>
-            <output name="output1" ftype="bgzip" >
+            <output name="output1" ftype="bgzip">
                 <assert_contents>
-                    <has_size value="270" delta="10" />
+                    <has_size value="270" delta="10"/>
+                </assert_contents>
+            </output>
+            <output name="output1" ftype="bgzip" decompress="true">
+                <assert_contents>
+                    <has_size value="887"/>
                 </assert_contents>
             </output>
             <assert_command>

--- a/lib/galaxy/datatypes/converters/vcf_to_vcf_bgzip_converter.xml
+++ b/lib/galaxy/datatypes/converters/vcf_to_vcf_bgzip_converter.xml
@@ -17,7 +17,7 @@
             <param name="input1" ftype="vcf" value="vcf_to_maf_in.vcf"/>
             <output name="output1" ftype="vcf_bgzip" value="vcf_bgzip_to_maf_in.vcf_bgzip" decompress="true">
                 <assert_contents>
-                    <has_size value="717" delta="10"/>
+                    <has_size value="1182"/>
                 </assert_contents>
             </output>
         </test>


### PR DESCRIPTION
First I tried to be as unintrusive as possible, i.e. to keep assertions for the zipped output. But finally I went for having only tests wrt the decompressed output (i.e. with `decompress="true"`). 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
