### PR TITLE
Fix Workflow Comment Model for Pydantic 2

### DIFF
--- a/lib/galaxy/schema/workflow/comments.py
+++ b/lib/galaxy/schema/workflow/comments.py
@@ -23,8 +23,12 @@ class BaseComment(BaseModel):
 
 
 class TextCommentData(BaseModel):
-    bold: Optional[bool] = Field(description="If the Comments text is bold. Absent is interpreted as false")
-    italic: Optional[bool] = Field(description="If the Comments text is italic. Absent is interpreted as false")
+    bold: Optional[bool] = Field(
+        default=None, description="If the Comments text is bold. Absent is interpreted as false"
+    )
+    italic: Optional[bool] = Field(
+        default=None, description="If the Comments text is italic. Absent is interpreted as false"
+    )
     size: int = Field(..., description="Relative size (1 -> 100%) of the text compared to the default text sitz")
     text: str = Field(..., description="The plaintext text of this comment")
 
@@ -51,10 +55,10 @@ class FrameComment(BaseComment):
     type: Literal["frame"]
     data: FrameCommentData
     child_comments: Optional[List[int]] = Field(
-        description="A list of ids (see `id`) of all Comments which are encompassed by this Frame"
+        default=None, description="A list of ids (see `id`) of all Comments which are encompassed by this Frame"
     )
     child_steps: Optional[List[int]] = Field(
-        description="A list of ids of all Steps (see WorkflowStep.id) which are encompassed by this Frame"
+        default=None, description="A list of ids of all Steps (see WorkflowStep.id) which are encompassed by this Frame"
     )
 
 
@@ -72,4 +76,4 @@ class FreehandComment(BaseComment):
 
 
 class WorkflowCommentModel(RootModel):
-    root: Union[TextComment, MarkdownComment, FrameComment, FreehandComment]
+    root: Union[TextComment, MarkdownComment, FrameComment, FreehandComment] = Field(..., discriminator="type")


### PR DESCRIPTION
The Pydantic 2 migration broke the Workflow Comment model, due to the `Optional` type no longer marking fields as optional. (see here: https://docs.pydantic.dev/2.0/migration/#required-optional-and-nullable-fields)

In order to mark a field as optional in v2, it needs a default value.

Also adds a discriminator to the root model union, making it far easier to track down failed validations.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
