### PR TITLE
Cancel all active jobs when the user is deleted

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -40,6 +40,7 @@ from galaxy.managers import (
 )
 from galaxy.managers.base import combine_lists
 from galaxy.model import (
+    Job,
     User,
     UserAddress,
     UserQuotaUsage,
@@ -161,6 +162,23 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
                 "The configuration of this Galaxy instance does not allow admins to delete users."
             )
         super().delete(user, flush=flush)
+        self._stop_all_jobs_from_user(user)
+
+    def _stop_all_jobs_from_user(self, user):
+        active_jobs = self._get_all_active_jobs_from_user(user)
+        message = "User deleted"
+        session = self.session()
+        for job in active_jobs:
+            job.mark_deleted(self.app.config.track_jobs_in_database)
+            with transaction(session):
+                session.commit()
+            self.app.job_manager.stop(job, message)
+
+    def _get_all_active_jobs_from_user(self, user: User) -> List[Job]:
+        """Get all jobs that are not ready yet and belong to the given user."""
+        stmt = select(Job).where(and_(Job.user_id == user.id, Job.state.in_(Job.non_ready_states)))
+        jobs = self.session().scalars(stmt)
+        return jobs
 
     def undelete(self, user, flush=True):
         """Remove the deleted flag for the given user."""

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -166,13 +166,11 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
 
     def _stop_all_jobs_from_user(self, user):
         active_jobs = self._get_all_active_jobs_from_user(user)
-        message = "User deleted"
         session = self.session()
         for job in active_jobs:
             job.mark_deleted(self.app.config.track_jobs_in_database)
-            with transaction(session):
-                session.commit()
-            self.app.job_manager.stop(job, message)
+        with transaction(session):
+            session.commit()
 
     def _get_all_active_jobs_from_user(self, user: User) -> List[Job]:
         """Get all jobs that are not ready yet and belong to the given user."""

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -156,10 +156,15 @@ class TestUsersApi(ApiTestCase):
             )
             self._assert_status_code_is_ok(run_response)
 
-            # Get the job state
             job_id = run_response.json()["outputs"][0]["id"]
+
+            # Wait a bit for the job to be ready
+            expected_job_states = ["new", "queued", "running"]
+            dataset_populator.wait_for_job(job_id, ok_states=expected_job_states)
+
+            # Get the job state
             job_response = self._get(f"jobs/{job_id}").json()
-            assert job_response["state"] in ["new", "queued", "running"], job_response
+            assert job_response["state"] in expected_job_states, job_response
 
             # Delete user will cancel all jobs
             self._delete(f"users/{user_id}", admin=True)

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -156,7 +156,7 @@ class TestUsersApi(ApiTestCase):
             )
             self._assert_status_code_is_ok(run_response)
 
-            job_id = run_response.json()["outputs"][0]["id"]
+            job_id = run_response.json()["jobs"][0]["id"]
 
             # Wait a bit for the job to be ready
             expected_job_states = ["new", "queued", "running"]

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -164,9 +164,9 @@ class TestUsersApi(ApiTestCase):
             # Delete user will cancel all jobs
             self._delete(f"users/{user_id}", admin=True)
 
-            # Get the job state again (this time as admin), it should be deleted
+            # Get the job state again (this time as admin), it should be deleting
             job_response = self._get(f"jobs/{job_id}", admin=True).json()
-            assert job_response["state"] == "deleted", job_response
+            assert job_response["state"] == "deleting", job_response
 
     @requires_new_user
     def test_information(self):

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -2,13 +2,18 @@ from galaxy_test.api._framework import ApiTestCase
 from galaxy_test.base.api_asserts import assert_object_id_error
 from galaxy_test.base.decorators import (
     requires_admin,
+    requires_new_history,
     requires_new_user,
 )
-from galaxy_test.base.populators import skip_without_tool
+from galaxy_test.base.populators import (
+    DatasetPopulator,
+    skip_without_tool,
+)
 
 TEST_USER_EMAIL = "user_for_users_index_test@bx.psu.edu"
 TEST_USER_EMAIL_INDEX_DELETED = "user_for_users_index_deleted_test@bx.psu.edu"
 TEST_USER_EMAIL_DELETE = "user_for_delete_test@bx.psu.edu"
+TEST_USER_EMAIL_DELETE_CANCEL_JOBS = "user_for_delete_cancel_jobs_test@bx.psu.edu"
 TEST_USER_EMAIL_PURGE = "user_for_purge_test@bx.psu.edu"
 TEST_USER_EMAIL_UNDELETE = "user_for_undelete_test@bx.psu.edu"
 TEST_USER_EMAIL_SHOW = "user_for_show_test@bx.psu.edu"
@@ -128,6 +133,40 @@ class TestUsersApi(ApiTestCase):
         self._post(f"users/deleted/{user['id']}/undelete", admin=True)
         undeleted_user = self._get(f"users/{user['id']}", admin=True).json()
         assert undeleted_user["deleted"] is False, undeleted_user
+
+    @requires_admin
+    @requires_new_user
+    @requires_new_history
+    @skip_without_tool("cat_data_and_sleep")
+    def test_delete_user_cancel_all_jobs(self):
+        dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        with self._different_user(TEST_USER_EMAIL_DELETE_CANCEL_JOBS):
+            user_id = self._get_current_user_id()
+            history_id = dataset_populator.new_history()
+            hda_id = dataset_populator.new_dataset(history_id)["id"]
+
+            inputs = {
+                "input1": {"src": "hda", "id": hda_id},
+                "sleep_time": 6000,
+            }
+            run_response = dataset_populator.run_tool_raw(
+                "cat_data_and_sleep",
+                inputs,
+                history_id,
+            )
+            self._assert_status_code_is_ok(run_response)
+
+            # Get the job state
+            job_id = run_response.json()["outputs"][0]["id"]
+            job_response = self._get(f"jobs/{job_id}").json()
+            assert job_response["state"] in ["new", "queued", "running"], job_response
+
+            # Delete user will cancel all jobs
+            self._delete(f"users/{user_id}", admin=True)
+
+            # Get the job state again (this time as admin), it should be deleted
+            job_response = self._get(f"jobs/{job_id}", admin=True).json()
+            assert job_response["state"] == "deleted", job_response
 
     @requires_new_user
     def test_information(self):


### PR DESCRIPTION
When a user is deleted there is not much point in keeping running any pending job, even if the user can be "undeleted" later.

This also helps admins easily stop right away any malicious attempt to abuse the server resources.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
