### PR TITLE
[23.2] Fix Subworkflow Edit Button

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -688,11 +688,14 @@ export default {
             const runUrl = `/workflows/run?id=${this.id}`;
             this.onNavigate(runUrl);
         },
-        onNavigate(url) {
-            this.onSave(true).then(() => {
-                this.hasChanges = false;
-                this.$router.push(url);
-            });
+        async onNavigate(url) {
+            if (this.isNewTempWorkflow) {
+                await this.onCreate();
+            }
+
+            await this.onSave(true);
+            this.hasChanges = false;
+            this.$router.push(url);
         },
         onSave(hideProgress = false) {
             if (!this.nameValidate()) {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -691,9 +691,10 @@ export default {
         async onNavigate(url) {
             if (this.isNewTempWorkflow) {
                 await this.onCreate();
+            } else {
+                await this.onSave(true);
             }
 
-            await this.onSave(true);
             this.hasChanges = false;
             this.$router.push(url);
         },

--- a/client/src/entry/analysis/modules/WorkflowEditor.vue
+++ b/client/src/entry/analysis/modules/WorkflowEditor.vue
@@ -37,19 +37,27 @@ export default {
     },
     methods: {
         async getEditorConfig() {
-            const storedWorkflowId = Query.get("id");
-            const workflowId = Query.get("workflow_id");
-            const params = {};
-            if (workflowId) {
-                params.workflow_id = workflowId;
-            } else if (storedWorkflowId) {
-                params.id = storedWorkflowId;
+            let reloadEditor = true;
+
+            // this will only be the case the first time the route updates from a new workflow
+            if (!this.storedWorkflowId && !this.workflowId) {
+                reloadEditor = false;
             }
 
-            const previousId = this.editorConfig?.id;
+            this.storedWorkflowId = Query.get("id");
+            this.workflowId = Query.get("workflow_id");
+
+            const params = {};
+
+            if (this.workflowId) {
+                params.workflow_id = this.workflowId;
+            } else if (this.storedWorkflowId) {
+                params.id = this.storedWorkflowId;
+            }
+
             this.editorConfig = await urlData({ url: "/workflow/editor", params });
 
-            if (previousId !== undefined && previousId !== this.editorConfig?.id) {
+            if (reloadEditor) {
                 this.editorReloadKey += 1;
             }
         },

--- a/client/src/entry/analysis/modules/WorkflowEditor.vue
+++ b/client/src/entry/analysis/modules/WorkflowEditor.vue
@@ -1,6 +1,7 @@
 <template>
     <Editor
         v-if="editorConfig"
+        :key="editorReloadKey"
         :workflow-id="editorConfig.id"
         :data-managers="editorConfig.dataManagers"
         :initial-version="editorConfig.initialVersion"
@@ -23,6 +24,7 @@ export default {
             storedWorkflowId: null,
             workflowId: null,
             editorConfig: null,
+            editorReloadKey: 0,
         };
     },
     watch: {
@@ -43,7 +45,13 @@ export default {
             } else if (storedWorkflowId) {
                 params.id = storedWorkflowId;
             }
+
+            const previousId = this.editorConfig?.id;
             this.editorConfig = await urlData({ url: "/workflow/editor", params });
+
+            if (previousId !== undefined && previousId !== this.editorConfig?.id) {
+                this.editorReloadKey += 1;
+            }
         },
     },
 };


### PR DESCRIPTION
Explanation of the fix:

The editor requires a reload, when switching to a completely new workflow, to properly initiate the loading process.
This can be achieved by keying it in the `WorkflowEditor` page. Keying it simply to the id doesn't work, since that will also trigger a reload if a workflow is saved for the very first time, which is not what we want. So we use a counter instead, which is incremented manually.

The reload-counter is not incremented if no id was previously set. This only happens for new workflows. This way we avoid reloading when a new workflow is saved for the first time.

Fixing the first issue revealed another issue, which was that onNavigate in the workflow editor didn't work for new (unsaved) workflows, since they need to be created first. Adding a check in this function fixed the issue.

ping @martenson 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
