### PR TITLE
[WIP] Customisable login structure(s)

### DIFF
--- a/client/src/components/Login/InternalLogin.vue
+++ b/client/src/components/Login/InternalLogin.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { BButton, BForm, BFormGroup, BFormInput, BFormText } from "bootstrap-vue";
+import { computed, type PropType, ref } from "vue";
+import { useRouter } from "vue-router/composables";
+
+import localize from "@/utils/localization";
+
+const router = useRouter();
+
+// TODO: investigate why `PropType` is needed
+interface Props {
+    showAsBox?: boolean;
+    passwordState: PropType<boolean> | null;
+    connectExternalProvider: PropType<string> | null;
+    connectExternalEmail: PropType<string> | null;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    showAsBox: false,
+    passwordState: null,
+});
+
+const emit = defineEmits<{
+    (e: "submit-login", login: string | null, password: string | null): void;
+    (e: "reset-login", login: string | null): void;
+}>();
+
+const labelNameAddress = localize("Public Name or Email Address");
+const labelPassword = localize("Password");
+
+const login = ref<string | null>(null);
+const password = ref<string | null>(null);
+const resetText = computed(() =>
+    props.showAsBox ? localize("Forgot password?") : localize("Click here to reset your password.")
+);
+
+function resetClick() {
+    if (!props.showAsBox) {
+        emit("reset-login", login.value);
+    } else {
+        router.push("/login/start");
+    }
+}
+</script>
+
+<template>
+    <BForm
+        id="login"
+        :inline="props.showAsBox"
+        :class="{ 'd-flex align-items-baseline': props.showAsBox }"
+        @submit.prevent="emit('submit-login', login, password)">
+        <label v-if="!props.showAsBox" for="login-form-name">
+            {{ labelNameAddress }}
+        </label>
+        <BFormInput
+            v-if="props.showAsBox || !props.connectExternalProvider"
+            id="login-form-name"
+            v-model="login"
+            name="login"
+            :size="props.showAsBox ? 'sm' : undefined"
+            :placeholder="props.showAsBox ? labelNameAddress : undefined"
+            required
+            type="text" />
+        <BFormInput
+            v-else
+            id="login-form-name"
+            disabled
+            required
+            :value="props.connectExternalEmail"
+            name="login"
+            type="text" />
+        <!-- </BFormGroup> -->
+        <BFormGroup :class="!props.showAsBox ? 'mt-2' : 'mr-2'">
+            <label v-if="!props.showAsBox" for="login-form-password">
+                {{ labelPassword }}
+            </label>
+            <BFormInput
+                id="login-form-password"
+                v-model="password"
+                :state="props.passwordState"
+                required
+                :size="props.showAsBox ? 'sm' : undefined"
+                :placeholder="props.showAsBox ? labelPassword : undefined"
+                name="password"
+                type="password" />
+            <BFormText>
+                <span v-if="!props.showAsBox" v-localize>Forgot password?</span>
+                <a
+                    v-b-tooltip.noninteractive.hover
+                    :title="props.showAsBox ? 'Click here to reset your password' : undefined"
+                    href="javascript:void(0)"
+                    role="button"
+                    @click.prevent="resetClick">
+                    {{ resetText }}
+                </a>
+            </BFormText>
+        </BFormGroup>
+        <BButton v-localize name="login" type="submit" :size="props.showAsBox ? 'sm' : undefined">Login</BButton>
+    </BForm>
+</template>
+
+<style scoped>
+::-webkit-input-placeholder {
+    font-style: italic;
+}
+:-moz-placeholder {
+    font-style: italic;
+}
+::-moz-placeholder {
+    font-style: italic;
+}
+:-ms-input-placeholder {
+    font-style: italic;
+}
+</style>

