### PR TITLE
Fix quotas ID encoding

### DIFF
--- a/lib/galaxy/quota/_schema.py
+++ b/lib/galaxy/quota/_schema.py
@@ -11,7 +11,7 @@ from pydantic import (
 from typing_extensions import Literal
 
 from galaxy.schema.fields import (
-    DecodedDatabaseIdField,
+    EncodedDatabaseIdField,
     ModelClassField,
 )
 from galaxy.schema.schema import (
@@ -107,7 +107,7 @@ class QuotaBase(Model, WithModelClass):
     """Base model containing common fields for Quotas."""
 
     model_class: QUOTA = ModelClassField(QUOTA)
-    id: DecodedDatabaseIdField = Field(
+    id: EncodedDatabaseIdField = Field(
         ...,
         title="ID",
         description="The `encoded identifier` of the quota.",

--- a/lib/galaxy/webapps/galaxy/services/quotas.py
+++ b/lib/galaxy/webapps/galaxy/services/quotas.py
@@ -55,13 +55,13 @@ class QuotasService(ServiceBase):
             encoded_id = Security.security.encode_id(quota.id)
             item["url"] = url_for(route, id=encoded_id)
             rval.append(item)
-        return QuotaSummaryList.model_construct(root=rval)
+        return QuotaSummaryList(root=rval)
 
     def show(self, trans: ProvidesUserContext, id: DecodedDatabaseIdField, deleted: bool = False) -> QuotaDetails:
         """Displays information about a quota."""
         quota = self.quota_manager.get_quota(trans, id, deleted=deleted)
         rval = quota.to_dict(view="element", value_mapper={"total_disk_usage": float})
-        return QuotaDetails.model_construct(**rval)
+        return QuotaDetails(**rval)
 
     def create(self, trans: ProvidesUserContext, params: CreateQuotaParams) -> CreateQuotaResult:
         """Creates a new quota."""
@@ -71,7 +71,7 @@ class QuotasService(ServiceBase):
         item = quota.to_dict()
         item["url"] = url_for("quota", id=Security.security.encode_id(quota.id))
         item["message"] = message
-        return CreateQuotaResult.model_construct(**item)
+        return CreateQuotaResult(**item)
 
     def update(self, trans: ProvidesUserContext, id: DecodedDatabaseIdField, params: UpdateQuotaParams) -> str:
         """Modifies a quota."""

--- a/test/integration/test_quota.py
+++ b/test/integration/test_quota.py
@@ -25,6 +25,18 @@ class TestQuotaIntegration(integration_util.IntegrationTestCase):
         json_response = index_response.json()
         assert len(json_response) > 0
 
+    def test_index_returns_encoded_ids(self):
+        quota = self._create_quota_with_name("test-index-encoded-quota")
+        created_quota_id = quota["id"]
+        index_response = self._get("quotas")
+        index_response.raise_for_status()
+        json_response = index_response.json()
+        assert len(json_response) > 0
+        quota_ids = [quota["id"] for quota in json_response]
+        for quota_id in quota_ids:
+            assert isinstance(quota_id, str)
+        assert created_quota_id in quota_ids
+
     def test_index_deleted(self):
         quota = self._create_quota_with_name("test-index-deleted-quota")
         quota_id = quota["id"]


### PR DESCRIPTION
Fixes #17306

Using `model_construct` will not auto-encode the IDs.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Follow steps described in #17306

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
