### PR TITLE
Add element_identifier and ext to inputs config file export

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -6539,7 +6539,7 @@ response to this directive.
         </xs:attribute>
         <xs:attribute name="data_style" type="InputsConfigfileDatastyleType">
           <xs:annotation>
-            <xs:documentation xml:lang="en">Set to 'paths' to include dataset paths in the resulting file. Set to 'staging_path_and_source_path' to include a element identifiers, datatype, staging path, a source path and all metadata files.</xs:documentation>
+            <xs:documentation xml:lang="en">Set to 'paths' to include dataset paths in the resulting file. Set to 'staging_path_and_source_path' to include element identifiers, datatype, staging path, a source path and all metadata files.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -6513,8 +6513,11 @@ A contrived example of a tool that uses this is the test tool
 
 By default this file will not contain paths for data or collection inputs. To include simple
 paths for data or collection inputs set the ``data_style`` attribute to ``paths`` (see [inputs_as_json_with_paths.xml](https://github.com/galaxyproject/galaxy/blob/dev/test/functional/tools/inputs_as_json_with_paths.xml) for an example).
-To include a dictionary with staging paths, paths and metadata files set the ``data_style`` attribute to ``staging_path_and_source_path``.
+To include a dictionary with element identifiers, datatypes, staging paths, paths and metadata files set the ``data_style`` attribute to ``staging_path_and_source_path`` (element identifiers and datatypes are available since 24.0).
 An example tool that uses ``staging_path_and_source_path`` is [inputs_as_json_with_staging_path_and_source_path.xml](https://github.com/galaxyproject/galaxy/blob/dev/test/functional/tools/inputs_as_json_with_staging_path_and_source_path.xml)
+
+Note that the element identifiers are stored as lists, where the last element is the actual element identifier of the dataset
+and the other elements the identifiers of the collections containing the dataset.
 
 For tools with profile >= 20.05 a select with ``multiple="true"`` is rendered as an array which is empty if nothing is selected. For older profile versions select lists are rendered as comma separated strings or a literal ``null`` in case nothing is selected.
 ]]></xs:documentation>
@@ -6536,7 +6539,7 @@ response to this directive.
         </xs:attribute>
         <xs:attribute name="data_style" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">Set to 'paths' to include dataset paths in the resulting file. Set to 'staging_path_and_source_path' to include a staging path, a source path and all metadata files.</xs:documentation>
+            <xs:documentation xml:lang="en">Set to 'paths' to include dataset paths in the resulting file. Set to 'staging_path_and_source_path' to include a element identifiers, datatype, staging path, a source path and all metadata files.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -7606,7 +7606,7 @@ the only supported options.</xs:documentation>
       <xs:documentation xml:lang="en">Allowed collection types</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:enumeration value="path"/>
+      <xs:enumeration value="paths"/>
       <xs:enumeration value="staging_path_and_source_path"/>
     </xs:restriction>
   </xs:simpleType>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -6537,7 +6537,7 @@ response to this directive.
             <xs:documentation xml:lang="en">Path relative to the working directory of the tool for the inputs JSON file created in response to this directive.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="data_style" type="xs:string">
+        <xs:attribute name="data_style" type="InputsConfigfileDatastyleType">
           <xs:annotation>
             <xs:documentation xml:lang="en">Set to 'paths' to include dataset paths in the resulting file. Set to 'staging_path_and_source_path' to include a element identifiers, datatype, staging path, a source path and all metadata files.</xs:documentation>
           </xs:annotation>
@@ -7599,6 +7599,15 @@ the only supported options.</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:pattern value="(list|paired)([:,](list|paired))*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="InputsConfigfileDatastyleType">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">Allowed collection types</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="path"/>
+      <xs:enumeration value="staging_path_and_source_path"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/lib/galaxy/tools/parameters/wrapped_json.py
+++ b/lib/galaxy/tools/parameters/wrapped_json.py
@@ -57,7 +57,7 @@ def data_collection_input_to_staging_path_and_source_path(
             *v.element_identifiers_extensions_paths_and_metadata_files
         )
     else:
-        element_identifiers, extensions, source_paths, metadata_files = [], [], [], []
+        element_identifiers, extensions, source_paths, metadata_files = (), (), (), ()
     return [
         {
             "element_identifier": element_identifier,

--- a/lib/galaxy/tools/parameters/wrapped_json.py
+++ b/lib/galaxy/tools/parameters/wrapped_json.py
@@ -5,9 +5,16 @@ from typing import (
     Dict,
     List,
     Sequence,
+    TYPE_CHECKING,
 )
 
 from packaging.version import Version
+
+if TYPE_CHECKING:
+    from galaxy.tools.parameters.wrappers import (
+        DatasetCollectionWrapper,
+        DatasetFilenameWrapper,
+    )
 
 log = logging.getLogger(__name__)
 
@@ -40,28 +47,41 @@ def data_collection_input_to_path(v):
 
 
 def data_collection_input_to_staging_path_and_source_path(
-    v, invalid_chars: Sequence[str] = ("/",), include_collection_name: bool = False
+    v: "DatasetCollectionWrapper", invalid_chars: Sequence[str] = ("/",), include_collection_name: bool = False
 ) -> List[Dict[str, Any]]:
     staging_paths = v.get_all_staging_paths(
         invalid_chars=invalid_chars, include_collection_name=include_collection_name
     )
-    source_paths = v.all_paths
-    metadata_files = v.all_metadata_files
+    if v.element_identifiers_extensions_paths_and_metadata_files:
+        element_identifiers, extensions, source_paths, metadata_files = zip(
+            *v.element_identifiers_extensions_paths_and_metadata_files
+        )
+    else:
+        element_identifiers, extensions, source_paths, metadata_files = [], [], [], []
     return [
         {
+            "element_identifier": element_identifier,
+            "ext": extension,
             "staging_path": staging_path,
             "source_path": source_path,
             "metadata_files": [
                 {"staging_path": f"{staging_path}.{mf[0]}", "source_path": mf[1]} for mf in metadata_files
             ],
         }
-        for staging_path, source_path, metadata_files in zip(staging_paths, source_paths, metadata_files)
+        for element_identifier, extension, staging_path, source_path, metadata_files in zip(
+            element_identifiers, extensions, staging_paths, source_paths, metadata_files
+        )
     ]
 
 
-def data_input_to_staging_path_and_source_path(v, invalid_chars: Sequence[str] = ("/",)) -> Dict[str, Any]:
+def data_input_to_staging_path_and_source_path(
+    v: "DatasetFilenameWrapper", invalid_chars: Sequence[str] = ("/",)
+) -> Dict[str, Any]:
     staging_path = v.get_staging_path(invalid_chars=invalid_chars)
+    # note that the element identifier should be always a list
     return {
+        "element_identifier": [v.element_identifier],
+        "ext": v.file_ext,
         "staging_path": staging_path,
         "source_path": data_input_to_path(v),
         "metadata_files": [

--- a/test/functional/tools/inputs_as_json_with_staging_path_and_source_path.xml
+++ b/test/functional/tools/inputs_as_json_with_staging_path_and_source_path.xml
@@ -11,7 +11,23 @@ import sys
 input_json_path = sys.argv[1]
 as_dict = json.load(open(input_json_path, "r"))
 
+data_input_with_staging_details = as_dict["data_input"]
+assert data_input_with_staging_details['element_identifier'] == ["1.tabular"]
+assert data_input_with_staging_details['ext'] == "tabular"
+assert data_input_with_staging_details['staging_path'] == "1.tabular.tabular"
+assert len(data_input_with_staging_details['metadata_files']) == 0
+
+multiple_data_input_with_staging_details = as_dict["multiple_data_input"]
+assert len(multiple_data_input_with_staging_details) == 2
+assert multiple_data_input_with_staging_details[0]['element_identifier'] == ["simple_line.txt"]
+assert multiple_data_input_with_staging_details[0]['ext'] == "txt"
+assert multiple_data_input_with_staging_details[0]['staging_path'] == "simple_line.txt.txt"
+assert len(multiple_data_input_with_staging_details[0]['metadata_files']) == 0
+
 collection_input_with_staging_details = as_dict["collection_input"]
+## element identifier and ext are available since 24.x
+assert collection_input_with_staging_details[0]['element_identifier'] == ["list", "element1"]
+assert collection_input_with_staging_details[0]['ext'] == "bam"
 assert collection_input_with_staging_details[0]['staging_path'] == "list/element1.bam"
 assert collection_input_with_staging_details[0]['metadata_files'][0]['staging_path'] == "list/element1.bam.bai"
 
@@ -22,13 +38,15 @@ with open("output", "w") as f:
     <inputs>
         <param name="data_input" type="data" optional="true" />
         <param name="multiple_data_input" type="data" optional="true" multiple="true" />
-        <param name="collection_input" type="data_collection" optional="true"/>
+        <param name="collection_input" type="data_collection" collection_type="list:list" optional="true"/>
     </inputs>
     <outputs>
         <data name="out_file1" from_work_dir="output" format="txt" />
     </outputs>
     <tests>
         <test>
+            <param name="data_input" value="1.tabular" ftype="tabular"/>
+            <param name="multiple_data_input" value="simple_line.txt,simple_line_alternative.txt" ftype="txt"/>
             <param name="collection_input">
                 <collection type="list:list">
                     <element name="list">
@@ -38,6 +56,11 @@ with open("output", "w") as f:
                     </element>
                 </collection>
             </param>
+            <output name="out_file1">
+                <assert_contents>
+                    <has_text text="okay"/>
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help>


### PR DESCRIPTION
element identifiers are crucial for collections and need to be exposed in the inputs configfile export. it's too hacky to parse the identifier from the staging path (plus: the staging path is sanitised).

I suggest to make the element_identifier a list, because it is for collections (there the first list elements are collection identifiers and the last the element identifier of the dataset), such that users (tool developers) do not need to check if it is a list or a string.

TODO: 

- [x] docs in xsd

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
