### PR TITLE
Update k8s docker python to 3.12

### DIFF
--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -18,7 +18,7 @@
 ARG ROOT_DIR=/galaxy
 ARG SERVER_DIR=$ROOT_DIR/server
 
-ARG STAGE1_BASE=python:3.10-slim
+ARG STAGE1_BASE=python:3.12-slim
 ARG FINAL_STAGE_BASE=$STAGE1_BASE
 ARG GALAXY_USER=galaxy
 ARG GALAXY_PLAYBOOK_REPO=https://github.com/galaxyproject/galaxy-docker-k8s


### PR DESCRIPTION
@nsoranzo This doesn't build because it looks like the psycopg2-binary wheel is missing for 3.12?
```
Installing build dependencies: started\n  Installing build dependencies: finished with status 'done'\n  Getting requirements to build wheel: started\n  Getting requirements to build wheel: finished with status 'error'\n\n:stderr:   Running command git clone --filter=blob:none --quiet https://github.com/nsoranzo/python-future.git /tmp/pip-install-8k3z0kzu/future_f95765cba8c1450fa7da17fad7fa99af\n  Running command git rev-parse -q --verify 'sha^9ef05b386ce45dd40d2dab5915aec3ed78d81ed9'\n  Running command git fetch -q https://github.com/nsoranzo/python-future.git 9ef05b386ce45dd40d2dab5915aec3ed78d81ed9\n  Running command git checkout -q 9ef05b386ce45dd40d2dab5915aec3ed78d81ed9\n  error: subprocess-exited-with-error\n  \n  × Getting requirements to build wheel did not run successfully.\n  │ exit code: 1\n  ╰─> [21 lines of output]\n      running egg_info\n      writing psycopg2_binary.egg-info/PKG-INFO\n      writing dependency_links to psycopg2_binary.egg-info/dependency_links.txt\n      writing top-level names to psycopg2_binary.egg-info/top_level.txt\n      \n      Error: pg_config executable not found.\n      \n      pg_config is required to build psycopg2 from source.  Please add the directory\n      containing pg_config to the $PATH or specify the full executable path with the\n      option:\n      \n          python setup.py build_ext --pg-config /path/to/pg_config build ...\n      \n      or with the pg_config option in 'setup.cfg'.\n      \n      If you prefer to avoid building psycopg2 from source, please install the PyPI\n      'psycopg2-binary' package instead.\n      \n      For further information please check the 'doc/src/install.rst' file (also at\n      <https://www.psycopg.org/docs/install.html>).\n      \n      [end of output]\n  \n  note: This error originates from a subprocess, and is likely not a problem with pip.\nerror: subprocess-exited-with-error\n\n× Getting requirements to build wheel did not run successfully.\n│ exit code: 1\n╰─> See above for output.\n\nnote: This error originates from a subprocess, and is likely not a problem with pip.\n"}
```
## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
