### PR TITLE
[23.1] Set webdav file source to use temp files by default

### DIFF
--- a/lib/galaxy/config/sample/file_sources_conf.yml.sample
+++ b/lib/galaxy/config/sample/file_sources_conf.yml.sample
@@ -15,6 +15,9 @@
   # By default, the plugin will use temp files to avoid loading entire files into memory. 
   # You can change the directory here or omit to use the default temp directory.
   temp_path: /your/temp/path
+  # Set writable to true if you have write access to this source
+  # and want to allow exporting files to it, by default is read only.
+  writable: false
 
 - type: posix
   root: '/data/5/galaxy_import/galaxy_user_data/covid-19/data/sequences/'

--- a/lib/galaxy/config/sample/file_sources_conf.yml.sample
+++ b/lib/galaxy/config/sample/file_sources_conf.yml.sample
@@ -12,6 +12,9 @@
   root: ${user.preferences['owncloud|root']}
   login: ${user.preferences['owncloud|username']}
   password: ${user.preferences['owncloud|password']}
+  # By default, the plugin will use temp files to avoid loading entire files into memory. 
+  # You can change the directory here or omit to use the default temp directory.
+  temp_path: /your/temp/path
 
 - type: posix
   root: '/data/5/galaxy_import/galaxy_user_data/covid-19/data/sequences/'

--- a/lib/galaxy/files/sources/webdav.py
+++ b/lib/galaxy/files/sources/webdav.py
@@ -3,6 +3,7 @@ try:
 except ImportError:
     WebDAVFS = None
 
+import tempfile
 from typing import (
     Optional,
     Union,
@@ -22,6 +23,11 @@ class WebDavFilesSource(PyFilesystem2FilesSource):
 
     def _open_fs(self, user_context=None, opts: Optional[FilesSourceOptions] = None):
         props = self._serialization_props(user_context)
+        use_temp_files = props.pop("use_temp_files", None)
+        if use_temp_files is None:
+            # Default to True to avoid memory issues with large files.
+            props["use_temp_files"] = True
+            props["temp_path"] = props.get("temp_path", tempfile.gettempdir())
         extra_props: Union[FilesSourceProperties, dict] = opts.extra_props or {} if opts else {}
         handle = WebDAVFS(**{**props, **extra_props})
         return handle

--- a/lib/galaxy/files/sources/webdav.py
+++ b/lib/galaxy/files/sources/webdav.py
@@ -27,7 +27,7 @@ class WebDavFilesSource(PyFilesystem2FilesSource):
         if use_temp_files is None:
             # Default to True to avoid memory issues with large files.
             props["use_temp_files"] = True
-            props["temp_path"] = props.get("temp_path", tempfile.gettempdir())
+            props["temp_path"] = props.get("temp_path", tempfile.TemporaryDirectory(prefix="webdav_"))
         extra_props: Union[FilesSourceProperties, dict] = opts.extra_props or {} if opts else {}
         handle = WebDAVFS(**{**props, **extra_props})
         return handle


### PR DESCRIPTION
By default, the `webdav` file source plugin will use temp files instead of loading the entire file into memory. Otherwise, dealing with big files can create hard-to-debug issues.

I have updated the sample configuration with some comments.

Thanks to @alpapan for reporting.

xref #17372

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
