### PR TITLE
Allow etree.XMLParser to resolve external entities

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -379,7 +379,7 @@ def parse_xml(
     if remove_comments and LXML_AVAILABLE:
         # If using stdlib etree comments are always removed,
         # but lxml doesn't do this by default
-        parser = etree.XMLParser(remove_comments=remove_comments)
+        parser = etree.XMLParser(remove_comments=remove_comments, resolve_entities=True)
 
     if LXML_AVAILABLE and schemafname:
         with open(str(schemafname), "rb") as schema_file:

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -392,14 +392,8 @@ def parse_xml(
     parser = None
     schema = None
     if LXML_AVAILABLE:
+        parser = etree.XMLParser(resolve_entities=True, remove_comments=remove_comments)
         base_dir = Path(str(fname)).resolve().parent
-        if remove_comments:
-            # If using stdlib etree comments are always removed,
-            # but lxml doesn't do this by default
-            parser = etree.XMLParser(remove_comments=True, resolve_entities=True)
-        else:
-            parser = etree.XMLParser(resolve_entities=True)
-
         parser.resolvers.add(LocalOnlyResolver(base_dir))
         if schemafname:
             with open(str(schemafname), "rb") as schema_file:

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -120,6 +120,21 @@ try:
     def XML(text: Union[str, bytes]) -> Element:
         return cast(Element, etree.XML(text))
 
+    class LocalOnlyResolver(etree.Resolver):
+        def __init__(self, base_dir: Path):
+            super().__init__()
+            self.base_dir = base_dir.resolve()
+
+        def resolve(self, system_url, public_id, context):
+            requested_path = Path(system_url).resolve()
+
+            try:
+                requested_path.relative_to(self.base_dir)
+            except ValueError:
+                raise OSError(f"Blocked external entity: {requested_path} is outside {self.base_dir}")
+
+            return self.resolve_filename(str(requested_path), context)
+
 except ImportError:
     LXML_AVAILABLE = False
     import xml.etree.ElementTree as etree  # type: ignore[no-redef]
@@ -376,15 +391,20 @@ def parse_xml(
     """Returns a parsed xml tree"""
     parser = None
     schema = None
-    if remove_comments and LXML_AVAILABLE:
-        # If using stdlib etree comments are always removed,
-        # but lxml doesn't do this by default
-        parser = etree.XMLParser(remove_comments=remove_comments, resolve_entities=True)
+    if LXML_AVAILABLE:
+        base_dir = Path(str(fname)).resolve().parent
+        if remove_comments:
+            # If using stdlib etree comments are always removed,
+            # but lxml doesn't do this by default
+            parser = etree.XMLParser(remove_comments=True, resolve_entities=True)
+        else:
+            parser = etree.XMLParser(resolve_entities=True)
 
-    if LXML_AVAILABLE and schemafname:
-        with open(str(schemafname), "rb") as schema_file:
-            schema_root = etree.XML(schema_file.read())
-            schema = etree.XMLSchema(schema_root)
+        parser.resolvers.add(LocalOnlyResolver(base_dir))
+        if schemafname:
+            with open(str(schemafname), "rb") as schema_file:
+                schema_root = etree.XML(schema_file.read())
+                schema = etree.XMLSchema(schema_root)
 
     source = Path(fname) if isinstance(fname, (str, os.PathLike)) else fname
     try:

--- a/test/unit/util/test_xml_parse.py
+++ b/test/unit/util/test_xml_parse.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import pytest
+
+from galaxy.util import (
+    LXML_AVAILABLE,
+    parse_xml,
+)
+
+if not LXML_AVAILABLE:
+    pytest.skip("LXML is not available", allow_module_level=True)
+
+
+@pytest.fixture
+def local_entity_file(tmp_path: Path):
+    entity = tmp_path / "entity.txt"
+    entity.write_text("Hello from entity!")
+    return entity
+
+
+@pytest.fixture
+def external_entity_file(tmp_path: Path):
+    # Put it outside tmp_path to trigger the block
+    outside_file = tmp_path.parent / "external.txt"
+    outside_file.write_text("Should be blocked")
+    yield outside_file
+    outside_file.unlink(missing_ok=True)
+
+
+def test_parse_xml_allows_local_entity(tmp_path: Path, local_entity_file: Path):
+    xml = f"""<?xml version="1.0"?>
+    <!DOCTYPE root [
+        <!ENTITY local SYSTEM "{local_entity_file.name}">
+    ]>
+    <root>&local;</root>
+    """
+    doc_path = tmp_path / "doc.xml"
+    doc_path.write_text(xml)
+
+    tree = parse_xml(doc_path)
+    root_text = tree.getroot().text
+    assert root_text
+    assert root_text.strip() == "Hello from entity!"
+
+
+def test_parse_xml_blocks_external_entity(tmp_path: Path, external_entity_file: Path):
+    xml = f"""<?xml version="1.0"?>
+    <!DOCTYPE root [
+        <!ENTITY ext SYSTEM "{external_entity_file.resolve()}">
+    ]>
+    <root>&ext;</root>
+    """
+    doc_path = tmp_path / "doc.xml"
+    doc_path.write_text(xml)
+
+    with pytest.raises(OSError, match="Blocked external entity"):
+        parse_xml(doc_path)


### PR DESCRIPTION
We use XML external (file) entities to include .rst files for the help section in tool XMLs. U ntil recently this wasn't a problem, but the default in lxml was recently changed and there is no way in planemo linting or testing to set this flag for the XMLParser. 

This change mainly makes `parse_xml()` use the old default by setting `resolve_entities=True` for `etree.XMLParser`

Without this change planemo 75.20 on  Galaxy 22.05 fails with the following error message. The same error message also appears when running planemo serve (at the very beginining) but does not make it fail. Tools load fine and work normally.

```
galaxy.util ERROR: Error parsing file <REDACTED>/xml/defaults.xml
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/galaxy/util/__init__.py", line 305, in parse_xml
    tree = etree.parse(str(fname), parser=parser)
  File "src/lxml/etree.pyx", line 3547, in lxml.etree.parse
  File "src/lxml/parser.pxi", line 1952, in lxml.etree._parseDocument
  File "src/lxml/parser.pxi", line 1978, in lxml.etree._parseDocumentFromURL
  File "src/lxml/parser.pxi", line 1881, in lxml.etree._parseDocFromFile
  File "src/lxml/parser.pxi", line 1200, in lxml.etree._BaseParser._parseDocFromFile
  File "src/lxml/parser.pxi", line 633, in lxml.etree._ParserContext._handleParseResultDoc
  File "src/lxml/parser.pxi", line 743, in lxml.etree._handleParseResult
  File "src/lxml/parser.pxi", line 672, in lxml.etree._raiseParseError
  File "<REDACTED>/xml/defaults.xml", line 38
lxml.etree.XMLSyntaxError: Entity 'help_text' not defined, line 38, column 18
Error loading tool with path <REDACTED>.xml
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/galaxy/tool_util/loader_directory.py", line 103, in _load_tools_from_path
    tool_element = loader_func(possible_tool_file)
  File "<REDACTED>/xml/defaults.xml", line 38
lxml.etree.XMLSyntaxError: Entity 'help_text' not defined, line 38, column 18
```



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
 
The tools use a doctype declaration and XML macro to include .rst files as help section:

xml/defaults.xml:
```
<?xml version="1.0" encoding="UTF-8"?>

<!DOCTYPE documentation [
  <!ENTITY help_text SYSTEM "../README.rst">
  <!ENTITY changes_text SYSTEM "../CHANGES.rst">
]>

<macros>
  <xml name="help"> 
    <help>
      &help_text;
      &changes_text;
    </help>
  </xml>
</macros>
```

tool.xml:
```
...

  <macros>
    <import>xml/defaults.xml</import>
  </macros>

  <expand macro="help"/>

...

```

Running planemo lint or test on this causes the above error.


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
