### PR TITLE
Faster FASTA and FASTQ metadata setting

### DIFF
--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -357,7 +357,9 @@ class Fasta(Sequence):
         sequences = 0
         with compression_utils.get_fileobj(dataset.get_file_name()) as fh:
             for line in fh:
-                if line.startswith(">"):
+                if not line:
+                    continue
+                elif line[0] == ">":
                     sequences += 1
                     data_lines += 1
                 else:

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -715,24 +715,11 @@ class BaseFastq(Sequence):
             return
         data_lines = 0
         sequences = 0
-        seq_counter = 0  # blocks should be 4 lines long
         with compression_utils.get_fileobj(dataset.get_file_name()) as in_file:
             for line in in_file:
-                line = line.strip()
-                if line and line.startswith("#") and not data_lines:
-                    # We don't count comment lines for sequence data types
-                    continue
-                seq_counter += 1
+                if line.startswith("@"):
+                    sequences += 1
                 data_lines += 1
-                if line and line.startswith("@"):
-                    if seq_counter >= 4:
-                        # count previous block
-                        # blocks should be 4 lines long
-                        sequences += 1
-                        seq_counter = 1
-            if seq_counter >= 4:
-                # count final block
-                sequences += 1
             dataset.metadata.data_lines = data_lines
             dataset.metadata.sequences = sequences
 

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -349,6 +349,22 @@ class Fasta(Sequence):
     edam_format = "format_1929"
     file_ext = "fasta"
 
