### PR TITLE
[23.1] Fix history bulk operations menu (part 2)

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
@@ -25,8 +25,13 @@ const TASKS_CONFIG = {
 };
 
 const getMenuSelectorFor = (option) => `[data-description="${option} option"]`;
-const getPurgedContentSelection = () => new Map([["FAKE_ID", { purged: true }]]);
-const getNonPurgedContentSelection = () => new Map([["FAKE_ID", { purged: false }]]);
+
+const getPurgedSelection = () => new Map([["FAKE_ID", { purged: true }]]);
+const getNonPurgedSelection = () => new Map([["FAKE_ID", { purged: false }]]);
+const getVisibleSelection = () => new Map([["FAKE_ID", { visible: true }]]);
+const getHiddenSelection = () => new Map([["FAKE_ID", { visible: false }]]);
+const getDeletedSelection = () => new Map([["FAKE_ID", { deleted: true }]]);
+const getActiveSelection = () => new Map([["FAKE_ID", { deleted: false }]]);
 
 async function mountSelectionOperationsWrapper(config) {
     const wrapper = shallowMount(
@@ -76,32 +81,62 @@ describe("History Selection Operations", () => {
                 expect(wrapper.find('[data-description="selected count"]').text()).toContain("10");
             });
 
-            it("should display 'hide' option only on visible items", async () => {
+            it("should display 'hide' option on visible items", async () => {
                 const option = getMenuSelectorFor("hide");
                 expect(wrapper.find(option).exists()).toBe(true);
+                await wrapper.setProps({ filterText: "visible:true" });
+                expect(wrapper.find(option).exists()).toBe(true);
+            });
+
+            it("should display 'hide' option when visible and hidden items are mixed", async () => {
+                const option = getMenuSelectorFor("hide");
+                expect(wrapper.find(option).exists()).toBe(true);
+                await wrapper.setProps({ filterText: "visible:any" });
+                expect(wrapper.find(option).exists()).toBe(true);
+            });
+
+            it("should not display 'hide' option when only hidden items are selected", async () => {
+                const option = getMenuSelectorFor("hide");
+                expect(wrapper.find(option).exists()).toBe(true);
+                await wrapper.setProps({ filterText: "visible:any", contentSelection: getHiddenSelection() });
+                expect(wrapper.find(option).exists()).toBe(false);
                 await wrapper.setProps({ filterText: "visible:false" });
                 expect(wrapper.find(option).exists()).toBe(false);
             });
 
             it("should display 'unhide' option on hidden items", async () => {
                 const option = getMenuSelectorFor("unhide");
-                expect(wrapper.find(option).exists()).toBe(false);
                 await wrapper.setProps({ filterText: "visible:false" });
                 expect(wrapper.find(option).exists()).toBe(true);
             });
 
             it("should display 'unhide' option when hidden and visible items are mixed", async () => {
                 const option = getMenuSelectorFor("unhide");
-                expect(wrapper.find(option).exists()).toBe(false);
                 await wrapper.setProps({ filterText: "visible:any" });
+                expect(wrapper.find(option).exists()).toBe(true);
+            });
+
+            it("should not display 'unhide' option when only visible items are selected", async () => {
+                const option = getMenuSelectorFor("unhide");
+                await wrapper.setProps({
+                    filterText: "visible:any",
+                    contentSelection: getVisibleSelection(),
+                });
+                expect(wrapper.find(option).exists()).toBe(false);
+            });
+
+            it("should display 'delete' option on non-deleted items", async () => {
+                const option = getMenuSelectorFor("delete");
+                expect(wrapper.find(option).exists()).toBe(true);
+                await wrapper.setProps({ filterText: "deleted:false" });
                 expect(wrapper.find(option).exists()).toBe(true);
             });
 
             it("should display 'delete' option on non-deleted items", async () => {
                 const option = getMenuSelectorFor("delete");
                 expect(wrapper.find(option).exists()).toBe(true);
-                await wrapper.setProps({ filterText: "deleted:true" });
-                expect(wrapper.find(option).exists()).toBe(false);
+                await wrapper.setProps({ filterText: "deleted:false" });
+                expect(wrapper.find(option).exists()).toBe(true);
             });
 
             it("should display 'delete' option when non-deleted and deleted items are mixed", async () => {
@@ -110,10 +145,17 @@ describe("History Selection Operations", () => {
                 expect(wrapper.find(option).exists()).toBe(true);
             });
 
+            it("should not display 'delete' option when only deleted items are selected", async () => {
+                const option = getMenuSelectorFor("delete");
+                expect(wrapper.find(option).exists()).toBe(true);
+                await wrapper.setProps({ filterText: "deleted:any", contentSelection: getDeletedSelection() });
+                expect(wrapper.find(option).exists()).toBe(false);
+            });
+
             it("should display 'permanently delete' option always", async () => {
                 const option = getMenuSelectorFor("purge");
                 expect(wrapper.find(option).exists()).toBe(true);
-                await wrapper.setProps({ filterText: "deleted:true" });
+                await wrapper.setProps({ filterText: "deleted:any visible:any" });
                 expect(wrapper.find(option).exists()).toBe(true);
             });
 
@@ -122,7 +164,7 @@ describe("History Selection Operations", () => {
                 expect(wrapper.find(option).exists()).toBe(false);
                 await wrapper.setProps({
                     filterText: "deleted:true",
-                    contentSelection: getNonPurgedContentSelection(),
+                    contentSelection: getNonPurgedSelection(),
                 });
                 expect(wrapper.find(option).exists()).toBe(true);
             });
@@ -131,16 +173,24 @@ describe("History Selection Operations", () => {
                 const option = getMenuSelectorFor("undelete");
                 await wrapper.setProps({
                     filterText: "deleted:any",
-                    contentSelection: getNonPurgedContentSelection(),
+                    contentSelection: getNonPurgedSelection(),
                 });
                 expect(wrapper.find(option).exists()).toBe(true);
             });
 
-            it("should not display 'undelete' when is manual selection mode and all selected items are purged", async () => {
+            it("should not display 'undelete' when only non-deleted items are selected", async () => {
                 const option = getMenuSelectorFor("undelete");
                 await wrapper.setProps({
-                    filterText: "deleted:true",
-                    contentSelection: getPurgedContentSelection(),
+                    filterText: "deleted:any",
+                    contentSelection: getActiveSelection(),
+                });
+                expect(wrapper.find(option).exists()).toBe(false);
+            });
+
+            it("should not display 'undelete' when only purged items are selected", async () => {
+                const option = getMenuSelectorFor("undelete");
+                await wrapper.setProps({
+                    contentSelection: getPurgedSelection(),
                     isQuerySelection: false,
                 });
                 expect(wrapper.find(option).exists()).toBe(false);
@@ -151,7 +201,7 @@ describe("History Selection Operations", () => {
                 // In query selection mode we don't know if some items may not be purged, so we allow to undelete
                 await wrapper.setProps({
                     filterText: "deleted:true",
-                    contentSelection: getPurgedContentSelection(),
+                    contentSelection: getPurgedSelection(),
                     isQuerySelection: true,
                 });
                 expect(wrapper.find(option).exists()).toBe(true);
@@ -160,33 +210,26 @@ describe("History Selection Operations", () => {
             it("should display 'undelete' option when is query selection mode and filtering by any deleted state", async () => {
                 const option = getMenuSelectorFor("undelete");
                 // In query selection mode we don't know if some items may not be purged, so we allow to undelete
-                await wrapper.setProps({
-                    filterText: "deleted:any",
-                    contentSelection: getPurgedContentSelection(),
-                    isQuerySelection: true,
-                });
+                await wrapper.setProps({ filterText: "deleted:any", isQuerySelection: true });
                 expect(wrapper.find(option).exists()).toBe(true);
             });
 
-            it("should display collection building options only on visible and non-deleted items", async () => {
+            it("should display collection building options only on active (non-deleted) items", async () => {
                 const buildListOption = '[data-description="build list"]';
                 const buildPairOption = '[data-description="build pair"]';
                 const buildListOfPairsOption = '[data-description="build list of pairs"]';
+                await wrapper.setProps({ filterText: "visible:true deleted:false" });
                 expect(wrapper.find(buildListOption).exists()).toBe(true);
                 expect(wrapper.find(buildPairOption).exists()).toBe(true);
                 expect(wrapper.find(buildListOfPairsOption).exists()).toBe(true);
-                await wrapper.setProps({ filterText: "visible:false" });
-                expect(wrapper.find(buildListOption).exists()).toBe(false);
-                expect(wrapper.find(buildPairOption).exists()).toBe(false);
-                expect(wrapper.find(buildListOfPairsOption).exists()).toBe(false);
                 await wrapper.setProps({ filterText: "deleted:true" });
                 expect(wrapper.find(buildListOption).exists()).toBe(false);
                 expect(wrapper.find(buildPairOption).exists()).toBe(false);
                 expect(wrapper.find(buildListOfPairsOption).exists()).toBe(false);
-                await wrapper.setProps({ filterText: "visible:any" });
-                expect(wrapper.find(buildListOption).exists()).toBe(false);
-                expect(wrapper.find(buildPairOption).exists()).toBe(false);
-                expect(wrapper.find(buildListOfPairsOption).exists()).toBe(false);
+                await wrapper.setProps({ filterText: "visible:any deleted:false" });
+                expect(wrapper.find(buildListOption).exists()).toBe(true);
+                expect(wrapper.find(buildPairOption).exists()).toBe(true);
+                expect(wrapper.find(buildListOfPairsOption).exists()).toBe(true);
                 await wrapper.setProps({ filterText: "deleted:any" });
                 expect(wrapper.find(buildListOption).exists()).toBe(false);
                 expect(wrapper.find(buildPairOption).exists()).toBe(false);

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
@@ -24,6 +24,7 @@ const TASKS_CONFIG = {
     enable_celery_tasks: true,
 };
 
+const getMenuSelectorFor = (option) => `[data-description="${option} option"]`;
 const getPurgedContentSelection = () => new Map([["FAKE_ID", { purged: true }]]);
 const getNonPurgedContentSelection = () => new Map([["FAKE_ID", { purged: false }]]);
 
@@ -76,48 +77,48 @@ describe("History Selection Operations", () => {
             });
 
             it("should display 'hide' option only on visible items", async () => {
-                const option = '[data-description="hide option"]';
+                const option = getMenuSelectorFor("hide");
                 expect(wrapper.find(option).exists()).toBe(true);
                 await wrapper.setProps({ filterText: "visible:false" });
                 expect(wrapper.find(option).exists()).toBe(false);
             });
 
             it("should display 'unhide' option on hidden items", async () => {
-                const option = '[data-description="unhide option"]';
+                const option = getMenuSelectorFor("unhide");
                 expect(wrapper.find(option).exists()).toBe(false);
                 await wrapper.setProps({ filterText: "visible:false" });
                 expect(wrapper.find(option).exists()).toBe(true);
             });
 
             it("should display 'unhide' option when hidden and visible items are mixed", async () => {
-                const option = '[data-description="unhide option"]';
+                const option = getMenuSelectorFor("unhide");
                 expect(wrapper.find(option).exists()).toBe(false);
                 await wrapper.setProps({ filterText: "visible:any" });
                 expect(wrapper.find(option).exists()).toBe(true);
             });
 
             it("should display 'delete' option on non-deleted items", async () => {
-                const option = '[data-description="delete option"]';
+                const option = getMenuSelectorFor("delete");
                 expect(wrapper.find(option).exists()).toBe(true);
                 await wrapper.setProps({ filterText: "deleted:true" });
                 expect(wrapper.find(option).exists()).toBe(false);
             });
 
             it("should display 'delete' option when non-deleted and deleted items are mixed", async () => {
-                const option = '[data-description="delete option"]';
+                const option = getMenuSelectorFor("delete");
                 await wrapper.setProps({ filterText: "deleted:any" });
                 expect(wrapper.find(option).exists()).toBe(true);
             });
 
             it("should display 'permanently delete' option always", async () => {
-                const option = '[data-description="purge option"]';
+                const option = getMenuSelectorFor("purge");
                 expect(wrapper.find(option).exists()).toBe(true);
                 await wrapper.setProps({ filterText: "deleted:true" });
                 expect(wrapper.find(option).exists()).toBe(true);
             });
 
             it("should display 'undelete' option on deleted and non-purged items", async () => {
-                const option = '[data-description="undelete option"]';
+                const option = getMenuSelectorFor("undelete");
                 expect(wrapper.find(option).exists()).toBe(false);
                 await wrapper.setProps({
                     filterText: "deleted:true",
@@ -127,7 +128,7 @@ describe("History Selection Operations", () => {
             });
 
             it("should display 'undelete' option when non-purged items (deleted or not) are mixed", async () => {
-                const option = '[data-description="undelete option"]';
+                const option = getMenuSelectorFor("undelete");
                 await wrapper.setProps({
                     filterText: "deleted:any",
                     contentSelection: getNonPurgedContentSelection(),
@@ -136,7 +137,7 @@ describe("History Selection Operations", () => {
             });
 
             it("should not display 'undelete' when is manual selection mode and all selected items are purged", async () => {
-                const option = '[data-description="undelete option"]';
+                const option = getMenuSelectorFor("undelete");
                 await wrapper.setProps({
                     filterText: "deleted:true",
                     contentSelection: getPurgedContentSelection(),
@@ -146,7 +147,7 @@ describe("History Selection Operations", () => {
             });
 
             it("should display 'undelete' option when is query selection mode and filtering by deleted", async () => {
-                const option = '[data-description="undelete option"]';
+                const option = getMenuSelectorFor("undelete");
                 // In query selection mode we don't know if some items may not be purged, so we allow to undelete
                 await wrapper.setProps({
                     filterText: "deleted:true",
@@ -157,7 +158,7 @@ describe("History Selection Operations", () => {
             });
 
             it("should display 'undelete' option when is query selection mode and filtering by any deleted state", async () => {
-                const option = '[data-description="undelete option"]';
+                const option = getMenuSelectorFor("undelete");
                 // In query selection mode we don't know if some items may not be purged, so we allow to undelete
                 await wrapper.setProps({
                     filterText: "deleted:any",

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -199,17 +199,11 @@ export default {
     computed: {
         /** @returns {Boolean} */
         canUnhideSelection() {
-            return (
-                this.areAllSelectedHidden ||
-                (HistoryFilters.checkFilter(this.filterText, "visible", "any") && !this.areAllSelectedVisible)
-            );
+            return this.areAllSelectedHidden || (this.isAnyVisibilityAllowed && !this.areAllSelectedVisible);
         },
         /** @returns {Boolean} */
         canHideSelection() {
-            return (
-                this.areAllSelectedVisible ||
-                (HistoryFilters.checkFilter(this.filterText, "visible", "any") && !this.areAllSelectedHidden)
-            );
+            return this.areAllSelectedVisible || (this.isAnyVisibilityAllowed && !this.areAllSelectedHidden);
         },
         /** @returns {Boolean} */
         showDeleted() {
@@ -217,10 +211,7 @@ export default {
         },
         /** @returns {Boolean} */
         canDeleteSelection() {
-            return (
-                this.areAllSelectedActive ||
-                (HistoryFilters.checkFilter(this.filterText, "deleted", "any") && !this.areAllSelectedDeleted)
-            );
+            return this.areAllSelectedActive || (this.isAnyDeletedStateAllowed && !this.areAllSelectedDeleted);
         },
         /** @returns {Boolean} */
         canUndeleteSelection() {
@@ -288,6 +279,12 @@ export default {
                 }
             }
             return true;
+        },
+        isAnyVisibilityAllowed() {
+            return HistoryFilters.checkFilter(this.filterText, "visible", "any");
+        },
+        isAnyDeletedStateAllowed() {
+            return HistoryFilters.checkFilter(this.filterText, "deleted", "any");
         },
     },
     watch: {


### PR DESCRIPTION
Follow-up to [#17433](https://github.com/galaxyproject/galaxy/pull/17433#issuecomment-1933844379)

Extend the test coverage even more for missing cases and slightly increase the readability of conditions and tests.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
