### PR TITLE
freeze (make sticky) header row in tabular files

### DIFF
--- a/client/src/style/scss/overrides.scss
+++ b/client/src/style/scss/overrides.scss
@@ -151,6 +151,10 @@ table.info_data_table td:nth-child(1) {
 table.info_data_table th:nth-child(1) {
     width: 25%;
 }
+table thead.thead-dark tr th[role="columnheader"] {
+    position: sticky;
+    top: 0;
+}
 
 // increase visibility of links within alert boxes
 .alert-info,


### PR DESCRIPTION
Linked to issue #17380 
![demo_17380_freeze_header_row](https://github.com/galaxyproject/galaxy/assets/3672779/6571f19a-38e2-4203-9635-c24ef3814243)
_Table header rows always visible during scrolling_

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
