### PR TITLE
[23.2] Fix cardinality violation error: subquery must return at most 1 result

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8293,6 +8293,7 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
             .filter(WorkflowInvocationStep.workflow_invocation_id == self.id)
             .filter(~Job.state.in_(Job.finished_states))
             .with_for_update()
+            .limit(1)
             .scalar_subquery()
         )
         sa_session.execute(update(Job.table).where(Job.id == job_subq).values({"state": Job.states.DELETING}))


### PR DESCRIPTION
Fixes `(psycopg2.errors.CardinalityViolation) more than one row returned by a subquery used as an expression`

Cause: we are using the result of a scalar subquery in a WHERE clause; but the result contains more than one row.

**Option 1: use this ONLY if we expect ONE job at most**

Alternative solution: #17224

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
