### PR TITLE
Workflow anonymous user buttons

### DIFF
--- a/client/src/components/Workflow/WorkflowActions.vue
+++ b/client/src/components/Workflow/WorkflowActions.vue
@@ -11,6 +11,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton } from "bootstrap-vue";
+import { storeToRefs } from "pinia";
 import { computed, type ComputedRef } from "vue";
 import { useRouter } from "vue-router/composables";
 
@@ -67,6 +68,7 @@ const emit = defineEmits<{
 
 const router = useRouter();
 const userStore = useUserStore();
+const { isAnonymous } = storeToRefs(userStore);
 const { confirm } = useConfirmDialog();
 
 const shared = computed(() => {
@@ -164,7 +166,7 @@ const actions: ComputedRef<(AAction | BAction)[]> = computed(() => {
 const menuActions: ComputedRef<BAction[]> = computed(() => {
     return [
         {
-            condition: !shared.value && !props.workflow.deleted,
+            condition: !isAnonymous.value && !shared.value && !props.workflow.deleted,
             class: "workflow-delete-button",
             component: "button",
             title: "Delete workflow",

--- a/client/src/components/Workflow/WorkflowActionsExtend.vue
+++ b/client/src/components/Workflow/WorkflowActionsExtend.vue
@@ -108,7 +108,7 @@ async function onRestore() {
             </BButton>
 
             <BButton
-                v-if="!shared && !workflow.deleted"
+                v-if="!isAnonymous && !shared && !workflow.deleted"
                 id="workflow-share-button"
                 v-b-tooltip.hover.noninteractive
                 :size="buttonSize"

--- a/client/src/components/Workflow/WorkflowRunButton.vue
+++ b/client/src/components/Workflow/WorkflowRunButton.vue
@@ -10,6 +10,8 @@ library.add(faPlay);
 interface Props {
     id: string;
     full?: boolean;
+    title?: string;
+    disabled?: boolean;
 }
 
 const props = defineProps<Props>();
@@ -25,10 +27,11 @@ function ExecuteWorkflow() {
     <BButton
         id="workflow-run-button"
         v-b-tooltip.hover.top.noninteractive
-        title="Run workflow"
+        :title="title ?? 'Run workflow'"
         :data-workflow-run="id"
         variant="primary"
         size="sm"
+        :disabled="disabled"
         @click.stop="ExecuteWorkflow">
         <FontAwesomeIcon :icon="faPlay" />
         <span v-if="full" v-localize>Run</span>


### PR DESCRIPTION
Fixes #17514. This PR disables workflow card buttons (edit, import, run) with detailed titles for anonymous users, removes the workflow invocations count widget and rename button, and disables the edit button for non-owners and anonymous users.  

## Non-owner user
![image](https://github.com/galaxyproject/galaxy/assets/8046843/9306ee54-20ed-4a3d-a400-e8f95ad73317)

## Anonymous user
![image](https://github.com/galaxyproject/galaxy/assets/8046843/4cc48ee8-7c9b-4859-8450-29bd2a363c4d)

## Owner
![image](https://github.com/galaxyproject/galaxy/assets/8046843/5f8426a0-349a-4d80-a6ae-fdd60f6660f0)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
