### PR TITLE
Fix IUC best practices links, mention data_source_async in XSD

### DIFF
--- a/doc/parse_gx_xsd.py
+++ b/doc/parse_gx_xsd.py
@@ -140,7 +140,7 @@ def _get_bp_link(annotation_el):
     anchor = annotation_el.attrib.get("{http://galaxyproject.org/xml/1.0}best_practices", None)
     link = None
     if anchor:
-        link = "https://planemo.readthedocs.io/en/latest/standards/docs/best_practices/tool_xml.html#%s" % anchor
+        link = "https://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html#%s" % anchor
     return link
 
 

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -220,13 +220,14 @@ graphical tool form by setting this to ``false``.</xs:documentation>
           <xs:documentation xml:lang="en">Allows for certain framework
 functionality to be performed on certain types of tools. Normal tools that execute
 typical command-line jobs do not need to specify this, special kinds of tools such
-as [Data Source](https://galaxyproject.org/admin/internals/data-sources/) and
+as [Data Source](https://docs.galaxyproject.org/en/latest/dev/data_source.html) and
 [Data Manager](https://galaxyproject.org/admin/tools/data-managers/) tools should
-set this to have values such as ``data_source`` or ``manage_data``.</xs:documentation>
+set this to have values such as ``data_source``, ``data_source_async`` or
+``manage_data``.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="profile" type="xs:string">
-        <xs:annotation>
+        <xs:annotation gxdocs:best_practices="tool-profile">
           <xs:documentation xml:lang="en">This string specifies the minimum Galaxy
 version that should be required to run this tool. Certain legacy behaviors such
 as using standard error content to detect errors instead of exit code are disabled
@@ -265,7 +266,7 @@ this tool is usable within a workflow (defaults to ``true`` for normal tools and
       <xs:attribute name="URL_method" type="URLmethodType">
         <xs:annotation>
           <xs:documentation xml:lang="en">Only used if ``tool_type`` attribute value
-is ``data_source`` - this attribute defines the HTTP request method to use when
+is ``data_source`` or ``data_source_async`` - this attribute defines the HTTP request method to use when
 communicating with an external data source application (the default is ``get``).</xs:documentation>
         </xs:annotation>
       </xs:attribute>
@@ -3531,7 +3532,7 @@ rendered as a one line text box (if ``false``, the default) or a multi-line text
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="argument" type="xs:string">
-          <xs:annotation>
+          <xs:annotation gxdocs:best_practices="parameter-name-argument-and-help">
             <xs:documentation xml:lang="en"><![CDATA[
 
 If the parameter reflects just one command line argument of a certain tool, this
@@ -3552,7 +3553,7 @@ displayed on the tool page as the label of the form field
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="help" type="xs:string">
-          <xs:annotation gxdocs:best_practices="parameter-help">
+          <xs:annotation>
             <xs:documentation xml:lang="en">Short bit of text, rendered on the
 tool form just below the associated field to provide information about the
 field.</xs:documentation>
@@ -6513,7 +6514,7 @@ Examples are included in the test tools directory including:
 
   <xs:complexType name="RequestParameterTranslation">
     <xs:annotation>
-      <xs:documentation xml:lang="en"><![CDATA[See [/tools/data_source/ucsc_tablebrowser.xml](https://github.com/galaxyproject/galaxy/blob/dev/tools/data_source/ucsc_tablebrowser.xml) for an example of how to use this tag set. This tag set is used only in "data_source" tools (i.e. whose ``tool_type`` attribute is ``data_source``). This tag set contains a set of [request_param](#tool-request-param-translation-request-param) elements.]]></xs:documentation>
+      <xs:documentation xml:lang="en"><![CDATA[See [/tools/data_source/ucsc_tablebrowser.xml](https://github.com/galaxyproject/galaxy/blob/dev/tools/data_source/ucsc_tablebrowser.xml) for an example of how to use this tag set. This tag set is used only in "data_source" tools (i.e. whose ``tool_type`` attribute is ``data_source`` or ``data_source_async``). This tag set contains a set of [request_param](#tool-request-param-translation-request-param) elements.]]></xs:documentation>
     </xs:annotation>
     <xs:sequence>
       <xs:element name="request_param" minOccurs="0" maxOccurs="unbounded" type="RequestParameter"/>
@@ -7369,7 +7370,7 @@ and ``contains``. In addition there is ``sim_size`` which is discouraged in favo
     </xs:union>
   </xs:simpleType>
   <xs:complexType name="EdamTopics">
-    <xs:annotation>
+    <xs:annotation gxdocs:best_practices="tool-annotations-edam">
       <xs:documentation xml:lang="en"><![CDATA[
 Container tag set for the ``<edam_topic>`` tags.
 A tool can have any number of EDAM topic references.
@@ -7393,7 +7394,7 @@ A tool can have any number of EDAM topic references.
     </xs:sequence>
   </xs:complexType>
   <xs:complexType name="EdamOperations">
-    <xs:annotation>
+    <xs:annotation gxdocs:best_practices="tool-annotations-edam">
       <xs:documentation xml:lang="en"><![CDATA[
 Container tag set for the ``<edam_operation>`` tags.
 A tool can have any number of EDAM operation references.
@@ -7418,7 +7419,7 @@ A tool can have any number of EDAM operation references.
     </xs:sequence>
   </xs:complexType>
   <xs:complexType name="xrefs">
-    <xs:annotation>
+    <xs:annotation gxdocs:best_practices="tool-cross-references-bio-tools">
       <xs:documentation xml:lang="en"><![CDATA[
 Container tag set for the ``<xref>`` tags.
 A tool can refer multiple reference IDs.


### PR DESCRIPTION
- Best practice links are currently broken as they are still pointing to the planemo docs.

- "data_source_async" was before not mentioned anywhere as an available tool_type.

- Data source tool description has been moved away from the hub in https://github.com/galaxyproject/galaxy-hub/pull/2333


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
