### PR TITLE
Display workflow invocation counts.

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1793,6 +1793,10 @@ export interface paths {
         /** Add the deleted flag to a workflow. */
         delete: operations["delete_workflow_api_workflows__workflow_id__delete"];
     };
+    "/api/workflows/{workflow_id}/counts": {
+        /** Get state counts for accessible workflow. */
+        get: operations["workflows__invocation_counts"];
+    };
     "/api/workflows/{workflow_id}/disable_link_access": {
         /**
          * Makes this item inaccessible by a URL link.
@@ -9558,6 +9562,10 @@ export interface components {
              * @description The relative URL to access this item.
              */
             url: string;
+        };
+        /** RootModel[Dict[str, int]] */
+        RootModel_Dict_str__int__: {
+            [key: string]: number | undefined;
         };
         /** SearchJobsPayload */
         SearchJobsPayload: {
@@ -21493,6 +21501,37 @@ export interface operations {
             200: {
                 content: {
                     "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    workflows__invocation_counts: {
+        /** Get state counts for accessible workflow. */
+        parameters: {
+            /** @description Is provided workflow id for Workflow instead of StoredWorkflow? */
+            query?: {
+                instance?: boolean | null;
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string | null;
+            };
+            /** @description The encoded database identifier of the Stored Workflow. */
+            path: {
+                workflow_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["RootModel_Dict_str__int__"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/workflows.ts
+++ b/client/src/api/workflows.ts
@@ -1,3 +1,5 @@
 import { fetcher } from "@/api/schema";
 
 export const workflowsFetcher = fetcher.path("/api/workflows").method("get").create();
+
+export const invocationCountsFetcher = fetcher.path("/api/workflows/{workflow_id}/counts").method("get").create();

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -150,6 +150,7 @@ from galaxy.schema.schema import (
     DatasetCollectionPopulatedState,
     DatasetState,
     DatasetValidatedState,
+    InvocationsStateCounts,
     JobState,
 )
 from galaxy.schema.workflow.comments import WorkflowCommentModel
@@ -7475,6 +7476,20 @@ class StoredWorkflow(Base, HasTags, Dictifiable, RepresentById):
             new_swta = src_swta.copy()
             new_swta.user = target_user
             self.tags.append(new_swta)
+
+    def invocation_counts(self) -> InvocationsStateCounts:
+        sa_session = object_session(self)
+        stmt = (
+            select([WorkflowInvocation.state, func.count(WorkflowInvocation.state)])
+            .select_from(StoredWorkflow)
+            .join(Workflow, Workflow.stored_workflow_id == StoredWorkflow.id)
+            .join(WorkflowInvocation, WorkflowInvocation.workflow_id == Workflow.id)
+            .group_by(WorkflowInvocation.state)
+            .where(StoredWorkflow.id == self.id)
+        )
+        rows = sa_session.execute(stmt).all()
+        rows_as_dict = dict(r for r in rows if r[0] is not None)
+        return InvocationsStateCounts(rows_as_dict)
 
     def to_dict(self, view="collection", value_mapper=None):
         rval = super().to_dict(view=view, value_mapper=value_mapper)

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2404,6 +2404,9 @@ class WorkflowStepLayoutPosition(Model):
     width: int = Field(..., title="Width", description="Width of the box in pixels.")
 
 
+InvocationsStateCounts = RootModel[Dict[str, int]]
+
+
 class WorkflowStepToExportBase(Model):
     id: int = Field(
         ...,


### PR DESCRIPTION
Provide backend API to restore component implemented by @itisAliRH added in https://github.com/galaxyproject/galaxy/pull/16607.

Performance: Workflows render fine without the data, data is fetched asynchronously from other queries, joins only happen across a couple of fields that are all indexed, avoiding serializing objects and such - the SQL is quite low-level.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Load the grid and see the invocation counts.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
