### PR TITLE
[23.0] Fix bug: true >> True

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -201,7 +201,7 @@ class WorkflowsManager(sharable.SharableModelManager, deletable.DeletableManager
                             query = query.filter(model.StoredWorkflow.published == true())
                         elif q == "deleted":
                             query = query.filter(model.StoredWorkflow.deleted == true())
-                            show_deleted = true
+                            show_deleted = True
                         elif q == "shared_with_me":
                             if not show_shared:
                                 message = "Can only use tag is:shared_with_me if show_shared parameter also true."


### PR DESCRIPTION
This was silent because `true` is a function identifier, so when used in a boolean expression it simply evaluated to `True`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
