### PR TITLE
Add new optional has_data_lines metadata attribute and use it to filter technically empty datasets

### DIFF
--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -810,6 +810,8 @@ class Sam(Tabular, _BamOrSam):
         if dataset.has_data():
             with open(dataset.get_file_name()) as dataset_fh:
                 comment_lines = 0
+                dataset.metadata.data_lines = None
+                dataset.metadata.has_data_lines = False
                 if (
                     self.max_optional_metadata_filesize >= 0
                     and dataset.get_size() > self.max_optional_metadata_filesize
@@ -819,8 +821,9 @@ class Sam(Tabular, _BamOrSam):
                         if line.startswith("@"):
                             comment_lines += 1
                         else:
-                            # No more comments, and the file is too big to look at the whole thing. Give up.
-                            dataset.metadata.data_lines = None
+                            # No more comments, and the file is too big to look at the whole thing.
+                            # Give up, but record the fact that there was at least one line of data
+                            dataset.metadata.has_data_lines = True
                             break
                 else:
                     # Otherwise, read the whole thing and set num data lines.
@@ -828,6 +831,7 @@ class Sam(Tabular, _BamOrSam):
                         if line.startswith("@"):
                             comment_lines += 1
                     dataset.metadata.data_lines = i + 1 - comment_lines
+                    dataset.metadata.has_data_lines = bool(dataset.metadata.data_lines)
             dataset.metadata.comment_lines = comment_lines
             dataset.metadata.columns = 12
             dataset.metadata.column_types = [

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -3494,7 +3494,10 @@ class FilterEmptyDatasetsTool(FilterDatasetsTool):
     @staticmethod
     def element_is_valid(element: model.DatasetCollectionElement):
         dataset_instance: model.DatasetInstance = element.element_object
-        if dataset_instance.has_data():
+        has_data_lines = dataset_instance.metadata.get("has_data_lines")
+        if has_data_lines:
+            return True
+        if has_data_lines is None and dataset_instance.has_data():
             # We have data, but it might just be a compressed archive of nothing
             file_name = dataset_instance.get_file_name()
             _, fh = get_fileobj_raw(file_name, mode="rb")


### PR DESCRIPTION
The need to filter "technically" empty datasets, like BAMs with only a header, but no read records, has come up in discussions more than once.

The new metadata flag here is intended to indicate whether a dataset has more than just header lines. If set, the Filter empty datasets collection operation can make use of it as demonstrated here for SAM datasets.

Before investing more time in this, I'd like to get opinions whether this looks like a reasonable way to approach the problem.

I think that the filtering functionality might better be added as a new tool instead of changing the behavior of the existing Filter empty datasets tool so feel free to comment also on this aspect.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
