### PR TITLE
Add missing re-usable commit-id output

### DIFF
--- a/.github/workflows/build_client.yaml
+++ b/.github/workflows/build_client.yaml
@@ -1,6 +1,10 @@
 name: Build client for selenium tests
 on:
   workflow_call:
+    outputs:
+      commit-id:
+        description: Commit ID
+        value: ${{ jobs.build-client.outputs.commit-id }}
 jobs:
   build-client:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Otherwise the cache key for recovery is wrong.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
