### PR TITLE
Scoped Store Refactor and Store Composition Refactor

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -492,7 +492,7 @@ export default {
                 label: null,
                 position: defaultPosition(this.graphOffset, this.transform),
             });
-            this.stateStore.setActiveNode(id);
+            this.stateStore.activeNodeId = id;
         },
         onInsertTool(tool_id, tool_name) {
             this._insertStep(tool_id, tool_name, "tool");
@@ -570,11 +570,11 @@ export default {
         },
         onAttributes() {
             this._ensureParametersSet();
-            this.stateStore.setActiveNode(null);
+            this.stateStore.activeNodeId = null;
             this.showInPanel = "attributes";
         },
         onWorkflowTextEditor() {
-            this.stateStore.setActiveNode(null);
+            this.stateStore.activeNodeId = null;
             this.showInPanel = "attributes";
         },
         onAnnotation(nodeId, newAnnotation) {
@@ -667,7 +667,7 @@ export default {
         },
         onLint() {
             this._ensureParametersSet();
-            this.stateStore.setActiveNode(null);
+            this.stateStore.activeNodeId = null;
             this.showInPanel = "lint";
         },
         onUpgrade() {
@@ -752,7 +752,7 @@ export default {
                         outputs: response.outputs,
                         config_form: response.config_form,
                     });
-                    this.stateStore.setActiveNode(stepData.id);
+                    this.stateStore.activeNodeId = stepData.id;
                 }
             );
         },

