### PR TITLE
[23.2] Fix upload modal loses its content when closed

### DIFF
--- a/client/src/components/Upload/DefaultBox.vue
+++ b/client/src/components/Upload/DefaultBox.vue
@@ -113,15 +113,15 @@ const queue = new UploadQueue({
 });
 
 /** Add files to queue */
-function addFiles(files) {
+function addFiles(files, immediate = false) {
     if (!isRunning.value) {
+        if (immediate || !props.multiple) {
+            eventReset();
+        }
         if (props.multiple) {
             queue.add(files);
-        } else {
-            eventReset();
-            if (files.length > 0) {
-                queue.add([files[0]]);
-            }
+        } else if (files.length > 0) {
+            queue.add([files[0]]);
         }
     }
 }

--- a/client/src/components/Upload/UploadContainer.vue
+++ b/client/src/components/Upload/UploadContainer.vue
@@ -112,7 +112,7 @@ const showRegular = computed(() => !props.formats || hasRegularExtension);
 const showRules = computed(() => !props.formats || props.multiple);
 
 function immediateUpload(files) {
-    regular.value?.addFiles(files);
+    regular.value?.addFiles(files, true);
 }
 
 function toData(items, history_id, composite = false) {

--- a/client/src/components/Upload/UploadModal.vue
+++ b/client/src/components/Upload/UploadModal.vue
@@ -86,7 +86,6 @@ defineExpose({
         <UploadContainer
             v-if="currentHistoryId"
             ref="content"
-            :key="showModal"
             :current-user-id="currentUser?.id"
             :current-history-id="currentHistoryId"
             v-bind="options"

--- a/lib/galaxy_test/selenium/test_uploads.py
+++ b/lib/galaxy_test/selenium/test_uploads.py
@@ -175,6 +175,36 @@ class TestUploads(SeleniumTestCase, UsesHistoryItemAssertions):
         self.history_panel_wait_for_hid_hidden(4)
 
     @selenium_test
+    def test_upload_modal_retains_content(self):
+        self.home()
+
+        # initialize 2 uploads and close modal
+        self.upload_start_click()
+        self.upload_queue_local_file(self.get_filename("1.sam"))
+        self.upload_paste_data("some pasted data")
+        self.wait_for_and_click_selector("button#btn-close")
+
+        # reopen modal and check that the files are still there
+        self.upload_start_click()
+        self.wait_for_selector_visible("#upload-row-0.upload-init")
+        self.wait_for_selector_visible("#upload-row-1.upload-init")
+
+        # perform upload and close modal
+        self.upload_start()
+        self.wait_for_and_click_selector("button#btn-close")
+
+        # add another pasted file, but don't upload it
+        self.upload_start_click()
+        self.upload_paste_data("some more pasted data")
+        self.wait_for_and_click_selector("button#btn-close")
+
+        # reopen modal and see 2 uploaded, 1 yet to upload
+        self.upload_start_click()
+        self.wait_for_selector_visible("#upload-row-0.upload-success")
+        self.wait_for_selector_visible("#upload-row-1.upload-success")
+        self.wait_for_selector_visible("#upload-row-2.upload-init")
+
+    @selenium_test
     @pytest.mark.gtn_screenshot
     @pytest.mark.local
     def test_rules_example_1_datasets(self):


### PR DESCRIPTION
This also fixes the problem of not being able to clear the upload activity.
Fixes https://github.com/galaxyproject/galaxy/issues/16342

Removed the `:key="showModal"` from `UploadContainer` that causes component data to be destroyed when modal is closed.
Also, `eventReset()` the modal when there is an "immediate" drag-drop upload.

| Before |
| ------ |
| <video src="https://github.com/galaxyproject/galaxy/assets/78516064/f2fff777-a739-41dd-a16d-341b17a35c54"> |
| Closing the modal - regardless of an "immediate" upload - meant losing the modal content and the progress percentage in the activity/upload-button would remain unsynced. |

| After |
| ----- |
| <video src="https://github.com/galaxyproject/galaxy/assets/78516064/ab417d07-1c32-4535-9fc4-d39307f0f434"> |
| The modal content remains as is upon reopening the modal, even if the user is in the progress of uploading data. The only case where we reset the modal content is when the user performs an "immediate" drag-drop upload (outside of the modal); in that case, we reset the modal content with only the dropped file(s) |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
