### PR TITLE
Fixing data_source tools and incrementing tool profile

### DIFF
--- a/lib/galaxy/tool_util/linters/_util.py
+++ b/lib/galaxy/tool_util/linters/_util.py
@@ -3,7 +3,7 @@ import re
 
 def is_datasource(tool_xml):
     """Returns true if the tool is a datasource tool"""
-    return tool_xml.getroot().attrib.get("tool_type", "") == "data_source"
+    return tool_xml.getroot().attrib.get("tool_type", "") in ["data_source", "data_source_async"]
 
 
 def is_valid_cheetah_placeholder(name):

--- a/lib/galaxy/tool_util/linters/xml_order.py
+++ b/lib/galaxy/tool_util/linters/xml_order.py
@@ -42,6 +42,7 @@ TAG_ORDER = [
 DATASOURCE_TAG_ORDER = [
     "description",
     "macros",
+    "requirements",
     "command",
     "configfiles",
     "inputs",
@@ -62,7 +63,7 @@ class XMLOrder(Linter):
             return
         tool_root = tool_xml.getroot()
 
-        if tool_root.attrib.get("tool_type", "") == "data_source":
+        if tool_root.attrib.get("tool_type", "") in ["data_source", "data_source_async"]:
             tag_ordering = DATASOURCE_TAG_ORDER
         else:
             tag_ordering = TAG_ORDER

--- a/lib/galaxy/tool_util/linters/xml_order.py
+++ b/lib/galaxy/tool_util/linters/xml_order.py
@@ -4,15 +4,17 @@ For more information on the IUC standard for XML block order see -
 https://github.com/galaxy-iuc/standards.
 """
 
-from typing import TYPE_CHECKING
+from typing import (
+    Optional,
+    TYPE_CHECKING,
+)
 
 from galaxy.tool_util.lint import Linter
+from ._util import is_datasource
 
 if TYPE_CHECKING:
     from galaxy.tool_util.lint import LintContext
     from galaxy.tool_util.parser.interface import ToolSource
-
-from typing import Optional
 
 # https://github.com/galaxy-iuc/standards
 # https://github.com/galaxy-iuc/standards/pull/7/files
@@ -63,7 +65,7 @@ class XMLOrder(Linter):
             return
         tool_root = tool_xml.getroot()
 
-        if tool_root.attrib.get("tool_type", "") in ["data_source", "data_source_async"]:
+        if is_datasource(tool_xml):
             tag_ordering = DATASOURCE_TAG_ORDER
         else:
             tag_ordering = TAG_ORDER

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -6688,6 +6688,7 @@ Examples are included in the test tools directory including:
       <xs:enumeration value="dbkey" />
       <xs:enumeration value="organism" />
       <xs:enumeration value="table" />
+      <xs:enumeration value="position" />
       <xs:enumeration value="description" />
       <xs:enumeration value="name" />
       <xs:enumeration value="info" />

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -68,6 +68,7 @@ List of behavior changes associated with profile versions:
 ### 24.0
 
 - Do not use Galaxy python environment for `data_source_async` tools.
+- Drop request parameters received by data source tools that are not declared in `<request_param_translation>` section.
 
 ### Examples
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2904,6 +2904,8 @@ class DataSourceTool(OutputParameterJSONTool):
         super().parse_inputs(tool_source)
         # Open all data_source tools in _top.
         self.target = "_top"
+        # data_source tools cannot check param values
+        self.check_values = False
         if "GALAXY_URL" not in self.inputs:
             self.inputs["GALAXY_URL"] = self._build_GALAXY_URL_parameter()
             self.inputs_by_page[0]["GALAXY_URL"] = self.inputs["GALAXY_URL"]

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2895,6 +2895,13 @@ class DataSourceTool(OutputParameterJSONTool):
     tool_type = "data_source"
     default_tool_action = DataSourceToolAction
 
+    @property
+    def wants_params_cleaned(self):
+        """Indicates whether received, but undeclared request params should be cleaned."""
+        if self.profile < 24.0:
+            return False
+        return True
+
     def _build_GALAXY_URL_parameter(self):
         return ToolParameter.build(
             self, XML(f'<param name="GALAXY_URL" type="baseurl" value="/tool_runner?tool_id={self.id}" />')

--- a/lib/galaxy/tools/parameters/input_translation.py
+++ b/lib/galaxy/tools/parameters/input_translation.py
@@ -62,6 +62,8 @@ class ToolInputTranslator:
             value_trans = {}
             append_param = None
 
+            rval.vocabulary.add(remote_name)
+
             value_trans_elem = req_param.find("value_translation")
             if value_trans_elem is not None:
                 for value_elem in value_trans_elem.findall("value"):
@@ -81,6 +83,7 @@ class ToolInputTranslator:
                     value_missing = value_elem.get("missing")
                     if None not in [value_name, value_missing]:
                         append_dict[value_name] = value_missing
+                        rval.vocabulary.add(value_name)
                 append_param = Bunch(
                     separator=separator, first_separator=first_separator, join_str=join_str, append_dict=append_dict
                 )
@@ -93,6 +96,7 @@ class ToolInputTranslator:
 
     def __init__(self):
         self.param_trans_dict = {}
+        self.vocabulary = set()
 
     def translate(self, params):
         """

--- a/lib/galaxy/webapps/galaxy/controllers/async.py
+++ b/lib/galaxy/webapps/galaxy/controllers/async.py
@@ -86,7 +86,7 @@ class ASync(BaseUIController):
                     translator.galaxy_name for translator in tool.input_translator.param_trans_dict.values()
                 }
                 for param in params:
-                    if param in tool_declared_params:
+                    if param in tool_declared_params or not tool.wants_params_cleaned:
                         params_dict[param] = params.get(param, None)
             params = params_dict
 

--- a/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
@@ -78,20 +78,30 @@ class ToolRunner(BaseUIController):
         # execute tool without displaying form
         # (used for datasource tools, but note that data_source_async tools
         # are handled separately by the async controller)
-        params = galaxy.util.Params(kwd, sanitize=False)
-        if tool.tool_type == "data_source":
-            # preserve original params sent by the remote server as extra dict
-            params.update({"incoming_request_params": params.__dict__.copy()})
-        # do param translation here, used by datasource tools
+        params = galaxy.util.Params(kwd, sanitize=False).__dict__
         if tool.input_translator:
-            tool.input_translator.translate(params)
-        if "runtool_btn" not in params.__dict__ and "URL" not in params.__dict__:
-            error("Tool execution through the `tool_runner` requires a `runtool_btn` flag or `URL` parameter.")
+            # perform test translation of the incoming params without affecting originals
+            # the actual translation will happen later
+            # this is only for checking if we end up with required parameters
+            test_params = params.copy()
+            tool.input_translator.translate(test_params)
+        else:
+            test_params = params
+        if tool.tool_type == "data_source":
+            if "URL" not in test_params:
+                error("Execution of `data_source` tools requires a `URL` parameter")
+            # preserve original params sent by the remote server as extra dict
+            # before in-place translation happens
+            params.update({"incoming_request_params": params.copy()})
+        else:
+            if "runtool_btn" not in test_params:
+                error("Tool execution through the `tool_runner` requires a `runtool_btn` flag")
+
         # We may be visiting Galaxy for the first time ( e.g., sending data from UCSC ),
         # so make sure to create a new history if we've never had one before.
         history = tool.get_default_history_by_trans(trans, create=True)
         try:
-            vars = tool.handle_input(trans, params.__dict__, history=history)
+            vars = tool.handle_input(trans, params, history=history)
         except Exception as e:
             error(galaxy.util.unicodify(e))
         if len(params) > 0:

--- a/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
@@ -91,8 +91,14 @@ class ToolRunner(BaseUIController):
             if "URL" not in test_params:
                 error("Execution of `data_source` tools requires a `URL` parameter")
             # preserve original params sent by the remote server as extra dict
-            # before in-place translation happens
+            # before in-place translation happens, then clean the incoming params
             params.update({"incoming_request_params": params.copy()})
+            if tool.input_translator:
+                for k in list(params.keys()):
+                    if k not in tool.input_translator.vocabulary and k not in ("URL", "incoming_request_params"):
+                        # the remote server has sent a param
+                        # that the tool is not expecting -> drop it
+                        del params[k]
         else:
             if "runtool_btn" not in test_params:
                 error("Tool execution through the `tool_runner` requires a `runtool_btn` flag")

--- a/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
@@ -93,7 +93,7 @@ class ToolRunner(BaseUIController):
             # preserve original params sent by the remote server as extra dict
             # before in-place translation happens, then clean the incoming params
             params.update({"incoming_request_params": params.copy()})
-            if tool.input_translator:
+            if tool.input_translator and tool.wants_params_cleaned:
                 for k in list(params.keys()):
                     if k not in tool.input_translator.vocabulary and k not in ("URL", "incoming_request_params"):
                         # the remote server has sent a param

--- a/tools/data_source/ucsc_tablebrowser.xml
+++ b/tools/data_source/ucsc_tablebrowser.xml
@@ -27,6 +27,7 @@ python '$__tool_directory__/data_source.py' '$output' $__app__.config.output_siz
         <request_param galaxy_name="organism" remote_name="org" missing="unknown species" />
         <request_param galaxy_name="table" remote_name="hgta_table" missing="unknown table" />
         <request_param galaxy_name="description" remote_name="hgta_regionType" missing="no description" />
+        <request_param galaxy_name="position" remote_name="position" missing="unknown position" />
         <request_param galaxy_name="data_type" remote_name="hgta_outputType" missing="auto" >
             <value_translation>
                 <value galaxy_value="auto" remote_value="primaryTable" />
@@ -41,7 +42,7 @@ python '$__tool_directory__/data_source.py' '$output' $__app__.config.output_siz
     </request_param_translation>
     <uihints minwidth="800"/>
     <outputs>
-        <data name="output" format="tabular" label="${tool.name} on ${organism}: ${table} (#if $description == 'range' then $getVar( 'position', 'unknown position' ) else $description#)"/>
+        <data name="output" format="tabular" label="${tool.name} on ${organism}: ${table} (#if $description == 'range' then $position else $description#)"/>
     </outputs>
     <options sanitize="False" refresh="True"/>
     <citations>

--- a/tools/data_source/ucsc_tablebrowser_archaea.xml
+++ b/tools/data_source/ucsc_tablebrowser_archaea.xml
@@ -27,6 +27,7 @@ python '$__tool_directory__/data_source.py' '$output' $__app__.config.output_siz
         <request_param galaxy_name="organism" remote_name="org" missing="unknown species" />
         <request_param galaxy_name="table" remote_name="hgta_table" missing="unknown table" />
         <request_param galaxy_name="description" remote_name="hgta_regionType" missing="no description" />
+        <request_param galaxy_name="position" remote_name="position" missing="unknown position" />
         <request_param galaxy_name="data_type" remote_name="hgta_outputType" missing="auto" >
             <value_translation>
                 <value galaxy_value="auto" remote_value="primaryTable" />
@@ -41,7 +42,7 @@ python '$__tool_directory__/data_source.py' '$output' $__app__.config.output_siz
     </request_param_translation>
     <uihints minwidth="800"/>
     <outputs>
-        <data name="output" format="tabular" label="${tool.name} on ${organism}: ${table} (#if $description == 'range' then $getVar( 'position', 'unknown position' ) else $description#)"/>
+        <data name="output" format="tabular" label="${tool.name} on ${organism}: ${table} (#if $description == 'range' then $position else $description#)"/>
     </outputs>
     <options sanitize="False" refresh="True"/>
     <citations>

--- a/tools/data_source/ucsc_tablebrowser_test.xml
+++ b/tools/data_source/ucsc_tablebrowser_test.xml
@@ -27,6 +27,7 @@ python '$__tool_directory__/data_source.py' '$output' $__app__.config.output_siz
         <request_param galaxy_name="organism" remote_name="org" missing="unknown species" />
         <request_param galaxy_name="table" remote_name="hgta_table" missing="unknown table" />
         <request_param galaxy_name="description" remote_name="hgta_regionType" missing="no description" />
+        <request_param galaxy_name="position" remote_name="position" missing="unknown position" />
         <request_param galaxy_name="data_type" remote_name="hgta_outputType" missing="auto" >
             <value_translation>
                 <value galaxy_value="auto" remote_value="primaryTable" />
@@ -41,7 +42,7 @@ python '$__tool_directory__/data_source.py' '$output' $__app__.config.output_siz
     </request_param_translation>
     <uihints minwidth="800"/>
     <outputs>
-        <data name="output" format="tabular" label="${tool.name} on ${organism}: ${table} (#if $description == 'range' then $getVar( 'position', 'unknown position' ) else $description#)"/>
+        <data name="output" format="tabular" label="${tool.name} on ${organism}: ${table} (#if $description == 'range' then $position else $description#)"/>
     </outputs>
     <options sanitize="False" refresh="True"/>
     <citations>


### PR DESCRIPTION
Still discovering a few quirks with data_source and data_source_async tools after #17422 

- [x] currently, these tools have to set `check_values="false"` in their `<inputs>` tag.
  Forgetting to do this leads to hard to debug problems, because the default is `"true"`, while this can never make sense for any data_source tool. The proposed solution is to overwrite the setting for the tool class.
- [x] currently, translation of input params is requested in several places in the code base, i.e., at the controllers level here:
  https://github.com/galaxyproject/galaxy/blob/2a9c8d05fbd18053d48026fbce280682a5fd0128/lib/galaxy/webapps/galaxy/controllers/tool_runner.py#L86-L87 and here:
  https://github.com/galaxyproject/galaxy/blob/2a9c8d05fbd18053d48026fbce280682a5fd0128/lib/galaxy/webapps/galaxy/controllers/async.py#L83-L84
  and at the tool level, here:
  https://github.com/galaxyproject/galaxy/blob/2a9c8d05fbd18053d48026fbce280682a5fd0128/lib/galaxy/tools/__init__.py#L1834-L1835 and here:
  https://github.com/galaxyproject/galaxy/blob/2a9c8d05fbd18053d48026fbce280682a5fd0128/lib/galaxy/tools/__init__.py#L2502-L2503

  The controller-level translations are required, but repeated translations at the tool level can break data_source tools.
  In particular, [URL append operations](https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-request-param-translation-request-param-append-param) are broken because the same params get added to the URL twice.
  That's why I'd like to disable the tool-level translations, but I'm worried that this could have side-effects, and really would like feedback first. We could play it safe and disable extra translations only for data_source tools with sth like:
  `if self.input_translator and not isinstance(self, DataSourceTool):` just in case input translation has some exotic undocumented use outside data_source tools?

~~- [ ] I need help with an additional bug with this [usage pattern](https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-request-param-translation-request-param-append-param-value) where an ampersand is used to join GET request parameters. Unfortunately, that char gets sanitized by Galaxy (to an X by default), but I fail to understand where that happens~~

@mvdbeek maybe you can help me with the open points? :pray: 

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. run considerable subset (or all) data source tools on Main



## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
