### PR TITLE
[23.1] Always copy datasets in collection builder modals

### DIFF
--- a/client/src/components/Collections/ListCollectionCreatorModal.js
+++ b/client/src/components/Collections/ListCollectionCreatorModal.js
@@ -28,7 +28,6 @@ function listCollectionCreatorModal(elements, options) {
  */
 function createListCollection(contents, defaultHideSourceItems = true) {
     const elements = contents.toJSON();
-    let copyElements;
     const promise = listCollectionCreatorModal(elements, {
         defaultHideSourceItems: defaultHideSourceItems,
         creationFn: function (elements, name, hideSourceItems) {
@@ -38,8 +37,7 @@ function createListCollection(contents, defaultHideSourceItems = true) {
                 //TODO: this allows for list:list even if the filter above does not - reconcile
                 src: element.src || (element.history_content_type == "dataset" ? "hda" : "hdca"),
             }));
-            copyElements = !hideSourceItems;
-            return contents.createHDCA(elements, "list", name, hideSourceItems, copyElements);
+            return contents.createHDCA(elements, "list", name, hideSourceItems);
         },
     });
     return promise;

--- a/client/src/components/Collections/PairCollectionCreatorModal.js
+++ b/client/src/components/Collections/PairCollectionCreatorModal.js
@@ -24,7 +24,6 @@ function pairCollectionCreatorModal(elements, options) {
 }
 function createPairCollection(contents, defaultHideSourceItems = true) {
     var elements = contents.toJSON();
-    var copyElements;
     var promise = pairCollectionCreatorModal(elements, {
         defaultHideSourceItems: defaultHideSourceItems,
         creationFn: function (elements, name, hideSourceItems) {
@@ -32,8 +31,7 @@ function createPairCollection(contents, defaultHideSourceItems = true) {
                 { name: "forward", src: elements[0].src || "hda", id: elements[0].id },
                 { name: "reverse", src: elements[1].src || "hda", id: elements[1].id },
             ];
-            copyElements = !hideSourceItems;
-            return contents.createHDCA(elements, "paired", name, hideSourceItems, copyElements);
+            return contents.createHDCA(elements, "paired", name, hideSourceItems);
         },
     });
     return promise;

--- a/client/src/components/Collections/PairedListCollectionCreatorModal.js
+++ b/client/src/components/Collections/PairedListCollectionCreatorModal.js
@@ -27,7 +27,6 @@ function pairedListCollectionCreatorModal(elements, options) {
  */
 function createPairedListCollection(contents, defaultHideSourceItems) {
     const elements = contents.toJSON();
-    var copyElements;
     const promise = pairedListCollectionCreatorModal(elements, {
         defaultHideSourceItems: defaultHideSourceItems,
         creationFn: function (elements, name, hideSourceItems) {
@@ -48,8 +47,7 @@ function createPairedListCollection(contents, defaultHideSourceItems) {
                     },
                 ],
             }));
-            copyElements = !hideSourceItems;
-            return contents.createHDCA(elements, "list:paired", name, hideSourceItems, copyElements);
+            return contents.createHDCA(elements, "list:paired", name, hideSourceItems);
         },
     });
     return promise;

