### PR TITLE
Refactor the route POST: `/api/workflows/get_tool_predictions` to FastAPI

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1792,6 +1792,10 @@ export interface paths {
          */
         get: operations["index_api_workflows_get"];
     };
+    "/api/workflows/get_tool_predictions": {
+        /** Fetch predicted tools for a workflow */
+        post: operations["get_tool_predictions_api_workflows_get_tool_predictions_post"];
+    };
     "/api/workflows/menu": {
         /** Get workflows present in the tools panel. */
         get: operations["get_workflow_menu_api_workflows_menu_get"];
@@ -5037,6 +5041,19 @@ export interface components {
             src: "ftp_import";
             /** Tags */
             tags?: string[] | null;
+        };
+        /** GetToolPredictionsPayload */
+        GetToolPredictionsPayload: {
+            /**
+             * Remote Model URL
+             * @description Path to the deep learning model
+             */
+            remote_model_url?: Record<string, never> | null;
+            /**
+             * Tool Sequence
+             * @description comma separated sequence of tool ids
+             */
+            tool_sequence?: Record<string, never> | null;
         };
         /**
          * GroupCreatePayload
@@ -10380,6 +10397,19 @@ export interface components {
              * @description A `\t` (TAB) separated list of column __contents__. You must specify a value for each of the columns of the data table.
              */
             values: string;
+        };
+        /** ToolPredictionsSummary */
+        ToolPredictionsSummary: {
+            /**
+             * Current Tools
+             * @description A comma separated sequence of the current tool ids
+             */
+            current_tool?: Record<string, never> | null;
+            /**
+             * Recommended Tools
+             * @description List of predictions
+             */
+            predicted_data?: Record<string, never> | null;
         };
         /** Tour */
         Tour: {
@@ -21503,6 +21533,34 @@ export interface operations {
             200: {
                 content: {
                     "application/json": Record<string, never>[];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_tool_predictions_api_workflows_get_tool_predictions_post: {
+        /** Fetch predicted tools for a workflow */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GetToolPredictionsPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never> | components["schemas"]["ToolPredictionsSummary"];
                 };
             };
             /** @description Validation Error */

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -1,0 +1,34 @@
+from typing import (
+    Any,
+    Optional,
+)
+
+from pydantic import Field
+
+from galaxy.schema.schema import Model
+
+
+class GetToolPredictionsPayload(Model):
+    tool_sequence: Optional[Any] = Field(
+        None,
+        title="Tool Sequence",
+        description="comma separated sequence of tool ids",
+    )
+    remote_model_url: Optional[Any] = Field(
+        None,
+        title="Remote Model URL",
+        description="Path to the deep learning model",
+    )
+
+
+class ToolPredictionsSummary(Model):
+    current_tool: Optional[Any] = Field(
+        None,
+        title="Current Tools",
+        description="A comma separated sequence of the current tool ids",
+    )
+    predicted_data: Optional[Any] = Field(
+        None,
+        title="Recommended Tools",
+        description="List of predictions",
+    )

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -580,12 +580,6 @@ def populate_api_routes(webapp, app):
         controller="container_resolution",
         conditions=dict(method=["POST"]),
     )
-    webapp.mapper.connect(
-        "/api/workflows/get_tool_predictions",
-        action="get_tool_predictions",
-        controller="workflows",
-        conditions=dict(method=["POST"]),
-    )
 
     webapp.mapper.resource("visualization", "visualizations", path_prefix="/api")
     webapp.mapper.resource("plugins", "plugins", path_prefix="/api")


### PR DESCRIPTION
This is a part of #10889.

## Summary
- Refactored API routes:
     - [x] POST: `/api/workflows/get_tool_predictions`
         - [x] Added pydantic models to input
         - [x] Added pydantic models to return
         - [x] Removed the mapping to the legacy routes
         - [ ] Added appropriate testing

## How to test the changes?
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
    ...


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).