### PR TITLE
[23.1] Fix `url_for` in tool error reports

### DIFF
--- a/lib/galaxy/tools/error_reports/plugins/slack.py
+++ b/lib/galaxy/tools/error_reports/plugins/slack.py
@@ -8,7 +8,6 @@ from typing import (
 
 import requests
 
-from galaxy import web
 from galaxy.util import string_as_bool
 from .base_git import BaseGitPlugin
 
@@ -38,7 +37,7 @@ class SlackPlugin(BaseGitPlugin):
 
     def submit_report(self, dataset, job, tool, **kwargs):
         history_id_encoded = self.app.security.encode_id(dataset.history_id)
-        history_view_link = web.url_for("/histories/view", id=history_id_encoded, qualified=True)
+        history_view_link = self.app.url_for("/histories/view", id=history_id_encoded, qualified=True)
         error_report_id = str(uuid.uuid4())[0:13]
         title = self._generate_error_title(job)
 

--- a/lib/galaxy/tools/errors.py
+++ b/lib/galaxy/tools/errors.py
@@ -8,7 +8,6 @@ import markupsafe
 from galaxy import (
     model,
     util,
-    web,
 )
 from galaxy.security.validate_user_input import validate_email_str
 from galaxy.util import unicodify
@@ -159,11 +158,11 @@ class ErrorReporter:
     def create_report(self, user, email="", message="", redact_user_details_in_bugreport=False, **kwd):
         hda = self.hda
         job = self.job
-        host = web.url_for("/", qualified=True)
+        host = self.app.url_for("/", qualified=True)
         history_id_encoded = self.app.security.encode_id(hda.history_id)
-        history_view_link = web.url_for("/histories/view", id=history_id_encoded, qualified=True)
+        history_view_link = self.app.url_for("/histories/view", id=history_id_encoded, qualified=True)
         hda_id_encoded = self.app.security.encode_id(hda.id)
-        hda_show_params_link = web.url_for(
+        hda_show_params_link = self.app.url_for(
             controller="dataset", action="details", dataset_id=hda_id_encoded, qualified=True
         )
         # Build the email message


### PR DESCRIPTION
Partial backport of #17058 to 23.1

Reported by @natefoo on Matrix:

> Bug reports on .org are suddenly sporadically failing url_for here: https://github.com/galaxyproject/galaxy/blob/573b9024808b2e1583f49f82c5c7f14d541900f7/lib/galaxy/web/framework/__init__.py#L21 meaning the error report emails have no links
I haven't figured out yet under what conditions it works (that it's sporadic like this is weird enough).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