--- a/client/src/components/Login/LoginForm.vue
+++ b/client/src/components/Login/LoginForm.vue
@@ -1,9 +1,163 @@
+<script setup lang="ts">
+import axios from "axios";
+import { capitalize } from "lodash";
+import { computed, ref } from "vue";
+
+import { useConfig } from "@/composables/config";
+import { Toast } from "@/composables/toast";
+import localize from "@/utils/localization";
+import { withPrefix } from "@/utils/redirect";
+
+import Heading from "../Common/Heading.vue";
+import InternalLogin from "./InternalLogin.vue";
+import NewUserConfirmation from "./NewUserConfirmation.vue";
+import ExternalLogin from "@/components/User/ExternalIdentities/ExternalLogin.vue";
+
+interface Props {
+    allowUserCreation: boolean;
+    enableOidc: boolean;
+    redirect: string;
+    registrationWarningMessage: string;
+    sessionCsrfToken: string;
+    showAsBox: boolean;
+    showWelcomeWithLogin: boolean;
+    termsUrl: string;
+    welcomeUrl: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    allowUserCreation: false,
+    enableOidc: false,
+    showAsBox: false,
+    showWelcomeWithLogin: false,
+});
+
+const emit = defineEmits<{
+    (e: "toggle-login"): void;
+}>();
+
+const urlParams = new URLSearchParams(window.location.search);
+
+const { config } = useConfig();
+
+const login = ref<string | null>(null);
+const password = ref<string | null>(null);
+const passwordState = ref<boolean | null>(null);
+const messageText = ref<string | null>(null);
+const messageVariant = ref<string | null>(null);
+const headerWelcome = ref<string>(
+    localize(props.showAsBox ? "Please log in to Galaxy" : "Welcome to Galaxy, please log in")
+);
+
+const confirmURL = ref<boolean>(urlParams.has("confirm") && urlParams.get("confirm") == "true");
+const connectExternalEmail = ref<string | null>(urlParams.get("connect_external_email"));
+const connectExternalProvider = ref<string | null>(urlParams.get("connect_external_provider"));
+const connectExternalLabel = ref<string | null>(urlParams.get("connect_external_label"));
+
+const boxSection = ref<number>(1);
+const boxSections = computed(() => {
+    const sections = ["galaxy"]; // TODO: what if localdb is disabled
+    if (config.value?.enable_oidc && config.value?.oidc) {
+        sections.push(...Object.keys(config.value.oidc));
+    }
+    return sections;
+});
+const totalSections = computed(() => boxSections.value.length);
+
+const welcomeUrlWithRoot = computed(() => {
+    return withPrefix(props.welcomeUrl);
+});
+
+function toggleLogin() {
+    emit("toggle-login");
+}
+
+function submitLogin(formLogin: string | null, formPassword: string | null) {
+    login.value = formLogin;
+    password.value = formPassword;
+    passwordState.value = null;
+    let redirect = props.redirect;
+    if (connectExternalEmail.value) {
+        login.value = connectExternalEmail.value;
+    }
+    if (localStorage.getItem("redirect_url")) {
+        redirect = localStorage.getItem("redirect_url")!;
+    }
+    const currentPath = window.location.pathname;
+    axios
+        .post(withPrefix("/user/login"), {
+            login: login.value,
+            password: password.value,
+            redirect: redirect,
+            session_csrf_token: props.sessionCsrfToken,
+        })
+        .then(({ data }) => {
+            let location;
+            if (data.message && data.status) {
+                alert(data.message);
+            }
+            if (data.expired_user) {
+                location = withPrefix(`/root/login?expired_user=${data.expired_user}`);
+            } else if (connectExternalProvider.value) {
+                location = withPrefix("/user/external_ids?connect_external=true");
+            } else if (data.redirect) {
+                location = encodeURI(data.redirect);
+            } else if (props.showAsBox) {
+                location = withPrefix(currentPath);
+            } else {
+                location = withPrefix("/");
+            }
+            window.location = location as string & Location;
+        })
+        .catch((error) => {
+            messageVariant.value = "danger";
+            const message = error.response && error.response.data && error.response.data.err_msg;
+            if (connectExternalProvider.value && message && message.toLowerCase().includes("invalid")) {
+                messageText.value =
+                    message + " Try logging in to the existing account through an external provider below.";
+            } else {
+                messageText.value = message || "Login failed for an unknown reason.";
+            }
+            if (messageText.value && props.showAsBox) {
+                Toast.error(messageText.value);
+            }
+            if (message === "Invalid password.") {
+                passwordState.value = false;
+            }
+        });
+}
+
+function setRedirect(url: string) {
+    localStorage.setItem("redirect_url", url);
+}
+
+function resetLogin(formLogin: string | null) {
+    login.value = formLogin;
+    axios
+        .post(withPrefix("/user/reset_password"), { email: login.value })
+        .then((response) => {
+            messageVariant.value = "info";
+            messageText.value = response.data.message;
+        })
+        .catch((error) => {
+            messageVariant.value = "danger";
+            const message = error.response.data && error.response.data.err_msg;
+            messageText.value = message || "Password reset failed for an unknown reason.";
+        });
+}
+
+function returnToLogin() {
+    window.location = withPrefix("/login/start") as string & Location;
+}
+</script>
+
 <template>
