### PR TITLE
Synchronize WF Editor Labels and Labels referenced in the WF Report

### DIFF
--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -76,14 +76,11 @@ import Vue from "vue";
 
 import { useWorkflowStore } from "@/stores/workflowStore";
 
+import { splitMarkdown as splitMarkdownUnrendered } from "./parse";
+
 import MarkdownContainer from "./MarkdownContainer.vue";
 import LoadingSpan from "components/LoadingSpan.vue";
 import StsDownloadButton from "components/StsDownloadButton.vue";
-
-const FUNCTION_VALUE_REGEX = `\\s*(?:[\\w_\\-]+|\\"[^\\"]+\\"|\\'[^\\']+\\')\\s*`;
-const FUNCTION_CALL = `\\s*[\\w\\|]+\\s*=` + FUNCTION_VALUE_REGEX;
-const FUNCTION_CALL_LINE = `\\s*(\\w+)\\s*\\(\\s*(?:(${FUNCTION_CALL})(,${FUNCTION_CALL})*)?\\s*\\)\\s*`;
-const FUNCTION_CALL_LINE_TEMPLATE = new RegExp(FUNCTION_CALL_LINE, "m");
 
 const mdNewline = markdownItRegexp(/<br>/, () => {
     return "<div style='clear:both;'/><br>";
@@ -200,69 +197,14 @@ export default {
             }
         },
         splitMarkdown(markdown) {
-            const sections = [];
-            let digest = markdown;
-            while (digest.length > 0) {
-                const galaxyStart = digest.indexOf("```galaxy");
-                if (galaxyStart != -1) {
-                    const galaxyEnd = digest.substr(galaxyStart + 1).indexOf("```");
-                    if (galaxyEnd != -1) {
-                        if (galaxyStart > 0) {
-                            const defaultContent = digest.substr(0, galaxyStart).trim();
-                            if (defaultContent) {
-                                sections.push({
-                                    name: "default",
-                                    content: md.render(defaultContent),
-                                });
-                            }
-                        }
-                        const galaxyEndIndex = galaxyEnd + 4;
-                        const galaxySection = digest.substr(galaxyStart, galaxyEndIndex);
-                        let args = null;
-                        try {
-                            args = this.getArgs(galaxySection);
-                            sections.push(args);
-                        } catch (e) {
-                            this.markdownErrors.push({
-                                error: "Found an unresolved tag.",
-                                line: galaxySection,
-                            });
-                        }
-                        digest = digest.substr(galaxyStart + galaxyEndIndex);
-                    } else {
-                        digest = digest.substr(galaxyStart + 1);
-                    }
-                } else {
-                    sections.push({
-                        name: "default",
-                        content: md.render(digest),
-                    });
-                    break;
+            const { sections, markdownErrors } = splitMarkdownUnrendered(markdown);
+            markdownErrors.forEach((error) => markdownErrors.push(error));
+            sections.forEach((section) => {
+                if (section.name == "default") {
+                    section.content = md.render(section.content);
                 }
-            }
+            });
             return sections;
-        },
-        getArgs(content) {
-            const galaxy_function = FUNCTION_CALL_LINE_TEMPLATE.exec(content);
-            const args = {};
-            const function_name = galaxy_function[1];
-            // we need [... ] to return empty string, if regex doesn't match
-            const function_arguments = [...content.matchAll(new RegExp(FUNCTION_CALL, "g"))];
-            for (let i = 0; i < function_arguments.length; i++) {
-                if (function_arguments[i] === undefined) {
-                    continue;
-                }
-                const arguments_str = function_arguments[i].toString().replace(/,/g, "").trim();
-                if (arguments_str) {
-                    const [key, val] = arguments_str.split("=");
-                    args[key.trim()] = val.replace(/['"]+/g, "").trim();
-                }
-            }
-            return {
-                name: function_name,
-                args: args,
-                content: content,
-            };
         },
     },
 };

--- a/client/src/components/Markdown/parse.test.js
+++ b/client/src/components/Markdown/parse.test.js
@@ -1,10 +1,112 @@
-import { getArgs } from "./parse";
+import { getArgs, replaceLabel, splitMarkdown } from "./parse";
 
 describe("parse.ts", () => {
     describe("getArgs", () => {
         it("parses simple directive expression", () => {
             const args = getArgs("job_metrics(job_id=THISFAKEID)");
             expect(args.name).toBe("job_metrics");
+        });
+    });
+
+    describe("splitMarkdown", () => {
+        it("strip leading whitespace by default", () => {
+            const { sections } = splitMarkdown("\n```galaxy\njob_metrics(job_id=THISFAKEID)\n```");
+            expect(sections.length).toBe(1);
+        });
+
+        it("should not strip leading whitespace if disabled", () => {
+            const { sections } = splitMarkdown("\n```galaxy\njob_metrics(job_id=THISFAKEID)\n```", true);
+            expect(sections.length).toBe(2);
+            expect(sections[0].content).toBe("\n");
+        });
+    });
+
+    describe("replaceLabel", () => {
+        it("should leave unaffected markdown alone", () => {
+            const input = "some random\n`markdown content`\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(result);
+        });
+
+        it("should leave unaffected galaxy directives alone", () => {
+            const input = "some random\n`markdown content`\n```galaxy\ncurrent_time()\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(result);
+        });
+
+        it("should leave galaxy directives of same type with other labels alone", () => {
+            const input = "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(output=moo)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(result);
+        });
+
+        it("should leave galaxy directives of other types with same labels alone", () => {
+            const input = "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(input=from)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(result);
+        });
+
+        it("should swap simple directives of specified type", () => {
+            const input = "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(output=from)\n```\n";
+            const output = "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(output=to)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(output);
+        });
+
+        it("should swap single quoted directives of specified type", () => {
+            const input = "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(output='from')\n```\n";
+            const output = "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(output=to)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(output);
+        });
+
+        it("should swap single quoted directives of specified type with extra args", () => {
+            const input =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output='from', title=dog)\n```\n";
+            const output =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output=to, title=dog)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(output);
+        });
+
+        it("should swap double quoted directives of specified type", () => {
+            const input = 'some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(output="from")\n```\n';
+            const output = "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(output=to)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(output);
+        });
+
+        it("should swap double quoted directives of specified type with extra args", () => {
+            const input =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output=\"from\", title=dog)\n```\n";
+            const output =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output=to, title=dog)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(output);
+        });
+
+        it("should leave non-arguments alone", () => {
+            const input =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(title='cow from farm', output=from)\n```\n";
+            const output =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(title='cow from farm', output=to)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(output);
+        });
+
+        // not a valid workflow label per se but make sure we're escaping the regex to be safe
+        it("should not be messed up by labels containing regexp content", () => {
+            const input = "```galaxy\nhistory_dataset_embedded(output='from(')\n```\n";
+            const output = "```galaxy\nhistory_dataset_embedded(output=to$1)\n```\n";
+            const result = replaceLabel(input, "output", "from(", "to$1");
+            expect(result).toBe(output);
+        });
+
+        it("should not swallow leading newlines", () => {
+            const input = "\n```galaxy\nhistory_dataset_embedded(output='from')\n```\n";
+            const output = "\n```galaxy\nhistory_dataset_embedded(output=to)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(output);
         });
     });
 });

