### PR TITLE
Fix for a regression change - auto-select/highlight file name text

### DIFF
--- a/client/src/components/Upload/DefaultRow.vue
+++ b/client/src/components/Upload/DefaultRow.vue
@@ -3,13 +3,15 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { faEdit, faFolderOpen, faLaptop } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { bytesToString } from "utils/utils";
-import { computed } from "vue";
+import { computed, onMounted, ref } from "vue";
 
 import UploadExtension from "./UploadExtension.vue";
 import UploadSelect from "./UploadSelect.vue";
 import UploadSettings from "./UploadSettings.vue";
 
 library.add(faEdit, faLaptop, faFolderOpen);
+
+const fileField = ref(null);
 
 const props = defineProps({
     deferred: {
@@ -104,6 +106,14 @@ function removeUpload() {
         emit("remove", props.index);
     }
 }
+
+onMounted(() => {
+    autoSelectFileInput();
+});
+
+function autoSelectFileInput() {
+    fileField.value.select();
+}
 </script>
 
 <template>
@@ -115,6 +125,7 @@ function removeUpload() {
                 <FontAwesomeIcon v-if="fileMode == 'url'" icon="fa-folder-open" fixed-width />
             </div>
             <b-input
+                ref="fileField"
                 :value="fileName"
                 class="upload-title p-1 border rounded"
                 :disabled="isDisabled"


### PR DESCRIPTION
Addresses #17394 regression. Change was lost when not carried over to newer code platform from https://github.com/galaxyproject/galaxy/blob/release_23.1/client/src/mvc/upload/default/default-row.js#L139

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
