### PR TITLE
[23.1] Fix ancient bug: incorrect usage of func.coalesce in User model

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -919,7 +919,7 @@ WHERE user_id = :user_id and quota_source_label = :label
         assert amount is not None
         if amount != 0:
             if quota_source_label is None:
-                self.disk_usage = func.coalesce(self.table.c.disk_usage, 0) + amount
+                self.disk_usage = (self.disk_usage or 0) + amount
             else:
                 # else would work on newer sqlite - 3.24.0
                 engine = object_session(self).bind


### PR DESCRIPTION
SQLAlchemy BinaryExpression incorrectly assigned as value to `user.disk_usage`. Should be a numeric value.

This bug was introduced [9 years ago](https://github.com/galaxyproject/galaxy/commit/4cebca81c677a6692e22006468310d0e21195251). I believe here's what happened: when this was introduced, there was one other use of `func.coalesce` related to disk size calculation ([here](https://github.com/galaxyproject/galaxy/blob/4cebca81c677a6692e22006468310d0e21195251/lib/galaxy/model/__init__.py#L1269)); however, in that other case, the expression was part of a SELECT statement - so it was sent to the database, where it invoked the database's coalesce function, which did what it should do. However, in the new expression, it was not sent to the database. This was never caught because we never checked that value *before* flushing the session somewhere else, and upon flush, the session *did* send that value to the database, where that value was evaluated by the db and was stored correctly. However, if we were to access `user.disk_usage` *after* calling `adjust_disk_usage()` but *before* flushing or committing to the database, we'd get an error, because instead of a decimal, we'd get a SQLAlchemy BinaryExpression type:
```
(Pdb) u1.total_disk_usage
<sqlalchemy.sql.elements.BinaryExpression object at 0x7f8da9b5c8e0>
(Pdb) str(u1.total_disk_usage)
'coalesce(galaxy_user.disk_usage, :coalesce_1) + :coalesce_2'
```
This is currently tested in `test_galaxy_mapping.py`. It works because before accessing this attribute, the test calls `session.expunge()`.




## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
