### PR TITLE
Workflow node connector improvements followup

### DIFF
--- a/client/src/components/Workflow/Editor/_nodeTerminalStyle.scss
+++ b/client/src/components/Workflow/Editor/_nodeTerminalStyle.scss
@@ -1,6 +1,6 @@
 @mixin node-terminal-style($side) {
     --size: 11px;
-    --offset-extra: 0px;
+    --offset-extra: 4px;
 
     position: absolute;
     #{$side}: calc(var(--offset-extra) * -1 - 0.65rem);


### PR DESCRIPTION
Small followup to #17240

Increases the default size of all nodes, input and output, to make dragging out a connection and deleting a connection easier.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
