### PR TITLE
Fixes for output discovery

### DIFF
--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -474,11 +474,11 @@ def collect_primary_datasets(job_context: Union[JobContext, SessionlessJobContex
 
     # Loop through output file names, looking for generated primary
     # datasets in form specified by discover dataset patterns or in tool provided metadata.
-    primary_output_assigned = False
     new_outdata_name = None
     primary_datasets: Dict[str, Dict[str, Union[HistoryDatasetAssociation, LibraryDatasetDatasetAssociation]]] = {}
     storage_callbacks: List[Callable] = []
-    for output_index, (name, outdata) in enumerate(output.items()):
+    for name, outdata in output.items():
+        primary_output_assigned = False
         dataset_collectors = [DEFAULT_DATASET_COLLECTOR]
         output_def = job_context.output_def(name)
         if output_def is not None:
@@ -504,7 +504,7 @@ def collect_primary_datasets(job_context: Union[JobContext, SessionlessJobContex
             dbkey = fields_match.dbkey
             if dbkey == INPUT_DBKEY_TOKEN:
                 dbkey = job_context.input_dbkey
-            if filename_index == 0 and extra_file_collector.assign_primary_output and output_index == 0:
+            if filename_index == 0 and extra_file_collector.assign_primary_output:
                 new_outdata_name = fields_match.name or f"{outdata.name} ({designation})"
                 outdata.change_datatype(ext)
                 outdata.dbkey = dbkey

--- a/test/functional/tools/multi_output_assign_primary2.xml
+++ b/test/functional/tools/multi_output_assign_primary2.xml
@@ -1,4 +1,4 @@
-<tool id="multi_output_assign_primary" name="multi_output_assign_primary" version="0.1.0">
+<tool id="multi_output_assign_primary2" name="multi_output_assign_primary2" version="0.1.0">
   <command>
     echo "other" > '$other';
     echo "1" > sample1.report.tsv;
@@ -10,10 +10,10 @@
     <param name="input" type="data" />
   </inputs>
   <outputs>
-    <data name="other" format="txt" label="other"/>  
     <data format="tabular" name="sample">
       <discover_datasets pattern="(?P&lt;designation&gt;.+)\.report\.tsv" ext="tabular" visible="true" assign_primary_output="true" />
     </data>
+    <data name="other" format="txt" label="other"/>  
   </outputs>
   <tests>
     <test>


### PR DESCRIPTION
Fixes: https://github.com/galaxyproject/galaxy/issues/17263 .. guess both bugs are there forever (>10 years)

1. `primary_output_assigned` needs to be reset for each output

   lets say there are two outputs: `datasets` (a normal dataset)
   and `discovered` (discovered datasets). if `datasets` is
   processed after `discovered` then `primary_output_assigned`
   is still true from the first loop (where `discovered` was precessed).
   this leads to overwriting of info (e.g. name) of the `dataset` output
   (in the `if primary_output_assigned` branch at the end of the outer
   loop).

2. assign_primary_output must be obeyed for all outputs (not just the
   first).

   sticking to the above example, `assign_primary_output` would
   work only if `dataset` is processed after `discovered`

I added a test case for the 2nd part. No idea how to test the first (I manually tested it with `planemo serve`).

https://github.com/galaxyproject/galaxy/issues/16203 is still broken

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
