### PR TITLE
[23.2] Fix ``test_page_encoding`` and ``test_collection_explicit_and_implicit`` integration tests

### DIFF
--- a/test/integration/test_workflow_scheduling_options.py
+++ b/test/integration/test_workflow_scheduling_options.py
@@ -90,7 +90,7 @@ steps:
             inputs = {
                 "0": {"src": "hdca", "id": hdca1["id"]},
             }
-            self.workflow_populator.invoke_workflow_and_wait(history_id, workflow_id, inputs)
+            self.workflow_populator.invoke_workflow_and_wait(workflow_id, history_id, inputs)
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
             assert "a\nc\nb\nd\ne\ng\nf\nh\n" == self.dataset_populator.get_history_dataset_content(history_id, hid=0)
 


### PR DESCRIPTION
Don't assume that the history has unencoded id 1.

Broken by commit 85630e2ca90211bfaea459192a90b7070c0a024a .

Fix the following error:

```
______________ TestPageJsonEncodingIntegration.test_page_encoding ______________

self = <integration.test_page_revision_json_encoding.TestPageJsonEncodingIntegration object at 0x7fe178521190>
history_id = '529fd61ab1c6cc36'

    def test_page_encoding(self, history_id: str):
        request = dict(
            slug="mypage",
            title="MY PAGE",
            content=f"""<p>Page!<div class="embedded-item" id="History-{history_id}"></div></p>""",
        )
        page_response = self._post("pages", request, json=True)
        api_asserts.assert_status_code_is_ok(page_response)
        sa_session = self._app.model.session
        page_revision = sa_session.scalars(select(model.PageRevision).filter_by(content_format="html")).all()[0]
>       assert '''id="History-1"''' in page_revision.content, page_revision.content
E       AssertionError: <p>Page!</p><div class="embedded-item history placeholder" id="History-2"><p class="title">Embedded Galaxy History - 'test_history'</p><p class="content">[Do not edit this block; Galaxy will fill it in with the annotated History when it is displayed]</p></div><p></p>
E       assert 'id="History-1"' in '<p>Page!</p><div class="embedded-item history placeholder" id="History-2"><p class="title">Embedded Galaxy History - \'test_history\'</p><p class="content">[Do not edit this block; Galaxy will fill it in with the annotated History when it is displayed]</p></div><p></p>'
E        +  where '<p>Page!</p><div class="embedded-item history placeholder" id="History-2"><p class="title">Embedded Galaxy History - \'test_history\'</p><p class="content">[Do not edit this block; Galaxy will fill it in with the annotated History when it is displayed]</p></div><p></p>' = <galaxy.model.PageRevision(1) at 0x7fe0d74d81d0>.content

test/integration/test_page_revision_json_encoding.py:33: AssertionError
```

Fix also the ``test_collection_explicit_and_implicit`` integration test, which also started failing from the same commit but was always broken.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
