### PR TITLE
Add explicit cache_ok attribute to JSONType subclass

### DIFF
--- a/lib/galaxy/model/custom_types.py
+++ b/lib/galaxy/model/custom_types.py
@@ -117,6 +117,8 @@ class JSONType(TypeDecorator):
 
 
 class DoubleEncodedJsonType(JSONType):
+    cache_ok = True
+
     def process_result_value(self, value, dialect):
         value = super().process_result_value(value, dialect)
         if isinstance(value, str):


### PR DESCRIPTION
As for the other JSONType subclasses this is safe.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
