### PR TITLE
Tag Autocomplete Rework

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -55,6 +55,7 @@
     "d3v3": "npm:d3@3",
     "date-fns": "^2.30.0",
     "decode-uri-component": "^0.2.1",
+    "dexie": "^3.2.5",
     "dom-to-image": "^2.6.0",
     "dompurify": "^3.0.6",
     "dumpmeta-webpack-plugin": "^0.2.0",

--- a/client/src/components/TagsMultiselect/HeadlessMultiselect.vue
+++ b/client/src/components/TagsMultiselect/HeadlessMultiselect.vue
@@ -41,6 +41,8 @@ const emit = defineEmits<{
     (e: "input", selected: string[]): void;
     /** emitted when a new option is selected, which wasn't part of the options prop */
     (e: "addOption", newOption: string): void;
+    /** emitted when a option is added */
+    (e: "selected", option: string): void;
 }>();
 
 const inputField = ref<HTMLInputElement | null>(null);
@@ -154,6 +156,7 @@ function onOptionSelected(option: string) {
         set.delete(option);
     } else {
         set.add(option);
+        emit("selected", option);
     }
 
     emit("input", Array.from(set));

--- a/client/src/components/TagsMultiselect/HeadlessMultiselect.vue
+++ b/client/src/components/TagsMultiselect/HeadlessMultiselect.vue
@@ -88,7 +88,9 @@ const filteredOptions = computed(() => {
 
 /** options trimmed to `maxShownOptions` and reordered so the search value appears first */
 const trimmedOptions = computed(() => {
-    const optionsSliced = filteredOptions.value.slice(0, props.maxShownOptions);
+    const optionsSliced = filteredOptions.value
+        .slice(0, props.maxShownOptions)
+        .map((tag) => tag.replace(/^name:/, "#"));
 
     // remove search value to put it in front
     const optionsSet = new Set(optionsSliced);

--- a/client/src/components/TagsMultiselect/StatelessTags.test.js
+++ b/client/src/components/TagsMultiselect/StatelessTags.test.js
@@ -20,10 +20,12 @@ const mountWithProps = (props) => {
 };
 
 jest.mock("@/stores/userTagsStore");
-const addLocalTagMock = jest.fn((tag) => tag);
+const onNewTagSeenMock = jest.fn((tag) => tag);
 useUserTagsStore.mockReturnValue({
     userTags: computed(() => autocompleteTags),
-    addLocalTag: addLocalTagMock,
+    onNewTagSeen: onNewTagSeenMock,
+    onTagUsed: jest.fn(),
+    onMultipleNewTagsSeen: jest.fn(),
 });
 
 jest.mock("composables/toast");
@@ -103,8 +105,8 @@ describe("StatelessTags", () => {
         multiselect.find(selectors.options).trigger("click");
         await wrapper.vm.$nextTick();
 
-        expect(addLocalTagMock.mock.calls.length).toBe(1);
-        expect(addLocalTagMock.mock.results[0].value).toBe("new_tag");
+        expect(onNewTagSeenMock.mock.calls.length).toBe(1);
+        expect(onNewTagSeenMock.mock.results[0].value).toBe("new_tag");
     });
 
     it("warns about not allowed tags", async () => {

--- a/client/src/components/TagsMultiselect/StatelessTags.vue
+++ b/client/src/components/TagsMultiselect/StatelessTags.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { BButton } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
-import { computed, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 
 import { useToast } from "@/composables/toast";
 import { useUid } from "@/composables/utils/uid";
@@ -37,11 +37,15 @@ const userTagsStore = useUserTagsStore();
 const { userTags } = storeToRefs(userTagsStore);
 const { warning } = useToast();
 
+onMounted(() => {
+    userTagsStore.onMultipleNewTagsSeen(props.value);
+});
+
 function onAddTag(tag: string) {
     const newTag = tag.trim();
 
     if (isValid(newTag)) {
-        userTagsStore.addLocalTag(newTag);
+        userTagsStore.onNewTagSeen(newTag);
         emit("input", [...props.value, newTag]);
     } else {
         warning(`"${newTag}" is not a valid tag.`, "Invalid Tag");
@@ -111,7 +115,8 @@ function onTagClicked(tag: string) {
                 :placeholder="props.placeholder"
                 :validator="isValid"
                 @addOption="onAddTag"
-                @input="onInput" />
+                @input="onInput"
+                @selected="(tag) => userTagsStore.onTagUsed(tag)" />
         </div>
 
         <div v-else>

--- a/client/src/components/Workflow/Editor/Attributes.test.js
+++ b/client/src/components/Workflow/Editor/Attributes.test.js
@@ -20,8 +20,11 @@ const autocompleteTags = ["#named_uer_tag", "abc", "my_tag"];
 jest.mock("@/stores/userTagsStore");
 useUserTagsStore.mockReturnValue({
     userTags: computed(() => autocompleteTags),
-    addLocalTag: jest.fn(),
+    onNewTagSeen: jest.fn(),
+    onTagUsed: jest.fn(),
+    onMultipleNewTagsSeen: jest.fn(),
 });
+
 describe("Attributes", () => {
     it("test attributes", async () => {
         const localVue = createLocalVue();

--- a/client/src/stores/userTagsStore.ts
+++ b/client/src/stores/userTagsStore.ts
@@ -27,7 +27,7 @@ class UserTagStoreDatabase extends Dexie {
 const maxDbEntriesPerUser = 10000;
 
 function normalizeTag(tag: string) {
-    return tag.replace(/^name:/, "#");
+    return tag.replace(/^#/, "name:");
 }
 
 export const useUserTagsStore = defineStore("userTagsStore", () => {

--- a/client/src/stores/userTagsStore.ts
+++ b/client/src/stores/userTagsStore.ts
@@ -1,27 +1,126 @@
+import { until } from "@vueuse/core";
+import Dexie from "dexie";
 import { defineStore, storeToRefs } from "pinia";
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
+
+import { useHashedUserId } from "@/composables/hashedUserId";
+import { assertDefined, ensureDefined } from "@/utils/assertions";
 
 import { useUserStore } from "./userStore";
 
+interface StoredTag {
+    id?: number;
+    tag: string;
+    userHash: string;
+    lastUsed: number;
+}
+
+class UserTagStoreDatabase extends Dexie {
+    tags!: Dexie.Table<StoredTag, number>;
+
+    constructor() {
+        super("userTagStoreDatabase");
+        this.version(1).stores({ tags: "++id, userHash, lastUsed" });
+    }
+}
+
+const maxDbEntriesPerUser = 500;
+
+function normalizeTag(tag: string) {
+    return tag.replace(/^name:/, "#");
+}
+
 export const useUserTagsStore = defineStore("userTagsStore", () => {
-    const localTags = ref<string[]>([]);
-
     const { currentUser } = storeToRefs(useUserStore());
+    const { hashedUserId } = useHashedUserId(currentUser);
 
+    const db = new UserTagStoreDatabase();
+    const tags = ref<StoredTag[]>([]);
+    const dbLoaded = ref(false);
+
+    watch(
+        () => hashedUserId.value,
+        async (userHash) => {
+            if (userHash) {
+                tags.value = await db.tags.where("userHash").equals(userHash).sortBy("lastUsed");
+
+                console.log(tags.value);
+
+                if (tags.value.length > maxDbEntriesPerUser) {
+                    await removeOldestEntries(tags.value.length - maxDbEntriesPerUser);
+                }
+
+                dbLoaded.value = true;
+            }
+        },
+        { immediate: true }
+    );
+
+    /** removes the x oldest tags from the database */
+    async function removeOldestEntries(count: number) {
+        const oldestTags = tags.value.filter((o) => o.id !== undefined).splice(0, count);
+        await db.tags.bulkDelete(oldestTags.map((o) => o.id!));
+    }
+
+    /** tags as string array */
     const userTags = computed(() => {
-        let tags: string[];
-        if (currentUser.value && !currentUser.value.isAnonymous) {
-            tags = [...(currentUser.value.tags_used ?? []), ...localTags.value];
-        } else {
-            tags = localTags.value;
-        }
-        const tagSet = new Set(tags);
-        return Array.from(tagSet).map((tag) => tag.replace(/^name:/, "#"));
+        return tags.value.map((o) => o.tag).reverse();
     });
 
-    const addLocalTag = (tag: string) => {
-        localTags.value.push(tag);
-    };
+    async function onNewTagSeen(tag: string) {
+        await until(dbLoaded).toBe(true);
 
-    return { localTags, userTags, addLocalTag };
+        assertDefined(hashedUserId.value);
+        tag = normalizeTag(tag);
+
+        const tagSet = new Set(userTags.value);
+
+        if (!tagSet.has(tag)) {
+            const tagObject: StoredTag = {
+                tag,
+                userHash: hashedUserId.value,
+                lastUsed: Date.now(),
+            };
+
+            tags.value.push(tagObject);
+            await db.tags.add(tagObject);
+        }
+    }
+
+    async function onMultipleNewTagsSeen(newTags: string[]) {
+        await until(dbLoaded).toBe(true);
+
+        const userHash = ensureDefined(hashedUserId.value);
+        const tagSet = new Set(userTags.value);
+
+        // only the ones that really are new
+        const filteredNewTags = newTags.map(normalizeTag).filter((tag) => !tagSet.has(tag));
+
+        if (filteredNewTags.length > 0) {
+            const now = Date.now();
+            const newTagObjects: StoredTag[] = filteredNewTags.map((tag) => ({
+                tag,
+                userHash,
+                lastUsed: now,
+            }));
+
+            tags.value = tags.value.concat(newTagObjects);
+            await db.tags.bulkAdd(newTagObjects);
+        }
+    }
+
+    async function onTagUsed(tag: string) {
+        await until(dbLoaded).toBe(true);
+        tag = normalizeTag(tag);
+
+        const storedTag = tags.value.find((o) => o.tag === tag);
+        const id = storedTag?.id;
+
+        if (id !== undefined) {
+            // put instead of update, because `removeOldestEntries` may have deleted this tag on init
+            await db.tags.put({ ...storedTag, lastUsed: Date.now() } as StoredTag, id);
+        }
+    }
+
+    return { userTags, onNewTagSeen, onTagUsed, onMultipleNewTagsSeen };
 });

--- a/client/src/stores/userTagsStore.ts
+++ b/client/src/stores/userTagsStore.ts
@@ -24,7 +24,7 @@ class UserTagStoreDatabase extends Dexie {
     }
 }
 
-const maxDbEntriesPerUser = 500;
+const maxDbEntriesPerUser = 10000;
 
 function normalizeTag(tag: string) {
     return tag.replace(/^name:/, "#");
@@ -58,7 +58,7 @@ export const useUserTagsStore = defineStore("userTagsStore", () => {
 
     /** removes the x oldest tags from the database */
     async function removeOldestEntries(count: number) {
-        const oldestTags = tags.value.filter((o) => o.id !== undefined).splice(0, count);
+        const oldestTags = tags.value.splice(0, count);
         await db.tags.bulkDelete(oldestTags.map((o) => o.id!));
     }
 

--- a/client/tests/jest/jest.config.js
+++ b/client/tests/jest/jest.config.js
@@ -35,6 +35,7 @@ module.exports = {
             "<rootDir>/node_modules/rxjs/dist/esm/internal/scheduler/AsyncScheduler.js",
         "^@/(.*)$": "<rootDir>/src/$1",
         "^@tests/(.*)$": "<rootDir>/tests/$1",
+        dexie: "<rootDir>/node_modules/dexie/dist/dexie.js",
     },
     modulePathIgnorePatterns: ["<rootDir>/src/.*/__mocks__"],
     rootDir: path.join(__dirname, "../../"),

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5054,6 +5054,13 @@ detect-node@^2.0.4:
   resolved "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
+dexie@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/dexie/-/dexie-3.2.5.tgz#f68e34b98e0e5e3412cf86b540a2cc6cbf9b0266"
+  integrity sha512-MA7vYQvXxWN2+G50D0GLS4FqdYUyRYQsN0FikZIVebOmRoNCSCL9+eUbIF80dqrfns3kmY+83+hE2GN9CnAGyA==
+  dependencies:
+    karma-safari-launcher "^1.0.0"
+
 diff-sequences@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
@@ -7937,6 +7944,11 @@ just-debounce@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/just-debounce/-/just-debounce-1.1.0.tgz"
   integrity sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ==
+
+karma-safari-launcher@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz#96982a2cc47d066aae71c553babb28319115a2ce"
+  integrity sha512-qmypLWd6F2qrDJfAETvXDfxHvKDk+nyIjpH9xIeI3/hENr0U3nuqkxaftq73PfXZ4aOuOChA6SnLW4m4AxfRjQ==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"


### PR DESCRIPTION
Partial fix for issue #17443

Does not remove `tags_used` from the user object. Would prefer doing this in a followup PR, to keep this PR focused.

Replaces the back-end provided `tags_used` array, with a front-end indexdDB with [dexie](https://dexie.org/).

Stores up to 10 000 tags in the database, based on tags which are seen/used client-side.
On load, orders these tags by most recently used (or most recently seen as a fallback). In order for the select to behave somewhat predictably, this only happens at the start of a session (open to changing this, please let me know if you have an opinion on this behavior).
Completely new tags will be added to the top of the auto-complete.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
