### PR TITLE
Fix minor oidc_backends_config comment bug

### DIFF
--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -150,7 +150,7 @@ Please mind `http` and `https`.
         <!-- <icon>https://path/to/icon</icon>  -->
         <!-- (Optional) Enable PKCE for this IDP -->
         <!-- <pkce_support>false</pkce_support> -->
-        <!-- (Optional) the audiences accepted on the access-token for this IDP.
+        <!-- (Optional) the audiences accepted on the access-token for this IDP. -->
         <!-- <accepted_audiences>galaxy</accepted_audiences> -->
 
     </provider>


### PR DESCRIPTION
The comment for `<accepted_audiences>` in `oidc_backend_config` causes an error when starting Galaxy:

```
    File "config/oidc_backends_config.xml", line 154
lxml.etree.XMLSyntaxError: Double hyphen within comment, line 154, column 11
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
