### PR TITLE
Reload built-in converters on toolbox reload

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -703,9 +703,6 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
         self.datatypes_registry.load_external_metadata_tool(self.toolbox)
         # Load history import/export tools.
         load_lib_tools(self.toolbox)
-        # Load built-in converters
-        if self.config.display_builtin_converters:
-            self.toolbox.load_builtin_converters()
         self.toolbox.persist_cache(register_postfork=True)
         # visualizations registry: associates resources with visualizations, controls how to render
         self.visualizations_registry = self._register_singleton(

--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -158,6 +158,10 @@ class MockApp(di.Container, GalaxyDataTestApp):
     def toolbox(self) -> ToolBox:
         return self._toolbox
 
+    @toolbox.setter
+    def toolbox(self, toolbox: ToolBox):
+        self._toolbox = toolbox
+
     def wait_for_toolbox_reload(self, toolbox):
         # TODO: If the tpm test case passes, does the operation really
         # need to wait.
@@ -258,6 +262,7 @@ class MockAppConfig(GalaxyDataTestConfig, CommonConfigurationMixin):
         self.integrated_tool_panel_config = None
         self.vault_config_file = kwargs.get("vault_config_file")
         self.max_discovered_files = 10000
+        self.display_builtin_converters = True
         self.enable_notification_system = True
 
     @property

--- a/lib/galaxy/app_unittest_utils/tools_support.py
+++ b/lib/galaxy/app_unittest_utils/tools_support.py
@@ -1,6 +1,6 @@
 """ Module contains test fixtures meant to aide in the testing of jobs and
 tool evaluation. Such extensive "fixtures" are something of an anti-pattern
-so use of this should be limitted to tests of very 'extensive' classes.
+so use of this should be limited to tests of very 'extensive' classes.
 """
 
 import os.path

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -442,7 +442,9 @@ class ToolBox(AbstractToolBox):
             default_panel_view=default_panel_view,
             save_integrated_tool_panel=save_integrated_tool_panel,
         )
-
+        # Load built-in converters
+        if app.config.display_builtin_converters:
+            self.load_builtin_converters()
         if old_toolbox := getattr(app, "toolbox", None):
             self.dependency_manager = old_toolbox.dependency_manager
         else:

--- a/test/unit/tool_shed/test_tool_panel_manager.py
+++ b/test/unit/tool_shed/test_tool_panel_manager.py
@@ -25,20 +25,20 @@ class TestToolPanelManager(BaseToolBoxTestCase):
         assert section_id == "tid"
         assert len(section.elems) == 1  # tool.xml
         assert section.id == "tid"
-        assert len(toolbox._tool_panel) == 1
+        assert len(toolbox._tool_panel) == 2  # section + built-in converters section
 
         section_id, section = tpm.handle_tool_panel_section(toolbox, new_tool_panel_section_label="tid2")
         assert section_id == "tid2"
         assert len(section.elems) == 0  # new section
         assert section.id == "tid2"
-        assert len(toolbox._tool_panel) == 2
+        assert len(toolbox._tool_panel) == 3  # 2 sections + built-in converters section
 
         # Test re-fetch new section by same id.
         section_id, section = tpm.handle_tool_panel_section(toolbox, new_tool_panel_section_label="tid2")
         assert section_id == "tid2"
         assert len(section.elems) == 0  # new section
         assert section.id == "tid2"
-        assert len(toolbox._tool_panel) == 2
+        assert len(toolbox._tool_panel) == 3  # 2 sections + built-in converters section
 
     def test_add_tool_to_panel(self):
         self._init_ts_tool(guid=DEFAULT_GUID)


### PR DESCRIPTION
fixes #16947

also adds a setter to `MockApp` in order to fix the following which was shown during tests

```
  /home/berntm/projects/galaxy/.venv/lib/python3.10/site-packages/_pytest/threadexception.py:73: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-7 (check)

  Traceback (most recent call last):
    File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
      self.run()
    File "/usr/lib/python3.10/threading.py", line 953, in run
      self._target(*self._args, **self._kwargs)
    File "/home/berntm/projects/galaxy/lib/galaxy/tool_util/toolbox/watcher.py", line 153, in check
      self.reload_callback()
    File "/home/berntm/projects/galaxy/lib/galaxy/app_unittest_utils/toolbox_support.py", line 44, in <lambda>
      app.watchers.tool_config_watcher.reload_callback = lambda: reload_callback(test_case)
    File "/home/berntm/projects/galaxy/lib/galaxy/app_unittest_utils/toolbox_support.py", line 193, in reload_callback
      test_case._toolbox = test_case.app.toolbox = SimplifiedToolBox(test_case)
  AttributeError: can't set attribute 'toolbox'

    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
```


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
