### PR TITLE
Only check access permissions in ``/api/{history_dataset_collection_id}/contents/{dataset_collection_id}``

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -802,7 +802,7 @@ class DatasetCollectionManager:
             raise RequestParameterInvalidException("History dataset collection association not found")
         # TODO: that sure looks like a bug, we can't check ownership using the history of the object we're checking ownership for ...
         history = getattr(trans, "history", collection_instance.history)
-        if check_ownership:
+        if check_ownership and collection_instance.history.published is False:
             self.history_manager.error_unless_owner(collection_instance.history, trans.user, current_history=history)
         if check_accessible:
             self.history_manager.error_unless_accessible(

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -802,7 +802,7 @@ class DatasetCollectionManager:
             raise RequestParameterInvalidException("History dataset collection association not found")
         # TODO: that sure looks like a bug, we can't check ownership using the history of the object we're checking ownership for ...
         history = getattr(trans, "history", collection_instance.history)
-        if check_ownership and collection_instance.history.published is False:
+        if check_ownership:
             self.history_manager.error_unless_owner(collection_instance.history, trans.user, current_history=history)
         if check_accessible:
             self.history_manager.error_unless_accessible(

--- a/lib/galaxy/webapps/galaxy/services/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/services/dataset_collections.py
@@ -248,7 +248,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
                 "Parameter instance_type not being 'history' is not yet implemented."
             )
         hdca: HistoryDatasetCollectionAssociation = self.collection_manager.get_dataset_collection_instance(
-            trans, "history", hdca_id, check_ownership=True
+            trans, "history", hdca_id
         )
 
         # check to make sure the dsc is part of the validated hdca

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -418,6 +418,18 @@ class TestDatasetCollectionsApi(ApiTestCase):
             contents_response = self._get(contents_url)
             self._assert_status_code_is(contents_response, 403)
 
+    @requires_new_user
+    def test_published_collection_contents_accessible(self, history_id):
+        # request contents on an hdca that is in a published history
+        hdca, contents_url = self._create_collection_contents_pair(history_id)
+        with self._different_user():
+            contents_response = self._get(contents_url)
+            self._assert_status_code_is(contents_response, 403)
+        self.dataset_populator.make_public(history_id)
+        with self._different_user():
+            contents_response = self._get(contents_url)
+            self._assert_status_code_is(contents_response, 200)
+
     def test_collection_contents_invalid_collection(self, history_id):
         # request an invalid collection from a valid hdca, should get 404
         hdca, contents_url = self._create_collection_contents_pair(history_id)


### PR DESCRIPTION
Only check ownership in `__get_history_collection_instance` if:
`collection_instance.history.published` = False

Fixes https://github.com/galaxyproject/galaxy/issues/17252
Closes https://github.com/galaxyproject/galaxy/issues/15917

### -
_Is this currently the right way to go about this or do we also need to add a `published` param to the api as well to add context?..._

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
