### PR TITLE
Make Multiselect conditionally rendered

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -84,6 +84,7 @@
             :elements-datatypes="item.elements_datatypes" />
         <StatelessTags
             v-if="!tagsDisabled || hasTags"
+            class="px-2"
             :value="tags"
             :disabled="tagsDisabled"
             :clickable="filterable"

--- a/client/src/components/TagsMultiselect/StatelessTags.test.js
+++ b/client/src/components/TagsMultiselect/StatelessTags.test.js
@@ -7,6 +7,7 @@ import { computed } from "vue";
 import StatelessTags from "./StatelessTags";
 
 const autocompleteTags = ["#named_user_tag", "abc", "my_tag"];
+const toggleButton = ".toggle-button";
 
 const localVue = getLocalVue();
 
@@ -65,11 +66,12 @@ describe("StatelessTags", () => {
             disabled: false,
         });
 
-        const multiselect = wrapper.find(".multiselect");
-
-        multiselect.find("button").trigger("click");
+        wrapper.find(toggleButton).trigger("click");
         await wrapper.vm.$nextTick();
 
+        const multiselect = wrapper.find(".multiselect");
+
+        await wrapper.vm.$nextTick();
         const options = multiselect.findAll(".multiselect-option");
         const visibleOptions = options.filter((option) => option.isVisible());
 
@@ -85,10 +87,9 @@ describe("StatelessTags", () => {
             disabled: false,
         });
 
-        const multiselect = wrapper.find(".multiselect");
-
-        multiselect.find("button").trigger("click");
+        wrapper.find(toggleButton).trigger("click");
         await wrapper.vm.$nextTick();
+        const multiselect = wrapper.find(".multiselect");
         await multiselect.find("input").setValue("new_tag");
         await wrapper.vm.$nextTick();
         multiselect.find(".multiselect-option").trigger("click");
@@ -103,10 +104,9 @@ describe("StatelessTags", () => {
             disabled: false,
         });
 
-        const multiselect = wrapper.find(".multiselect");
-
-        multiselect.find("button").trigger("click");
+        wrapper.find(toggleButton).trigger("click");
         await wrapper.vm.$nextTick();
+        const multiselect = wrapper.find(".multiselect");
         await multiselect.find("input").setValue(":illegal_tag");
         await wrapper.vm.$nextTick();
 

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -234,7 +234,7 @@ history_panel:
   tag_editor:
     selectors:
       _: '${scope} .details .stateless-tags'
-      toggle: '${_} .toggle-link'
+      toggle: '${_} .toggle-button'
       display: '${_} .tag span'
       input: '${_} input'
       tag_area: '${_} .multiselect__tags'

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -262,7 +262,7 @@ history_panel:
       title_input: '.dataset-collection-panel .controls .title input'
       subtitle: '.dataset-collection-panel .controls .title .subtitle'
       elements_warning: '.dataset-collection-panel .controls .elements-warning'
-      tag_area_button: '.details .stateless-tags .multiselect button'
+      tag_area_button: '.details .stateless-tags .toggle-button'
       tag_area_input: '.details .stateless-tags .multiselect input'
       list_items: '.dataset-collection-panel .listing .content-item'
       back_to_history: svg[data-description="back to history"]
@@ -279,7 +279,7 @@ history_panel:
     empty_message: '.empty-message'
     size: '.history-size'
     tag_area: '.details .stateless-tags'
-    tag_area_button: '.details .stateless-tags .multiselect button'
+    tag_area_button: '.details .stateless-tags .toggle-button'
     tag_area_input: '.details .stateless-tags .multiselect input'
     tag_close_btn: '.tags-display .tag-delete-button'
     tags: '.tag span'


### PR DESCRIPTION
Second fix for #17250

Causes the vue multiselect component used inside the stateless tags component to unmount when closed, and uses custom elements to render the closed state instead.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
