### PR TITLE
LDAP3 fix for attributes returned as strings

### DIFF
--- a/lib/galaxy/auth/providers/ldap_ad.py
+++ b/lib/galaxy/auth/providers/ldap_ad.py
@@ -17,6 +17,7 @@ from urllib.parse import urlparse
 from galaxy.exceptions import ConfigurationError
 from galaxy.security.validate_user_input import transform_publicname
 from galaxy.util import (
+    listify,
     string_as_bool,
     unicodify,
 )
@@ -385,6 +386,8 @@ class LDAP3(LDAP):
                 dn = response[0]["dn"]
                 attrs = response[0]["attributes"]
                 log.debug("LDAP3 authenticate: dn is %s", dn)
+                for attr in attributes:
+                    attrs[attr] = listify(attrs[attr])
                 log.debug("LDAP3 authenticate: search attributes are %s", attrs)
                 for attr in attributes:
                     if self.role_search_attribute and attr == self.role_search_attribute[1:-1]:  # strip curly brackets


### PR DESCRIPTION
LDAP3 seems to return some of the search results as str instead of List[str]. Log shows for instance

```
LDAP3 authenticate: search attributes are {'mail': 'user@mail.org', 'uid': ['userid']}
```

instead of (what happened with the `python-ldap` module)

```
LDAP authenticate: search attributes are {'uid': [b'userid'], 'mail': [b'user@mail.com']}
```

accessing the `'mail'` attribute with `attrs[attr][0]` then leads to an invalid email adress (and failure to register the user).

Fix implemented here is to ensure that the returned attribues are lists.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
