### PR TITLE
[23.2] Fix workflow report markdown editor toolbox becoming non-responsive.

### DIFF
--- a/client/src/components/Markdown/MarkdownSelector.vue
+++ b/client/src/components/Markdown/MarkdownSelector.vue
@@ -1,6 +1,12 @@
 <template>
     <span>
-        <b-modal v-model="modalShow" :title="title" ok-title="Continue" @ok="onOk" @cancel="onCancel">
+        <b-modal
+            v-model="modalShow"
+            :title="title"
+            ok-title="Continue"
+            @ok="onOk"
+            @cancel="onCancel"
+            @hidden="onCancel">
             <div class="ml-2">
                 <h2 class="mb-3 h-text">Select {{ labelTitle }} Label:</h2>
                 <div v-if="hasLabels">


### PR DESCRIPTION
If you close the label selector without explicitly clicking "Cancel" the state in MarkdownDialog doesn't get updated and new ToolBox selections are non-responsive.

The page editor modals are all based on SelectionDialog which handles these details it seems - so they seem to be unaffected.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Edit a workflow
  2. Edit the workflow markdown.
  3. Click any of the selections in the side toolbox that result in a modal for selection - e.g. "Dataset Details"
  4. Close the dialog by clicking somewhere outside the modal.
  5. Click the same toolbox selection again and notice nothing happens.
  6. Apply the change, and the selection continues to work.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
