### PR TITLE
Update h5ad datatype

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1565,7 +1565,7 @@ class Anndata(H5):
                 # Shape we determine here due to the non-standard representation of 'X' dimensions
                 shape = anndata_file["X"].attrs.get("shape")
                 if shape is not None:
-                    dataset.metadata.shape = tuple(shape)
+                    dataset.metadata.shape = (int(shape[0]), int(shape[1]))
                 elif hasattr(anndata_file["X"], "shape"):
                     dataset.metadata.shape = tuple(anndata_file["X"].shape)
 


### PR DESCRIPTION
A small fix to the h5ad shape metadata. Recently, found an issue setting the metadata of an anndata object as part of this PR tests: https://github.com/galaxyproject/tools-iuc/pull/5740
Surprisingly, in all these years, we did not encounter a dataset with this particular case of setting metadata.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
