### PR TITLE
Stringify cgroups metrics formatted value return

### DIFF
--- a/lib/galaxy/job_metrics/__init__.py
+++ b/lib/galaxy/job_metrics/__init__.py
@@ -107,7 +107,7 @@ class JobMetrics:
                 safety = DEFAULT_SAFETY
             return DictifiableMetric(
                 title,
-                value,
+                str(value),
                 str(metric_value),
                 metric_name,
                 metric_plugin,

--- a/lib/galaxy/job_metrics/__init__.py
+++ b/lib/galaxy/job_metrics/__init__.py
@@ -107,7 +107,7 @@ class JobMetrics:
                 safety = DEFAULT_SAFETY
             return DictifiableMetric(
                 title,
-                str(value),
+                value,
                 str(metric_value),
                 metric_name,
                 metric_plugin,

--- a/lib/galaxy/job_metrics/instrumenters/cgroup.py
+++ b/lib/galaxy/job_metrics/instrumenters/cgroup.py
@@ -114,18 +114,18 @@ Metric = namedtuple("Metric", ("key", "subkey", "value"))
 
 
 class CgroupPluginFormatter(formatting.JobMetricFormatter):
-    def format(self, key, value):
+    def format(self, key: str, value: Any) -> formatting.FormattedMetric:
         title = TITLES.get(key, key)
         if key in CONVERSION:
-            return title, CONVERSION[key](value)
+            return formatting.FormattedMetric(title, CONVERSION[key](value))
         elif key.endswith("_bytes"):
             try:
-                return title, nice_size(value)
+                return formatting.FormattedMetric(title, nice_size(value))
             except ValueError:
                 pass
         elif isinstance(value, (decimal.Decimal, numbers.Integral, numbers.Real)) and value == int(value):
             value = int(value)
-        return title, value
+        return formatting.FormattedMetric(title, str(value))
 
 
 class CgroupPlugin(InstrumentPlugin):

--- a/lib/galaxy/job_metrics/instrumenters/hostname.py
+++ b/lib/galaxy/job_metrics/instrumenters/hostname.py
@@ -4,21 +4,14 @@ import logging
 from typing import Any
 
 from . import InstrumentPlugin
-from .. import formatting
 
 log = logging.getLogger(__name__)
-
-
-class HostnameFormatter(formatting.JobMetricFormatter):
-    def format(self, key: str, value: Any):
-        return formatting.FormattedMetric(key, value)
 
 
 class HostnamePlugin(InstrumentPlugin):
     """Gather hostname"""
 
     plugin_type = "hostname"
-    formatter = HostnameFormatter()
 
     def __init__(self, **kwargs):
         pass

--- a/lib/galaxy/job_metrics/instrumenters/hostname.py
+++ b/lib/galaxy/job_metrics/instrumenters/hostname.py
@@ -1,6 +1,7 @@
 """The module describes the ``hostname`` job metrics plugin."""
 
 import logging
+from typing import Any
 
 from . import InstrumentPlugin
 from .. import formatting
@@ -9,8 +10,8 @@ log = logging.getLogger(__name__)
 
 
 class HostnameFormatter(formatting.JobMetricFormatter):
-    def format(self, key, value):
-        return key, value
+    def format(self, key: str, value: Any):
+        return formatting.FormattedMetric(key, value)
 
 
 class HostnamePlugin(InstrumentPlugin):

--- a/lib/galaxy/job_metrics/instrumenters/hostname.py
+++ b/lib/galaxy/job_metrics/instrumenters/hostname.py
@@ -1,7 +1,6 @@
 """The module describes the ``hostname`` job metrics plugin."""
 
 import logging
-from typing import Any
 
 from . import InstrumentPlugin
 

--- a/lib/galaxy/job_metrics/instrumenters/meminfo.py
+++ b/lib/galaxy/job_metrics/instrumenters/meminfo.py
@@ -15,7 +15,7 @@ MEMINFO_TITLES = {"memtotal": "Total System Memory", "swaptotal": "Total System 
 
 
 class MemInfoFormatter(formatting.JobMetricFormatter):
-    def format(self, key: str, value: Any):
+    def format(self, key: str, value: Any) -> formatting.FormattedMetric:
         title = MEMINFO_TITLES.get(key, key)
         return formatting.FormattedMetric(title, util.nice_size(value * 1000))  # kB = *1000, KB = *1024 - wikipedia
 

--- a/lib/galaxy/job_metrics/instrumenters/meminfo.py
+++ b/lib/galaxy/job_metrics/instrumenters/meminfo.py
@@ -1,6 +1,7 @@
 """The module describes the ``meminfo`` job metrics plugin."""
 
 import re
+from typing import Any
 
 from galaxy import util
 from . import InstrumentPlugin
@@ -14,9 +15,9 @@ MEMINFO_TITLES = {"memtotal": "Total System Memory", "swaptotal": "Total System 
 
 
 class MemInfoFormatter(formatting.JobMetricFormatter):
-    def format(self, key, value):
+    def format(self, key: str, value: Any):
         title = MEMINFO_TITLES.get(key, key)
-        return title, util.nice_size(value * 1000)  # kB = *1000, KB = *1024 - wikipedia
+        return formatting.FormattedMetric(title, util.nice_size(value * 1000))  # kB = *1000, KB = *1024 - wikipedia
 
 
 class MemInfoPlugin(InstrumentPlugin):


### PR DESCRIPTION
FormattedMetric should always be str, str.  This fixes the formatter and adds typing.  Fixes the following error when using cgroups metrics and displaying dataset details:  (error visible on test.galaxyproject.org right now -- just go to view a dataset info page and see the 500s)

```
Feb 20 10:53:35 galaxy07 galaxyctl[19673]: File "/cvmfs/test.galaxyproject.org/venv/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 851, in run
Feb 20 10:53:35 galaxy07 galaxyctl[19673]: result = context.run(func, *args)
Feb 20 10:53:35 galaxy07 galaxyctl[19673]: ^^^^^^^^^^^^^^^^^^^^^^^^
Feb 20 10:53:35 galaxy07 galaxyctl[19673]: File "/cvmfs/test.galaxyproject.org/venv/lib/python3.11/site-packages/sentry_sdk/integrations/fastapi.py", line 85, in _sentry_call
Feb 20 10:53:35 galaxy07 galaxyctl[19673]: return old_call(*args, **kwargs)
Feb 20 10:53:35 galaxy07 galaxyctl[19673]: ^^^^^^^^^^^^^^^^^^^^^^^^^
Feb 20 10:53:35 galaxy07 galaxyctl[19673]: File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/webapps/galaxy/api/jobs.py", line 513, in show
Feb 20 10:53:35 galaxy07 galaxyctl[19673]: return ShowFullJobResponse(**self.service.show(trans, job_id, bool(full)))
Feb 20 10:53:35 galaxy07 galaxyctl[19673]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Feb 20 10:53:35 galaxy07 galaxyctl[19673]: File "/cvmfs/test.galaxyproject.org/venv/lib/python3.11/site-packages/pydantic/main.py", line 164, in __init__
Feb 20 10:53:35 galaxy07 galaxyctl[19673]: __pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)
Feb 20 10:53:35 galaxy07 galaxyctl[19673]: pydantic_core._pydantic_core.ValidationError: 1 validation error for ShowFullJobResponse
Feb 20 10:53:35 galaxy07 galaxyctl[19673]: job_metrics.10.value
Feb 20 10:53:35 galaxy07 galaxyctl[19673]: Input should be a valid string [type=string_type, input_value=0, input_type=int]
Feb 20 10:53:35 galaxy07 galaxyctl[19673]: For further information visit https://errors.pydantic.dev/2.5/v/string_type
```

To test manually, enable metrics locally and look at the dataset info page of a job.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
