### PR TITLE
[23.2] Fix job parameter display

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6738,7 +6738,7 @@ export interface components {
              * Value
              * @description The values of the job parameter
              */
-            value: Record<string, never>;
+            value?: Record<string, never>;
         };
         /**
          * JobSourceType

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -218,7 +218,7 @@ class JobParameter(Model):
         title="Depth",
         description="The depth of the job parameter.",
     )
-    value: Any = Field(default=Required, title="Value", description="The values of the job parameter")
+    value: Optional[Any] = Field(default=None, title="Value", description="The values of the job parameter")
     notes: Optional[str] = Field(default=None, title="Notes", description="Notes associated with the job parameter.")
 
 


### PR DESCRIPTION
Fixes

```
7 validation errors for JobDisplayParametersSummary
response -> parameters -> 6 -> value
  field required (type=value_error.missing)
response -> parameters -> 9 -> value
  field required (type=value_error.missing)
response -> parameters -> 11 -> value
  field required (type=value_error.missing)
response -> parameters -> 15 -> value
  field required (type=value_error.missing)
response -> parameters -> 19 -> value
  field required (type=value_error.missing)
response -> parameters -> 23 -> value
  field required (type=value_error.missing)
response -> parameters -> 25 -> value
  field required (type=value_error.missing)
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
