### PR TITLE
[23.2] Tagging component performance improvements

### DIFF
--- a/client/src/components/TagsMultiselect/StatelessTags.test.js
+++ b/client/src/components/TagsMultiselect/StatelessTags.test.js
@@ -1,8 +1,9 @@
 import { mount } from "@vue/test-utils";
 import { useToast } from "composables/toast";
-import { useUserTags } from "composables/user";
 import { getLocalVue } from "tests/jest/helpers";
 import { computed } from "vue";
+
+import { useUserTagsStore } from "@/stores/userTagsStore";
 
 import StatelessTags from "./StatelessTags";
 
@@ -19,7 +20,7 @@ const mountWithProps = (props) => {
 
 jest.mock("composables/user");
 const addLocalTagMock = jest.fn((tag) => tag);
-useUserTags.mockReturnValue({
+useUserTagsStore.mockReturnValue({
     userTags: computed(() => autocompleteTags),
     addLocalTag: addLocalTagMock,
 });

--- a/client/src/components/TagsMultiselect/StatelessTags.test.js
+++ b/client/src/components/TagsMultiselect/StatelessTags.test.js
@@ -18,7 +18,7 @@ const mountWithProps = (props) => {
     });
 };
 
-jest.mock("composables/user");
+jest.mock("@/stores/userTagsStore");
 const addLocalTagMock = jest.fn((tag) => tag);
 useUserTagsStore.mockReturnValue({
     userTags: computed(() => autocompleteTags),

--- a/client/src/components/TagsMultiselect/StatelessTags.vue
+++ b/client/src/components/TagsMultiselect/StatelessTags.vue
@@ -8,8 +8,8 @@ import Multiselect from "vue-multiselect";
 
 import { useToast } from "@/composables/toast";
 import { useMultiselect } from "@/composables/useMultiselect";
-import { useUserTags } from "@/composables/user";
 import { useUid } from "@/composables/utils/uid";
+import { useUserTagsStore } from "@/stores/userTagsStore";
 
 import Tag from "./Tag.vue";
 
@@ -39,7 +39,7 @@ const emit = defineEmits<{
 
 library.add(faTags, faCheck, faTimes, faPlus);
 
-const { userTags, addLocalTag } = useUserTags();
+const { userTags, addLocalTag } = useUserTagsStore();
 const { warning } = useToast();
 
 function onAddTag(tag: string) {

--- a/client/src/components/Workflow/Editor/Attributes.test.js
+++ b/client/src/components/Workflow/Editor/Attributes.test.js
@@ -17,7 +17,7 @@ const TEST_VERSIONS = [
 ];
 const autocompleteTags = ["#named_uer_tag", "abc", "my_tag"];
 
-jest.mock("composables/user");
+jest.mock("@/stores/userTagsStore");
 useUserTagsStore.mockReturnValue({
     userTags: computed(() => autocompleteTags),
     addLocalTag: jest.fn(),

--- a/client/src/components/Workflow/Editor/Attributes.test.js
+++ b/client/src/components/Workflow/Editor/Attributes.test.js
@@ -1,7 +1,8 @@
 import { createLocalVue, mount } from "@vue/test-utils";
-import { useUserTags } from "composables/user";
 import { isDate } from "date-fns";
 import { computed } from "vue";
+
+import { useUserTagsStore } from "@/stores/userTagsStore";
 
 import Attributes from "./Attributes";
 import { UntypedParameters } from "./modules/parameters";
@@ -17,7 +18,7 @@ const TEST_VERSIONS = [
 const autocompleteTags = ["#named_uer_tag", "abc", "my_tag"];
 
 jest.mock("composables/user");
-useUserTags.mockReturnValue({
+useUserTagsStore.mockReturnValue({
     userTags: computed(() => autocompleteTags),
     addLocalTag: jest.fn(),
 });

--- a/client/src/components/Workflow/WorkflowList.test.js
+++ b/client/src/components/Workflow/WorkflowList.test.js
@@ -2,12 +2,13 @@ import { createTestingPinia } from "@pinia/testing";
 import { mount } from "@vue/test-utils";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
-import { useUserTags } from "composables/user";
 import { formatDistanceToNow, parseISO } from "date-fns";
 import flushPromises from "flush-promises";
 import { PiniaVuePlugin } from "pinia";
 import { getLocalVue, wait } from "tests/jest/helpers";
 import { computed } from "vue";
+
+import { useUserTagsStore } from "@/stores/userTagsStore";
 
 import Tag from "../TagsMultiselect/Tag";
 import Workflows from "../Workflow/WorkflowList";
@@ -17,7 +18,7 @@ localVue.use(PiniaVuePlugin);
 
 const autocompleteTags = ["#named_user_tags", "abc", "my_tag"];
 jest.mock("composables/user");
-useUserTags.mockReturnValue({
+useUserTagsStore.mockReturnValue({
     userTags: computed(() => autocompleteTags),
     addLocalTag: jest.fn(),
 });

--- a/client/src/components/Workflow/WorkflowList.test.js
+++ b/client/src/components/Workflow/WorkflowList.test.js
@@ -17,7 +17,7 @@ const localVue = getLocalVue();
 localVue.use(PiniaVuePlugin);
 
 const autocompleteTags = ["#named_user_tags", "abc", "my_tag"];
-jest.mock("composables/user");
+jest.mock("@/stores/userTagsStore");
 useUserTagsStore.mockReturnValue({
     userTags: computed(() => autocompleteTags),
     addLocalTag: jest.fn(),

--- a/client/src/composables/user.ts
+++ b/client/src/composables/user.ts
@@ -1,5 +1,4 @@
-import { storeToRefs } from "pinia";
-import { computed, ref } from "vue";
+import { computed } from "vue";
 
 import { useUserStore } from "@/stores/userStore";
 
@@ -13,28 +12,4 @@ export function useCurrentTheme() {
         currentTheme,
         setCurrentTheme,
     };
-}
-
-// temporarily stores tags which have not yet been fetched from the backend
-const localTags = ref<string[]>([]);
-
-/**
- * Keeps tracks of the tags the current user has used.
- */
-export function useUserTags() {
-    const { currentUser } = storeToRefs(useUserStore());
-    const userTags = computed(() => {
-        let tags: string[];
-        if (currentUser.value && !currentUser.value.isAnonymous) {
-            tags = [...currentUser.value.tags_used, ...localTags.value];
-        } else {
-            tags = localTags.value;
-        }
-        const tagSet = new Set(tags);
-        return Array.from(tagSet).map((tag) => tag.replace(/^name:/, "#"));
-    });
-    const addLocalTag = (tag: string) => {
-        localTags.value.push(tag);
-    };
-    return { userTags, addLocalTag };
 }

--- a/client/src/stores/userTagsStore.ts
+++ b/client/src/stores/userTagsStore.ts
@@ -1,0 +1,27 @@
+import { defineStore, storeToRefs } from "pinia";
+import { computed, ref } from "vue";
+
+import { useUserStore } from "./userStore";
+
+export const useUserTagsStore = defineStore("userTagsStore", () => {
+    const localTags = ref<string[]>([]);
+
+    const { currentUser } = storeToRefs(useUserStore());
+
+    const userTags = computed(() => {
+        let tags: string[];
+        if (currentUser.value && !currentUser.value.isAnonymous) {
+            tags = [...currentUser.value.tags_used, ...localTags.value];
+        } else {
+            tags = localTags.value;
+        }
+        const tagSet = new Set(tags);
+        return Array.from(tagSet).map((tag) => tag.replace(/^name:/, "#"));
+    });
+
+    const addLocalTag = (tag: string) => {
+        localTags.value.push(tag);
+    };
+
+    return { userTags, addLocalTag };
+});

--- a/client/src/stores/userTagsStore.ts
+++ b/client/src/stores/userTagsStore.ts
@@ -11,7 +11,7 @@ export const useUserTagsStore = defineStore("userTagsStore", () => {
     const userTags = computed(() => {
         let tags: string[];
         if (currentUser.value && !currentUser.value.isAnonymous) {
-            tags = [...currentUser.value.tags_used, ...localTags.value];
+            tags = [...(currentUser.value.tags_used ?? []), ...localTags.value];
         } else {
             tags = localTags.value;
         }


### PR DESCRIPTION
Partial fix for #17250

Improves performance for adding and removing tags. Could neither locate a memory leak (profiled in Firefox), nor replicate the scrolling performance issues.

Performance is improved due to less duplication of data by using a store.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
