### PR TITLE
Set minimal metadata also for empty bed datasets

### DIFF
--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -509,8 +509,8 @@ class Bed(Interval):
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         """Sets the metadata information for datasets previously determined to be in bed format."""
+        i = 0
         if dataset.has_data():
-            i = 0
             for i, line in enumerate(open(dataset.get_file_name())):  # noqa: B007
                 line = line.rstrip("\r\n")
                 if line and not line.startswith("#"):
@@ -526,7 +526,7 @@ class Bed(Interval):
                             if overwrite or not dataset.metadata.element_is_set("strandCol"):
                                 dataset.metadata.strandCol = 6
                         break
-            Tabular.set_meta(self, dataset, overwrite=overwrite, skip=i)
+        Tabular.set_meta(self, dataset, overwrite=overwrite, skip=i)
 
     def as_ucsc_display_file(self, dataset: DatasetProtocol, **kwd) -> Union[FileObjType, str]:
         """Returns file contents with only the bed data. If bed 6+, treat as interval."""

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -5402,8 +5402,8 @@ This only applies to collections that are mapped over a non-collection input and
     <xs:attribute name="metadata_source" type="xs:string">
       <xs:annotation>
         <xs:documentation xml:lang="en">This copies the metadata information
-from the tool's input dataset. This is particularly useful for interval data
-types where the order of the columns is not set.</xs:documentation>
+from the tool's input dataset to serve as default for information that cannot be detected from the output.
+One prominent use case is interval data with a non-standard column order that cannot be deduced from a header line, but which is known to be identical in the input and output datasets.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="from_work_dir" type="xs:string">


### PR DESCRIPTION
Currently, set_metadata does nothing for empty bed datasets, however, for tools like `gops_intersect` that use `metadata_source="input1"` for their output, this means that `data_lines` gets inherited from the input, which subsequently shows up in the blurb of the dataset and is very confusing for users, who see that Galaxy thinks there is data there, but then they can't display it.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  using built-in tools
  1. Create an interval with the "Create single interval" tool (e.g. with default settings)
  2. Use " Select lines that match an expression" with settings that don't match the interval (e.g. change "Matching" to "NOT Matching"
  
  The result will be an empty bed that claims to have 1 region without the patch and 0 regions (correct answer) with it.
## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
