### PR TITLE
Add accepted extensions to form data input

### DIFF
--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -3,7 +3,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCopy, faFile, faFolder } from "@fortawesome/free-regular-svg-icons";
 import { faCaretDown, faCaretUp, faExclamation, faLink, faUnlink } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton, BButtonGroup, BCollapse, BFormCheckbox, BTooltip } from "bootstrap-vue";
+import { BAlert, BButton, BButtonGroup, BCollapse, BFormCheckbox, BTooltip } from "bootstrap-vue";
 import { computed, onMounted, type Ref, ref, watch } from "vue";
 
 import { getGalaxyInstance } from "@/app";
@@ -481,7 +481,18 @@ const formatsButtonId = useUid("form-data-formats-");
             :multiple="currentVariant.multiple"
             :optional="optional"
             :options="formattedOptions"
-            :placeholder="`Select a ${placeholder}`" />
+            :placeholder="`Select a ${placeholder}`">
+            <template v-slot:no-options>
+                <BAlert v-if="!extensions || extensions.length < 1" variant="warning" show>
+                    No datasets available
+                </BAlert>
+                <BAlert v-else-if="extensions.length === 1" variant="warning" class="w-100" show>
+                    No {{ extensions[0] }} datasets available
+                </BAlert>
+                <BAlert v-else variant="warning" show> No compatible datasets available </BAlert>
+            </template>
+        </FormSelect>
+
         <template v-if="currentVariant && currentVariant.batch !== BATCH.DISABLED">
             <BFormCheckbox
                 v-if="currentVariant.batch === BATCH.ENABLED"

--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -16,10 +16,10 @@ import FormSelect from "@/components/Form/Elements/FormSelect.vue";
 
 library.add(faCopy, faExclamation, faFile, faFolder, faLink, faUnlink);
 
