### PR TITLE
XSD schema doc building: quote pipe characters in attribute tables

### DIFF
--- a/doc/parse_gx_xsd.py
+++ b/doc/parse_gx_xsd.py
@@ -167,6 +167,7 @@ def _build_attributes_table(tag, attributes, hide_attributes=False, attribute_na
 
             use = attribute.attrib.get("use", "optional") == "required"
             details = details.replace("\n", " ").strip()
+            details = details.replace("|", "\\|").strip()
             best_practices = _get_bp_link(annotation_el)
             if best_practices:
                 details += (

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -5267,7 +5267,7 @@ If ``true``, this output will sniffed and its format determined automatically by
     <xs:attribute name="default_identifier_source" type="xs:string">
       <xs:annotation>
         <xs:documentation xml:lang="en">Sets the source of element identifier to the specified input.
-This only applies to collections that are mapped over a non-collection input and that have equivalent structures. If this references input elements in conditionals, this value should be qualified (e.g. ``cond\|input`` instead of ``input`` if ``input`` is in a conditional with ``name="cond"``).</xs:documentation>
+This only applies to collections that are mapped over a non-collection input and that have equivalent structures. If this references input elements in conditionals, this value should be qualified (e.g. ``cond|input`` instead of ``input`` if ``input`` is in a conditional with ``name="cond"``).</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="metadata_source" type="xs:string">


### PR DESCRIPTION
With this `default_identifier_source` and other things using `|` are shown correctly:

![Screenshot from 2024-01-26 16-23-12](https://github.com/galaxyproject/galaxy/assets/25689525/96236a7d-a3eb-47a1-a29a-21bffae6bf15)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. make doc

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
