### PR TITLE
Workflow node connector improvements

### DIFF
--- a/client/src/components/Workflow/Editor/Draggable.vue
+++ b/client/src/components/Workflow/Editor/Draggable.vue
@@ -32,6 +32,10 @@ const props = defineProps({
         type: Boolean,
         default: false,
     },
+    snappable: {
+        type: Boolean,
+        default: true,
+    },
 });
 
 const emit = defineEmits<{
@@ -81,7 +85,7 @@ const { toolbarStore } = useWorkflowStores();
 const { snapActive } = storeToRefs(toolbarStore);
 
 function getSnappedPosition<T extends Position>(position: T) {
-    if (snapActive.value) {
+    if (props.snappable && snapActive.value) {
         return {
             ...position,
             x: Math.round(position.x / toolbarStore.snapDistance) * toolbarStore.snapDistance,

--- a/client/src/components/Workflow/Editor/DraggablePan.vue
+++ b/client/src/components/Workflow/Editor/DraggablePan.vue
@@ -35,6 +35,10 @@ const props = defineProps({
         type: Number,
         default: 60,
     },
+    snappable: {
+        type: Boolean,
+        default: true,
+    },
 });
 
 type Position = { x: number; y: number };
@@ -157,6 +161,7 @@ function onStart() {
         :stop-propagation="stopPropagation"
         :drag-data="dragData"
         :disabled="disabled"
+        :snappable="snappable"
         @move="onMove"
         @mouseup="onMouseUp"
         @start="onStart"

--- a/client/src/components/Workflow/Editor/NodeInput.vue
+++ b/client/src/components/Workflow/Editor/NodeInput.vue
@@ -202,6 +202,7 @@ function onDrop(event: DragEvent) {
                 'can-accept': acceptsInput,
                 'can-not-accept': !acceptsInput,
                 'mapped-over': isMultiple,
+                'is-dragging': Boolean(draggingTerminal),
             }"
             :input-name="input.name"
             @drop.prevent="onDrop"
@@ -257,6 +258,15 @@ function onDrop(event: DragEvent) {
 
         &.can-not-accept {
             color: $brand-warning;
+        }
+
+        // expand size on drag
+        &.is-dragging {
+            --offset-extra: 10px;
+        }
+
+        &.mapped-over.is-dragging {
+            --offset-extra: 5px;
         }
     }
 }

--- a/client/src/components/Workflow/Editor/NodeInput.vue
+++ b/client/src/components/Workflow/Editor/NodeInput.vue
@@ -207,7 +207,7 @@ function onDrop(event: DragEvent) {
             @drop.prevent="onDrop"
             @dragenter.prevent="dragEnter"
             @dragleave.prevent="dragLeave">
-            <b-tooltip :target="id" :show="showTooltip">
+            <b-tooltip v-if="reason" :target="id" :show="showTooltip">
                 {{ reason }}
             </b-tooltip>
             <FontAwesomeIcon class="terminal-icon" icon="fa-chevron-circle-right" />

--- a/client/src/components/Workflow/Editor/NodeInput.vue
+++ b/client/src/components/Workflow/Editor/NodeInput.vue
@@ -191,7 +191,8 @@ function onDrop(event: DragEvent) {
 </script>
 
 <template>
-    <div class="node-input" :class="rowClass">
+    <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
+    <div class="node-input" :class="rowClass" @drop.prevent="onDrop">
         <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
         <div
             :id="id"
@@ -205,7 +206,6 @@ function onDrop(event: DragEvent) {
                 'is-dragging': Boolean(draggingTerminal),
             }"
             :input-name="input.name"
-            @drop.prevent="onDrop"
             @dragenter.prevent="dragEnter"
             @dragleave.prevent="dragLeave">
             <b-tooltip v-if="reason" :target="id" :show="showTooltip">

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -388,6 +388,7 @@ const removeTagsAction = computed(() => {
             :drag-data="{ stepId: stepId, output: effectiveOutput }"
             :draggable="!readonly"
             :disabled="readonly"
+            :snappable="false"
             @pan-by="onPanBy"
             @start="isDragging = true"
             @stop="onStopDragging"

--- a/client/src/components/Workflow/Editor/_nodeTerminalStyle.scss
+++ b/client/src/components/Workflow/Editor/_nodeTerminalStyle.scss
@@ -1,36 +1,38 @@
 @mixin node-terminal-style($side) {
+    --size: 11px;
+    --offset-extra: 0px;
+
     position: absolute;
-    #{$side}: -0.65rem;
-    border-radius: 50%;
-    background-color: $white;
+    #{$side}: calc(var(--offset-extra) * -1 - 0.65rem);
     display: grid;
     place-items: center;
-    width: 11px;
-    height: 11px;
+    width: calc(var(--size) + var(--offset-extra) * 2);
+    height: calc(var(--size) + var(--offset-extra) * 2);
     margin-top: 0.25rem;
+    transform: translateY(calc(var(--offset-extra) * -1));
 
     color: $brand-primary;
 
-    &.mapped-over {
-        width: 20px;
-        height: 20px;
-        margin-top: 0;
-        #{$side}: -0.8rem;
+    &::after {
+        content: "";
+        width: var(--size);
+        height: var(--size);
+        border-radius: 50%;
+        background-color: $white;
+    }
 
-        .terminal-icon {
-            top: -1px;
-            left: -1px;
-            width: 22px;
-            height: 22px;
-        }
+    &.mapped-over {
+        --size: 20px;
+        #{$side}: calc(var(--offset-extra) * -1 - 0.8rem);
+        margin-top: 0;
     }
 
     .terminal-icon {
         position: absolute;
-        top: -1px;
-        left: -1px;
-        width: 13px;
-        height: 13px;
+        top: calc(var(--offset-extra) - 1px);
+        left: calc(var(--offset-extra) - 1px);
+        width: calc(var(--size) + 2px);
+        height: calc(var(--size) + 2px);
         pointer-events: none;
     }
 }

--- a/client/src/components/Workflow/Editor/_nodeTerminalStyle.scss
+++ b/client/src/components/Workflow/Editor/_nodeTerminalStyle.scss
@@ -14,6 +14,8 @@
     color: $brand-primary;
 
     &::after {
+        position: absolute;
+        z-index: -1;
         content: "";
         width: var(--size);
         height: var(--size);


### PR DESCRIPTION
closes #17195

Makes several quality of life changes to the input connectors on workflow nodes.
* Node drop area is now larger, expanding beyond the input connector point on every direction
* Node drop area is now square, allowing for additional leeway when attaching connections
* The entire node input can now be used to attach a node to
* When a connection will be made on drop, the input is highlighted

![image](https://github.com/galaxyproject/galaxy/assets/44241786/7a9e0d35-7dc1-4058-851d-0e524f524bfe)

![image](https://github.com/galaxyproject/galaxy/assets/44241786/d29406b0-fd92-4a59-b94d-d861d9ddea95)

(the cursor is a dragging hand, but my screenshot software can unfortunately not capture it in that state)

Additionally fixes two minor bugs
* Node connector no longer snaps when snapping is active
* Tooltip no longer appears on input nodes when empty

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
