### PR TITLE
[23.1] Separate collection and non-collection data element

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -5282,11 +5282,19 @@ on Human (hg18)``.
 
   <xs:group name="OutputCollectionElement">
     <xs:choice>
-      <xs:element name="data" type="OutputData" />
+      <xs:element name="data" type="OutputCollectionDataElement" />
       <xs:element name="discover_datasets" type="OutputCollectionDiscoverDatasets" />
       <xs:element name="filter" type="OutputFilter" />
     </xs:choice>
   </xs:group>
+
+  <xs:complexType name="OutputCollectionDataElement">
+    <xs:sequence>
+      <xs:group ref="OutputCollectionElement" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:attributeGroup ref="OutputCommon" />
+    <xs:attributeGroup ref="OutputDataAttributes" />
+  </xs:complexType>
 
   <xs:complexType name="OutputCollection">
     <xs:annotation>
@@ -5335,7 +5343,6 @@ This tag describes an output to the tool.
     </xs:annotation>
     <xs:sequence>
       <xs:group ref="OutputDataElement" minOccurs="0" maxOccurs="unbounded" />
-      <xs:group ref="OutputCollectionElement" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
     <xs:attributeGroup ref="OutputCommon"/>
     <xs:attributeGroup ref="OutputCollectionAttributes"/>

--- a/test/unit/files/test_ftp.py
+++ b/test/unit/files/test_ftp.py
@@ -1,5 +1,8 @@
 import os
 
+import pytest
+from fs.errors import RemoteConnectionError
+
 from ._util import (
     assert_realizes_contains,
     configured_file_sources,
@@ -19,12 +22,15 @@ def test_file_source_ftp_specific():
     assert file_source_pair.path == test_url
     assert file_source_pair.file_source.id == "test1"
 
-    assert_realizes_contains(
-        file_sources,
-        test_url,
-        "This is ftp.gnu.org, the FTP server of the the GNU project.",
-        user_context=user_context,
-    )
+    try:
+        assert_realizes_contains(
+            file_sources,
+            test_url,
+            "This is ftp.gnu.org, the FTP server of the the GNU project.",
+            user_context=user_context,
+        )
+    except RemoteConnectionError:
+        pytest.skip("ftp.gnu.org not available")
 
 
 def test_file_source_ftp_generic():


### PR DESCRIPTION
in tool schema. New lxml is more strict when validating the xml schema and fails with

```
lxml.etree.XMLSchemaParseError: complex type 'Output': The content model is not determinist., line 5329
```

this is because `filter` and `discover_datasets` are present in OutputDataElement and OutputCollectionElement, making

```
     <xs:sequence>
       <xs:group ref="OutputDataElement" minOccurs="0" maxOccurs="unbounded" />
       <xs:group ref="OutputCollectionElement" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
```

not deterministic.

In any case this isn't an accurate model of what is allowed and parsed, as you can't use collection-specific discover_datasets options outside of a dataset collection.

I **think** that the reason for adding
OutputCollectionElement to the sequence is that you can have a `data` element nested in a `collection` element.

To continue allowing this and making it more precise I've added an additional `OutputCollectionDataElement` type that is allowed within `collection`. This then should allow us to remove
`OutputCollectionElement` from the `OutputData` type.

A quick test against IUC and devteam revealed no problem with this approach per se, however it showed that https://github.com/galaxyproject/tools-iuc/blob/aa8360cb3ec9faf1488938a430855977632706ff/tools/krakentools/extract_kraken_reads.xml#L145 uses `change_format` which is not implemented for collections.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
