### PR TITLE
Combines legacy qv-pattern and advanced filter pattern in history index endpoint

### DIFF
--- a/client/src/api/histories.ts
+++ b/client/src/api/histories.ts
@@ -6,5 +6,4 @@ export const deleteHistory = fetcher.path("/api/histories/{history_id}").method(
 export const deleteHistories = fetcher.path("/api/histories/batch/delete").method("put").create();
 export const undeleteHistory = fetcher.path("/api/histories/deleted/{history_id}/undelete").method("post").create();
 export const undeleteHistories = fetcher.path("/api/histories/batch/undelete").method("put").create();
-export const historiesQuery = fetcher.path("/api/histories").method("get").create();
 export const publishedHistoriesFetcher = fetcher.path("/api/histories/published").method("get").create();

--- a/client/src/api/histories.ts
+++ b/client/src/api/histories.ts
@@ -6,5 +6,5 @@ export const deleteHistory = fetcher.path("/api/histories/{history_id}").method(
 export const deleteHistories = fetcher.path("/api/histories/batch/delete").method("put").create();
 export const undeleteHistory = fetcher.path("/api/histories/deleted/{history_id}/undelete").method("post").create();
 export const undeleteHistories = fetcher.path("/api/histories/batch/undelete").method("put").create();
-export const historiesQuery = fetcher.path("/api/histories/query").method("get").create();
+export const historiesQuery = fetcher.path("/api/histories").method("get").create();
 export const publishedHistoriesFetcher = fetcher.path("/api/histories/published").method("get").create();

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -476,7 +476,7 @@ export interface paths {
         get: operations["search_forum_api_help_forum_search_get"];
     };
     "/api/histories": {
-        /** Returns histories for the current user. */
+        /** Returns histories available to the current user. */
         get: operations["index_api_histories_get"];
         /**
          * Creates a new history.
@@ -528,10 +528,6 @@ export interface paths {
     "/api/histories/published": {
         /** Return all histories that are published. */
         get: operations["published_api_histories_published_get"];
-    };
-    "/api/histories/query": {
-        /** Returns histories available to the current user. */
-        get: operations["query_api_histories_query_get"];
     };
     "/api/histories/shared_with_me": {
         /** Return all histories that are shared with the current user. */
@@ -13823,8 +13819,46 @@ export interface operations {
         };
     };
     index_api_histories_get: {
-        /** Returns histories for the current user. */
+        /** Returns histories available to the current user. */
         parameters?: {
+            /** @description The maximum number of items to return. */
+            /** @description Starts at the beginning skip the first ( offset - 1 ) items and begin returning at the Nth item */
+            /** @description Sort index by this specified attribute */
+            /** @description Sort in descending order? */
+            /**
+             * @description A mix of free text and GitHub-style tags used to filter the index operation.
+             *
+             * ## Query Structure
+             *
+             * GitHub-style filter tags (not be confused with Galaxy tags) are tags of the form
+             * `<tag_name>:<text_no_spaces>` or `<tag_name>:'<text with potential spaces>'`. The tag name
+             * *generally* (but not exclusively) corresponds to the name of an attribute on the model
+             * being indexed (i.e. a column in the database).
+             *
+             * If the tag is quoted, the attribute will be filtered exactly. If the tag is unquoted,
+             * generally a partial match will be used to filter the query (i.e. in terms of the implementation
+             * this means the database operation `ILIKE` will typically be used).
+             *
+             * Once the tagged filters are extracted from the search query, the remaining text is just
+             * used to search various documented attributes of the object.
+             *
+             * ## GitHub-style Tags Available
+             *
+             * `name`
+             * : The history's name.
+             *
+             * `annotation`
+             * : The history's annotation. (The tag `a` can be used a short hand alias for this tag to filter on this attribute.)
+             *
+             * `tag`
+             * : The history's tags. (The tag `t` can be used a short hand alias for this tag to filter on this attribute.)
+             *
+             * ## Free Text
+             *
+             * Free text search terms will be searched against the following attributes of the
+             * Historys: `title`, `description`, `slug`, `tag`.
+             */
+            /** @description Filtering parameters are evaluated in q/qv-mode */
             /** @description Whether all histories from other users in this Galaxy should be included. Only admins are allowed to query all histories. */
             /**
              * @deprecated
@@ -13832,18 +13866,23 @@ export interface operations {
              */
             /** @description Generally a property name to filter by followed by an (often optional) hyphen and operator string. */
             /** @description The value to filter by. */
-            /** @description Starts at the beginning skip the first ( offset - 1 ) items and begin returning at the Nth item */
-            /** @description The maximum number of items to return. */
             /** @description String containing one of the valid ordering attributes followed (optionally) by '-asc' or '-dsc' for ascending and descending order respectively. Orders can be stacked as a comma-separated list of values. */
             /** @description View to be passed to the serializer */
             /** @description Comma-separated list of keys to be passed to the serializer */
             query?: {
+                limit?: number | null;
+                offset?: number | null;
+                show_own?: boolean;
+                show_published?: boolean;
+                show_shared?: boolean;
+                sort_by?: "create_time" | "name" | "update_time" | "username";
+                sort_desc?: boolean;
+                search?: string | null;
+                qqv_mode?: boolean | null;
                 all?: boolean | null;
                 deleted?: boolean | null;
                 q?: string[] | null;
                 qv?: string[] | null;
-                offset?: number | null;
-                limit?: number | null;
                 order?: string | null;
                 view?: string | null;
                 keys?: string | null;
@@ -13857,11 +13896,13 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": (
-                        | components["schemas"]["HistoryDetailed"]
-                        | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryMinimal"]
-                    )[];
+                    "application/json":
+                        | (
+                              | components["schemas"]["HistoryDetailed"]
+                              | components["schemas"]["HistorySummary"]
+                              | components["schemas"]["HistoryMinimal"]
+                          )[]
+                        | components["schemas"]["HistoryQueryResultList"];
                 };
             };
             /** @description Validation Error */
@@ -14272,76 +14313,6 @@ export interface operations {
                         | components["schemas"]["HistorySummary"]
                         | components["schemas"]["HistoryMinimal"]
                     )[];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    query_api_histories_query_get: {
-        /** Returns histories available to the current user. */
-        parameters?: {
-            /** @description The maximum number of items to return. */
-            /** @description Starts at the beginning skip the first ( offset - 1 ) items and begin returning at the Nth item */
-            /** @description Sort index by this specified attribute */
-            /** @description Sort in descending order? */
-            /**
-             * @description A mix of free text and GitHub-style tags used to filter the index operation.
-             *
-             * ## Query Structure
-             *
-             * GitHub-style filter tags (not be confused with Galaxy tags) are tags of the form
-             * `<tag_name>:<text_no_spaces>` or `<tag_name>:'<text with potential spaces>'`. The tag name
-             * *generally* (but not exclusively) corresponds to the name of an attribute on the model
-             * being indexed (i.e. a column in the database).
-             *
-             * If the tag is quoted, the attribute will be filtered exactly. If the tag is unquoted,
-             * generally a partial match will be used to filter the query (i.e. in terms of the implementation
-             * this means the database operation `ILIKE` will typically be used).
-             *
-             * Once the tagged filters are extracted from the search query, the remaining text is just
-             * used to search various documented attributes of the object.
-             *
-             * ## GitHub-style Tags Available
-             *
-             * `name`
-             * : The history's name.
-             *
-             * `annotation`
-             * : The history's annotation. (The tag `a` can be used a short hand alias for this tag to filter on this attribute.)
-             *
-             * `tag`
-             * : The history's tags. (The tag `t` can be used a short hand alias for this tag to filter on this attribute.)
-             *
-             * ## Free Text
-             *
-             * Free text search terms will be searched against the following attributes of the
-             * Historys: `title`, `description`, `slug`, `tag`.
-             */
-            query?: {
-                limit?: number | null;
-                offset?: number | null;
-                show_own?: boolean;
-                show_published?: boolean;
-                show_shared?: boolean;
-                sort_by?: "create_time" | "name" | "update_time" | "username";
-                sort_desc?: boolean;
-                search?: string | null;
-            };
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string | null;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["HistoryQueryResultList"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -2235,6 +2235,11 @@ export interface components {
              */
             user_id?: string | null;
             /**
+             * Username
+             * @description Owner of the history
+             */
+            username?: string | null;
+            /**
              * Username and slug
              * @description The relative URL in the form of /u/{username}/h/{slug}
              */
@@ -6400,6 +6405,11 @@ export interface components {
              */
             user_id?: string | null;
             /**
+             * Username
+             * @description Owner of the history
+             */
+            username?: string | null;
+            /**
              * Username and slug
              * @description The relative URL in the form of /u/{username}/h/{slug}
              */
@@ -6426,61 +6436,6 @@ export interface components {
             user_id?: string | null;
             [key: string]: unknown | undefined;
         };
-        /** HistoryQueryResult */
-        HistoryQueryResult: {
-            /**
-             * Annotation
-             * @description The annotation of this History.
-             */
-            annotation?: string | null;
-            /**
-             * Create Time
-             * @description The time and date this item was created.
-             */
-            create_time: string | null;
-            /**
-             * Deleted
-             * @description Whether this History has been deleted.
-             */
-            deleted: boolean;
-            /**
-             * ID
-             * @description Encoded ID of the History.
-             * @example 0123456789ABCDEF
-             */
-            id: string;
-            /**
-             * Importable
-             * @description Whether this History can be imported.
-             */
-            importable: boolean;
-            /**
-             * Name
-             * @description The name of the History.
-             */
-            name: string;
-            /**
-             * Published
-             * @description Whether this History has been published.
-             */
-            published: boolean;
-            /**
-             * Tags
-             * @description A list of tags to add to this item.
-             */
-            tags: components["schemas"]["TagCollection"] | null;
-            /**
-             * Update Time
-             * @description The last time and date this item was updated.
-             */
-            update_time: string | null;
-            [key: string]: unknown | undefined;
-        };
-        /**
-         * HistoryQueryResultList
-         * @default []
-         */
-        HistoryQueryResultList: components["schemas"]["HistoryQueryResult"][];
         /**
          * HistorySummary
          * @description History summary information.
@@ -13894,13 +13849,11 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json":
-                        | (
-                              | components["schemas"]["HistoryDetailed"]
-                              | components["schemas"]["HistorySummary"]
-                              | components["schemas"]["HistoryMinimal"]
-                          )[]
-                        | components["schemas"]["HistoryQueryResultList"];
+                    "application/json": (
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["HistorySummary"]
+                        | components["schemas"]["HistoryMinimal"]
+                    )[];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -13858,7 +13858,6 @@ export interface operations {
              * Free text search terms will be searched against the following attributes of the
              * Historys: `title`, `description`, `slug`, `tag`.
              */
-            /** @description Filtering parameters are evaluated in q/qv-mode */
             /** @description Whether all histories from other users in this Galaxy should be included. Only admins are allowed to query all histories. */
             /**
              * @deprecated
@@ -13878,7 +13877,6 @@ export interface operations {
                 sort_by?: "create_time" | "name" | "update_time" | "username";
                 sort_desc?: boolean;
                 search?: string | null;
-                qqv_mode?: boolean | null;
                 all?: boolean | null;
                 deleted?: boolean | null;
                 q?: string[] | null;

--- a/client/src/components/Grid/configs/histories.ts
+++ b/client/src/components/Grid/configs/histories.ts
@@ -34,7 +34,6 @@ async function getData(offset: number, limit: number, search: string, sort_by: s
     const { data, headers } = await historiesQuery({
         limit,
         offset,
-        qqv_mode: false,
         search,
         sort_by: sort_by as SortKeyLiteral,
         sort_desc,

--- a/client/src/components/Grid/configs/histories.ts
+++ b/client/src/components/Grid/configs/histories.ts
@@ -10,7 +10,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { useEventBus } from "@vueuse/core";
 
-import { deleteHistories, deleteHistory, historiesQuery, undeleteHistories, undeleteHistory } from "@/api/histories";
+import { deleteHistories, deleteHistory, historiesFetcher, undeleteHistories, undeleteHistory } from "@/api/histories";
 import { updateTags } from "@/api/tags";
 import { useHistoryStore } from "@/stores/historyStore";
 import Filtering, { contains, equals, expandNameTag, toBool, type ValidFilter } from "@/utils/filtering";
@@ -31,7 +31,7 @@ type SortKeyLiteral = "create_time" | "name" | "update_time" | undefined;
  * Request and return data from server
  */
 async function getData(offset: number, limit: number, search: string, sort_by: string, sort_desc: boolean) {
-    const { data, headers } = await historiesQuery({
+    const { data, headers } = await historiesFetcher({
         limit,
         offset,
         search,

--- a/client/src/components/Grid/configs/histories.ts
+++ b/client/src/components/Grid/configs/histories.ts
@@ -34,6 +34,7 @@ async function getData(offset: number, limit: number, search: string, sort_by: s
     const { data, headers } = await historiesQuery({
         limit,
         offset,
+        qqv_mode: false,
         search,
         sort_by: sort_by as SortKeyLiteral,
         sort_desc,

--- a/client/src/components/Grid/configs/historiesShared.ts
+++ b/client/src/components/Grid/configs/historiesShared.ts
@@ -1,7 +1,7 @@
 import { faEye } from "@fortawesome/free-solid-svg-icons";
 import { useEventBus } from "@vueuse/core";
 
-import { historiesQuery } from "@/api/histories";
+import { historiesFetcher } from "@/api/histories";
 import { updateTags } from "@/api/tags";
 import Filtering, { contains, expandNameTag, type ValidFilter } from "@/utils/filtering";
 import _l from "@/utils/localization";
@@ -21,7 +21,7 @@ type SortKeyLiteral = "create_time" | "name" | "update_time" | undefined;
  * Request and return data from server
  */
 async function getData(offset: number, limit: number, search: string, sort_by: string, sort_desc: boolean) {
-    const { data, headers } = await historiesQuery({
+    const { data, headers } = await historiesFetcher({
         limit,
         offset,
         search,

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1283,7 +1283,6 @@ HistoryStateIds = Dict[DatasetState, List[DecodedDatabaseIdField]]
 
 class HistoryDetailed(HistorySummary):  # Equivalent to 'dev-detailed' view, which seems the default
     """History detailed information."""
-
     contents_url: ContentsUrlField
     size: int = Field(
         ...,
@@ -1305,6 +1304,11 @@ class HistoryDetailed(HistorySummary):  # Equivalent to 'dev-detailed' view, whi
         None,
         title="Slug",
         description="Part of the URL to uniquely identify this History by link in a readable way.",
+    )
+    username: Optional[str] = Field(
+        None,
+        title="Username",
+        description="Owner of the history",
     )
     username_and_slug: Optional[str] = Field(
         None,
@@ -1332,6 +1336,13 @@ class HistoryDetailed(HistorySummary):  # Equivalent to 'dev-detailed' view, whi
             "A dictionary keyed to possible dataset states and valued with the number "
             "of datasets in this history that have those states."
         ),
+    )
+
+
+class HistoryDetailedList(RootModel):
+    root: List[HistoryDetailed] = Field(
+        default=[],
+        title="List with detailed information of Histories.",
     )
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1283,6 +1283,7 @@ HistoryStateIds = Dict[DatasetState, List[DecodedDatabaseIdField]]
 
 class HistoryDetailed(HistorySummary):  # Equivalent to 'dev-detailed' view, which seems the default
     """History detailed information."""
+
     contents_url: ContentsUrlField
     size: int = Field(
         ...,
@@ -1336,13 +1337,6 @@ class HistoryDetailed(HistorySummary):  # Equivalent to 'dev-detailed' view, whi
             "A dictionary keyed to possible dataset states and valued with the number "
             "of datasets in this history that have those states."
         ),
-    )
-
-
-class HistoryDetailedList(RootModel):
-    root: List[HistoryDetailed] = Field(
-        default=[],
-        title="List with detailed information of Histories.",
     )
 
 

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -36,7 +36,6 @@ from galaxy.schema import (
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.history import (
     HistoryIndexQueryPayload,
-    HistoryQueryResultList,
     HistorySortByEnum,
 )
 from galaxy.schema.schema import (
@@ -186,7 +185,7 @@ class FastAPIHistories:
             description="Whether to return only deleted items.",
             deprecated=True,  # Marked as deprecated as it seems just like '/api/histories/deleted'
         ),
-    ) -> Union[List[AnyHistoryView], HistoryQueryResultList]:
+    ) -> List[AnyHistoryView]:
         if search is None:
             return self.service.index(
                 trans, serialization_params, filter_query_params, deleted_only=deleted, all_histories=all

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -108,12 +108,6 @@ JehaIDPathParam: Union[DecodedDatabaseIdField, LatestLiteral] = Path(
     examples=["latest"],
 )
 
-QQVModeParam: bool = Query(
-    default=True,
-    title="Use query parameters q/qv-mode",
-    description="Filtering parameters are evaluated in q/qv-mode",
-)
-
 SearchQueryParam: Optional[str] = search_query_param(
     model_name="History",
     tags=query_tags,
@@ -183,7 +177,6 @@ class FastAPIHistories:
         sort_by: HistorySortByEnum = SortByQueryParam,
         sort_desc: bool = SortDescQueryParam,
         search: Optional[str] = SearchQueryParam,
-        qqv_mode: Optional[bool] = QQVModeParam,
         filter_query_params: FilterQueryParams = Depends(get_filter_query_params),
         serialization_params: SerializationParams = Depends(query_serialization_params),
         all: Optional[bool] = AllHistoriesQueryParam,
@@ -194,7 +187,7 @@ class FastAPIHistories:
             deprecated=True,  # Marked as deprecated as it seems just like '/api/histories/deleted'
         ),
     ) -> Union[List[AnyHistoryView], HistoryQueryResultList]:
-        if qqv_mode:
+        if search is None:
             return self.service.index(
                 trans, serialization_params, filter_query_params, deleted_only=deleted, all_histories=all
             )

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -51,9 +51,7 @@ from galaxy.schema import (
     SerializationParams,
 )
 from galaxy.schema.fields import DecodedDatabaseIdField
-from galaxy.schema.history import (
-    HistoryIndexQueryPayload,
-)
+from galaxy.schema.history import HistoryIndexQueryPayload
 from galaxy.schema.schema import (
     AnyArchivedHistoryView,
     AnyHistoryView,
@@ -65,7 +63,6 @@ from galaxy.schema.schema import (
     CustomBuildsMetadataResponse,
     ExportHistoryArchivePayload,
     HistoryArchiveExportResult,
-    HistoryDetailedList,
     HistoryImportArchiveSourceType,
     JobExportHistoryArchiveModel,
     JobIdResponse,
@@ -220,15 +217,16 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         trans,
         payload: HistoryIndexQueryPayload,
         include_total_count: bool = False,
-    ) -> Tuple[HistoryDetailedList, int]:
+    ) -> Tuple[List[AnyHistoryView], int]:
         """Return a list of History accessible by the user
 
         :rtype:     list
         :returns:   dictionaries containing History details
         """
+        serialization_params = SerializationParams(default_view="detailed")
         entries, total_matches = self.manager.index_query(trans, payload, include_total_count)
         return (
-            HistoryDetailedList(root=[entry.to_dict(view="element") for entry in entries]),
+            [self._serialize_history(trans, entry, serialization_params) for entry in entries],
             total_matches,
         )
 

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -53,7 +53,6 @@ from galaxy.schema import (
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.history import (
     HistoryIndexQueryPayload,
-    HistoryQueryResultList,
 )
 from galaxy.schema.schema import (
     AnyArchivedHistoryView,
@@ -66,6 +65,7 @@ from galaxy.schema.schema import (
     CustomBuildsMetadataResponse,
     ExportHistoryArchivePayload,
     HistoryArchiveExportResult,
+    HistoryDetailedList,
     HistoryImportArchiveSourceType,
     JobExportHistoryArchiveModel,
     JobIdResponse,
@@ -220,7 +220,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         trans,
         payload: HistoryIndexQueryPayload,
         include_total_count: bool = False,
-    ) -> Tuple[HistoryQueryResultList, int]:
+    ) -> Tuple[HistoryDetailedList, int]:
         """Return a list of History accessible by the user
 
         :rtype:     list
@@ -228,7 +228,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         """
         entries, total_matches = self.manager.index_query(trans, payload, include_total_count)
         return (
-            HistoryQueryResultList(root=[entry.to_dict(view="element") for entry in entries]),
+            HistoryDetailedList(root=[entry.to_dict(view="element") for entry in entries]),
             total_matches,
         )
 

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -176,6 +176,47 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
             index_response = self._get(f"histories{query}").json()
             assert len(index_response) == 3
 
+    def test_index_advanced_filter(self):
+        # Create the histories with a different user to ensure the test
+        # is not conflicted with the current user's histories.
+        with self._different_user(f"user_{uuid4()}@bx.psu.edu"):
+            unique_id = uuid4()
+            expected_history_name = f"Test History That Match Query_{unique_id}"
+            self._create_history(expected_history_name)
+            self._create_history(expected_history_name.upper())
+            history_0 = self._create_history(expected_history_name.lower())["id"]
+            history_1 = self._create_history(f"Another history_{uuid4()}")["id"]
+            self._delete(f"histories/{history_1}")
+
+            name_contains = "history"
+            query = f"?search={name_contains}"
+            index_response = self._get(f"histories{query}").json()
+            assert len(index_response) == 3
+
+            name_contains = "history that match query"
+            query = f"?search={name_contains}"
+            index_response = self._get(f"histories{query}").json()
+            assert len(index_response) == 3
+
+            name_contains = "ANOTHER"
+            query = f"?search={name_contains}"
+            index_response = self._get(f"histories{query}").json()
+            assert len(index_response) == 0
+
+            name_contains = "test"
+            query = f"?search={name_contains}"
+            index_response = self._get(f"histories{query}").json()
+            assert len(index_response) == 3
+
+            data = dict(search="is:deleted", show_published=False)
+            index_response = self._get("histories", data=data).json()
+            assert len(index_response) == 1
+
+            self._update(history_0, {"published": True})
+            data = dict(search="is:published")
+            index_response = self._get("histories", data=data).json()
+            assert len(index_response) == 1
+
     def test_delete(self):
         # Setup a history and ensure it is in the index
         history_id = self._create_history("TestHistoryForDelete")["id"]


### PR DESCRIPTION
Requires #17282. This PR combines the legacy q/qv and the advanced filter history index endpoints as discussed in the backend group meeting. In a follow-up the q/qv endpoint parameters will be deprecated.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
