### PR TITLE
Fix data_source and data_source_async bugs

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -58,6 +58,7 @@ List of behavior changes associated with profile versions:
 ### 21.09
 
 - Do not strip leading and trailing whitespaces in `from_work_dir` attribute.
+- Do not use Galaxy python environment for `data_source` and `data_source_async` tools.
 
 ### 23.0
 

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -58,12 +58,16 @@ List of behavior changes associated with profile versions:
 ### 21.09
 
 - Do not strip leading and trailing whitespaces in `from_work_dir` attribute.
-- Do not use Galaxy python environment for `data_source` and `data_source_async` tools.
+- Do not use Galaxy python environment for `data_source` tools.
 
 ### 23.0
 
 - Text parameters that are inferred to be optional (i.e the `optional` tag is not set, but the tool parameter accepts an empty string)
   are set to `None` for templating in Cheetah. Older tools receive the empty string `""` as the templated value.
+
+### 24.0
+
+- Do not use Galaxy python environment for `data_source_async` tools.
 
 ### Examples
 

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -58,7 +58,7 @@ List of behavior changes associated with profile versions:
 ### 21.09
 
 - Do not strip leading and trailing whitespaces in `from_work_dir` attribute.
-- Do not use Galaxy python environment for `data_source` tools.
+- Do not use Galaxy Python virtual environment for `data_source` tools. `data_source` tools should explicitly use the `galaxy-util` package.
 
 ### 23.0
 

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -270,9 +270,11 @@ this tool is usable within a workflow (defaults to ``true`` for normal tools and
       </xs:attribute>
       <xs:attribute name="URL_method" type="URLmethodType">
         <xs:annotation>
-          <xs:documentation xml:lang="en">Only used if ``tool_type`` attribute value
-is ``data_source`` or ``data_source_async`` - this attribute defines the HTTP request method to use when
-communicating with an external data source application (the default is ``get``).</xs:documentation>
+          <xs:documentation xml:lang="en">*Deprecated* and ignored,
+use a [request_param](#tool-request-param-translation-request-param) element with ``galaxy_name="URL_method"`` instead.
+Was only used if ``tool_type`` attribute value is ``data_source`` or ``data_source_async`` -
+this attribute defined the HTTP request method to use when communicating with an external data source application
+(default: ``get``).</xs:documentation>
         </xs:annotation>
       </xs:attribute>
     </xs:complexType>
@@ -1726,7 +1728,7 @@ useful for non-deterministic output.
         <xs:documentation xml:lang="en"><![CDATA[
 
 If specified, the target output's MD5 hash should match the value specified
-here. For large static files it may be inconvenient to upload the entiry file
+here. For large static files it may be inconvenient to upload the entire file
 and this can be used instead.
 
 ]]></xs:documentation>
@@ -1739,7 +1741,7 @@ and this can be used instead.
 If specified, the target output's checksum should match the value specified
 here. This value should have the form ``hash_type$hash_value``
 (e.g. ``sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041``). For large static files
-it may be inconvenient to upload the entiry file and this can be used instead.
+it may be inconvenient to upload the entire file and this can be used instead.
 
 ]]></xs:documentation>
       </xs:annotation>
@@ -2857,7 +2859,9 @@ tools will not need to specify any attributes on this tag itself.]]>
     </xs:attribute>
     <xs:attribute name="method" type="URLmethodType">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Data source HTTP action (e.g. ``get`` or ``put``) to use.</xs:documentation>
