### PR TITLE
[23.0] Fix History contents `genome_build` filter postgresql bug

### DIFF
--- a/lib/galaxy/managers/genomes.py
+++ b/lib/galaxy/managers/genomes.py
@@ -78,6 +78,7 @@ class GenomesManager:
 
 class GenomeFilterMixin:
     orm_filter_parsers: "OrmFilterParsersType"
+    database_connection: str
     valid_ops = ("eq", "contains", "has")
 
     def create_genome_filter(self, attr, op, val):
@@ -89,19 +90,21 @@ class GenomeFilterMixin:
             # Doesn't filter genome_build for collections
             if model_class.__name__ == "HistoryDatasetCollectionAssociation":
                 return False
-            # TODO: should use is_postgres(self.app.config.database_connection) in 23.2
-            if self.app.config.database_connection.startswith("postgres"):
+            # TODO: should use is_postgres(self.database_connection) in 23.2
+            if self.database_connection.startswith("postgres"):
                 column = text("convert_from(metadata, 'UTF8')::json ->> 'dbkey'")
             else:
                 column = func.json_extract(model_class.table.c._metadata, "$.dbkey")
             lower_val = val.lower()  # Ignore case
+            # dbkey can either be "hg38" or '["hg38"]', so we need to check both
             if op == "eq":
-                cond = func.lower(column) == lower_val
+                cond = func.lower(column) == lower_val or func.lower(column) == f'["{lower_val}"]'
             else:
                 cond = func.lower(column).contains(lower_val, autoescape=True)
             return cond
 
         return _create_genome_filter
 
-    def _add_parsers(self):
+    def _add_parsers(self, database_connection: str):
+        self.database_connection = database_connection
         self.orm_filter_parsers.update({"genome_build": self.create_genome_filter})

--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -631,9 +631,10 @@ class HistoryContentsFilters(
         return [self.decode_type_id(type_id) for type_id in type_id_list_string.split(sep)]
 
     def _add_parsers(self):
+        database_connection: str = self.app.config.database_connection
         super()._add_parsers()
         annotatable.AnnotatableFilterMixin._add_parsers(self)
-        genomes.GenomeFilterMixin._add_parsers(self)
+        genomes.GenomeFilterMixin._add_parsers(self, database_connection)
         deletable.PurgableFiltersMixin._add_parsers(self)
         taggable.TaggableFilterMixin._add_parsers(self)
         tools.ToolFilterMixin._add_parsers(self)

--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -631,8 +631,8 @@ class HistoryContentsFilters(
         return [self.decode_type_id(type_id) for type_id in type_id_list_string.split(sep)]
 
     def _add_parsers(self):
-        database_connection: str = self.app.config.database_connection
         super()._add_parsers()
+        database_connection: str = self.app.config.database_connection
         annotatable.AnnotatableFilterMixin._add_parsers(self)
         genomes.GenomeFilterMixin._add_parsers(self, database_connection)
         deletable.PurgableFiltersMixin._add_parsers(self)


### PR DESCRIPTION
Check the user's db connection and use appropriate query/function.
Fixes #17371 
This was caused in #15505 ; `json_extract` only works for sqlite databases.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