--- a/client/src/components/Markdown/parse.test.js
+++ b/client/src/components/Markdown/parse.test.js
@@ -1,0 +1,10 @@
+import { getArgs } from "./parse";
+
+describe("parse.ts", () => {
+    describe("getArgs", () => {
+        it("parses simple directive expression", () => {
+            const args = getArgs("job_metrics(job_id=THISFAKEID)");
+            expect(args.name).toBe("job_metrics");
+        });
+    });
+});

--- a/client/src/components/Markdown/parse.ts
+++ b/client/src/components/Markdown/parse.ts
@@ -3,8 +3,14 @@ const FUNCTION_ARGUMENT_REGEX = `\\s*[\\w\\|]+\\s*=` + FUNCTION_ARGUMENT_VALUE_R
 const FUNCTION_CALL_LINE = `\\s*(\\w+)\\s*\\(\\s*(?:(${FUNCTION_ARGUMENT_REGEX})(,${FUNCTION_ARGUMENT_REGEX})*)?\\s*\\)\\s*`;
 const FUNCTION_CALL_LINE_TEMPLATE = new RegExp(FUNCTION_CALL_LINE, "m");
 
-export function splitMarkdown(markdown: string) {
-    const sections = [];
+type DefaultSection = { name: "default"; content: string };
+type GalaxyDirectiveSection = { name: string; content: string; args: { [key: string]: string } };
+type Section = DefaultSection | GalaxyDirectiveSection;
+
+type WorkflowLabelKind = "input" | "output" | "step";
+
+export function splitMarkdown(markdown: string, preserveWhitespace: boolean = false) {
+    const sections: Section[] = [];
     const markdownErrors = [];
     let digest = markdown;
     while (digest.length > 0) {
@@ -13,11 +19,12 @@ export function splitMarkdown(markdown: string) {
             const galaxyEnd = digest.substr(galaxyStart + 1).indexOf("```");
             if (galaxyEnd != -1) {
                 if (galaxyStart > 0) {
-                    const defaultContent = digest.substr(0, galaxyStart).trim();
-                    if (defaultContent) {
+                    const rawContent = digest.substr(0, galaxyStart);
+                    const defaultContent = rawContent.trim();
+                    if (preserveWhitespace || defaultContent) {
                         sections.push({
                             name: "default",
-                            content: defaultContent,
+                            content: preserveWhitespace ? rawContent : defaultContent,
                         });
                     }
                 }
@@ -48,14 +55,54 @@ export function splitMarkdown(markdown: string) {
     return { sections, markdownErrors };
 }
 
-export function getArgs(content: string) {
+export function replaceLabel(
+    markdown: string,
+    labelType: WorkflowLabelKind,
+    fromLabel: string,
+    toLabel: string
+): string {
+    const { sections } = splitMarkdown(markdown, true);
+
+    function rewriteSection(section: Section) {
+        if ("args" in section) {
+            const directiveSection = section as GalaxyDirectiveSection;
+            const args = directiveSection.args;
+            if (!(labelType in args)) {
+                return section;
+            }
+            const labelValue = args[labelType];
+            if (labelValue != fromLabel) {
+                return section;
+            }
+            // we've got a section with a matching label and type...
+            const newArgs = { ...args };
+            newArgs[labelType] = toLabel;
+            const argRexExp = namedArgumentRegex(labelType);
+            const escapedToLabel = escapeRegExpReplacement(toLabel);
+            const content = directiveSection.content.replace(argRexExp, `$1${escapedToLabel}`);
+            return {
+                name: directiveSection.name,
+                args: newArgs,
+                content: content,
+            };
+        } else {
+            return section;
+        }
+    }
+
+    const rewrittenSections = sections.map(rewriteSection);
+    const rewrittenMarkdown = rewrittenSections.map((section) => section.content).join("");
+    return rewrittenMarkdown;
+}
+
+export function getArgs(content: string): GalaxyDirectiveSection {
     const galaxy_function = FUNCTION_CALL_LINE_TEMPLATE.exec(content);
     if (galaxy_function == null) {
         throw Error("Failed to parse galaxy directive");
     }
     type ArgsType = { [key: string]: string };
     const args: ArgsType = {};
-    const function_name = galaxy_function[1];
+    const function_name = galaxy_function[1] as string;
     // we need [... ] to return empty string, if regex doesn't match
     const function_arguments = [...content.matchAll(new RegExp(FUNCTION_ARGUMENT_REGEX, "g"))];
     for (let i = 0; i < function_arguments.length; i++) {
@@ -76,4 +123,13 @@ export function getArgs(content: string) {
         args: args,
         content: content,
     };
+}
+
+function namedArgumentRegex(argument: string): RegExp {
+    return new RegExp(`(\\s*${argument}\\s*=)` + FUNCTION_ARGUMENT_VALUE_REGEX);
+}
+
+// https://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
+function escapeRegExpReplacement(value: string): string {
+    return value.replace(/\$/g, "$$$$");
 }

--- a/client/src/components/Markdown/parse.ts
+++ b/client/src/components/Markdown/parse.ts
@@ -1,6 +1,6 @@
-const FUNCTION_VALUE_REGEX = `\\s*(?:[\\w_\\-]+|\\"[^\\"]+\\"|\\'[^\\']+\\')\\s*`;
-const FUNCTION_CALL = `\\s*[\\w\\|]+\\s*=` + FUNCTION_VALUE_REGEX;
-const FUNCTION_CALL_LINE = `\\s*(\\w+)\\s*\\(\\s*(?:(${FUNCTION_CALL})(,${FUNCTION_CALL})*)?\\s*\\)\\s*`;
+const FUNCTION_ARGUMENT_VALUE_REGEX = `\\s*(?:[\\w_\\-]+|\\"[^\\"]+\\"|\\'[^\\']+\\')\\s*`;
+const FUNCTION_ARGUMENT_REGEX = `\\s*[\\w\\|]+\\s*=` + FUNCTION_ARGUMENT_VALUE_REGEX;
+const FUNCTION_CALL_LINE = `\\s*(\\w+)\\s*\\(\\s*(?:(${FUNCTION_ARGUMENT_REGEX})(,${FUNCTION_ARGUMENT_REGEX})*)?\\s*\\)\\s*`;
 const FUNCTION_CALL_LINE_TEMPLATE = new RegExp(FUNCTION_CALL_LINE, "m");
 
 export function splitMarkdown(markdown: string) {
@@ -57,7 +57,7 @@ export function getArgs(content: string) {
     const args: ArgsType = {};
     const function_name = galaxy_function[1];
     // we need [... ] to return empty string, if regex doesn't match
-    const function_arguments = [...content.matchAll(new RegExp(FUNCTION_CALL, "g"))];
+    const function_arguments = [...content.matchAll(new RegExp(FUNCTION_ARGUMENT_REGEX, "g"))];
     for (let i = 0; i < function_arguments.length; i++) {
         if (function_arguments[i] === undefined) {
             continue;

--- a/client/src/components/Markdown/parse.ts
+++ b/client/src/components/Markdown/parse.ts
@@ -1,0 +1,79 @@
+const FUNCTION_VALUE_REGEX = `\\s*(?:[\\w_\\-]+|\\"[^\\"]+\\"|\\'[^\\']+\\')\\s*`;
+const FUNCTION_CALL = `\\s*[\\w\\|]+\\s*=` + FUNCTION_VALUE_REGEX;
+const FUNCTION_CALL_LINE = `\\s*(\\w+)\\s*\\(\\s*(?:(${FUNCTION_CALL})(,${FUNCTION_CALL})*)?\\s*\\)\\s*`;
+const FUNCTION_CALL_LINE_TEMPLATE = new RegExp(FUNCTION_CALL_LINE, "m");
+
+export function splitMarkdown(markdown: string) {
+    const sections = [];
+    const markdownErrors = [];
+    let digest = markdown;
+    while (digest.length > 0) {
+        const galaxyStart = digest.indexOf("```galaxy");
+        if (galaxyStart != -1) {
+            const galaxyEnd = digest.substr(galaxyStart + 1).indexOf("```");
+            if (galaxyEnd != -1) {
+                if (galaxyStart > 0) {
+                    const defaultContent = digest.substr(0, galaxyStart).trim();
+                    if (defaultContent) {
+                        sections.push({
+                            name: "default",
+                            content: defaultContent,
+                        });
+                    }
+                }
+                const galaxyEndIndex = galaxyEnd + 4;
+                const galaxySection = digest.substr(galaxyStart, galaxyEndIndex);
+                let args = null;
+                try {
+                    args = getArgs(galaxySection);
+                    sections.push(args);
+                } catch (e) {
+                    markdownErrors.push({
+                        error: "Found an unresolved tag.",
+                        line: galaxySection,
+                    });
+                }
+                digest = digest.substr(galaxyStart + galaxyEndIndex);
+            } else {
+                digest = digest.substr(galaxyStart + 1);
+            }
+        } else {
+            sections.push({
+                name: "default",
+                content: digest,
+            });
+            break;
+        }
+    }
+    return { sections, markdownErrors };
+}
+
+export function getArgs(content: string) {
+    const galaxy_function = FUNCTION_CALL_LINE_TEMPLATE.exec(content);
+    if (galaxy_function == null) {
+        throw Error("Failed to parse galaxy directive");
+    }
+    type ArgsType = { [key: string]: string };
+    const args: ArgsType = {};
+    const function_name = galaxy_function[1];
+    // we need [... ] to return empty string, if regex doesn't match
+    const function_arguments = [...content.matchAll(new RegExp(FUNCTION_CALL, "g"))];
+    for (let i = 0; i < function_arguments.length; i++) {
+        if (function_arguments[i] === undefined) {
+            continue;
+        }
+        const arguments_str = function_arguments[i]?.toString().replace(/,/g, "").trim();
+        if (arguments_str) {
+            const [key, val] = arguments_str.split("=");
+            if (key == undefined || val == undefined) {
+                throw Error("Failed to parse galaxy directive");
+            }
+            args[key.trim()] = val.replace(/['"]+/g, "").trim();
+        }
+    }
+    return {
+        name: function_name,
+        args: args,
+        content: content,
+    };
+}

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -169,6 +169,7 @@ import { Toast } from "composables/toast";
 import { storeToRefs } from "pinia";
 import Vue, { computed, onUnmounted, ref, unref } from "vue";
 
+import { replaceLabel } from "@/components/Markdown/parse";
 import { getUntypedWorkflowParameters } from "@/components/Workflow/Editor/modules/parameters";
 import { ConfirmDialog } from "@/composables/confirmDialog";
 import { useDatatypesMapper } from "@/composables/datatypesMapper";
@@ -653,7 +654,10 @@ export default {
         },
         onLabel(nodeId, newLabel) {
             const step = { ...this.steps[nodeId], label: newLabel };
+            const oldLabel = this.steps[nodeId].label;
             this.onUpdateStep(step);
+            const newMarkdown = replaceLabel(this.markdownText, "step", oldLabel, newLabel);
+            this.onReportUpdate(newMarkdown);
         },
         onScrollTo(stepId) {
             this.scrollToId = stepId;

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -334,6 +334,7 @@ export default {
             showSaveAsModal: false,
             transform: { x: 0, y: 0, k: 1 },
             graphOffset: { left: 0, top: 0, width: 0, height: 0 },
+            debounceTimer: null,
         };
     },
     computed: {
@@ -656,8 +657,18 @@ export default {
             const step = { ...this.steps[nodeId], label: newLabel };
             const oldLabel = this.steps[nodeId].label;
             this.onUpdateStep(step);
-            const newMarkdown = replaceLabel(this.markdownText, "step", oldLabel, newLabel);
+            const stepType = this.steps[nodeId].type;
+            const isInput = ["data_input", "data_collection_input", "parameter_input"].indexOf(stepType) >= 0;
+            const labelType = isInput ? "input" : "step";
+            const newMarkdown = replaceLabel(this.markdownText, labelType, oldLabel, newLabel);
+            if (newMarkdown !== this.markdownText) {
+                this.debouncedToast("Label updated in workflow report.", 1500);
+            }
             this.onReportUpdate(newMarkdown);
+        },
+        debouncedToast(message, delay) {
+            clearTimeout(this.debounceTimer);
+            this.debounceTimer = setTimeout(() => Toast.success(message), delay);
         },
         onScrollTo(stepId) {
             this.scrollToId = stepId;


### PR DESCRIPTION
Fix for #16864 
Relies on @jmchilton 's work on #17264 

Simply implementing the replaceLabel function when the label is changed.  

## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. Create a workflow with a label on one of the steps
  2. Go to edit the Report, and create an item in the report that references a label
  3. Navigate back to workflow steps, and change the label.
  4. Go back to the report and see that the label is changed. 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
