### PR TITLE
Adjust  Flex Panel Drag Handle and Collapse Button

### DIFF
--- a/client/src/components/Panels/FlexPanel.vue
+++ b/client/src/components/Panels/FlexPanel.vue
@@ -49,8 +49,8 @@ const hoverDraggableOrToggle = computed(
     () => (hoverDraggableDebounced.value || hoverToggle.value) && !isDragging.value
 );
 
-const toggleLinger = 1000;
-const toggleShowDelay = 100;
+const toggleLinger = 500;
+const toggleShowDelay = 800;
 let showToggleTimeout: ReturnType<typeof setTimeout> | undefined;
 
 watch(
@@ -198,7 +198,7 @@ const sideClasses = computed(() => ({
         border-right-style: solid;
 
         .drag-handle {
-            right: -0.75rem;
+            right: -4px;
         }
     }
 
@@ -206,7 +206,7 @@ const sideClasses = computed(() => ({
         border-left-style: solid;
 
         .drag-handle {
-            left: -0.75rem;
+            left: -4px;
         }
     }
 }
@@ -215,9 +215,10 @@ const sideClasses = computed(() => ({
     background: none;
     border: none;
     position: absolute;
-    width: 1rem;
+    width: 10px;
     padding: 0;
     height: 100%;
+    z-index: 10000;
 
     &:hover {
         cursor: ew-resize;

--- a/client/src/components/Panels/FlexPanel.vue
+++ b/client/src/components/Panels/FlexPanel.vue
@@ -50,7 +50,7 @@ const hoverDraggableOrToggle = computed(
 );
 
 const toggleLinger = 500;
-const toggleShowDelay = 800;
+const toggleShowDelay = 600;
 let showToggleTimeout: ReturnType<typeof setTimeout> | undefined;
 
 watch(
@@ -169,44 +169,66 @@ const sideClasses = computed(() => ({
 <style scoped lang="scss">
 @import "theme/blue.scss";
 
+$border-width: 6px;
+
 .flex-panel {
     z-index: 100;
     flex-shrink: 0;
     display: flex;
     width: var(--width);
     position: relative;
-    border-color: $border-color;
-    border-width: 1px;
+    border-color: transparent;
+    border-width: $border-width;
     box-shadow: 1px 0 transparent;
     transition: border-color 0.1s, box-shadow 0.1s;
     align-items: stretch;
     flex-direction: column;
 
+    &::after {
+        content: "";
+        position: absolute;
+        height: 100%;
+        width: 1px;
+        background-color: $border-color;
+    }
+
     &.show-hover {
         border-color: $brand-info;
 
-        &.left {
-            box-shadow: 1px 0 $brand-info;
-        }
-
-        &.right {
-            box-shadow: -1px 0 $brand-info;
+        &::after {
+            background-color: $brand-info;
         }
     }
 
     &.left {
         border-right-style: solid;
 
+        &::after {
+            right: -1px;
+        }
+
         .drag-handle {
-            right: -4px;
+            right: -$border-width;
+
+            &:hover {
+                right: calc(-1 * $border-width - var(--hover-expand) / 2);
+            }
         }
     }
 
     &.right {
         border-left-style: solid;
 
+        &::after {
+            left: -1px;
+        }
+
         .drag-handle {
-            left: -4px;
+            left: -$border-width;
+
+            &:hover {
+                left: calc(-1 * $border-width - var(--hover-expand) / 2);
+            }
         }
     }
 }
@@ -214,14 +236,18 @@ const sideClasses = computed(() => ({
 .drag-handle {
     background: none;
     border: none;
+    border-radius: 0;
     position: absolute;
-    width: 10px;
+    width: $border-width;
     padding: 0;
     height: 100%;
     z-index: 10000;
 
+    --hover-expand: 4px;
+
     &:hover {
         cursor: ew-resize;
+        width: calc($border-width + var(--hover-expand));
     }
 }
 


### PR DESCRIPTION
Fixes #17277

* Removes the overlap between the drag handle and the panels
  - adds a slight overlap on hover, so it's easier to stay hovered
* Makes drag handle sorted above flex panel content, so it can better be grabbed on the panels side of the edge
* Significantly increases the delay which the collapse button needs to show, and shortens it's linger time

(no visual changes)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
