### PR TITLE
[23.1] Fix history bulk operations menu conditions

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
@@ -82,18 +82,31 @@ describe("History Selection Operations", () => {
                 expect(wrapper.find(option).exists()).toBe(false);
             });
 
-            it("should display 'unhide' option only on hidden items", async () => {
+            it("should display 'unhide' option on hidden items", async () => {
                 const option = '[data-description="unhide option"]';
                 expect(wrapper.find(option).exists()).toBe(false);
                 await wrapper.setProps({ filterText: "visible:false" });
                 expect(wrapper.find(option).exists()).toBe(true);
             });
 
-            it("should display 'delete' option only on non-deleted items", async () => {
+            it("should display 'unhide' option when hidden and visible items are mixed", async () => {
+                const option = '[data-description="unhide option"]';
+                expect(wrapper.find(option).exists()).toBe(false);
+                await wrapper.setProps({ filterText: "visible:any" });
+                expect(wrapper.find(option).exists()).toBe(true);
+            });
+
+            it("should display 'delete' option on non-deleted items", async () => {
                 const option = '[data-description="delete option"]';
                 expect(wrapper.find(option).exists()).toBe(true);
                 await wrapper.setProps({ filterText: "deleted:true" });
                 expect(wrapper.find(option).exists()).toBe(false);
+            });
+
+            it("should display 'delete' option when non-deleted and deleted items are mixed", async () => {
+                const option = '[data-description="delete option"]';
+                await wrapper.setProps({ filterText: "deleted:any" });
+                expect(wrapper.find(option).exists()).toBe(true);
             });
 
             it("should display 'permanently delete' option always", async () => {
@@ -103,11 +116,20 @@ describe("History Selection Operations", () => {
                 expect(wrapper.find(option).exists()).toBe(true);
             });
 
-            it("should display 'undelete' option only on deleted and non-purged items", async () => {
+            it("should display 'undelete' option on deleted and non-purged items", async () => {
                 const option = '[data-description="undelete option"]';
                 expect(wrapper.find(option).exists()).toBe(false);
                 await wrapper.setProps({
                     filterText: "deleted:true",
+                    contentSelection: getNonPurgedContentSelection(),
+                });
+                expect(wrapper.find(option).exists()).toBe(true);
+            });
+
+            it("should display 'undelete' option when non-purged items (deleted or not) are mixed", async () => {
+                const option = '[data-description="undelete option"]';
+                await wrapper.setProps({
+                    filterText: "deleted:any",
                     contentSelection: getNonPurgedContentSelection(),
                 });
                 expect(wrapper.find(option).exists()).toBe(true);
@@ -134,6 +156,17 @@ describe("History Selection Operations", () => {
                 expect(wrapper.find(option).exists()).toBe(true);
             });
 
+            it("should display 'undelete' option when is query selection mode and filtering by any deleted state", async () => {
+                const option = '[data-description="undelete option"]';
+                // In query selection mode we don't know if some items may not be purged, so we allow to undelete
+                await wrapper.setProps({
+                    filterText: "deleted:any",
+                    contentSelection: getPurgedContentSelection(),
+                    isQuerySelection: true,
+                });
+                expect(wrapper.find(option).exists()).toBe(true);
+            });
+
             it("should display collection building options only on visible and non-deleted items", async () => {
                 const buildListOption = '[data-description="build list"]';
                 const buildPairOption = '[data-description="build pair"]';
@@ -146,6 +179,14 @@ describe("History Selection Operations", () => {
                 expect(wrapper.find(buildPairOption).exists()).toBe(false);
                 expect(wrapper.find(buildListOfPairsOption).exists()).toBe(false);
                 await wrapper.setProps({ filterText: "deleted:true" });
+                expect(wrapper.find(buildListOption).exists()).toBe(false);
+                expect(wrapper.find(buildPairOption).exists()).toBe(false);
+                expect(wrapper.find(buildListOfPairsOption).exists()).toBe(false);
+                await wrapper.setProps({ filterText: "visible:any" });
+                expect(wrapper.find(buildListOption).exists()).toBe(false);
+                expect(wrapper.find(buildPairOption).exists()).toBe(false);
+                expect(wrapper.find(buildListOfPairsOption).exists()).toBe(false);
+                await wrapper.setProps({ filterText: "deleted:any" });
                 expect(wrapper.find(buildListOption).exists()).toBe(false);
                 expect(wrapper.find(buildPairOption).exists()).toBe(false);
                 expect(wrapper.find(buildListOfPairsOption).exists()).toBe(false);

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -25,7 +25,10 @@
                     data-description="undelete option">
                     <span v-localize>Undelete</span>
                 </b-dropdown-item>
-                <b-dropdown-item v-if="!showDeleted" v-b-modal:delete-selected-content data-description="delete option">
+                <b-dropdown-item
+                    v-if="!showStrictDeleted"
+                    v-b-modal:delete-selected-content
+                    data-description="delete option">
                     <span v-localize>Delete</span>
                 </b-dropdown-item>
                 <b-dropdown-item v-b-modal:purge-selected-content data-description="purge option">
@@ -193,10 +196,14 @@ export default {
     computed: {
         /** @returns {Boolean} */
         showHidden() {
-            return HistoryFilters.checkFilter(this.filterText, "visible", false);
+            return !HistoryFilters.checkFilter(this.filterText, "visible", true);
         },
         /** @returns {Boolean} */
         showDeleted() {
+            return !HistoryFilters.checkFilter(this.filterText, "deleted", false);
+        },
+        /** @returns {Boolean} */
+        showStrictDeleted() {
             return HistoryFilters.checkFilter(this.filterText, "deleted", true);
         },
         /** @returns {Boolean} */

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1417,8 +1417,12 @@ class HistoryItemOperator:
 
     def _delete(self, item: HistoryItemModel, trans: ProvidesHistoryContext):
         if isinstance(item, HistoryDatasetCollectionAssociation):
-            return self.dataset_collection_manager.delete(trans, "history", item.id, recursive=True, purge=False)
-        return self.hda_manager.delete(item, flush=self.flush)
+            self.dataset_collection_manager.delete(trans, "history", item.id, recursive=True, purge=False)
+        else:
+            self.hda_manager.delete(item, flush=self.flush)
+        # In the edge case where all selected items are already deleted we need to force an update
+        # otherwise the history will wait indefinitely for the items to be deleted
+        item.update()
 
     def _undelete(self, item: HistoryItemModel):
         if getattr(item, "purged", False):


### PR DESCRIPTION
Fixes #17267

This regression was introduced when we changed the filtering to accept `visible:any` and `deleted:any`. The menu options did not consider those new cases.

I increased the test coverage to include these new filters and adapted the conditions.


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
