### PR TITLE
add shm_size based on ShmSize 

### DIFF
--- a/lib/galaxy/tool_util/deps/requirements.py
+++ b/lib/galaxy/tool_util/deps/requirements.py
@@ -243,6 +243,7 @@ ResourceType = Literal[
     "gpu_memory_min",
     "cuda_device_count_min",
     "cuda_device_count_max",
+    "shm_size",
 ]
 VALID_RESOURCE_TYPES = get_args(ResourceType)
 
@@ -287,6 +288,7 @@ def resource_requirements_from_list(requirements: Iterable[Dict[str, Any]]) -> L
         "gpuMemoryMin": "gpu_memory_min",
         "cudaDeviceCountMin": "cuda_device_count_min",
         "cudaDeviceCountMax": "cuda_device_count_max",
+        "ShmSize": "shm_size",
     }
     rr = []
     for r in requirements:

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -7269,6 +7269,11 @@ and ``bibtex`` are the only supported options.</xs:documentation>
           <xs:documentation xml:lang="en">Maximum CUDA device count, if runtime allows it (not yet implemented in Galaxy).</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
+      <xs:enumeration value="shm_size">
+        <xs:annotation>
+          <xs:documentation xml:lang="en"><![CDATA[Size of /dev/shm. The format is `<number><unit>`. <number> must be greater than 0. Unit is optional and can be `b` (bytes), `k` (kilobytes), `m` (megabytes), or `g` (gigabytes). If you omit the unit, the default is bytes. If you omit the size entirely, the value is `64m`.]]></xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="ContainerType">

--- a/test/functional/tools/resource_requirements.xml
+++ b/test/functional/tools/resource_requirements.xml
@@ -11,6 +11,7 @@
         <resource type="gpu_memory_min">4042</resource>
         <resource type="cuda_device_count_min">1</resource>
         <resource type="cuda_device_count_max">2</resource>
+        <resource type="shm_size">67108864</resource>
     </requirements>
     <command><![CDATA[
 echo "\$GALAXY_SLOTS" > $output

--- a/test/unit/tool_util/test_parsing.py
+++ b/test/unit/tool_util/test_parsing.py
@@ -36,6 +36,7 @@ TOOL_XML_1 = """
         <resource type="gpu_memory_min">4042</resource>
         <resource type="cuda_device_count_min">1</resource>
         <resource type="cuda_device_count_max">2</resource>
+        <resource type="shm_size">67108864</resource>
     </requirements>
     <outputs>
         <data name="out1" format="bam" from_work_dir="out1.bam" />
@@ -140,6 +141,8 @@ requirements:
     cuda_device_count_min: 1
   - type: resource
     cuda_device_count_max: 2
+  - type: resource
+    shm_size: 67108864
 containers:
   - type: docker
     identifier: "awesome/bowtie"
@@ -331,6 +334,7 @@ class TestXmlLoader(BaseLoaderTestCase):
         assert resource_requirements[3].resource_type == "gpu_memory_min"
         assert resource_requirements[4].resource_type == "cuda_device_count_min"
         assert resource_requirements[5].resource_type == "cuda_device_count_max"
+        assert resource_requirements[6].resource_type == "shm_size"
         assert not resource_requirements[0].runtime_required
 
     def test_outputs(self):
@@ -506,7 +510,7 @@ class TestYamlLoader(BaseLoaderTestCase):
             "resolve_dependencies": False,
             "shell": "/bin/sh",
         }
-        assert len(resource_requirements) == 6
+        assert len(resource_requirements) == 7
         assert resource_requirements[0].to_dict() == {"resource_type": "cores_min", "value_or_expression": 1}
         assert resource_requirements[1].to_dict() == {"resource_type": "cuda_version_min", "value_or_expression": 10.2}
         assert resource_requirements[2].to_dict() == {
@@ -521,6 +525,10 @@ class TestYamlLoader(BaseLoaderTestCase):
         assert resource_requirements[5].to_dict() == {
             "resource_type": "cuda_device_count_max",
             "value_or_expression": 2,
+        }
+        assert resource_requirements[6].to_dict() == {
+            "resource_type": "shm_size",
+            "value_or_expression": "67108864",
         }
 
     def test_outputs(self):

--- a/test/unit/tool_util/test_parsing.py
+++ b/test/unit/tool_util/test_parsing.py
@@ -528,7 +528,7 @@ class TestYamlLoader(BaseLoaderTestCase):
         }
         assert resource_requirements[6].to_dict() == {
             "resource_type": "shm_size",
-            "value_or_expression": "67108864",
+            "value_or_expression": 67108864,
         }
 
     def test_outputs(self):


### PR DESCRIPTION
Added shm_size as a requirement based on CWL's ShmSize.  I added this so it could be used in the NCBI FCS GX tool, hoping to clean up the current solution.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
