### PR TITLE
[23.2] Fix notification badge delay

### DIFF
--- a/client/src/stores/notificationsStore.ts
+++ b/client/src/stores/notificationsStore.ts
@@ -37,6 +37,7 @@ export const useNotificationsStore = defineStore("notificationsStore", () => {
                 loadingNotifications.value = true;
                 await broadcastsStore.loadBroadcasts();
                 await loadNotifications();
+                updateUnreadCount();
             } else {
                 const data = await loadNotificationsStatus(lastNotificationUpdate.value);
                 totalUnreadCount.value = data.total_unread_count;
@@ -76,6 +77,10 @@ export const useNotificationsStore = defineStore("notificationsStore", () => {
 
     async function updateNotification(notification: UserNotification, changes: NotificationChanges) {
         return updateBatchNotification({ notification_ids: [notification.id], changes });
+    }
+
+    function updateUnreadCount() {
+        totalUnreadCount.value = notifications.value.filter((n) => !n.seen_time).length;
     }
 
     return {


### PR DESCRIPTION
The first time we load the page and retrieve the notifications, the count badge is not updated until the first status poll is done a few seconds after. Resulting in the notification count badge lagging behind the real status of the notifications.

This should update the badge right away the first time and then relay on the status count afterwards.

|   Before | After   |
|------------|----------|
|![BeforeNotificationBadgeFix](https://github.com/galaxyproject/galaxy/assets/46503462/88b4dc5a-4a94-4097-a6c3-0110550607f9) | ![AfterNotificationBadgeFix](https://github.com/galaxyproject/galaxy/assets/46503462/480ba04c-6be4-4d10-b1e6-9b1fe3b94b61) |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
