### PR TITLE
More defensive access of extra props in filesources

### DIFF
--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -1,4 +1,5 @@
 import abc
+from dataclasses import dataclass, field
 import os
 import time
 from typing import (
@@ -52,6 +53,7 @@ class FilesSourceProperties(TypedDict):
     browsable: NotRequired[bool]
 
 
+@dataclass
 class FilesSourceOptions:
     """Options to control behavior of file source operations, such as realize_to, write_from and list."""
 
@@ -64,7 +66,7 @@ class FilesSourceOptions:
     # the HTTPFilesSource passes in additional http_headers through these properties, which
     # are merged with constructor defined http_headers. The interpretation of these properties
     # are filesystem specific.
-    extra_props: Optional[FilesSourceProperties] = {}
+    extra_props: Optional[FilesSourceProperties] = field(default_factory=lambda: {})
 
 
 class SingleFileSource(metaclass=abc.ABCMeta):

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -53,13 +53,18 @@ class FilesSourceProperties(TypedDict):
 
 
 class FilesSourceOptions:
-    """Options to control behaviour of filesource operations, such as realize_to and write_from"""
+    """Options to control behavior of file source operations, such as realize_to, write_from and list."""
+
+    # Indicates access to the FS operation with intent to write.
+    # Even if a file source is "writeable" some directories (or elements) may be restricted or read-only
+    # so those should be skipped while browsing with writeable=True.
+    writeable: Optional[bool] = False
 
     # Property overrides for values initially configured through the constructor. For example
     # the HTTPFilesSource passes in additional http_headers through these properties, which
     # are merged with constructor defined http_headers. The interpretation of these properties
     # are filesystem specific.
-    extra_props: Optional[FilesSourceProperties]
+    extra_props: Optional[FilesSourceProperties] = {}
 
 
 class SingleFileSource(metaclass=abc.ABCMeta):

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -1,7 +1,10 @@
 import abc
-from dataclasses import dataclass, field
 import os
 import time
+from dataclasses import (
+    dataclass,
+    field,
+)
 from typing import (
     Any,
     ClassVar,
@@ -66,7 +69,7 @@ class FilesSourceOptions:
     # the HTTPFilesSource passes in additional http_headers through these properties, which
     # are merged with constructor defined http_headers. The interpretation of these properties
     # are filesystem specific.
-    extra_props: Optional[FilesSourceProperties] = field(default_factory=lambda: {})
+    extra_props: Optional[FilesSourceProperties] = field(default_factory=lambda: FilesSourceProperties())
 
 
 class SingleFileSource(metaclass=abc.ABCMeta):


### PR DESCRIPTION
Based on bug and solution described in: https://github.com/galaxyproject/galaxy/issues/17442

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
