### PR TITLE
Refactor the route POST: `/api/tools` to FastAPI

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -4825,68 +4825,6 @@ export interface components {
              */
             src: components["schemas"]["DataItemSourceType"];
         };
-        /** ExecuteToolPayload */
-        ExecuteToolPayload: {
-            /**
-             * Action
-             * @description The action to perform
-             */
-            action?: string | null;
-            /**
-             * Data Manager Mode
-             * @description The mode of the data manager
-             */
-            data_manager_mode?: string | null;
-            /**
-             * History ID
-             * @description The ID of the history
-             */
-            history_id?: string | null;
-            /**
-             * Input Format
-             * @description The format of the input
-             * @default legacy
-             */
-            input_format?: string | null;
-            /**
-             * Inputs
-             * @description The input data
-             * @default {}
-             */
-            inputs?: Record<string, never>;
-            /**
-             * Preferred Object Store ID
-             * @description The ID of the preferred object store
-             */
-            preferred_object_store_id?: string | null;
-            /**
-             * Send Email Notification
-             * @description Flag indicating whether to send email notification
-             */
-            send_email_notification?: boolean | null;
-            /**
-             * Tool ID
-             * @description The ID of the tool to execute.
-             */
-            tool_id?: Record<string, never> | null;
-            /**
-             * Tool UUID
-             * @description The UUID of the tool to execute.
-             */
-            tool_uuid?: Record<string, never> | null;
-            /**
-             * Tool Version
-             * @description The version of the tool
-             */
-            tool_version?: string | null;
-            /**
-             * Use Cached Job
-             * @description Flag indicating whether to use a cached job
-             * @default false
-             */
-            use_cached_job?: boolean | null;
-            [key: string]: unknown | undefined;
-        };
         /** ExportHistoryArchivePayload */
         ExportHistoryArchivePayload: {
             /**

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -4797,6 +4797,11 @@ export interface components {
              */
             tool_id: string;
             /**
+             * Tool Version
+             * @description Version of the tool that generated this job.
+             */
+            tool_version?: string | null;
+            /**
              * Update Time
              * Format: date-time
              * @description The last time and date this item was updated.
@@ -4824,6 +4829,44 @@ export interface components {
              * @description The source of this dataset, either `hda`, `ldda`, `hdca`, `dce` or `dc` depending of its origin.
              */
             src: components["schemas"]["DataItemSourceType"];
+        };
+        /** ExecuteToolResponse */
+        ExecuteToolResponse: {
+            /**
+             * Errors
+             * @description Errors encountered while executing the tool.
+             * @default []
+             */
+            errors?: Record<string, never>[];
+            /**
+             * Implicit Collections
+             * @description The implicit dataset collections of the job.
+             * @default []
+             */
+            implicit_collections?: components["schemas"]["HDCAToolOutput"][];
+            /**
+             * Jobs
+             * @description The jobs of the tool.
+             * @default []
+             */
+            jobs?: components["schemas"]["JobBaseModel"][];
+            /**
+             * Output Collections
+             * @description The output dataset collections of the job.
+             * @default []
+             */
+            output_collections?: components["schemas"]["HDCAToolOutput"][];
+            /**
+             * Outputs
+             * @description The outputs of the job.
+             * @default []
+             */
+            outputs?: components["schemas"]["HDAToolOutput"][];
+            /**
+             * Produces Entry Points
+             * @description Flag indicating whether the creation of the tool produces entry points for interactive tools.
+             */
+            produces_entry_points: boolean;
         };
         /** ExportHistoryArchivePayload */
         ExportHistoryArchivePayload: {
@@ -6258,6 +6301,249 @@ export interface components {
              */
             visible: boolean;
         };
+        /** HDAToolOutput */
+        HDAToolOutput: {
+            /**
+             * Accessible
+             * @description Whether this item is accessible to the current user due to permissions.
+             */
+            accessible?: boolean | null;
+            /**
+             * Annotation
+             * @description An annotation to provide details or to help understand the purpose and usage of this item.
+             */
+            annotation?: string | null;
+            /**
+             * API Type
+             * @deprecated
+             * @description TODO
+             */
+            api_type?: "file" | null;
+            /** Copied From Ldda Id */
+            copied_from_ldda_id?: string | null;
+            /**
+             * Create Time
+             * @description The time and date this item was created.
+             */
+            create_time?: string | null;
+            /**
+             * Created from basename
+             * @description The basename of the output that produced this dataset.
+             */
+            created_from_basename?: string | null;
+            /**
+             * Creating Job ID
+             * @description The encoded ID of the job that created this dataset.
+             */
+            creating_job?: string | null;
+            /**
+             * Data Type
+             * @description The fully qualified name of the class implementing the data type of this dataset.
+             */
+            data_type?: string | null;
+            /**
+             * Dataset ID
+             * @description The encoded ID of the dataset associated with this item.
+             * @example 0123456789ABCDEF
+             */
+            dataset_id?: string;
+            /**
+             * Deleted
+             * @description Whether this item is marked as deleted.
+             */
+            deleted?: boolean | null;
+            /**
+             * Display Applications
+             * @description Contains new-style display app urls.
+             */
+            display_apps?: components["schemas"]["DisplayApp"][] | null;
+            /**
+             * Legacy Display Applications
+             * @description Contains old-style display app urls.
+             */
+            display_types?: components["schemas"]["DisplayApp"][] | null;
+            /**
+             * Download URL
+             * @description The URL to download this item from the server.
+             */
+            download_url?: string | null;
+            /**
+             * DRS ID
+             * @description The DRS ID of the dataset.
+             */
+            drs_id?: string | null;
+            /**
+             * Extension
+             * @description The extension of the dataset.
+             */
+            extension?: string | null;
+            /**
+             * File extension
+             * @description The extension of the file.
+             */
+            file_ext?: string | null;
+            /**
+             * File Name
+             * @description The full path to the dataset file.
+             */
+            file_name?: string | null;
+            /**
+             * File Size
+             * @description The file size in bytes.
+             */
+            file_size?: number | null;
+            /**
+             * Genome Build
+             * @description TODO
+             */
+            genome_build?: string | null;
+            /**
+             * Hashes
+             * @description The list of hashes associated with this dataset.
+             */
+            hashes?: components["schemas"]["DatasetHash"][] | null;
+            /**
+             * HDA or LDDA
+             * @description Whether this dataset belongs to a history (HDA) or a library (LDDA).
+             */
+            hda_ldda?: components["schemas"]["DatasetSourceType"] | null;
+            /**
+             * HID
+             * @description The index position of this item in the History.
+             */
+            hid?: number | null;
+            /**
+             * History Content Type
+             * @description This is always `dataset` for datasets.
+             */
+            history_content_type?: "dataset" | null;
+            /**
+             * History ID
+             * @example 0123456789ABCDEF
+             */
+            history_id?: string;
+            /**
+             * Id
+             * @example 0123456789ABCDEF
+             */
+            id?: string;
+            /**
+             * Metadata Files
+             * @description Collection of metadata files associated with this dataset.
+             */
+            meta_files?: components["schemas"]["MetadataFile"][] | null;
+            /**
+             * Metadata
+             * @description The metadata associated with this dataset.
+             */
+            metadata?: Record<string, never> | null;
+            /**
+             * Miscellaneous Blurb
+             * @description TODO
+             */
+            misc_blurb?: string | null;
+            /**
+             * Miscellaneous Information
+             * @description TODO
+             */
+            misc_info?: string | null;
+            /**
+             * Model class
+             * @description The name of the database model class.
+             * @constant
+             */
+            model_class?: "HistoryDatasetAssociation";
+            /**
+             * Name
+             * @description The name of the item.
+             */
+            name?: string | null;
+            /**
+             * Output Name
+             * @description The name of the tool output
+             */
+            output_name: string;
+            /**
+             * Peek
+             * @description A few lines of contents from the start of the file.
+             */
+            peek?: string | null;
+            /**
+             * Permissions
+             * @description Role-based access and manage control permissions for the dataset.
+             */
+            permissions?: components["schemas"]["DatasetPermissions"] | null;
+            /**
+             * Purged
+             * @description Whether this dataset has been removed from disk.
+             */
+            purged?: boolean | null;
+            /**
+             * Rerunnable
+             * @description Whether the job creating this dataset can be run again.
+             */
+            rerunnable?: boolean | null;
+            /**
+             * Resubmitted
+             * @description Whether the job creating this dataset has been resubmitted.
+             */
+            resubmitted?: boolean | null;
+            /**
+             * Sources
+             * @description The list of sources associated with this dataset.
+             */
+            sources?: components["schemas"]["DatasetSource"][] | null;
+            /**
+             * State
+             * @description The current state of this dataset.
+             */
+            state?: components["schemas"]["DatasetState"] | null;
+            tags?: components["schemas"]["TagCollection"] | null;
+            /**
+             * Type
+             * @description This is always `file` for datasets.
+             */
+            type?: "file" | null;
+            /**
+             * Type - ID
+             * @description The type and the encoded ID of this item. Used for caching.
+             */
+            type_id?: string | null;
+            /**
+             * Update Time
+             * @description The last time and date this item was updated.
+             */
+            update_time?: string | null;
+            /**
+             * URL
+             * @deprecated
+             * @description The relative URL to access this item.
+             */
+            url?: string | null;
+            /** Uuid */
+            uuid?: string | null;
+            /**
+             * Validated State
+             * @description The state of the datatype validation for this dataset.
+             */
+            validated_state?: components["schemas"]["DatasetValidatedState"] | null;
+            /**
+             * Validated State Message
+             * @description The message with details about the datatype validation result for this dataset.
+             */
+            validated_state_message?: string | null;
+            /**
+             * Visible
+             * @description Whether this item is visible or hidden to the user by default.
+             */
+            visible?: boolean | null;
+            /**
+             * Visualizations
+             * @description The collection of visualizations that can be applied to this dataset.
+             */
+            visualizations?: components["schemas"]["Visualization"][] | null;
+            [key: string]: unknown | undefined;
+        };
         /**
          * HDCADetailed
          * @description History Dataset Collection Association detailed information.
@@ -6488,6 +6774,154 @@ export interface components {
              * @description The name of the item.
              */
             name: string | null;
+            /**
+             * Populated State
+             * @description Indicates the general state of the elements in the dataset collection:- 'new': new dataset collection, unpopulated elements.- 'ok': collection elements populated (HDAs may or may not have errors).- 'failed': some problem populating, won't be populated.
+             */
+            populated_state: components["schemas"]["DatasetCollectionPopulatedState"];
+            /**
+             * Populated State Message
+             * @description Optional message with further information in case the population of the dataset collection failed.
+             */
+            populated_state_message?: string | null;
+            tags: components["schemas"]["TagCollection"];
+            /**
+             * Type
+             * @description This is always `collection` for dataset collections.
+             * @default collection
+             * @constant
+             * @enum {string}
+             */
+            type?: "collection";
+            /**
+             * Type - ID
+             * @description The type and the encoded ID of this item. Used for caching.
+             */
+            type_id?: string | null;
+            /**
+             * Update Time
+             * @description The last time and date this item was updated.
+             */
+            update_time: string | null;
+            /**
+             * URL
+             * @deprecated
+             * @description The relative URL to access this item.
+             */
+            url: string;
+            /**
+             * Visible
+             * @description Whether this item is visible or hidden to the user by default.
+             */
+            visible: boolean;
+        };
+        /** HDCAToolOutput */
+        HDCAToolOutput: {
+            /**
+             * Dataset Collection ID
+             * @example 0123456789ABCDEF
+             */
+            collection_id: string;
+            /**
+             * Collection Type
+             * @description The type of the collection, can be `list`, `paired`, or define subcollections using `:` as separator like `list:paired` or `list:list`.
+             */
+            collection_type: string;
+            /**
+             * Contents URL
+             * @description The relative URL to access the contents of this History.
+             */
+            contents_url: string;
+            /**
+             * Create Time
+             * @description The time and date this item was created.
+             */
+            create_time: string | null;
+            /**
+             * Deleted
+             * @description Whether this item is marked as deleted.
+             */
+            deleted: boolean;
+            /**
+             * Element Count
+             * @description The number of elements contained in the dataset collection. It may be None or undefined if the collection could not be populated.
+             */
+            element_count?: number | null;
+            /**
+             * Elements
+             * @description The summary information of each of the elements inside the dataset collection.
+             * @default []
+             */
+            elements?: components["schemas"]["DCESummary"][];
+            /**
+             * Elements Datatypes
+             * @description A set containing all the different element datatypes in the collection.
+             */
+            elements_datatypes: string[];
+            /**
+             * HID
+             * @description The index position of this item in the History.
+             */
+            hid: number;
+            /**
+             * History Content Type
+             * @description This is always `dataset_collection` for dataset collections.
+             * @constant
+             * @enum {string}
+             */
+            history_content_type: "dataset_collection";
+            /**
+             * History ID
+             * @example 0123456789ABCDEF
+             */
+            history_id: string;
+            /**
+             * Id
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /**
+             * Implicit Collection Jobs Id
+             * @description Encoded ID for the ICJ object describing the collection of jobs corresponding to this collection
+             */
+            implicit_collection_jobs_id?: string | null;
+            /**
+             * Job Source ID
+             * @description The encoded ID of the Job that produced this dataset collection. Used to track the state of the job.
+             */
+            job_source_id?: string | null;
+            /**
+             * Job Source Type
+             * @description The type of job (model class) that produced this dataset collection. Used to track the state of the job.
+             */
+            job_source_type?: components["schemas"]["JobSourceType"] | null;
+            /**
+             * Job State Summary
+             * @description Overview of the job states working inside the dataset collection.
+             */
+            job_state_summary?: components["schemas"]["HDCJobStateSummary"] | null;
+            /**
+             * Model class
+             * @description The name of the database model class.
+             * @constant
+             * @enum {string}
+             */
+            model_class: "HistoryDatasetCollectionAssociation";
+            /**
+             * Name
+             * @description The name of the item.
+             */
+            name: string | null;
+            /**
+             * Output Name
+             * @description The name of the tool output
+             */
+            output_name: string;
+            /**
+             * Populated
+             * @description Whether the dataset collection elements (and any subcollections elements) were successfully populated.
+             */
+            populated?: boolean;
             /**
              * Populated State
              * @description Indicates the general state of the elements in the dataset collection:- 'new': new dataset collection, unpopulated elements.- 'ok': collection elements populated (HDAs may or may not have errors).- 'failed': some problem populating, won't be populated.
@@ -8504,6 +8938,11 @@ export interface components {
              */
             tool_id: string;
             /**
+             * Tool Version
+             * @description Version of the tool that generated this job.
+             */
+            tool_version?: string | null;
+            /**
              * Update Time
              * Format: date-time
              * @description The last time and date this item was updated.
@@ -8667,6 +9106,11 @@ export interface components {
              * @description Identifier of the tool that generated this job.
              */
             tool_id: string;
+            /**
+             * Tool Version
+             * @description Version of the tool that generated this job.
+             */
+            tool_version?: string | null;
             /**
              * Update Time
              * Format: date-time
@@ -8938,6 +9382,11 @@ export interface components {
              * @description Identifier of the tool that generated this job.
              */
             tool_id: string;
+            /**
+             * Tool Version
+             * @description Version of the tool that generated this job.
+             */
+            tool_version?: string | null;
             /**
              * Update Time
              * Format: date-time
@@ -11540,6 +11989,11 @@ export interface components {
              */
             tool_stdout?: string | null;
             /**
+             * Tool Version
+             * @description Version of the tool that generated this job.
+             */
+            tool_version?: string | null;
+            /**
              * Update Time
              * Format: date-time
              * @description The last time and date this item was updated.
@@ -12068,48 +12522,6 @@ export interface components {
              * @description A `\t` (TAB) separated list of column __contents__. You must specify a value for each of the columns of the data table.
              */
             values: string;
-        };
-        /** ToolResponse */
-        ToolResponse: {
-            /**
-             * Errors
-             * @description Job errors related to the creation of the tool.
-             * @default []
-             */
-            errors?: Record<string, never>[];
-            /**
-             * Implicit Collections
-             * @description The implicit dataset collections of the tool.
-             * @default []
-             */
-            implicit_collections?: Record<string, never>[];
-            /**
-             * Jobs
-             * @description The jobs of the tool.
-             * @default []
-             */
-            jobs?: (
-                | components["schemas"]["ShowFullJobResponse"]
-                | components["schemas"]["EncodedJobDetails"]
-                | components["schemas"]["JobSummary"]
-            )[];
-            /**
-             * Output Collections
-             * @description The output dataset collections of the tool.
-             * @default []
-             */
-            output_collections?: Record<string, never>[];
-            /**
-             * Outputs
-             * @description The outputs of the tool.
-             * @default []
-             */
-            outputs?: Record<string, never>[];
-            /**
-             * Produces Entry Points
-             * @description Flag indicating whether the creation of the tool produces entry points.
-             */
-            produces_entry_points: boolean;
         };
         /** ToolStep */
         ToolStep: {
@@ -22727,7 +23139,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["ToolResponse"];
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -22755,7 +23167,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["ToolResponse"];
+                    "application/json": components["schemas"]["ExecuteToolResponse"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1592,6 +1592,10 @@ export interface paths {
         /** Show installed tool shed repository. */
         get: operations["show_api_tool_shed_repositories__id__get"];
     };
+    "/api/tools": {
+        /** Execute tool with a given parameter payload */
+        post: operations["create_api_tools_post"];
+    };
     "/api/tools/fetch": {
         /** Upload files to Galaxy */
         post: operations["fetch_form_api_tools_fetch_post"];
@@ -3413,6 +3417,68 @@ export interface components {
              * @description The relative URL to get this particular Quota details from the rest API.
              */
             url: string;
+        };
+        /** CreateToolPayload */
+        CreateToolPayload: {
+            /**
+             * Action
+             * @description The action to perform
+             */
+            action?: string | null;
+            /**
+             * Data Manager Mode
+             * @description The mode of the data manager
+             */
+            data_manager_mode?: string | null;
+            /**
+             * History ID
+             * @description The ID of the history
+             */
+            history_id?: string | null;
+            /**
+             * Input Format
+             * @description The format of the input
+             * @default legacy
+             */
+            input_format?: string | null;
+            /**
+             * Inputs
+             * @description The input data
+             * @default {}
+             */
+            inputs?: Record<string, never>;
+            /**
+             * Preferred Object Store ID
+             * @description The ID of the preferred object store
+             */
+            preferred_object_store_id?: string | null;
+            /**
+             * Send Email Notification
+             * @description Flag indicating whether to send email notification
+             */
+            send_email_notification?: boolean | null;
+            /**
+             * Tool ID
+             * @description The ID of the tool to execute.
+             */
+            tool_id?: Record<string, never> | null;
+            /**
+             * Tool UUID
+             * @description The UUID of the tool to execute.
+             */
+            tool_uuid?: Record<string, never> | null;
+            /**
+             * Tool Version
+             * @description The version of the tool
+             */
+            tool_version?: string | null;
+            /**
+             * Use Cached Job
+             * @description Flag indicating whether to use a cached job
+             * @default false
+             */
+            use_cached_job?: boolean | null;
+            [key: string]: unknown | undefined;
         };
         /** CreatedEntryResponse */
         CreatedEntryResponse: {
@@ -12064,6 +12130,44 @@ export interface components {
              * @description A `\t` (TAB) separated list of column __contents__. You must specify a value for each of the columns of the data table.
              */
             values: string;
+        };
+        /** ToolResponse */
+        ToolResponse: {
+            /**
+             * Errors
+             * @description Job errors related to the creation of the tool.
+             * @default []
+             */
+            errors?: Record<string, never>[];
+            /**
+             * Implicit Collections
+             * @description The implicit dataset collections of the tool.
+             * @default []
+             */
+            implicit_collections?: Record<string, never>[];
+            /**
+             * Jobs
+             * @description The jobs of the tool.
+             * @default []
+             */
+            jobs?: Record<string, never>[];
+            /**
+             * Output Collections
+             * @description The output dataset collections of the tool.
+             * @default []
+             */
+            output_collections?: Record<string, never>[];
+            /**
+             * Outputs
+             * @description The outputs of the tool.
+             * @default []
+             */
+            outputs?: Record<string, never>[];
+            /**
+             * Produces Entry Points
+             * @description Flag indicating whether the creation of the tool produces entry points.
+             */
+            produces_entry_points: boolean;
         };
         /** ToolStep */
         ToolStep: {
@@ -22659,6 +22763,34 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["InstalledToolShedRepository"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_api_tools_post: {
+        /** Execute tool with a given parameter payload */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateToolPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ToolResponse"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1594,7 +1594,7 @@ export interface paths {
     };
     "/api/tools": {
         /** Execute tool with a given parameter payload */
-        post: operations["execute_form_api_tools_post"];
+        post: operations["execute_api_tools_post"];
     };
     "/api/tools/fetch": {
         /** Upload files to Galaxy */
@@ -2531,42 +2531,6 @@ export interface components {
             history_id?: Record<string, never>;
             /** Name */
             name?: Record<string, never>;
-        };
-        /** Body_execute_form_api_tools_post */
-        Body_execute_form_api_tools_post: {
-            /** Action */
-            action?: Record<string, never>;
-            /** Data Manager Mode */
-            data_manager_mode?: Record<string, never>;
-            /** Files */
-            files?: string[] | null;
-            /** History Id */
-            history_id?: Record<string, never>;
-            /**
-             * Input Format
-             * @default legacy
-             */
-            input_format?: Record<string, never>;
-            /**
-             * Inputs
-             * @default {}
-             */
-            inputs?: Record<string, never>;
-            /** Preferred Object Store Id */
-            preferred_object_store_id?: Record<string, never>;
-            /** Send Email Notification */
-            send_email_notification?: Record<string, never>;
-            /** Tool Id */
-            tool_id?: Record<string, never>;
-            /** Tool Uuid */
-            tool_uuid?: Record<string, never>;
-            /** Tool Version */
-            tool_version?: Record<string, never>;
-            /**
-             * Use Cached Job
-             * @default false
-             */
-            use_cached_job?: Record<string, never>;
         };
         /** Body_fetch_form_api_tools_fetch_post */
         Body_fetch_form_api_tools_fetch_post: {
@@ -22813,17 +22777,12 @@ export interface operations {
             };
         };
     };
-    execute_form_api_tools_post: {
+    execute_api_tools_post: {
         /** Execute tool with a given parameter payload */
         parameters?: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
                 "run-as"?: string | null;
-            };
-        };
-        requestBody?: {
-            content: {
-                "multipart/form-data": components["schemas"]["Body_execute_form_api_tools_post"];
             };
         };
         responses: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1594,7 +1594,7 @@ export interface paths {
     };
     "/api/tools": {
         /** Execute tool with a given parameter payload */
-        post: operations["create_api_tools_post"];
+        post: operations["create_form_api_tools_post"];
     };
     "/api/tools/fetch": {
         /** Upload files to Galaxy */
@@ -2531,6 +2531,42 @@ export interface components {
             history_id?: Record<string, never>;
             /** Name */
             name?: Record<string, never>;
+        };
+        /** Body_create_form_api_tools_post */
+        Body_create_form_api_tools_post: {
+            /** Action */
+            action?: Record<string, never>;
+            /** Data Manager Mode */
+            data_manager_mode?: Record<string, never>;
+            /** Files */
+            files?: string[] | null;
+            /** History Id */
+            history_id?: Record<string, never>;
+            /**
+             * Input Format
+             * @default legacy
+             */
+            input_format?: Record<string, never>;
+            /**
+             * Inputs
+             * @default {}
+             */
+            inputs?: Record<string, never>;
+            /** Preferred Object Store Id */
+            preferred_object_store_id?: Record<string, never>;
+            /** Send Email Notification */
+            send_email_notification?: Record<string, never>;
+            /** Tool Id */
+            tool_id?: Record<string, never>;
+            /** Tool Uuid */
+            tool_uuid?: Record<string, never>;
+            /** Tool Version */
+            tool_version?: Record<string, never>;
+            /**
+             * Use Cached Job
+             * @default false
+             */
+            use_cached_job?: Record<string, never>;
         };
         /** Body_fetch_form_api_tools_fetch_post */
         Body_fetch_form_api_tools_fetch_post: {
@@ -12150,7 +12186,11 @@ export interface components {
              * @description The jobs of the tool.
              * @default []
              */
-            jobs?: Record<string, never>[];
+            jobs?: (
+                | components["schemas"]["ShowFullJobResponse"]
+                | components["schemas"]["EncodedJobDetails"]
+                | components["schemas"]["JobSummary"]
+            )[];
             /**
              * Output Collections
              * @description The output dataset collections of the tool.
@@ -20477,7 +20517,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["ToolResponse"];
                 };
             };
             /** @description Validation Error */
@@ -22773,7 +22813,7 @@ export interface operations {
             };
         };
     };
-    create_api_tools_post: {
+    create_form_api_tools_post: {
         /** Execute tool with a given parameter payload */
         parameters?: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
@@ -22781,9 +22821,9 @@ export interface operations {
                 "run-as"?: string | null;
             };
         };
-        requestBody: {
+        requestBody?: {
             content: {
-                "application/json": components["schemas"]["CreateToolPayload"];
+                "multipart/form-data": components["schemas"]["Body_create_form_api_tools_post"];
             };
         };
         responses: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -23139,7 +23139,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["ExecuteToolResponse"];
                 };
             };
             /** @description Validation Error */
@@ -23167,7 +23167,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["ExecuteToolResponse"];
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1594,7 +1594,7 @@ export interface paths {
     };
     "/api/tools": {
         /** Execute tool with a given parameter payload */
-        post: operations["create_form_api_tools_post"];
+        post: operations["execute_form_api_tools_post"];
     };
     "/api/tools/fetch": {
         /** Upload files to Galaxy */
@@ -2532,8 +2532,8 @@ export interface components {
             /** Name */
             name?: Record<string, never>;
         };
-        /** Body_create_form_api_tools_post */
-        Body_create_form_api_tools_post: {
+        /** Body_execute_form_api_tools_post */
+        Body_execute_form_api_tools_post: {
             /** Action */
             action?: Record<string, never>;
             /** Data Manager Mode */
@@ -3453,68 +3453,6 @@ export interface components {
              * @description The relative URL to get this particular Quota details from the rest API.
              */
             url: string;
-        };
-        /** CreateToolPayload */
-        CreateToolPayload: {
-            /**
-             * Action
-             * @description The action to perform
-             */
-            action?: string | null;
-            /**
-             * Data Manager Mode
-             * @description The mode of the data manager
-             */
-            data_manager_mode?: string | null;
-            /**
-             * History ID
-             * @description The ID of the history
-             */
-            history_id?: string | null;
-            /**
-             * Input Format
-             * @description The format of the input
-             * @default legacy
-             */
-            input_format?: string | null;
-            /**
-             * Inputs
-             * @description The input data
-             * @default {}
-             */
-            inputs?: Record<string, never>;
-            /**
-             * Preferred Object Store ID
-             * @description The ID of the preferred object store
-             */
-            preferred_object_store_id?: string | null;
-            /**
-             * Send Email Notification
-             * @description Flag indicating whether to send email notification
-             */
-            send_email_notification?: boolean | null;
-            /**
-             * Tool ID
-             * @description The ID of the tool to execute.
-             */
-            tool_id?: Record<string, never> | null;
-            /**
-             * Tool UUID
-             * @description The UUID of the tool to execute.
-             */
-            tool_uuid?: Record<string, never> | null;
-            /**
-             * Tool Version
-             * @description The version of the tool
-             */
-            tool_version?: string | null;
-            /**
-             * Use Cached Job
-             * @description Flag indicating whether to use a cached job
-             * @default false
-             */
-            use_cached_job?: boolean | null;
-            [key: string]: unknown | undefined;
         };
         /** CreatedEntryResponse */
         CreatedEntryResponse: {
@@ -4922,6 +4860,68 @@ export interface components {
              * @description The source of this dataset, either `hda`, `ldda`, `hdca`, `dce` or `dc` depending of its origin.
              */
             src: components["schemas"]["DataItemSourceType"];
+        };
+        /** ExecuteToolPayload */
+        ExecuteToolPayload: {
+            /**
+             * Action
+             * @description The action to perform
+             */
+            action?: string | null;
+            /**
+             * Data Manager Mode
+             * @description The mode of the data manager
+             */
+            data_manager_mode?: string | null;
+            /**
+             * History ID
+             * @description The ID of the history
+             */
+            history_id?: string | null;
+            /**
+             * Input Format
+             * @description The format of the input
+             * @default legacy
+             */
+            input_format?: string | null;
+            /**
+             * Inputs
+             * @description The input data
+             * @default {}
+             */
+            inputs?: Record<string, never>;
+            /**
+             * Preferred Object Store ID
+             * @description The ID of the preferred object store
+             */
+            preferred_object_store_id?: string | null;
+            /**
+             * Send Email Notification
+             * @description Flag indicating whether to send email notification
+             */
+            send_email_notification?: boolean | null;
+            /**
+             * Tool ID
+             * @description The ID of the tool to execute.
+             */
+            tool_id?: Record<string, never> | null;
+            /**
+             * Tool UUID
+             * @description The UUID of the tool to execute.
+             */
+            tool_uuid?: Record<string, never> | null;
+            /**
+             * Tool Version
+             * @description The version of the tool
+             */
+            tool_version?: string | null;
+            /**
+             * Use Cached Job
+             * @description Flag indicating whether to use a cached job
+             * @default false
+             */
+            use_cached_job?: boolean | null;
+            [key: string]: unknown | undefined;
         };
         /** ExportHistoryArchivePayload */
         ExportHistoryArchivePayload: {
@@ -22813,7 +22813,7 @@ export interface operations {
             };
         };
     };
-    create_form_api_tools_post: {
+    execute_form_api_tools_post: {
         /** Execute tool with a given parameter payload */
         parameters?: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
@@ -22823,7 +22823,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                "multipart/form-data": components["schemas"]["Body_create_form_api_tools_post"];
+                "multipart/form-data": components["schemas"]["Body_execute_form_api_tools_post"];
             };
         };
         responses: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -20419,7 +20419,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["ToolResponse"];
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -22755,7 +22755,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["ToolResponse"];
                 };
             };
             /** @description Validation Error */

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1949,6 +1949,10 @@ class JobBaseModel(Model, WithModelClass):
         title="Tool ID",
         description="Identifier of the tool that generated this job.",
     )
+    tool_version: Optional[str] = Field(
+        None,
+        description="Version of the tool that generated this job.",
+    )
     state: JobState = Field(
         ...,
         title="State",

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -93,6 +93,9 @@ class ExecuteToolPayload(Model):
     type: Optional[str] = Field(
         default=None,
     )
+    assert_ok: Optional[bool] = Field(
+        default=None,
+    )
     model_config = ConfigDict(extra="allow")
 
     @model_validator(mode="after")

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -4,6 +4,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Union,
 )
 
 from pydantic import (
@@ -13,20 +14,17 @@ from pydantic import (
 )
 
 from galaxy.schema.fields import DecodedDatabaseIdField
-from galaxy.schema.schema import Model
+from galaxy.schema.jobs import (
+    EncodedJobDetails,
+    ShowFullJobResponse,
+)
+from galaxy.schema.schema import (
+    JobSummary,
+    Model,
+)
 
 
 class CreateToolPayload(Model):
-    # def __init__(self, **data):
-    #     self.model_config = ConfigDict(extra="allow")
-    #     # Dynamically add fields based on keys starting with 'files_' or '__files_'
-    #     for key, value in data.items():
-    #         if key.startswith("files_") or key.startswith("__files_"):
-    #             setattr(
-    #                 self, key, Field(default=value, title=key, description="Files related to the creation of the tool.")
-    #             )
-    #     super().__init__(**data)
-
     tool_id: Optional[Any] = Field(
         default=None,
         title="Tool ID",
@@ -104,8 +102,8 @@ class ToolResponse(Model):
         title="Output Collections",
         description="The output dataset collections of the tool.",
     )
-    #    jobs: List[Union[ShowFullJobResponse, EncodedJobDetails, JobSummary]] = Field(
-    jobs: List[Dict[str, Any]] = Field(
+    jobs: List[Union[ShowFullJobResponse, EncodedJobDetails, JobSummary]] = Field(
+        #   jobs: List[Dict[str, Any]] = Field(
         default=[],
         title="Jobs",
         description="The jobs of the tool.",

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -4,7 +4,6 @@ from typing import (
     Dict,
     List,
     Optional,
-    Union,
 )
 
 from pydantic import (
@@ -14,23 +13,20 @@ from pydantic import (
 )
 
 from galaxy.schema.fields import DecodedDatabaseIdField
-from galaxy.schema.jobs import (
-    EncodedJobDetails,
-    ShowFullJobResponse,
-)
-from galaxy.schema.schema import (
-    JobSummary,
-    Model,
-)
+from galaxy.schema.schema import Model
 
 
 class CreateToolPayload(Model):
     # def __init__(self, **data):
+    #     self.model_config = ConfigDict(extra="allow")
     #     # Dynamically add fields based on keys starting with 'files_' or '__files_'
     #     for key, value in data.items():
     #         if key.startswith("files_") or key.startswith("__files_"):
-    #             setattr(self, key, Field(default=value,title=key,description="Files related to the creation of the tool."))
+    #             setattr(
+    #                 self, key, Field(default=value, title=key, description="Files related to the creation of the tool.")
+    #             )
     #     super().__init__(**data)
+
     tool_id: Optional[Any] = Field(
         default=None,
         title="Tool ID",
@@ -97,7 +93,7 @@ class CreateToolPayload(Model):
     model_config = ConfigDict(extra="allow")
 
 
-class CreateToolResponse(Model):
+class ToolResponse(Model):
     outputs: List[Dict[str, Any]] = Field(
         default=[],
         title="Outputs",
@@ -108,7 +104,8 @@ class CreateToolResponse(Model):
         title="Output Collections",
         description="The output dataset collections of the tool.",
     )
-    jobs: List[Union[ShowFullJobResponse, EncodedJobDetails, JobSummary]] = Field(
+    #    jobs: List[Union[ShowFullJobResponse, EncodedJobDetails, JobSummary]] = Field(
+    jobs: List[Dict[str, Any]] = Field(
         default=[],
         title="Jobs",
         description="The jobs of the tool.",

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -88,6 +88,11 @@ class ExecuteToolPayload(Model):
         title="Send Email Notification",
         description="Flag indicating whether to send email notification",
     )
+    upload_type: Optional[str] = Field(
+        default=None,
+        title="Upload Type",
+        description="TODO",
+    )
     model_config = ConfigDict(extra="allow")
 
 

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -12,6 +12,7 @@ from pydantic import (
     Field,
     field_validator,
 )
+from typing_extensions import Annotated
 
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.jobs import (
@@ -19,9 +20,20 @@ from galaxy.schema.jobs import (
     ShowFullJobResponse,
 )
 from galaxy.schema.schema import (
+    HDCADetailed,
+    HDCASummary,
     JobSummary,
     Model,
 )
+
+ToolOutputName = Annotated[
+    str,
+    Field(
+        ...,
+        title="Output Name",
+        description="The name of the tool output",
+    ),
+]
 
 
 class ExecuteToolPayload(Model):
@@ -96,13 +108,24 @@ class ExecuteToolPayload(Model):
     model_config = ConfigDict(extra="allow")
 
 
+class ExtendedHDCASummary(HDCASummary):
+    output_name: ToolOutputName
+
+
+class ExtendedHDCADetailed(HDCADetailed):
+    output_name: ToolOutputName
+
+
+ExtendedAnyHDCA = Union[ExtendedHDCADetailed, ExtendedHDCASummary]
+
+
 class ToolResponse(Model):
     outputs: List[Dict[str, Any]] = Field(
         default=[],
         title="Outputs",
         description="The outputs of the tool.",
     )
-    output_collections: List[Dict[str, Any]] = Field(
+    output_collections: List[ExtendedAnyHDCA] = Field(
         default=[],
         title="Output Collections",
         description="The output dataset collections of the tool.",
@@ -112,7 +135,7 @@ class ToolResponse(Model):
         title="Jobs",
         description="The jobs of the tool.",
     )
-    implicit_collections: List[Dict[str, Any]] = Field(
+    implicit_collections: List[ExtendedAnyHDCA] = Field(
         default=[],
         title="Implicit Collections",
         description="The implicit dataset collections of the tool.",

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -88,6 +88,9 @@ class ExecuteToolPayload(Model):
         title="Send Email Notification",
         description="Flag indicating whether to send email notification",
     )
+    state: Optional[str] = Field(
+        default=None,
+    )
     model_config = ConfigDict(extra="allow")
 
 

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -37,7 +37,7 @@ ToolOutputName = Annotated[
 
 
 class ExecuteToolPayload(Model):
-    tool_id: Optional[Any] = Field(
+    tool_id: Optional[str] = Field(
         default=None,
         title="Tool ID",
         description="The ID of the tool to execute.",

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -19,7 +19,6 @@ from typing_extensions import (
     Self,
 )
 
-from galaxy import exceptions
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     HDACustom,
@@ -98,7 +97,7 @@ class ExecuteToolPayload(Model):
         if self.model_extra is not None:
             for field_name in self.model_extra.keys():
                 if not field_name.startswith("files_"):
-                    raise exceptions.RequestParameterInvalidException(f"Invalid field name: {field_name}")
+                    raise ValueError(f"Invalid field name: {field_name}")
         return self
 
 

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -10,13 +10,16 @@ from pydantic import (
     ConfigDict,
     Field,
     field_validator,
+    model_validator,
     UUID4,
 )
 from typing_extensions import (
     Annotated,
     Literal,
+    Self,
 )
 
+from galaxy import exceptions
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     HDACustom,
@@ -38,7 +41,6 @@ ToolOutputName = Annotated[
 class ExecuteToolPayload(Model):
     tool_id: Optional[str] = Field(
         default=None,
-        description="",
     )
     tool_uuid: Optional[UUID4] = Field(
         default=None,
@@ -50,11 +52,9 @@ class ExecuteToolPayload(Model):
     )
     tool_version: Optional[str] = Field(
         default=None,
-        description="",
     )
     history_id: Optional[DecodedDatabaseIdField] = Field(
         default=None,
-        description="",
     )
 
     @field_validator("inputs", mode="before", check_fields=False)
@@ -74,7 +74,6 @@ class ExecuteToolPayload(Model):
     )
     preferred_object_store_id: Optional[str] = Field(
         default=None,
-        description="",
     )
     input_format: Optional[Literal["legacy", "21.01"]] = Field(
         default=None,
@@ -83,7 +82,6 @@ class ExecuteToolPayload(Model):
     )
     data_manager_mode: Optional[Literal["populate", "dry_run", "bundle"]] = Field(
         default=None,
-        description="",
     )
     send_email_notification: Optional[bool] = Field(
         default=None,
@@ -127,6 +125,6 @@ class ExecuteToolResponse(Model):
     produces_entry_points: bool = Field(
         default=...,
         title="Produces Entry Points",
-        description="Flag indicating whether the creation of the tool produces entry points.",
+        description="Flag indicating whether the creation of the tool produces entry points for interactive tools.",
     )
     errors: List[Any] = Field(default=[], title="Errors", description="Errors encountered while executing the tool.")

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -137,7 +137,7 @@ class HDCADetailedWithOutputName(HDCADetailed):
 AnyHDCAWithOutputName = Union[HDCADetailedWithOutputName, HDCASummaryWithOutputName]
 
 
-class ToolResponse(Model):
+class ExecuteToolResponse(Model):
     outputs: List[AnyHDAWithOutputName] = Field(
         default=[],
         title="Outputs",

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -103,7 +103,6 @@ class ToolResponse(Model):
         description="The output dataset collections of the tool.",
     )
     jobs: List[Union[ShowFullJobResponse, EncodedJobDetails, JobSummary]] = Field(
-        #   jobs: List[Dict[str, Any]] = Field(
         default=[],
         title="Jobs",
         description="The jobs of the tool.",

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -20,6 +20,9 @@ from galaxy.schema.jobs import (
     ShowFullJobResponse,
 )
 from galaxy.schema.schema import (
+    HDACustom,
+    HDADetailed,
+    HDASummary,
     HDCADetailed,
     HDCASummary,
     JobSummary,
@@ -108,24 +111,39 @@ class ExecuteToolPayload(Model):
     model_config = ConfigDict(extra="allow")
 
 
-class ExtendedHDCASummary(HDCASummary):
+class HDACustomWithOutputName(HDACustom):
     output_name: ToolOutputName
 
 
-class ExtendedHDCADetailed(HDCADetailed):
+class HDADetailedWithOutputName(HDADetailed):
     output_name: ToolOutputName
 
 
-ExtendedAnyHDCA = Union[ExtendedHDCADetailed, ExtendedHDCASummary]
+class HDASummaryWithOutputName(HDASummary):
+    output_name: ToolOutputName
+
+
+AnyHDAWithOutputName = Union[HDACustomWithOutputName, HDADetailedWithOutputName, HDASummaryWithOutputName]
+
+
+class HDCASummaryWithOutputName(HDCASummary):
+    output_name: ToolOutputName
+
+
+class HDCADetailedWithOutputName(HDCADetailed):
+    output_name: ToolOutputName
+
+
+AnyHDCAWithOutputName = Union[HDCADetailedWithOutputName, HDCASummaryWithOutputName]
 
 
 class ToolResponse(Model):
-    outputs: List[Dict[str, Any]] = Field(
+    outputs: List[AnyHDAWithOutputName] = Field(
         default=[],
         title="Outputs",
         description="The outputs of the tool.",
     )
-    output_collections: List[ExtendedAnyHDCA] = Field(
+    output_collections: List[AnyHDCAWithOutputName] = Field(
         default=[],
         title="Output Collections",
         description="The output dataset collections of the tool.",
@@ -135,7 +153,7 @@ class ToolResponse(Model):
         title="Jobs",
         description="The jobs of the tool.",
     )
-    implicit_collections: List[ExtendedAnyHDCA] = Field(
+    implicit_collections: List[AnyHDCAWithOutputName] = Field(
         default=[],
         title="Implicit Collections",
         description="The implicit dataset collections of the tool.",

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -90,6 +90,9 @@ class ExecuteToolPayload(Model):
     state: Optional[str] = Field(
         default=None,
     )
+    type: Optional[str] = Field(
+        default=None,
+    )
     model_config = ConfigDict(extra="allow")
 
     @model_validator(mode="after")

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -1,0 +1,126 @@
+import json
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Union,
+)
+
+from pydantic import (
+    ConfigDict,
+    Field,
+    field_validator,
+)
+
+from galaxy.schema.fields import DecodedDatabaseIdField
+from galaxy.schema.jobs import (
+    EncodedJobDetails,
+    ShowFullJobResponse,
+)
+from galaxy.schema.schema import (
+    JobSummary,
+    Model,
+)
+
+
+class CreateToolPayload(Model):
+    # def __init__(self, **data):
+    #     # Dynamically add fields based on keys starting with 'files_' or '__files_'
+    #     for key, value in data.items():
+    #         if key.startswith("files_") or key.startswith("__files_"):
+    #             setattr(self, key, Field(default=value,title=key,description="Files related to the creation of the tool."))
+    #     super().__init__(**data)
+    tool_id: Optional[Any] = Field(
+        default=None,
+        title="Tool ID",
+        description="The ID of the tool to execute.",
+    )
+    tool_uuid: Optional[Any] = Field(
+        default=None,
+        title="Tool UUID",
+        description="The UUID of the tool to execute.",
+    )
+    action: Optional[str] = Field(
+        default=None,
+        title="Action",
+        description="The action to perform",
+    )
+    tool_version: Optional[str] = Field(
+        default=None,
+        title="Tool Version",
+        description="The version of the tool",
+    )
+    history_id: Optional[DecodedDatabaseIdField] = Field(
+        default=None,
+        title="History ID",
+        description="The ID of the history",
+    )
+
+    @field_validator("inputs", mode="before", check_fields=False)
+    @classmethod
+    def inputs_string_to_json(cls, v):
+        if isinstance(v, str):
+            return json.loads(v)
+        return v
+
+    inputs: Dict[str, Any] = Field(
+        default={},
+        title="Inputs",
+        description="The input data",
+    )
+    use_cached_job: Optional[bool] = Field(
+        default=False,
+        title="Use Cached Job",
+        description="Flag indicating whether to use a cached job",
+    )
+    preferred_object_store_id: Optional[str] = Field(
+        default=None,
+        title="Preferred Object Store ID",
+        description="The ID of the preferred object store",
+    )
+    input_format: Optional[str] = Field(
+        default="legacy",
+        title="Input Format",
+        description="The format of the input",
+    )
+    data_manager_mode: Optional[str] = Field(
+        default=None,
+        title="Data Manager Mode",
+        description="The mode of the data manager",
+    )
+    send_email_notification: Optional[bool] = Field(
+        default=None,
+        title="Send Email Notification",
+        description="Flag indicating whether to send email notification",
+    )
+    model_config = ConfigDict(extra="allow")
+
+
+class CreateToolResponse(Model):
+    outputs: List[Dict[str, Any]] = Field(
+        default=[],
+        title="Outputs",
+        description="The outputs of the tool.",
+    )
+    output_collections: List[Dict[str, Any]] = Field(
+        default=[],
+        title="Output Collections",
+        description="The output dataset collections of the tool.",
+    )
+    jobs: List[Union[ShowFullJobResponse, EncodedJobDetails, JobSummary]] = Field(
+        default=[],
+        title="Jobs",
+        description="The jobs of the tool.",
+    )
+    implicit_collections: List[Dict[str, Any]] = Field(
+        default=[],
+        title="Implicit Collections",
+        description="The implicit dataset collections of the tool.",
+    )
+    produces_entry_points: bool = Field(
+        default=...,
+        title="Produces Entry Points",
+        description="Flag indicating whether the creation of the tool produces entry points.",
+    )
+    errors: List[Any] = Field(default=[], title="Errors", description="Job errors related to the creation of the tool.")

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -11,6 +11,7 @@ from pydantic import (
     ConfigDict,
     Field,
     field_validator,
+    UUID4,
 )
 from typing_extensions import Annotated
 
@@ -45,7 +46,7 @@ class ExecuteToolPayload(Model):
         title="Tool ID",
         description="The ID of the tool to execute.",
     )
-    tool_uuid: Optional[Any] = Field(
+    tool_uuid: Optional[UUID4] = Field(
         default=None,
         title="Tool UUID",
         description="The UUID of the tool to execute.",

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -24,7 +24,7 @@ from galaxy.schema.schema import (
 )
 
 
-class CreateToolPayload(Model):
+class ExecuteToolPayload(Model):
     tool_id: Optional[Any] = Field(
         default=None,
         title="Tool ID",

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -4,7 +4,6 @@ from typing import (
     Dict,
     List,
     Optional,
-    Union,
 )
 
 from pydantic import (
@@ -19,17 +18,10 @@ from typing_extensions import (
 )
 
 from galaxy.schema.fields import DecodedDatabaseIdField
-from galaxy.schema.jobs import (
-    EncodedJobDetails,
-    ShowFullJobResponse,
-)
 from galaxy.schema.schema import (
     HDACustom,
-    HDADetailed,
-    HDASummary,
     HDCADetailed,
-    HDCASummary,
-    JobSummary,
+    JobBaseModel,
     Model,
 )
 
@@ -103,49 +95,31 @@ class ExecuteToolPayload(Model):
 
 # The following models should eventually be removed as we move towards creating jobs asynchronously
 # xref: https://github.com/galaxyproject/galaxy/pull/17393
-class HDACustomWithOutputName(HDACustom):
+class HDAToolOutput(HDACustom):
     output_name: ToolOutputName
 
 
-class HDADetailedWithOutputName(HDADetailed):
+class HDCAToolOutput(HDCADetailed):
     output_name: ToolOutputName
-
-
-class HDASummaryWithOutputName(HDASummary):
-    output_name: ToolOutputName
-
-
-AnyHDAWithOutputName = Union[HDACustomWithOutputName, HDADetailedWithOutputName, HDASummaryWithOutputName]
-
-
-class HDCASummaryWithOutputName(HDCASummary):
-    output_name: ToolOutputName
-
-
-class HDCADetailedWithOutputName(HDCADetailed):
-    output_name: ToolOutputName
-
-
-AnyHDCAWithOutputName = Union[HDCADetailedWithOutputName, HDCASummaryWithOutputName]
 
 
 class ExecuteToolResponse(Model):
-    outputs: List[AnyHDAWithOutputName] = Field(
+    outputs: List[HDAToolOutput] = Field(
         default=[],
         title="Outputs",
         description="The outputs of the job.",
     )
-    output_collections: List[AnyHDCAWithOutputName] = Field(
+    output_collections: List[HDCAToolOutput] = Field(
         default=[],
         title="Output Collections",
         description="The output dataset collections of the job.",
     )
-    jobs: List[Union[ShowFullJobResponse, EncodedJobDetails, JobSummary]] = Field(
+    jobs: List[JobBaseModel] = Field(
         default=[],
         title="Jobs",
         description="The jobs of the tool.",
     )
-    implicit_collections: List[AnyHDCAWithOutputName] = Field(
+    implicit_collections: List[HDCAToolOutput] = Field(
         default=[],
         title="Implicit Collections",
         description="The implicit dataset collections of the job.",

--- a/lib/galaxy/schema/tools.py
+++ b/lib/galaxy/schema/tools.py
@@ -93,6 +93,14 @@ class ExecuteToolPayload(Model):
     )
     model_config = ConfigDict(extra="allow")
 
+    @model_validator(mode="after")
+    def validate_extra_fields(self) -> Self:
+        if self.model_extra is not None:
+            for field_name in self.model_extra.keys():
+                if not field_name.startswith("files_"):
+                    raise exceptions.RequestParameterInvalidException(f"Invalid field name: {field_name}")
+        return self
+
 
 # The following models should eventually be removed as we move towards creating jobs asynchronously
 # xref: https://github.com/galaxyproject/galaxy/pull/17393

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -818,7 +818,7 @@ class GalaxyInteractorApi:
         data = dict(
             history_id=history_id, tool_id=tool_id, inputs=dumps(tool_input), tool_version=tool_version, **extra_data
         )
-        return self._post("tools", files=files, data=data)
+        return self._post("tools", files=files, data=data, json=True)
 
     def ensure_user_with_email(self, email, password=None):
         admin_key = self.master_api_key

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -818,7 +818,7 @@ class GalaxyInteractorApi:
         data = dict(
             history_id=history_id, tool_id=tool_id, inputs=dumps(tool_input), tool_version=tool_version, **extra_data
         )
-        return self._post("tools", files=files, data=data, json=True)
+        return self._post("tools", files=files, data=data)
 
     def ensure_user_with_email(self, email, password=None):
         admin_key = self.master_api_key

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -27,7 +27,6 @@ from fastapi import (
     APIRouter,
     Form,
     Header,
-    HTTPException,
     Query,
     Request,
     Response,
@@ -69,6 +68,7 @@ from galaxy import (
 )
 from galaxy.exceptions import (
     AdminRequiredException,
+    MessageException,
     UserCannotRunAsException,
 )
 from galaxy.managers.session import GalaxySessionManager
@@ -614,18 +614,18 @@ def depend_on_either_json_or_form_data(model: Type[B]):
     async def get_body(request: Request):
         content_type = request.headers.get("Content-Type")
         if content_type is None:
-            raise HTTPException(status_code=400, detail="No Content-Type provided!")
+            raise MessageException("No Content-Type provided!")
         elif content_type == "application/json":
             try:
                 return model(**await request.json())
             except JSONDecodeError:
-                raise HTTPException(status_code=400, detail="Invalid JSON data")
+                raise MessageException("Invalid JSON data")
         elif content_type == "application/x-www-form-urlencoded" or content_type.startswith("multipart/form-data"):
             try:
                 return model(**await request.form())
             except Exception:
-                raise HTTPException(status_code=400, detail="Invalid Form data")
+                raise MessageException("Invalid Form data")
         else:
-            raise HTTPException(status_code=400, detail="Content-Type not supported!")
+            raise MessageException("Content-Type not supported!")
 
     return Depends(get_body)

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -76,7 +76,7 @@ FetchDataForm = as_form(FetchDataFormPayload)
 
 
 @router.cbv
-class FetchTools:
+class FastAPITools:
     service: ToolsService = depends(ToolsService)
 
     @router.post("/api/tools/fetch", summary="Upload files to Galaxy", route_class_override=JsonApiRoute)

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -35,7 +35,7 @@ from galaxy.schema.fetch_data import (
 )
 from galaxy.schema.tools import (
     CreateToolPayload,
-    CreateToolResponse,
+    ToolResponse,
 )
 from galaxy.tools.evaluation import global_tool_errors
 from galaxy.util.zipstream import ZipstreamWrapper
@@ -126,7 +126,7 @@ class FetchTools:
         self,
         payload: CreateToolBody,
         trans: ProvidesHistoryContext = DependsOnTrans,
-    ) -> CreateToolResponse:
+    ) -> ToolResponse:
         tool_id = payload.tool_id
         tool_uuid = payload.tool_uuid
         if tool_id in PROTECTED_TOOLS:
@@ -135,7 +135,7 @@ class FetchTools:
             )
         if tool_id is None and tool_uuid is None:
             raise HTTPException(status_code=400, detail="Must specify a valid tool_id to use this endpoint.")
-        return CreateToolResponse(**self.service.create(trans, payload.model_dump()))
+        return ToolResponse(**self.service.create(trans, payload.model_dump()))
 
 
 class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -176,7 +176,7 @@ class FetchTools:
         create_payload = payload.model_dump()
 
         for i, file in enumerate(files2):
-            create_payload[f"files_{i}|file_data"] = file
+            create_payload[f"files_{i}|file_data"] = file.file
         return self.service.create(trans, create_payload)
 
 

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -123,7 +123,7 @@ class FetchTools:
         summary="Execute tool with a given parameter payload",
         route_class_override=JsonApiRoute,
     )
-    def execute_json(
+    async def execute_json(
         self,
         payload: CreateToolBody,
         trans: ProvidesHistoryContext = DependsOnTrans,

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -33,7 +33,7 @@ from galaxy.schema.fetch_data import (
 )
 from galaxy.schema.tools import (
     ExecuteToolPayload,
-    ToolResponse,
+    ExecuteToolResponse,
 )
 from galaxy.tools.evaluation import global_tool_errors
 from galaxy.util.zipstream import ZipstreamWrapper
@@ -80,9 +80,7 @@ class FetchTools:
     service: ToolsService = depends(ToolsService)
 
     @router.post("/api/tools/fetch", summary="Upload files to Galaxy", route_class_override=JsonApiRoute)
-    async def fetch_json(
-        self, payload: FetchDataPayload = Body(...), trans: ProvidesHistoryContext = DependsOnTrans
-    ) -> ToolResponse:
+    async def fetch_json(self, payload: FetchDataPayload = Body(...), trans: ProvidesHistoryContext = DependsOnTrans):
         return self.service.create_fetch(trans, payload)
 
     @router.post(
@@ -96,7 +94,7 @@ class FetchTools:
         payload: FetchDataFormPayload = Depends(FetchDataForm.as_form),
         files: Optional[List[UploadFile]] = None,
         trans: ProvidesHistoryContext = DependsOnTrans,
-    ) -> ToolResponse:
+    ):
         files2: List[StarletteUploadFile] = cast(List[StarletteUploadFile], files or [])
 
         # FastAPI's UploadFile is a very light wrapper around starlette's UploadFile
@@ -115,7 +113,7 @@ class FetchTools:
         self,
         payload: ExecuteToolPayload = depend_on_either_json_or_form_data(ExecuteToolPayload),
         trans: ProvidesHistoryContext = DependsOnTrans,
-    ) -> ToolResponse:
+    ) -> ExecuteToolResponse:
         return self.service.execute(trans, payload)
 
 

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -16,7 +16,6 @@ from fastapi import (
     UploadFile,
 )
 from starlette.datastructures import UploadFile as StarletteUploadFile
-from typing_extensions import Annotated
 
 from galaxy import (
     exceptions,
@@ -62,15 +61,6 @@ log = logging.getLogger(__name__)
 # Tool search bypasses the fulltext for the following list of terms
 SEARCH_RESERVED_TERMS_FAVORITES = ["#favs", "#favorites", "#favourites"]
 
-CreateToolBody = Annotated[
-    ExecuteToolPayload,
-    Body(
-        default=...,
-        title="",
-        description="",
-    ),
-]
-
 
 class FormDataApiRoute(APIContentTypeRoute):
     match_content_type = "multipart/form-data"
@@ -83,8 +73,6 @@ class JsonApiRoute(APIContentTypeRoute):
 router = Router(tags=["tools"])
 
 FetchDataForm = as_form(FetchDataFormPayload)
-
-CreateDataForm = as_form(ExecuteToolPayload)
 
 
 @router.cbv

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -415,8 +415,13 @@ def populate_api_routes(webapp, app):
         controller="tools",
         conditions=dict(method=["POST"]),
     )
+    webapp.mapper.connect(
+        "api/tools",
+        action="index",
+        controller="tools",
+        conditions=dict(method=["GET"]),
+    )
     webapp.mapper.connect("/api/tools/{id:.+?}", action="show", controller="tools")
-    webapp.mapper.resource("tool", "tools", path_prefix="/api")
     webapp.mapper.resource("dynamic_tools", "dynamic_tools", path_prefix="/api")
 
     webapp.mapper.connect(

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import shutil
 import tempfile
 from json import dumps
@@ -78,30 +77,13 @@ class ToolsService(ServiceBase):
             )
         return files_payload
 
-    def create_temp_file_execute(self, trans, files) -> Dict[str, FilesPayload]:
-        # TODO - could access headers from request maybe better to do that
-        # header_content = request.headers["content-type"]
-        files_payload = {}
-        for i, upload_file in enumerate(files):
-            with tempfile.NamedTemporaryFile(
-                dir=trans.app.config.new_file_path, prefix="upload_file_data_", delete=False
-            ) as dest:
-                shutil.copyfileobj(upload_file.file, dest)  # type: ignore[misc]  # https://github.com/python/mypy/issues/15031
-            upload_file.file.close()
-
-            # try to grab the name from the header
-            try:
-                header_items = upload_file.headers.items()[0]
-                name_search = re.search(r'name="([^"]+)"', header_items[1])
-                if name_search:
-                    name = name_search.group(1)
-                else:
-                    raise Exception("No name found in header")
-            # if we can't find the name in the header use the index
-            except Exception:
-                name = f"files_{i}|file_data"
-            files_payload[name] = FilesPayload(filename=upload_file.filename, local_filename=dest.name)
-        return files_payload
+    def create_temp_file_execute(self, trans, upload_file) -> FilesPayload:
+        with tempfile.NamedTemporaryFile(
+            dir=trans.app.config.new_file_path, prefix="upload_file_data_", delete=False
+        ) as dest:
+            shutil.copyfileobj(upload_file.file, dest)  # type: ignore[misc]  # https://github.com/python/mypy/issues/15031
+        upload_file.file.close()
+        return FilesPayload(filename=upload_file.filename, local_filename=dest.name)
 
     def create_fetch(
         self,
@@ -142,7 +124,6 @@ class ToolsService(ServiceBase):
         self,
         trans: ProvidesHistoryContext,
         payload: ExecuteToolPayload,
-        files: Optional[List[UploadFile]] = None,
     ) -> ToolResponse:
         tool_id = payload.tool_id
         tool_uuid = payload.tool_uuid
@@ -152,10 +133,14 @@ class ToolsService(ServiceBase):
             )
         if tool_id is None and tool_uuid is None:
             raise HTTPException(status_code=400, detail="Must specify a valid tool_id to use this endpoint.")
-
         create_payload = payload.model_dump(exclude_unset=True)
-        if files:
-            create_payload.update(self.create_temp_file_execute(trans, files))
+
+        # create temporary files from the uploaded files
+        files = {}
+        for key in list(create_payload.keys()):
+            if key.startswith("files_") or key.startswith("__files_"):
+                files[key] = self.create_temp_file_execute(trans, create_payload.pop(key))
+        create_payload.update(files)
         return self._create(trans, create_payload)
 
     def _create(self, trans: ProvidesHistoryContext, payload) -> ToolResponse:

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -10,7 +10,6 @@ from typing import (
     Union,
 )
 
-from fastapi import HTTPException
 from starlette.datastructures import UploadFile
 
 from galaxy import (
@@ -46,8 +45,8 @@ from galaxy.webapps.galaxy.services.base import ServiceBase
 
 log = logging.getLogger(__name__)
 
-# Do not allow these tools to be called directly - they (it) enforces extra security and
-# provides access via a different API endpoint.
+# Do not allow these tools to be called directly - they enforce extra security and
+# provide access via a different API endpoint.
 PROTECTED_TOOLS = ["__DATA_FETCH__"]
 
 
@@ -136,11 +135,11 @@ class ToolsService(ServiceBase):
         tool_id = payload.tool_id
         tool_uuid = str(payload.tool_uuid) if payload.tool_uuid else None
         if tool_id in PROTECTED_TOOLS:
-            raise HTTPException(
-                status_code=400, detail=f"Cannot execute tool [{tool_id}] directly, must use alternative endpoint."
+            raise exceptions.MessageException(
+                f"Cannot execute tool [{tool_id}] directly, must use alternative endpoint."
             )
         if tool_id is None and tool_uuid is None:
-            raise HTTPException(status_code=400, detail="Must specify a valid tool_id to use this endpoint.")
+            raise exceptions.RequestParameterInvalidException("Must specify a valid tool_id to use this endpoint.")
         create_payload = payload.model_dump(exclude_unset=True)
         create_payload["tool_uuid"] = tool_uuid
         # process files, when they come in as multipart file data

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -153,7 +153,7 @@ class ToolsService(ServiceBase):
         if tool_id is None and tool_uuid is None:
             raise HTTPException(status_code=400, detail="Must specify a valid tool_id to use this endpoint.")
 
-        create_payload = payload.model_dump()
+        create_payload = payload.model_dump(exclude_unset=True)
         if files:
             create_payload.update(self.create_temp_file_execute(trans, files))
         return self.create(trans, create_payload)

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -292,8 +292,6 @@ class ToolsService(ServiceBase):
             output_dict["output_name"] = output_name
             rval["implicit_collections"].append(output_dict)
 
-        trans.security.encode_all_ids(rval, recursive=True)
-
         # Encoding the job ids is handled by the pydantic model
         for job in vars.get("jobs", []):
             rval["jobs"].append(job.to_dict(view="collection"))

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -74,6 +74,7 @@ class ToolsService(ServiceBase):
                 dir=trans.app.config.new_file_path, prefix="upload_file_data_", delete=False
             ) as dest:
                 shutil.copyfileobj(upload_file.file, dest)  # type: ignore[misc]  # https://github.com/python/mypy/issues/15031
+                util.umask_fix_perms(dest.name, trans.app.config.umask, 0o0666)
             upload_file.file.close()
             files_payload[f"files_{i}|file_data"] = FilesPayload(
                 filename=upload_file.filename, local_filename=dest.name

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -134,7 +134,7 @@ class ToolsService(ServiceBase):
         payload: ExecuteToolPayload,
     ) -> ExecuteToolResponse:
         tool_id = payload.tool_id
-        tool_uuid = payload.tool_uuid
+        tool_uuid = str(payload.tool_uuid) if payload.tool_uuid else None
         if tool_id in PROTECTED_TOOLS:
             raise HTTPException(
                 status_code=400, detail=f"Cannot execute tool [{tool_id}] directly, must use alternative endpoint."
@@ -142,7 +142,7 @@ class ToolsService(ServiceBase):
         if tool_id is None and tool_uuid is None:
             raise HTTPException(status_code=400, detail="Must specify a valid tool_id to use this endpoint.")
         create_payload = payload.model_dump(exclude_unset=True)
-
+        create_payload["tool_uuid"] = tool_uuid
         # process files, when they come in as multipart file data
         files = {}
         for key in list(create_payload.keys()):

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -64,7 +64,11 @@ class ToolsService(ServiceBase):
         self.toolbox_search = toolbox_search
         self.history_manager = history_manager
 
-    def create_temp_file(self, trans, files) -> Dict[str, FilesPayload]:
+    def create_temp_file(
+        self,
+        trans: ProvidesHistoryContext,
+        files: List[UploadFile],
+    ) -> Dict[str, FilesPayload]:
         files_payload = {}
         for i, upload_file in enumerate(files):
             with tempfile.NamedTemporaryFile(
@@ -77,7 +81,11 @@ class ToolsService(ServiceBase):
             )
         return files_payload
 
-    def create_temp_file_execute(self, trans, upload_file) -> FilesPayload:
+    def create_temp_file_execute(
+        self,
+        trans: ProvidesHistoryContext,
+        upload_file: UploadFile,
+    ) -> FilesPayload:
         with tempfile.NamedTemporaryFile(
             dir=trans.app.config.new_file_path, prefix="upload_file_data_", delete=False
         ) as dest:
@@ -143,7 +151,11 @@ class ToolsService(ServiceBase):
         create_payload.update(files)
         return self._create(trans, create_payload)
 
-    def _create(self, trans: ProvidesHistoryContext, payload) -> ToolResponse:
+    def _create(
+        self,
+        trans: ProvidesHistoryContext,
+        payload: Dict[str, Any],
+    ) -> ToolResponse:
         if trans.user_is_bootstrap_admin:
             raise exceptions.RealUserRequiredException("Only real users can execute tools or run jobs.")
         action = payload.get("action")

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -136,7 +136,7 @@ class ToolsService(ServiceBase):
             },
         }
         create_payload.update(files_payload)
-        return self.create(trans, create_payload)
+        return self._create(trans, create_payload)
 
     def execute(
         self,
@@ -156,9 +156,9 @@ class ToolsService(ServiceBase):
         create_payload = payload.model_dump(exclude_unset=True)
         if files:
             create_payload.update(self.create_temp_file_execute(trans, files))
-        return self.create(trans, create_payload)
+        return self._create(trans, create_payload)
 
-    def create(self, trans: ProvidesHistoryContext, payload) -> ToolResponse:
+    def _create(self, trans: ProvidesHistoryContext, payload) -> ToolResponse:
         if trans.user_is_bootstrap_admin:
             raise exceptions.RealUserRequiredException("Only real users can execute tools or run jobs.")
         action = payload.get("action")

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -135,10 +135,10 @@ class ToolsService(ServiceBase):
             raise HTTPException(status_code=400, detail="Must specify a valid tool_id to use this endpoint.")
         create_payload = payload.model_dump(exclude_unset=True)
 
-        # create temporary files from the uploaded files
+        # process files, when they come in as multipart file data
         files = {}
         for key in list(create_payload.keys()):
-            if key.startswith("files_") or key.startswith("__files_"):
+            if key.startswith("files_") and isinstance(create_payload[key], UploadFile):
                 files[key] = self.create_temp_file_execute(trans, create_payload.pop(key))
         create_payload.update(files)
         return self._create(trans, create_payload)

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -97,9 +97,9 @@ class ToolsService(ServiceBase):
             },
         }
         create_payload.update(files_payload)
-        return self._create(trans, create_payload)
+        return self.create(trans, create_payload)
 
-    def _create(self, trans: ProvidesHistoryContext, payload, **kwd):
+    def create(self, trans: ProvidesHistoryContext, payload):
         if trans.user_is_bootstrap_admin:
             raise exceptions.RealUserRequiredException("Only real users can execute tools or run jobs.")
         action = payload.get("action")
@@ -136,7 +136,6 @@ class ToolsService(ServiceBase):
         # History not set correctly as part of this API call for
         # dataset upload.
         if history_id := payload.get("history_id"):
-            history_id = trans.security.decode_id(history_id) if isinstance(history_id, str) else history_id
             target_history = self.history_manager.get_mutable(history_id, trans.user, current_history=trans.history)
         else:
             target_history = None

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -629,7 +629,7 @@ class TestDatasetCollectionsApi(ApiTestCase):
             history_id=history_id,
             input_format="legacy",
         )
-        response = self._post("tools", payload).json()
+        response = self._post("tools", payload, json=True).json()
         self.dataset_populator.wait_for_history(history_id, assert_ok=False)
         output_collection = response["output_collections"][0]
         # collection should not inherit tags from input collection elements, only parent collection

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -989,7 +989,7 @@ steps:
         inputs = json.dumps({"input1": {"src": "hda", "id": dataset_id}})
         search_payload = self._search_payload(history_id=history_id, tool_id="cat1", inputs=inputs)
         # create a job
-        tool_response = self._post("tools", data=search_payload)
+        tool_response = self._post("tools", data=search_payload, json=True)
         job_id = tool_response.json()["jobs"][0]["id"]
         # delete the job without message
         delete_job_response = self._delete(f"jobs/{job_id}")
@@ -1039,7 +1039,7 @@ steps:
     def _create_and_search_job(self, history_id, inputs, tool_id):
         # create a job
         search_payload = self._search_payload(history_id=history_id, tool_id=tool_id, inputs=inputs)
-        tool_response = self._post("tools", data=search_payload)
+        tool_response = self._post("tools", data=search_payload, json=True)
         self.dataset_populator.wait_for_tool_run(history_id, run_response=tool_response)
         # search for the job and get the corresponding values
         search_response = self._post("jobs/search", data=search_payload, json=True)
@@ -1051,7 +1051,7 @@ steps:
         empty_search_response = self._post("jobs/search", data=search_payload, json=True)
         self._assert_status_code_is(empty_search_response, 200)
         assert len(empty_search_response.json()) == 0
-        tool_response = self._post("tools", data=search_payload)
+        tool_response = self._post("tools", data=search_payload, json=True)
         self.dataset_populator.wait_for_tool_run(history_id, run_response=tool_response)
         self._search(search_payload, expected_search_count=1)
         return tool_response

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -376,7 +376,7 @@ steps:
             inputs=inputs,
             history_id=history_id,
         )
-        return self._post("tools", data=payload).json()
+        return self._post("tools", data=payload, json=True).json()
 
     @skip_without_tool("detect_errors_aggressive")
     def test_unhide_on_error(self):
@@ -491,7 +491,7 @@ steps:
             inputs={"error_bool": "true"},
             history_id=history_id,
         )
-        run_response = self._post("tools", data=payload).json()
+        run_response = self._post("tools", data=payload, json=True).json()
         job_id = run_response["jobs"][0]["id"]
         self.dataset_populator.wait_for_job(job_id)
         dataset_id = run_response["outputs"][0]["id"]
@@ -506,7 +506,7 @@ steps:
                 inputs={"error_bool": "true"},
                 history_id=history_id,
             )
-            run_response = self._post("tools", data=payload, key=self.master_api_key)
+            run_response = self._post("tools", data=payload, key=self.master_api_key, json=True)
             self._assert_status_code_is(run_response, 400)
 
     @pytest.mark.require_new_history
@@ -621,7 +621,7 @@ steps:
             ),
             history_id=history_id,
         )
-        run_response = self._post("tools", data=payload)
+        run_response = self._post("tools", data=payload, json=True)
         run_response.raise_for_status()
         run_object = run_response.json()
         outputs = run_object["outputs"]
@@ -662,7 +662,7 @@ steps:
             },
             history_id=history_id,
         )
-        run_response = self._post("tools", data=payload).json()
+        run_response = self._post("tools", data=payload, json=True).json()
         output = run_response["outputs"][0]
         # Submit second job that waits on job1
         payload = self.dataset_populator.run_tool_payload(
@@ -670,7 +670,7 @@ steps:
             inputs={"input1": {"src": "hda", "id": hda1["id"]}, "queries_0|input2": {"src": "hda", "id": output["id"]}},
             history_id=history_id,
         )
-        run_response = self._post("tools", data=payload).json()
+        run_response = self._post("tools", data=payload, json=True).json()
         job_id = run_response["jobs"][0]["id"]
         output = run_response["outputs"][0]
         # Delete second jobs input while second job is waiting for first job

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -118,7 +118,7 @@ class TestsTools:
             payload["tool_version"] = tool_version
         if use_cached_job:
             payload["use_cached_job"] = True
-        create_response = self.dataset_populator._post("tools", data=payload)
+        create_response = self.dataset_populator._post("tools", data=payload, json=True)
         if wait_for_job:
             self.dataset_populator.wait_for_job(job_id=create_response.json()["jobs"][0]["id"])
         if assert_ok:
@@ -274,7 +274,7 @@ class TestToolsApi(ApiTestCase, TestsTools):
                 },
                 history_id=history_id,
             )
-            create_response = self._post("tools", data=payload)
+            create_response = self._post("tools", data=payload, json=True)
             self._assert_status_code_is(create_response, 200)
             create_object = create_response.json()
             self._assert_has_keys(create_object, "outputs")
@@ -298,7 +298,7 @@ class TestToolsApi(ApiTestCase, TestsTools):
                 },
                 history_id=history_id,
             )
-            create_response = self._post("tools", data=payload)
+            create_response = self._post("tools", data=payload, json=True)
             self._assert_status_code_is(create_response, 200)
             create_object = create_response.json()
             self._assert_has_keys(create_object, "outputs")
@@ -320,7 +320,7 @@ class TestToolsApi(ApiTestCase, TestsTools):
                 },
                 history_id=history_id,
             )
-            create_response = self._post("tools", data=payload)
+            create_response = self._post("tools", data=payload, json=True)
             self._assert_status_code_is(create_response, 200)
             create_object = create_response.json()
             self._assert_has_keys(create_object, "outputs")

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -36,7 +36,7 @@ class TestToolsUpload(ApiTestCase):
     def test_upload1_paste(self):
         with self.dataset_populator.test_history() as history_id:
             payload = self.dataset_populator.upload_payload(history_id, "Hello World")
-            create_response = self._post("tools", data=payload)
+            create_response = self._post("tools", data=payload, json=True)
             self._assert_has_keys(create_response.json(), "outputs")
 
     def test_upload1_paste_bad_datatype(self):
@@ -44,7 +44,7 @@ class TestToolsUpload(ApiTestCase):
         with self.dataset_populator.test_history() as history_id:
             file_type = "johnsawesomebutfakedatatype"
             payload = self.dataset_populator.upload_payload(history_id, "Hello World", file_type=file_type)
-            create = self._post("tools", data=payload).json()
+            create = self._post("tools", data=payload, json=True).json()
             self._assert_has_keys(create, "err_msg")
             assert file_type in create["err_msg"]
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -905,9 +905,7 @@ class BaseDatasetPopulator(BasePopulator):
         if "auto_decompress" in kwds:
             upload_params["files_0|auto_decompress"] = kwds["auto_decompress"]
         upload_params.update(kwds.get("extra_inputs", {}))
-        return self.run_tool_payload(
-            tool_id="upload1", inputs=upload_params, history_id=history_id, upload_type="upload_dataset"
-        )
+        return self.run_tool_payload(tool_id="upload1", inputs=upload_params, history_id=history_id)
 
     def get_remote_files(self, target: str = "ftp") -> dict:
         response = self._get("remote_files", data={"target": target})

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -941,7 +941,7 @@ class BaseDatasetPopulator(BasePopulator):
         return tool_response.json()
 
     def tools_post(self, payload: dict, url="tools") -> Response:
-        tool_response = self._post(url, data=payload)
+        tool_response = self._post(url, data=payload, json=True)
         return tool_response
 
     def materialize_dataset_instance(self, history_id: str, id: str, source: str = "hda"):
@@ -1049,7 +1049,7 @@ class BaseDatasetPopulator(BasePopulator):
             },
             history_id=history_id,
         )
-        create_response = self._post("tools", data=payload)
+        create_response = self._post("tools", data=payload, json=True)
         api_asserts.assert_status_code_is(create_response, 200)
         create_object = create_response.json()
         api_asserts.assert_has_keys(create_object, "outputs")

--- a/lib/tool_shed/webapp/api2/__init__.py
+++ b/lib/tool_shed/webapp/api2/__init__.py
@@ -1,17 +1,14 @@
 import logging
-from json import JSONDecodeError
 from typing import (
     AsyncGenerator,
     cast,
     List,
     Optional,
     Type,
-    TypeVar,
 )
 
 from fastapi import (
     Depends,
-    HTTPException,
     Path,
     Query,
     Request,
@@ -23,7 +20,6 @@ from fastapi.security import (
     APIKeyHeader,
     APIKeyQuery,
 )
-from pydantic import BaseModel
 from starlette_context import context as request_context
 
 from galaxy.exceptions import AdminRequiredException
@@ -159,32 +155,8 @@ class Router(FrameworkRouter):
     admin_user_dependency = AdminUserRequired
 
 
-B = TypeVar("B", bound=BaseModel)
-
-
 # async def depend_on_either_json_or_form_data(model: Type[T]):
 #    return Depends(get_body)
-
-
-def depend_on_either_json_or_form_data(model: Type[B]) -> B:
-    async def get_body(request: Request):
-        content_type = request.headers.get("Content-Type")
-        if content_type is None:
-            raise HTTPException(status_code=400, detail="No Content-Type provided!")
-        elif content_type == "application/json":
-            try:
-                return model(**await request.json())
-            except JSONDecodeError:
-                raise HTTPException(status_code=400, detail="Invalid JSON data")
-        elif content_type == "application/x-www-form-urlencoded" or content_type.startswith("multipart/form-data"):
-            try:
-                return model(**await request.form())
-            except Exception:
-                raise HTTPException(status_code=400, detail="Invalid Form data")
-        else:
-            raise HTTPException(status_code=400, detail="Content-Type not supported!")
-
-    return Depends(get_body)
 
 
 UserIdPathParam: str = Path(..., title="User ID", description="The encoded database identifier of the user.")

--- a/lib/tool_shed/webapp/api2/repositories.py
+++ b/lib/tool_shed/webapp/api2/repositories.py
@@ -21,7 +21,10 @@ from starlette.datastructures import UploadFile as StarletteUploadFile
 
 from galaxy.exceptions import InsufficientPermissionsException
 from galaxy.model.base import transaction
-from galaxy.webapps.galaxy.api import as_form
+from galaxy.webapps.galaxy.api import (
+    as_form,
+    depend_on_either_json_or_form_data,
+)
 from tool_shed.context import SessionRequestContext
 from tool_shed.managers.repositories import (
     can_manage_repo,
@@ -62,7 +65,6 @@ from tool_shed_client.schema import (
 from . import (
     ChangesetRevisionPathParam,
     CommitMessageQueryParam,
-    depend_on_either_json_or_form_data,
     depends,
     DependsOnTrans,
     DownloadableQueryParam,

--- a/test/integration/test_resolvers.py
+++ b/test/integration/test_resolvers.py
@@ -80,7 +80,7 @@ class TestCondaResolutionIntegration(integration_util.IntegrationTestCase):
             inputs={},
             history_id=history_id,
         )
-        create_response = self._post("tools", data=payload)
+        create_response = self._post("tools", data=payload, json=True)
         self._assert_status_code_is(create_response, 200)
         dataset_populator.wait_for_history(history_id, assert_ok=True)
 

--- a/test/integration/test_tool_data_bundles.py
+++ b/test/integration/test_tool_data_bundles.py
@@ -17,7 +17,7 @@ class TestDataBundlesIntegration(BaseSwiftObjectStoreIntegrationTestCase, DataMa
             data_manager_mode="bundle",
             history_id=history_id,
         )
-        create_response = self._post("tools", data=payload)
+        create_response = self._post("tools", data=payload, json=True)
         create_response.raise_for_status()
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         data_manager_dataset = self.dataset_populator.get_history_dataset_details(history_id)
@@ -57,7 +57,7 @@ class TestDataBundlesIntegration(BaseSwiftObjectStoreIntegrationTestCase, DataMa
             data_manager_mode="bundle",
             history_id=history_id,
         )
-        create_response = self._post("tools", data=payload)
+        create_response = self._post("tools", data=payload, json=True)
         create_response.raise_for_status()
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         data_manager_dataset = self.dataset_populator.get_history_dataset_details(history_id)

--- a/test/integration/test_tool_data_delete.py
+++ b/test/integration/test_tool_data_delete.py
@@ -59,7 +59,7 @@ class TestAdminToolDataIntegration(DataManagerIntegrationTestCase):
             inputs={"ignored_value": "moo"},
             history_id=history_id,
         )
-        create_response = self._post("tools", data=payload)
+        create_response = self._post("tools", data=payload, json=True)
         create_response.raise_for_status()
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         time.sleep(2)


### PR DESCRIPTION
This is a part of #10889.

## Summary
- [x] Refactored API route
     - POST: `/api/tools`
- [x] Added pydantic model to input
- [x] Added pydantic model to return
- [x] Removed the mapping to the legacy route

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
    You can find the interactive API documentation here: [http://127.0.0.1:8080/api/docs#/tools/execute_form_api_tools_post]()
    
![image](https://github.com/galaxyproject/galaxy/assets/117033448/d9da8b4f-57f4-4ee4-b421-372f16928188)

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).