-    <div class="container">
-        <div class="row justify-content-md-center">
+    <div :class="{ container: !showAsBox }">
+        <div :class="!showAsBox ? 'row justify-content-md-center' : ''">
             <template v-if="!confirmURL">
-                <div class="col col-lg-6">
+                <div v-if="!showAsBox" class="col col-lg-6">
                     <b-alert :show="!!messageText" :variant="messageVariant">
+                        <!-- eslint-disable-next-line vue/no-v-html -->
                         <span v-html="messageText" />
                     </b-alert>
                     <b-alert :show="!!connectExternalProvider" variant="info">
@@ -11,80 +165,94 @@
                         >. In order to associate this account with <i>{{ connectExternalLabel }}</i
                         >, you must first login to your existing account.
                     </b-alert>
-                    <b-form id="login" @submit.prevent="submitLogin()">
-                        <b-card no-body>
-                            <b-card-header v-if="!connectExternalProvider">
-                                <span>{{ headerWelcome }}</span>
-                            </b-card-header>
-                            <b-card-body>
-                                <div>
-                                    <!-- standard internal galaxy login -->
-                                    <b-form-group :label="labelNameAddress" label-for="login-form-name">
-                                        <b-form-input
-                                            v-if="!connectExternalProvider"
-                                            id="login-form-name"
-                                            v-model="login"
-                                            name="login"
-                                            type="text" />
-                                        <b-form-input
-                                            v-else
-                                            id="login-form-name"
-                                            disabled
-                                            :value="connectExternalEmail"
-                                            name="login"
-                                            type="text" />
-                                    </b-form-group>
-                                    <b-form-group :label="labelPassword" label-for="login-form-password">
-                                        <b-form-input
-                                            id="login-form-password"
-                                            v-model="password"
-                                            name="password"
-                                            type="password" />
-                                        <b-form-text v-if="showResetLink">
-                                            <span v-localize>Forgot password?</span>
-                                            <a
-                                                v-localize
-                                                href="javascript:void(0)"
-                                                role="button"
-                                                @click.prevent="resetLogin">
-                                                Click here to reset your password.
-                                            </a>
-                                        </b-form-text>
-                                    </b-form-group>
-                                    <b-button v-localize name="login" type="submit">Login</b-button>
-                                </div>
-                                <div v-if="enableOidc">
-                                    <!-- OIDC login-->
-                                    <ExternalLogin :login_page="true" :exclude_idps="[connectExternalProvider]" />
-                                </div>
-                            </b-card-body>
-                            <b-card-footer>
-                                <span v-if="!connectExternalProvider">
-                                    Don't have an account?
-                                    <span v-if="allowUserCreation">
-                                        <a
-                                            id="register-toggle"
-                                            v-localize
-                                            href="javascript:void(0)"
-                                            role="button"
-                                            @click.prevent="toggleLogin">
-                                            Register here.
-                                        </a>
-                                    </span>
-                                    <span v-else>
-                                        Registration for this Galaxy instance is disabled. Please contact an
-                                        administrator for assistance.
-                                    </span>
-                                </span>
-                                <span v-else>
-                                    Do not wish to connect to an external provider?
-                                    <a href="javascript:void(0)" role="button" @click.prevent="returnToLogin">
-                                        Return to login here.
+                    <b-card no-body>
+                        <b-card-header v-if="!connectExternalProvider">
+                            <span>{{ headerWelcome }}</span>
+                        </b-card-header>
+                        <b-card-body>
+                            <div>
+                                <!-- standard internal galaxy login -->
+                                <InternalLogin
+                                    :password-state="passwordState"
+                                    :connect-external-provider="connectExternalProvider"
+                                    :connect-external-email="connectExternalEmail"
+                                    @reset-login="resetLogin"
+                                    @submit-login="submitLogin" />
+                            </div>
+                            <div v-if="enableOidc">
+                                <!-- OIDC login-->
+                                <ExternalLogin :login_page="true" :exclude_idps="[connectExternalProvider]" />
+                            </div>
+                        </b-card-body>
+                        <b-card-footer>
+                            <span v-if="!connectExternalProvider">
+                                Don't have an account?
+                                <span v-if="allowUserCreation">
+                                    <a
+                                        id="register-toggle"
+                                        v-localize
+                                        href="javascript:void(0)"
+                                        role="button"
+                                        @click.prevent="toggleLogin">
+                                        Register here.
                                     </a>
                                 </span>
