### PR TITLE
Better display of estimated line numbers and add number of columns for tabular

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -1100,7 +1100,7 @@ class Text(Data):
                     else:
                         est_lines = self.estimate_file_lines(dataset)
                         if est_lines is not None:
-                            dataset.blurb = f"~{util.trailing_zeros_to_powerof10(util.roundify(str(est_lines)))} {inflector.cond_plural(est_lines, self.line_class)}"
+                            dataset.blurb = f"~{util.trailing_zeros_to_powerof10(util.roundify(est_lines))} {inflector.cond_plural(est_lines, self.line_class)}"
                         else:
                             dataset.blurb = "Error: Cannot estimate lines in dataset"
             else:

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -1100,7 +1100,7 @@ class Text(Data):
                     else:
                         est_lines = self.estimate_file_lines(dataset)
                         if est_lines is not None:
-                            dataset.blurb = f"~{util.trailing_zeros_to_powerof10(est_lines)} {inflector.cond_plural(est_lines, self.line_class)}"
+                            dataset.blurb = f"~{util.shorten_with_metric_prefix(est_lines)} {inflector.cond_plural(est_lines, self.line_class)}"
                         else:
                             dataset.blurb = "Error: Cannot estimate lines in dataset"
             else:

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -1100,7 +1100,7 @@ class Text(Data):
                     else:
                         est_lines = self.estimate_file_lines(dataset)
                         if est_lines is not None:
-                            dataset.blurb = f"~{util.commaify(util.roundify(str(est_lines)))} {inflector.cond_plural(est_lines, self.line_class)}"
+                            dataset.blurb = f"~{util.trailing_zeros_to_powerof10(util.roundify(str(est_lines)))} {inflector.cond_plural(est_lines, self.line_class)}"
                         else:
                             dataset.blurb = "Error: Cannot estimate lines in dataset"
             else:

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -1100,7 +1100,7 @@ class Text(Data):
                     else:
                         est_lines = self.estimate_file_lines(dataset)
                         if est_lines is not None:
-                            dataset.blurb = f"~{util.trailing_zeros_to_powerof10(util.roundify(est_lines))} {inflector.cond_plural(est_lines, self.line_class)}"
+                            dataset.blurb = f"~{util.trailing_zeros_to_powerof10(est_lines)} {inflector.cond_plural(est_lines, self.line_class)}"
                         else:
                             dataset.blurb = "Error: Cannot estimate lines in dataset"
             else:

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -127,6 +127,7 @@ class TabularData(Text):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         kwd.setdefault("line_wrap", False)
         super().set_peek(dataset, **kwd)
+        dataset.blurb = f"{dataset.blurb} {dataset.metadata.columns} columns"
         if dataset.metadata.comment_lines:
             dataset.blurb = f"{dataset.blurb}, {util.commaify(str(dataset.metadata.comment_lines))} comments"
 

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1139,7 +1139,7 @@ def commaify(amount):
         return commaify(new)
 
 
-def trailing_zeros_to_powerof10(amount):
+def trailing_zeros_to_powerof10(amount: int):
     """
     >>> trailing_zeros_to_powerof10(23000)
     '23000'
@@ -1168,7 +1168,7 @@ def trailing_zeros_to_powerof10(amount):
         return f"{amount[: i+1]}\u22C510^{zeros}"
 
 
-def roundify(amount, sfs=2):
+def roundify(amount: int, sfs: int = 2):
     """
     Take a number and round it to 'sfs' significant figures.
 

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1135,32 +1135,6 @@ def commaify(amount):
         return commaify(new)
 
 
