### PR TITLE
[23.2] Fix Multiselect in BModal overflows out of view bug

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -91,6 +91,7 @@
             id="change-dbkey-of-selected-content"
             title="Change Database/Build?"
             title-tag="h2"
+            body-class="modal-with-selector"
             @ok="changeDbkeyOfSelected">
             <p v-localize>Select a new Database/Build for {{ numSelected }} items:</p>
             <DbKeyProvider v-slot="{ item: dbkeys, loading: loadingDbKeys }">
@@ -99,7 +100,6 @@
                     :loading="loadingDbKeys"
                     :items="dbkeys"
                     :current-item-id="selectedDbKey"
-                    class="mb-5 pb-5"
                     @update:selected-item="onSelectedDbKey" />
             </DbKeyProvider>
         </b-modal>
@@ -107,6 +107,7 @@
             id="change-datatype-of-selected-content"
             title="Change data type?"
             title-tag="h2"
+            body-class="modal-with-selector"
             :ok-disabled="selectedDatatype == null"
             @ok="changeDatatypeOfSelected">
             <p v-localize>Select a new data type for {{ numSelected }} items:</p>
@@ -116,7 +117,6 @@
                     :loading="loadingDatatypes"
                     :items="datatypes"
                     :current-item-id="selectedDatatype"
-                    class="mb-5 pb-5"
                     @update:selected-item="onSelectedDatatype" />
             </DatatypesProvider>
         </b-modal>
@@ -347,3 +347,9 @@ export default {
     },
 };
 </script>
+
+<style>
+.modal-with-selector {
+    overflow: initial;
+}
+</style>

--- a/client/src/components/Upload/UploadModal.vue
+++ b/client/src/components/Upload/UploadModal.vue
@@ -101,6 +101,6 @@ defineExpose({
 
 .upload-dialog-body {
     height: 500px;
-    overflow: hidden;
+    overflow: initial;
 }
 </style>


### PR DESCRIPTION
Use `overflow: initial` to fix make sure the multiselect goes beyond the modal. Fixes #17163 .

## In the Upload Modal
| Before | After |
| ------ | ----- |
| ![Screen Shot 2023-12-15 at 7 32 50 PM](https://github.com/galaxyproject/galaxy/assets/78516064/90b591c4-0cc5-4fb9-a13d-b184218ff76f) | ![image](https://github.com/galaxyproject/galaxy/assets/78516064/8ebf2694-3e45-4d01-997c-1f5e9463b206) |

## In other modals with selectors, e.g.: change database in History item selection
| Before | After |
| ------ | ----- |
| ![image](https://github.com/galaxyproject/galaxy/assets/78516064/ec6e56ee-224f-4113-93ce-723abf3acecc) | ![image](https://github.com/galaxyproject/galaxy/assets/78516064/608f2d48-4656-4c50-acc5-77b46698ca95) |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
