### PR TITLE
Purge `groups` and `roles` from DB (for real)

### DIFF
--- a/lib/galaxy/managers/groups.py
+++ b/lib/galaxy/managers/groups.py
@@ -110,19 +110,22 @@ class GroupsManager:
             trans.sa_session.commit()
 
     def purge(self, trans: ProvidesAppContext, group_id: int):
-        group = self._get_group(trans.sa_session, group_id)
+        sa_session = trans.sa_session
+        group = self._get_group(sa_session, group_id)
         if not group.deleted:
             raise RequestParameterInvalidException(
                 f"Group '{group.name}' has not been deleted, so it cannot be purged."
             )
         # Delete UserGroupAssociations
         for uga in group.users:
-            trans.sa_session.delete(uga)
+            sa_session.delete(uga)
         # Delete GroupRoleAssociations
         for gra in group.roles:
-            trans.sa_session.delete(gra)
-        with transaction(trans.sa_session):
-            trans.sa_session.commit()
+            sa_session.delete(gra)
+        # Delete the group
+        sa_session.delete(group)
+        with transaction(sa_session):
+            sa_session.commit()
 
     def undelete(self, trans: ProvidesAppContext, group_id: int):
         group = self._get_group(trans.sa_session, group_id)

--- a/lib/galaxy/managers/roles.py
+++ b/lib/galaxy/managers/roles.py
@@ -144,6 +144,8 @@ class RoleManager(base.ModelManager[model.Role]):
         # Delete DatasetPermissionss
         for dp in role.dataset_actions:
             sa_session.delete(dp)
+        # Delete the role
+        sa_session.delete(role)
         with transaction(sa_session):
             sa_session.commit()
         return role

--- a/lib/galaxy_test/api/test_groups.py
+++ b/lib/galaxy_test/api/test_groups.py
@@ -101,6 +101,35 @@ class TestGroupsApi(ApiTestCase):
         update_response = self._put(f"groups/{group_b_id}", data=update_payload, admin=True, json=True)
         self._assert_status_code_is(update_response, 409)
 
+    def test_delete(self):
+        group = self.test_create_valid()
+        group_id = group["id"]
+        delete_response = self._delete(f"groups/{group_id}", admin=True)
+        self._assert_status_code_is_ok(delete_response)
+
+    def test_delete_duplicating_name_raises_409(self):
+        group = self.test_create_valid()
+        group_id = group["id"]
+        group_name = group["name"]
+
+        delete_response = self._delete(f"groups/{group_id}", admin=True)
+        self._assert_status_code_is_ok(delete_response)
+
+        # Create a new group with the same name as the deleted one is not allowed
+        payload = self._build_valid_group_payload(group_name)
+        response = self._post("groups", payload, admin=True, json=True)
+        self._assert_status_code_is(response, 409)
+
+    def test_purge(self):
+        group = self.test_create_valid()
+        group_id = group["id"]
+
+        # Delete and purge the group
+        delete_response = self._delete(f"groups/{group_id}", admin=True)
+        self._assert_status_code_is_ok(delete_response)
+        purge_response = self._post(f"groups/{group_id}/purge", admin=True)
+        self._assert_status_code_is_ok(purge_response)
+
     def _assert_valid_group(self, group, assert_id=None):
         self._assert_has_keys(group, "id", "name", "model_class", "url")
         if assert_id is not None:

--- a/lib/galaxy_test/api/test_groups.py
+++ b/lib/galaxy_test/api/test_groups.py
@@ -72,10 +72,10 @@ class TestGroupsApi(ApiTestCase):
         self._assert_status_code_is(response, 400)
 
     def test_update(self):
-        group = self.test_create_valid(group_name="group-test")
+        group = self.test_create_valid(group_name=f"group-test-{self.dataset_populator.get_random_name()}")
 
         group_id = group["id"]
-        updated_name = "group-test-updated"
+        updated_name = f"group-test-updated-{self.dataset_populator.get_random_name()}"
         update_payload = {
             "name": updated_name,
         }

--- a/lib/galaxy_test/api/test_groups.py
+++ b/lib/galaxy_test/api/test_groups.py
@@ -130,6 +130,26 @@ class TestGroupsApi(ApiTestCase):
         purge_response = self._post(f"groups/{group_id}/purge", admin=True)
         self._assert_status_code_is_ok(purge_response)
 
+        # The group is deleted and purged, so it cannot be found
+        response = self._get(f"groups/{group_id}", admin=True)
+        self._assert_status_code_is(response, 404)
+
+    def test_purge_can_reuse_name(self):
+        group = self.test_create_valid()
+        group_id = group["id"]
+        group_name = group["name"]
+
+        # Delete and purge the group
+        delete_response = self._delete(f"groups/{group_id}", admin=True)
+        self._assert_status_code_is_ok(delete_response)
+        purge_response = self._post(f"groups/{group_id}/purge", admin=True)
+        self._assert_status_code_is_ok(purge_response)
+
+        # Create a new group with the same name as the deleted one is allowed
+        payload = self._build_valid_group_payload(group_name)
+        response = self._post("groups", payload, admin=True, json=True)
+        self._assert_status_code_is(response, 200)
+
     def _assert_valid_group(self, group, assert_id=None):
         self._assert_has_keys(group, "id", "name", "model_class", "url")
         if assert_id is not None:

