### PR TITLE
Remove virtual scroller from History

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,8 @@
   "browserslist": [
     "defaults",
     "not op_mini all",
-    "not ios_saf <= 15.0"
+    "not ios_saf <= 15.0",
+    "not kaios > 0"
   ],
   "resolutions": {
     "chokidar": "3.5.3",

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -103,6 +103,10 @@ const historyItems = computed(() => {
     return historyItemsStore.getHistoryItems(props.history.id, filterText.value);
 });
 
+const visibleHistoryItems = computed(() => {
+    return historyItems.value.filter((item) => !invisibleHistoryItems.value[item.hid]);
+});
+
 const formattedSearchError = computed(() => {
     const newError = unref(searchError);
     if (!newError) {
@@ -368,7 +372,7 @@ onMounted(async () => {
             @query-selection-break="querySelectionBreak = true">
             <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
             <section
-                class="history-layout d-flex flex-column w-100"
+                class="history-layout d-flex flex-column w-100 h-100"
                 @drop.prevent="onDrop"
                 @dragenter.prevent="onDragEnter"
                 @dragover.prevent
@@ -443,9 +447,9 @@ onMounted(async () => {
                         @hide="operationError = null" />
                 </section>
 
-                <section v-if="!showAdvanced" class="position-relative flex-grow-1 scroller">
+                <section v-show="!showAdvanced" class="position-relative flex-grow-1 scroller overflow-hidden">
                     <HistoryDropZone v-if="showDropZone" />
-                    <div>
+                    <div class="h-100">
                         <div v-if="isLoading && historyItems && historyItems.length === 0">
                             <BAlert class="m-2" variant="info" show>
                                 <LoadingSpan message="Loading History" />
@@ -468,12 +472,12 @@ onMounted(async () => {
                         <ListingLayout
                             v-else
                             :offset="listOffset"
-                            :items="historyItems"
+                            :items="visibleHistoryItems"
                             :query-key="queryKey"
+                            data-key="hid"
                             @scroll="onScroll">
                             <template v-slot:item="{ item, currentOffset }">
                                 <ContentItem
-                                    v-if="!invisibleHistoryItems[item.hid]"
                                     :id="item.hid"
                                     is-history-item
                                     :item="item"
@@ -502,3 +506,10 @@ onMounted(async () => {
         </SelectedItems>
     </ExpandedItems>
 </template>
+
+<style scoped lang="scss">
+.history-item-list {
+    overflow-y: auto;
+    height: 100%;
+}
+</style>

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -506,10 +506,3 @@ onMounted(async () => {
         </SelectedItems>
     </ExpandedItems>
 </template>
-
-<style scoped lang="scss">
-.history-item-list {
-    overflow-y: auto;
-    height: 100%;
-}
-</style>

--- a/client/src/components/History/Layout/IntersectionObservable.vue
+++ b/client/src/components/History/Layout/IntersectionObservable.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from "vue";
+
+const props = defineProps<{
+    observer: IntersectionObserver;
+}>();
+
+const element = ref<HTMLDivElement>();
+
+onMounted(() => {
+    if (element.value) {
+        props.observer.observe(element.value);
+    }
+});
+
+onBeforeUnmount(() => {
+    if (element.value) {
+        props.observer.unobserve(element.value);
+    }
+});
+</script>
+
+<template>
+    <div ref="element">
+        <slot></slot>
+    </div>
+</template>

--- a/client/src/components/History/Layout/ListingLayout.vue
+++ b/client/src/components/History/Layout/ListingLayout.vue
@@ -5,7 +5,7 @@ import IntersectionObservable from "./IntersectionObservable.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 const props = defineProps<{
-    items: unknown[];
+    items: any[];
     queryKey?: string;
     dataKey?: string;
     loading?: boolean;
@@ -51,15 +51,9 @@ function scrollToOffset(offset: number) {
 
 const observer = new IntersectionObserver(
     (items) => {
-        for (let index = 0; index < items.length; index++) {
-            const element = items[index]!;
-            if (element.isIntersecting) {
-                const target = element.target as HTMLDivElement;
-                const targetIndex = parseInt(target.getAttribute("data-index") ?? "0");
-                currentOffset.value = targetIndex;
-                break;
-            }
-        }
+        const intersecting = items.filter((item) => item.isIntersecting);
+        const indices = intersecting.map((item) => parseInt(item.target.getAttribute("data-index") ?? "0"));
+        currentOffset.value = indices.length > 0 ? Math.min(...indices) : 0;
     },
     { root: root.value }
 );
@@ -81,7 +75,7 @@ function getKey(item: unknown, index: number) {
             class="listing-layout-item"
             :data-index="i"
             :observer="observer">
-            <slot name="item" :item="item" :current-offset="currentOffset" />
+            <slot name="item" :item="item" :current-offset="i" />
         </IntersectionObservable>
         <LoadingSpan v-if="props.loading" class="m-2" message="Loading" />
     </div>

--- a/client/src/components/History/Layout/ListingLayout.vue
+++ b/client/src/components/History/Layout/ListingLayout.vue
@@ -1,88 +1,98 @@
-<template>
-    <div class="listing-layout">
-        <VirtualList
-            ref="listing"
-            class="listing"
-            role="list"
-            :data-key="dataKey"
-            :offset="offset"
-            :data-sources="items"
-            :data-component="{}"
-            :estimate-size="estimatedItemHeight"
-            :keeps="estimatedItemCount"
-            @scroll="onScroll">
-            <template v-slot:item="{ item }">
-                <slot name="item" :item="item" :current-offset="getOffset()" />
-            </template>
-            <template v-slot:footer>
-                <LoadingSpan v-if="loading" class="m-2" message="Loading" />
-            </template>
-        </VirtualList>
-    </div>
-</template>
-<script>
-import { useElementBounding } from "@vueuse/core";
-import LoadingSpan from "components/LoadingSpan";
-import { computed, ref } from "vue";
-import VirtualList from "vue-virtual-scroll-list";
+<script setup lang="ts">
+import { nextTick, ref, watch } from "vue";
 
-export default {
-    components: {
-        LoadingSpan,
-        VirtualList,
-    },
-    props: {
-        dataKey: { type: String, default: "id" },
-        offset: { type: Number, default: 0 },
-        loading: { type: Boolean, default: false },
-        items: { type: Array, default: null },
-        queryKey: { type: String, default: null },
-    },
-    setup() {
-        const listing = ref(null);
-        const { height } = useElementBounding(listing);
+import IntersectionObservable from "./IntersectionObservable.vue";
+import LoadingSpan from "@/components/LoadingSpan.vue";
 
-        const estimatedItemHeight = 40;
-        const estimatedItemCount = computed(() => {
-            const baseCount = Math.ceil(height.value / estimatedItemHeight);
-            return baseCount + 20;
+const props = defineProps<{
+    items: unknown[];
+    queryKey?: string;
+    dataKey?: string;
+    loading?: boolean;
+    offset?: number;
+}>();
+
+const emit = defineEmits<{
+    (e: "scroll", currentOffset: number): void;
+}>();
+
+const root = ref<HTMLDivElement>();
+const currentOffset = ref(0);
+
+watch(
+    () => currentOffset.value,
+    (offset) => emit("scroll", offset)
+);
+
+watch(
+    () => props.queryKey,
+    () => {
+        root.value?.scrollTo({
+            top: 0,
         });
+    }
+);
 
-        return { listing, estimatedItemHeight, estimatedItemCount };
+watch(
+    () => props.offset,
+    async (offset) => {
+        await nextTick();
+        if (offset !== undefined) {
+            scrollToOffset(offset);
+        }
     },
-    data() {
-        return {
-            previousStart: undefined,
-        };
-    },
-    watch: {
-        queryKey() {
-            this.listing.scrollToOffset(0);
-        },
-    },
-    methods: {
-        onScroll() {
-            const rangeStart = this.listing.range.start;
-            if (this.previousStart !== rangeStart) {
-                this.previousStart = rangeStart;
-                this.$emit("scroll", rangeStart);
+    { immediate: true }
+);
+
+function scrollToOffset(offset: number) {
+    const element = root.value?.querySelector(`.listing-layout-item[data-index="${offset}"]`);
+    element?.scrollIntoView();
+}
+
+// eslint-disable-next-line compat/compat
+const observer = new IntersectionObserver(
+    (items) => {
+        for (let index = 0; index < items.length; index++) {
+            const element = items[index]!;
+            if (element.isIntersecting) {
+                const target = element.target as HTMLDivElement;
+                const targetIndex = parseInt(target.getAttribute("data-index") ?? "0");
+                currentOffset.value = targetIndex;
+                break;
             }
-        },
-        getOffset() {
-            return this.listing?.getOffset() || 0;
-        },
+        }
     },
-};
+    { root: root.value }
+);
+
+function getKey(item: unknown, index: number) {
+    if (props.dataKey) {
+        return (item as Record<string, unknown>)[props.dataKey];
+    } else {
+        return index;
+    }
+}
 </script>
 
+<template>
+    <div ref="root" class="listing-layout">
+        <IntersectionObservable
+            v-for="(item, i) in props.items"
+            :key="getKey(item, i)"
+            class="listing-layout-item"
+            :data-index="i"
+            :observer="observer">
+            <slot name="item" :item="item" :current-offset="currentOffset" />
+        </IntersectionObservable>
+        <LoadingSpan v-if="props.loading" class="m-2" message="Loading" />
+    </div>
+</template>
+
 <style scoped lang="scss">
-@import "scss/mixins.scss";
 .listing-layout {
-    .listing {
-        @include absfill();
-        scroll-behavior: smooth;
-        overflow-y: scroll;
-        overflow-x: hidden;
-    }
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    overflow-y: scroll;
 }
 </style>

--- a/client/src/components/History/Layout/ListingLayout.vue
+++ b/client/src/components/History/Layout/ListingLayout.vue
@@ -49,7 +49,6 @@ function scrollToOffset(offset: number) {
     element?.scrollIntoView();
 }
 
-// eslint-disable-next-line compat/compat
 const observer = new IntersectionObserver(
     (items) => {
         for (let index = 0; index < items.length; index++) {

--- a/client/src/stores/historyItemsStore.ts
+++ b/client/src/stores/historyItemsStore.ts
@@ -6,7 +6,7 @@
 
 import { reverse } from "lodash";
 import { defineStore } from "pinia";
-import Vue, { computed, ref } from "vue";
+import { computed, ref, set } from "vue";
 
 import type { DatasetSummary, HDCASummary } from "@/api";
 import { HistoryFilters } from "@/components/History/HistoryFilters";
@@ -82,7 +82,7 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", () => {
             payload.forEach((item: HistoryItem) => {
                 // current `item.hid` is related to item with hid = `relatedHid`
                 const relationKey = `${historyId}-${relatedHid}-${item.hid}`;
-                Vue.set(relatedItems.value, relationKey, true);
+                set(relatedItems.value, relationKey, true);
             });
         }
     }

--- a/client/src/utils/lastQueue.ts
+++ b/client/src/utils/lastQueue.ts
@@ -5,6 +5,8 @@ type QueuedAction<T extends (...args: any) => R, R = unknown> = {
     reject: (e: Error) => void;
 };
 
+export class ActionSkippedError extends Error {}
+
 /**
  * This queue waits until the current promise is resolved and only executes the last enqueued
  * promise. Promises added between the last and the currently executing promise are skipped.
@@ -13,15 +15,22 @@ type QueuedAction<T extends (...args: any) => R, R = unknown> = {
  */
 export class LastQueue<T extends (arg: any) => R, R = unknown> {
     throttlePeriod: number;
+    /** Throw an error if a queued action is skipped. This avoids dangling promises */
+    rejectSkipped: boolean;
     private queuedPromises: Record<string | number, QueuedAction<T, R>> = {};
     private pendingPromise = false;
 
-    constructor(throttlePeriod = 1000) {
+    constructor(throttlePeriod = 1000, rejectSkipped = false) {
         this.throttlePeriod = throttlePeriod;
+        this.rejectSkipped = rejectSkipped;
     }
 
     async enqueue(action: T, arg: Parameters<T>[0], key: string | number = 0) {
         return new Promise((resolve, reject) => {
+            if (this.rejectSkipped && this.queuedPromises[key]) {
+                this.queuedPromises[key]?.reject(new ActionSkippedError());
+            }
+
             this.queuedPromises[key] = { action, arg, resolve, reject };
             this.dequeue();
         });

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -265,7 +265,7 @@ history_panel:
       elements_warning: '.dataset-collection-panel .controls .elements-warning'
       tag_area_button: '.details .stateless-tags .toggle-button'
       tag_area_input: '.details .stateless-tags .headless-multiselect input'
-      list_items: '.dataset-collection-panel .listing .content-item'
+      list_items: '.dataset-collection-panel .listing-layout .content-item'
       back_to_history: svg[data-description="back to history"]
 
   selectors:

--- a/client/tests/jest/jest-environment.js
+++ b/client/tests/jest/jest-environment.js
@@ -2,11 +2,20 @@ import "jsdom-worker";
 
 import JSDOMEnvironment from "jest-environment-jsdom";
 
+class MockObserver {
+    constructor(...args) {}
+
+    observe(...args) {}
+    unobserve(...args) {}
+}
+
 export default class CustomJSDOMEnvironment extends JSDOMEnvironment {
     constructor(...args) {
         super(...args);
 
         this.global.Worker = Worker;
+
+        this.global.IntersectionObserver = MockObserver;
 
         // FIXME https://github.com/jsdom/jsdom/issues/3363
         this.global.structuredClone = structuredClone;


### PR DESCRIPTION
Removes the virtual scroller from the history component in the side panel, replacing it with a div with scroll overflow.
Implements offset tracking using the intersection api.
Makes scrolling the history much smoother.

Also makes small changes to the history item store to remove dangling promises.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
