### PR TITLE
Accept any number of arguments to the secret decoder ring

### DIFF
--- a/scripts/secret_decoder_ring.py
+++ b/scripts/secret_decoder_ring.py
@@ -20,8 +20,8 @@ logging.basicConfig()
 log = logging.getLogger(__name__)
 
 parser = argparse.ArgumentParser()
-parser.add_argument("action", metavar="ACTION", type=str, default=None, help="decode|encode")
-parser.add_argument("value", metavar="VALUE", type=str, default=None, help="value to encode or decode")
+parser.add_argument("action", metavar="ACTION", type=str, default=None, choices=("decode", "encode"))
+parser.add_argument("value", metavar="VALUE", nargs="+", type=str, default=None, help="value to encode or decode")
 populate_config_args(parser)
 args = parser.parse_args()
 
@@ -39,9 +39,10 @@ security_helper = IdEncodingHelper(id_secret=id_secret)
 # Login manager to manage current_user functionality
 
 if args.action == "decode":
-    sys.stdout.write(security_helper.decode_guid(args.value.lstrip("F")))
+    for value in args.value:
+        sys.stdout.write(security_helper.decode_guid(value.lstrip("F")))
+        sys.stdout.write("\n")
 elif args.action == "encode":
-    sys.stdout.write(unicodify(security_helper.encode_guid(args.value)))
-else:
-    sys.stdout.write("Unknown argument")
-sys.stdout.write("\n")
+    for value in args.value:
+        sys.stdout.write(unicodify(security_helper.encode_guid(value)))
+        sys.stdout.write("\n")


### PR DESCRIPTION
Useful with `xargs(1)`

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  ```sh-session
  (.venv)nate@wain% python ./scripts/secret_decoder_ring.py encode
  usage: secret_decoder_ring.py [-h] [-c CONFIG_FILE] ACTION VALUE [VALUE ...]
  secret_decoder_ring.py: error: the following arguments are required: VALUE
  (.venv)nate@wain% python ./scripts/secret_decoder_ring.py encode 1
  f1b9d3d3ea50e2f2
  (.venv)nate@wain% python ./scripts/secret_decoder_ring.py encode 1 2 3
  f1b9d3d3ea50e2f2
  2ff02a62db42a49d
  54b64fc919efa108
  ```

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
