### PR TITLE
Allow for upper case container tags

### DIFF
--- a/lib/galaxy/tool_util/deps/requirements.py
+++ b/lib/galaxy/tool_util/deps/requirements.py
@@ -195,8 +195,8 @@ class ContainerDescription:
         if identifier:
             parts = identifier.rsplit(os.sep, 1)
             if ":" in parts[-1]:
-                id, tag = parts[-1].rsplit(":")
-                parts[-1] = f"{id.lower()}:{tag}"
+                name, tag = parts[-1].rsplit(":", 1)
+                parts[-1] = f"{name.lower()}:{tag}"
             else:
                 parts[-1] = parts[-1].lower()
 

--- a/lib/galaxy/tool_util/deps/requirements.py
+++ b/lib/galaxy/tool_util/deps/requirements.py
@@ -189,11 +189,17 @@ class ContainerDescription:
     ) -> None:
         # Force to lowercase because container image names must be lowercase.
         # Cached singularity images include the path on disk, so only lowercase
-        # the image identifier portion.
+        # the image identifier portion. Note, the tag can also contain upper case
+        # letters.
         self.identifier = identifier
         if identifier:
             parts = identifier.rsplit(os.sep, 1)
-            parts[-1] = parts[-1].lower()
+            if ":" in parts[-1]:
+                id, tag = parts[-1].rsplit(":")
+                parts[-1] = f"{id.lower()}:{tag}"
+            else:
+                parts[-1] = parts[-1].lower()
+
             self.identifier = os.sep.join(parts)
         self.type = type
         self.resolve_dependencies = resolve_dependencies


### PR DESCRIPTION
Seems to be allowed https://docs.docker.com/engine/reference/commandline/tag/#extended-description.
And is also used, e.g. breaks for instance the beagle tool which has: `quay.io/biocontainers/beagle:5.2_21Apr21.304--hdfd78af_0` 

Since we lower case this for a long while (https://github.com/galaxyproject/galaxy/pull/9733, https://github.com/galaxyproject/galaxy/pull/14431) I'm wondering why the beagle tool ever passed the tests 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