--- a/lib/galaxy_test/api/test_roles.py
+++ b/lib/galaxy_test/api/test_roles.py
@@ -103,15 +103,7 @@ class TestRolesApi(ApiTestCase):
     def test_create_valid(self):
         name = self.dataset_populator.get_random_name()
         description = "A test role."
-        payload = {
-            "name": name,
-            "description": description,
-            "user_ids": [self.dataset_populator.user_id()],
-        }
-        response = self._post("roles", payload, admin=True, json=True)
-        assert_status_code_is(response, 200)
-        role = response.json()
-        self.check_role_dict(role)
+        role = self._create_role(name=name, description=description)
 
         assert role["name"] == name
         assert role["description"] == description
@@ -146,6 +138,56 @@ class TestRolesApi(ApiTestCase):
         response_err = response.json()
         assert response_err["err_code"] == 403006
         assert "administrator" in response_err["err_msg"]
+
+    @requires_admin
+    def test_delete(self):
+        role = self._create_role()
+        role_id = role["id"]
+        response = self._delete(f"roles/{role_id}", admin=True)
+        assert_status_code_is(response, 200)
+
+    @requires_admin
+    def test_delete_duplicating_name_raises_409(self):
+        role = self._create_role()
+        role_id = role["id"]
+        role_name = role["name"]
+
+        delete_response = self._delete(f"roles/{role_id}", admin=True)
+        self._assert_status_code_is_ok(delete_response)
+
+        # Create a new role with the same name as the deleted one is not allowed
+        payload = self._build_valid_role_payload(role_name)
+        response = self._post("roles", payload, admin=True, json=True)
+        self._assert_status_code_is(response, 409)
+
+    @requires_admin
+    def test_purge(self):
+        role = self._create_role()
+        role_id = role["id"]
+
+        # Delete and purge the role
+        delete_response = self._delete(f"roles/{role_id}", admin=True)
+        self._assert_status_code_is_ok(delete_response)
+        purge_response = self._post(f"roles/{role_id}/purge", admin=True)
+        self._assert_status_code_is_ok(purge_response)
+
+    def _create_role(self, name: Optional[str] = None, description: Optional[str] = None) -> Dict[str, Any]:
+        payload = self._build_valid_role_payload(name=name, description=description)
+        response = self._post("roles", payload, admin=True, json=True)
+        assert_status_code_is(response, 200)
+        role = response.json()
+        self.check_role_dict(role)
+        return role
+
+    def _build_valid_role_payload(self, name: Optional[str] = None, description: Optional[str] = None):
+        name = name or self.dataset_populator.get_random_name()
+        description = description or f"A test role with name: {name}."
+        payload = {
+            "name": name,
+            "description": description,
+            "user_ids": [self.dataset_populator.user_id()],
+        }
+        return payload
 
     @staticmethod
     def check_role_dict(role_dict: Dict[str, Any], assert_id: Optional[str] = None) -> None:

--- a/lib/galaxy_test/api/test_roles.py
+++ b/lib/galaxy_test/api/test_roles.py
@@ -125,11 +125,11 @@ class TestRolesApi(ApiTestCase):
         response = self._get("roles/badroleid")
         assert_status_code_is(response, 400)
 
-        # Trying to access roles are errors - should probably be 403 not 400 though?
+        # Trying to access others roles raise (not found) error
         with self._different_user():
             different_user_role_id = self.dataset_populator.user_private_role_id()
         response = self._get(f"roles/{different_user_role_id}")
-        assert_status_code_is(response, 400)
+        assert_status_code_is(response, 404)
 
     @requires_admin
     def test_create_only_admin(self):

--- a/lib/galaxy_test/api/test_roles.py
+++ b/lib/galaxy_test/api/test_roles.py
@@ -171,6 +171,27 @@ class TestRolesApi(ApiTestCase):
         purge_response = self._post(f"roles/{role_id}/purge", admin=True)
         self._assert_status_code_is_ok(purge_response)
 
+        # The role is deleted and purged, so it cannot be found
+        response = self._get(f"roles/{role_id}", admin=True)
+        self._assert_status_code_is(response, 404)
+
+    @requires_admin
+    def test_purge_can_reuse_name(self):
+        role = self._create_role()
+        role_id = role["id"]
+        role_name = role["name"]
+
+        # Delete and purge the role
+        delete_response = self._delete(f"roles/{role_id}", admin=True)
+        self._assert_status_code_is_ok(delete_response)
+        purge_response = self._post(f"roles/{role_id}/purge", admin=True)
+        self._assert_status_code_is_ok(purge_response)
+
+        # Create a new role with the same name as the deleted one is allowed
+        payload = self._build_valid_role_payload(role_name)
+        response = self._post("roles", payload, admin=True, json=True)
+        self._assert_status_code_is(response, 200)
+
     def _create_role(self, name: Optional[str] = None, description: Optional[str] = None) -> Dict[str, Any]:
         payload = self._build_valid_role_payload(name=name, description=description)
         response = self._post("roles", payload, admin=True, json=True)


### PR DESCRIPTION
Fixes #15350

In addition to removing the purged groups and roles from DB. Increases a bit the test coverage, includes some small refactorings, and makes some error codes more explicit and consistent between both APIs:
- Returning 409 (Conflict) when creating/updating a role and the name is already in use.
- Returning 404 (instead of 400) when the role doesn't exist or the user doesn't have access to it.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
