### PR TITLE
[23.2] Fix categories in ToolShed repo create API

### DIFF
--- a/lib/tool_shed/test/base/populators.py
+++ b/lib/tool_shed/test/base/populators.py
@@ -231,13 +231,13 @@ class ToolShedPopulator:
             api_asserts.assert_status_code_is_ok(response)
         return RepositoryUpdate(__root__=response.json())
 
-    def new_repository(self, category_id, prefix=DEFAULT_PREFIX) -> Repository:
+    def new_repository(self, category_ids: Union[List[str], str], prefix: str = DEFAULT_PREFIX) -> Repository:
         name = random_name(prefix=prefix)
         synopsis = random_name(prefix=prefix)
         request = CreateRepositoryRequest(
             name=name,
             synopsis=synopsis,
-            category_ids=category_id,
+            category_ids=category_ids,
         )
         return self.create_repository(request)
 
@@ -281,6 +281,11 @@ class ToolShedPopulator:
         response = self._api_interactor.get(f"categories/{category_id}/repositories")
         response.raise_for_status()
         return RepositoriesByCategory(**response.json())
+
+    def assert_category_has_n_repositories(self, category_id: str, n: int):
+        category_repos = self.repositories_by_category(category_id)
+        assert category_repos.repository_count == n
+        assert len(category_repos.repositories) == n
 
     def get_ordered_installable_revisions(self, owner: str, name: str) -> OrderedInstallableRevisions:
         request = GetOrderedInstallableRevisionsRequest(owner=owner, name=name)

--- a/lib/tool_shed/test/functional/test_shed_repositories.py
+++ b/lib/tool_shed/test/functional/test_shed_repositories.py
@@ -24,16 +24,18 @@ COLUMN_MAKER_PATH = resource_path(__package__, "../test_data/column_maker/column
 class TestShedRepositoriesApi(ShedApiTestCase):
     def test_create(self):
         populator = self.populator
-        category_id = populator.new_category(prefix="testcreate").id
+        category1_id = populator.new_category(prefix="testcreate").id
+        populator.assert_category_has_n_repositories(category1_id, 0)
 
-        repos_by_category = populator.repositories_by_category(category_id)
-        repos = repos_by_category.repositories
-        assert len(repos) == 0
+        populator.new_repository(category1_id)
+        populator.assert_category_has_n_repositories(category1_id, 1)
 
-        populator.new_repository(category_id)
-        repos_by_category = populator.repositories_by_category(category_id)
-        repos = repos_by_category.repositories
-        assert len(repos) == 1
+        # Test creating repository with multiple categories
+        category2_id = populator.new_category(prefix="testcreate").id
+        populator.assert_category_has_n_repositories(category2_id, 0)
+        populator.new_repository([category1_id, category2_id])
+        populator.assert_category_has_n_repositories(category1_id, 2)
+        populator.assert_category_has_n_repositories(category2_id, 1)
 
     def test_update_repository(self):
         populator = self.populator

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 from typing import (
+    List,
     Optional,
     Tuple,
     TYPE_CHECKING,
@@ -190,7 +191,7 @@ def create_repository(
     description,
     long_description,
     user_id,
-    category_ids=None,
+    category_ids: Optional[List[str]] = None,
     remote_repository_url=None,
     homepage_url=None,
 ) -> Tuple["Repository", str]:

--- a/lib/tool_shed/webapp/frontend/src/schema/schema.ts
+++ b/lib/tool_shed/webapp/frontend/src/schema/schema.ts
@@ -305,7 +305,7 @@ export interface components {
         /** CreateRepositoryRequest */
         CreateRepositoryRequest: {
             /** Category IDs */
-            "category_ids[]": string
+            "category_ids[]": string[] | string
             /** Description */
             description?: string
             /** Homepage Url */

--- a/lib/tool_shed_client/schema/__init__.py
+++ b/lib/tool_shed_client/schema/__init__.py
@@ -113,7 +113,7 @@ class CreateRepositoryRequest(BaseModel):
         alias="type",
         title="Type",
     )
-    category_ids: str = Field(
+    category_ids: Optional[Union[List[str], str]] = Field(
         ...,
         alias="category_ids[]",
         title="Category IDs",


### PR DESCRIPTION
Fix https://github.com/galaxyproject/galaxy/issues/17215 .

Also:
- Add API test for creation of TS repo with multiple categories.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
