### PR TITLE
Add galaxy to user agent

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -138,8 +138,8 @@ from galaxy.util import (
     heartbeat,
     listify,
     StructuredExecutionTimer,
-    user_agent, # noqa: F401
 )
+from galaxy.util import user_agent  # noqa: F401
 from galaxy.util.task import IntervalTask
 from galaxy.util.tool_shed import tool_shed_registry
 from galaxy.visualization.data_providers.registry import DataProviderRegistry

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -133,13 +133,13 @@ from galaxy.tours import (
     build_tours_registry,
     ToursRegistry,
 )
+from galaxy.util import user_agent  # noqa: F401
 from galaxy.util import (
     ExecutionTimer,
     heartbeat,
     listify,
     StructuredExecutionTimer,
 )
-from galaxy.util import user_agent  # noqa: F401
 from galaxy.util.task import IntervalTask
 from galaxy.util.tool_shed import tool_shed_registry
 from galaxy.visualization.data_providers.registry import DataProviderRegistry

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -138,7 +138,7 @@ from galaxy.util import (
     heartbeat,
     listify,
     StructuredExecutionTimer,
-    user_agent,
+    user_agent, # noqa: F401
 )
 from galaxy.util.task import IntervalTask
 from galaxy.util.tool_shed import tool_shed_registry

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -17,7 +17,6 @@ from typing import (
 
 from beaker.cache import CacheManager
 from beaker.util import parse_cache_config_options
-import requests
 
 import galaxy.model
 import galaxy.model.security
@@ -139,6 +138,7 @@ from galaxy.util import (
     heartbeat,
     listify,
     StructuredExecutionTimer,
+    user_agent,
 )
 from galaxy.util.task import IntervalTask
 from galaxy.util.tool_shed import tool_shed_registry
@@ -481,12 +481,6 @@ class MinimalGalaxyApplication(BasicSharedApp, HaltableContainer, SentryClientMi
         for sig, handler in handlers.items():
             signal.signal(sig, handler)
 
-    def _configure_user_agent(self):
-        """Append 'galaxy' to the python requests http user agent string if it's not already there."""
-        original_function = requests.utils.default_user_agent
-        if not original_function().endswith(" galaxy"):
-            requests.utils.default_user_agent = lambda *args: original_function(*args) + " galaxy"
-
     def _wait_for_database(self, url):
         attempts = self.config.database_wait_attempts
         pause = self.config.database_wait_sleep
@@ -779,9 +773,6 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
         if self.heartbeat:
             handlers[signal.SIGUSR1] = self.heartbeat.dump_signal_handler
         self._configure_signal_handlers(handlers)
-
-        # Set HTTP User-Agent header string
-        self._configure_user_agent()
 
         self.database_heartbeat = DatabaseHeartbeat(application_stack=self.application_stack)
         self.database_heartbeat.add_change_callback(self.watchers.change_state)

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -26,11 +26,11 @@ from galaxy.files.uris import (
     stream_to_file,
     stream_url_to_file,
 )
+from galaxy.util import user_agent  # noqa: F401
 from galaxy.util import (
     in_directory,
     safe_makedirs,
 )
-from galaxy.util import user_agent  # noqa: F401
 from galaxy.util.bunch import Bunch
 from galaxy.util.compression_utils import CompressedFile
 from galaxy.util.hash_util import (

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -29,6 +29,7 @@ from galaxy.files.uris import (
 from galaxy.util import (
     in_directory,
     safe_makedirs,
+    user_agent,
 )
 from galaxy.util.bunch import Bunch
 from galaxy.util.compression_utils import CompressedFile

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -29,7 +29,7 @@ from galaxy.files.uris import (
 from galaxy.util import (
     in_directory,
     safe_makedirs,
-    user_agent,
+    user_agent, # noqa: F401
 )
 from galaxy.util.bunch import Bunch
 from galaxy.util.compression_utils import CompressedFile

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -29,8 +29,8 @@ from galaxy.files.uris import (
 from galaxy.util import (
     in_directory,
     safe_makedirs,
-    user_agent, # noqa: F401
 )
+from galaxy.util import user_agent  # noqa: F401
 from galaxy.util.bunch import Bunch
 from galaxy.util.compression_utils import CompressedFile
 from galaxy.util.hash_util import (

--- a/lib/galaxy/util/user_agent.py
+++ b/lib/galaxy/util/user_agent.py
@@ -2,6 +2,7 @@ import urllib
 
 import requests
 
+from galaxy.version import VERSION
 
 def __append_word_to_user_agent(word):
 
@@ -31,4 +32,4 @@ def __append_word_to_user_agent(word):
     urllib.request.build_opener = new_build_opener
 
 
-__append_word_to_user_agent("galaxy")
+__append_word_to_user_agent(f"galaxy/{VERSION}")

--- a/lib/galaxy/util/user_agent.py
+++ b/lib/galaxy/util/user_agent.py
@@ -4,6 +4,7 @@ import requests
 
 from galaxy.version import VERSION
 
+
 def __append_word_to_user_agent(word):
 
     # set requests User-Agent

--- a/lib/galaxy/util/user_agent.py
+++ b/lib/galaxy/util/user_agent.py
@@ -23,8 +23,9 @@ def __append_word_to_user_agent(word):
 
     def new_build_opener(*handlers):
         opener = old_build_opener(*handlers)
-        opener.addheaders = [ modify_user_agent_header(header)
-           for header in opener.addheaders ]
+        opener.addheaders = [
+            modify_user_agent_header(header) for header in opener.addheaders
+        ]
         return opener
 
     urllib.request.build_opener = new_build_opener

--- a/lib/galaxy/util/user_agent.py
+++ b/lib/galaxy/util/user_agent.py
@@ -25,9 +25,7 @@ def __append_word_to_user_agent(word):
 
     def new_build_opener(*handlers):
         opener = old_build_opener(*handlers)
-        opener.addheaders = [
-            modify_user_agent_header(header) for header in opener.addheaders
-        ]
+        opener.addheaders = [modify_user_agent_header(header) for header in opener.addheaders]
         return opener
 
     urllib.request.build_opener = new_build_opener

--- a/lib/galaxy/util/user_agent.py
+++ b/lib/galaxy/util/user_agent.py
@@ -1,0 +1,42 @@
+import requests
+import urllib
+
+
+def __append_word_to_user_agent(word):
+
+    # set requests User-Agent
+    old_default_user_agent = requests.utils.default_user_agent
+
+    def new_default_user_agent(*args):
+        return f"{old_default_user_agent(*args)} {word}"
+
+    requests.utils.default_user_agent = new_default_user_agent
+
+    # set urllib User-Agent
+    old_build_opener = urllib.request.build_opener
+
+    # def old_user_agent(opener):
+    #     user_agent_tuple = next((t for t in opener.addheaders
+    #         if t[0].lower() == 'user-agent'), None)
+    #     if user_agent_tuple is None:
+    #         return f"Python-urllib/{urllib.request.__version__}"
+    #     else:
+    #         return user_agent_tuple[1]
+
+    def modify_user_agent_header(header):
+        if header[0].lower() == "user-agent":
+            return (header[0], f"{header[1]} {word}")
+        return header
+
+    def new_build_opener(*handlers):
+        opener = old_build_opener(*handlers)
+        # agent = f"{old_user_agent(opener)} {word}"
+        # opener.addheaders.append(("User-Agent", agent))
+        opener.addheaders = [ modify_user_agent_header(header)
+           for header in opener.addheaders ]
+        return opener
+
+    urllib.request.build_opener = new_build_opener
+
+
+__append_word_to_user_agent("galaxy")

--- a/lib/galaxy/util/user_agent.py
+++ b/lib/galaxy/util/user_agent.py
@@ -15,14 +15,6 @@ def __append_word_to_user_agent(word):
     # set urllib User-Agent
     old_build_opener = urllib.request.build_opener
 
-    # def old_user_agent(opener):
-    #     user_agent_tuple = next((t for t in opener.addheaders
-    #         if t[0].lower() == 'user-agent'), None)
-    #     if user_agent_tuple is None:
-    #         return f"Python-urllib/{urllib.request.__version__}"
-    #     else:
-    #         return user_agent_tuple[1]
-
     def modify_user_agent_header(header):
         if header[0].lower() == "user-agent":
             return (header[0], f"{header[1]} {word}")
@@ -30,8 +22,6 @@ def __append_word_to_user_agent(word):
 
     def new_build_opener(*handlers):
         opener = old_build_opener(*handlers)
-        # agent = f"{old_user_agent(opener)} {word}"
-        # opener.addheaders.append(("User-Agent", agent))
         opener.addheaders = [ modify_user_agent_header(header)
            for header in opener.addheaders ]
         return opener

--- a/lib/galaxy/util/user_agent.py
+++ b/lib/galaxy/util/user_agent.py
@@ -1,5 +1,6 @@
-import requests
 import urllib
+
+import requests
 
 
 def __append_word_to_user_agent(word):


### PR DESCRIPTION
Hi, my name is Steve, and I'm an engineer on the Dockstore team. This PR attempts to append the string "galaxy" to the `User-Agent` header of all Galaxy HTTP requests.  For example, it modifies the "requests" package's `User-Agent` so it looks like:

```
python-requests/2.31.0 galaxy
```

Galaxy uses both the "requests" and the "urllib" packages, so it also changes urllib's `User-Agent` similarly.

This PR would allow us to differentiate Galaxy requests from other Python-based Dockstore traffic . After this change, we'd be able to better track Galaxy usage and handle its requests more appropriately. For example, it'd be more feasible for us to filter a DOS attack and not affect Galaxy traffic, or to tweak our webservice with a Galaxy-specific accommodation.

In addition to adding the word "galaxy", we could include the Galaxy version, or the host name so that different installations could be more easily differentiated.  Your call!

The `User-Agent` is modified via the new `user_agent` package, which patches the appropriate methods in both the "requests" and "urllib" packages when it is imported.  For it to work 100% correctly, it must be imported before any HTTP requests are made.  I figured it was easiest to import at all of the entry points to the code.  The main app and the data_fetch script are covered, but there may be some I've missed...

If you want me to try to cook up an automated test, please let me know.
 
## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Create an instance of Galaxy that incorporates the changes, and induce it to make HTTP requests to servers that log the `User-Agent` header and you have access to.  Check the logs and confirm that the `User-Agent` includes "galaxy".

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
