### PR TITLE
Refactor Workflow API routes - Part 1

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -10977,7 +10977,7 @@ export interface components {
             deleted: boolean;
             /**
              * Email Hash
-             * @description The hash of the email of ?
+             * @description The hash of the email of the creator of this workflow
              */
             email_hash: string | null;
             /**
@@ -10992,7 +10992,7 @@ export interface components {
             id: string;
             /**
              * Importable
-             * @description Indicates if the workflow is importable by ?.
+             * @description Indicates if the workflow is importable by the current user.
              */
             importable: boolean | null;
             /**
@@ -22919,7 +22919,7 @@ export interface operations {
             header?: {
                 "run-as"?: string | null;
             };
-            /** @description The database identifier - UUID or encoded - of the Workflow.. */
+            /** @description The database identifier - UUID or encoded - of the Workflow. */
             path: {
                 workflow_id: string | string | string;
             };
@@ -23659,7 +23659,7 @@ export interface operations {
             header?: {
                 "run-as"?: string | null;
             };
-            /** @description The database identifier - UUID or encoded - of the Workflow.. */
+            /** @description The database identifier - UUID or encoded - of the Workflow. */
             path: {
                 workflow_id: string | string | string;
             };

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -5202,7 +5202,7 @@ export interface components {
              * Tool Sequence
              * @description comma separated sequence of tool ids
              */
-            tool_sequence: Record<string, never>;
+            tool_sequence?: Record<string, never> | null;
         };
         /**
          * GroupCreatePayload
@@ -11282,6 +11282,19 @@ export interface components {
              * @description A `\t` (TAB) separated list of column __contents__. You must specify a value for each of the columns of the data table.
              */
             values: string;
+        };
+        /** ToolPredictionsSummary */
+        ToolPredictionsSummary: {
+            /**
+             * Current Tools
+             * @description A comma separated sequence of the current tool ids
+             */
+            current_tool?: Record<string, never> | null;
+            /**
+             * Recommended Tools
+             * @description List of predictions
+             */
+            predicted_data?: Record<string, never> | null;
         };
         /** ToolStep */
         ToolStep: {
@@ -22710,7 +22723,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": Record<string, never> | components["schemas"]["ToolPredictionsSummary"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1807,6 +1807,10 @@ export interface paths {
         /** Get workflows present in the tools panel. */
         get: operations["get_workflow_menu_api_workflows_menu_get"];
     };
+    "/api/workflows/{encoded_workflow_id}": {
+        /** Displays information needed to run a workflow. */
+        get: operations["show_workflow_api_workflows__encoded_workflow_id__get"];
+    };
     "/api/workflows/{workflow_id}": {
         /** Add the deleted flag to a workflow. */
         delete: operations["delete_workflow_api_workflows__workflow_id__delete"];
@@ -22243,6 +22247,40 @@ export interface operations {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
                 "run-as"?: string | null;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    show_workflow_api_workflows__encoded_workflow_id__get: {
+        /** Displays information needed to run a workflow. */
+        parameters: {
+            /** @description Use the legacy workflow format. */
+            /** @description The version of the workflow to fetch. */
+            query?: {
+                instance?: boolean | null;
+                legacy?: boolean | null;
+                version?: number | null;
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string | null;
+            };
+            /** @description The encoded database identifier of the Stored Workflow. */
+            path: {
+                encoded_workflow_id: string;
             };
         };
         responses: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1835,7 +1835,7 @@ export interface paths {
          *
          * :raises: exceptions.MessageException, exceptions.RequestParameterInvalidException
          */
-        post: operations["Invoke_workflow__api_workflows__workflow_id__invocations_post"];
+        post: operations["Invoke_workflow_api_workflows__workflow_id__invocations_post"];
     };
     "/api/workflows/{workflow_id}/invocations/{invocation_id}": {
         /**
@@ -1948,6 +1948,15 @@ export interface paths {
          * @deprecated
          */
         get: operations["index_invocations_api_workflows__workflow_id__usage_get"];
+        /**
+         * Schedule the workflow specified by `workflow_id` to run.
+         * @deprecated
+         * @description .. note:: This method takes the same arguments as
+         *     :func:`galaxy.webapps.galaxy.api.workflows.WorkflowsAPIController.create` above.
+         *
+         * :raises: exceptions.MessageException, exceptions.RequestParameterInvalidException
+         */
+        post: operations["Invoke_workflow_api_workflows__workflow_id__usage_post"];
     };
     "/api/workflows/{workflow_id}/usage/{invocation_id}": {
         /**
@@ -21894,7 +21903,7 @@ export interface operations {
             };
         };
     };
-    Invoke_workflow__api_workflows__workflow_id__invocations_post: {
+    Invoke_workflow_api_workflows__workflow_id__invocations_post: {
         /**
          * Schedule the workflow specified by `workflow_id` to run.
          * @description .. note:: This method takes the same arguments as
@@ -22591,6 +22600,46 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["WorkflowInvocationResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    Invoke_workflow_api_workflows__workflow_id__usage_post: {
+        /**
+         * Schedule the workflow specified by `workflow_id` to run.
+         * @deprecated
+         * @description .. note:: This method takes the same arguments as
+         *     :func:`galaxy.webapps.galaxy.api.workflows.WorkflowsAPIController.create` above.
+         *
+         * :raises: exceptions.MessageException, exceptions.RequestParameterInvalidException
+         */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string | null;
+            };
+            path: {
+                workflow_id: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InvokeWorkflowPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json":
+                        | components["schemas"]["WorkflowInvocationResponse"]
+                        | components["schemas"]["WorkflowInvocationResponse"][];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1807,11 +1807,9 @@ export interface paths {
         /** Get workflows present in the tools panel. */
         get: operations["get_workflow_menu_api_workflows_menu_get"];
     };
-    "/api/workflows/{encoded_workflow_id}": {
-        /** Displays information needed to run a workflow. */
-        get: operations["show_workflow_api_workflows__encoded_workflow_id__get"];
-    };
     "/api/workflows/{workflow_id}": {
+        /** Displays information needed to run a workflow. */
+        get: operations["show_workflow_api_workflows__workflow_id__get"];
         /** Add the deleted flag to a workflow. */
         delete: operations["delete_workflow_api_workflows__workflow_id__delete"];
     };
@@ -6835,6 +6833,129 @@ export interface components {
              */
             to_posix_lines?: "Yes" | boolean | null;
         };
+        /** InputDataCollectionStep */
+        InputDataCollectionStep: {
+            /**
+             * Annotation
+             * @description An annotation to provide details or to help understand the purpose and usage of this item.
+             */
+            annotation: string | null;
+            /**
+             * ID
+             * @description The identifier of the step. It matches the index order of the step inside the workflow.
+             */
+            id: number;
+            /**
+             * Input Steps
+             * @description A dictionary containing information about the inputs connected to this workflow step.
+             */
+            input_steps: {
+                [key: string]: components["schemas"]["InputStep"] | undefined;
+            };
+            /**
+             * Tool ID
+             * @description The unique name of the tool associated with this step.
+             */
+            tool_id?: string | null;
+            /**
+             * Tool Inputs
+             * @description TODO
+             */
+            tool_inputs?: Record<string, never>;
+            /**
+             * Tool Version
+             * @description The version of the tool associated with this step.
+             */
+            tool_version?: string | null;
+            /**
+             * Type
+             * @description The type of workflow module.
+             * @default data_collection_input
+             */
+            type?: components["schemas"]["WorkflowModuleType"];
+        };
+        /** InputDataStep */
+        InputDataStep: {
+            /**
+             * Annotation
+             * @description An annotation to provide details or to help understand the purpose and usage of this item.
+             */
+            annotation: string | null;
+            /**
+             * ID
+             * @description The identifier of the step. It matches the index order of the step inside the workflow.
+             */
+            id: number;
+            /**
+             * Input Steps
+             * @description A dictionary containing information about the inputs connected to this workflow step.
+             */
+            input_steps: {
+                [key: string]: components["schemas"]["InputStep"] | undefined;
+            };
+            /**
+             * Tool ID
+             * @description The unique name of the tool associated with this step.
+             */
+            tool_id?: string | null;
+            /**
+             * Tool Inputs
+             * @description TODO
+             */
+            tool_inputs?: Record<string, never>;
+            /**
+             * Tool Version
+             * @description The version of the tool associated with this step.
+             */
+            tool_version?: string | null;
+            /**
+             * Type
+             * @description The type of workflow module.
+             * @default data_input
+             */
+            type?: components["schemas"]["WorkflowModuleType"];
+        };
+        /** InputParameterStep */
+        InputParameterStep: {
+            /**
+             * Annotation
+             * @description An annotation to provide details or to help understand the purpose and usage of this item.
+             */
+            annotation: string | null;
+            /**
+             * ID
+             * @description The identifier of the step. It matches the index order of the step inside the workflow.
+             */
+            id: number;
+            /**
+             * Input Steps
+             * @description A dictionary containing information about the inputs connected to this workflow step.
+             */
+            input_steps: {
+                [key: string]: components["schemas"]["InputStep"] | undefined;
+            };
+            /**
+             * Tool ID
+             * @description The unique name of the tool associated with this step.
+             */
+            tool_id?: string | null;
+            /**
+             * Tool Inputs
+             * @description TODO
+             */
+            tool_inputs?: Record<string, never>;
+            /**
+             * Tool Version
+             * @description The version of the tool associated with this step.
+             */
+            tool_version?: string | null;
+            /**
+             * Type
+             * @description The type of workflow module.
+             * @default parameter_input
+             */
+            type?: components["schemas"]["WorkflowModuleType"];
+        };
         /** InputReferenceByLabel */
         InputReferenceByLabel: {
             /**
@@ -6860,6 +6981,19 @@ export interface components {
              * @description The order_index of the step being referenced. The order indices of a workflow start at 0.
              */
             order_index: number;
+        };
+        /** InputStep */
+        InputStep: {
+            /**
+             * Source Step
+             * @description The identifier of the workflow step connected to this particular input.
+             */
+            source_step: number;
+            /**
+             * Step Output
+             * @description The name of the output generated by the source step.
+             */
+            step_output: string;
         };
         /** InstalledRepositoryToolShedStatus */
         InstalledRepositoryToolShedStatus: {
@@ -9239,20 +9373,6 @@ export interface components {
              */
             up_to_date: boolean;
         };
-        /** Organization */
-        Organization: {
-            /**
-             * Name
-             * @description Name of the organization responsible for the service
-             */
-            name: string;
-            /**
-             * Url
-             * Format: uri
-             * @description URL of the website of the organization (RFC 3986 format)
-             */
-            url: string;
-        };
         /** OutputReferenceByLabel */
         OutputReferenceByLabel: {
             /**
@@ -9580,6 +9700,80 @@ export interface components {
              * @default false
              */
             to_posix_lines?: boolean;
+        };
+        /** PauseStep */
+        PauseStep: {
+            /**
+             * Annotation
+             * @description An annotation to provide details or to help understand the purpose and usage of this item.
+             */
+            annotation: string | null;
+            /**
+             * ID
+             * @description The identifier of the step. It matches the index order of the step inside the workflow.
+             */
+            id: number;
+            /**
+             * Input Steps
+             * @description A dictionary containing information about the inputs connected to this workflow step.
+             */
+            input_steps: {
+                [key: string]: components["schemas"]["InputStep"] | undefined;
+            };
+            /**
+             * Type
+             * @description The type of workflow module.
+             * @default pause
+             */
+            type?: components["schemas"]["WorkflowModuleType"];
+        };
+        /** Person */
+        Person: {
+            /** Address */
+            address?: string | null;
+            /** Alternate Name */
+            alternateName?: string | null;
+            /**
+             * Class
+             * @default Person
+             */
+            class?: string;
+            /** Email */
+            email?: string | null;
+            /** Family Name */
+            familyName?: string | null;
+            /** Fax Number */
+            faxNumber?: string | null;
+            /** Given Name */
+            givenName?: string | null;
+            /**
+             * Honorific Prefix
+             * @description Honorific Prefix (e.g. Dr/Mrs/Mr)
+             */
+            honorificPrefix?: string | null;
+            /**
+             * Honorific Suffix
+             * @description Honorific Suffix (e.g. M.D.)
+             */
+            honorificSuffix?: string | null;
+            /**
+             * Identifier
+             * @description Identifier (typically an orcid.org ID)
+             */
+            identifier?: string | null;
+            /** Image URL */
+            image?: string | null;
+            /** Job Title */
+            jobTitle?: string | null;
+            /**
+             * Name
+             * @description The name of the creator.
+             */
+            name: string;
+            /** Telephone */
+            telephone?: string | null;
+            /** URL */
+            url?: string | null;
         };
         /**
          * PersonalNotificationCategory
@@ -10227,7 +10421,7 @@ export interface components {
              */
             name: string;
             /** @description Organization providing the service */
-            organization: components["schemas"]["Organization"];
+            organization: components["schemas"]["galaxy__schema__drs__Organization"];
             type: components["schemas"]["ServiceType"];
             /**
              * Updatedat
@@ -10768,6 +10962,184 @@ export interface components {
          * @enum {string}
          */
         StoredItemOrderBy: "name-asc" | "name-dsc" | "size-asc" | "size-dsc" | "update_time-asc" | "update_time-dsc";
+        /** StoredWorkflowDetailed */
+        StoredWorkflowDetailed: {
+            /**
+             * Annotation
+             * @description An annotation to provide details or to help understand the purpose and usage of this item.
+             */
+            annotation: string | null;
+            /**
+             * Annotations
+             * @description An list of annotations to provide details or to help understand the purpose and usage of this workflow.
+             */
+            annotations?: string[] | null;
+            /**
+             * Create Time
+             * Format: date-time
+             * @description The time and date this item was created.
+             */
+            create_time: string;
+            /**
+             * Creator
+             * @description Additional information about the creator (or multiple creators) of this workflow.
+             */
+            creator?:
+                | (components["schemas"]["Person"] | components["schemas"]["galaxy__schema__schema__Organization"])[]
+                | null;
+            /**
+             * Deleted
+             * @description Whether this item is marked as deleted.
+             */
+            deleted: boolean;
+            /**
+             * Email Hash
+             * @description The hash of the email of ?
+             */
+            email_hash: string | null;
+            /**
+             * Hidden
+             * @description TODO
+             */
+            hidden: boolean;
+            /**
+             * Id
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /**
+             * Importable
+             * @description Indicates if the workflow is importable by ?.
+             */
+            importable: boolean | null;
+            /**
+             * Inputs
+             * @description A dictionary containing information about all the inputs of the workflow.
+             * @default {}
+             */
+            inputs?: {
+                [key: string]: components["schemas"]["WorkflowInput"] | undefined;
+            };
+            /**
+             * Latest workflow UUID
+             * Format: uuid4
+             * @description TODO
+             */
+            latest_workflow_uuid: string;
+            /**
+             * License
+             * @description SPDX Identifier of the license associated with this workflow.
+             */
+            license?: string | null;
+            /**
+             * Model class
+             * @description The name of the database model class.
+             * @constant
+             */
+            model_class: "StoredWorkflow";
+            /**
+             * Name
+             * @description The name of the history.
+             */
+            name: string;
+            /**
+             * Number of Steps
+             * @description The number of steps that make up this workflow.
+             */
+            number_of_steps?: number | null;
+            /**
+             * Owner
+             * @description The name of the user who owns this workflow.
+             */
+            owner: string;
+            /**
+             * Published
+             * @description Whether this workflow is currently publicly available to all users.
+             */
+            published: boolean;
+            /**
+             * Show in Tool Panel
+             * @description Whether to display this workflow in the Tools Panel.
+             */
+            show_in_tool_panel?: boolean | null;
+            /**
+             * Slug
+             * @description The slug of the workflow.
+             */
+            slug: string | null;
+            /**
+             * Source Metadata
+             * @description The source metadata of the workflow.
+             */
+            source_metadata: string | null;
+            /**
+             * Steps
+             * @description A dictionary with information about all the steps of the workflow.
+             * @default {}
+             */
+            steps?: {
+                [key: string]:
+                    | (
+                          | components["schemas"]["InputDataStep"]
+                          | components["schemas"]["InputDataCollectionStep"]
+                          | components["schemas"]["InputParameterStep"]
+                          | components["schemas"]["PauseStep"]
+                          | components["schemas"]["ToolStep"]
+                          | components["schemas"]["SubworkflowStep"]
+                      )
+                    | undefined;
+            };
+            tags: components["schemas"]["TagCollection"];
+            /**
+             * Update Time
+             * Format: date-time
+             * @description The last time and date this item was updated.
+             */
+            update_time: string;
+            /**
+             * URL
+             * @deprecated
+             * @description The relative URL to access this item.
+             */
+            url: string;
+            /**
+             * Version
+             * @description The version of the workflow represented by an incremental number.
+             */
+            version: number;
+        };
+        /** SubworkflowStep */
+        SubworkflowStep: {
+            /**
+             * Annotation
+             * @description An annotation to provide details or to help understand the purpose and usage of this item.
+             */
+            annotation: string | null;
+            /**
+             * ID
+             * @description The identifier of the step. It matches the index order of the step inside the workflow.
+             */
+            id: number;
+            /**
+             * Input Steps
+             * @description A dictionary containing information about the inputs connected to this workflow step.
+             */
+            input_steps: {
+                [key: string]: components["schemas"]["InputStep"] | undefined;
+            };
+            /**
+             * Type
+             * @description The type of workflow module.
+             * @default subworkflow
+             */
+            type?: components["schemas"]["WorkflowModuleType"];
+            /**
+             * Workflow ID
+             * @description The encoded ID of the workflow that will be run on this step.
+             * @example 0123456789ABCDEF
+             */
+            workflow_id: string;
+        };
         /** SuitableConverter */
         SuitableConverter: {
             /**
@@ -10910,6 +11282,47 @@ export interface components {
              * @description A `\t` (TAB) separated list of column __contents__. You must specify a value for each of the columns of the data table.
              */
             values: string;
+        };
+        /** ToolStep */
+        ToolStep: {
+            /**
+             * Annotation
+             * @description An annotation to provide details or to help understand the purpose and usage of this item.
+             */
+            annotation: string | null;
+            /**
+             * ID
+             * @description The identifier of the step. It matches the index order of the step inside the workflow.
+             */
+            id: number;
+            /**
+             * Input Steps
+             * @description A dictionary containing information about the inputs connected to this workflow step.
+             */
+            input_steps: {
+                [key: string]: components["schemas"]["InputStep"] | undefined;
+            };
+            /**
+             * Tool ID
+             * @description The unique name of the tool associated with this step.
+             */
+            tool_id?: string | null;
+            /**
+             * Tool Inputs
+             * @description TODO
+             */
+            tool_inputs?: Record<string, never>;
+            /**
+             * Tool Version
+             * @description The version of the tool associated with this step.
+             */
+            tool_version?: string | null;
+            /**
+             * Type
+             * @description The type of workflow module.
+             * @default tool
+             */
+            type?: components["schemas"]["WorkflowModuleType"];
         };
         /** Tour */
         Tour: {
@@ -11706,6 +12119,25 @@ export interface components {
          * @default []
          */
         VisualizationSummaryList: components["schemas"]["VisualizationSummary"][];
+        /** WorkflowInput */
+        WorkflowInput: {
+            /**
+             * Label
+             * @description Label of the input.
+             */
+            label: string;
+            /**
+             * UUID
+             * Format: uuid4
+             * @description Universal unique identifier of the input.
+             */
+            uuid: string;
+            /**
+             * Value
+             * @description TODO
+             */
+            value: string;
+        };
         /** WorkflowInvocationCollectionView */
         WorkflowInvocationCollectionView: {
             /**
@@ -11890,6 +12322,18 @@ export interface components {
                 [key: string]: number | undefined;
             };
         };
+        /**
+         * WorkflowModuleType
+         * @description Available types of modules that represent a step in a Workflow.
+         * @enum {string}
+         */
+        WorkflowModuleType:
+            | "data_input"
+            | "data_collection_input"
+            | "parameter_input"
+            | "subworkflow"
+            | "tool"
+            | "pause";
         /** WriteInvocationStoreToPayload */
         WriteInvocationStoreToPayload: {
             /**
@@ -12007,6 +12451,52 @@ export interface components {
              * @description External resource vendor prefix
              */
             namespace: string;
+        };
+        /** Organization */
+        galaxy__schema__drs__Organization: {
+            /**
+             * Name
+             * @description Name of the organization responsible for the service
+             */
+            name: string;
+            /**
+             * Url
+             * Format: uri
+             * @description URL of the website of the organization (RFC 3986 format)
+             */
+            url: string;
+        };
+        /** Organization */
+        galaxy__schema__schema__Organization: {
+            /** Address */
+            address?: string | null;
+            /** Alternate Name */
+            alternateName?: string | null;
+            /**
+             * Class
+             * @default Organization
+             */
+            class?: string;
+            /** Email */
+            email?: string | null;
+            /** Fax Number */
+            faxNumber?: string | null;
+            /**
+             * Identifier
+             * @description Identifier (typically an orcid.org ID)
+             */
+            identifier?: string | null;
+            /** Image URL */
+            image?: string | null;
+            /**
+             * Name
+             * @description The name of the creator.
+             */
+            name: string;
+            /** Telephone */
+            telephone?: string | null;
+            /** URL */
+            url?: string | null;
         };
     };
     responses: never;
@@ -22264,7 +22754,7 @@ export interface operations {
             };
         };
     };
-    show_workflow_api_workflows__encoded_workflow_id__get: {
+    show_workflow_api_workflows__workflow_id__get: {
         /** Displays information needed to run a workflow. */
         parameters: {
             /** @description Use the legacy workflow format. */
@@ -22280,14 +22770,14 @@ export interface operations {
             };
             /** @description The encoded database identifier of the Stored Workflow. */
             path: {
-                encoded_workflow_id: string;
+                workflow_id: string;
             };
         };
         responses: {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["StoredWorkflowDetailed"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1799,10 +1799,6 @@ export interface paths {
          */
         get: operations["index_api_workflows_get"];
     };
-    "/api/workflows/get_tool_predictions": {
-        /** Fetch predicted tools for a workflow */
-        post: operations["get_tool_predictions_api_workflows_get_tool_predictions_post"];
-    };
     "/api/workflows/menu": {
         /** Get workflows present in the tools panel. */
         get: operations["get_workflow_menu_api_workflows_menu_get"];
@@ -5190,19 +5186,6 @@ export interface components {
             src: "ftp_import";
             /** Tags */
             tags?: string[] | null;
-        };
-        /** GetToolPredictionsPayload */
-        GetToolPredictionsPayload: {
-            /**
-             * Remote Model URL
-             * @description Path to the deep learning model
-             */
-            remote_model_url?: Record<string, never> | null;
-            /**
-             * Tool Sequence
-             * @description comma separated sequence of tool ids
-             */
-            tool_sequence?: Record<string, never> | null;
         };
         /**
          * GroupCreatePayload
@@ -11282,19 +11265,6 @@ export interface components {
              * @description A `\t` (TAB) separated list of column __contents__. You must specify a value for each of the columns of the data table.
              */
             values: string;
-        };
-        /** ToolPredictionsSummary */
-        ToolPredictionsSummary: {
-            /**
-             * Current Tools
-             * @description A comma separated sequence of the current tool ids
-             */
-            current_tool?: Record<string, never> | null;
-            /**
-             * Recommended Tools
-             * @description List of predictions
-             */
-            predicted_data?: Record<string, never> | null;
         };
         /** ToolStep */
         ToolStep: {
@@ -22696,34 +22666,6 @@ export interface operations {
             200: {
                 content: {
                     "application/json": Record<string, never>[];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_tool_predictions_api_workflows_get_tool_predictions_post: {
-        /** Fetch predicted tools for a workflow */
-        parameters?: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string | null;
-            };
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["GetToolPredictionsPayload"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": Record<string, never> | components["schemas"]["ToolPredictionsSummary"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1828,6 +1828,14 @@ export interface paths {
     "/api/workflows/{workflow_id}/invocations": {
         /** Get the list of a user's workflow invocations. */
         get: operations["index_invocations_api_workflows__workflow_id__invocations_get"];
+        /**
+         * Schedule the workflow specified by `workflow_id` to run.
+         * @description .. note:: This method takes the same arguments as
+         *     :func:`galaxy.webapps.galaxy.api.workflows.WorkflowsAPIController.create` above.
+         *
+         * :raises: exceptions.MessageException, exceptions.RequestParameterInvalidException
+         */
+        post: operations["Invoke_workflow__api_workflows__workflow_id__invocations_post"];
     };
     "/api/workflows/{workflow_id}/invocations/{invocation_id}": {
         /**
@@ -7367,6 +7375,104 @@ export interface components {
              * @description Whether to take action on the invocation step.
              */
             action: boolean;
+        };
+        /** InvokeWorkflowPayload */
+        InvokeWorkflowPayload: {
+            /**
+             * Allow Tool State Corrections
+             * @default false
+             */
+            allow_tool_state_corrections?: boolean | null;
+            /**
+             * Batch
+             * @description If true, the workflow is invoked as a batch.
+             * @default false
+             */
+            batch?: boolean | null;
+            /** Ds Map */
+            ds_map?: {
+                [key: string]: Record<string, never> | undefined;
+            } | null;
+            /** Effective Outputs */
+            effective_outputs?: boolean | null;
+            /**
+             * History
+             * @description The history to import the workflow into.
+             */
+            history?: string | null;
+            /**
+             * History ID
+             * @description The history to import the workflow into.
+             */
+            history_id?: string | null;
+            /**
+             * History Name
+             * @description The name of the history to import the workflow into.
+             */
+            history_name?: string | null;
+            /** Inputs */
+            inputs?: Record<string, never> | null;
+            /** Inputs By */
+            inputs_by?: string | null;
+            /**
+             * Is Instance
+             * @description If true, the workflow is invoked as an instance.
+             * @default false
+             */
+            instance?: boolean | null;
+            /**
+             * Legacy
+             * @default false
+             */
+            legacy?: boolean | null;
+            /**
+             * New History Name
+             * @description The name of the new history to import the workflow into.
+             */
+            new_history_name?: string | null;
+            /**
+             * No Add To History
+             * @default false
+             */
+            no_add_to_history?: boolean | null;
+            /** Parameters */
+            parameters?: Record<string, never> | null;
+            /**
+             * Parameters Normalized
+             * @default false
+             */
+            parameters_normalized?: boolean | null;
+            /** Preferred Intermediate Object Store Id */
+            preferred_intermediate_object_store_id?: string | null;
+            /**
+             * Preferred Object Store ID
+             * @description The ID of the object store that should be used to store new datasets in this history.
+             */
+            preferred_object_store_id?: string | null;
+            /** Preferred Outputs Object Store Id */
+            preferred_outputs_object_store_id?: string | null;
+            /** Replacement Params */
+            replacement_params?: Record<string, never> | null;
+            /**
+             * Require Exact Tool Versions
+             * @description If true, exact tool versions are required for workflow invocation.
+             * @default false
+             */
+            require_exact_tool_versions?: boolean | null;
+            /** Resource Params */
+            resource_params?: Record<string, never> | null;
+            /**
+             * Scheduler
+             * @description Scheduler to use for workflow invocation.
+             */
+            scheduler?: string | null;
+            /** Step Parameters */
+            step_parameters?: Record<string, never> | null;
+            /**
+             * Use Cached Job
+             * @default false
+             */
+            use_cached_job?: boolean | null;
         };
         /**
          * ItemTagsCreatePayload
@@ -21739,6 +21845,45 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["WorkflowInvocationResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    Invoke_workflow__api_workflows__workflow_id__invocations_post: {
+        /**
+         * Schedule the workflow specified by `workflow_id` to run.
+         * @description .. note:: This method takes the same arguments as
+         *     :func:`galaxy.webapps.galaxy.api.workflows.WorkflowsAPIController.create` above.
+         *
+         * :raises: exceptions.MessageException, exceptions.RequestParameterInvalidException
+         */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string | null;
+            };
+            path: {
+                workflow_id: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InvokeWorkflowPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json":
+                        | components["schemas"]["WorkflowInvocationResponse"]
+                        | components["schemas"]["WorkflowInvocationResponse"][];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1799,6 +1799,10 @@ export interface paths {
          */
         get: operations["index_api_workflows_get"];
     };
+    "/api/workflows/get_tool_predictions": {
+        /** Fetch predicted tools for a workflow */
+        post: operations["get_tool_predictions_api_workflows_get_tool_predictions_post"];
+    };
     "/api/workflows/menu": {
         /** Get workflows present in the tools panel. */
         get: operations["get_workflow_menu_api_workflows_menu_get"];
@@ -5184,6 +5188,19 @@ export interface components {
             src: "ftp_import";
             /** Tags */
             tags?: string[] | null;
+        };
+        /** GetToolPredictionsPayload */
+        GetToolPredictionsPayload: {
+            /**
+             * Remote Model URL
+             * @description Path to the deep learning model
+             */
+            remote_model_url?: Record<string, never> | null;
+            /**
+             * Tool Sequence
+             * @description comma separated sequence of tool ids
+             */
+            tool_sequence: Record<string, never>;
         };
         /**
          * GroupCreatePayload
@@ -22172,6 +22189,34 @@ export interface operations {
             200: {
                 content: {
                     "application/json": Record<string, never>[];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_tool_predictions_api_workflows_get_tool_predictions_post: {
+        /** Fetch predicted tools for a workflow */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GetToolPredictionsPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1828,13 +1828,7 @@ export interface paths {
     "/api/workflows/{workflow_id}/invocations": {
         /** Get the list of a user's workflow invocations. */
         get: operations["index_invocations_api_workflows__workflow_id__invocations_get"];
-        /**
-         * Schedule the workflow specified by `workflow_id` to run.
-         * @description .. note:: This method takes the same arguments as
-         *     :func:`galaxy.webapps.galaxy.api.workflows.WorkflowsAPIController.create` above.
-         *
-         * :raises: exceptions.MessageException, exceptions.RequestParameterInvalidException
-         */
+        /** Schedule the workflow specified by `workflow_id` to run. */
         post: operations["Invoke_workflow_api_workflows__workflow_id__invocations_post"];
     };
     "/api/workflows/{workflow_id}/invocations/{invocation_id}": {
@@ -1896,6 +1890,10 @@ export interface paths {
          */
         put: operations["publish_api_workflows__workflow_id__publish_put"];
     };
+    "/api/workflows/{workflow_id}/refactor": {
+        /** Updates the workflow stored with the given ID. */
+        put: operations["refactor_api_workflows__workflow_id__refactor_put"];
+    };
     "/api/workflows/{workflow_id}/share_with_users": {
         /**
          * Share this item with specific users.
@@ -1951,10 +1949,6 @@ export interface paths {
         /**
          * Schedule the workflow specified by `workflow_id` to run.
          * @deprecated
-         * @description .. note:: This method takes the same arguments as
-         *     :func:`galaxy.webapps.galaxy.api.workflows.WorkflowsAPIController.create` above.
-         *
-         * :raises: exceptions.MessageException, exceptions.RequestParameterInvalidException
          */
         post: operations["Invoke_workflow_api_workflows__workflow_id__usage_post"];
     };
@@ -2113,6 +2107,63 @@ export interface components {
              * @description The link to be opened when the button is clicked.
              */
             link: string;
+        };
+        /** AddInputAction */
+        AddInputAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "add_input";
+            /** Collection Type */
+            collection_type?: string | null;
+            /** Default */
+            default?: Record<string, never> | null;
+            /** Label */
+            label?: string | null;
+            /**
+             * Optional
+             * @default false
+             */
+            optional?: boolean | null;
+            position?: components["schemas"]["Position"] | null;
+            /** Restrict On Connections */
+            restrict_on_connections?: boolean | null;
+            /** Restrictions */
+            restrictions?: string[] | null;
+            /** Suggestions */
+            suggestions?: string[] | null;
+            /** Type */
+            type: string;
+        };
+        /**
+         * AddStepAction
+         * @description Add a new action to the workflow.
+         *
+         * After the workflow is updated, an order_index will be assigned
+         * and this step may cause other steps to have their output_index
+         * adjusted.
+         */
+        AddStepAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "add_step";
+            /**
+             * Label
+             * @description A unique label for the step being added, must be distinct from the labels already present in the workflow.
+             */
+            label?: string | null;
+            /** @description The location of the step in the Galaxy workflow editor. */
+            position?: components["schemas"]["Position"] | null;
+            /** Tool State */
+            tool_state?: Record<string, never> | null;
+            /**
+             * Type
+             * @description Module type of the step to add, see galaxy.workflow.modules for available types.
+             */
+            type: string;
         };
         /** AnonUserModel */
         AnonUserModel: {
@@ -2972,6 +3023,20 @@ export interface components {
              * @description The quota source label corresponding to the object store the dataset is stored in (or would be stored in)
              */
             source: string | null;
+        };
+        /** ConnectAction */
+        ConnectAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "connect";
+            /** Input */
+            input: components["schemas"]["InputReferenceByOrderIndex"] | components["schemas"]["InputReferenceByLabel"];
+            /** Output */
+            output:
+                | components["schemas"]["OutputReferenceByOrderIndex"]
+                | components["schemas"]["OutputReferenceByLabel"];
         };
         /** ContentsObject */
         ContentsObject: {
@@ -4283,6 +4348,20 @@ export interface components {
              */
             username: string;
         };
+        /** DisconnectAction */
+        DisconnectAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "disconnect";
+            /** Input */
+            input: components["schemas"]["InputReferenceByOrderIndex"] | components["schemas"]["InputReferenceByLabel"];
+            /** Output */
+            output:
+                | components["schemas"]["OutputReferenceByOrderIndex"]
+                | components["schemas"]["OutputReferenceByLabel"];
+        };
         /**
          * DisplayApp
          * @description Basic linked information about an application that can display certain datatypes.
@@ -4739,6 +4818,32 @@ export interface components {
          * @enum {string}
          */
         ExtraFilesEntryClass: "Directory" | "File";
+        /** ExtractInputAction */
+        ExtractInputAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "extract_input";
+            /** Input */
+            input: components["schemas"]["InputReferenceByOrderIndex"] | components["schemas"]["InputReferenceByLabel"];
+            /** Label */
+            label?: string | null;
+            position?: components["schemas"]["Position"] | null;
+        };
+        /** ExtractUntypedParameter */
+        ExtractUntypedParameter: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "extract_untyped_parameter";
+            /** Label */
+            label?: string | null;
+            /** Name */
+            name: string;
+            position?: components["schemas"]["Position"] | null;
+        };
         /** FavoriteObject */
         FavoriteObject: {
             /**
@@ -4831,6 +4936,14 @@ export interface components {
              * @default false
              */
             to_posix_lines?: boolean;
+        };
+        /** FileDefaultsAction */
+        FileDefaultsAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "fill_defaults";
         };
         /** FileLibraryFolderItem */
         FileLibraryFolderItem: {
@@ -4942,6 +5055,16 @@ export interface components {
             | components["schemas"]["BrowsableFilesSourcePlugin"]
             | components["schemas"]["FilesSourcePlugin"]
         )[];
+        /** FillStepDefaultsAction */
+        FillStepDefaultsAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "fill_step_defaults";
+            /** Step */
+            step: components["schemas"]["StepReferenceByOrderIndex"] | components["schemas"]["StepReferenceByLabel"];
+        };
         /** FolderLibraryFolderItem */
         FolderLibraryFolderItem: {
             /** Can Manage */
@@ -6691,6 +6814,32 @@ export interface components {
              */
             to_posix_lines?: "Yes" | boolean | null;
         };
+        /** InputReferenceByLabel */
+        InputReferenceByLabel: {
+            /**
+             * Input Name
+             * @description The input name as defined by the workflow module corresponding to the step being referenced. For Galaxy tool steps these inputs should be normalized using '|' (e.g. 'cond|repeat_0|input').
+             */
+            input_name: string;
+            /**
+             * Label
+             * @description The unique label of the step being referenced.
+             */
+            label: string;
+        };
+        /** InputReferenceByOrderIndex */
+        InputReferenceByOrderIndex: {
+            /**
+             * Input Name
+             * @description The input name as defined by the workflow module corresponding to the step being referenced. For Galaxy tool steps these inputs should be normalized using '|' (e.g. 'cond|repeat_0|input').
+             */
+            input_name: string;
+            /**
+             * Order Index
+             * @description The order_index of the step being referenced. The order indices of a workflow start at 0.
+             */
+            order_index: number;
+        };
         /** InstalledRepositoryToolShedStatus */
         InstalledRepositoryToolShedStatus: {
             /**
@@ -7434,7 +7583,7 @@ export interface components {
             inputs_by?: string | null;
             /**
              * Is instance
-             * @description TODO
+             * @description True when fetching by Workflow ID, False when fetching by StoredWorkflow ID
              * @default false
              */
             instance?: boolean | null;
@@ -9083,6 +9232,34 @@ export interface components {
              */
             url: string;
         };
+        /** OutputReferenceByLabel */
+        OutputReferenceByLabel: {
+            /**
+             * Label
+             * @description The unique label of the step being referenced.
+             */
+            label: string;
+            /**
+             * Output Name
+             * @description The output name as defined by the workflow module corresponding to the step being referenced. The default is 'output', corresponding to the output defined by input step types.
+             * @default output
+             */
+            output_name?: string | null;
+        };
+        /** OutputReferenceByOrderIndex */
+        OutputReferenceByOrderIndex: {
+            /**
+             * Order Index
+             * @description The order_index of the step being referenced. The order indices of a workflow start at 0.
+             */
+            order_index: number;
+            /**
+             * Output Name
+             * @description The output name as defined by the workflow module corresponding to the step being referenced. The default is 'output', corresponding to the output defined by input step types.
+             * @default output
+             */
+            output_name?: string | null;
+        };
         /**
          * PageContentFormat
          * @enum {string}
@@ -9396,6 +9573,13 @@ export interface components {
          * @enum {string}
          */
         PluginKind: "rfs" | "drs" | "rdm" | "stock";
+        /** Position */
+        Position: {
+            /** Left */
+            left: number;
+            /** Top */
+            top: number;
+        };
         /** PrepareStoreDownloadPayload */
         PrepareStoreDownloadPayload: {
             /**
@@ -9569,6 +9753,146 @@ export interface components {
          * @default []
          */
         QuotaSummaryList: components["schemas"]["QuotaSummary"][];
+        /** RefactorActionExecution */
+        RefactorActionExecution: {
+            /** Action */
+            action:
+                | components["schemas"]["AddInputAction"]
+                | components["schemas"]["AddStepAction"]
+                | components["schemas"]["ConnectAction"]
+                | components["schemas"]["DisconnectAction"]
+                | components["schemas"]["ExtractInputAction"]
+                | components["schemas"]["ExtractUntypedParameter"]
+                | components["schemas"]["FileDefaultsAction"]
+                | components["schemas"]["FillStepDefaultsAction"]
+                | components["schemas"]["UpdateAnnotationAction"]
+                | components["schemas"]["UpdateCreatorAction"]
+                | components["schemas"]["UpdateNameAction"]
+                | components["schemas"]["UpdateLicenseAction"]
+                | components["schemas"]["UpdateOutputLabelAction"]
+                | components["schemas"]["UpdateReportAction"]
+                | components["schemas"]["UpdateStepLabelAction"]
+                | components["schemas"]["UpdateStepPositionAction"]
+                | components["schemas"]["UpgradeSubworkflowAction"]
+                | components["schemas"]["UpgradeToolAction"]
+                | components["schemas"]["UpgradeAllStepsAction"]
+                | components["schemas"]["RemoveUnlabeledWorkflowOutputs"];
+            /** Messages */
+            messages: components["schemas"]["RefactorActionExecutionMessage"][];
+        };
+        /** RefactorActionExecutionMessage */
+        RefactorActionExecutionMessage: {
+            /**
+             * From Order Index
+             * @description For dropped connections these optional attributes refer to the output
+             * side of the connection that was dropped.
+             */
+            from_order_index?: number | null;
+            /**
+             * From Step Label
+             * @description For dropped connections these optional attributes refer to the output
+             * side of the connection that was dropped.
+             */
+            from_step_label?: string | null;
+            /**
+             * Input Name
+             * @description If this message is about an input to a step,
+             * this field describes the target input name. $The input name as defined by the workflow module corresponding to the step being referenced. For Galaxy tool steps these inputs should be normalized using '|' (e.g. 'cond|repeat_0|input').
+             */
+            input_name?: string | null;
+            /** Message */
+            message: string;
+            message_type: components["schemas"]["RefactorActionExecutionMessageTypeEnum"];
+            /**
+             * Order Index
+             * @description Reference to the step the message refers to. $
+             *
+             * Messages don't have to be bound to a step, but if they are they will
+             * have a step_label and order_index included in the execution message.
+             * These are the label and order_index before applying the refactoring,
+             * the result of applying the action may change one or both of these.
+             * If connections are dropped this step reference will refer to the
+             * step with the previously connected input.
+             */
+            order_index?: number | null;
+            /**
+             * Output Label
+             * @description If the message_type is workflow_output_drop_forced, this is the output label dropped.
+             */
+            output_label?: string | null;
+            /**
+             * Output Name
+             * @description If this message is about an output to a step,
+             * this field describes the target output name. The output name as defined by the workflow module corresponding to the step being referenced.
+             */
+            output_name?: string | null;
+            /**
+             * Step Label
+             * @description Reference to the step the message refers to. $
+             *
+             * Messages don't have to be bound to a step, but if they are they will
+             * have a step_label and order_index included in the execution message.
+             * These are the label and order_index before applying the refactoring,
+             * the result of applying the action may change one or both of these.
+             * If connections are dropped this step reference will refer to the
+             * step with the previously connected input.
+             */
+            step_label?: string | null;
+        };
+        /**
+         * RefactorActionExecutionMessageTypeEnum
+         * @enum {string}
+         */
+        RefactorActionExecutionMessageTypeEnum:
+            | "tool_version_change"
+            | "tool_state_adjustment"
+            | "connection_drop_forced"
+            | "workflow_output_drop_forced";
+        /** RefactorRequest */
+        RefactorRequest: {
+            /** Actions */
+            actions: (
+                | components["schemas"]["AddInputAction"]
+                | components["schemas"]["AddStepAction"]
+                | components["schemas"]["ConnectAction"]
+                | components["schemas"]["DisconnectAction"]
+                | components["schemas"]["ExtractInputAction"]
+                | components["schemas"]["ExtractUntypedParameter"]
+                | components["schemas"]["FileDefaultsAction"]
+                | components["schemas"]["FillStepDefaultsAction"]
+                | components["schemas"]["UpdateAnnotationAction"]
+                | components["schemas"]["UpdateCreatorAction"]
+                | components["schemas"]["UpdateNameAction"]
+                | components["schemas"]["UpdateLicenseAction"]
+                | components["schemas"]["UpdateOutputLabelAction"]
+                | components["schemas"]["UpdateReportAction"]
+                | components["schemas"]["UpdateStepLabelAction"]
+                | components["schemas"]["UpdateStepPositionAction"]
+                | components["schemas"]["UpgradeSubworkflowAction"]
+                | components["schemas"]["UpgradeToolAction"]
+                | components["schemas"]["UpgradeAllStepsAction"]
+                | components["schemas"]["RemoveUnlabeledWorkflowOutputs"]
+            )[];
+            /**
+             * Dry Run
+             * @default false
+             */
+            dry_run?: boolean;
+            /**
+             * Style
+             * @default export
+             */
+            style?: string;
+        };
+        /** RefactorResponse */
+        RefactorResponse: {
+            /** Action Executions */
+            action_executions: components["schemas"]["RefactorActionExecution"][];
+            /** Dry Run */
+            dry_run: boolean;
+            /** Workflow */
+            workflow: string;
+        };
         /** ReloadFeedback */
         ReloadFeedback: {
             /** Failed */
@@ -9651,6 +9975,19 @@ export interface components {
              * @description Email of the user
              */
             remote_user_email: string;
+        };
+        /** RemoveUnlabeledWorkflowOutputs */
+        RemoveUnlabeledWorkflowOutputs: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "remove_unlabeled_workflow_outputs";
+        };
+        /** Report */
+        Report: {
+            /** Markdown */
+            markdown: string;
         };
         /** ReportJobErrorPayload */
         ReportJobErrorPayload: {
@@ -10321,6 +10658,22 @@ export interface components {
          * @enum {string}
          */
         Src: "url" | "pasted" | "files" | "path" | "composite" | "ftp_import" | "server_dir";
+        /** StepReferenceByLabel */
+        StepReferenceByLabel: {
+            /**
+             * Label
+             * @description The unique label of the step being referenced.
+             */
+            label: string;
+        };
+        /** StepReferenceByOrderIndex */
+        StepReferenceByOrderIndex: {
+            /**
+             * Order Index
+             * @description The order_index of the step being referenced. The order indices of a workflow start at 0.
+             */
+            order_index: number;
+        };
         /** StorageItemCleanupError */
         StorageItemCleanupError: {
             /** Error */
@@ -10649,6 +11002,16 @@ export interface components {
              */
             ids: string[];
         };
+        /** UpdateAnnotationAction */
+        UpdateAnnotationAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "update_annotation";
+            /** Annotation */
+            annotation: string;
+        };
         /**
          * UpdateCollectionAttributePayload
          * @description Contains attributes that can be updated for all elements in a dataset collection.
@@ -10676,6 +11039,16 @@ export interface components {
              */
             id: string;
             [key: string]: unknown | undefined;
+        };
+        /** UpdateCreatorAction */
+        UpdateCreatorAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "update_creator";
+            /** Creator */
+            creator?: Record<string, never>;
         };
         /**
          * UpdateHistoryContentsBatchPayload
@@ -10765,6 +11138,26 @@ export interface components {
              */
             synopsis?: string | null;
         };
+        /** UpdateLicenseAction */
+        UpdateLicenseAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "update_license";
+            /** License */
+            license: string;
+        };
+        /** UpdateNameAction */
+        UpdateNameAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "update_name";
+            /** Name */
+            name: string;
+        };
         /** UpdateObjectStoreIdPayload */
         UpdateObjectStoreIdPayload: {
             /**
@@ -10772,6 +11165,20 @@ export interface components {
              * @description Object store ID to update to, it must be an object store with the same device ID as the target dataset currently.
              */
             object_store_id: string;
+        };
+        /** UpdateOutputLabelAction */
+        UpdateOutputLabelAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "update_output_label";
+            /** Output */
+            output:
+                | components["schemas"]["OutputReferenceByOrderIndex"]
+                | components["schemas"]["OutputReferenceByLabel"];
+            /** Output Label */
+            output_label: string;
         };
         /** UpdateQuotaParams */
         UpdateQuotaParams: {
@@ -10812,6 +11219,47 @@ export interface components {
              */
             operation?: components["schemas"]["QuotaOperation"];
         };
+        /** UpdateReportAction */
+        UpdateReportAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "update_report";
+            report: components["schemas"]["Report"];
+        };
+        /** UpdateStepLabelAction */
+        UpdateStepLabelAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "update_step_label";
+            /**
+             * Label
+             * @description The unique label of the step being referenced.
+             */
+            label: string;
+            /**
+             * Step
+             * @description The target step for this action.
+             */
+            step: components["schemas"]["StepReferenceByOrderIndex"] | components["schemas"]["StepReferenceByLabel"];
+        };
+        /** UpdateStepPositionAction */
+        UpdateStepPositionAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "update_step_position";
+            position_shift: components["schemas"]["Position"];
+            /**
+             * Step
+             * @description The target step for this action.
+             */
+            step: components["schemas"]["StepReferenceByOrderIndex"] | components["schemas"]["StepReferenceByLabel"];
+        };
         /**
          * UpdateUserNotificationPreferencesRequest
          * @description Contains the new notification preferences of a user.
@@ -10824,6 +11272,44 @@ export interface components {
             preferences: {
                 [key: string]: components["schemas"]["NotificationCategorySettings"] | undefined;
             };
+        };
+        /** UpgradeAllStepsAction */
+        UpgradeAllStepsAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "upgrade_all_steps";
+        };
+        /** UpgradeSubworkflowAction */
+        UpgradeSubworkflowAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "upgrade_subworkflow";
+            /** Content Id */
+            content_id?: string | null;
+            /**
+             * Step
+             * @description The target step for this action.
+             */
+            step: components["schemas"]["StepReferenceByOrderIndex"] | components["schemas"]["StepReferenceByLabel"];
+        };
+        /** UpgradeToolAction */
+        UpgradeToolAction: {
+            /**
+             * Action Type
+             * @constant
+             */
+            action_type: "upgrade_tool";
+            /**
+             * Step
+             * @description The target step for this action.
+             */
+            step: components["schemas"]["StepReferenceByOrderIndex"] | components["schemas"]["StepReferenceByLabel"];
+            /** Tool Version */
+            tool_version?: string | null;
         };
         /** UrlDataElement */
         UrlDataElement: {
@@ -21899,13 +22385,7 @@ export interface operations {
         };
     };
     Invoke_workflow_api_workflows__workflow_id__invocations_post: {
-        /**
-         * Schedule the workflow specified by `workflow_id` to run.
-         * @description .. note:: This method takes the same arguments as
-         *     :func:`galaxy.webapps.galaxy.api.workflows.WorkflowsAPIController.create` above.
-         *
-         * :raises: exceptions.MessageException, exceptions.RequestParameterInvalidException
-         */
+        /** Schedule the workflow specified by `workflow_id` to run. */
         parameters: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -22245,6 +22725,41 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["SharingStatus"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    refactor_api_workflows__workflow_id__refactor_put: {
+        /** Updates the workflow stored with the given ID. */
+        parameters: {
+            query?: {
+                instance?: boolean | null;
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string | null;
+            };
+            /** @description The encoded database identifier of the Stored Workflow. */
+            path: {
+                workflow_id: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RefactorRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["RefactorResponse"];
                 };
             };
             /** @description Validation Error */
@@ -22610,10 +23125,6 @@ export interface operations {
         /**
          * Schedule the workflow specified by `workflow_id` to run.
          * @deprecated
-         * @description .. note:: This method takes the same arguments as
-         *     :func:`galaxy.webapps.galaxy.api.workflows.WorkflowsAPIController.create` above.
-         *
-         * :raises: exceptions.MessageException, exceptions.RequestParameterInvalidException
          */
         parameters: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -11054,7 +11054,7 @@ export interface components {
              * Source Metadata
              * @description The source metadata of the workflow.
              */
-            source_metadata: string | null;
+            source_metadata: Record<string, never> | null;
             /**
              * Steps
              * @description A dictionary with information about all the steps of the workflow.

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -7389,13 +7389,13 @@ export interface components {
         InvokeWorkflowPayload: {
             /**
              * Allow tool state corrections
-             * @description TODO
+             * @description Indicates if tool state corrections are allowed for workflow invocation.
              * @default false
              */
             allow_tool_state_corrections?: boolean | null;
             /**
              * Batch
-             * @description TODO
+             * @description Indicates if the workflow is invoked as a batch.
              * @default false
              */
             batch?: boolean | null;
@@ -7411,22 +7411,17 @@ export interface components {
              * Effective Outputs
              * @description TODO
              */
-            effective_outputs?: boolean | null;
+            effective_outputs?: Record<string, never> | null;
             /**
              * History
-             * @description TODO
+             * @description The encoded history id - passed exactly like this 'hist_id=...' -  into which to import. Or the name of the new history into which to import.
              */
             history?: string | null;
             /**
              * History ID
-             * @description TODO
+             * @description The encoded history id into which to import.
              */
             history_id?: string | null;
-            /**
-             * History Name
-             * @description TODO
-             */
-            history_name?: string | null;
             /**
              * Inputs
              * @description TODO
@@ -7434,7 +7429,7 @@ export interface components {
             inputs?: Record<string, never> | null;
             /**
              * Inputs By
-             * @description TODO
+             * @description How inputs maps to inputs (datasets/collections) to workflows steps.
              */
             inputs_by?: string | null;
             /**
@@ -7445,36 +7440,36 @@ export interface components {
             instance?: boolean | null;
             /**
              * Legacy
-             * @description TODO
+             * @description Indicating if to use legacy workflow invocation.
              * @default false
              */
             legacy?: boolean | null;
             /**
              * New History Name
-             * @description TODO
+             * @description The name of the new history into which to import.
              */
             new_history_name?: string | null;
             /**
              * No Add to History
-             * @description TODO
+             * @description Indicates if the workflow invocation should not be added to the history.
              * @default false
              */
             no_add_to_history?: boolean | null;
             /**
              * Parameters
-             * @description TODO
+             * @description The raw parameters for the workflow invocation.
              * @default {}
              */
             parameters?: Record<string, never> | null;
             /**
              * Parameters Normalized
-             * @description TODO
+             * @description Indicates if parameters are already normalized for workflow invocation.
              * @default false
              */
             parameters_normalized?: boolean | null;
             /**
              * Preferred Intermediate Object Store ID
-             * @description TODO
+             * @description The ID of the ? object store that should be used to store ? datasets in this history.
              */
             preferred_intermediate_object_store_id?: string | null;
             /**
@@ -7484,7 +7479,7 @@ export interface components {
             preferred_object_store_id?: string | null;
             /**
              * Preferred Outputs Object Store ID
-             * @description TODO
+             * @description The ID of the object store that should be used to store ? datasets in this history.
              */
             preferred_outputs_object_store_id?: string | null;
             /**
@@ -7495,7 +7490,7 @@ export interface components {
             replacement_params?: Record<string, never> | null;
             /**
              * Require Exact Tool Versions
-             * @description TODO
+             * @description If true, exact tool versions are required for workflow invocation.
              * @default true
              */
             require_exact_tool_versions?: boolean | null;
@@ -7507,7 +7502,7 @@ export interface components {
             resource_params?: Record<string, never> | null;
             /**
              * Scheduler
-             * @description TODO
+             * @description Scheduler to use for workflow invocation.
              */
             scheduler?: string | null;
             /**
@@ -7517,7 +7512,7 @@ export interface components {
             step_parameters?: Record<string, never> | null;
             /**
              * Use cached job
-             * @description TODO
+             * @description Indicated whether to use a cached job for workflow invocation.
              * @default false
              */
             use_cached_job?: boolean | null;
@@ -21916,8 +21911,9 @@ export interface operations {
             header?: {
                 "run-as"?: string | null;
             };
+            /** @description The database identifier - UUID or encoded - of the Workflow.. */
             path: {
-                workflow_id: string;
+                workflow_id: string | string | string;
             };
         };
         requestBody: {
@@ -22624,8 +22620,9 @@ export interface operations {
             header?: {
                 "run-as"?: string | null;
             };
+            /** @description The database identifier - UUID or encoded - of the Workflow.. */
             path: {
-                workflow_id: string;
+                workflow_id: string | string | string;
             };
         };
         requestBody: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -7379,97 +7379,136 @@ export interface components {
         /** InvokeWorkflowPayload */
         InvokeWorkflowPayload: {
             /**
-             * Allow Tool State Corrections
+             * Allow tool state corrections
+             * @description TODO
              * @default false
              */
             allow_tool_state_corrections?: boolean | null;
             /**
              * Batch
-             * @description If true, the workflow is invoked as a batch.
+             * @description TODO
              * @default false
              */
             batch?: boolean | null;
-            /** Ds Map */
+            /**
+             * Dataset Map
+             * @description TODO
+             * @default {}
+             */
             ds_map?: {
                 [key: string]: Record<string, never> | undefined;
             } | null;
-            /** Effective Outputs */
+            /**
+             * Effective Outputs
+             * @description TODO
+             */
             effective_outputs?: boolean | null;
             /**
              * History
-             * @description The history to import the workflow into.
+             * @description TODO
              */
             history?: string | null;
             /**
              * History ID
-             * @description The history to import the workflow into.
+             * @description TODO
              */
             history_id?: string | null;
             /**
              * History Name
-             * @description The name of the history to import the workflow into.
+             * @description TODO
              */
             history_name?: string | null;
-            /** Inputs */
+            /**
+             * Inputs
+             * @description TODO
+             */
             inputs?: Record<string, never> | null;
-            /** Inputs By */
+            /**
+             * Inputs By
+             * @description TODO
+             */
             inputs_by?: string | null;
             /**
-             * Is Instance
-             * @description If true, the workflow is invoked as an instance.
+             * Is instance
+             * @description TODO
              * @default false
              */
             instance?: boolean | null;
             /**
              * Legacy
+             * @description TODO
              * @default false
              */
             legacy?: boolean | null;
             /**
              * New History Name
-             * @description The name of the new history to import the workflow into.
+             * @description TODO
              */
             new_history_name?: string | null;
             /**
-             * No Add To History
+             * No Add to History
+             * @description TODO
              * @default false
              */
             no_add_to_history?: boolean | null;
-            /** Parameters */
+            /**
+             * Parameters
+             * @description TODO
+             * @default {}
+             */
             parameters?: Record<string, never> | null;
             /**
              * Parameters Normalized
+             * @description TODO
              * @default false
              */
             parameters_normalized?: boolean | null;
-            /** Preferred Intermediate Object Store Id */
+            /**
+             * Preferred Intermediate Object Store ID
+             * @description TODO
+             */
             preferred_intermediate_object_store_id?: string | null;
             /**
              * Preferred Object Store ID
              * @description The ID of the object store that should be used to store new datasets in this history.
              */
             preferred_object_store_id?: string | null;
-            /** Preferred Outputs Object Store Id */
+            /**
+             * Preferred Outputs Object Store ID
+             * @description TODO
+             */
             preferred_outputs_object_store_id?: string | null;
-            /** Replacement Params */
+            /**
+             * Replacement Parameters
+             * @description TODO
+             * @default {}
+             */
             replacement_params?: Record<string, never> | null;
             /**
              * Require Exact Tool Versions
-             * @description If true, exact tool versions are required for workflow invocation.
-             * @default false
+             * @description TODO
+             * @default true
              */
             require_exact_tool_versions?: boolean | null;
-            /** Resource Params */
+            /**
+             * Resource Parameters
+             * @description TODO
+             * @default {}
+             */
             resource_params?: Record<string, never> | null;
             /**
              * Scheduler
-             * @description Scheduler to use for workflow invocation.
+             * @description TODO
              */
             scheduler?: string | null;
-            /** Step Parameters */
+            /**
+             * Step Parameters
+             * @description TODO
+             */
             step_parameters?: Record<string, never> | null;
             /**
-             * Use Cached Job
+             * Use cached job
+             * @description TODO
              * @default false
              */
             use_cached_job?: boolean | null;

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2344,35 +2344,6 @@ class Person(Creator):
     )
 
 
-class StoredWorkflowDetailed(StoredWorkflowSummary):
-    annotation: Optional[str] = AnnotationField  # Inconsistency? See comment on StoredWorkflowSummary.annotations
-    license: Optional[str] = Field(
-        None, title="License", description="SPDX Identifier of the license associated with this workflow."
-    )
-    version: int = Field(
-        ..., title="Version", description="The version of the workflow represented by an incremental number."
-    )
-    inputs: Dict[int, WorkflowInput] = Field(
-        {}, title="Inputs", description="A dictionary containing information about all the inputs of the workflow."
-    )
-    creator: Optional[List[Union[Person, Organization]]] = Field(
-        None,
-        title="Creator",
-        description=("Additional information about the creator (or multiple creators) of this workflow."),
-    )
-    steps: Dict[
-        int,
-        Union[
-            InputDataStep,
-            InputDataCollectionStep,
-            InputParameterStep,
-            PauseStep,
-            ToolStep,
-            SubworkflowStep,
-        ],
-    ] = Field({}, title="Steps", description="A dictionary with information about all the steps of the workflow.")
-
-
 class Input(Model):
     name: str = Field(..., title="Name", description="The name of the input.")
     description: str = Field(..., title="Description", description="The annotation or description of the input.")

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2112,10 +2112,12 @@ class StoredWorkflowSummary(Model, WithModelClass):
         title="Published",
         description="Whether this workflow is currently publicly available to all users.",
     )
-    annotations: List[str] = Field(  # Inconsistency? Why workflows summaries use a list instead of an optional string?
-        ...,
-        title="Annotations",
-        description="An list of annotations to provide details or to help understand the purpose and usage of this workflow.",
+    annotations: Optional[List[str]] = (
+        Field(  # Inconsistency? Why workflows summaries use a list instead of an optional string?
+            None,
+            title="Annotations",
+            description="An list of annotations to provide details or to help understand the purpose and usage of this workflow.",
+        )
     )
     tags: TagCollection
     deleted: bool = Field(
@@ -2138,13 +2140,13 @@ class StoredWorkflowSummary(Model, WithModelClass):
         title="Latest workflow UUID",
         description="TODO",
     )
-    number_of_steps: int = Field(
-        ...,
+    number_of_steps: Optional[int] = Field(
+        None,
         title="Number of Steps",
         description="The number of steps that make up this workflow.",
     )
-    show_in_tool_panel: bool = Field(
-        ...,
+    show_in_tool_panel: Optional[bool] = Field(
+        None,
         title="Show in Tool Panel",
         description="Whether to display this workflow in the Tools Panel.",
     )

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -75,7 +75,7 @@ class InvokeWorkflowPayload(GetTargetHistoryPayload):
     instance: Optional[bool] = Field(
         False,
         title="Is instance",
-        description="TODO",
+        description="True when fetching by Workflow ID, False when fetching by StoredWorkflow ID",
     )
     scheduler: Optional[str] = Field(
         None,

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -70,6 +70,19 @@ class GetTargetHistoryPayload(Model):
     )
 
 
+class GetToolPredictionsPayload(Model):
+    tool_sequence: Any = Field(
+        ...,
+        title="Tool Sequence",
+        description="comma separated sequence of tool ids",
+    )
+    remote_model_url: Optional[Any] = Field(
+        None,
+        title="Remote Model URL",
+        description="Path to the deep learning model",
+    )
+
+
 class InvokeWorkflowPayload(GetTargetHistoryPayload):
     # TODO - Are the descriptions correct?
     instance: Optional[bool] = Field(

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -47,59 +47,71 @@ from galaxy.schema.schema import (
 #         description="Name of the workflow to create when extracting a workflow from history",
 #     )
 
-# TODO - add description to fields
-
 
 class GetTargetHistoryPayload(Model):
+    # TODO - add description to fields
     history: Optional[str] = Field(
         None,
         title="History",
-        description="The history to import the workflow into.",
+        # description="The history to import the workflow into.",
+        description="TODO",
     )
     history_id: Optional[str] = Field(
         None,
         title="History ID",
-        description="The history to import the workflow into.",
+        # description="The history to import the workflow into.",
+        description="TODO",
     )
     history_name: Optional[str] = Field(
         None,
         title="History Name",
-        description="The name of the history to import the workflow into.",
+        # description="The name of the history to import the workflow into.",
+        description="TODO",
     )
     new_history_name: Optional[str] = Field(
         None,
         title="New History Name",
-        description="The name of the new history to import the workflow into.",
+        # description="The name of the new history to import the workflow into.",
+        description="TODO",
     )
 
 
 class InvokeWorkflowPayload(GetTargetHistoryPayload):
+    # TODO - add description to fields
     instance: Optional[bool] = Field(
         False,
-        title="Is Instance",
-        description="If true, the workflow is invoked as an instance.",
+        title="Is instance",
+        description="TODO",
     )
     scheduler: Optional[str] = Field(
         None,
         title="Scheduler",
-        description="Scheduler to use for workflow invocation.",
+        # description="Scheduler to use for workflow invocation.",
+        description="TODO",
     )
     batch: Optional[bool] = Field(
         False,
         title="Batch",
-        description="If true, the workflow is invoked as a batch.",
+        # description="If true, the workflow is invoked as a batch.",
+        description="TODO",
     )
     require_exact_tool_versions: Optional[bool] = Field(
-        False,
+        True,
         title="Require Exact Tool Versions",
-        description="If true, exact tool versions are required for workflow invocation.",
+        # description="If true, exact tool versions are required for workflow invocation.",
+        description="TODO",
     )
-    allow_tool_state_corrections: Optional[bool] = False
-    use_cached_job: Optional[bool] = False
+    allow_tool_state_corrections: Optional[bool] = Field(
+        False,
+        title="Allow tool state corrections",
+        description="TODO",
+    )
+    use_cached_job: Optional[bool] = Field(
+        False,
+        title="Use cached job",
+        description="TODO",
+    )
 
-    # input_step_parameters: Dict[str, InvocationInputParameter] = Field(
-    #     default=..., title="Input step parameters", description="Input step parameters of the workflow invocation."
-    # )
     @field_validator(
         "parameters",
         "inputs",
@@ -116,17 +128,69 @@ class InvokeWorkflowPayload(GetTargetHistoryPayload):
             return json.loads(v)
         return v
 
-    parameters: Optional[Dict[str, Any]] = None
-    inputs: Optional[Dict[str, Any]] = None
-    ds_map: Optional[Dict[str, Dict[str, Any]]] = None
-    resource_params: Optional[Dict[str, Any]] = None
-    replacement_params: Optional[Dict[str, Any]] = None
-    step_parameters: Optional[Dict[str, Any]] = None
-    no_add_to_history: Optional[bool] = False
-    legacy: Optional[bool] = False
-    parameters_normalized: Optional[bool] = False
-    inputs_by: Optional[str] = None
-    effective_outputs: Optional[bool] = None
+    parameters: Optional[Dict[str, Any]] = Field(
+        {},
+        title="Parameters",
+        description="TODO",
+    )
+    inputs: Optional[Dict[str, Any]] = Field(
+        None,
+        title="Inputs",
+        description="TODO",
+    )
+    ds_map: Optional[Dict[str, Dict[str, Any]]] = Field(
+        {},
+        title="Dataset Map",
+        description="TODO",
+    )
+    resource_params: Optional[Dict[str, Any]] = Field(
+        {},
+        title="Resource Parameters",
+        description="TODO",
+    )
+    replacement_params: Optional[Dict[str, Any]] = Field(
+        {},
+        title="Replacement Parameters",
+        description="TODO",
+    )
+    step_parameters: Optional[Dict[str, Any]] = Field(
+        None,
+        title="Step Parameters",
+        description="TODO",
+    )
+    no_add_to_history: Optional[bool] = Field(
+        False,
+        title="No Add to History",
+        description="TODO",
+    )
+    legacy: Optional[bool] = Field(
+        False,
+        title="Legacy",
+        description="TODO",
+    )
+    parameters_normalized: Optional[bool] = Field(
+        False,
+        title="Parameters Normalized",
+        description="TODO",
+    )
+    inputs_by: Optional[str] = Field(
+        None,
+        title="Inputs By",
+        description="TODO",
+    )
+    effective_outputs: Optional[bool] = Field(
+        None,
+        title="Effective Outputs",
+        description="TODO",
+    )
+    preferred_intermediate_object_store_id: Optional[str] = Field(
+        None,
+        title="Preferred Intermediate Object Store ID",
+        description="TODO",
+    )
+    preferred_outputs_object_store_id: Optional[str] = Field(
+        None,
+        title="Preferred Outputs Object Store ID",
+        description="TODO",
+    )
     preferred_object_store_id: Optional[str] = PreferredObjectStoreIdField
-    preferred_intermediate_object_store_id: Optional[str] = None
-    preferred_outputs_object_store_id: Optional[str] = None

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -1,0 +1,81 @@
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
+
+from pydantic import Field
+
+from galaxy.schema.schema import (
+    HistoryID,
+    Model,
+    PreferredObjectStoreIdField,
+)
+
+# class WorkflowExtractionParams(Model):
+#     from_history_id: str = Field(..., title="From History ID", description="Id of history to extract a workflow from.")
+#     job_ids: Optional[str] = Field(
+#         None,
+#         title="Job IDs",
+#         description="List of jobs to include when extracting a workflow from history",
+#     )
+
+#     @field_validator("dataset_ids", mode="before", check_fields=False)
+#     @classmethod
+#     def inputs_string_to_json(cls, v):
+#         if isinstance(v, str):
+#             return json.loads(v)
+#         return v
+
+#     dataset_ids: Optional[str] = Field(
+#         None,
+#         title="Dataset IDs",
+#         description="List of HDA 'hid's corresponding to workflow inputs when extracting a workflow from history",
+#         alias="ds_map",
+#     )
+#     dataset_collection_ids: Optional[str] = Field(
+#         None,
+#         title="Dataset Collection IDs",
+#         description="List of HDCA 'hid's corresponding to workflow inputs when extracting a workflow from history",
+#     )
+#     workflow_name: Optional[str] = Field(
+#         None,
+#         title="Workflow Name",
+#         description="Name of the workflow to create when extracting a workflow from history",
+#     )
+
+
+class GetTargetHistoryPayload(Model):
+    history_id: HistoryID
+    history_name: Optional[str] = Field(
+        None,
+        title="History Name",
+        description="The name of the history to import the workflow into.",
+    )
+    new_history_name: Optional[str] = Field(
+        None,
+        title="New History Name",
+        description="The name of the new history to import the workflow into.",
+    )
+
+
+class InvokeWorkflowPayload(GetTargetHistoryPayload):
+    allow_tool_state_corrections: Optional[bool] = False
+    use_cached_job: Optional[bool] = False
+    step_parameters: Optional[Dict[str, Any]] = None
+    # input_step_parameters: Dict[str, InvocationInputParameter] = Field(
+    #     default=..., title="Input step parameters", description="Input step parameters of the workflow invocation."
+    # )
+    parameters: Optional[Dict[str, Any]] = None
+    inputs: Optional[Dict[str, Any]] = None
+    ds_map: Optional[Dict[str, Any]] = None
+    no_add_to_history: Optional[bool] = False
+    legacy: Optional[bool] = False
+    parameters_normalized: Optional[bool] = False
+    inputs_by: Optional[str] = None
+    resource_params: Optional[Dict[str, Any]] = None
+    replacement_params: Optional[Dict[str, Any]] = None
+    effective_outputs: Optional[bool] = None
+    preferred_object_store_id: Optional[str] = PreferredObjectStoreIdField
+    preferred_intermediate_object_store_id: Optional[str] = None
+    preferred_outputs_object_store_id: Optional[str] = None

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -2,7 +2,9 @@ import json
 from typing import (
     Any,
     Dict,
+    List,
     Optional,
+    Union,
 )
 
 from pydantic import (
@@ -11,8 +13,19 @@ from pydantic import (
 )
 
 from galaxy.schema.schema import (
+    AnnotationField,
+    InputDataCollectionStep,
+    InputDataStep,
+    InputParameterStep,
     Model,
+    Organization,
+    PauseStep,
+    Person,
     PreferredObjectStoreIdField,
+    StoredWorkflowSummary,
+    SubworkflowStep,
+    ToolStep,
+    WorkflowInput,
 )
 
 # class WorkflowExtractionParams(Model):
@@ -201,3 +214,32 @@ class InvokeWorkflowPayload(GetTargetHistoryPayload):
         description="The ID of the object store that should be used to store ? datasets in this history.",
     )
     preferred_object_store_id: Optional[str] = PreferredObjectStoreIdField
+
+
+class StoredWorkflowDetailed(StoredWorkflowSummary):
+    annotation: Optional[str] = AnnotationField  # Inconsistency? See comment on StoredWorkflowSummary.annotations
+    license: Optional[str] = Field(
+        None, title="License", description="SPDX Identifier of the license associated with this workflow."
+    )
+    version: int = Field(
+        ..., title="Version", description="The version of the workflow represented by an incremental number."
+    )
+    inputs: Dict[int, WorkflowInput] = Field(
+        {}, title="Inputs", description="A dictionary containing information about all the inputs of the workflow."
+    )
+    creator: Optional[List[Union[Person, Organization]]] = Field(
+        None,
+        title="Creator",
+        description=("Additional information about the creator (or multiple creators) of this workflow."),
+    )
+    steps: Dict[
+        int,
+        Union[
+            InputDataStep,
+            InputDataCollectionStep,
+            InputParameterStep,
+            PauseStep,
+            ToolStep,
+            SubworkflowStep,
+        ],
+    ] = Field({}, title="Steps", description="A dictionary with information about all the steps of the workflow.")

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -96,27 +96,36 @@ class InvokeWorkflowPayload(GetTargetHistoryPayload):
     )
     allow_tool_state_corrections: Optional[bool] = False
     use_cached_job: Optional[bool] = False
-    step_parameters: Optional[Dict[str, Any]] = None
+
     # input_step_parameters: Dict[str, InvocationInputParameter] = Field(
     #     default=..., title="Input step parameters", description="Input step parameters of the workflow invocation."
     # )
-    parameters: Optional[Dict[str, Any]] = None
-    inputs: Optional[Dict[str, Any]] = None
-
-    @field_validator("ds_map", mode="before", check_fields=False)
+    @field_validator(
+        "parameters",
+        "inputs",
+        "ds_map",
+        "resource_params",
+        "replacement_params",
+        "step_parameters",
+        mode="before",
+        check_fields=False,
+    )
     @classmethod
     def inputs_string_to_json(cls, v):
         if isinstance(v, str):
             return json.loads(v)
         return v
 
+    parameters: Optional[Dict[str, Any]] = None
+    inputs: Optional[Dict[str, Any]] = None
     ds_map: Optional[Dict[str, Dict[str, Any]]] = None
+    resource_params: Optional[Dict[str, Any]] = None
+    replacement_params: Optional[Dict[str, Any]] = None
+    step_parameters: Optional[Dict[str, Any]] = None
     no_add_to_history: Optional[bool] = False
     legacy: Optional[bool] = False
     parameters_normalized: Optional[bool] = False
     inputs_by: Optional[str] = None
-    resource_params: Optional[Dict[str, Any]] = None
-    replacement_params: Optional[Dict[str, Any]] = None
     effective_outputs: Optional[bool] = None
     preferred_object_store_id: Optional[str] = PreferredObjectStoreIdField
     preferred_intermediate_object_store_id: Optional[str] = None

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -243,3 +243,24 @@ class StoredWorkflowDetailed(StoredWorkflowSummary):
             SubworkflowStep,
         ],
     ] = Field({}, title="Steps", description="A dictionary with information about all the steps of the workflow.")
+    # TODO - Check descriptions of newly added fields
+    importable: Optional[bool] = Field(
+        ...,
+        title="Importable",
+        description="Indicates if the workflow is importable by ?.",
+    )
+    email_hash: Optional[str] = Field(
+        ...,
+        title="Email Hash",
+        description="The hash of the email of ?",
+    )
+    slug: Optional[str] = Field(
+        ...,
+        title="Slug",
+        description="The slug of the workflow.",
+    )
+    source_metadata: Optional[str] = Field(
+        ...,
+        title="Source Metadata",
+        description="The source metadata of the workflow.",
+    )

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -83,32 +83,6 @@ class GetTargetHistoryPayload(Model):
     )
 
 
-class GetToolPredictionsPayload(Model):
-    tool_sequence: Optional[Any] = Field(
-        None,
-        title="Tool Sequence",
-        description="comma separated sequence of tool ids",
-    )
-    remote_model_url: Optional[Any] = Field(
-        None,
-        title="Remote Model URL",
-        description="Path to the deep learning model",
-    )
-
-
-class ToolPredictionsSummary(Model):
-    current_tool: Optional[Any] = Field(
-        None,
-        title="Current Tools",
-        description="A comma separated sequence of the current tool ids",
-    )
-    predicted_data: Optional[Any] = Field(
-        None,
-        title="Recommended Tools",
-        description="List of predictions",
-    )
-
-
 class InvokeWorkflowPayload(GetTargetHistoryPayload):
     # TODO - Are the descriptions correct?
     instance: Optional[bool] = Field(

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -213,7 +213,7 @@ class StoredWorkflowDetailed(StoredWorkflowSummary):
         title="Slug",
         description="The slug of the workflow.",
     )
-    source_metadata: Optional[str] = Field(
+    source_metadata: Optional[Dict[str, Any]] = Field(
         ...,
         title="Source Metadata",
         description="The source metadata of the workflow.",

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -84,8 +84,8 @@ class GetTargetHistoryPayload(Model):
 
 
 class GetToolPredictionsPayload(Model):
-    tool_sequence: Any = Field(
-        ...,
+    tool_sequence: Optional[Any] = Field(
+        None,
         title="Tool Sequence",
         description="comma separated sequence of tool ids",
     )

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -96,6 +96,19 @@ class GetToolPredictionsPayload(Model):
     )
 
 
+class ToolPredictionsSummary(Model):
+    current_tool: Optional[Any] = Field(
+        None,
+        title="Current Tools",
+        description="A comma separated sequence of the current tool ids",
+    )
+    predicted_data: Optional[Any] = Field(
+        None,
+        title="Recommended Tools",
+        description="List of predictions",
+    )
+
+
 class InvokeWorkflowPayload(GetTargetHistoryPayload):
     # TODO - Are the descriptions correct?
     instance: Optional[bool] = Field(

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -49,35 +49,29 @@ from galaxy.schema.schema import (
 
 
 class GetTargetHistoryPayload(Model):
-    # TODO - add description to fields
+    # TODO - Are the descriptions correct?
     history: Optional[str] = Field(
         None,
         title="History",
-        # description="The history to import the workflow into.",
-        description="TODO",
+        # description="The encoded history id - passed exactly like this 'hist_id=...' -  to import the workflow into. Or the name of the new history to import the workflow into.",
+        description="The encoded history id - passed exactly like this 'hist_id=...' -  into which to import. Or the name of the new history into which to import.",
     )
     history_id: Optional[str] = Field(
         None,
         title="History ID",
         # description="The history to import the workflow into.",
-        description="TODO",
-    )
-    history_name: Optional[str] = Field(
-        None,
-        title="History Name",
-        # description="The name of the history to import the workflow into.",
-        description="TODO",
+        description="The encoded history id into which to import.",
     )
     new_history_name: Optional[str] = Field(
         None,
         title="New History Name",
         # description="The name of the new history to import the workflow into.",
-        description="TODO",
+        description="The name of the new history into which to import.",
     )
 
 
 class InvokeWorkflowPayload(GetTargetHistoryPayload):
-    # TODO - add description to fields
+    # TODO - Are the descriptions correct?
     instance: Optional[bool] = Field(
         False,
         title="Is instance",
@@ -86,30 +80,33 @@ class InvokeWorkflowPayload(GetTargetHistoryPayload):
     scheduler: Optional[str] = Field(
         None,
         title="Scheduler",
-        # description="Scheduler to use for workflow invocation.",
-        description="TODO",
+        description="Scheduler to use for workflow invocation.",
     )
     batch: Optional[bool] = Field(
         False,
         title="Batch",
-        # description="If true, the workflow is invoked as a batch.",
-        description="TODO",
+        description="Indicates if the workflow is invoked as a batch.",
     )
     require_exact_tool_versions: Optional[bool] = Field(
         True,
         title="Require Exact Tool Versions",
-        # description="If true, exact tool versions are required for workflow invocation.",
-        description="TODO",
+        description="If true, exact tool versions are required for workflow invocation.",
+        # description="TODO",
     )
     allow_tool_state_corrections: Optional[bool] = Field(
         False,
         title="Allow tool state corrections",
-        description="TODO",
+        description="Indicates if tool state corrections are allowed for workflow invocation.",
     )
     use_cached_job: Optional[bool] = Field(
         False,
         title="Use cached job",
-        description="TODO",
+        description="Indicated whether to use a cached job for workflow invocation.",
+    )
+    parameters_normalized: Optional[bool] = Field(
+        False,
+        title="Parameters Normalized",
+        description="Indicates if parameters are already normalized for workflow invocation.",
     )
 
     @field_validator(
@@ -131,7 +128,7 @@ class InvokeWorkflowPayload(GetTargetHistoryPayload):
     parameters: Optional[Dict[str, Any]] = Field(
         {},
         title="Parameters",
-        description="TODO",
+        description="The raw parameters for the workflow invocation.",
     )
     inputs: Optional[Dict[str, Any]] = Field(
         None,
@@ -161,36 +158,33 @@ class InvokeWorkflowPayload(GetTargetHistoryPayload):
     no_add_to_history: Optional[bool] = Field(
         False,
         title="No Add to History",
-        description="TODO",
+        description="Indicates if the workflow invocation should not be added to the history.",
     )
     legacy: Optional[bool] = Field(
         False,
         title="Legacy",
-        description="TODO",
-    )
-    parameters_normalized: Optional[bool] = Field(
-        False,
-        title="Parameters Normalized",
-        description="TODO",
+        description="Indicating if to use legacy workflow invocation.",
     )
     inputs_by: Optional[str] = Field(
         None,
         title="Inputs By",
-        description="TODO",
+        # lib/galaxy/workflow/run_request.py - see line 60
+        description="How inputs maps to inputs (datasets/collections) to workflows steps.",
     )
-    effective_outputs: Optional[bool] = Field(
+    effective_outputs: Optional[Any] = Field(
         None,
         title="Effective Outputs",
+        # lib/galaxy/workflow/run_request.py - see line 455
         description="TODO",
     )
     preferred_intermediate_object_store_id: Optional[str] = Field(
         None,
         title="Preferred Intermediate Object Store ID",
-        description="TODO",
+        description="The ID of the ? object store that should be used to store ? datasets in this history.",
     )
     preferred_outputs_object_store_id: Optional[str] = Field(
         None,
         title="Preferred Outputs Object Store ID",
-        description="TODO",
+        description="The ID of the object store that should be used to store ? datasets in this history.",
     )
     preferred_object_store_id: Optional[str] = PreferredObjectStoreIdField

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -198,16 +198,15 @@ class StoredWorkflowDetailed(StoredWorkflowSummary):
             SubworkflowStep,
         ],
     ] = Field({}, title="Steps", description="A dictionary with information about all the steps of the workflow.")
-    # TODO - Check descriptions of newly added fields
     importable: Optional[bool] = Field(
         ...,
         title="Importable",
-        description="Indicates if the workflow is importable by ?.",
+        description="Indicates if the workflow is importable by the current user.",
     )
     email_hash: Optional[str] = Field(
         ...,
         title="Email Hash",
-        description="The hash of the email of ?",
+        description="The hash of the email of the creator of this workflow",
     )
     slug: Optional[str] = Field(
         ...,

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -28,38 +28,6 @@ from galaxy.schema.schema import (
     WorkflowInput,
 )
 
-# class WorkflowExtractionParams(Model):
-#     from_history_id: str = Field(..., title="From History ID", description="Id of history to extract a workflow from.")
-#     job_ids: Optional[str] = Field(
-#         None,
-#         title="Job IDs",
-#         description="List of jobs to include when extracting a workflow from history",
-#     )
-
-#     @field_validator("dataset_ids", mode="before", check_fields=False)
-#     @classmethod
-#     def inputs_string_to_json(cls, v):
-#         if isinstance(v, str):
-#             return json.loads(v)
-#         return v
-
-#     dataset_ids: Optional[str] = Field(
-#         None,
-#         title="Dataset IDs",
-#         description="List of HDA 'hid's corresponding to workflow inputs when extracting a workflow from history",
-#         alias="ds_map",
-#     )
-#     dataset_collection_ids: Optional[str] = Field(
-#         None,
-#         title="Dataset Collection IDs",
-#         description="List of HDCA 'hid's corresponding to workflow inputs when extracting a workflow from history",
-#     )
-#     workflow_name: Optional[str] = Field(
-#         None,
-#         title="Workflow Name",
-#         description="Name of the workflow to create when extracting a workflow from history",
-#     )
-
 
 class GetTargetHistoryPayload(Model):
     # TODO - Are the descriptions correct?

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1081,7 +1081,7 @@ class FastAPIWorkflows:
 
         :raises: exceptions.MessageException, exceptions.RequestParameterInvalidException
         """
-        return self.service.invoke_workflow(trans, workflow_id, payload.model_dump(exclude_unset=True))
+        return self.service.invoke_workflow(trans, workflow_id, payload)
 
     @router.get(
         "/api/workflows/{workflow_id}/versions",

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -80,7 +80,10 @@ from galaxy.schema.schema import (
     SharingStatus,
     WorkflowSortByEnum,
 )
-from galaxy.schema.workflows import InvokeWorkflowPayload
+from galaxy.schema.workflows import (
+    GetToolPredictionsPayload,
+    InvokeWorkflowPayload,
+)
 from galaxy.structured_app import StructuredApp
 from galaxy.tool_shed.galaxy_install.install_manager import InstallRepositoryManager
 from galaxy.tools import recommendations
@@ -587,29 +590,6 @@ class WorkflowsAPIController(
             step_dict["tool_version"] = module.get_version()
         return step_dict
 
-    @expose_api
-    def get_tool_predictions(self, trans: ProvidesUserContext, payload, **kwd):
-        """
-        POST /api/workflows/get_tool_predictions
-
-        Fetch predicted tools for a workflow
-
-        :type   payload: dict
-        :param  payload:
-
-            a dictionary containing two parameters
-            'tool_sequence' - comma separated sequence of tool ids
-            'remote_model_url' - (optional) path to the deep learning model
-        """
-        remote_model_url = payload.get("remote_model_url", trans.app.config.tool_recommendation_model_path)
-        tool_sequence = payload.get("tool_sequence", "")
-        if "tool_sequence" not in payload or remote_model_url is None:
-            return
-        tool_sequence, recommended_tools = self.tool_recommendations.get_predictions(
-            trans, tool_sequence, remote_model_url
-        )
-        return {"current_tool": tool_sequence, "predicted_data": recommended_tools}
-
     #
     # -- Helper methods --
     #
@@ -909,6 +889,15 @@ RefactorWorkflowBody = Annotated[
     ),
 ]
 
+GetToolPredictionsBody = Annotated[
+    GetToolPredictionsPayload,
+    Body(
+        default=...,
+        title="Get tool predictions",
+        description="The values to get tool predictions for a workflow.",
+    ),
+]
+
 
 @router.cbv
 class FastAPIWorkflows:
@@ -954,6 +943,17 @@ class FastAPIWorkflows:
         workflows, total_matches = self.service.index(trans, payload, include_total_count=True)
         response.headers["total_matches"] = str(total_matches)
         return workflows
+
+    @router.post(
+        "/api/workflows/get_tool_predictions",
+        summary="Fetch predicted tools for a workflow",
+    )
+    def get_tool_predictions(
+        self,
+        payload: GetToolPredictionsBody,
+        trans: ProvidesUserContext = DependsOnTrans,
+    ):
+        return self.service.get_tool_predictions(trans, payload.model_dump(exclude_unset=True))
 
     @router.get(
         "/api/workflows/{workflow_id}/sharing",

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -135,7 +135,6 @@ class WorkflowsAPIController(
     ConsumesModelStores,
 ):
     service: WorkflowsService = depends(WorkflowsService)
-    invocations_service: InvocationsService = depends(InvocationsService)
 
     def __init__(self, app: StructuredApp):
         super().__init__(app)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -81,10 +81,8 @@ from galaxy.schema.schema import (
     WorkflowSortByEnum,
 )
 from galaxy.schema.workflows import (
-    GetToolPredictionsPayload,
     InvokeWorkflowPayload,
     StoredWorkflowDetailed,
-    ToolPredictionsSummary,
 )
 from galaxy.structured_app import StructuredApp
 from galaxy.tool_shed.galaxy_install.install_manager import InstallRepositoryManager
@@ -559,6 +557,26 @@ class WorkflowsAPIController(
             step_dict["tool_version"] = module.get_version()
         return step_dict
 
+    @expose_api
+    def get_tool_predictions(self, trans: ProvidesUserContext, payload, **kwd):
+        """
+        POST /api/workflows/get_tool_predictions
+        Fetch predicted tools for a workflow
+        :type   payload: dict
+        :param  payload:
+            a dictionary containing two parameters
+            'tool_sequence' - comma separated sequence of tool ids
+            'remote_model_url' - (optional) path to the deep learning model
+        """
+        remote_model_url = payload.get("remote_model_url", trans.app.config.tool_recommendation_model_path)
+        tool_sequence = payload.get("tool_sequence", "")
+        if "tool_sequence" not in payload or remote_model_url is None:
+            return
+        tool_sequence, recommended_tools = self.tool_recommendations.get_predictions(
+            trans, tool_sequence, remote_model_url
+        )
+        return {"current_tool": tool_sequence, "predicted_data": recommended_tools}
+
     #
     # -- Helper methods --
     #
@@ -874,15 +892,6 @@ RefactorWorkflowBody = Annotated[
     ),
 ]
 
-GetToolPredictionsBody = Annotated[
-    GetToolPredictionsPayload,
-    Body(
-        default=...,
-        title="Get tool predictions",
-        description="The values to get tool predictions for a workflow.",
-    ),
-]
-
 
 @router.cbv
 class FastAPIWorkflows:
@@ -928,17 +937,6 @@ class FastAPIWorkflows:
         workflows, total_matches = self.service.index(trans, payload, include_total_count=True)
         response.headers["total_matches"] = str(total_matches)
         return workflows
-
-    @router.post(
-        "/api/workflows/get_tool_predictions",
-        summary="Fetch predicted tools for a workflow",
-    )
-    def get_tool_predictions(
-        self,
-        payload: GetToolPredictionsBody,
-        trans: ProvidesUserContext = DependsOnTrans,
-    ) -> Union[dict, ToolPredictionsSummary]:
-        return self.service.get_tool_predictions(trans, payload.model_dump(exclude_unset=True))
 
     @router.get(
         "/api/workflows/{workflow_id}/sharing",

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -47,9 +47,7 @@ from galaxy.managers.workflows import (
     MissingToolsException,
     RefactorRequest,
     RefactorResponse,
-    WorkflowContentsManager,
     WorkflowCreateOptions,
-    WorkflowsManager,
     WorkflowUpdateOptions,
 )
 from galaxy.model.base import transaction
@@ -778,7 +776,7 @@ MultiTypeWorkflowIDPathParam = Annotated[
     Path(
         ...,
         title="Workflow ID",
-        description="The database identifier - UUID or encoded - of the Workflow..",
+        description="The database identifier - UUID or encoded - of the Workflow.",
     ),
 ]
 
@@ -896,8 +894,6 @@ RefactorWorkflowBody = Annotated[
 @router.cbv
 class FastAPIWorkflows:
     service: WorkflowsService = depends(WorkflowsService)
-    manager: WorkflowsManager = depends(WorkflowsManager)
-    contents_manager: WorkflowContentsManager = depends(WorkflowContentsManager)
 
     @router.get(
         "/api/workflows",
@@ -985,8 +981,7 @@ class FastAPIWorkflows:
         instance: InstanceQueryParam = False,
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> RefactorResponse:
-        stored_workflow = self.manager.get_stored_workflow(trans, workflow_id, by_stored_id=not instance)
-        return self.contents_manager.refactor(trans, stored_workflow, payload)
+        return self.service.refactor(trans, workflow_id, payload, instance or False)
 
     @router.put(
         "/api/workflows/{workflow_id}/publish",

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1064,8 +1064,14 @@ class FastAPIWorkflows:
 
     @router.post(
         "/api/workflows/{workflow_id}/invocations",
-        name="Invoke workflow.",
+        name="Invoke workflow",
         summary="Schedule the workflow specified by `workflow_id` to run.",
+    )
+    @router.post(
+        "/api/workflows/{workflow_id}/usage",
+        name="Invoke workflow",
+        summary="Schedule the workflow specified by `workflow_id` to run.",
+        deprecated=True,
     )
     def invoke(
         self,

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -81,8 +81,6 @@ from galaxy.schema.schema import (
     WorkflowSortByEnum,
 )
 from galaxy.schema.workflows import InvokeWorkflowPayload
-
-# from galaxy.schema.workflows import InvokeWorkflowPayload
 from galaxy.structured_app import StructuredApp
 from galaxy.tool_shed.galaxy_install.install_manager import InstallRepositoryManager
 from galaxy.tools import recommendations
@@ -1097,16 +1095,9 @@ class FastAPIWorkflows:
     def invoke(
         self,
         payload: InvokeWorkflowBody,
-        # workflow_id: str = Path(...),
         workflow_id: MultiTypeWorkflowIDPathParam,
         trans: ProvidesHistoryContext = DependsOnTrans,
     ) -> Union[WorkflowInvocationResponse, List[WorkflowInvocationResponse]]:
-        """
-        .. note:: This method takes the same arguments as
-            :func:`galaxy.webapps.galaxy.api.workflows.WorkflowsAPIController.create` above.
-
-        :raises: exceptions.MessageException, exceptions.RequestParameterInvalidException
-        """
         return self.service.invoke_workflow(trans, workflow_id, payload)
 
     @router.get(

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -83,6 +83,7 @@ from galaxy.schema.schema import (
 from galaxy.schema.workflows import (
     GetToolPredictionsPayload,
     InvokeWorkflowPayload,
+    StoredWorkflowDetailed,
 )
 from galaxy.structured_app import StructuredApp
 from galaxy.tool_shed.galaxy_install.install_manager import InstallRepositoryManager
@@ -1146,7 +1147,7 @@ class FastAPIWorkflows:
         legacy: LegacyQueryParam = False,
         version: VersionQueryParam = None,
         trans: ProvidesHistoryContext = DependsOnTrans,
-    ):
+    ) -> StoredWorkflowDetailed:
         return self.service.show_workflow(trans, workflow_id, instance, legacy, version)
 
 

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -23,6 +23,10 @@ from fastapi import (
 )
 from gxformat2._yaml import ordered_dump
 from markupsafe import escape
+from pydantic import (
+    UUID1,
+    UUID4,
+)
 from starlette.responses import StreamingResponse
 from typing_extensions import Annotated
 
@@ -821,6 +825,15 @@ InvocationsInstanceQueryParam = Annotated[
     ),
 ]
 
+MultiTypeWorkflowIDPathParam = Annotated[
+    Union[UUID4, UUID1, DecodedDatabaseIdField],
+    Path(
+        ...,
+        title="Workflow ID",
+        description="The database identifier - UUID or encoded - of the Workflow..",
+    ),
+]
+
 DeletedQueryParam: bool = Query(
     default=False, title="Display deleted", description="Whether to restrict result to deleted workflows."
 )
@@ -1075,9 +1088,9 @@ class FastAPIWorkflows:
     )
     def invoke(
         self,
-        # workflow_id: StoredWorkflowIDPathParam,
         payload: InvokeWorkflowBody,
-        workflow_id: str = Path(...),
+        # workflow_id: str = Path(...),
+        workflow_id: MultiTypeWorkflowIDPathParam,
         trans: ProvidesHistoryContext = DependsOnTrans,
     ) -> Union[WorkflowInvocationResponse, List[WorkflowInvocationResponse]]:
         """

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -84,6 +84,7 @@ from galaxy.schema.workflows import (
     GetToolPredictionsPayload,
     InvokeWorkflowPayload,
     StoredWorkflowDetailed,
+    ToolPredictionsSummary,
 )
 from galaxy.structured_app import StructuredApp
 from galaxy.tool_shed.galaxy_install.install_manager import InstallRepositoryManager
@@ -936,7 +937,7 @@ class FastAPIWorkflows:
         self,
         payload: GetToolPredictionsBody,
         trans: ProvidesUserContext = DependsOnTrans,
-    ):
+    ) -> Union[dict, ToolPredictionsSummary]:
         return self.service.get_tool_predictions(trans, payload.model_dump(exclude_unset=True))
 
     @router.get(

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1135,19 +1135,19 @@ class FastAPIWorkflows:
         )
 
     @router.get(
-        "/api/workflows/{encoded_workflow_id}",
+        "/api/workflows/{workflow_id}",
         summary="Displays information needed to run a workflow.",
         name="show_workflow",
     )
     def show_workflow(
         self,
-        encoded_workflow_id: StoredWorkflowIDPathParam,
+        workflow_id: StoredWorkflowIDPathParam,
         instance: InstanceQueryParam = False,
         legacy: LegacyQueryParam = False,
         version: VersionQueryParam = None,
         trans: ProvidesHistoryContext = DependsOnTrans,
     ):
-        return self.service.show_workflow(trans, encoded_workflow_id, instance, legacy, version)
+        return self.service.show_workflow(trans, workflow_id, instance, legacy, version)
 
 
 StepDetailQueryParam = Annotated[

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -74,6 +74,8 @@ from galaxy.schema.schema import (
     SharingStatus,
     WorkflowSortByEnum,
 )
+
+# from galaxy.schema.workflows import InvokeWorkflowPayload
 from galaxy.structured_app import StructuredApp
 from galaxy.tool_shed.galaxy_install.install_manager import InstallRepositoryManager
 from galaxy.tools import recommendations
@@ -968,6 +970,15 @@ SkipStepCountsQueryParam: bool = Query(
     description="Set this to true to skip joining workflow step counts and optimize the resulting index query. Response objects will not contain step counts.",
 )
 
+# InvokeWorkflowBody = Annotated[
+#     InvokeWorkflowPayload,
+#     Body(
+#         default=...,
+#         title="Invoke workflow",
+#         description="The values to invoke a workflow.",
+#     ),
+# ]
+
 
 @router.cbv
 class FastAPIWorkflows:
@@ -1123,6 +1134,25 @@ class FastAPIWorkflows:
     ):
         self.service.undelete(trans, workflow_id)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    # @router.post(
+    #     "/api/workflows/{workflow_id}/invocations",
+    #     name="Invoke workflow.",
+    #     summary="Schedule the workflow specified by `workflow_id` to run.",
+    # )
+    # def invoke(
+    #     self,
+    #     workflow_id: StoredWorkflowIDPathParam,
+    #     payload: InvokeWorkflowBody,
+    #     trans: ProvidesHistoryContext = DependsOnTrans,
+    # ):
+    #     """
+    #     .. note:: This method takes the same arguments as
+    #         :func:`galaxy.webapps.galaxy.api.workflows.WorkflowsAPIController.create` above.
+
+    #     :raises: exceptions.MessageException, exceptions.RequestParameterInvalidException
+    #     """
+    #     return self.service.invoke_workflow(trans, workflow_id, payload)
 
     @router.get(
         "/api/workflows/{workflow_id}/versions",

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -580,12 +580,6 @@ def populate_api_routes(webapp, app):
         controller="container_resolution",
         conditions=dict(method=["POST"]),
     )
-    webapp.mapper.connect(
-        "/api/workflows/get_tool_predictions",
-        action="get_tool_predictions",
-        controller="workflows",
-        conditions=dict(method=["POST"]),
-    )
 
     webapp.mapper.resource("visualization", "visualizations", path_prefix="/api")
     webapp.mapper.resource("plugins", "plugins", path_prefix="/api")

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -690,6 +690,19 @@ def populate_api_routes(webapp, app):
     #     conditions=dict(method=["POST"]),
     # )
 
+    invoke_names = {
+        "invocations": "",
+        "usage": "_deprecated",
+    }
+    for noun, suffix in invoke_names.items():
+        name = f"{noun}{suffix}"
+        webapp.mapper.connect(
+            f"workflow_{name}",
+            "/api/workflows/{workflow_id}/%s" % noun,
+            controller="workflows",
+            action="invoke",
+            conditions=dict(method=["POST"]),
+        )
     # ================================
     # ===== USERS API =====
     # ================================

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -580,6 +580,12 @@ def populate_api_routes(webapp, app):
         controller="container_resolution",
         conditions=dict(method=["POST"]),
     )
+    webapp.mapper.connect(
+        "/api/workflows/get_tool_predictions",
+        action="get_tool_predictions",
+        controller="workflows",
+        conditions=dict(method=["POST"]),
+    )
 
     webapp.mapper.resource("visualization", "visualizations", path_prefix="/api")
     webapp.mapper.resource("plugins", "plugins", path_prefix="/api")

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -689,19 +689,24 @@ def populate_api_routes(webapp, app):
     #     action="import_tool_version",
     #     conditions=dict(method=["POST"]),
     # )
-
-    invoke_names = {
-        "usage": "_deprecated",
-    }
-    for noun, suffix in invoke_names.items():
-        name = f"{noun}{suffix}"
-        webapp.mapper.connect(
-            f"workflow_{name}",
-            "/api/workflows/{workflow_id}/%s" % noun,
-            controller="workflows",
-            action="invoke",
-            conditions=dict(method=["POST"]),
-        )
+    webapp.mapper.connect(
+        "/api/workflows/{encoded_workflow_id}",
+        controller="workflows",
+        action="show",
+        conditions=dict(method=["GET"]),
+    )
+    webapp.mapper.connect(
+        "/api/workflows/{encoded_workflow_id}",
+        controller="workflows",
+        action="update",
+        conditions=dict(method=["PUT"]),
+    )
+    webapp.mapper.connect(
+        "/api/workflows",
+        controller="workflows",
+        action="create",
+        conditions=dict(method=["POST"]),
+    )
     # ================================
     # ===== USERS API =====
     # ================================

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -690,22 +690,6 @@ def populate_api_routes(webapp, app):
     #     conditions=dict(method=["POST"]),
     # )
 
-    # API refers to usages and invocations - these mean the same thing but the
-    # usage routes should be considered deprecated.
-    invoke_names = {
-        "invocations": "",
-        "usage": "_deprecated",
-    }
-    for noun, suffix in invoke_names.items():
-        name = f"{noun}{suffix}"
-        webapp.mapper.connect(
-            f"workflow_{name}",
-            "/api/workflows/{workflow_id}/%s" % noun,
-            controller="workflows",
-            action="invoke",
-            conditions=dict(method=["POST"]),
-        )
-
     # ================================
     # ===== USERS API =====
     # ================================

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -593,9 +593,6 @@ def populate_api_routes(webapp, app):
     webapp.mapper.connect(
         "/api/workflows/menu", action="set_workflow_menu", controller="workflows", conditions=dict(method=["PUT"])
     )
-    webapp.mapper.connect(
-        "/api/workflows/{id}/refactor", action="refactor", controller="workflows", conditions=dict(method=["PUT"])
-    )
     webapp.mapper.resource("workflow", "workflows", path_prefix="/api")
 
     # ---- visualizations registry ---- generic template renderer

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -691,7 +691,6 @@ def populate_api_routes(webapp, app):
     # )
 
     invoke_names = {
-        "invocations": "",
         "usage": "_deprecated",
     }
     for noun, suffix in invoke_names.items():

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -683,12 +683,6 @@ def populate_api_routes(webapp, app):
     webapp.mapper.connect(
         "/api/workflows/{encoded_workflow_id}",
         controller="workflows",
-        action="show",
-        conditions=dict(method=["GET"]),
-    )
-    webapp.mapper.connect(
-        "/api/workflows/{encoded_workflow_id}",
-        controller="workflows",
         action="update",
         conditions=dict(method=["PUT"]),
     )

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -120,18 +120,15 @@ class WorkflowsService(ServiceBase):
         payload: InvokeWorkflowPayload,
     ) -> Union[WorkflowInvocationResponse, List[WorkflowInvocationResponse]]:
         # Get workflow + accessibility check.
-        # by_stored_id = not payload.get("instance", False)
         by_stored_id = not payload.instance
         stored_workflow = self._workflows_manager.get_stored_accessible_workflow(trans, workflow_id, by_stored_id)
         workflow = stored_workflow.latest_workflow
         run_configs = build_workflow_run_configs(trans, workflow, payload.model_dump(exclude_unset=True))
         is_batch = payload.batch
-        # is_batch = payload.get("batch")
         if not is_batch and len(run_configs) != 1:
             raise HTTPException(status_code=400, detail="Must specify 'batch' to use batch parameters.")
 
         require_exact_tool_versions = payload.require_exact_tool_versions
-        # require_exact_tool_versions = util.string_as_bool(payload.get("require_exact_tool_versions", "true"))
         tools = self._workflow_contents_manager.get_all_tools(workflow)
         missing_tools = [
             tool
@@ -162,7 +159,6 @@ class WorkflowsService(ServiceBase):
         invocations = []
         for run_config in run_configs:
             workflow_scheduler_id = payload.scheduler
-            # workflow_scheduler_id = payload.get("scheduler", None)
             # TODO: workflow scheduler hints
             work_request_params = dict(scheduler=workflow_scheduler_id)
             workflow_invocation = queue_invoke(

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -17,6 +17,7 @@ from galaxy import (
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.notification import NotificationManager
 from galaxy.managers.workflows import (
+    RefactorResponse,
     WorkflowContentsManager,
     WorkflowSerializer,
     WorkflowsManager,
@@ -216,6 +217,16 @@ class WorkflowsService(ServiceBase):
             payload,
         )
         return {"ids_in_menu": ids_in_menu, "workflows": workflows}
+
+    def refactor(
+        self,
+        trans,
+        workflow_id,
+        payload,
+        instance: bool,
+    ) -> RefactorResponse:
+        stored_workflow = self._workflows_manager.get_stored_workflow(trans, workflow_id, by_stored_id=not instance)
+        return self._workflow_contents_manager.refactor(trans, stored_workflow, payload)
 
     def show_workflow(self, trans, workflow_id, instance, legacy, version) -> StoredWorkflowDetailed:
         stored_workflow = self._workflows_manager.get_stored_workflow(trans, workflow_id, by_stored_id=not instance)

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -25,7 +25,8 @@ from galaxy.schema.schema import (
     InvocationsStateCounts,
     WorkflowIndexQueryPayload,
 )
-from galaxy.schema.workflows import InvokeWorkflowPayload
+from galaxy.schema.workflows import InvokeWorkflowPayload  # GetToolPredictionsPayload,
+from galaxy.tools import recommendations
 from galaxy.util.tool_shed.tool_shed_registry import Registry
 from galaxy.webapps.galaxy.services.base import ServiceBase
 from galaxy.webapps.galaxy.services.sharable import ShareableService
@@ -53,6 +54,21 @@ class WorkflowsService(ServiceBase):
         self._serializer = serializer
         self.shareable_service = ShareableService(workflows_manager, serializer, notification_manager)
         self._tool_shed_registry = tool_shed_registry
+        self.tool_recommendations = recommendations.ToolRecommendations()
+
+    def get_tool_predictions(
+        self,
+        trans: ProvidesUserContext,
+        payload,
+    ):
+        remote_model_url = payload.get("remote_model_url", trans.app.config.tool_recommendation_model_path)
+        tool_sequence = payload.get("tool_sequence", "")
+        if "tool_sequence" not in payload or remote_model_url is None:
+            return {}
+        tool_sequence, recommended_tools = self.tool_recommendations.get_predictions(
+            trans, tool_sequence, remote_model_url
+        )
+        return {"current_tool": tool_sequence, "predicted_data": recommended_tools}
 
     def index(
         self,

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -105,6 +105,76 @@ class WorkflowsService(ServiceBase):
             return workflows, total_matches
         return rval, total_matches
 
+    # def invoke_workflow(self, trans, workflow_id, payload):
+    #     # Get workflow + accessibility check.
+    #     stored_workflow = self._workflows_manager.get_stored_accessible_workflow(
+    #         trans, workflow_id, instance=payload.get("instance", False)
+    #     )
+    #     workflow = stored_workflow.latest_workflow
+    #     run_configs = build_workflow_run_configs(trans, workflow, payload)
+    #     is_batch = payload.get("batch")
+    #     if not is_batch and len(run_configs) != 1:
+    #         raise HTTPException(status_code=400, detail="Must specify 'batch' to use batch parameters.")
+
+    #     require_exact_tool_versions = util.string_as_bool(payload.get("require_exact_tool_versions", "true"))
+    #     tools = self._workflow_contents_manager.get_all_tools(workflow)
+    #     missing_tools = [
+    #         tool
+    #         for tool in tools
+    #         if not self.app.toolbox.has_tool(
+    #             tool["tool_id"], tool_version=tool["tool_version"], exact=require_exact_tool_versions
+    #         )
+    #     ]
+    #     if missing_tools:
+    #         missing_tools_message = "Workflow was not invoked; the following required tools are not installed: "
+    #         if require_exact_tool_versions:
+    #             missing_tools_message += ", ".join(
+    #                 [f"{tool['tool_id']} (version {tool['tool_version']})" for tool in missing_tools]
+    #             )
+    #         else:
+    #             missing_tools_message += ", ".join([tool["tool_id"] for tool in missing_tools])
+    #         raise HTTPException(status_code=400, detail=missing_tools_message)
+    #     # if missing_tools:
+    #     #     missing_tools_message = "Workflow was not invoked; the following required tools are not installed: "
+    #     #     if require_exact_tool_versions:
+    #     #         missing_tools_message += ", ".join(
+    #     #             [f"{tool['tool_id']} (version {tool['tool_version']})" for tool in missing_tools]
+    #     #         )
+    #     #     else:
+    #     #         missing_tools_message += ", ".join([tool["tool_id"] for tool in missing_tools])
+    #     #     raise exceptions.MessageException(missing_tools_message)
+
+    #     invocations = []
+    #     for run_config in run_configs:
+    #         workflow_scheduler_id = payload.get("scheduler", None)
+    #         # TODO: workflow scheduler hints
+    #         work_request_params = dict(scheduler=workflow_scheduler_id)
+    #         workflow_invocation = queue_invoke(
+    #             trans=trans,
+    #             workflow=workflow,
+    #             workflow_run_config=run_config,
+    #             request_params=work_request_params,
+    #             flush=False,
+    #         )
+    #         invocations.append(workflow_invocation)
+
+    #     with transaction(trans.sa_session):
+    #         trans.sa_session.commit()
+    #     encoded_invocations = []
+    #     for invocation in invocations:
+    #         as_dict = workflow_invocation.to_dict()
+    #         as_dict = self.encode_all_ids(trans, as_dict, recursive=True)
+    #         as_dict["messages"] = [
+    #             InvocationMessageResponseModel.model_validate(message).model_dump(mode="json")
+    #             for message in invocation.messages
+    #         ]
+    #         encoded_invocations.append(as_dict)
+
+    #     if is_batch:
+    #         return encoded_invocations
+    #     else:
+    #         return encoded_invocations[0]
+
     def delete(self, trans, workflow_id):
         workflow_to_delete = self._workflows_manager.get_stored_workflow(trans, workflow_id)
         self._workflows_manager.check_security(trans, workflow_to_delete)

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -8,8 +8,6 @@ from typing import (
     Union,
 )
 
-from fastapi import HTTPException
-
 from galaxy import (
     exceptions,
     web,
@@ -133,7 +131,7 @@ class WorkflowsService(ServiceBase):
         run_configs = build_workflow_run_configs(trans, workflow, payload.model_dump(exclude_unset=True))
         is_batch = payload.batch
         if not is_batch and len(run_configs) != 1:
-            raise HTTPException(status_code=400, detail="Must specify 'batch' to use batch parameters.")
+            raise exceptions.RequestParameterInvalidException("Must specify 'batch' to use batch parameters.")
 
         require_exact_tool_versions = payload.require_exact_tool_versions
         tools = self._workflow_contents_manager.get_all_tools(workflow)
@@ -152,16 +150,7 @@ class WorkflowsService(ServiceBase):
                 )
             else:
                 missing_tools_message += ", ".join([tool["tool_id"] for tool in missing_tools])
-            raise HTTPException(status_code=400, detail=missing_tools_message)
-        # if missing_tools:
-        #     missing_tools_message = "Workflow was not invoked; the following required tools are not installed: "
-        #     if require_exact_tool_versions:
-        #         missing_tools_message += ", ".join(
-        #             [f"{tool['tool_id']} (version {tool['tool_version']})" for tool in missing_tools]
-        #         )
-        #     else:
-        #         missing_tools_message += ", ".join([tool["tool_id"] for tool in missing_tools])
-        #     raise exceptions.MessageException(missing_tools_message)
+            raise exceptions.MessageException(missing_tools_message)
 
         invocations = []
         for run_config in run_configs:

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -28,7 +28,10 @@ from galaxy.schema.schema import (
     InvocationsStateCounts,
     WorkflowIndexQueryPayload,
 )
-from galaxy.schema.workflows import InvokeWorkflowPayload  # GetToolPredictionsPayload,
+from galaxy.schema.workflows import (  # GetToolPredictionsPayload,
+    InvokeWorkflowPayload,
+    StoredWorkflowDetailed,
+)
 from galaxy.tools import recommendations
 from galaxy.util.tool_shed.tool_shed_registry import Registry
 from galaxy.webapps.galaxy.services.base import ServiceBase
@@ -230,7 +233,7 @@ class WorkflowsService(ServiceBase):
         )
         return {"ids_in_menu": ids_in_menu, "workflows": workflows}
 
-    def show_workflow(self, trans, workflow_id, instance, legacy, version):
+    def show_workflow(self, trans, workflow_id, instance, legacy, version) -> StoredWorkflowDetailed:
         stored_workflow = self._workflows_manager.get_stored_workflow(trans, workflow_id, by_stored_id=not instance)
         if stored_workflow.importable is False and stored_workflow.user != trans.user and not trans.user_is_admin:
             wf_count = 0 if not trans.user else trans.user.count_stored_workflow_user_assocs(stored_workflow)
@@ -248,7 +251,10 @@ class WorkflowsService(ServiceBase):
                 if workflow.id == workflow_id:
                     version = i
                     break
-        return self._workflow_contents_manager.workflow_to_dict(trans, stored_workflow, style=style, version=version)
+        detailed_workflow = StoredWorkflowDetailed(
+            **self._workflow_contents_manager.workflow_to_dict(trans, stored_workflow, style=style, version=version)
+        )
+        return detailed_workflow
 
     def _get_workflows_list(
         self,

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -31,6 +31,7 @@ from galaxy.schema.schema import (
 from galaxy.schema.workflows import (  # GetToolPredictionsPayload,
     InvokeWorkflowPayload,
     StoredWorkflowDetailed,
+    ToolPredictionsSummary,
 )
 from galaxy.tools import recommendations
 from galaxy.util.tool_shed.tool_shed_registry import Registry
@@ -74,7 +75,7 @@ class WorkflowsService(ServiceBase):
         tool_sequence, recommended_tools = self.tool_recommendations.get_predictions(
             trans, tool_sequence, remote_model_url
         )
-        return {"current_tool": tool_sequence, "predicted_data": recommended_tools}
+        return ToolPredictionsSummary(current_tool=tool_sequence, recommended_tools=recommended_tools)
 
     def index(
         self,

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -28,12 +28,10 @@ from galaxy.schema.schema import (
     InvocationsStateCounts,
     WorkflowIndexQueryPayload,
 )
-from galaxy.schema.workflows import (  # GetToolPredictionsPayload,
+from galaxy.schema.workflows import (
     InvokeWorkflowPayload,
     StoredWorkflowDetailed,
-    ToolPredictionsSummary,
 )
-from galaxy.tools import recommendations
 from galaxy.util.tool_shed.tool_shed_registry import Registry
 from galaxy.webapps.galaxy.services.base import ServiceBase
 from galaxy.webapps.galaxy.services.sharable import ShareableService
@@ -61,21 +59,6 @@ class WorkflowsService(ServiceBase):
         self._serializer = serializer
         self.shareable_service = ShareableService(workflows_manager, serializer, notification_manager)
         self._tool_shed_registry = tool_shed_registry
-        self.tool_recommendations = recommendations.ToolRecommendations()
-
-    def get_tool_predictions(
-        self,
-        trans: ProvidesUserContext,
-        payload,
-    ):
-        remote_model_url = payload.get("remote_model_url", trans.app.config.tool_recommendation_model_path)
-        tool_sequence = payload.get("tool_sequence", "")
-        if "tool_sequence" not in payload or remote_model_url is None:
-            return {}
-        tool_sequence, recommended_tools = self.tool_recommendations.get_predictions(
-            trans, tool_sequence, remote_model_url
-        )
-        return ToolPredictionsSummary(current_tool=tool_sequence, recommended_tools=recommended_tools)
 
     def index(
         self,

--- a/lib/galaxy_test/api/test_workflow_extraction.py
+++ b/lib/galaxy_test/api/test_workflow_extraction.py
@@ -478,7 +478,7 @@ test_data:
     def __setup_and_run_cat1_workflow(self, history_id):
         workflow = self.workflow_populator.load_workflow(name="test_for_extract")
         workflow_request, history_id, workflow_id = self._setup_workflow_run(workflow, history_id=history_id)
-        run_workflow_response = self._post(f"workflows/{workflow_id}/invocations", data=workflow_request)
+        run_workflow_response = self._post(f"workflows/{workflow_id}/invocations", data=workflow_request, json=True)
         self._assert_status_code_is(run_workflow_response, 200)
         invocation_response = run_workflow_response.json()
         self.workflow_populator.wait_for_invocation_and_jobs(

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -6633,7 +6633,7 @@ steps:
                 history=f"hist_id={history_id}", parameters=dumps(dict(validation_repeat={"r2_0|text": ""}))
             )
             url = f"workflows/{workflow_id}/invocations"
-            invocation_response = self._post(url, data=workflow_request)
+            invocation_response = self._post(url, data=workflow_request, json=True)
             # Take a valid stat and make it invalid, assert workflow won't run.
             self._assert_status_code_is(invocation_response, 400)
 

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -5172,8 +5172,7 @@ outer_input:
         workflow = self.workflow_populator.load_workflow(name="test_for_run_cannot_access")
         workflow_request, _, workflow_id = self._setup_workflow_run(workflow)
         with self._different_user():
-            # run_workflow_response = self._post(f"workflows/{workflow_id}/invocations", data=workflow_request, json=True)
-            run_workflow_response = self._post(f"workflows/{workflow_id}/invocations", data=workflow_request)
+            run_workflow_response = self._post(f"workflows/{workflow_id}/invocations", data=workflow_request, json=True)
             self._assert_status_code_is(run_workflow_response, 403)
 
     def test_400_on_invalid_workflow_id(self):
@@ -5188,7 +5187,7 @@ outer_input:
         with self._different_user():
             other_history_id = self.dataset_populator.new_history()
         workflow_request["history"] = f"hist_id={other_history_id}"
-        run_workflow_response = self._post(f"workflows/{workflow_id}/invocations", data=workflow_request)
+        run_workflow_response = self._post(f"workflows/{workflow_id}/invocations", data=workflow_request, json=True)
         self._assert_status_code_is(run_workflow_response, 403)
 
     def test_cannot_run_bootstrap_admin_workflow(self):

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -6538,7 +6538,7 @@ steps:
                 "parameters_normalized": True,
                 "parameters": dumps(parameters),
             }
-            invocation_response = self._post(f"workflows/{workflow_id}/usage", data=workflow_request)
+            invocation_response = self._post(f"workflows/{workflow_id}/usage", data=workflow_request, json=True)
             self._assert_status_code_is(invocation_response, 200)
             time.sleep(5)
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
@@ -6590,7 +6590,7 @@ steps:
                 "parameters_normalized": True,
                 "parameters": dumps(parameters),
             }
-            invocation_response = self._post(f"workflows/{workflow_id}/usage", data=workflow_request)
+            invocation_response = self._post(f"workflows/{workflow_id}/usage", data=workflow_request, json=True)
             self._assert_status_code_is(invocation_response, 200)
             time.sleep(5)
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -5172,6 +5172,7 @@ outer_input:
         workflow = self.workflow_populator.load_workflow(name="test_for_run_cannot_access")
         workflow_request, _, workflow_id = self._setup_workflow_run(workflow)
         with self._different_user():
+            # run_workflow_response = self._post(f"workflows/{workflow_id}/invocations", data=workflow_request, json=True)
             run_workflow_response = self._post(f"workflows/{workflow_id}/invocations", data=workflow_request)
             self._assert_status_code_is(run_workflow_response, 403)
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1821,7 +1821,7 @@ class BaseWorkflowPopulator(BasePopulator):
 
     def invoke_workflow_raw(self, workflow_id: str, request: dict, assert_ok: bool = False) -> Response:
         url = f"workflows/{workflow_id}/invocations"
-        invocation_response = self._post(url, data=request)
+        invocation_response = self._post(url, data=request, json=True)
         if assert_ok:
             invocation_response.raise_for_status()
         return invocation_response

--- a/test/integration/test_workflow_handler_configuration.py
+++ b/test/integration/test_workflow_handler_configuration.py
@@ -120,7 +120,7 @@ class BaseWorkflowHandlerConfigurationTestCase(integration_util.IntegrationTestC
         request["inputs_by"] = "step_index"
         url = f"workflows/{workflow_id}/invocations"
         for _ in range(n):
-            self._post(url, data=request)
+            self._post(url, data=request, json=True)
 
     def _get_workflow_invocations(self, history_id: str):
         # Consider exposing handler via the API to reduce breaking

--- a/test/integration/test_workflow_invocation.py
+++ b/test/integration/test_workflow_invocation.py
@@ -110,7 +110,7 @@ steps:
             )
             self._assert_status_code_is(invocation_response, 400)
             assert (
-                invocation_response.json().get("err_msg")
+                invocation_response.json().get("detail")
                 == "Workflow was not invoked; the following required tools are not installed: nonexistent_tool (version 0.1), compose_text_param (version 0.0.1)"
             )
             # should fail but return only the tool_id of non_existent tool as another version of compose_text_param is installed
@@ -119,6 +119,6 @@ steps:
             )
             self._assert_status_code_is(invocation_response, 400)
             assert (
-                invocation_response.json().get("err_msg")
+                invocation_response.json().get("detail")
                 == "Workflow was not invoked; the following required tools are not installed: nonexistent_tool"
             )

--- a/test/integration/test_workflow_invocation.py
+++ b/test/integration/test_workflow_invocation.py
@@ -110,7 +110,7 @@ steps:
             )
             self._assert_status_code_is(invocation_response, 400)
             assert (
-                invocation_response.json().get("detail")
+                invocation_response.json().get("err_msg")
                 == "Workflow was not invoked; the following required tools are not installed: nonexistent_tool (version 0.1), compose_text_param (version 0.0.1)"
             )
             # should fail but return only the tool_id of non_existent tool as another version of compose_text_param is installed
@@ -119,6 +119,6 @@ steps:
             )
             self._assert_status_code_is(invocation_response, 400)
             assert (
-                invocation_response.json().get("detail")
+                invocation_response.json().get("err_msg")
                 == "Workflow was not invoked; the following required tools are not installed: nonexistent_tool"
             )

--- a/test/integration/test_workflow_scheduling_options.py
+++ b/test/integration/test_workflow_scheduling_options.py
@@ -36,7 +36,7 @@ class TestMaximumWorkflowInvocationDuration(integration_util.IntegrationTestCase
         request["inputs"] = dumps(index_map)
         request["inputs_by"] = "step_index"
         url = f"workflows/{workflow_id}/invocations"
-        invocation_response = self._post(url, data=request)
+        invocation_response = self._post(url, data=request, json=True)
         invocation_url = url + "/" + invocation_response.json()["id"]
         time.sleep(5)
         state = self._get(invocation_url).json()["state"]


### PR DESCRIPTION
This is a part of #10889.

## Summary
- Refactored API routes:
     - [x] POST: `/api/workflows/{workflow_id}/invocations`
         - [x] Added pydantic models to input
         - [x] Added pydantic models to return
         - [x] Removed the mapping to the legacy routes
     - [x] PUT: `/api/workflows/{workflow_id}/refactor`
         - [x] Added pydantic models to input
         - [x] Added pydantic models to return
         - [x] Removed the mapping to the legacy routes
     - [x] GET: `/api/workflows/{workflow_id}`
         - [x] Added pydantic models to input
         - [x] Added pydantic models to return
         - [x] Removed the mapping to the legacy routes

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
You can find the interactive API documentation here: [http://127.0.0.1:8080/api/docs#/workflows](https://github.com/galaxyproject/galaxy/pull/url)
![image](https://github.com/galaxyproject/galaxy/assets/117033448/e10b8ba6-a2ef-4d01-bbc5-e9ef32f506b6)


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).