### PR TITLE
Fix ``test_index_advanced_filter`` API test re-running

### DIFF
--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -189,31 +189,26 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
             self._delete(f"histories/{history_1}")
 
             name_contains = "history"
-            query = f"?search={name_contains}"
-            index_response = self._get(f"histories{query}").json()
+            data = dict(search=name_contains, show_published=False)
+            index_response = self._get("histories", data=data).json()
             assert len(index_response) == 3
 
             name_contains = "history that match query"
-            query = f"?search={name_contains}"
-            index_response = self._get(f"histories{query}").json()
+            data = dict(search=name_contains, show_published=False)
+            index_response = self._get("histories", data=data).json()
             assert len(index_response) == 3
 
             name_contains = "ANOTHER"
-            query = f"?search={name_contains}"
-            index_response = self._get(f"histories{query}").json()
+            data = dict(search=name_contains, show_published=False)
+            index_response = self._get("histories", data=data).json()
             assert len(index_response) == 0
-
-            name_contains = "test"
-            query = f"?search={name_contains}"
-            index_response = self._get(f"histories{query}").json()
-            assert len(index_response) == 3
 
             data = dict(search="is:deleted", show_published=False)
             index_response = self._get("histories", data=data).json()
             assert len(index_response) == 1
 
             self._update(history_0, {"published": True})
-            data = dict(search="is:published")
+            data = dict(search=f"query_{unique_id} is:published")
             index_response = self._get("histories", data=data).json()
             assert len(index_response) == 1
 


### PR DESCRIPTION
At the end of this test one history is made public. So, when re-running the API tests locally without wiping the database, the public history was also included in the results from the searches, causing the following error:

```
            name_contains = "history"
            query = f"?search={name_contains}"
            index_response = self._get(f"histories{query}").json()
>           assert len(index_response) == 3
E           AssertionError: assert 4 == 3
E            +  where 4 = len([{'annotation': None, 'archived': False, 'contents_url': '/api/histories/3393d74dbae390cc/contents', 'count': 0, ...}, {'annotation': None, 'archived': False, 'contents_url': '/api/histories/8cf91205f2f737f4/contents', 'count': 0, ...}, {'annotation': None, 'archived': False, 'contents_url': '/api/histories/b5065b03be4c41dc/contents', 'count': 0, ...}, {'annotation': None, 'archived': False, 'contents_url': '/api/histories/d9abeb98649a6a7e/contents', 'count': 0, ...}])

lib/galaxy_test/api/test_histories.py:194: AssertionError
```

Similarly, in the last part of the test the number of published histories was growing at each re-run.

Also removed a redundant test.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