-def trailing_zeros_to_powerof10(amount: int) -> str:
-    """
-    >>> trailing_zeros_to_powerof10(23000)
-    '23K'
-    >>> trailing_zeros_to_powerof10(2300000)
-    '2.3M'
-    >>> trailing_zeros_to_powerof10(23000000)
-    '23M'
-    >>> trailing_zeros_to_powerof10(1)
-    '1'
-    >>> trailing_zeros_to_powerof10(0)
-    '0'
-    >>> trailing_zeros_to_powerof10(100)
-    '100'
-    >>> trailing_zeros_to_powerof10(-100)
-    '-100'
-    """
-    m, prefix = metric_prefix(amount, 1000)
-    m_str = str(int(m)) if m.is_integer() else f"{m:.1f}"
-    exp = f"{m_str}{prefix}"
-    if len(exp) <= len(str(amount)):
-        return exp
-    else:
-        return str(amount)
-
-
 @overload
 def unicodify(  # type: ignore[misc]
     value: Literal[None],
@@ -1486,7 +1460,7 @@ def docstring_trim(docstring):
     return "\n".join(trimmed)
 
 
-def metric_prefix(number: Union[int, float], base: int, text: bool = True) -> Tuple[float, str]:
+def metric_prefix(number: Union[int, float], base: int) -> Tuple[float, str]:
     """
     >>> metric_prefix(100, 1000)
     (100.0, '')
@@ -1494,10 +1468,6 @@ def metric_prefix(number: Union[int, float], base: int, text: bool = True) -> Tu
     (999.0, '')
     >>> metric_prefix(1000, 1000)
     (1.0, 'K')
-    >>> metric_prefix(999, 1000, False)
-    (999.0, '0')
-    >>> metric_prefix(1000, 1000, False)
-    (1.0, '3')
     >>> metric_prefix(1001, 1000)
     (1.001, 'K')
     >>> metric_prefix(1000000, 1000)
@@ -1514,12 +1484,38 @@ def metric_prefix(number: Union[int, float], base: int, text: bool = True) -> Tu
     else:
         sign = 1
 
-    for i, prefix in enumerate(prefixes):
+    for prefix in prefixes:
         if number < base:
-            return sign * float(number), prefix if text else str(i * 3)
+            return sign * float(number), prefix
         number /= base
     else:
-        return sign * float(number) * base, prefix if text else str(i * 3)
+        return sign * float(number) * base, prefix
+
+
+def shorten_with_metric_prefix(amount: int) -> str:
+    """
+    >>> shorten_with_metric_prefix(23000)
+    '23K'
+    >>> shorten_with_metric_prefix(2300000)
+    '2.3M'
+    >>> shorten_with_metric_prefix(23000000)
+    '23M'
+    >>> shorten_with_metric_prefix(1)
+    '1'
+    >>> shorten_with_metric_prefix(0)
+    '0'
+    >>> shorten_with_metric_prefix(100)
+    '100'
+    >>> shorten_with_metric_prefix(-100)
+    '-100'
+    """
+    m, prefix = metric_prefix(amount, 1000)
+    m_str = str(int(m)) if m.is_integer() else f"{m:.1f}"
+    exp = f"{m_str}{prefix}"
+    if len(exp) <= len(str(amount)):
+        return exp
+    else:
+        return str(amount)
 
 
 def nice_size(size: Union[float, int, str]) -> str:

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1144,9 +1144,9 @@ def trailing_zeros_to_powerof10(amount: int):
     >>> trailing_zeros_to_powerof10(23000)
     '23000'
     >>> trailing_zeros_to_powerof10(2300000)
-    '23\u22C510^5'
+    '23\u00d710^5'
     >>> trailing_zeros_to_powerof10(23000000)
-    '23\u22C510^6'
+    '23\u00d710^6'
     >>> trailing_zeros_to_powerof10(1)
     '1'
     >>> trailing_zeros_to_powerof10(0)
@@ -1162,10 +1162,10 @@ def trailing_zeros_to_powerof10(amount: int):
     while i >= 0 and amount[i] == "0":
         zeros += 1
         i -= 1
-    if len(amount) < len(f"{amount[: i+1]}\u22C510^{zeros}"):
+    if len(amount) < len(f"{amount[: i+1]}\u00d710^{zeros}"):
         return amount
     else:
-        return f"{amount[: i+1]}\u22C510^{zeros}"
+        return f"{amount[: i+1]}\u00d710^{zeros}"
 
 
 def roundify(amount: int, sfs: int = 2):

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -32,6 +32,10 @@ from datetime import (
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from hashlib import md5
+from math import (
+    floor,
+    log10,
+)
 from os.path import relpath
 from typing import (
     Any,
@@ -1135,14 +1139,49 @@ def commaify(amount):
         return commaify(new)
 
 
-def roundify(amount, sfs=2):
+def trailing_zeros_to_powerof10(amount):
     """
-    Take a number in string form and truncate to 'sfs' significant figures.
+    >>> trailing_zeros_to_powerof10(23000)
+    '23000'
+    >>> trailing_zeros_to_powerof10(2300000)
+    '23 10^5'
+    >>> trailing_zeros_to_powerof10(23000000)
+    '23 10^6'
+    >>> trailing_zeros_to_powerof10(1)
+    '1'
+    >>> trailing_zeros_to_powerof10(0)
+    '0'
+    >>> trailing_zeros_to_powerof10(100)
+    '100'
+    >>> trailing_zeros_to_powerof10(-100)
+    '-100'
     """
-    if len(amount) <= sfs:
+    amount = str(amount)
+    zeros = 0
+    i = len(amount) - 1
+    while i >= 0 and amount[i] == "0":
+        zeros += 1
+        i -= 1
+    if len(amount) < len(f"{amount[:i+1]} 10^{zeros}"):
         return amount
     else:
-        return amount[0:sfs] + "0" * (len(amount) - sfs)
+        return f"{amount[:i+1]} 10^{zeros}"
+
+
+def roundify(amount, sfs=2):
+    """
+    Take a number and round it to 'sfs' significant figures.
+
+    >>> roundify(99)
+    99
+    >>> roundify(-99)
+    -99
+    >>> roundify(1111)
+    1100
+    >>> roundify(1999)
+    2000
+    """
+    return round(amount, -int(floor(log10(abs(amount)))) + sfs - 1)
 
 
 @overload

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1144,9 +1144,9 @@ def trailing_zeros_to_powerof10(amount):
     >>> trailing_zeros_to_powerof10(23000)
     '23000'
     >>> trailing_zeros_to_powerof10(2300000)
-    '23 10^5'
+    '23\u22C510^5'
     >>> trailing_zeros_to_powerof10(23000000)
-    '23 10^6'
+    '23\u22C510^6'
     >>> trailing_zeros_to_powerof10(1)
     '1'
     >>> trailing_zeros_to_powerof10(0)
@@ -1162,10 +1162,10 @@ def trailing_zeros_to_powerof10(amount):
     while i >= 0 and amount[i] == "0":
         zeros += 1
         i -= 1
-    if len(amount) < len(f"{amount[:i+1]} 10^{zeros}"):
+    if len(amount) < len(f"{amount[: i+1]}\u22C510^{zeros}"):
         return amount
     else:
-        return f"{amount[:i+1]} 10^{zeros}"
+        return f"{amount[: i+1]}\u22C510^{zeros}"
 
 
 def roundify(amount, sfs=2):


### PR DESCRIPTION
- Show estimated line number as a power of 10: showing all these zeros for an estimated number seems like a waste of space
- Show number of columns for tabular

Cherry picked from https://github.com/galaxyproject/galaxy/pull/13918

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
