### PR TITLE
[23.1] Disable tag editing on non-owned Pages

### DIFF
--- a/client/src/components/Page/PageList.test.js
+++ b/client/src/components/Page/PageList.test.js
@@ -7,6 +7,7 @@ import flushPromises from "flush-promises";
 import { PiniaVuePlugin } from "pinia";
 import { createTestingPinia } from "@pinia/testing";
 import { parseISO, formatDistanceToNow } from "date-fns";
+import { useUserStore } from "stores/userStore";
 
 jest.mock("app");
 
@@ -95,11 +96,24 @@ describe("PgeList.vue", () => {
     const mockPublishedPageData = [publishedPage];
     const mockTwoPageData = [privatePage, pageA];
 
-    function mountPersonalGrid() {
+    function mountGrid(propsData) {
+        const pinia = createTestingPinia();
+        const userStore = useUserStore();
+        userStore.currentUser = { username: "jimmyPage", tags_used: [] };
+
         wrapper = mount(PageList, {
-            propsData: propsDataPersonalGrid,
+            propsData,
             localVue,
+            pinia,
         });
+    }
+
+    function mountPersonalGrid() {
+        mountGrid(propsDataPersonalGrid);
+    }
+
+    function mountPublishedGrid() {
+        mountGrid(propsDataPublishedGrid);
     }
 
     describe(" with empty page list", () => {
@@ -135,11 +149,7 @@ describe("PgeList.vue", () => {
             jest.spyOn(PageList.methods, "decorateData").mockImplementation((page) => {
                 page.shared = false;
             });
-            wrapper = mount(PageList, {
-                propsData: propsDataPersonalGrid,
-                localVue,
-                pinia: createTestingPinia(),
-            });
+            mountPersonalGrid();
             await flushPromises();
         });
 
@@ -202,11 +212,7 @@ describe("PgeList.vue", () => {
             jest.spyOn(PageList.methods, "decorateData").mockImplementation((page) => {
                 page.shared = true;
             });
-            wrapper = mount(PageList, {
-                propsData: propsDataPersonalGrid,
-                localVue,
-                pinia: createTestingPinia(),
-            });
+            mountPersonalGrid();
             await flushPromises();
         });
         it("updates filter when published icon is clicked", async () => {
@@ -241,11 +247,7 @@ describe("PgeList.vue", () => {
             jest.spyOn(PageList.methods, "decorateData").mockImplementation((page) => {
                 page.shared = false;
             });
-            wrapper = mount(PageList, {
-                propsData: propsDataPublishedGrid,
-                localVue,
-                pinia: createTestingPinia(),
-            });
+            mountPublishedGrid();
             await flushPromises();
         });
 
@@ -282,11 +284,7 @@ describe("PgeList.vue", () => {
             jest.spyOn(PageList.methods, "decorateData").mockImplementation((page) => {
                 page.shared = false;
             });
-            wrapper = mount(PageList, {
-                propsData: propsDataPublishedGrid,
-                localVue,
-                pinia: createTestingPinia(),
-            });
+            mountPublishedGrid();
             await flushPromises();
         });
 

--- a/client/src/components/Page/PageList.vue
+++ b/client/src/components/Page/PageList.vue
@@ -37,7 +37,7 @@
                 <StatelessTags
                     :value="row.item.tags"
                     :index="row.index"
-                    :disabled="published"
+                    :disabled="published || !currentUserOwnsItem(row.item)"
                     @input="(tags) => onTags(tags, row.index)"
                     @tag-click="onTagClick" />
             </template>
@@ -80,6 +80,7 @@
 <script>
 import _l from "utils/localization";
 import { getAppRoot } from "onload/loadConfig";
+import { storeToRefs } from "pinia";
 import { updateTags } from "./services";
 import { pagesProvider } from "components/providers/PageProvider";
 import StatelessTags from "components/TagsMultiselect/StatelessTags";
@@ -93,6 +94,8 @@ import IndexFilter from "components/Indices/IndexFilter";
 import { absPath } from "@/utils/redirect";
 import { useRouter } from "vue-router/composables";
 import { getGalaxyInstance } from "app";
+
+import { useUserStore } from "@/stores/userStore";
 
 import SharingIndicators from "components/Indices/SharingIndicators";
 
@@ -155,8 +158,10 @@ export default {
     },
     setup() {
         const router = useRouter();
+        const { currentUser } = storeToRefs(useUserStore());
         return {
             router,
+            currentUser,
         };
     },
     data() {
@@ -228,6 +233,9 @@ export default {
         },
         shareLink: function (item) {
             this.router.push(`sharing?id=${item.id}`);
+        },
+        currentUserOwnsItem: function (item) {
+            return item.username === this.currentUser.username;
         },
         decorateData(page) {
             const Galaxy = getGalaxyInstance();


### PR DESCRIPTION
Fixes #17336

To be able to edit the tags of a Page, the user needs to be the owner. This disables the tag edit component in other cases.

![image](https://github.com/galaxyproject/galaxy/assets/46503462/a7b7cf24-118d-4fe4-b083-a6792b491de5)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
