### PR TITLE
[23.2] Remove `SingleItemSelector` deselect label, fix history filters hidden on smaller screen

### DIFF
--- a/client/src/components/History/Index.vue
+++ b/client/src/components/History/Index.vue
@@ -1,5 +1,8 @@
 <template>
-    <div v-if="currentUser && currentHistory" id="current-history-panel" class="d-flex flex-column history-index">
+    <div
+        v-if="currentUser && currentHistory"
+        id="current-history-panel"
+        class="d-flex flex-column history-index overflow-auto">
         <HistoryPanel
             v-if="!breadcrumbs.length"
             :list-offset="listOffset"

--- a/client/src/components/Panels/Menus/PanelViewMenu.vue
+++ b/client/src/components/Panels/Menus/PanelViewMenu.vue
@@ -1,5 +1,14 @@
 <template>
+    <b-button
+        v-if="showAdvanced"
+        variant="link"
+        class="w-100"
+        size="sm"
+        @click="$emit('update:show-advanced', !showAdvanced)">
+        <slot name="panel-view-selector"></slot><span class="sr-only">Close advanced tool search menu</span>
+    </b-button>
     <b-dropdown
+        v-else
         v-b-tooltip.hover.top.noninteractive
         right
         block
@@ -58,6 +67,10 @@ export default {
         },
         currentPanelView: {
             type: String,
+        },
+        showAdvanced: {
+            type: Boolean,
+            default: false,
         },
         storeLoading: {
             type: Boolean,

--- a/client/src/components/Panels/ToolPanel.vue
+++ b/client/src/components/Panels/ToolPanel.vue
@@ -139,6 +139,7 @@ function onInsertWorkflowSteps(workflowId: string, workflowStepCount: number | u
                     v-if="panelViews && Object.keys(panelViews).length > 1"
                     :panel-views="panelViews"
                     :current-panel-view="currentPanelView"
+                    :show-advanced.sync="showAdvanced"
                     :store-loading="loading"
                     @updatePanelView="updatePanelView">
                     <template v-slot:panel-view-selector>

--- a/client/src/components/SingleItemSelector.vue
+++ b/client/src/components/SingleItemSelector.vue
@@ -4,7 +4,7 @@
         <Multiselect
             v-if="items"
             v-model="selectedItem"
-            deselect-label="Can't remove this value"
+            :deselect-label="null"
             track-by="id"
             label="text"
             :options="items"


### PR DESCRIPTION

In this PR:
- removed the `deselectLabel` for `SingleItemSelector`, since it is used to only select 1 item and deselecting is not even an option in this component, so the current label "_Can't remove this value_" was confusing
- added `overflow-auto` class to History `Index` to prevent filters in advanced menu from being hidden on smaller/zoomed-in screen
- fixed `PanelViewMenu` when advanced filters are shown in tool panel; currently it can be confusing as it shows panel view selector even when filter menu is toggled

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
