### PR TITLE
Add name_eq and genome_build_eq filters to HistoryFilters

### DIFF
--- a/client/src/components/History/HistoryFilters.js
+++ b/client/src/components/History/HistoryFilters.js
@@ -7,6 +7,7 @@ const states = Object.keys(STATES).filter((state) => !excludeStates.includes(sta
 
 const validFilters = {
     name: { placeholder: "name", type: String, handler: contains("name"), menuItem: true },
+    name_eq: { handler: equals("name"), menuItem: false },
     extension: { placeholder: "extension", type: String, handler: equals("extension"), menuItem: true },
     tag: { placeholder: "tag", type: String, handler: contains("tags", "tag", expandNameTag), menuItem: true },
     state: {
@@ -18,6 +19,7 @@ const validFilters = {
         menuItem: true,
     },
     genome_build: { placeholder: "database", type: String, handler: contains("genome_build"), menuItem: true },
+    genome_build_eq: { handler: equals("genome_build"), menuItem: false },
     related: { placeholder: "related", type: Number, handler: equals("related"), menuItem: true },
     hid: { placeholder: "index", type: Number, handler: equals("hid"), isRangeInput: true, menuItem: true },
     hid_ge: { handler: compare("hid", "ge"), menuItem: false },

--- a/client/src/utils/filtering.test.js
+++ b/client/src/utils/filtering.test.js
@@ -85,6 +85,8 @@ describe("filtering", () => {
         expect(HistoryFilters.getFilterValue(filterTexts[1], "create_time_gt", true)).toBe(1609459200);
         expect(HistoryFilters.getFilterValue("", "deleted")).toBe(false);
         expect(HistoryFilters.getFilterValue("", "visible")).toBe(true);
+        expect(HistoryFilters.getFilterValue("name_eq:Select", "name")).toBe(undefined);
+        expect(HistoryFilters.getFilterValue("name_eq:Select", "name_eq")).toBe("select");
     });
     test("parse get valid filters and settings", () => {
         sampleFilters.forEach((sample) => {
@@ -115,6 +117,9 @@ describe("filtering", () => {
             expect(filters[8][1]).toBe("false");
             expect(filters[9][0]).toBe("visible");
             expect(filters[9][1]).toBe("true");
+            const filters_eq = HistoryFilters.getFiltersForText('genome_build_eq:"hg19"');
+            expect(filters_eq[0][0]).toBe("genome_build_eq");
+            expect(filters_eq[0][1]).toBe("hg19");
         });
     });
     test("parse filter text as query dictionary", () => {
@@ -131,6 +136,8 @@ describe("filtering", () => {
             expect(queryDict["deleted"]).toBe(false);
             expect(queryDict["visible"]).toBe(true);
         });
+        const queryDict = HistoryFilters.getQueryDict("name_eq:'name of item'");
+        expect(queryDict["name-eq"]).toBe("name of item");
     });
     test("apply valid filters to existing filterText", () => {
         expect(HistoryFilters.applyFiltersToText(sampleFilters[0].filters, "")).toEqual("deleted:true visible:true");


### PR DESCRIPTION
Fixes #17370 
Allows users to filter `"name-eq:'Select random lines on data 58'"`

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
