### PR TITLE
`data_column` parameter: use `column_names` metadata if present

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3424,7 +3424,9 @@ $attribute_list:data_ref,dynamic_options,display,multiple:5
 
 #### ``data_column``
 
-This parameter type is used to select columns from a parameter.
+This parameter type is used to select columns from a data parameter.
+It uses the ``column_names`` metadata if present (only since 24.0)
+and as a fallback the tab separated values of the first line.
 
 $attribute_list:force_select,numerical,use_header_name,multiple:5
 

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1479,20 +1479,32 @@ class ColumnListParameter(SelectToolParameter):
         Show column labels rather than c1..cn if use_header_names=True
         """
         options: List[Tuple[str, Union[str, Tuple[str, str]], bool]] = []
-        if self.usecolnames:  # read first row - assume is a header with metadata useful for making good choices
+        # if available use column_names metadata for option names
+        # otherwise read first row - assume is a header with tab separated names
+        if self.usecolnames:
             dataset = other_values.get(self.data_ref, None)
-            try:
-                with open(dataset.get_file_name()) as f:
-                    head = f.readline()
-                cnames = head.rstrip("\n\r ").split("\t")
-                column_list = [("%d" % (i + 1), "c%d: %s" % (i + 1, x)) for i, x in enumerate(cnames)]
-                if self.numerical:  # If numerical was requested, filter columns based on metadata
-                    if hasattr(dataset, "metadata") and hasattr(dataset.metadata, "column_types"):
-                        if len(dataset.metadata.column_types) >= len(cnames):
-                            numerics = [i for i, x in enumerate(dataset.metadata.column_types) if x in ["int", "float"]]
-                            column_list = [column_list[i] for i in numerics]
-            except Exception:
-                column_list = self.get_column_list(trans, other_values)
+            if (
+                hasattr(dataset, "metadata")
+                and hasattr(dataset.metadata, "column_names")
+                and dataset.metadata.element_is_set("column_names")
+            ):
+                log.error(f"column_names {dataset.metadata.column_names}")
+                column_list = [
+                    ("%d" % (i + 1), "c%d: %s" % (i + 1, x)) for i, x in enumerate(dataset.metadata.column_names)
+                ]
+            else:
+                try:
+                    with open(dataset.get_file_name()) as f:
+                        head = f.readline()
+                    cnames = head.rstrip("\n\r ").split("\t")
+                    column_list = [("%d" % (i + 1), "c%d: %s" % (i + 1, x)) for i, x in enumerate(cnames)]
+                except Exception:
+                    column_list = self.get_column_list(trans, other_values)
+            if self.numerical:  # If numerical was requested, filter columns based on metadata
+                if hasattr(dataset, "metadata") and hasattr(dataset.metadata, "column_types"):
+                    if len(dataset.metadata.column_types) >= len(column_list):
+                        numerics = [i for i, x in enumerate(dataset.metadata.column_types) if x in ["int", "float"]]
+                        column_list = [column_list[i] for i in numerics]
         else:
             column_list = self.get_column_list(trans, other_values)
         for col in column_list:

--- a/test/functional/tools/column_param.xml
+++ b/test/functional/tools/column_param.xml
@@ -1,11 +1,16 @@
 <tool id="column_param" name="Column Param" version="1.0.0">
     <command><![CDATA[
-cut -f '$col' '$input1' > '$output1' &&
+cut
+    -f '$col'
+    #if $input1.is_of_type('csv')
+        -d','
+    #end if 
+    '$input1' > '$output1' &&
 echo "col $col" > '$output2' &&
 echo "col_names $col_names" >> '$output2'
     ]]></command>
     <inputs>
-        <param name="input1" type="data" format="tabular" label="Input 1" />
+        <param name="input1" type="data" format="tabular,csv" label="Input 1" />
         <param name="col" type="data_column" data_ref="input1" label="Column to Use" />
         <param name="col_names" type="data_column" data_ref="input1" use_header_names="true" label="Column to Use" />
     </inputs>
@@ -37,6 +42,23 @@ echo "col_names $col_names" >> '$output2'
             <output name="output1">
                 <assert_contents>
                     <has_line line="chr1" />
+                </assert_contents>
+            </output>
+            <output name="output2">
+                <assert_contents>
+                    <has_line line="col 1" />
+                    <has_line line="col_names 1" />
+                </assert_contents>
+            </output>
+        </test>
+        <!-- test csv input -->
+        <test>
+            <param name="input1" value="1.csv" ftype="csv"/>
+            <param name="col" value="1" />
+            <param name="col_names" value="c1: Transaction_date" />
+            <output name="output1">
+                <assert_contents>
+                    <has_line line="1/2/09 6:17" />
                 </assert_contents>
             </output>
             <output name="output2">


### PR DESCRIPTION
makes `data_column` work for all data types setting `column_names` and still fallback to try to take the first line (tab separated). The later is necessary for `tabular` which does not set the column names metadata.

fixes: https://github.com/galaxyproject/galaxy/issues/17468

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
