### PR TITLE
Escape pipe character in tool XSD docs

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -5267,7 +5267,7 @@ If ``true``, this output will sniffed and its format determined automatically by
     <xs:attribute name="default_identifier_source" type="xs:string">
       <xs:annotation>
         <xs:documentation xml:lang="en">Sets the source of element identifier to the specified input.
-This only applies to collections that are mapped over a non-collection input and that have equivalent structures. If this references input elements in conditionals, this value should be qualified (e.g. ``cond|input`` instead of ``input`` if ``input`` is in a conditional with ``name="cond"``).</xs:documentation>
+This only applies to collections that are mapped over a non-collection input and that have equivalent structures. If this references input elements in conditionals, this value should be qualified (e.g. ``cond\|input`` instead of ``input`` if ``input`` is in a conditional with ``name="cond"``).</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="metadata_source" type="xs:string">


### PR DESCRIPTION
Fixes rendering issue with un-escaped pipe character in tool XML schema docs (screenshot below), as mentioned in https://github.com/galaxyproject/tools-iuc/issues/5729:

![image](https://github.com/galaxyproject/galaxy/assets/42562517/b06cda74-5eb4-43f2-9b08-a5946ea79b26)

## How to test the changes?
(Select all options that apply)
Not applicable. Here it is built locally:

![image](https://github.com/galaxyproject/galaxy/assets/42562517/8a4b485b-e67e-43f2-a811-7bd28128ab60)

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
