### PR TITLE
Exclude password reset link from login form where users don't have the ability to manage accounts

### DIFF
--- a/client/src/components/Login/LoginForm.vue
+++ b/client/src/components/Login/LoginForm.vue
@@ -40,7 +40,7 @@
                                             v-model="password"
                                             name="password"
                                             type="password" />
-                                        <b-form-text>
+                                        <b-form-text v-if="showResetLink">
                                             <span v-localize>Forgot password?</span>
                                             <a
                                                 v-localize
@@ -141,6 +141,10 @@ export default {
         showWelcomeWithLogin: {
             type: Boolean,
             default: false,
+        },
+        showResetLink: {
+            type: Boolean,
+            default: true,
         },
         termsUrl: {
             type: String,

--- a/client/src/components/Login/LoginIndex.vue
+++ b/client/src/components/Login/LoginIndex.vue
@@ -10,6 +10,7 @@
             :show-welcome-with-login="showWelcomeWithLogin"
             :terms-url="termsUrl"
             :welcome-url="welcomeUrl"
+            :show-reset-link="showResetLink"
             @toggle-login="toggleLogin" />
         <RegisterForm
             v-else
@@ -42,6 +43,10 @@ export default {
         allowUserCreation: {
             type: Boolean,
             required: true,
+        },
+        showResetLink: {
+            type: Boolean,
+            default: true,
         },
         enableOidc: {
             type: Boolean,

--- a/client/src/entry/analysis/modules/Login.vue
+++ b/client/src/entry/analysis/modules/Login.vue
@@ -17,6 +17,7 @@
             :server-mail-configured="config.server_mail_configured"
             :session-csrf-token="sessionCsrfToken"
             :show-welcome-with-login="config.show_welcome_with_login"
+            :show-reset-link="config.enable_account_interface"
             :terms-url="config.terms_url"
             :welcome-url="config.welcome_url" />
     </div>


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/17472

I left the current structure in place here and just drilled the prop through since there was no use of config in the subcomponents, but want to follow up shortly, separately, with a refactoring of these login components.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