--- a/client/src/components/Workflow/Editor/WorkflowGraph.vue
+++ b/client/src/components/Workflow/Editor/WorkflowGraph.vue
@@ -153,7 +153,7 @@ function onZoom(zoomLevel: number, panTo: XYPosition | null = null) {
     if (panTo) {
         panBy({ x: panTo.x - transform.value.x, y: panTo.y - transform.value.y });
     }
-    stateStore.setScale(zoomLevel);
+    stateStore.scale = zoomLevel;
 }
 function onStopDragging() {
     stateStore.draggingPosition = null;
@@ -167,16 +167,16 @@ function onDragConnector(position: TerminalPosition, draggingTerminal: OutputTer
 }
 function onActivate(nodeId: number | null) {
     if (activeNodeId.value !== nodeId) {
-        stateStore.setActiveNode(nodeId);
+        stateStore.activeNodeId = nodeId;
     }
 }
 function onDeactivate() {
-    stateStore.setActiveNode(null);
+    stateStore.activeNodeId = null;
 }
 
 watch(
     () => transform.value.k,
-    () => stateStore.setScale(transform.value.k)
+    () => (stateStore.scale = transform.value.k)
 );
 
 watch(transform, () => emit("transform", transform.value));

--- a/client/src/components/Workflow/Published/WorkflowPublished.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublished.vue
@@ -89,7 +89,7 @@ const { stateStore } = provideScopedWorkflowStores(props.id);
 
 watch(
     () => props.zoom,
-    () => stateStore.setScale(props.zoom),
+    () => (stateStore.scale = props.zoom),
     { immediate: true }
 );
 

--- a/client/src/stores/scopedStore.ts
+++ b/client/src/stores/scopedStore.ts
@@ -1,0 +1,11 @@
+import { defineStore } from "pinia";
+
+import { useScopePointerStore } from "./scopePointerStore";
+
+export function defineScopedStore<ID extends string, S>(id: ID, setup: (scopeId: string) => S) {
+    return (scopeId: string) => {
+        const { scope } = useScopePointerStore();
+
+        return defineStore<`${ID}-${typeof scopeId}`, S>(`${id}-${scope(scopeId)}`, () => setup(scopeId))();
+    };
+}

--- a/client/src/stores/workflowConnectionStore.ts
+++ b/client/src/stores/workflowConnectionStore.ts
@@ -1,10 +1,9 @@
-import { defineStore } from "pinia";
-import Vue from "vue";
+import { computed, del, ref, set } from "vue";
 
 import { useWorkflowStepStore } from "@/stores/workflowStepStore";
 import { pushOrSet } from "@/utils/pushOrSet";
 
-import { useScopePointerStore } from "./scopePointerStore";
+import { defineScopedStore } from "./scopedStore";
 
 interface InvalidConnections {
     [index: ConnectionId]: string | undefined;
@@ -43,87 +42,6 @@ export interface OutputTerminal extends BaseTerminal {
 interface TerminalToOutputTerminals {
     [index: string]: OutputTerminal[];
 }
-
-export const useConnectionStore = (workflowId: string) => {
-    const { scope } = useScopePointerStore();
-
-    return defineStore(`workflowConnectionStore${scope(workflowId)}`, {
-        state: (): State => ({
-            connections: [] as Array<Readonly<Connection>>,
-            invalidConnections: {} as InvalidConnections,
-            inputTerminalToOutputTerminals: {} as TerminalToOutputTerminals,
-            terminalToConnection: {} as { [index: string]: Connection[] },
-            stepToConnections: {} as { [index: number]: Connection[] },
-        }),
-        getters: {
-            getOutputTerminalsForInputTerminal(state: State) {
-                return (terminalId: string): OutputTerminal[] => {
-                    return state.inputTerminalToOutputTerminals[terminalId] || [];
-                };
-            },
-            getConnectionsForTerminal(state: State) {
-                return (terminalId: string): Connection[] => {
-                    return state.terminalToConnection[terminalId] || [];
-                };
-            },
-            getConnectionsForStep(state: State) {
-                return (stepId: number): Connection[] => state.stepToConnections[stepId] || [];
-            },
-        },
-        actions: {
-            addConnection(this, _connection: Connection) {
-                const connection = Object.freeze(_connection);
-                this.connections.push(connection);
-                const stepStore = useWorkflowStepStore(workflowId);
-                stepStore.addConnection(connection);
-                this.terminalToConnection = updateTerminalToConnection(this.connections);
-                this.inputTerminalToOutputTerminals = updateTerminalToTerminal(this.connections);
-                this.stepToConnections = updateStepToConnections(this.connections);
-            },
-            markInvalidConnection(this: State, connectionId: string, reason: string) {
-                Vue.set(this.invalidConnections, connectionId, reason);
-            },
-            dropFromInvalidConnections(this: State, connectionId: string) {
-                Vue.delete(this.invalidConnections, connectionId);
-            },
-            removeConnection(this, terminal: InputTerminal | OutputTerminal | ConnectionId) {
-                const stepStore = useWorkflowStepStore(workflowId);
-                this.connections = this.connections.filter((connection) => {
-                    const id = getConnectionId(connection);
-
-                    if (typeof terminal === "string") {
-                        if (id === terminal) {
-                            stepStore.removeConnection(connection);
-                            Vue.delete(this.invalidConnections, id);
-                            return false;
-                        } else {
-                            return true;
-                        }
-                    } else if (terminal.connectorType === "input") {
-                        if (connection.input.stepId == terminal.stepId && connection.input.name == terminal.name) {
-                            stepStore.removeConnection(connection);
-                            Vue.delete(this.invalidConnections, id);
-                            return false;
-                        } else {
-                            return true;
-                        }
-                    } else {
-                        if (connection.output.stepId == terminal.stepId && connection.output.name == terminal.name) {
-                            stepStore.removeConnection(connection);
-                            Vue.delete(this.invalidConnections, id);
-                            return false;
-                        } else {
-                            return true;
-                        }
-                    }
-                });
-                this.terminalToConnection = updateTerminalToConnection(this.connections);
-                this.inputTerminalToOutputTerminals = updateTerminalToTerminal(this.connections);
-                this.stepToConnections = updateStepToConnections(this.connections);
-            },
-        },
-    })();
-};
 
 function updateTerminalToTerminal(connections: Connection[]) {
     const inputTerminalToOutputTerminals: TerminalToOutputTerminals = {};
@@ -170,3 +88,103 @@ export function getTerminals(item: Connection): { input: InputTerminal; output: 
 export function getConnectionId(item: Connection): ConnectionId {
     return `${item.input.stepId}-${item.input.name}-${item.output.stepId}-${item.output.name}`;
 }
+
+export const useConnectionStore = defineScopedStore("workflowConnectionStore", (workflowId) => {
+    const connections = ref<Readonly<Connection>[]>([]);
+    const invalidConnections = ref<InvalidConnections>({});
+    const inputTerminalToOutputTerminals = ref<TerminalToOutputTerminals>({});
+    const terminalToConnection = ref<{ [index: string]: Connection[] }>({});
+    const stepToConnections = ref<{ [index: number]: Connection[] }>({});
+
+    function $reset() {
+        connections.value = [];
+        invalidConnections.value = {};
+        inputTerminalToOutputTerminals.value = {};
+        terminalToConnection.value = {};
+        stepToConnections.value = {};
+    }
+
+    const getOutputTerminalsForInputTerminal = computed(
+        () => (terminalId: string) => inputTerminalToOutputTerminals.value[terminalId] || ([] as OutputTerminal[])
+    );
+
+    const getConnectionsForTerminal = computed(
+        () => (terminalId: string) => terminalToConnection.value[terminalId] || ([] as Connection[])
+    );
+
+    const getConnectionsForStep = computed(
+        () => (stepId: number) => stepToConnections.value[stepId] || ([] as Connection[])
+    );
+
+    const stepStore = useWorkflowStepStore(workflowId);
+
+    function addConnection(connection: Connection) {
+        Object.freeze(connection);
+        connections.value.push(connection);
+        stepStore.addConnection(connection);
+
+        terminalToConnection.value = updateTerminalToConnection(connections.value);
+        inputTerminalToOutputTerminals.value = updateTerminalToTerminal(connections.value);
+        stepToConnections.value = updateStepToConnections(connections.value);
+    }
+
+    function removeConnection(terminal: InputTerminal | OutputTerminal | ConnectionId) {
+        connections.value = connections.value.filter((connection) => {
+            const id = getConnectionId(connection);
+
+            if (typeof terminal === "string") {
+                if (id === terminal) {
+                    stepStore.removeConnection(connection);
+                    del(invalidConnections.value, id);
+                    return false;
+                } else {
+                    return true;
+                }
+            } else if (terminal.connectorType === "input") {
+                if (connection.input.stepId == terminal.stepId && connection.input.name == terminal.name) {
+                    stepStore.removeConnection(connection);
+                    del(invalidConnections.value, id);
+                    return false;
+                } else {
+                    return true;
+                }
+            } else {
+                if (connection.output.stepId == terminal.stepId && connection.output.name == terminal.name) {
+                    stepStore.removeConnection(connection);
+                    del(invalidConnections.value, id);
+                    return false;
+                } else {
+                    return true;
+                }
+            }
+        });
+
+        terminalToConnection.value = updateTerminalToConnection(connections.value);
+        inputTerminalToOutputTerminals.value = updateTerminalToTerminal(connections.value);
+        stepToConnections.value = updateStepToConnections(connections.value);
+    }
+
+    function markInvalidConnection(connectionId: string, reason: string) {
+        set(invalidConnections.value, connectionId, reason);
+    }
+
+    function dropFromInvalidConnections(connectionId: string) {
+        del(invalidConnections.value, connectionId);
+    }
+
+    return {
+        connections,
+        invalidConnections,
+        inputTerminalToOutputTerminals,
+        terminalToConnection,
+        stepToConnections,
+        $reset,
+        getOutputTerminalsForInputTerminal,
+        getConnectionsForTerminal,
+        getConnectionsForStep,
+        addConnection,
+        removeConnection,
+        markInvalidConnection,
+        dropFromInvalidConnections,
+    };
+});

--- a/client/src/stores/workflowEditorToolbarStore.ts
+++ b/client/src/stores/workflowEditorToolbarStore.ts
@@ -1,10 +1,9 @@
 import { useMagicKeys } from "@vueuse/core";
-import { defineStore } from "pinia";
 import { computed, onScopeDispose, reactive, ref, watch } from "vue";
 
 import { useUserLocalStorage } from "@/composables/userLocalStorage";
 
-import { useScopePointerStore } from "./scopePointerStore";
+import { defineScopedStore } from "./scopedStore";
 import { WorkflowCommentColor } from "./workflowEditorCommentStore";
 
 export type CommentTool = "textComment" | "markdownComment" | "frameComment" | "freehandComment" | "freehandEraser";
@@ -28,74 +27,70 @@ export interface InputCatcherEvent {
 
 export type WorkflowEditorToolbarStore = ReturnType<typeof useWorkflowEditorToolbarStore>;
 
-export const useWorkflowEditorToolbarStore = (workflowId: string) => {
-    const { scope } = useScopePointerStore();
+export const useWorkflowEditorToolbarStore = defineScopedStore("workflowEditorToolbarStore", () => {
+    const snapActive = useUserLocalStorage("workflow-editor-toolbar-snap-active", false);
+    const currentTool = ref<EditorTool>("pointer");
+    const inputCatcherActive = ref<boolean>(false);
+    const inputCatcherEventListeners = new Set<InputCatcherEventListener>();
+    const snapDistance = ref<10 | 20 | 50 | 100 | 200>(10);
 
-    return defineStore(`workflowEditorToolbarStore${scope(workflowId)}`, () => {
-        const snapActive = useUserLocalStorage("workflow-editor-toolbar-snap-active", false);
-        const currentTool = ref<EditorTool>("pointer");
-        const inputCatcherActive = ref<boolean>(false);
-        const inputCatcherEventListeners = new Set<InputCatcherEventListener>();
-        const snapDistance = ref<10 | 20 | 50 | 100 | 200>(10);
+    const commentOptions = reactive({
+        bold: false,
+        italic: false,
+        color: "none" as WorkflowCommentColor,
+        textSize: 2,
+        lineThickness: 5,
+        smoothing: 2,
+    });
 
-        const commentOptions = reactive({
-            bold: false,
-            italic: false,
-            color: "none" as WorkflowCommentColor,
-            textSize: 2,
-            lineThickness: 5,
-            smoothing: 2,
-        });
+    const inputCatcherPressed = ref(false);
 
-        const inputCatcherPressed = ref(false);
-
-        function onInputCatcherEvent(type: InputCatcherEventType, callback: InputCatcherEventListener["callback"]) {
-            const listener = {
-                type,
-                callback,
-            };
-
-            inputCatcherEventListeners.add(listener);
-
-            onScopeDispose(() => {
-                inputCatcherEventListeners.delete(listener);
-            });
-        }
-
-        onInputCatcherEvent("pointerdown", () => (inputCatcherPressed.value = true));
-        onInputCatcherEvent("pointerup", () => (inputCatcherPressed.value = false));
-        onInputCatcherEvent("temporarilyDisabled", () => (inputCatcherPressed.value = false));
-
-        watch(
-            () => inputCatcherActive.value,
-            () => {
-                if (!inputCatcherActive.value) {
-                    inputCatcherPressed.value = false;
-                }
-            }
-        );
-
-        const { shift, space, alt, ctrl } = useMagicKeys();
-        const inputCatcherEnabled = computed(() => !(shift?.value || space?.value || alt?.value || ctrl?.value));
-
-        function emitInputCatcherEvent(type: InputCatcherEventType, event: InputCatcherEvent) {
-            inputCatcherEventListeners.forEach((listener) => {
-                if (listener.type === type) {
-                    listener.callback(event);
-                }
-            });
-        }
-
-        return {
-            snapActive,
-            snapDistance,
-            currentTool,
-            inputCatcherActive,
-            inputCatcherEnabled,
-            commentOptions,
-            inputCatcherPressed,
-            onInputCatcherEvent,
-            emitInputCatcherEvent,
+    function onInputCatcherEvent(type: InputCatcherEventType, callback: InputCatcherEventListener["callback"]) {
+        const listener = {
+            type,
+            callback,
         };
-    })();
-};
+
+        inputCatcherEventListeners.add(listener);
+
+        onScopeDispose(() => {
+            inputCatcherEventListeners.delete(listener);
+        });
+    }
+
+    onInputCatcherEvent("pointerdown", () => (inputCatcherPressed.value = true));
+    onInputCatcherEvent("pointerup", () => (inputCatcherPressed.value = false));
+    onInputCatcherEvent("temporarilyDisabled", () => (inputCatcherPressed.value = false));
+
+    watch(
+        () => inputCatcherActive.value,
+        () => {
+            if (!inputCatcherActive.value) {
+                inputCatcherPressed.value = false;
+            }
+        }
+    );
+
+    const { shift, space, alt, ctrl } = useMagicKeys();
+    const inputCatcherEnabled = computed(() => !(shift?.value || space?.value || alt?.value || ctrl?.value));
+
+    function emitInputCatcherEvent(type: InputCatcherEventType, event: InputCatcherEvent) {
+        inputCatcherEventListeners.forEach((listener) => {
+            if (listener.type === type) {
+                listener.callback(event);
+            }
+        });
+    }
+
+    return {
+        snapActive,
+        snapDistance,
+        currentTool,
+        inputCatcherActive,
+        inputCatcherEnabled,
+        commentOptions,
+        inputCatcherPressed,
+        onInputCatcherEvent,
+        emitInputCatcherEvent,
+    };
+});

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -1,19 +1,10 @@
-import { defineStore } from "pinia";
-import Vue from "vue";
+import { computed, del, ref, set } from "vue";
 
 import type { CollectionTypeDescriptor } from "@/components/Workflow/Editor/modules/collectionTypeDescription";
 import { type Connection, getConnectionId, useConnectionStore } from "@/stores/workflowConnectionStore";
 import { assertDefined } from "@/utils/assertions";
 
-import { useScopePointerStore } from "./scopePointerStore";
-
-interface State {
-    steps: { [index: string]: Step };
-    stepIndex: number;
-    stepMapOver: { [index: number]: CollectionTypeDescriptor };
-    stepInputMapOver: StepInputMapOver;
-    stepExtraInputs: { [index: number]: InputTerminalSource[] };
-}
+import { defineScopedStore } from "./scopedStore";
 
 interface StepPosition {
     top: number;
@@ -146,191 +137,237 @@ interface StepInputMapOver {
     [index: number]: { [index: string]: CollectionTypeDescriptor };
 }
 
-export const useWorkflowStepStore = (workflowId: string) => {
-    const { scope } = useScopePointerStore();
+export const useWorkflowStepStore = defineScopedStore("workflowStepStore", (workflowId) => {
+    const steps = ref<Steps>({});
+    const stepMapOver = ref<{ [index: number]: CollectionTypeDescriptor }>({});
+    const stepInputMapOver = ref<StepInputMapOver>({});
+    const stepIndex = ref(-1);
+    const stepExtraInputs = ref<{ [index: number]: InputTerminalSource[] }>({});
 
-    return defineStore(`workflowStepStore${scope(workflowId)}`, {
-        state: (): State => ({
-            steps: {} as Steps,
-            stepMapOver: {} as { [index: number]: CollectionTypeDescriptor },
-            stepInputMapOver: {} as StepInputMapOver,
-            stepIndex: -1,
-            stepExtraInputs: {} as { [index: number]: InputTerminalSource[] },
-        }),
-        getters: {
-            getStep(state: State) {
-                return (stepId: number): Step | undefined => {
-                    return state.steps[stepId.toString()];
-                };
-            },
-            getStepExtraInputs(state: State) {
-                return (stepId: number) => state.stepExtraInputs[stepId] || [];
-            },
-            getStepIndex(state: State) {
-                return Math.max(...Object.values(state.steps).map((step) => step.id), state.stepIndex);
-            },
-            hasActiveOutputs(state: State) {
-                return Boolean(Object.values(state.steps).find((step) => step.workflow_outputs?.length));
-            },
-            workflowOutputs(state: State) {
-                const workflowOutputs: WorkflowOutputs = {};
-                Object.values(state.steps).forEach((step) => {
-                    if (step.workflow_outputs?.length) {
-                        step.workflow_outputs.forEach((workflowOutput) => {
-                            if (workflowOutput.label) {
-                                workflowOutputs[workflowOutput.label] = {
-                                    outputName: workflowOutput.output_name,
-                                    stepId: step.id,
-                                };
-                            }
-                        });
+    function $reset() {
+        steps.value = {};
+        stepMapOver.value = {};
+        stepInputMapOver.value = {};
+        stepIndex.value = -1;
+        stepExtraInputs.value = {};
+    }
+
+    const getStep = computed(() => (stepId: number) => steps.value[stepId.toString()]);
+
+    const getStepExtraInputs = computed(() => (stepId: number) => stepExtraInputs.value[stepId] || []);
+
+    const getStepIndex = computed(() =>
+        Math.max(...Object.values(steps.value).map((step) => step.id), stepIndex.value)
+    );
+
+    const hasActiveOutputs = computed(() =>
+        Boolean(Object.values(steps.value).find((step) => step.workflow_outputs?.length))
+    );
+
+    const workflowOutputs = computed(() => {
+        const workflowOutputs: WorkflowOutputs = {};
+
+        Object.values(steps.value).forEach((step) => {
+            if (step.workflow_outputs?.length) {
+                step.workflow_outputs.forEach((workflowOutput) => {
+                    if (workflowOutput.label) {
+                        workflowOutputs[workflowOutput.label] = {
+                            outputName: workflowOutput.output_name,
+                            stepId: step.id,
+                        };
                     }
                 });
-                return workflowOutputs;
-            },
-            duplicateLabels(state: State) {
-                const duplicateLabels: Set<string> = new Set();
-                const labels: Set<string> = new Set();
-                Object.values(state.steps).forEach((step) => {
-                    if (step.workflow_outputs?.length) {
-                        step.workflow_outputs.forEach((workflowOutput) => {
-                            if (workflowOutput.label) {
-                                if (labels.has(workflowOutput.label)) {
-                                    duplicateLabels.add(workflowOutput.label);
-                                }
-                                labels.add(workflowOutput.label);
-                            }
-                        });
+            }
+        });
+
+        return workflowOutputs;
+    });
+
+    const duplicateLabels = computed(() => {
+        const duplicateLabels: Set<string> = new Set();
+        const labels: Set<string> = new Set();
+
+        Object.values(steps.value).forEach((step) => {
+            if (step.workflow_outputs?.length) {
+                step.workflow_outputs.forEach((workflowOutput) => {
+                    if (workflowOutput.label) {
+                        if (labels.has(workflowOutput.label)) {
+                            duplicateLabels.add(workflowOutput.label);
+                        }
+                        labels.add(workflowOutput.label);
                     }
                 });
-                return duplicateLabels;
-            },
-        },
-        actions: {
-            addStep(newStep: NewStep): Step {
-                const stepId = newStep.id ? newStep.id : this.getStepIndex + 1;
-                const step = Object.freeze({ ...newStep, id: stepId } as Step);
-                Vue.set(this.steps, stepId.toString(), step);
-                const connectionStore = useConnectionStore(workflowId);
-                stepToConnections(step).map((connection) => connectionStore.addConnection(connection));
-                this.stepExtraInputs[step.id] = getStepExtraInputs(step);
-                return step;
-            },
-            insertNewStep(
-                contentId: NewStep["content_id"],
-                name: NewStep["name"],
-                type: NewStep["type"],
-                position: NewStep["position"]
-            ) {
-                const stepData: NewStep = {
-                    name: name,
-                    content_id: contentId,
-                    input_connections: {},
-                    type: type,
-                    inputs: [],
-                    outputs: [],
-                    position: position,
-                    post_job_actions: {},
-                    tool_state: {},
-                };
-                return this.addStep(stepData);
-            },
-            updateStep(this: State, step: Step) {
-                const workflow_outputs = step.workflow_outputs?.filter((workflowOutput) =>
-                    step.outputs.find((output) => workflowOutput.output_name == output.name)
-                );
-                this.steps[step.id.toString()] = Object.freeze({ ...step, workflow_outputs });
-                this.stepExtraInputs[step.id] = getStepExtraInputs(step);
-            },
-            changeStepMapOver(stepId: number, mapOver: CollectionTypeDescriptor) {
-                Vue.set(this.stepMapOver, stepId, mapOver);
-            },
-            resetStepInputMapOver(stepId: number) {
-                Vue.set(this.stepInputMapOver, stepId, {});
-            },
-            changeStepInputMapOver(stepId: number, inputName: string, mapOver: CollectionTypeDescriptor) {
-                if (this.stepInputMapOver[stepId]) {
-                    Vue.set(this.stepInputMapOver[stepId]!, inputName, mapOver);
-                } else {
-                    Vue.set(this.stepInputMapOver, stepId, { [inputName]: mapOver });
-                }
-            },
-            addConnection(connection: Connection) {
-                const inputStep = this.getStep(connection.input.stepId);
-                assertDefined(
-                    inputStep,
-                    `Failed to add connection, because step with id ${connection.input.stepId} is undefined`
-                );
-                const input = inputStep.inputs.find((input) => input.name === connection.input.name);
-                const connectionLink: ConnectionOutputLink = {
-                    output_name: connection.output.name,
-                    id: connection.output.stepId,
-                };
-                if (input && "input_subworkflow_step_id" in input && input.input_subworkflow_step_id !== undefined) {
-                    connectionLink["input_subworkflow_step_id"] = input.input_subworkflow_step_id;
-                }
-                let connectionLinks: ConnectionOutputLink[] = [connectionLink];
-                let inputConnection = inputStep.input_connections[connection.input.name];
-                if (inputConnection) {
-                    if (!Array.isArray(inputConnection)) {
-                        inputConnection = [inputConnection];
-                    }
-                    inputConnection = inputConnection.filter(
-                        (connection) =>
-                            !(
-                                connection.id === connectionLink.id &&
-                                connection.output_name === connectionLink.output_name
-                            )
-                    );
-                    connectionLinks = [...connectionLinks, ...inputConnection];
-                }
-                const updatedStep = {
-                    ...inputStep,
-                    input_connections: {
-                        ...inputStep.input_connections,
-                        [connection.input.name]: connectionLinks.sort((a, b) =>
-                            a.id === b.id ? a.output_name.localeCompare(b.output_name) : a.id - b.id
-                        ),
-                    },
-                };
-                this.updateStep(updatedStep);
-            },
-            removeConnection(connection: Connection) {
-                const inputStep = this.getStep(connection.input.stepId);
-                assertDefined(
-                    inputStep,
-                    `Failed to remove connection, because step with id ${connection.input.stepId} is undefined`
-                );
+            }
+        });
 
-                const inputConnections = inputStep.input_connections[connection.input.name];
-                if (this.getStepExtraInputs(inputStep.id).find((input) => connection.input.name === input.name)) {
-                    inputStep.input_connections[connection.input.name] = undefined;
-                } else {
-                    if (Array.isArray(inputConnections)) {
-                        inputStep.input_connections[connection.input.name] = inputConnections.filter(
-                            (outputLink) =>
-                                !(outputLink.id === connection.output.stepId,
-                                outputLink.output_name === connection.output.name)
-                        );
-                    } else {
-                        Vue.delete(inputStep.input_connections, connection.input.name);
-                    }
-                }
-                this.updateStep(inputStep);
-            },
-            removeStep(this: State, stepId: number) {
-                const connectionStore = useConnectionStore(workflowId);
-                connectionStore
-                    .getConnectionsForStep(stepId)
-                    .forEach((connection) => connectionStore.removeConnection(getConnectionId(connection)));
-                Vue.delete(this.steps, stepId.toString());
-                Vue.delete(this.stepExtraInputs, stepId);
-            },
-        },
-    })();
-};
+        return duplicateLabels;
+    });
 
-export function stepToConnections(step: Step): Connection[] {
+    const connectionStore = useConnectionStore(workflowId);
+
+    function addStep(newStep: NewStep): Step {
+        const stepId = newStep.id ? newStep.id : getStepIndex.value + 1;
+        const step = Object.freeze({ ...newStep, id: stepId } as Step);
+
+        set(steps.value, stepId.toString(), step);
+        stepToConnections(step).map((connection) => connectionStore.addConnection(connection));
+        stepExtraInputs.value[step.id] = findStepExtraInputs(step);
+
+        return step;
+    }
+
+    function insertNewStep(
+        contentId: NewStep["content_id"],
+        name: NewStep["name"],
+        type: NewStep["type"],
+        position: NewStep["position"]
+    ) {
+        const stepData: NewStep = {
+            name: name,
+            content_id: contentId,
+            input_connections: {},
+            type: type,
+            inputs: [],
+            outputs: [],
+            position: position,
+            post_job_actions: {},
+            tool_state: {},
+        };
+
+        return addStep(stepData);
+    }
+
+    function updateStep(step: Step) {
+        const workflow_outputs = step.workflow_outputs?.filter((workflowOutput) =>
+            step.outputs.find((output) => workflowOutput.output_name == output.name)
+        );
+
+        steps.value[step.id.toString()] = Object.freeze({ ...step, workflow_outputs });
+        stepExtraInputs.value[step.id] = findStepExtraInputs(step);
+    }
+
+    function changeStepMapOver(stepId: number, mapOver: CollectionTypeDescriptor) {
+        set(stepMapOver.value, stepId, mapOver);
+    }
+
+    function resetStepInputMapOver(stepId: number) {
+        set(stepInputMapOver.value, stepId, {});
+    }
+
+    function changeStepInputMapOver(stepId: number, inputName: string, mapOver: CollectionTypeDescriptor) {
+        if (stepInputMapOver.value[stepId]) {
+            set(stepInputMapOver.value[stepId]!, inputName, mapOver);
+        } else {
+            set(stepInputMapOver.value, stepId, { [inputName]: mapOver });
+        }
+    }
+
+    function addConnection(connection: Connection) {
+        const inputStep = getStep.value(connection.input.stepId);
+
+        assertDefined(
+            inputStep,
+            `Failed to add connection, because step with id ${connection.input.stepId} is undefined`
+        );
+
+        const input = inputStep.inputs.find((input) => input.name === connection.input.name);
+        const connectionLink: ConnectionOutputLink = {
+            output_name: connection.output.name,
+            id: connection.output.stepId,
+        };
+
+        if (input && "input_subworkflow_step_id" in input && input.input_subworkflow_step_id !== undefined) {
+            connectionLink["input_subworkflow_step_id"] = input.input_subworkflow_step_id;
+        }
+
+        let connectionLinks: ConnectionOutputLink[] = [connectionLink];
+        let inputConnection = inputStep.input_connections[connection.input.name];
+
+        if (inputConnection) {
+            if (!Array.isArray(inputConnection)) {
+                inputConnection = [inputConnection];
+            }
+            inputConnection = inputConnection.filter(
+                (connection) =>
+                    !(connection.id === connectionLink.id && connection.output_name === connectionLink.output_name)
+            );
+            connectionLinks = [...connectionLinks, ...inputConnection];
+        }
+
+        const updatedStep = {
+            ...inputStep,
+            input_connections: {
+                ...inputStep.input_connections,
+                [connection.input.name]: connectionLinks.sort((a, b) =>
+                    a.id === b.id ? a.output_name.localeCompare(b.output_name) : a.id - b.id
+                ),
+            },
+        };
+
+        updateStep(updatedStep);
+    }
+
+    function removeConnection(connection: Connection) {
+        const inputStep = getStep.value(connection.input.stepId);
+
+        assertDefined(
+            inputStep,
+            `Failed to remove connection, because step with id ${connection.input.stepId} is undefined`
+        );
+
+        const inputConnections = inputStep.input_connections[connection.input.name];
+
+        if (getStepExtraInputs.value(inputStep.id).find((input) => connection.input.name === input.name)) {
+            inputStep.input_connections[connection.input.name] = undefined;
+        } else {
+            if (Array.isArray(inputConnections)) {
+                inputStep.input_connections[connection.input.name] = inputConnections.filter(
+                    (outputLink) =>
+                        !(outputLink.id === connection.output.stepId, outputLink.output_name === connection.output.name)
+                );
+            } else {
+                del(inputStep.input_connections, connection.input.name);
+            }
+        }
+
+        updateStep(inputStep);
+    }
+
+    function removeStep(stepId: number) {
+        connectionStore
+            .getConnectionsForStep(stepId)
+            .forEach((connection) => connectionStore.removeConnection(getConnectionId(connection)));
+
+        del(steps.value, stepId.toString());
+        del(stepExtraInputs.value, stepId);
+    }
+
+    return {
+        steps,
+        stepMapOver,
+        stepInputMapOver,
+        stepIndex,
+        stepExtraInputs,
+        $reset,
+        getStep,
+        getStepExtraInputs,
+        getStepIndex,
+        hasActiveOutputs,
+        workflowOutputs,
+        duplicateLabels,
+        addStep,
+        insertNewStep,
+        updateStep,
+        changeStepMapOver,
+        resetStepInputMapOver,
+        changeStepInputMapOver,
+        addConnection,
+        removeConnection,
+        removeStep,
+    };
+});
+
+function stepToConnections(step: Step): Connection[] {
     const connections: Connection[] = [];
     if (step.input_connections) {
         Object.entries(step?.input_connections).forEach(([inputName, outputArray]) => {
@@ -364,7 +401,7 @@ export function stepToConnections(step: Step): Connection[] {
     return connections;
 }
 
-function getStepExtraInputs(step: Step) {
+function findStepExtraInputs(step: Step) {
     const extraInputs: InputTerminalSource[] = [];
     if (step.when !== undefined) {
         Object.keys(step.input_connections).forEach((inputName) => {


### PR DESCRIPTION
Refactors scoped stores to use a custom `defineScopedStore` function, reducing nesting, repeated code and potential for errors.

Also refactors all stores using scope (currently just Workflow Stores) to composition.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