-                            </b-card-footer>
-                        </b-card>
-                    </b-form>
+                                <span v-else>
+                                    Registration for this Galaxy instance is disabled. Please contact an administrator
+                                    for assistance.
+                                </span>
+                            </span>
+                            <span v-else>
+                                Do not wish to connect to an external provider?
+                                <a href="javascript:void(0)" role="button" @click.prevent="returnToLogin">
+                                    Return to login here.
+                                </a>
+                            </span>
+                        </b-card-footer>
+                    </b-card>
+                </div>
+                <div v-else :class="{ 'd-flex': termsUrl }">
+                    <div class="border p-3 login-box">
+                        <div class="d-flex flex-column justify-content-center align-items-center h-100">
+                            <div class="w-100">
+                                <Heading h6 separator size="sm">{{ headerWelcome }}</Heading>
+                                <span v-if="boxSection == 1">
+                                    <InternalLogin
+                                        show-as-box
+                                        :password-state="passwordState"
+                                        :connect-external-provider="connectExternalProvider"
+                                        :connect-external-email="connectExternalEmail"
+                                        @reset-login="resetLogin"
+                                        @submit-login="submitLogin" />
+                                </span>
+                                <span v-else>
+                                    <ExternalLogin
+                                        :login_page="true"
+                                        indexed-view
+                                        :provider-key="boxSections[boxSection - 1]"
+                                        :exclude_idps="[connectExternalProvider]" />
+                                </span>
+                            </div>
+                            <div v-if="boxSections.length > 1" class="mt-auto text-center">
+                                <i>Try other login options</i>
+                                <b-pagination
+                                    v-model="boxSection"
+                                    align="center"
+                                    hide-goto-end-buttons
+                                    :per-page="1"
+                                    :total-rows="totalSections"
+                                    size="sm">
+                                    <template v-slot:page="{ page, active }">
+                                        <b v-if="active">{{ capitalize(boxSections[page - 1]) }}</b>
+                                        <span v-else>{{ capitalize(boxSections[page - 1]) }}</span>
+                                    </template>
+                                </b-pagination>
+                            </div>
+                        </div>
+                    </div>
+                    <div v-if="termsUrl" class="border p-3 login-box right-terms">
+                        <iframe title="terms-of-use" :src="termsUrl" frameborder="0" class="terms-iframe"></iframe>
+                    </div>
                 </div>
             </template>
             <template v-else>
@@ -100,151 +268,26 @@
     </div>
 </template>
 