+        <xs:documentation xml:lang="en">*Deprecated* and ignored,
+use a [request_param](#tool-request-param-translation-request-param) element with ``galaxy_name="URL_method"`` instead.
+Data source HTTP action (e.g. ``get`` or ``put``) to use.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="target" type="TargetType">
@@ -7155,6 +7159,7 @@ and ``bibtex`` are the only supported options.</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:enumeration value="data_source"/>
+      <xs:enumeration value="data_source_async"/>
       <xs:enumeration value="manage_data"/>
       <xs:enumeration value="interactive"/>
       <xs:enumeration value="expression"/>

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -910,13 +910,13 @@ class Tool(Dictifiable):
         # seem to require Galaxy's Python.
         # FIXME: the (instantiated) tool class should emit this behavior, and not
         #        use inspection by string check
-        if self.tool_type not in ["default", "manage_data", "interactive", "data_source"]:
+        if self.tool_type not in ["default", "manage_data", "interactive", "data_source", "data_source_async"]:
             return True
 
         if self.tool_type == "manage_data" and self.profile < 18.09:
             return True
 
-        if self.tool_type == "data_source" and self.profile < 21.09:
+        if self.tool_type in ["data_source", "data_source_async"] and self.profile < 21.09:
             return True
 
         config = self.app.config

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -916,7 +916,10 @@ class Tool(Dictifiable):
         if self.tool_type == "manage_data" and self.profile < 18.09:
             return True
 
-        if self.tool_type in ["data_source", "data_source_async"] and self.profile < 21.09:
+        if self.tool_type == "data_source" and self.profile < 21.09:
+            return True
+
+        if self.tool_type == "data_source_async" and self.profile < 24.0:
             return True
 
         config = self.app.config

--- a/lib/galaxy/webapps/galaxy/controllers/async.py
+++ b/lib/galaxy/webapps/galaxy/controllers/async.py
@@ -1,5 +1,5 @@
 """
-Upload class
+Controller to handle communication of tools of type data_source_async
 """
 
 import logging
@@ -134,9 +134,21 @@ class ASync(BaseUIController):
 
             return f"Data {data_id} with status {STATUS} received. OK"
         else:
-            #
             # no data_id must be parameter submission
             #
+            # create new dataset, put it into running state,
+            # send request for data to remote server and see if the response
+            # ends in ok;
+            # the request that's getting sent goes to the URL found in
+            # params.URL or, in its absence, to the one found as the value of
+            # the "action" attribute of the data source tool's "inputs" tag.
+            # Included in the request are the parameters:
+            # - data_id, which indicates to the remote server that Galaxy is
+            #   ready to accept data
+            # - GALAXY_URL, which takes the form:
+            #   {base_url}/async/{tool_id}/{data_id}/{data_secret}, and which
+            #   when used by the remote server to send a data download link,
+            #   will trigger the if branch above.
             GALAXY_TYPE = None
             if params.data_type:
                 GALAXY_TYPE = params.data_type

--- a/lib/galaxy/webapps/galaxy/controllers/async.py
+++ b/lib/galaxy/webapps/galaxy/controllers/async.py
@@ -71,11 +71,21 @@ class ASync(BaseUIController):
                 data.state = data.blurb = data.states.RUNNING
                 log.debug(f"executing tool {tool.id}")
                 trans.log_event(f"Async executing tool {tool.id}", tool_id=tool.id)
+                params_dict = {}
+                if tool.input_translator:
+                    tool.input_translator.translate(params)
+                    tool_declared_params = {
+                        translator.galaxy_name
+                        for translator in tool.input_translator.param_trans_dict.values()
+                    }
+                    for param in params:
+                        if param in tool_declared_params:
+                            params_dict[param] = params.get(param, None)
                 galaxy_url = f"{trans.request.url_path}/async/{tool_id}/{data.id}/{key}"
-                galaxy_url = params.get("GALAXY_URL", galaxy_url)
                 params = dict(
                     URL=URL, GALAXY_URL=galaxy_url, name=data.name, info=data.info, dbkey=data.dbkey, data_type=data.ext
                 )
+                params.update(params_dict)
 
                 # Assume there is exactly one output file possible
                 TOOL_OUTPUT_TYPE = None

--- a/lib/galaxy/webapps/galaxy/controllers/async.py
+++ b/lib/galaxy/webapps/galaxy/controllers/async.py
@@ -69,7 +69,8 @@ class ASync(BaseUIController):
             # ignore any other params that may have been passed by the remote
             # server with the exception of STATUS and URL;
             # if name, info, dbkey and data_type are not handled via incoming params,
-            # use the metadata from the already existing dataset
+            # use the metadata from the already existing dataset;
+            # preserve original params under nested dict
             params_dict = dict(
                 STATUS=params.STATUS,
                 URL=params.URL,
@@ -77,6 +78,7 @@ class ASync(BaseUIController):
                 info=data.info,
                 dbkey=data.dbkey,
                 data_type=data.ext,
+                incoming_request_params=params.__dict__.copy(),
             )
             if tool.input_translator:
                 tool.input_translator.translate(params)

--- a/lib/galaxy/webapps/galaxy/controllers/async.py
+++ b/lib/galaxy/webapps/galaxy/controllers/async.py
@@ -75,8 +75,7 @@ class ASync(BaseUIController):
                 if tool.input_translator:
                     tool.input_translator.translate(params)
                     tool_declared_params = {
-                        translator.galaxy_name
-                        for translator in tool.input_translator.param_trans_dict.values()
+                        translator.galaxy_name for translator in tool.input_translator.param_trans_dict.values()
                     }
                     for param in params:
                         if param in tool_declared_params:

--- a/lib/galaxy/webapps/galaxy/controllers/async.py
+++ b/lib/galaxy/webapps/galaxy/controllers/async.py
@@ -58,6 +58,14 @@ class ASync(BaseUIController):
 
             if not data:
                 return f"Data {data_id} does not exist or has already been deleted"
+            if data.state in data.dataset.terminal_states:
+                log.debug(
+                    f"Tool {tool.id}: execution stopped as data {data_id} has entered terminal state prematurely"
+                )
+                trans.log_event(
+                    f"Tool {tool.id}: execution stopped as data {data_id} has entered terminal state prematurely"
+                )
+                return f"Data {data_id} has finished processing before job could be completed"
 
             # map params from the tool's <request_param_translation> section;
             # ignore any other params that may have been passed by the remote

--- a/lib/galaxy/webapps/galaxy/controllers/async.py
+++ b/lib/galaxy/webapps/galaxy/controllers/async.py
@@ -60,7 +60,9 @@ class ASync(BaseUIController):
                 return f"Data {data_id} does not exist or has already been deleted"
             if data.state in data.dataset.terminal_states:
                 log.debug(f"Tool {tool.id}: execution stopped as data {data_id} has entered terminal state prematurely")
-                trans.log_event(f"Tool {tool.id}: execution stopped as data {data_id} has entered terminal state prematurely")
+                trans.log_event(
+                    f"Tool {tool.id}: execution stopped as data {data_id} has entered terminal state prematurely"
+                )
                 return f"Data {data_id} has finished processing before job could be completed"
 
             # map params from the tool's <request_param_translation> section;

--- a/lib/galaxy/webapps/galaxy/controllers/async.py
+++ b/lib/galaxy/webapps/galaxy/controllers/async.py
@@ -59,12 +59,8 @@ class ASync(BaseUIController):
             if not data:
                 return f"Data {data_id} does not exist or has already been deleted"
             if data.state in data.dataset.terminal_states:
-                log.debug(
-                    f"Tool {tool.id}: execution stopped as data {data_id} has entered terminal state prematurely"
-                )
-                trans.log_event(
-                    f"Tool {tool.id}: execution stopped as data {data_id} has entered terminal state prematurely"
-                )
+                log.debug(f"Tool {tool.id}: execution stopped as data {data_id} has entered terminal state prematurely")
+                trans.log_event(f"Tool {tool.id}: execution stopped as data {data_id} has entered terminal state prematurely")
                 return f"Data {data_id} has finished processing before job could be completed"
 
             # map params from the tool's <request_param_translation> section;
@@ -73,7 +69,12 @@ class ASync(BaseUIController):
             # if name, info, dbkey and data_type are not handled via incoming params,
             # use the metadata from the already existing dataset
             params_dict = dict(
-                STATUS=params.STATUS, URL=params.URL, name=data.name, info=data.info, dbkey=data.dbkey, data_type=data.ext
+                STATUS=params.STATUS,
+                URL=params.URL,
+                name=data.name,
+                info=data.info,
+                dbkey=data.dbkey,
+                data_type=data.ext,
             )
             if tool.input_translator:
                 tool.input_translator.translate(params)

--- a/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
@@ -75,7 +75,9 @@ class ToolRunner(BaseUIController):
         if tool.tool_type in ["default", "interactivetool"]:
             return trans.response.send_redirect(url_for(controller="root", tool_id=tool_id))
 
-        # execute tool without displaying form (used for datasource tools)
+        # execute tool without displaying form
+        # (used for datasource tools, but note that data_source_async tools
+        # are handled separately by the async controller)
         params = galaxy.util.Params(kwd, sanitize=False)
         if tool.tool_type == "data_source":
             # preserve original params sent by the remote server as extra dict

--- a/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
@@ -77,6 +77,9 @@ class ToolRunner(BaseUIController):
 
         # execute tool without displaying form (used for datasource tools)
         params = galaxy.util.Params(kwd, sanitize=False)
+        if tool.tool_type == "data_source":
+            # preserve original params sent by the remote server as extra dict
+            params.update({"incoming_request_params": params.__dict__.copy()})
         # do param translation here, used by datasource tools
         if tool.input_translator:
             tool.input_translator.translate(params)

--- a/test/functional/tools/test_data_source.xml
+++ b/test/functional/tools/test_data_source.xml
@@ -4,11 +4,11 @@
     the initial response.  If value of 'URL_method' is 'post', any additional params coming back in the
     initial response ( in addition to 'URL' ) will be encoded and appended to URL and a post will be performed.
 -->
-<tool name="test_data_source" id="test_data_source" tool_type="data_source" version="1.0.0">
+<tool name="test_data_source" id="test_data_source" tool_type="data_source" version="1.0.0" profile="20.09">
     <command><![CDATA[
 python '$__tool_directory__/data_source.py' '$output' $__app__.config.output_size_limit
     ]]></command>
-    <inputs action="http://ratmine.mcw.edu/ratmine/begin.do" check_values="false" method="get"> 
+    <inputs action="http://ratmine.mcw.edu/ratmine/begin.do" check_values="false" method="get">
         <display>go to Ratmine server $GALAXY_URL</display>
         <param name="GALAXY_URL" type="baseurl" value="/tool_runner?tool_id=ratmine" />
     </inputs>

--- a/tools/data_source/biomart.xml
+++ b/tools/data_source/biomart.xml
@@ -7,7 +7,7 @@
     TODO: Hack to get biomart to work - the 'add_to_URL' param can be eliminated when the Biomart team encodes URL prior to sending, meanwhile
     everything including and beyond the first '&' is truncated from URL.  They said they'll let us know when this is fixed at their end.
 -->
-<tool name="BioMart" id="biomart" tool_type="data_source" version="1.0.1">
+<tool name="BioMart" id="biomart" tool_type="data_source" version="1.0.1" profile="20.09">
     <description>Ensembl server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/biomart_test.xml
+++ b/tools/data_source/biomart_test.xml
@@ -7,7 +7,7 @@
     TODO: Hack to get biomart to work - the 'add_to_URL' param can be eliminated when the Biomart team encodes URL prior to sending, meanwhile
     everything including and beyond the first '&' is truncated from URL.  They said they'll let us know when this is fixed at their end.
 -->
-<tool name="BioMart" id="biomart_test" tool_type="data_source" version="1.0.1">
+<tool name="BioMart" id="biomart_test" tool_type="data_source" version="1.0.1" profile="20.09">
     <description>Test server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/cbi_rice_mart.xml
+++ b/tools/data_source/cbi_rice_mart.xml
@@ -4,7 +4,7 @@
     the initial response.  If value of 'URL_method' is 'post', any additional params coming back in the
     initial response ( in addition to 'URL' ) will be encoded and appended to URL and a post will be performed.
 -->
-<tool name="CBI Rice Mart" id="cbi_rice_mart" tool_type="data_source" version="1.0.1">
+<tool name="CBI Rice Mart" id="cbi_rice_mart" tool_type="data_source" version="1.0.1" profile="20.09">
     <description>rice mart</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/data_source.py
+++ b/tools/data_source/data_source.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python
 # Retrieves data from external data source applications and stores in a dataset file.
 # Data source application parameters are temporarily stored in the dataset file.
+import json
 import os
 import sys
-from json import (
-    dumps,
-    loads,
-)
+
 from urllib.parse import (
     urlencode,
     urlparse,
@@ -15,7 +13,6 @@ from urllib.request import urlopen
 
 from galaxy.datatypes import sniff
 from galaxy.datatypes.registry import Registry
-from galaxy.jobs import TOOL_PROVIDED_JOB_METADATA_FILE
 from galaxy.util import (
     DEFAULT_SOCKET_TIMEOUT,
     get_charset_from_http_headers,
@@ -32,72 +29,39 @@ def stop_err(msg):
     sys.exit()
 
 
-def load_input_parameters(filename, erase_file=True):
-    datasource_params = {}
-    try:
-        json_params = loads(open(filename).read())
-        datasource_params = json_params.get("param_dict")
-    except Exception:
-        json_params = None
-        for line in open(filename):
-            try:
-                line = line.strip()
-                fields = line.split("\t")
-                datasource_params[fields[0]] = fields[1]
-            except Exception:
-                continue
-    if erase_file:
-        open(filename, "w").close()  # open file for writing, then close, removes params from file
-    return json_params, datasource_params
-
-
 def __main__():
-    filename = sys.argv[1]
-    try:
+    if len(sys.argv) >= 3:
         max_file_size = int(sys.argv[2])
-    except Exception:
+    else:
         max_file_size = 0
 
-    job_params, params = load_input_parameters(filename)
-    if job_params is None:  # using an older tabular file
-        enhanced_handling = False
-        job_params = dict(param_dict=params)
-        job_params["output_data"] = [
-            dict(out_data_name="output", ext="data", file_name=filename, extra_files_path=None)
-        ]
-        job_params["job_config"] = dict(
-            GALAXY_ROOT_DIR=GALAXY_ROOT_DIR,
-            GALAXY_DATATYPES_CONF_FILE=GALAXY_DATATYPES_CONF_FILE,
-            TOOL_PROVIDED_JOB_METADATA_FILE=TOOL_PROVIDED_JOB_METADATA_FILE,
-        )
-    else:
-        enhanced_handling = True
-        json_file = open(
-            job_params["job_config"]["TOOL_PROVIDED_JOB_METADATA_FILE"], "w"
-        )  # specially named file for output junk to pass onto set metadata
+    with open(sys.argv[1]) as fh:
+        params = json.load(fh)
+
+    out_data_name = params['output_data'][0]["out_data_name"]
+
+    URL = params['param_dict'].get("URL", None)  # using exactly URL indicates that only one dataset is being downloaded
+    URL_method = params['param_dict'].get("URL_method", "get")
 
     datatypes_registry = Registry()
     datatypes_registry.load_datatypes(
-        root_dir=job_params["job_config"]["GALAXY_ROOT_DIR"],
-        config=job_params["job_config"]["GALAXY_DATATYPES_CONF_FILE"],
+        root_dir=params["job_config"]["GALAXY_ROOT_DIR"],
+        config=params["job_config"]["GALAXY_DATATYPES_CONF_FILE"],
     )
 
-    URL = params.get("URL", None)  # using exactly URL indicates that only one dataset is being downloaded
-    URL_method = params.get("URL_method", None)
-
-    for data_dict in job_params["output_data"]:
-        cur_filename = data_dict.get("file_name", filename)
-        cur_URL = params.get("%s|%s|URL" % (GALAXY_PARAM_PREFIX, data_dict["out_data_name"]), URL)
+    for data_dict in params["output_data"]:
+        cur_filename = data_dict["file_name"]
+        cur_URL = params['param_dict'].get("%s|%s|URL" % (GALAXY_PARAM_PREFIX, data_dict["out_data_name"]), URL)
         if not cur_URL or urlparse(cur_URL).scheme not in ("http", "https", "ftp"):
             open(cur_filename, "w").write("")
             stop_err("The remote data source application has not sent back a URL parameter in the request.")
 
         # The following calls to urlopen() will use the above default timeout
         try:
-            if not URL_method or URL_method == "get":
+            if URL_method == "get":
                 page = urlopen(cur_URL, timeout=DEFAULT_SOCKET_TIMEOUT)
             elif URL_method == "post":
-                page = urlopen(cur_URL, urlencode(params).encode("utf-8"), timeout=DEFAULT_SOCKET_TIMEOUT)
+                page = urlopen(cur_URL, urlencode(params["param_dict"]).encode("utf-8"), timeout=DEFAULT_SOCKET_TIMEOUT)
         except Exception as e:
             stop_err("The remote data source application may be off line, please try again later. Error: %s" % str(e))
         if max_file_size:
@@ -110,7 +74,7 @@ def __main__():
         try:
             cur_filename = stream_to_open_named_file(
                 page,
-                os.open(cur_filename, os.O_WRONLY | os.O_CREAT),
+                os.open(cur_filename, os.O_WRONLY | os.O_TRUNC | os.O_CREAT),
                 cur_filename,
                 source_encoding=get_charset_from_http_headers(page.headers),
             )
@@ -118,14 +82,14 @@ def __main__():
             stop_err("Unable to fetch %s:\n%s" % (cur_URL, e))
 
         # here import checks that upload tool performs
-        if enhanced_handling:
-            try:
-                ext = sniff.handle_uploaded_dataset_file(filename, datatypes_registry, ext=data_dict["ext"])
-            except Exception as e:
-                stop_err(str(e))
-            info = dict(type="dataset", dataset_id=data_dict["dataset_id"], ext=ext)
+        try:
+            ext = sniff.handle_uploaded_dataset_file(cur_filename, datatypes_registry, ext=data_dict["ext"])
+        except Exception as e:
+            stop_err(str(e))
+        info = dict(type="dataset", dataset_id=data_dict["dataset_id"], ext=ext)
 
-            json_file.write("%s\n" % dumps(info))
+        with open(params["job_config"]["TOOL_PROVIDED_JOB_METADATA_FILE"], "w") as json_file:
+            json.dump(info, json_file)
 
 
 if __name__ == "__main__":

--- a/tools/data_source/data_source.py
+++ b/tools/data_source/data_source.py
@@ -4,7 +4,6 @@
 import json
 import os
 import sys
-
 from urllib.parse import (
     urlencode,
     urlparse,

--- a/tools/data_source/data_source.py
+++ b/tools/data_source/data_source.py
@@ -81,10 +81,11 @@ def __main__():
             ext = sniff.handle_uploaded_dataset_file(cur_filename, datatypes_registry, ext=data_dict["ext"])
         except Exception as e:
             sys.exit(str(e))
-        info = dict(type="dataset", dataset_id=data_dict["dataset_id"], ext=ext)
+
+        tool_provided_metadata = {out_data_name: {"ext": ext}}
 
         with open(params["job_config"]["TOOL_PROVIDED_JOB_METADATA_FILE"], "w") as json_file:
-            json.dump(info, json_file)
+            json.dump(tool_provided_metadata, json_file)
 
 
 if __name__ == "__main__":

--- a/tools/data_source/data_source.py
+++ b/tools/data_source/data_source.py
@@ -33,10 +33,10 @@ def __main__():
     with open(sys.argv[1]) as fh:
         params = json.load(fh)
 
-    out_data_name = params['output_data'][0]["out_data_name"]
+    out_data_name = params["output_data"][0]["out_data_name"]
 
-    URL = params['param_dict'].get("URL", None)  # using exactly URL indicates that only one dataset is being downloaded
-    URL_method = params['param_dict'].get("URL_method", "get")
+    URL = params["param_dict"].get("URL", None)  # using exactly URL indicates that only one dataset is being downloaded
+    URL_method = params["param_dict"].get("URL_method", "get")
 
     datatypes_registry = Registry()
     datatypes_registry.load_datatypes(
@@ -46,7 +46,7 @@ def __main__():
 
     for data_dict in params["output_data"]:
         cur_filename = data_dict["file_name"]
-        cur_URL = params['param_dict'].get("%s|%s|URL" % (GALAXY_PARAM_PREFIX, data_dict["out_data_name"]), URL)
+        cur_URL = params["param_dict"].get("%s|%s|URL" % (GALAXY_PARAM_PREFIX, data_dict["out_data_name"]), URL)
         if not cur_URL or urlparse(cur_URL).scheme not in ("http", "https", "ftp"):
             open(cur_filename, "w").write("")
             sys.exit("The remote data source application has not sent back a URL parameter in the request.")

--- a/tools/data_source/data_source.py
+++ b/tools/data_source/data_source.py
@@ -55,7 +55,11 @@ def __main__():
             if URL_method == "get":
                 page = urlopen(cur_URL, timeout=DEFAULT_SOCKET_TIMEOUT)
             elif URL_method == "post":
-                page = urlopen(cur_URL, urlencode(params["param_dict"]).encode("utf-8"), timeout=DEFAULT_SOCKET_TIMEOUT)
+                page = urlopen(
+                    cur_URL,
+                    urlencode(params["param_dict"]["incoming_request_params"]).encode("utf-8"),
+                    timeout=DEFAULT_SOCKET_TIMEOUT
+                )
         except Exception as e:
             sys.exit("The remote data source application may be off line, please try again later. Error: %s" % str(e))
         if max_file_size:

--- a/tools/data_source/data_source.py
+++ b/tools/data_source/data_source.py
@@ -58,7 +58,7 @@ def __main__():
                 page = urlopen(
                     cur_URL,
                     urlencode(params["param_dict"]["incoming_request_params"]).encode("utf-8"),
-                    timeout=DEFAULT_SOCKET_TIMEOUT
+                    timeout=DEFAULT_SOCKET_TIMEOUT,
                 )
         except Exception as e:
             sys.exit("The remote data source application may be off line, please try again later. Error: %s" % str(e))

--- a/tools/data_source/ebi_sra.xml
+++ b/tools/data_source/ebi_sra.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool name="EBI SRA" id="ebi_sra_main" tool_type="data_source" version="1.0.1">
+<tool name="EBI SRA" id="ebi_sra_main" tool_type="data_source" version="1.0.1" profile="20.09">
     <description>ENA SRA</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/eupathdb.xml
+++ b/tools/data_source/eupathdb.xml
@@ -1,4 +1,4 @@
-<tool name="EuPathDB" id="eupathdb" tool_type="data_source" url_method="post" version="1.0.0">
+<tool name="EuPathDB" id="eupathdb" tool_type="data_source" url_method="post" version="1.0.0" profile="20.09">
     <description>server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/fly_modencode.xml
+++ b/tools/data_source/fly_modencode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool name="modENCODE fly" id="modENCODEfly" tool_type="data_source" version="1.0.1">
+<tool name="modENCODE fly" id="modENCODEfly" tool_type="data_source" version="1.0.1"  profile="20.09">
     <description>server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/flymine.xml
+++ b/tools/data_source/flymine.xml
@@ -4,7 +4,7 @@
     the initial response.  If value of 'URL_method' is 'post', any additional params coming back in the
     initial response ( in addition to 'URL' ) will be encoded and appended to URL and a post will be performed.
 -->
-<tool name="Flymine" id="flymine" tool_type="data_source" version="1.0.0">
+<tool name="Flymine" id="flymine" tool_type="data_source" version="1.0.0" profile="20.09">
     <description>server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/flymine_test.xml
+++ b/tools/data_source/flymine_test.xml
@@ -4,7 +4,7 @@
     the initial response.  If value of 'URL_method' is 'post', any additional params coming back in the
     initial response ( in addition to 'URL' ) will be encoded and appended to URL and a post will be performed.
 -->
-<tool name="Flymine test" id="flymine_test" tool_type="data_source" version="1.0.0">
+<tool name="Flymine test" id="flymine_test" tool_type="data_source" version="1.0.0" profile="20.09">
     <description>server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/gramene_mart.xml
+++ b/tools/data_source/gramene_mart.xml
@@ -7,7 +7,7 @@
     TODO: Hack to get biomart to work - the 'add_to_URL' param can be eliminated when the Biomart team encodes URL prior to sending, meanwhile
     everything including and beyond the first '&' is truncated from URL.  They said they'll let us know when this is fixed at their end.
 -->
-<tool name="GrameneMart" id="gramenemart" tool_type="data_source" version="1.0.1">
+<tool name="GrameneMart" id="gramenemart" tool_type="data_source" version="1.0.1" profile="20.09">
     <description> Central server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/hapmapmart.xml
+++ b/tools/data_source/hapmapmart.xml
@@ -11,7 +11,7 @@
     TODO: Hack to get biomart to work - the 'add_to_URL' param can be eliminated when the Biomart team encodes URL prior to sending, meanwhile
     everything including and beyond the first '&' is truncated from URL.  They said they'll let us know when this is fixed at their end.
 -->
-<tool name="HapMapMart" id="hapmapmart" tool_type="data_source" version="0.0.01">
+<tool name="HapMapMart" id="hapmapmart" tool_type="data_source" version="0.0.01" profile="20.09">
     <description>HapMap Biomart</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/hbvar.xml
+++ b/tools/data_source/hbvar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool name="HbVar" id="hbvar" tool_type="data_source" version="2.0.0">
+<tool name="HbVar" id="hbvar" tool_type="data_source" version="2.0.0" profile="20.09">
     <description>Human Hemoglobin Variants and Thalassemias</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/intermine.xml
+++ b/tools/data_source/intermine.xml
@@ -4,7 +4,7 @@
     the initial response.  If value of 'URL_method' is 'post', any additional params coming back in the
     initial response ( in addition to 'URL' ) will be encoded and appended to URL and a post will be performed.
 -->
-<tool name="InterMine" id="intermine" tool_type="data_source" version="1.0.0">
+<tool name="InterMine" id="intermine" tool_type="data_source" version="1.0.0" profile="20.09">
     <description>server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/metabolicmine.xml
+++ b/tools/data_source/metabolicmine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool name="metabolicMine" id="metabolicmine" tool_type="data_source" version="1.0.0">
+<tool name="metabolicMine" id="metabolicmine" tool_type="data_source" version="1.0.0" profile="20.09">
     <description>server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/modmine.xml
+++ b/tools/data_source/modmine.xml
@@ -4,7 +4,7 @@
     the initial response.  If value of 'URL_method' is 'post', any additional params coming back in the
     initial response ( in addition to 'URL' ) will be encoded and appended to URL and a post will be performed.
 -->
-<tool name="modENCODE modMine" id="modmine" tool_type="data_source" version="1.0.0">
+<tool name="modENCODE modMine" id="modmine" tool_type="data_source" version="1.0.0" profile="20.09">
     <description>server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/mousemine.xml
+++ b/tools/data_source/mousemine.xml
@@ -4,7 +4,7 @@
     the initial response.  If value of 'URL_method' is 'post', any additional params coming back in the
     initial response ( in addition to 'URL' ) will be encoded and appended to URL and a post will be performed.
 -->
-<tool name="MouseMine" id="mousemine" tool_type="data_source" version="1.0.0">
+<tool name="MouseMine" id="mousemine" tool_type="data_source" version="1.0.0" profile="20.09">
     <description>server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/ratmine.xml
+++ b/tools/data_source/ratmine.xml
@@ -4,7 +4,7 @@
     the initial response.  If value of 'URL_method' is 'post', any additional params coming back in the
     initial response ( in addition to 'URL' ) will be encoded and appended to URL and a post will be performed.
 -->
-<tool name="Ratmine" id="ratmine" tool_type="data_source" version="1.0.0">
+<tool name="Ratmine" id="ratmine" tool_type="data_source" version="1.0.0" profile="20.09">
     <description>server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/sra.xml
+++ b/tools/data_source/sra.xml
@@ -1,4 +1,4 @@
-<tool name="SRA" id="sra_source" tool_type="data_source" version="1.0.1" profile="16.04">
+<tool name="SRA" id="sra_source" tool_type="data_source" version="1.0.1" profile="20.09">
     <description>server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/ucsc_tablebrowser.xml
+++ b/tools/data_source/ucsc_tablebrowser.xml
@@ -4,7 +4,7 @@
     the initial response.  If value of 'URL_method' is 'post', any additional params coming back in the
     initial response ( in addition to 'URL' ) will be encoded and appended to URL and a post will be performed.
 -->
-<tool name="UCSC Main" id="ucsc_table_direct1" tool_type="data_source" version="1.0.0">
+<tool name="UCSC Main" id="ucsc_table_direct1" tool_type="data_source" version="1.0.0" profile="20.09">
     <description>table browser</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/ucsc_tablebrowser_archaea.xml
+++ b/tools/data_source/ucsc_tablebrowser_archaea.xml
@@ -4,7 +4,7 @@
     the initial response.  If value of 'URL_method' is 'post', any additional params coming back in the
     initial response ( in addition to 'URL' ) will be encoded and appended to URL and a post will be performed.
 -->
-<tool name="UCSC Archaea" id="ucsc_table_direct_archaea1" tool_type="data_source" version="1.0.0">
+<tool name="UCSC Archaea" id="ucsc_table_direct_archaea1" tool_type="data_source" version="1.0.0" profile="20.09">
     <description>table browser</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/ucsc_tablebrowser_test.xml
+++ b/tools/data_source/ucsc_tablebrowser_test.xml
@@ -4,7 +4,7 @@
     the initial response.  If value of 'URL_method' is 'post', any additional params coming back in the
     initial response ( in addition to 'URL' ) will be encoded and appended to URL and a post will be performed.
 -->
-<tool name="UCSC Test" id="ucsc_table_direct_test1" tool_type="data_source" version="1.0.1">
+<tool name="UCSC Test" id="ucsc_table_direct_test1" tool_type="data_source" version="1.0.1" profile="20.09">
     <description>table browser</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/worm_modencode.xml
+++ b/tools/data_source/worm_modencode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool name="modENCODE worm" id="modENCODEworm" tool_type="data_source" version="1.0.1">
+<tool name="modENCODE worm" id="modENCODEworm" tool_type="data_source" version="1.0.1" profile="20.09">
     <description>server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/wormbase.xml
+++ b/tools/data_source/wormbase.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool name="WormBase" id="wormbase" tool_type="data_source" version="1.0.1">
+<tool name="WormBase" id="wormbase" tool_type="data_source" version="1.0.1" profile="20.09">
     <description>server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/wormbase_test.xml
+++ b/tools/data_source/wormbase_test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool name="Wormbase" id="wormbase_test" tool_type="data_source" version="1.0.0">
+<tool name="Wormbase" id="wormbase_test" tool_type="data_source" version="1.0.0" profile="20.09">
 	<description>test server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/yeastmine.xml
+++ b/tools/data_source/yeastmine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool name="YeastMine" id="yeastmine" tool_type="data_source" version="1.0.0">
+<tool name="YeastMine" id="yeastmine" tool_type="data_source" version="1.0.0" profile="20.09">
     <description>server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>

--- a/tools/data_source/zebrafishmine.xml
+++ b/tools/data_source/zebrafishmine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool name="ZebrafishMine" id="zebrafishmine" tool_type="data_source" version="1.0.0">
+<tool name="ZebrafishMine" id="zebrafishmine" tool_type="data_source" version="1.0.0" profile="20.09">
     <description>server</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>


### PR DESCRIPTION
Currently, the behavior of tools of type `data_source` and `data_source_async` deviates from each other and from documented behavior. Here, I'll try to fix at least some of the following issues:

- [x] though undocumented, `data_source` tools that declare profile 21.09 or higher will have their python env isolated from Galaxy's. However, this was never implemented for `data_source_async` tools
- [x] `data_source_async` tools ignore their https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-request-param-translation section
- [x] `data_source_async` tools switch to error state when receiving a non-OK response from the remote server to their second request, but continue executing and fetching data, and when succesful flip their state to OK.
- [x] the default `data_source.py` script in `tools/data_source/` is full of historic cruft and currently only supports legacy tool-provided metadata.
- [x] shouldn't leak internal data through POST requests

While I'm working on this, feel free to comment on individual commits :-)

## How to test the changes?
You can test changes manually by playing with https://github.com/wm75/galaxy-data_source-examples/tree/main/cherrypy.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
