### PR TITLE
[23.2] Fix creating new erronous workflow can produce multiple empty workflows

### DIFF
--- a/client/src/components/SchemaOrg/CreatorEditor.vue
+++ b/client/src/components/SchemaOrg/CreatorEditor.vue
@@ -52,6 +52,7 @@ export default {
     props: {
         creators: {
             type: Array,
+            default: () => [],
         },
     },
     data() {
@@ -61,8 +62,11 @@ export default {
         };
     },
     watch: {
-        creators() {
-            this.creatorsCurrent = this.creators;
+        creators: {
+            handler(newCreators) {
+                this.creatorsCurrent = newCreators;
+            },
+            immediate: true,
         },
     },
     methods: {

--- a/client/src/components/Workflow/Editor/Attributes.vue
+++ b/client/src/components/Workflow/Editor/Attributes.vue
@@ -97,7 +97,7 @@ export default {
             default: "",
         },
         creator: {
-            type: Object,
+            type: Array,
             default: null,
         },
         version: {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -178,6 +178,7 @@ import { hide_modal } from "@/layout/modal";
 import { getAppRoot } from "@/onload/loadConfig";
 import { useScopePointerStore } from "@/stores/scopePointerStore";
 import { LastQueue } from "@/utils/promise-queue";
+import { errorMessageAsString } from "@/utils/simple-error";
 
 import { defaultPosition } from "./composables/useDefaultStepPosition";
 import { fromSimple, toSimple } from "./modules/model";
@@ -555,7 +556,15 @@ export default {
                 this.hasChanges = false;
                 await this.routeToWorkflow(newId);
             } catch (e) {
-                this.onWorkflowError("Saving workflow failed, please contact an administrator.");
+                if (create) {
+                    throw e;
+                }
+                const errorHeading = `Saving workflow as '${rename_name}' failed`;
+                this.onWorkflowError(errorHeading, errorMessageAsString(e) || "Please contact an administrator.", {
+                    Ok: () => {
+                        this.hideModal();
+                    },
+                });
             }
         },
         onSaveAs() {
@@ -617,13 +626,15 @@ export default {
                     );
                 }
             } catch (e) {
-                this.onWorkflowError("Creating workflow failed"),
-                    e || "Please contact an administrator.",
+                this.onWorkflowError(
+                    "Creating workflow failed",
+                    errorMessageAsString(e) || "Please contact an administrator.",
                     {
                         Ok: () => {
                             this.hideModal();
                         },
-                    };
+                    }
+                );
             }
         },
         nameValidate() {

--- a/client/src/components/Workflow/services.js
+++ b/client/src/components/Workflow/services.js
@@ -3,6 +3,8 @@ import axios from "axios";
 import { withPrefix } from "utils/redirect";
 import { rethrowSimple } from "utils/simple-error";
 
+import { toSimple } from "./Editor/modules/model";
+
 /** Workflow data request helper **/
 export class Services {
     async copyWorkflow(workflow) {
@@ -22,6 +24,16 @@ export class Services {
             const createWorkflow = createResponse.data;
             this._addAttributes(createWorkflow);
             return createWorkflow;
+        } catch (e) {
+            rethrowSimple(e);
+        }
+    }
+
+    async createWorkflow(workflow) {
+        const url = withPrefix("/api/workflows");
+        try {
+            const { data } = await axios.post(url, { workflow: toSimple(workflow.id, workflow) });
+            return data;
         } catch (e) {
             rethrowSimple(e);
         }


### PR DESCRIPTION
Use `POST api/workflows` to create and save-as workflows, instead of the `workflows/create` and `workflows/save_workflow_as` controllers. This prevents the bug of creating (or saving as) workflows with errors and getting no prompts.
On the front-end, handle errors better and show them in editor error modal.

Fixes https://github.com/galaxyproject/galaxy/issues/17405
Fixes https://github.com/galaxyproject/galaxy/issues/17130

### Before:
https://github.com/galaxyproject/galaxy/assets/78516064/ebdf71f8-da6f-4e8f-9e0c-08e10044d930

### After:
https://github.com/galaxyproject/galaxy/assets/78516064/72b2feda-bb34-4cc7-a6af-9d8fd1257c1c


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