-<script>
-import axios from "axios";
-import BootstrapVue from "bootstrap-vue";
-import ExternalLogin from "components/User/ExternalIdentities/ExternalLogin";
-import _l from "utils/localization";
-import { withPrefix } from "utils/redirect";
-import Vue from "vue";
-
-import NewUserConfirmation from "./NewUserConfirmation";
-
-Vue.use(BootstrapVue);
-
-export default {
-    components: {
-        ExternalLogin,
-        NewUserConfirmation,
-    },
-    props: {
-        allowUserCreation: {
-            type: Boolean,
-            default: false,
-        },
-        enableOidc: {
-            type: Boolean,
-            default: false,
-        },
-        redirect: {
-            type: String,
-            default: null,
-        },
-        registrationWarningMessage: {
-            type: String,
-            default: null,
-        },
-        sessionCsrfToken: {
-            type: String,
-            required: true,
-        },
-        showWelcomeWithLogin: {
-            type: Boolean,
-            default: false,
-        },
-        showResetLink: {
-            type: Boolean,
-            default: true,
-        },
-        termsUrl: {
-            type: String,
-            default: null,
-        },
-        welcomeUrl: {
-            type: String,
-            default: null,
-        },
-    },
-    data() {
-        const urlParams = new URLSearchParams(window.location.search);
-        return {
-            login: null,
-            password: null,
-            url: null,
-            messageText: null,
-            messageVariant: null,
-            headerWelcome: _l("Welcome to Galaxy, please log in"),
-            labelNameAddress: _l("Public Name or Email Address"),
-            labelPassword: _l("Password"),
-            confirmURL: urlParams.has("confirm") && urlParams.get("confirm") == "true",
-            connectExternalEmail: urlParams.get("connect_external_email"),
-            connectExternalProvider: urlParams.get("connect_external_provider"),
-            connectExternalLabel: urlParams.get("connect_external_label"),
-        };
-    },
-    computed: {
-        welcomeUrlWithRoot() {
-            return withPrefix(this.welcomeUrl);
-        },
-    },
-    methods: {
-        toggleLogin() {
-            this.$emit("toggle-login");
-        },
-        submitLogin() {
-            let redirect = this.redirect;
-            if (this.connectExternalEmail) {
-                this.login = this.connectExternalEmail;
-            }
-            if (localStorage.getItem("redirect_url")) {
-                redirect = localStorage.getItem("redirect_url");
-            }
-            axios
-                .post(withPrefix("/user/login"), {
-                    login: this.login,
-                    password: this.password,
-                    redirect: redirect,
-                    session_csrf_token: this.sessionCsrfToken,
-                })
-                .then(({ data }) => {
-                    if (data.message && data.status) {
-                        alert(data.message);
-                    }
-                    if (data.expired_user) {
-                        window.location = withPrefix(`/root/login?expired_user=${data.expired_user}`);
-                    } else if (this.connectExternalProvider) {
-                        window.location = withPrefix("/user/external_ids?connect_external=true");
-                    } else if (data.redirect) {
-                        window.location = encodeURI(data.redirect);
-                    } else {
-                        window.location = withPrefix("/");
-                    }
-                })
-                .catch((error) => {
-                    this.messageVariant = "danger";
-                    const message = error.response && error.response.data && error.response.data.err_msg;
-                    if (this.connectExternalProvider && message && message.toLowerCase().includes("invalid")) {
-                        this.messageText =
-                            message + " Try logging in to the existing account through an external provider below.";
-                    } else {
-                        this.messageText = message || "Login failed for an unknown reason.";
-                    }
-                });
-        },
-        setRedirect(url) {
-            localStorage.setItem("redirect_url", url);
-        },
-        resetLogin() {
-            axios
-                .post(withPrefix("/user/reset_password"), { email: this.login })
-                .then((response) => {
-                    this.messageVariant = "info";
-                    this.messageText = response.data.message;
-                })
-                .catch((error) => {
-                    this.messageVariant = "danger";
-                    const message = error.response.data && error.response.data.err_msg;
-                    this.messageText = message || "Password reset failed for an unknown reason.";
-                });
-        },
-        returnToLogin() {
-            window.location = withPrefix("/login/start");
-        },
-    },
-};
-</script>
-<style scoped>
+<style lang="scss" scoped>
 .card-body {
     overflow: visible;
+}
+.login-box {
+    border-radius: 4px;
+    &.right-terms {
+        flex: 1;
+    }
+
+    &:not(.right-terms) {
+        min-width: 30%;
+    }
+
+    .terms-iframe {
+        border: none;
+        overflow-y: auto;
+        width: 100%;
+        min-height: 10vh;
+        height: 100%;
+    }
 }
 </style>

