### PR TITLE
Add a layer of abstraction to committing

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -39,6 +39,7 @@ from galaxy.jobs.mapper import JobNotReadyException
 from galaxy.managers.jobs import get_jobs_to_check_at_startup
 from galaxy.model.base import (
     check_database_connection,
+    commit,
     transaction,
 )
 from galaxy.structured_app import MinimalManagerApp
@@ -301,7 +302,7 @@ class JobHandlerQueue(BaseJobHandlerQueue):
                 except Exception:
                     log.exception("Error while recovering job %s during application startup.", job.id)
             with transaction(session):
-                session.commit()
+                commit(session)
 
     def _check_job_at_startup(self, job):
         if not self.app.toolbox.has_tool(job.tool_id, job.tool_version, exact=True):
@@ -580,7 +581,7 @@ class JobHandlerQueue(BaseJobHandlerQueue):
             del self.job_wrappers[id]
         # Commit updated state
         with transaction(self.sa_session):
-            self.sa_session.commit()
+            commit(self.sa_session)
 
         # Done with the session
         self.sa_session.remove()

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -35,6 +35,7 @@ from galaxy.jobs.runners.util.job_script import (
 )
 from galaxy.model.base import (
     check_database_connection,
+    commit,
     transaction,
 )
 from galaxy.tool_util.deps.dependencies import (
@@ -638,7 +639,7 @@ class BaseJobRunner:
             # Flush with streams...
             self.sa_session.add(job)
             with transaction(self.sa_session):
-                self.sa_session.commit()
+                commit(self.sa_session)
 
             if not job_ok:
                 job_runner_state = JobState.runner_states.TOOL_DETECT_ERROR

--- a/lib/galaxy/jobs/runners/state_handlers/resubmit.py
+++ b/lib/galaxy/jobs/runners/state_handlers/resubmit.py
@@ -3,7 +3,10 @@ from datetime import datetime
 
 from galaxy import model
 from galaxy.jobs.runners import JobState
-from galaxy.model.base import transaction
+from galaxy.model.base import (
+    commit,
+    transaction,
+)
 from ._safe_eval import safe_eval
 
 __all__ = ("failure",)
@@ -85,7 +88,7 @@ def _handle_resubmit_definitions(resubmit_definitions, app, job_runner, job_stat
             job_runner.sa_session.add(job)
             # Is this safe to do here?
             with transaction(job_runner.sa_session):
-                job_runner.sa_session.commit()
+                commit(job_runner.sa_session)
         # Cache the destination to prevent rerunning dynamic after
         # resubmit
         job_state.job_wrapper.job_runner_mapper.cached_job_destination = new_destination

--- a/lib/galaxy/jobs/runners/tasks.py
+++ b/lib/galaxy/jobs/runners/tasks.py
@@ -6,7 +6,10 @@ from time import sleep
 from galaxy import model
 from galaxy.jobs import TaskWrapper
 from galaxy.jobs.runners import BaseJobRunner
-from galaxy.model.base import transaction
+from galaxy.model.base import (
+    commit,
+    transaction,
+)
 
 log = logging.getLogger(__name__)
 
@@ -50,7 +53,7 @@ class TaskedJobRunner(BaseJobRunner):
         try:
             job_wrapper.change_state(model.Job.states.RUNNING)
             with transaction(self.sa_session):
-                self.sa_session.commit()
+                commit(self.sa_session)
             # Split with the defined method.
             parallelism = job_wrapper.get_parallelism()
             try:
@@ -70,7 +73,7 @@ class TaskedJobRunner(BaseJobRunner):
             for task in tasks:
                 self.sa_session.add(task)
             with transaction(self.sa_session):
-                self.sa_session.commit()
+                commit(self.sa_session)
             # Must flush prior to the creation and queueing of task wrappers.
             for task in tasks:
                 tw = TaskWrapper(task, job_wrapper.queue)

--- a/lib/galaxy/model/base.py
+++ b/lib/galaxy/model/base.py
@@ -58,7 +58,7 @@ def commit(session: Union[scoped_session, Session, "SessionlessContext"]):
     finally:
         if err:
             session.rollback()
-            log.error("Database transaction rolled back due to the following error: %s" % err)
+            log.error("Database transaction rolled back due to the following error: %s", err)
 
 
 @contextlib.contextmanager

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -207,6 +207,9 @@ class SessionlessContext:
     def flush(self) -> None:
         pass
 
+    def rollback(self) -> None:
+        pass
+
     def add(self, obj: model.RepresentById) -> None:
         self.objects[obj.__class__][obj.id] = obj
 


### PR DESCRIPTION
Ref: [SQLAlchemy documentation](https://docs.sqlalchemy.org/en/14/faq/sessions.html#this-session-s-transaction-has-been-rolled-back-due-to-a-previous-exception-during-flush-or-similar), recent discussion on slack's admin channel.

A commit to the database may fail for various reasons. The database transaction is rolled back; however the outer "logical" transaction that maintains the transactional state of SQLAlchemy's session won't be closed until explicitly rolled back (see referenced docs for an explanation of why that is the case). As a result, if a commit error is improperly handled, after which the session attempts to access the database, a `PendingRollbackError` will be raised. 

The proposed solution follows the recommended practice (as per SA docs) and issues a rollback in case of any error, re-raising the error for handling by the caller. However, a `PendingRollbackError` is not re-raised: I think we don't need to; instead we may want to handle specific errors that are raised due to things like constraint violation, etc. Besides, a `PendingRollbackError` will be also raised if a database disconnect occurs prior to the call to `commit` - in that case the logical transaction will be invalidated (preventing any further db access via this session); rolling it back, I think, is the right way to handle it.

If this is an acceptable approach, I'll replace all the other calls to `Session.commit` with calls to this `commit` function.



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