-interface SelectOption {
+type SelectOption = {
     label: string;
     value: DataOption | null;
-}
+};
 
 const props = withDefaults(
     defineProps<{
@@ -39,11 +39,11 @@ const props = withDefaults(
         loading: false,
         multiple: false,
         optional: false,
-        value: null,
+        value: undefined,
         extensions: () => [],
         type: "data",
-        flavor: null,
-        tag: null,
+        flavor: undefined,
+        tag: undefined,
     }
 );
 
@@ -106,7 +106,7 @@ const currentValue = computed({
                 return value;
             }
         }
-        return null;
+        return undefined;
     },
     set: (val) => {
         $emit("input", createValue(val));
@@ -219,7 +219,7 @@ function clearHighlighting(timeout = 1000) {
 /**
  * Create final input element value
  */
-function createValue(val: Array<DataOption> | DataOption | null) {
+function createValue(val?: Array<DataOption> | DataOption | null) {
     if (val) {
         const values = Array.isArray(val) ? val : [val];
         if (variant.value && values.length > 0 && values[0]) {
@@ -429,6 +429,7 @@ watch(
 </script>
 
 <template>
+    <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
     <div
         :class="currentHighlighting && `ui-dragover-${currentHighlighting}`"
         @dragenter.prevent="onDragEnter"
@@ -437,7 +438,7 @@ watch(
         @drop.prevent="onDrop">
         <div>
             <div class="d-flex">
-                <BButtonGroup v-if="variant.length > 1" buttons class="align-self-start mr-2">
+                <BButtonGroup v-if="variant && variant.length > 1" buttons class="align-self-start mr-2">
                     <BButton
                         v-for="(v, index) in variant"
                         :key="index"
@@ -464,7 +465,7 @@ watch(
                     :options="formattedOptions"
                     :placeholder="`Select a ${placeholder}`" />
             </div>
-            <div v-if="currentVariant.batch !== BATCH.DISABLED">
+            <div v-if="currentVariant && currentVariant.batch !== BATCH.DISABLED">
                 <BFormCheckbox
                     v-if="currentVariant.batch === BATCH.ENABLED"
                     v-model="currentLinked"

--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -9,6 +9,7 @@ import { computed, onMounted, type Ref, ref, watch } from "vue";
 import { getGalaxyInstance } from "@/app";
 import { useUid } from "@/composables/utils/uid";
 import { type EventData, useEventStore } from "@/stores/eventStore";
+import { orList } from "@/utils/strings";
 
 import type { DataOption } from "./types";
 import { BATCH, SOURCE, VARIANTS } from "./variants";
@@ -428,6 +429,17 @@ watch(
 
 const formatsVisible = ref(false);
 const formatsButtonId = useUid("form-data-formats-");
+
+const warningListAmount = 4;
+const noOptionsWarningMessage = computed(() => {
+    if (!props.extensions || props.extensions.length === 0) {
+        return "No datasets available";
+    } else if (props.extensions.length <= warningListAmount) {
+        return `No ${orList(props.extensions)} datasets available`;
+    } else {
+        return "No compatible datasets available";
+    }
+});
 </script>
 
 <template>
@@ -483,13 +495,9 @@ const formatsButtonId = useUid("form-data-formats-");
             :options="formattedOptions"
             :placeholder="`Select a ${placeholder}`">
             <template v-slot:no-options>
-                <BAlert v-if="!extensions || extensions.length < 1" variant="warning" show>
-                    No datasets available
+                <BAlert variant="warning" show>
+                    {{ noOptionsWarningMessage }}
                 </BAlert>
-                <BAlert v-else-if="extensions.length === 1" variant="warning" class="w-100" show>
-                    No {{ extensions[0] }} datasets available
-                </BAlert>
-                <BAlert v-else variant="warning" show> No compatible datasets available </BAlert>
             </template>
         </FormSelect>
 

--- a/client/src/components/Form/Elements/FormData/types.ts
+++ b/client/src/components/Form/Elements/FormData/types.ts
@@ -1,4 +1,4 @@
-export interface DataOption {
+export type DataOption = {
     id: string;
     hid: number;
     is_dataset?: boolean;
@@ -7,4 +7,4 @@ export interface DataOption {
     name: string;
     src: string;
     tags: Array<string>;
-}
+};

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -154,23 +154,27 @@ onMounted(() => {
 </script>
 
 <template>
-    <Multiselect
-        v-if="hasOptions"
-        :id="id"
-        v-model="currentValue"
-        :allow-empty="optional"
-        :aria-expanded="ariaExpanded"
-        :close-on-select="!multiple"
-        :disabled="disabled"
-        :deselect-label="deselectLabel"
-        label="label"
-        :multiple="multiple"
-        :options="reorderedOptions"
-        :placeholder="placeholder"
-        :selected-label="selectedLabel"
-        select-label="Click to select"
-        track-by="value"
-        @open="onOpen"
-        @close="onClose" />
-    <b-alert v-else v-localize class="w-100" variant="warning" show> No options available. </b-alert>
+    <div>
+        <Multiselect
+            v-if="hasOptions"
+            :id="id"
+            v-model="currentValue"
+            :allow-empty="optional"
+            :aria-expanded="ariaExpanded"
+            :close-on-select="!multiple"
+            :disabled="disabled"
+            :deselect-label="deselectLabel"
+            label="label"
+            :multiple="multiple"
+            :options="reorderedOptions"
+            :placeholder="placeholder"
+            :selected-label="selectedLabel"
+            select-label="Click to select"
+            track-by="value"
+            @open="onOpen"
+            @close="onClose" />
+        <slot v-else name="no-options">
+            <b-alert v-localize class="w-100" variant="warning" show> No options available. </b-alert>
+        </slot>
+    </div>
 </template>

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -277,7 +277,7 @@ const isOptional = computed(() => !isRequired.value && attrs.value["optional"] !
                 :id="id"
                 v-model="currentValue"
                 :loading="loading"
-                :extension="attrs.extension"
+                :extensions="attrs.extensions"
                 :flavor="attrs.flavor"
                 :multiple="attrs.multiple"
                 :optional="attrs.optional"

--- a/client/src/utils/strings.ts
+++ b/client/src/utils/strings.ts
@@ -1,0 +1,30 @@
+/**
+ * Converts an array of strings to a list, ending with "or"
+ *
+ * @example
+ * // returns the string "a, b or c"
+ * orList(["a", "b", "c"]);
+ * @param items array of strings to join
+ * @returns human readable comma + or separated list
+ */
+export function orList(items: string[]): string {
+    if (items.length === 0) {
+        return "";
+    } else if (items.length === 1) {
+        return items[0] as string;
+    }
+
+    return items
+        .reverse()
+        .flatMap((item, index) => {
+            if (index === 0) {
+                return [item, " or "];
+            } else if (index !== 1) {
+                return [", ", item];
+            } else {
+                return [item];
+            }
+        })
+        .reverse()
+        .join("");
+}


### PR DESCRIPTION
closes [#9218](https://github.com/galaxyproject/galaxy/issues/9218)

![image](https://github.com/galaxyproject/galaxy/assets/44241786/bae6b5b5-4f0d-4a4c-a3f4-8f7dce595a20)

![image](https://github.com/galaxyproject/galaxy/assets/44241786/8c741776-799c-4fe6-bf49-ae21694c4488)

![image](https://github.com/galaxyproject/galaxy/assets/44241786/8798812a-cf57-4915-934d-ba5c1a8400ae)

![image](https://github.com/galaxyproject/galaxy/assets/44241786/6750db9c-81d4-41f6-a07d-7fcd9aa29e97)



This PR adds the following features:

* a drop-down listing all accepted data extensions, if they are specified.
* tool-tip previewing accepted extensions in a list
* new error message which names the accepted extension, if there are less than 5

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
