### PR TITLE
[23.2] Fix the purge historyless HDAs pgcleanup action

### DIFF
--- a/scripts/cleanup_datasets/pgcleanup.py
+++ b/scripts/cleanup_datasets/pgcleanup.py
@@ -912,7 +912,8 @@ class PurgeHistorylessHDAs(PurgesHDAs, RemovesMetadataFiles, RequiresDiskUsageRe
                      FROM dataset
                     WHERE history_id IS NULL{force_retry_sql}{object_store_id_sql}
                           AND history_dataset_association.update_time < (NOW() AT TIME ZONE 'utc' - interval '%(days)s days')
-                RETURNING id),
+                RETURNING history_dataset_association.id as id,
+                          history_dataset_association.history_id as history_id),
              hda_events
           AS (INSERT INTO cleanup_event_hda_association
                           (create_time, cleanup_event_id, hda_id)
@@ -920,12 +921,15 @@ class PurgeHistorylessHDAs(PurgesHDAs, RemovesMetadataFiles, RequiresDiskUsageRe
                      FROM purged_hda_ids),
              {purge_hda_dependencies_sql}
       SELECT purged_hda_ids.id AS purged_hda_id,
+             history.user_id AS recalculate_disk_usage_user_id,
              deleted_metadata_file_ids.id AS deleted_metadata_file_id,
              deleted_metadata_file_ids.uuid AS deleted_metadata_file_uuid,
              deleted_metadata_file_ids.object_store_id AS object_store_id,
              deleted_icda_ids.id AS deleted_icda_id,
              deleted_icda_ids.hda_id AS deleted_icda_hda_id
         FROM purged_hda_ids
+             LEFT OUTER JOIN history
+                             ON purged_hda_ids.history_id = history.id
              LEFT OUTER JOIN deleted_metadata_file_ids
                              ON deleted_metadata_file_ids.hda_id = purged_hda_ids.id
              LEFT OUTER JOIN deleted_icda_ids


### PR DESCRIPTION
Fixes two errors:

```
psycopg2.errors.AmbiguousColumn: column reference "id" is ambiguous
LINE 8:                 RETURNING id),
                                  ^
```

And

```
AttributeError: 'Record' object has no attribute 'recalculate_disk_usage_user_id'
```

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. ```
     UPDATE history_dataset_association SET history_id = null WHERE id = 1;
     ```
  2. ```
     python ./scripts/cleanup_datasets/pgcleanup.py -d -o 0 purge_historyless_hdas
     ```

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
