### PR TITLE
[23.2] Fix Display Application link generation

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -674,7 +674,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                                     ), f"Extra file content requested ({action_param_extra}), but allow_extra_files_access is False."
                                     file_name = os.path.join(value.extra_files_path, action_param_extra)
                                 else:
-                                    file_name = value.get_file_name()
+                                    file_name = value.file_name
                                 content_length = os.path.getsize(file_name)
                                 rval = open(file_name, "rb")
                             except OSError as e:


### PR DESCRIPTION
for metadata files and use same interface also for datasets, which should effectively give us test coverage?

Fixes:
```
Stack Trace(most recent call first)

AttributeError: 'Bunch' object has no attribute 'get_file_name'
  File "starlette/applications.py", line 122, in __call__
    await self.middleware_stack(scope, receive, send)
  File "starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "starlette_context/middleware/raw_middleware.py", line 93, in __call__
    await self.app(scope, receive, send_wrapper)
  File "starlette/middleware/base.py", line 109, in __call__
    await response(scope, receive, send)
  File "starlette/responses.py", line 270, in __call__
    async with anyio.create_task_group() as task_group:
  File "anyio/_backends/_asyncio.py", line 597, in __aexit__
    raise exceptions[0]
  File "starlette/responses.py", line 273, in wrap
    await func()
  File "starlette/middleware/base.py", line 134, in stream_response
    return await super().stream_response(send)
  File "starlette/responses.py", line 262, in stream_response
    async for chunk in self.body_iterator:
  File "starlette/middleware/base.py", line 98, in body_stream
    raise app_exc
  File "starlette/middleware/base.py", line 70, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "fastapi/middleware/asyncexitstack.py", line 20, in __call__
    raise e
  File "fastapi/middleware/asyncexitstack.py", line 17, in __call__
    await self.app(scope, receive, send)
  File "starlette/routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "starlette/routing.py", line 443, in handle
    await self.app(scope, receive, send)
  File "a2wsgi/wsgi.py", line 157, in __call__
    return await responder(scope, receive, send)
  File "a2wsgi/wsgi.py", line 198, in __call__
    raise self.exc_info[0].with_traceback(
  File "galaxy/web/framework/middleware/error.py", line 165, in __call__
    app_iter = self.application(environ, sr_checker)
  File "galaxy/web/framework/middleware/statsd.py", line 29, in __call__
    req = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.11/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 173, in __call__
    return self.handle_request(request_id, path_info, environ, start_response)
  File "galaxy/web/framework/base.py", line 262, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/web/framework/decorators.py", line 138, in set_nocache_headers
    return func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/controllers/dataset.py", line 677, in display_application
    file_name = value.get_file_name()
  File "galaxy/datatypes/display_applications/parameters.py", line 256, in __getattr__
    return getattr(self.value, key)
```
from https://sentry.galaxyproject.org/share/issue/c68d4f4d94f941c09e6eb5f62b163a69/

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