+    def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
+        """
+        Set the number of sequences and the number of data lines in a FASTA dataset.
+        """
+        data_lines = 0
+        sequences = 0
+        with compression_utils.get_fileobj(dataset.get_file_name()) as fh:
+            for line in fh:
+                if line.startswith(">"):
+                    sequences += 1
+                    data_lines += 1
+                else:
+                    data_lines += 1
+            dataset.metadata.data_lines = data_lines
+            dataset.metadata.sequences = sequences
+
     def sniff_prefix(self, file_prefix: FilePrefix) -> bool:
         """
         Determines whether the file is in fasta format

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -717,7 +717,7 @@ class BaseFastq(Sequence):
         sequences = 0
         with compression_utils.get_fileobj(dataset.get_file_name()) as in_file:
             for line in in_file:
-                if line.startswith("@"):
+                if line.startswith("@") and data_lines % 4 == 0:
                     sequences += 1
                 data_lines += 1
             dataset.metadata.data_lines = data_lines

--- a/lib/galaxy/datatypes/test/1.fasta
+++ b/lib/galaxy/datatypes/test/1.fasta
@@ -1,0 +1,1 @@
+../../../../test-data/1.fasta

--- a/test/unit/data/datatypes/test_sequence.py
+++ b/test/unit/data/datatypes/test_sequence.py
@@ -1,0 +1,52 @@
+from galaxy.datatypes.sequence import Fasta, FastqSanger, FastqSolexa
+from .util import (
+    get_dataset,
+)
+
+
+def test_fasta_set_meta():
+    b = Fasta()
+    with get_dataset("1.fasta") as dataset:
+        b.set_meta(dataset=dataset)
+        assert dataset.metadata.data_lines == 2
+        assert dataset.metadata.sequences == 1
+
+
+def test_fastagz_set_meta():
+    b = Fasta()
+    with get_dataset("1.fasta.gz") as dataset:
+        b.set_meta(dataset=dataset)
+        assert dataset.metadata.data_lines == 2
+        assert dataset.metadata.sequences == 1
+
+
+def test_fastqsanger_set_meta():
+    b = FastqSanger()
+    with get_dataset("1.fastqsanger") as dataset:
+        b.set_meta(dataset=dataset)
+        assert dataset.metadata.data_lines == 8
+        assert dataset.metadata.sequences == 2
+
+
+def test_fastqsangergz_set_meta():
+    b = FastqSanger()
+    with get_dataset("1.fastqsanger.gz") as dataset:
+        b.set_meta(dataset=dataset)
+        assert dataset.metadata.data_lines == 8
+        assert dataset.metadata.sequences == 2
+
+
+def test_fastqsangerbz2_set_meta():
+    b = FastqSanger()
+    with get_dataset("1.fastqsanger.bz2") as dataset:
+        b.set_meta(dataset=dataset)
+        assert dataset.metadata.data_lines == 8
+        assert dataset.metadata.sequences == 2
+
+
+def test_fastqsolexa_set_meta():
+    b = FastqSolexa()
+    with get_dataset("1.fastqsolexa") as dataset:
+        b.set_meta(dataset=dataset)
+        assert dataset.metadata.data_lines == 8
+        assert dataset.metadata.sequences == 2

--- a/test/unit/data/datatypes/test_sequence.py
+++ b/test/unit/data/datatypes/test_sequence.py
@@ -1,12 +1,24 @@
+import pytest
+
 from galaxy.datatypes.sequence import (
     Fasta,
     FastqSanger,
     FastqSolexa,
 )
-from .util import get_dataset
+from .util import (
+    get_dataset,
+    MockDatasetDataset,
+)
 
 
-def test_fasta_set_meta():
+@pytest.mark.parametrize(
+    "input_file",
+    [
+        "1.fasta",
+        "1.fasta.gz",
+    ],
+)
+def test_fasta_set_meta(input_file):
     b = Fasta()
     with get_dataset("1.fasta") as dataset:
         b.set_meta(dataset=dataset)
@@ -14,41 +26,19 @@ def test_fasta_set_meta():
         assert dataset.metadata.sequences == 1
 
 
-def test_fastagz_set_meta():
-    b = Fasta()
-    with get_dataset("1.fasta.gz") as dataset:
-        b.set_meta(dataset=dataset)
-        assert dataset.metadata.data_lines == 2
-        assert dataset.metadata.sequences == 1
-
-
-def test_fastqsanger_set_meta():
-    b = FastqSanger()
+@pytest.mark.parametrize(
+    "fastq_type,input_file",
+    [
+        [FastqSanger, "1.fastqsanger"],
+        [FastqSanger, "1.fastqsanger.gz"],
+        [FastqSanger, "1.fastqsanger.bz2"],
+        [FastqSolexa, "1.fastqssolexa"],
+    ],
+)
+def test_fastqsanger_set_meta(fastq_type, input_file):
+    b = fastq_type()
     with get_dataset("1.fastqsanger") as dataset:
-        b.set_meta(dataset=dataset)
-        assert dataset.metadata.data_lines == 8
-        assert dataset.metadata.sequences == 2
-
-
-def test_fastqsangergz_set_meta():
-    b = FastqSanger()
-    with get_dataset("1.fastqsanger.gz") as dataset:
-        b.set_meta(dataset=dataset)
-        assert dataset.metadata.data_lines == 8
-        assert dataset.metadata.sequences == 2
-
-
-def test_fastqsangerbz2_set_meta():
-    b = FastqSanger()
-    with get_dataset("1.fastqsanger.bz2") as dataset:
-        b.set_meta(dataset=dataset)
-        assert dataset.metadata.data_lines == 8
-        assert dataset.metadata.sequences == 2
-
-
-def test_fastqsolexa_set_meta():
-    b = FastqSolexa()
-    with get_dataset("1.fastqsolexa") as dataset:
+        dataset.dataset = MockDatasetDataset(dataset.get_file_name())
         b.set_meta(dataset=dataset)
         assert dataset.metadata.data_lines == 8
         assert dataset.metadata.sequences == 2

--- a/test/unit/data/datatypes/test_sequence.py
+++ b/test/unit/data/datatypes/test_sequence.py
@@ -1,7 +1,9 @@
-from galaxy.datatypes.sequence import Fasta, FastqSanger, FastqSolexa
-from .util import (
-    get_dataset,
+from galaxy.datatypes.sequence import (
+    Fasta,
+    FastqSanger,
+    FastqSolexa,
 )
+from .util import get_dataset
 
 
 def test_fasta_set_meta():


### PR DESCRIPTION
So far the Fasta datatype just used the `set_meta` method of `Sequence` which is quite general and allows for things like comments and unnecessarily strips spaces and checks for empty lines. By a more strict interpretation of the FASTA "standard" we can be nearly 50% faster ([see](https://github.com/galaxyproject/galaxy/issues/17451#issuecomment-1939610089)).

Implemented the same for FASTQ. The sniffer here is really strict (e.g. expects strictly 4 line blocks) so I think we can also simplify the code here...

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
