### PR TITLE
Enhance Avivator display app to support regular Tiffs

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -239,7 +239,9 @@
     <datatype extension="cnr" type="galaxy.datatypes.tabular:Tabular" subclass="true" display_in_upload="true"/>
     <datatype extension="hhr" type="galaxy.datatypes.data:Text" subclass="true" display_in_upload="true"/>
     <datatype extension="jpg" type="galaxy.datatypes.images:Jpg" mimetype="image/jpeg"/>
-    <datatype extension="tiff" type="galaxy.datatypes.images:Tiff" mimetype="image/tiff" display_in_upload="true"/>
+    <datatype extension="tiff" type="galaxy.datatypes.images:Tiff" mimetype="image/tiff" display_in_upload="true">
+      <display file="image/avivator.xml"/>
+    </datatype>
     <datatype extension="tf2" type="galaxy.datatypes.images:Tiff" subclass="true" display_in_upload="false"/>
     <datatype extension="tf8" type="galaxy.datatypes.images:Tiff" subclass="true" display_in_upload="false"/>
     <datatype extension="btf" type="galaxy.datatypes.images:Tiff" subclass="true" display_in_upload="false"/>

--- a/lib/galaxy/datatypes/display_applications/configs/image/avivator.xml
+++ b/lib/galaxy/datatypes/display_applications/configs/image/avivator.xml
@@ -1,7 +1,7 @@
 <display id="avivator" version="1.0.0" name="display at">
     <link id="main" name="Avivator">
         <url>http://avivator.gehlenborglab.org/?image_url=${qp($tiff_file.url)}</url>
-        <param type="data" name="tiff_file" url="galaxy_${DATASET_HASH}.ome.tiff" allow_cors="true"/>
+        <param type="data" name="tiff_file" url="galaxy_${DATASET_HASH}.${dataset.extension}" allow_cors="true"/>
         <param type="data" name="offsets_file" url="galaxy_${DATASET_HASH}.offsets.json" metadata="offsets" allow_cors="true"/>
     </link>
 </display>

--- a/lib/galaxy/datatypes/images.py
+++ b/lib/galaxy/datatypes/images.py
@@ -91,10 +91,6 @@ class Png(Image):
 class Tiff(Image):
     edam_format = "format_3591"
     file_ext = "tiff"
-
-
-class OMETiff(Tiff):
-    file_ext = "ome.tiff"
     MetadataElement(
         name="offsets",
         desc="Offsets File",
@@ -119,6 +115,10 @@ class OMETiff(Tiff):
         with open(offsets_file.get_file_name(), "w") as f:
             json.dump(offsets, f)
         dataset.metadata.offsets = offsets_file
+
+
+class OMETiff(Tiff):
+    file_ext = "ome.tiff"
 
     def sniff(self, filename: str) -> bool:
         with tifffile.TiffFile(filename) as tif:


### PR DESCRIPTION
As part of the Imaging Hackathon in Freiburg.

This will allow using the `Avivator` display application also with regular Tiffs (as long as the format is supported) and not just OME.tiff

![AvivatorForRegularTiffs](https://github.com/galaxyproject/galaxy/assets/46503462/52fc0655-1c1e-44b2-9b8b-b2a99030f519)



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Upload a regular Tiff to your history
  2. Follow the steps in the animated gif above.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