--- a/client/src/components/Login/LoginForm.vue
+++ b/client/src/components/Login/LoginForm.vue
@@ -2,6 +2,7 @@
 import axios from "axios";
 import { capitalize } from "lodash";
 import { computed, ref } from "vue";
+import { useRoute } from "vue-router/composables";
 
 import { useConfig } from "@/composables/config";
 import { Toast } from "@/composables/toast";
@@ -39,6 +40,7 @@ const emit = defineEmits<{
 const urlParams = new URLSearchParams(window.location.search);
 
 const { config } = useConfig();
+const route = useRoute();
 
 const login = ref<string | null>(null);
 const password = ref<string | null>(null);
@@ -83,7 +85,7 @@ function submitLogin(formLogin: string | null, formPassword: string | null) {
     if (localStorage.getItem("redirect_url")) {
         redirect = localStorage.getItem("redirect_url")!;
     }
-    const currentPath = window.location.pathname;
+    const currentPath = route.fullPath;
     axios
         .post(withPrefix("/user/login"), {
             login: login.value,

--- a/client/src/components/Login/LoginIndex.vue
+++ b/client/src/components/Login/LoginIndex.vue
@@ -7,6 +7,7 @@
             :redirect="redirect"
             :registration-warning-message="registrationWarningMessage"
             :session-csrf-token="sessionCsrfToken"
+            :show-as-box="showAsBox"
             :show-welcome-with-login="showWelcomeWithLogin"
             :terms-url="termsUrl"
             :welcome-url="welcomeUrl"
@@ -77,6 +78,10 @@ export default {
             required: true,
         },
         serverMailConfigured: {
+            type: Boolean,
+            default: false,
+        },
+        showAsBox: {
             type: Boolean,
             default: false,
         },

--- a/client/src/composables/usePanels.ts
+++ b/client/src/composables/usePanels.ts
@@ -3,14 +3,19 @@ import { useRoute } from "vue-router/composables";
 
 import { useUserStore } from "@/stores/userStore";
 
+import { useConfig } from "./config";
+
 export function usePanels() {
     const userStore = useUserStore();
     const route = useRoute();
+    const { config, isConfigLoaded } = useConfig();
 
     const showPanels = computed(() => {
         const panels = route.query.hide_panels;
         if (panels !== undefined && panels !== null && typeof panels === "string") {
             return panels.toLowerCase() != "true";
+        } else if (isConfigLoaded.value && config.value.require_login === true) {
+            return false;
         }
         return true;
     });

--- a/client/src/entry/analysis/modules/Analysis.vue
+++ b/client/src/entry/analysis/modules/Analysis.vue
@@ -1,8 +1,11 @@
 <script setup>
+import { storeToRefs } from "pinia";
 import { onMounted, onUnmounted, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
+import { useConfig } from "@/composables/config";
 import { usePanels } from "@/composables/usePanels";
+import { useUserStore } from "@/stores/userStore";
 
 import CenterFrame from "./CenterFrame.vue";
 import ActivityBar from "@/components/ActivityBar/ActivityBar.vue";
@@ -10,10 +13,13 @@ import HistoryIndex from "@/components/History/Index.vue";
 import FlexPanel from "@/components/Panels/FlexPanel.vue";
 import ToolPanel from "@/components/Panels/ToolPanel.vue";
 import DragAndDropModal from "@/components/Upload/DragAndDropModal.vue";
+import Login from "@/entry/analysis/modules/Login.vue";
 
 const router = useRouter();
 const showCenter = ref(false);
 const { showActivityBar, showToolbox, showPanels } = usePanels();
+const { isAnonymous } = storeToRefs(useUserStore());
+const { config, isConfigLoaded } = useConfig();
 
 // methods
 function hideCenter() {
@@ -42,10 +48,14 @@ onUnmounted(() => {
         <FlexPanel v-if="showToolbox" side="left">
             <ToolPanel />
         </FlexPanel>
-        <div id="center" class="overflow-auto p-3 w-100">
-            <CenterFrame v-show="showCenter" id="galaxy_main" @load="onLoad" />
-            <router-view v-show="!showCenter" :key="$route.fullPath" class="h-100" />
-        </div>
+        <!-- TODO: fix bug where center span pushes right panel out of view (tool: 'gene2exon1') -->
+        <span class="d-flex flex-column">
+            <Login v-if="isAnonymous && isConfigLoaded && config.show_login_on_header" class="p-3" show-as-box />
+            <div id="center" class="overflow-auto p-3 w-100 h-100 d-block">
+                <CenterFrame v-show="showCenter" id="galaxy_main" class="flex-grow-1" @load="onLoad" />
+                <router-view v-show="!showCenter" :key="$route.fullPath" class="h-100" />
+            </div>
+        </span>
         <FlexPanel v-if="showPanels" side="right">
             <HistoryIndex />
         </FlexPanel>

--- a/client/src/entry/analysis/modules/Login.vue
+++ b/client/src/entry/analysis/modules/Login.vue
@@ -1,7 +1,7 @@
 <template>
-    <div class="overflow-auto m-3">
+    <div :class="!showAsBox && 'overflow-auto m-3'">
         <ChangePassword
-            v-if="hasToken"
+            v-if="!showAsBox && hasToken"
             :expired-user="$route.query.expired_user"
             :message-text="$route.query.message"
             :message-variant="$route.query.status"
@@ -14,6 +14,7 @@
             :prefer-custos-login="config.prefer_custos_login"
             :redirect="$route.query.redirect"
             :registration-warning-message="config.registration_warning_message"
+            :show-as-box="showAsBox"
             :server-mail-configured="config.server_mail_configured"
             :session-csrf-token="sessionCsrfToken"
             :show-welcome-with-login="config.show_welcome_with_login"
@@ -32,6 +33,12 @@ export default {
     components: {
         ChangePassword,
         LoginIndex,
+    },
+    props: {
+        showAsBox: {
+            type: Boolean,
+            default: false,
+        },
     },
     computed: {
         config() {

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -324,6 +324,7 @@ export function getRouter(Galaxy) {
                         path: "histories/:historyId/invocations",
                         component: HistoryInvocations,
                         props: true,
+                        redirect: redirectAnon(),
                     },
                     {
                         path: "interactivetool_entry_points/list",

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3642,6 +3642,15 @@
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~
+``show_login_on_header``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Renders a login header on top of the center panel for most routes.
+:Default: ``false``
+:Type: bool
+
+~~~~~~~~~~~~~~~~~~~~~~~
 ``prefer_custos_login``
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2014,6 +2014,9 @@ galaxy:
   # page (even if require_login is true).
   #show_welcome_with_login: false
 
+  # Renders a login header on top of the center panel for most routes.
+  #show_login_on_header: false
+
   # Controls the order of the login page to prefer Custos-based login
   # and registration.
   #prefer_custos_login: false

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2653,6 +2653,13 @@ mapping:
           Show the site's welcome page (see welcome_url) alongside the login page
           (even if require_login is true).
 
+      show_login_on_header:
+        type: bool
+        default: false
+        required: False
+        desc: |
+          Renders a login header on top of the center panel for most routes.
+
       prefer_custos_login:
         type: bool
         default: false

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -143,6 +143,7 @@ class ConfigSerializer(base.ModelSerializer):
             "enable_oidc": _use_config,
             "oidc": _use_config,
             "prefer_custos_login": _use_config,
+            "show_login_on_header": _use_config,
             "enable_quotas": _use_config,
             "remote_user_logout_href": _use_config,
             "post_user_logout_href": _use_config,


### PR DESCRIPTION
This is a WIP.

First implementation here is of a fixed login "header" for the center panel _similar_ to the one shared in https://github.com/galaxyproject/galaxy/issues/16688 ([Login-page-layout-example.pdf](https://github.com/galaxyproject/galaxy/files/12602472/Login-page-layout-example.pdf)):

| Demo 1 |
| --------- |
| <video src="https://github.com/galaxyproject/galaxy/assets/78516064/dcd95322-6144-4bc2-ad12-e164f1c6050c" /> |
| The galaxy.yml config options that rendered this view: |
```
enable_oidc: true
oidc_config_file: oidc_config.xml
oidc_backends_config_file: oidc_backends_config.xml   # (with 2 providers)
show_login_on_header: true
``` 


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
