### PR TITLE
[23.2] Ignore empty lines in packages_by_dep_dag file when building packages

### DIFF
--- a/packages/build_packages.sh
+++ b/packages/build_packages.sh
@@ -10,14 +10,17 @@ cd "$(dirname "$0")"
 
 # ensure ordered by dependency dag
 while read -r package_dir; do
-    printf "\n========= RELEASING PACKAGE ${package_dir} =========\n\n"
-
-    cd "$package_dir"
-
-    make clean
-    make commit-version
-    make dist
-    make new-version
-
-    cd ..
+	if [ -n "$package_dir" ]
+	then
+		printf "\n========= RELEASING PACKAGE %s =========\n\n" "$package_dir"
+		
+		cd "$package_dir"
+		
+		make clean
+		make commit-version
+		make dist
+		make new-version
+		
+		cd ..
+	fi
 done < packages_by_dep_dag.txt

--- a/packages/build_packages.sh
+++ b/packages/build_packages.sh
@@ -10,17 +10,18 @@ cd "$(dirname "$0")"
 
 # ensure ordered by dependency dag
 while read -r package_dir; do
-	if [ -n "$package_dir" ]
-	then
-		printf "\n========= RELEASING PACKAGE %s =========\n\n" "$package_dir"
-		
-		cd "$package_dir"
-		
-		make clean
-		make commit-version
-		make dist
-		make new-version
-		
-		cd ..
-	fi
+    if [ -z "$package_dir" ]; then
+        # Skip empty lines
+        continue
+    fi
+    printf "\n========= RELEASING PACKAGE %s =========\n\n" "$package_dir"
+    
+    cd "$package_dir"
+    
+    make clean
+    make commit-version
+    make dist
+    make new-version
+    
+    cd ..
 done < packages_by_dep_dag.txt


### PR DESCRIPTION
The `packages_by_dep_dag.txt` contains empty lines (which is OK). However, the script tried to `cd` and then `..`, moving out of the `packages` directory. This fixes it. The `printf` edit is due to running shellcheck.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
