### PR TITLE
[23.0] Fix `datasetStore.saveDatasets` bug

### DIFF
--- a/client/src/store/historyStore/datasetStore.js
+++ b/client/src/store/historyStore/datasetStore.js
@@ -41,7 +41,7 @@ const mutations = {
                 const id = item.id;
                 if (state.items[id]) {
                     const localItem = state.items[id];
-                    Object.keys(localItem).forEach((key) => {
+                    Object.keys(item).forEach((key) => {
                         localItem[key] = item[key];
                     });
                 }


### PR DESCRIPTION
When we update the datasets in the `datasetStore`, we can sometimes set multiple properties to undefined. This happens because a dataset in the store fetched from `/api/datasets/${id}` has a keys mismatch from a dataset coming from `/api/histories/${historyId}/contents` in `watchHistory`, where the latter has lesser keys. To address this, I replaced `localItem` with `item` in the loop that updates the keys, ensuring the correct properties are retained during the store update.

This bug was fixed and doesn't occur in 23.2.

Fixes https://github.com/galaxyproject/galaxy/issues/16868 (this was the reason the re-run button would go away because we would set various properties such as `item.rerunnable` = _undefined_ when the history would be updated in `watchHistory`

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
