### PR TITLE
[23.2] Modify histories for non-published packages

### DIFF
--- a/packages/schema/HISTORY.rst
+++ b/packages/schema/HISTORY.rst
@@ -6,5 +6,3 @@ History
 ---------
 23.2.dev0
 ---------
-
-* First release.

--- a/packages/tool_shed/HISTORY.rst
+++ b/packages/tool_shed/HISTORY.rst
@@ -6,5 +6,3 @@ History
 ---------
 23.2.dev0
 ---------
-
-* First release.


### PR DESCRIPTION
The schema and tool_shed packages have not been published yet, which is why their history logs do not contain a date. The `galaxy-release-util` rightfully complains:
`
Exception: Error in '/home/sergey/0dev/galaxy/_galaxy/dev/packages/schema/HISTORY.rst'. Changelog entry for version '23.2.dev0' has no date but contains changes. You have to fix this manually.
`

I think the right way to handle this is to:
1) Keep it blank until its published and let the release script do its thing
2) Modify the release script to handle new/unpublished packages by *not* collecting all the commits since last version, but simply adding "First release" instead. So, for example, the history log for the schema package, instead of 
`no recorded changes since last release` would be just `First release.`

Does this make sense? If so, I'll modify `galaxy-release-util` accordingly.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
