### PR TITLE
[23.2] Fix cardinality violation error: subquery returns multiple results

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8293,9 +8293,8 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
             .filter(WorkflowInvocationStep.workflow_invocation_id == self.id)
             .filter(~Job.state.in_(Job.finished_states))
             .with_for_update()
-            .scalar_subquery()
         )
-        sa_session.execute(update(Job.table).where(Job.id == job_subq).values({"state": Job.states.DELETING}))
+        sa_session.execute(update(Job.table).where(Job.id.in_(job_subq)).values({"state": Job.states.DELETING}))
 
         job_collection_subq = (
             select(Job.id)


### PR DESCRIPTION
Fixes `(psycopg2.errors.CardinalityViolation) more than one row returned by a subquery used as an expression`

Cause: we are using the result of a scalar subquery in a WHERE clause; but the result contains more than one row.

Solution-2: do not use scalary subquery, delete all selected jobs instead

**Option 2: use this ONLY if we expect MULTIPLE jobs**

Alternative solution: #17223

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
