### PR TITLE
[23.2] Fix tools missing in panel bug

### DIFF
--- a/client/src/components/Panels/utilities.ts
+++ b/client/src/components/Panels/utilities.ts
@@ -158,22 +158,13 @@ export function getValidToolsInCurrentView(
     isWorkflowPanel = false,
     excludedSectionIds: string[] = []
 ) {
-    const addedToolTexts: string[] = [];
     const toolEntries = Object.entries(toolsById).filter(([, tool]) => {
-        // filter out duplicate tools (different ids, same exact name+description)
-        // related ticket: https://github.com/galaxyproject/galaxy/issues/16145
-        const toolText = tool.name + tool.description;
-        if (addedToolTexts.includes(toolText)) {
-            return false;
-        } else {
-            addedToolTexts.push(toolText);
-        }
         // filter on non-hidden, non-disabled, and workflow compatibile (based on props.workflow)
         return (
             !tool.hidden &&
             tool.disabled !== true &&
             !(isWorkflowPanel && !tool.is_workflow_compatible) &&
-            !excludedSectionIds.includes(tool.panel_section_id || "")
+            !excludedSectionIds.includes(tool.panel_section_id)
         );
     });
     return Object.fromEntries(toolEntries);

--- a/client/src/stores/toolStore.ts
+++ b/client/src/stores/toolStore.ts
@@ -27,7 +27,7 @@ export interface Tool {
     link: string;
     min_width: number;
     target: string;
-    panel_section_id: string | null;
+    panel_section_id: string;
     panel_section_name: string | null;
     form_style: string;
     disabled?: boolean;


### PR DESCRIPTION
Some tools would be filtered out from the tool panel needlessly when organizing the `ToolPanel` in `Panels/utilities.ts`.

This was caused due to the mistake of filtering out cases where tools had the same exact name+description, which is something we shouldn't have done because different id = different tool.

For example, because of this bug, we had _**FastQC** Read Quality reports_ missing, although, _**Porechop** adapter trimmer for Oxford Nanopore reads_ was found in the panel, even though both tools had multiple occurrences in the toolsList with same name+desc. What caused this: 
- first we were (erroneously) removing all repetitions after the first occurrence (referenced by first found tool id) of such a tool in the toolsList (... we would in fact include one occurrence in `toolsById` ...)
- then, we would use the `api/tool_panels/default` structure to display the tool panel, where in the case of _FastQC_, we didn't have the latest tool id in `toolsById`, and in the case of `Porechop` we just happened to store the latest tool id (by chance of the ordering of the toolsList) in `toolsById`

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
