### PR TITLE
tus wants a json response from v2.0.0

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/uploads.py
+++ b/lib/galaxy/webapps/galaxy/api/uploads.py
@@ -3,7 +3,7 @@ API operations for uploaded files in storage.
 """
 import logging
 
-from galaxy.web.framework.decorators import expose_api_raw_anonymous
+from galaxy.web.framework.decorators import expose_api_anonymous
 from . import BaseGalaxyAPIController
 
 log = logging.getLogger(__name__)
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 class UploadsAPIController(BaseGalaxyAPIController):
     READ_CHUNK_SIZE = 2**16
 
-    @expose_api_raw_anonymous
+    @expose_api_anonymous
     def hooks(self, trans, **kwds):
         """
         Exposed as POST /api/upload/hooks and /api/upload/resumable_upload


### PR DESCRIPTION
My tusd was not working, with version `v2.2.1`, and Galaxy release `23.1`, giving me this error:
`level=INFO event=ResponseOutgoing method=POST path="" requestId="" status=500 body="ERR_INTERNAL_SERVER_ERROR: failed to parse hook response: unexpected end of JSON input\n" `
When I changed [this line](https://github.com/tus/tusd/blob/b7b875a7d6864b050351325d90bb35b3ae73556e/pkg/hooks/http/http.go#L80) to print the Response body, I got '[]'. So I checked Galaxy's source code and indded, it seems to respond with a raw body, which throws an error in Go's JSON.Unmarshall [example](https://play.golang.com/p/rrNfRYdxsCz)
https://github.com/tus/tusd/pull/516
Was the breaking change I guess. I tried with tusd `v1.13.0` and that still worked for me. Could it be possible that it already broke down after they released `v2.0.0` on September 29 2023?

more info in tus' docs: 
https://github.com/tus/tusd/blob/main/docs/hooks.md#hook-requests-and-responses

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. (see the configuration decribed above)

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