--- a/client/src/components/Collections/RuleBasedCollectionCreatorModal.js
+++ b/client/src/components/Collections/RuleBasedCollectionCreatorModal.js
@@ -47,7 +47,6 @@ function createCollectionViaRules(selection, defaultHideSourceItems = true) {
     let elementsType;
     let importType;
     const selectionType = selection.selectionType;
-    const copyElements = !defaultHideSourceItems;
     if (!selectionType) {
         // Have HDAs from the history panel.
         elements = selection.toJSON();
@@ -81,7 +80,7 @@ function createCollectionViaRules(selection, defaultHideSourceItems = true) {
         ftpUploadSite: selection.ftpUploadSite,
         defaultHideSourceItems: defaultHideSourceItems,
         creationFn: function (elements, collectionType, name, hideSourceItems) {
-            return selection.createHDCA(elements, collectionType, name, hideSourceItems, copyElements);
+            return selection.createHDCA(elements, collectionType, name, hideSourceItems);
         },
     });
     return promise;

--- a/client/src/components/History/adapters/buildCollectionModal.js
+++ b/client/src/components/History/adapters/buildCollectionModal.js
@@ -45,12 +45,11 @@ const createBackboneContent = (historyId, selection) => {
         toJSON: () => selectionJson,
         // result must be a $.Deferred object instead of a promise because
         // that's the kind of deprecated data format that backbone likes to use.
-        createHDCA(element_identifiers, collection_type, name, hide_source_items, copy_elements, options = {}) {
+        createHDCA(element_identifiers, collection_type, name, hide_source_items, options = {}) {
             const def = jQuery.Deferred();
             return def.resolve(null, {
                 collection_type,
                 name,
-                copy_elements,
                 hide_source_items,
                 element_identifiers,
                 options,

--- a/lib/galaxy_test/selenium/test_collection_builders.py
+++ b/lib/galaxy_test/selenium/test_collection_builders.py
@@ -17,7 +17,7 @@ class TestCollectionBuilders(SeleniumTestCase):
         self.collection_builder_set_name("my cool list")
         self.screenshot("collection_builder_list")
         self.collection_builder_create()
-        self._wait_for_hid_visible(2)
+        self._wait_for_hid_visible(3)
 
     @selenium_test
     @managed_history
@@ -30,7 +30,6 @@ class TestCollectionBuilders(SeleniumTestCase):
         self.collection_builder_hide_originals()
         self.collection_builder_set_name("my cool list")
         self.collection_builder_create()
-        self.home()  # this shouldn't be necessary, and it isn't with a real browser.
         self._wait_for_hid_visible(3)
 
     @selenium_test
@@ -43,7 +42,7 @@ class TestCollectionBuilders(SeleniumTestCase):
         self.collection_builder_set_name("my awesome pair")
         self.screenshot("collection_builder_pair")
         self.collection_builder_create()
-        self._wait_for_hid_visible(3)
+        self._wait_for_hid_visible(5)
 
     @selenium_test
     @managed_history
@@ -58,11 +57,13 @@ class TestCollectionBuilders(SeleniumTestCase):
         self.collection_builder_set_name("my awesome paired list")
         self.screenshot("collection_builder_paired_list")
         self.collection_builder_create()
-        self._wait_for_hid_visible(3)
+        self._wait_for_hid_visible(5)
         # switch to hidden filters to see the hidden datasets appear
         self._show_hidden_content()
         self._wait_for_hid_visible(1)
         self._wait_for_hid_visible(2)
+        self._wait_for_hid_visible(3)
+        self._wait_for_hid_visible(4)
 
     @selenium_test
     @managed_history
@@ -98,9 +99,10 @@ class TestCollectionBuilders(SeleniumTestCase):
         self.collection_builder_set_name("my cool list")
         self.screenshot("collection_builder_rules_list")
         self.collection_builder_create()
-        self._wait_for_hid_visible(2)
+        self._wait_for_hid_visible(3)
         self._show_hidden_content()
         self._wait_for_hid_visible(1)
+        self._wait_for_hid_visible(2)
 
     def _wait_for_hid_visible(self, hid, state="ok"):
         # takes a little while for these things to upload and end up in the history

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -20,7 +20,7 @@ class TestCollectionEdit(SeleniumTestCase):
         self.check_current_data_value(dataValue)
         dataNew = "hg17"
         self.change_dbkey_value_and_click_submit(dataValue, dataNew)
-        self.history_panel_wait_for_hid_ok(4)
+        self.history_panel_wait_for_hid_ok(5)
         self.open_collection_edit_view()
         self.navigate_to_database_tab()
         self.check_current_data_value(dataNew)
@@ -42,7 +42,7 @@ class TestCollectionEdit(SeleniumTestCase):
         self.change_datatype_value_and_click_submit(dataValue, dataNew)
         self.check_current_data_value(dataNew)
         self.wait_for_history()
-        self.history_panel_expand_collection(2)
+        self.history_panel_expand_collection(3)
         self.history_panel_ensure_showing_item_details(1)
         item = self.history_panel_item_component(hid=1)
         item.datatype.wait_for_visible()
@@ -56,7 +56,7 @@ class TestCollectionEdit(SeleniumTestCase):
 
         self.collection_builder_set_name("my cool list")
         self.collection_builder_create()
-        self._wait_for_hid_visible(2)
+        self._wait_for_hid_visible(3)
 
     def open_collection_edit_view(self):
         self.components.history_panel.collection_menu_edit_attributes.wait_for_and_click()

--- a/lib/galaxy_test/selenium/test_uploads.py
+++ b/lib/galaxy_test/selenium/test_uploads.py
@@ -118,11 +118,11 @@ class TestUploads(SeleniumTestCase, UsesHistoryItemAssertions):
     @selenium_test
     def test_upload_list(self):
         self.upload_list([self.get_filename("1.tabular")], name="Test List")
-        self.history_panel_wait_for_hid_ok(2)
+        self.history_panel_wait_for_hid_ok(3)
         # Make sure modals disappeared - both List creator (TODO: upload).
         self.wait_for_selector_absent_or_hidden(".collection-creator")
 
-        self.assert_item_name(2, "Test List")
+        self.assert_item_name(3, "Test List")
 
         # Make sure source item is hidden when the collection is created.
         self.history_panel_wait_for_hid_hidden(1)
@@ -130,15 +130,17 @@ class TestUploads(SeleniumTestCase, UsesHistoryItemAssertions):
     @selenium_test
     def test_upload_pair(self):
         self.upload_list([self.get_filename("1.tabular"), self.get_filename("2.tabular")], name="Test Pair")
-        self.history_panel_wait_for_hid_ok(3)
+        self.history_panel_wait_for_hid_ok(5)
         # Make sure modals disappeared - both collection creator (TODO: upload).
         self.wait_for_selector_absent_or_hidden(".collection-creator")
 
-        self.assert_item_name(3, "Test Pair")
+        self.assert_item_name(5, "Test Pair")
 
         # Make sure source items are hidden when the collection is created.
         self.history_panel_wait_for_hid_hidden(1)
         self.history_panel_wait_for_hid_hidden(2)
+        self.history_panel_wait_for_hid_hidden(3)
+        self.history_panel_wait_for_hid_hidden(4)
 
     @selenium_test
     def test_upload_pair_specify_extension(self):
@@ -161,14 +163,16 @@ class TestUploads(SeleniumTestCase, UsesHistoryItemAssertions):
         self.upload_paired_list(
             [self.get_filename("1.tabular"), self.get_filename("2.tabular")], name="Test Paired List"
         )
-        self.history_panel_wait_for_hid_ok(3)
+        self.history_panel_wait_for_hid_ok(5)
         # Make sure modals disappeared - both collection creator (TODO: upload).
         self.wait_for_selector_absent_or_hidden(".collection-creator")
-        self.assert_item_name(3, "Test Paired List")
+        self.assert_item_name(5, "Test Paired List")
 
         # Make sure source items are hidden when the collection is created.
         self.history_panel_wait_for_hid_hidden(1)
         self.history_panel_wait_for_hid_hidden(2)
+        self.history_panel_wait_for_hid_hidden(3)
+        self.history_panel_wait_for_hid_hidden(4)
 
     @selenium_test
     @pytest.mark.gtn_screenshot


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/17249

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
