### PR TITLE
[23.0] Fix uploading of docs for release_NN.N branches

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -62,7 +62,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           case "$TARGET_BRANCH" in
-              release_[[:digit:]][[:digit:]].[[:digit:]][[:digit:]]|master)
+              release_[[:digit:]][[:digit:]].[[:digit:]][[:digit:]] | release_[[:digit:]][[:digit:]].[[:digit:]] | master)
                   UPLOAD_DIR=$TARGET_BRANCH
                   ;;
               dev)


### PR DESCRIPTION
https://docs.galaxyproject.org/en/release_23.0/ is currently empty (and same for 23.1 and 23.2).

See https://github.com/galaxyproject/galaxy/actions/runs/7725033385/job/21058422650#step:13:28

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
