### PR TITLE
API endpoint that allows "changing" the objectstore for "safe" scenarios. 

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -171,6 +171,10 @@ export interface paths {
          */
         get: operations["get_metrics_api_datasets__dataset_id__metrics_get"];
     };
+    "/api/datasets/{dataset_id}/object_store_id": {
+        /** Update an object store ID for a dataset you own. */
+        put: operations["datasets__update_object_store_id"];
+    };
     "/api/datasets/{dataset_id}/parameters_display": {
         /**
          * Resolve parameters as a list for nested display.
@@ -2910,6 +2914,8 @@ export interface components {
             badges: components["schemas"]["BadgeDict"][];
             /** Description */
             description?: string | null;
+            /** Device */
+            device?: string | null;
             /** Name */
             name?: string | null;
             /** Object Store Id */
@@ -10599,6 +10605,14 @@ export interface components {
              */
             synopsis?: string | null;
         };
+        /** UpdateObjectStoreIdPayload */
+        UpdateObjectStoreIdPayload: {
+            /**
+             * Object Store Id
+             * @description Object store ID to update to, it must be an object store with the same device ID as the target dataset currently.
+             */
+            object_store_id: string;
+        };
         /** UpdateQuotaParams */
         UpdateQuotaParams: {
             /**
@@ -12206,6 +12220,38 @@ export interface operations {
             200: {
                 content: {
                     "application/json": (components["schemas"]["JobMetric"] | null)[];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    datasets__update_object_store_id: {
+        /** Update an object store ID for a dataset you own. */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string | null;
+            };
+            /** @description The ID of the History Dataset. */
+            path: {
+                dataset_id: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateObjectStoreIdPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -262,6 +262,8 @@ class MinimalGalaxyApplication(BasicSharedApp, HaltableContainer, SentryClientMi
         self._register_singleton(GalaxyModelMapping, self.model)
         self._register_singleton(galaxy_scoped_session, self.model.context)
         self._register_singleton(install_model_scoped_session, self.install_model.context)
+        # Load quota management.
+        self.quota_agent = self._register_singleton(QuotaAgent, get_quota_agent(self.config, self.model))
 
     def configure_fluent_log(self):
         if self.config.fluent_log:
@@ -573,8 +575,6 @@ class GalaxyManagerApplication(MinimalManagerApp, MinimalGalaxyApplication, Inst
         self.host_security_agent = galaxy.model.security.HostAgent(
             model=self.security_agent.model, permitted_actions=self.security_agent.permitted_actions
         )
-        # Load quota management.
-        self.quota_agent = self._register_singleton(QuotaAgent, get_quota_agent(self.config, self.model))
 
         # We need the datatype registry for running certain tasks that modify HDAs, and to build the registry we need
         # to setup the installed repositories ... this is not ideal

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -61,6 +61,8 @@ class DatasetManager(base.ModelManager[model.Dataset], secured.AccessibleManager
         self.permissions = DatasetRBACPermissions(app)
         # needed for admin test
         self.user_manager = users.UserManager(app)
+        self.quota_agent = app.quota_agent
+        self.security_agent = app.model.security_agent
 
     def create(self, manage_roles=None, access_roles=None, flush=True, **kwargs):
         """
@@ -143,6 +145,36 @@ class DatasetManager(base.ModelManager[model.Dataset], secured.AccessibleManager
         """
         roles = user.all_roles_exploiting_cache() if user else []
         return self.app.security_agent.can_access_dataset(roles, dataset)
+
+    def update_object_store_id(self, trans, dataset, object_store_id: str):
+        device_source_map = self.app.object_store.get_device_source_map()
+        old_object_store_id = dataset.object_store_id
+        new_object_store_id = object_store_id
+        if old_object_store_id == new_object_store_id:
+            return None
+        old_device_id = device_source_map.get_device_id(old_object_store_id)
+        new_device_id = device_source_map.get_device_id(new_object_store_id)
+        if old_device_id != new_device_id:
+            raise exceptions.RequestParameterInvalidException(
+                "Cannot swap object store IDs for object stores that don't share a device ID."
+            )
+
+        if not self.security_agent.can_change_object_store_id(trans.user, dataset):
+            # TODO: probably want separate exceptions for doesn't own the dataset and dataset
+            # has been shared.
+            raise exceptions.InsufficientPermissionsException("Cannot change dataset permissions...")
+
+        quota_source_map = self.app.object_store.get_quota_source_map()
+        if quota_source_map:
+            old_label = quota_source_map.get_quota_source_label(old_object_store_id)
+            new_label = quota_source_map.get_quota_source_label(new_object_store_id)
+            if old_label != new_label:
+                self.quota_agent.relabel_quota_for_dataset(dataset, old_label, new_label)
+        sa_session = self.app.model.context
+        with transaction(sa_session):
+            dataset.object_store_id = new_object_store_id
+            sa_session.add(dataset)
+            sa_session.commit()
 
     def compute_hash(self, request: ComputeDatasetHashTaskRequest):
         # For files in extra_files_path

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4026,6 +4026,16 @@ class Dataset(Base, StorableObject, Serializable):
         quota_source_map = self.object_store.get_quota_source_map()
         return quota_source_map.get_quota_source_info(object_store_id)
 
+    @property
+    def device_source_label(self):
+        return self.device_source_info.label
+
+    @property
+    def device_source_info(self):
+        object_store_id = self.object_store_id
+        device_source_map = self.object_store.get_quota_source_map()
+        return device_source_map.get_device_source_info(object_store_id)
+
     def set_file_name(self, filename):
         if not filename:
             self.external_filename = None

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     select,
 )
 from sqlalchemy.orm import joinedload
+from sqlalchemy.sql import text
 
 import galaxy.model
 from galaxy.model import (
@@ -633,6 +634,24 @@ class GalaxyRBACAgent(RBACAgent):
 
     def can_manage_library_item(self, roles, item):
         return self.allow_action(roles, self.permitted_actions.LIBRARY_MANAGE, item)
+
+    def can_change_object_store_id(self, user, dataset):
+        # prevent update if dataset shared with anyone but the current user
+        # private object stores would prevent this but if something has been
+        # kept private in a sharable object store still allow the swap
+        if dataset.library_associations:
+            return False
+        else:
+            query = text(
+                """
+SELECT COUNT(*)
+FROM history
+INNER JOIN
+    history_dataset_association on history_dataset_association.history_id = history.id
+WHERE history.user_id != :user_id and history_dataset_association.dataset_id = :dataset_id
+"""
+            ).bindparams(dataset_id=dataset.id, user_id=user.id)
+            return self.sa_session.scalars(query).first() == 0
 
     def get_item_actions(self, action, item):
         # item must be one of: Dataset, Library, LibraryFolder, LibraryDataset, LibraryDatasetDatasetAssociation

--- a/lib/galaxy/quota/__init__.py
+++ b/lib/galaxy/quota/__init__.py
@@ -4,6 +4,7 @@ import logging
 from typing import Optional
 
 from sqlalchemy import select
+from sqlalchemy.orm import object_session
 from sqlalchemy.sql import text
 
 import galaxy.util
@@ -25,6 +26,13 @@ class QuotaAgent:  # metaclass=abc.ABCMeta
     possible to implement other backends for quota setting in the future such as managing
     the quota in other apps (LDAP maybe?) or via configuration files.
     """
+
+    def relabel_quota_for_dataset(self, dataset, from_label: Optional[str], to_label: Optional[str]):
+        """Update the quota source label for dataset and adjust relevant quotas.
+
+        Subtract quota for labels from users using old label and quota for new label
+        for these users.
+        """
 
     # TODO: make abstractmethod after they work better with mypy
     def get_quota(self, user, quota_source_label=None) -> Optional[int]:
@@ -80,6 +88,9 @@ class NoQuotaAgent(QuotaAgent):
         pass
 
     def get_quota(self, user, quota_source_label=None) -> Optional[int]:
+        return None
+
+    def relabel_quota_for_dataset(self, dataset, from_label: Optional[str], to_label: Optional[str]):
         return None
 
     @property
@@ -173,6 +184,97 @@ FROM (
                 return int(res[0]) if res[0] else None
             else:
                 return None
+
+    def relabel_quota_for_dataset(self, dataset, from_label: Optional[str], to_label: Optional[str]):
+        adjust = dataset.get_total_size()
+        with_quota_affected_users = """WITH quota_affected_users AS
+(
+    SELECT DISTINCT user_id
+    FROM history
+        INNER JOIN
+            history_dataset_association on history_dataset_association.history_id = history.id
+        INNER JOIN
+            dataset on history_dataset_association.dataset_id = dataset.id
+    WHERE
+        dataset_id = :dataset_id
+)"""
+        engine = object_session(dataset).bind
+
+        # Hack for older sqlite, would work on newer sqlite - 3.24.0
+        for_sqlite = "sqlite" in engine.dialect.name
+
+        if to_label == from_label:
+            return
+        if to_label is None:
+            to_statement = f"""
+{with_quota_affected_users}
+UPDATE galaxy_user
+SET disk_usage = coalesce(disk_usage, 0) + :adjust
+WHERE id in (select user_id from quota_affected_users)
+"""
+        else:
+            if for_sqlite:
+                to_statement = f"""
+{with_quota_affected_users},
+new_quota_sources (user_id, disk_usage, quota_source_label) AS (
+    SELECT user_id, :adjust as disk_usage, :to_label as quota_source_label
+    FROM quota_affected_users
+)
+INSERT OR REPLACE INTO user_quota_source_usage (id, user_id, quota_source_label, disk_usage)
+SELECT old.id, new.user_id, new.quota_source_label, COALESCE(old.disk_usage + :adjust, :adjust)
+FROM new_quota_sources as new LEFT JOIN user_quota_source_usage AS old ON new.user_id = old.user_id AND NEW.quota_source_label = old.quota_source_label"""
+            else:
+                to_statement = f"""
+{with_quota_affected_users},
+new_quota_sources (user_id, disk_usage, quota_source_label) AS (
+    SELECT user_id, :adjust as disk_usage, :to_label as quota_source_label
+    FROM quota_affected_users
+)
+INSERT INTO user_quota_source_usage(user_id, disk_usage, quota_source_label)
+SELECT * FROM new_quota_sources
+ON CONFLICT
+    ON constraint uqsu_unique_label_per_user
+    DO UPDATE SET disk_usage = user_quota_source_usage.disk_usage + :adjust
+"""
+
+        if from_label is None:
+            from_statement = f"""
+{with_quota_affected_users}
+UPDATE galaxy_user
+SET disk_usage = coalesce(disk_usage - :adjust, 0)
+WHERE id in (select user_id from quota_affected_users)
+"""
+        else:
+            if for_sqlite:
+                from_statement = f"""
+{with_quota_affected_users},
+new_quota_sources (user_id, disk_usage, quota_source_label) AS (
+    SELECT user_id, :adjust as disk_usage, :from_label as quota_source_label
+    FROM quota_affected_users
+)
+INSERT OR REPLACE INTO user_quota_source_usage (id, user_id, quota_source_label, disk_usage)
+SELECT old.id, new.user_id, new.quota_source_label, COALESCE(old.disk_usage - :adjust, 0)
+FROM new_quota_sources as new LEFT JOIN user_quota_source_usage AS old ON new.user_id = old.user_id AND NEW.quota_source_label = old.quota_source_label"""
+            else:
+                from_statement = f"""
+{with_quota_affected_users},
+new_quota_sources (user_id, disk_usage, quota_source_label) AS (
+    SELECT user_id, 0 as disk_usage, :from_label as quota_source_label
+    FROM quota_affected_users
+)
+INSERT INTO user_quota_source_usage(user_id, disk_usage, quota_source_label)
+SELECT * FROM new_quota_sources
+ON CONFLICT
+    ON constraint uqsu_unique_label_per_user
+    DO UPDATE SET disk_usage = user_quota_source_usage.disk_usage - :adjust
+"""
+
+        bind = {"dataset_id": dataset.id, "adjust": int(adjust), "to_label": to_label, "from_label": from_label}
+        engine = self.sa_session.get_bind()
+        with engine.connect() as conn:
+            with conn.begin():
+                conn.execute(text(from_statement), bind)
+                conn.execute(text(to_statement), bind)
 
     def _default_unregistered_quota(self, quota_source_label):
         return self._default_quota(self.model.DefaultQuotaAssociation.types.UNREGISTERED, quota_source_label)

--- a/lib/galaxy/security/__init__.py
+++ b/lib/galaxy/security/__init__.py
@@ -89,6 +89,9 @@ class RBACAgent:
     def can_modify_library_item(self, roles, item):
         raise Exception("Unimplemented Method")
 
+    def can_change_object_store_id(self, user, dataset):
+        raise Exception("Unimplemented Method")
+
     def can_manage_library_item(self, roles, item):
         raise Exception("Unimplemented Method")
 

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -69,6 +69,7 @@ from galaxy.webapps.galaxy.services.datasets import (
     DeleteDatasetBatchPayload,
     DeleteDatasetBatchResult,
     RequestDataType,
+    UpdateObjectStoreIdPayload,
 )
 
 log = logging.getLogger(__name__)
@@ -485,3 +486,16 @@ class FastAPIDatasets:
         payload: ComputeDatasetHashPayload = Body(...),
     ) -> AsyncTaskResultSummary:
         return self.service.compute_hash(trans, dataset_id, payload, hda_ldda=hda_ldda)
+
+    @router.put(
+        "/api/datasets/{dataset_id}/object_store_id",
+        summary="Update an object store ID for a dataset you own.",
+        operation_id="datasets__update_object_store_id",
+    )
+    def update_object_store_id(
+        self,
+        dataset_id: HistoryDatasetIDPathParam,
+        trans=DependsOnTrans,
+        payload: UpdateObjectStoreIdPayload = Body(...),
+    ) -> None:
+        self.service.update_object_store_id(trans, dataset_id, payload)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1182,6 +1182,13 @@ class BaseDatasetPopulator(BasePopulator):
         assert "total_disk_usage" in user_object
         return user_object["total_disk_usage"]
 
+    def update_object_store_id(self, dataset_id: str, object_store_id: str):
+        payload = {"object_store_id": object_store_id}
+        url = f"datasets/{dataset_id}/object_store_id"
+        update_response = self._put(url, payload, json=True)
+        update_response.raise_for_status()
+        return update_response
+
     def create_role(self, user_ids: list, description: Optional[str] = None) -> dict:
         using_requirement("admin")
         payload = {

--- a/test/integration/objectstore/test_changing_objectstore.py
+++ b/test/integration/objectstore/test_changing_objectstore.py
@@ -1,0 +1,97 @@
+"""Integration tests for changing object stores."""
+
+import string
+
+from ._base import BaseObjectStoreIntegrationTestCase
+
+DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE = string.Template(
+    """<?xml version="1.0"?>
+<object_store type="distributed" id="primary" order="0">
+    <backends>
+        <backend id="default" allow_selection="true" type="disk" weight="1" device="tmp_disk" name="Default Store 1">
+            <files_dir path="${temp_directory}/files_default"/>
+            <extra_dir type="temp" path="${temp_directory}/tmp_default"/>
+            <extra_dir type="job_work" path="${temp_directory}/job_working_directory_default"/>
+        </backend>
+        <backend id="temp_short" allow_selection="true" type="disk" weight="0" device="tmp_disk" name="Temp - Short Term">
+            <quota source="shorter_term" />
+            <files_dir path="${temp_directory}/files_temp"/>
+            <extra_dir type="temp" path="${temp_directory}/tmp_temp"/>
+            <extra_dir type="job_work" path="${temp_directory}/job_working_directory_temp"/>
+        </backend>
+        <backend id="temp_long" allow_selection="true" type="disk" weight="0" device="tmp_disk" name="Temp - Longer Term">
+            <quota source="longer_term" />
+            <files_dir path="${temp_directory}/files_temp"/>
+            <extra_dir type="temp" path="${temp_directory}/tmp_temp"/>
+            <extra_dir type="job_work" path="${temp_directory}/job_working_directory_temp"/>
+        </backend>
+    </backends>
+</object_store>
+"""
+)
+
+TEST_INPUT_FILES_CONTENT = "1 2 3"
+
+
+class TestChangingStoreObjectStoreIntegration(BaseObjectStoreIntegrationTestCase):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["new_user_dataset_access_role_default_private"] = True
+        cls._configure_object_store(DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE, config)
+        config["enable_quotas"] = True
+
+    def test_valid_in_device_swap(self):
+        with self.dataset_populator.test_history() as history_id:
+            hda = self.dataset_populator.new_dataset(history_id, content=TEST_INPUT_FILES_CONTENT, wait=True)
+
+            payload = {
+                "name": "quota_longer",
+                "description": "quota_longer desc",
+                "amount": "10 MB",
+                "operation": "=",
+                "default": "registered",
+                "quota_source_label": "longer_term",
+            }
+            self.dataset_populator.create_quota(payload)
+
+            payload = {
+                "name": "quota_shorter",
+                "description": "quota_shorter desc",
+                "amount": "20 MB",
+                "operation": "=",
+                "default": "registered",
+                "quota_source_label": "shorter_term",
+            }
+            self.dataset_populator.create_quota(payload)
+
+            quotas = self.dataset_populator.get_quotas()
+            assert len(quotas) == 2
+
+            usage = self.dataset_populator.get_usage_for("longer_term")
+            assert usage["total_disk_usage"] == 0
+            usage = self.dataset_populator.get_usage_for("shorter_term")
+            assert usage["total_disk_usage"] == 0
+            usage = self.dataset_populator.get_usage_for(None)
+            assert int(usage["total_disk_usage"]) == 6
+
+            self.dataset_populator.update_object_store_id(hda["id"], "temp_short")
+            usage = self.dataset_populator.get_usage_for("shorter_term")
+            assert int(usage["total_disk_usage"]) == 6
+            usage = self.dataset_populator.get_usage_for(None)
+            assert int(usage["total_disk_usage"]) == 0
+
+            self.dataset_populator.update_object_store_id(hda["id"], "temp_long")
+            usage = self.dataset_populator.get_usage_for("shorter_term")
+            assert int(usage["total_disk_usage"]) == 0
+            usage = self.dataset_populator.get_usage_for("longer_term")
+            assert int(usage["total_disk_usage"]) == 6
+            usage = self.dataset_populator.get_usage_for(None)
+            assert int(usage["total_disk_usage"]) == 0
+
+            self.dataset_populator.update_object_store_id(hda["id"], "temp_short")
+            usage = self.dataset_populator.get_usage_for("shorter_term")
+            assert int(usage["total_disk_usage"]) == 6
+            usage = self.dataset_populator.get_usage_for("longer_term")
+            assert int(usage["total_disk_usage"]) == 0
+            usage = self.dataset_populator.get_usage_for(None)
+            assert int(usage["total_disk_usage"]) == 0

--- a/test/integration/objectstore/test_private_handling.py
+++ b/test/integration/objectstore/test_private_handling.py
@@ -1,4 +1,4 @@
-"""Integration tests for mixing store_by."""
+"""Integration tests for private object store handling."""
 
 import string
 

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -524,13 +524,13 @@ def test_badges_parsing_conflicts():
 DISTRIBUTED_TEST_CONFIG = """<?xml version="1.0"?>
 <object_store type="distributed">
     <backends>
-        <backend id="files1" type="disk" weight="2">
+        <backend id="files1" type="disk" weight="2" device="primary_disk">
             <quota source="1files" />
             <files_dir path="${temp_directory}/files1"/>
             <extra_dir type="temp" path="${temp_directory}/tmp1"/>
             <extra_dir type="job_work" path="${temp_directory}/job_working_directory1"/>
         </backend>
-        <backend id="files2" type="disk" weight="1">
+        <backend id="files2" type="disk" weight="1" device="primary_disk">
             <quota source="2files" />
             <files_dir path="${temp_directory}/files2"/>
             <extra_dir type="temp" path="${temp_directory}/tmp2"/>
@@ -549,6 +549,7 @@ backends:
        source: 1files
      type: disk
      weight: 2
+     device: primary_disk
      files_dir: "${temp_directory}/files1"
      extra_dirs:
      - type: temp
@@ -560,6 +561,7 @@ backends:
        source: 2files
      type: disk
      weight: 1
+     device: primary_disk
      files_dir: "${temp_directory}/files2"
      extra_dirs:
      - type: temp
@@ -597,6 +599,12 @@ def test_distributed_store():
 
             extra_dirs = as_dict["extra_dirs"]
             assert len(extra_dirs) == 2
+
+            device_source_map = object_store.get_device_source_map()
+            assert device_source_map
+            print(device_source_map.backends)
+            assert device_source_map.get_device_id("files1") == "primary_disk"
+            assert device_source_map.get_device_id("files2") == "primary_disk"
 
 
 def test_distributed_store_empty_cache_targets():


### PR DESCRIPTION
It is safe to just relabel the object store that a dataset belongs to if the underlying paths mapped to by the object stores are the same (or are resolved in the same way) and if the dataset has not yet been copied to new histories, libraries, etc..

To facilitate this I've added the ability to assign a "device" ID to object stores - if the same device ID is found on two object stores Galaxy assumes that just relabeling the dataset is safe from a dataset access perspective. The actual implementation has custom, optimized SQL for handling the quota recalculation in this case and for checking that the dataset hasn't been copied out into new histories, etc..

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
