### PR TITLE
[24.0] Fix bugs relating to history keyboard navigation

### DIFF
--- a/client/src/components/History/Content/ContentItem.test.js
+++ b/client/src/components/History/Content/ContentItem.test.js
@@ -5,6 +5,8 @@ import { PiniaVuePlugin } from "pinia";
 import { getLocalVue } from "tests/jest/helpers";
 import VueRouter from "vue-router";
 
+import { mockFetcher } from "@/api/schema/__mocks__";
+
 import ContentItem from "./ContentItem";
 
 jest.mock("components/History/model/queries");
@@ -14,23 +16,31 @@ localVue.use(VueRouter);
 localVue.use(PiniaVuePlugin);
 const router = new VueRouter();
 
+jest.mock("vue-router/composables", () => ({
+    useRoute: jest.fn(() => ({})),
+    useRouter: jest.fn(() => ({})),
+}));
+
 // mock queries
 updateContentFields.mockImplementation(async () => {});
+
+const item = {
+    id: "item_id",
+    some_data: "some_data",
+    tags: ["tag1", "tag2", "tag3"],
+    deleted: false,
+    visible: true,
+};
 
 describe("ContentItem", () => {
     let wrapper;
 
     beforeEach(() => {
+        mockFetcher.path("/api/datasets/{dataset_id}").method("get").mock({ data: item });
         wrapper = mount(ContentItem, {
             propsData: {
                 expandDataset: true,
-                item: {
-                    id: "item_id",
-                    some_data: "some_data",
-                    tags: ["tag1", "tag2", "tag3"],
-                    deleted: false,
-                    visible: true,
-                },
+                item,
                 id: 1,
                 isDataset: true,
                 isHistoryItem: true,

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -4,7 +4,7 @@ import { faCheckSquare, faSquare } from "@fortawesome/free-regular-svg-icons";
 import { faArrowCircleDown, faArrowCircleUp, faCheckCircle, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BBadge, BButton, BCollapse } from "bootstrap-vue";
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import { useRoute, useRouter } from "vue-router/composables";
 
 import type { ItemUrls } from "@/components/History/Content/Dataset/index";
@@ -75,8 +75,6 @@ const emit = defineEmits<{
 }>();
 
 const entryPointStore = useEntryPointStore();
-
-const routeKey = ref(0);
 
 const jobState = computed(() => {
     return new JobStateSummary(props.item);
@@ -231,15 +229,11 @@ function onDisplay() {
         window.open(url, "_blank");
     } else {
         // vue-router 4 supports a native force push with clean URLs,
-        // but we're using a workaround with a routeKey query parameter to force a reload.
+        // but we're using a __vkey__ bit as a workaround
         // Only conditionally force to keep urls clean most of the time.
         if (route.path === itemUrls.value.display) {
-            routeKey.value++;
-            router.push({
-                path: itemUrls.value.display,
-                query: { key: `${routeKey.value}` },
-                params: { title: props.name },
-            });
+            // @ts-ignore
+            router.push(itemUrls.value.display, { title: props.name, force: true });
         } else if (itemUrls.value.display) {
             router.push({ path: itemUrls.value.display, params: { title: props.name } });
         }

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -1,3 +1,295 @@
+<script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faCheckSquare, faSquare } from "@fortawesome/free-regular-svg-icons";
+import { faArrowCircleDown, faArrowCircleUp, faCheckCircle, faSpinner } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BBadge, BButton, BCollapse } from "bootstrap-vue";
+import { computed, ref } from "vue";
+import { useRoute, useRouter } from "vue-router/composables";
+
+import type { ItemUrls } from "@/components/History/Content/Dataset/index";
+import { updateContentFields } from "@/components/History/model/queries";
+import { useEntryPointStore } from "@/stores/entryPointStore";
+import { clearDrag } from "@/utils/setDrag";
+
+import { JobStateSummary } from "./Collection/JobStateSummary";
+import { HIERARCHICAL_COLLECTION_JOB_STATES, type StateMap, STATES } from "./model/states";
+
+import CollectionDescription from "./Collection/CollectionDescription.vue";
+import ContentOptions from "./ContentOptions.vue";
+import DatasetDetails from "./Dataset/DatasetDetails.vue";
+import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
+
+library.add(faArrowCircleUp, faArrowCircleDown, faCheckCircle, faSpinner);
+
+const router = useRouter();
+const route = useRoute();
+
+interface Props {
+    id: number;
+    item: any;
+    name: string;
+    expandDataset?: boolean;
+    writable?: boolean;
+    addHighlightBtn?: boolean;
+    highlight?: string;
+    isDataset?: boolean;
+    isHistoryItem?: boolean;
+    selected?: boolean;
+    selectable?: boolean;
+    filterable?: boolean;
+    isPlaceholder?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    expandDataset: false,
+    writable: true,
+    addHighlightBtn: false,
+    highlight: undefined,
+    isDataset: true,
+    isHistoryItem: false,
+    selected: false,
+    selectable: false,
+    filterable: false,
+    isPlaceholder: false,
+});
+
+const emit = defineEmits<{
+    (e: "update:selected", selected: boolean): void;
+    (e: "update:expand-dataset", expand: boolean): void;
+    (e: "shift-select", direction: string): void;
+    (e: "init-key-selection"): void;
+    (e: "arrow-navigate", direction: string): void;
+    (e: "hide-selection"): void;
+    (e: "select-all"): void;
+    (e: "selected-to", reset: boolean): void;
+    (e: "delete", item: any, recursive: boolean): void;
+    (e: "undelete"): void;
+    (e: "unhide"): void;
+    (e: "view-collection", item: any, name: string): void;
+    (e: "drag-start", evt: DragEvent): void;
+    (e: "tag-change", item: any, newTags: Array<string>): void;
+    (e: "tag-click", tag: string): void;
+    (e: "toggleHighlights", item: any): void;
+    (e: "update:item-focused"): void;
+}>();
+
+const entryPointStore = useEntryPointStore();
+
+const routeKey = ref(0);
+
+const jobState = computed(() => {
+    return new JobStateSummary(props.item);
+});
+
+const contentId = computed(() => {
+    return `dataset-${props.item.id}`;
+});
+
+const contentCls = computed(() => {
+    const status = contentState.value && contentState.value.status;
+    if (props.selected) {
+        return "alert-info";
+    } else if (!status) {
+        return `alert-success`;
+    } else {
+        return `alert-${status}`;
+    }
+});
+
+const contentState = computed(() => {
+    return STATES[state.value] && STATES[state.value];
+});
+
+const hasTags = computed(() => {
+    return tags.value && tags.value.length > 0;
+});
+
+const hasStateIcon = computed(() => {
+    return contentState.value && contentState.value.icon;
+});
+
+const state = computed<keyof StateMap>(() => {
+    if (props.isPlaceholder) {
+        return "placeholder";
+    }
+    if (props.item.populated_state === "failed") {
+        return "failed_populated_state";
+    }
+    if (props.item.populated_state === "new") {
+        return "new_populated_state";
+    }
+    if (props.item.job_state_summary) {
+        for (const jobState of HIERARCHICAL_COLLECTION_JOB_STATES) {
+            if (props.item.job_state_summary[jobState] > 0) {
+                return jobState;
+            }
+        }
+    } else if (props.item.state) {
+        return props.item.state;
+    }
+    return "ok";
+});
+
+const dataState = computed(() => {
+    return state.value === "new_populated_state" ? "new" : state.value;
+});
+
+const tags = computed(() => {
+    return props.item.tags;
+});
+
+const tagsDisabled = computed(() => {
+    return !props.writable || !props.expandDataset || !props.isHistoryItem;
+});
+
+const isCollection = computed(() => {
+    return "collection_type" in props.item;
+});
+
+const itemUrls = computed<ItemUrls>(() => {
+    const id = props.item.id;
+    if (isCollection.value) {
+        return {
+            edit: `/collection/${id}/edit`,
+            showDetails:
+                props.item.job_source_id && props.item.job_source_type === "Job"
+                    ? `/jobs/${props.item.job_source_id}/view`
+                    : null,
+        };
+    }
+    return {
+        display: `/datasets/${id}/preview`,
+        edit: `/datasets/${id}/edit`,
+        showDetails: `/datasets/${id}/details`,
+        reportError: `/datasets/${id}/error`,
+        rerun: `/tool_runner/rerun?id=${id}`,
+        visualize: `/visualizations?dataset_id=${id}`,
+    };
+});
+
+const isBeingUsed = computed(() => {
+    return Object.values(itemUrls.value).includes(route.path) ? "being-used" : "";
+});
+
+function isCtrlKey(event: KeyboardEvent) {
+    const isMac = navigator.userAgent.indexOf("Mac") >= 0;
+    return isMac ? event.metaKey : event.ctrlKey;
+}
+
+function onKeyDown(event: KeyboardEvent) {
+    if (!(event.target as HTMLElement)?.classList?.contains("content-item")) {
+        return;
+    }
+
+    if (event.key === "Enter" || event.key === " ") {
+        onClick(event);
+    } else if ((event.key === "ArrowUp" || event.key === "ArrowDown") && event.shiftKey) {
+        event.preventDefault();
+        emit("shift-select", event.key);
+    } else if (event.key === "ArrowUp" || event.key === "ArrowDown") {
+        event.preventDefault();
+        emit("init-key-selection");
+        emit("arrow-navigate", event.key);
+    } else if (event.key === "Tab") {
+        emit("init-key-selection");
+    } else if (event.key === "Delete" && !props.selected && !props.item.deleted) {
+        event.preventDefault();
+        onDelete(event.shiftKey);
+    } else if (event.key === "Escape") {
+        event.preventDefault();
+        emit("hide-selection");
+    } else if (event.key === "a" && isCtrlKey(event)) {
+        event.preventDefault();
+        emit("select-all");
+    }
+}
+
+function onClick(event: KeyboardEvent) {
+    if (event && event.shiftKey && isCtrlKey(event)) {
+        emit("selected-to", false);
+    } else if (event && isCtrlKey(event)) {
+        emit("init-key-selection");
+        emit("update:selected", !props.selected);
+    } else if (event && event.shiftKey) {
+        emit("selected-to", true);
+    } else if (props.isPlaceholder) {
+        emit("init-key-selection");
+    } else if (props.isDataset) {
+        emit("init-key-selection");
+        emit("update:expand-dataset", !props.expandDataset);
+    } else {
+        emit("view-collection", props.item, props.name);
+    }
+}
+
+function onDisplay() {
+    const entryPointsForHda = entryPointStore.entryPointsForHda(props.item.id);
+    if (entryPointsForHda && entryPointsForHda.length > 0) {
+        // there can be more than one entry point, choose the first
+        const url = entryPointsForHda[0]?.target;
+        window.open(url, "_blank");
+    } else {
+        // vue-router 4 supports a native force push with clean URLs,
+        // but we're using a workaround with a routeKey query parameter to force a reload.
+        // Only conditionally force to keep urls clean most of the time.
+        if (route.path === itemUrls.value.display) {
+            routeKey.value++;
+            router.push({
+                path: itemUrls.value.display,
+                query: { key: `${routeKey.value}` },
+                params: { title: props.name },
+            });
+        } else if (itemUrls.value.display) {
+            router.push({ path: itemUrls.value.display, params: { title: props.name } });
+        }
+    }
+}
+
+function onDelete(recursive = false) {
+    emit("delete", props.item, recursive);
+    emit("update:selected", false);
+    emit("init-key-selection");
+}
+
+function onUndelete() {
+    emit("undelete");
+    emit("update:selected", false);
+    emit("init-key-selection");
+}
+
+function onDragStart(evt: DragEvent) {
+    emit("drag-start", evt);
+}
+
+function onDragEnd() {
+    clearDrag();
+}
+
+function onEdit() {
+    router.push(itemUrls.value.edit!);
+}
+
+function onShowCollectionInfo() {
+    router.push(itemUrls.value.showDetails!);
+}
+
+function onTags(newTags: string[]) {
+    emit("tag-change", props.item, newTags);
+    updateContentFields(props.item, { tags: newTags });
+}
+
+function onTagClick(tag: string) {
+    if (props.filterable) {
+        emit("tag-click", tag);
+    }
+}
+
+function toggleHighlights() {
+    emit("toggleHighlights", props.item);
+}
+</script>
+
 <template>
     <div
         :id="contentId"
@@ -7,24 +299,25 @@
         tabindex="0"
         role="button"
         @keydown="onKeyDown"
-        @focus="$emit('update:item-focused')">
+        @focus="emit('update:item-focused')">
+        <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/no-static-element-interactions -->
         <div class="p-1 cursor-pointer" draggable @dragstart="onDragStart" @dragend="onDragEnd" @click.stop="onClick">
             <div class="d-flex justify-content-between">
                 <span class="p-1" data-description="content item header info">
-                    <b-button v-if="selectable" class="selector p-0" @click.stop="$emit('update:selected', !selected)">
-                        <icon v-if="selected" fixed-width size="lg" :icon="['far', 'check-square']" />
-                        <icon v-else fixed-width size="lg" :icon="['far', 'square']" />
-                    </b-button>
-                    <b-button
+                    <BButton v-if="selectable" class="selector p-0" @click.stop="emit('update:selected', !selected)">
+                        <FontAwesomeIcon v-if="selected" fixed-width size="lg" :icon="faCheckSquare" />
+                        <FontAwesomeIcon v-else fixed-width size="lg" :icon="faSquare" />
+                    </BButton>
+                    <BButton
                         v-if="highlight == 'input'"
                         v-b-tooltip.hover
                         variant="link"
                         class="p-0"
                         title="Input"
                         @click.stop="toggleHighlights">
-                        <FontAwesomeIcon class="text-info" icon="arrow-circle-up" />
-                    </b-button>
-                    <b-button
+                        <FontAwesomeIcon class="text-info" :icon="faArrowCircleUp" />
+                    </BButton>
+                    <BButton
                         v-else-if="highlight == 'active'"
                         v-b-tooltip.hover
                         variant="link"
@@ -32,17 +325,17 @@
                         title="Inputs/Outputs highlighted for this item"
                         @click.stop="toggleHighlights"
                         @keypress="toggleHighlights">
-                        <FontAwesomeIcon icon="check-circle" />
-                    </b-button>
-                    <b-button
+                        <FontAwesomeIcon :icon="faCheckCircle" />
+                    </BButton>
+                    <BButton
                         v-else-if="highlight == 'output'"
                         v-b-tooltip.hover
                         variant="link"
                         class="p-0"
                         title="Output"
                         @click.stop="toggleHighlights">
-                        <FontAwesomeIcon class="text-info" icon="arrow-circle-down" />
-                    </b-button>
+                        <FontAwesomeIcon class="text-info" :icon="faArrowCircleDown" />
+                    </BButton>
                     <span v-if="hasStateIcon" class="state-icon">
                         <icon
                             fixed-width
@@ -54,9 +347,9 @@
                     <span class="content-title name font-weight-bold">{{ name }}</span>
                 </span>
                 <span v-if="item.purged" class="align-self-start btn-group p-1">
-                    <b-badge variant="secondary" title="This dataset has been permanently deleted">
+                    <BBadge variant="secondary" title="This dataset has been permanently deleted">
                         <icon icon="burn" /> Purged
-                    </b-badge>
+                    </BBadge>
                 </span>
                 <ContentOptions
                     v-if="!isPlaceholder && !item.purged"
@@ -72,7 +365,7 @@
                     @showCollectionInfo="onShowCollectionInfo"
                     @edit="onEdit"
                     @undelete="onUndelete"
-                    @unhide="$emit('unhide')" />
+                    @unhide="emit('unhide')" />
             </div>
         </div>
         <CollectionDescription
@@ -92,7 +385,7 @@
             @input="onTags"
             @tag-click="onTagClick" />
         <!-- collections are not expandable, so we only need the DatasetDetails component here -->
-        <b-collapse :visible="expandDataset" class="px-2 pb-2">
+        <BCollapse :visible="expandDataset" class="px-2 pb-2">
             <DatasetDetails
                 v-if="expandDataset && item.id"
                 :id="item.id"
@@ -101,238 +394,9 @@
                 :item-urls="itemUrls"
                 @edit="onEdit"
                 @toggleHighlights="toggleHighlights" />
-        </b-collapse>
+        </BCollapse>
     </div>
 </template>
-
-<script>
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { faArrowCircleDown, faArrowCircleUp, faCheckCircle, faSpinner } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { updateContentFields } from "components/History/model/queries";
-import StatelessTags from "components/TagsMultiselect/StatelessTags";
-import { useEntryPointStore } from "stores/entryPointStore";
-
-import { clearDrag } from "@/utils/setDrag.ts";
-
-import CollectionDescription from "./Collection/CollectionDescription";
-import { JobStateSummary } from "./Collection/JobStateSummary";
-import ContentOptions from "./ContentOptions";
-import DatasetDetails from "./Dataset/DatasetDetails";
-import { HIERARCHICAL_COLLECTION_JOB_STATES, STATES } from "./model/states";
-
-library.add(faArrowCircleUp, faArrowCircleDown, faCheckCircle, faSpinner);
-export default {
-    components: {
-        CollectionDescription,
-        ContentOptions,
-        DatasetDetails,
-        StatelessTags,
-        FontAwesomeIcon,
-    },
-    props: {
-        id: { type: Number, required: true },
-        item: { type: Object, required: true },
-        name: { type: String, required: true },
-        expandDataset: { type: Boolean, default: false },
-        writable: { type: Boolean, default: true },
-        addHighlightBtn: { type: Boolean, default: false },
-        highlight: { type: String, default: null },
-        isDataset: { type: Boolean, default: true },
-        isHistoryItem: { type: Boolean, default: false },
-        selected: { type: Boolean, default: false },
-        selectable: { type: Boolean, default: false },
-        filterable: { type: Boolean, default: false },
-        isPlaceholder: { type: Boolean, default: false },
-    },
-    computed: {
-        jobState() {
-            return new JobStateSummary(this.item);
-        },
-        contentId() {
-            return `dataset-${this.item.id}`;
-        },
-        contentCls() {
-            const status = this.contentState && this.contentState.status;
-            if (this.selected) {
-                return "alert-info";
-            } else if (!status) {
-                return `alert-success`;
-            } else {
-                return `alert-${status}`;
-            }
-        },
-        contentState() {
-            return STATES[this.state] && STATES[this.state];
-        },
-        hasTags() {
-            return this.tags && this.tags.length > 0;
-        },
-        hasStateIcon() {
-            return this.contentState && this.contentState.icon;
-        },
-        state() {
-            if (this.isPlaceholder) {
-                return "placeholder";
-            }
-            if (this.item.populated_state === "failed") {
-                return "failed_populated_state";
-            }
-            if (this.item.populated_state === "new") {
-                return "new_populated_state";
-            }
-            if (this.item.job_state_summary) {
-                for (const state of HIERARCHICAL_COLLECTION_JOB_STATES) {
-                    if (this.item.job_state_summary[state] > 0) {
-                        return state;
-                    }
-                }
-            } else if (this.item.state) {
-                return this.item.state;
-            }
-            return "ok";
-        },
-        dataState() {
-            return this.state === "new_populated_state" ? "new" : this.state;
-        },
-        tags() {
-            return this.item.tags;
-        },
-        tagsDisabled() {
-            return !this.writable || !this.expandDataset || !this.isHistoryItem;
-        },
-        isCollection() {
-            return "collection_type" in this.item;
-        },
-        /** Relative URLs for history item actions */
-        itemUrls() {
-            const id = this.item.id;
-            if (this.isCollection) {
-                return {
-                    edit: `/collection/${id}/edit`,
-                    showDetails:
-                        this.item.job_source_id && this.item.job_source_type === "Job"
-                            ? `/jobs/${this.item.job_source_id}/view`
-                            : null,
-                };
-            }
-            return {
-                display: `/datasets/${id}/preview`,
-                edit: `/datasets/${id}/edit`,
-                showDetails: `/datasets/${id}/details`,
-                reportError: `/datasets/${id}/error`,
-                rerun: `/tool_runner/rerun?id=${id}`,
-                visualize: `/visualizations?dataset_id=${id}`,
-            };
-        },
-        isBeingUsed() {
-            return Object.values(this.itemUrls).includes(this.$route.path) ? "being-used" : "";
-        },
-    },
-    methods: {
-        isCtrlKey(event) {
-            const isMac = navigator.userAgent.indexOf("Mac") >= 0;
-            return isMac ? event.metaKey : event.ctrlKey;
-        },
-        onKeyDown(event) {
-            if (!event.target.classList.contains("content-item")) {
-                return;
-            }
-
-            if (event.key === "Enter" || event.key === " ") {
-                this.onClick();
-            } else if ((event.key === "ArrowUp" || event.key === "ArrowDown") && event.shiftKey) {
-                event.preventDefault();
-                this.$emit("shift-select", event.key);
-            } else if (event.key === "ArrowUp" || event.key === "ArrowDown") {
-                event.preventDefault();
-                this.$emit("init-key-selection");
-                this.$emit("arrow-navigate", event.key);
-            } else if (event.key === "Tab") {
-                this.$emit("init-key-selection");
-            } else if (event.key === "Delete" && !this.selected && !this.item.deleted) {
-                event.preventDefault();
-                this.onDelete(event.shiftKey);
-            } else if (event.key === "Escape") {
-                event.preventDefault();
-                this.$emit("hide-selection");
-            } else if (event.key === "a" && this.isCtrlKey(event)) {
-                event.preventDefault();
-                this.$emit("select-all");
-            }
-        },
-        onClick(event) {
-            if (event && event.shiftKey && this.isCtrlKey(event)) {
-                this.$emit("selected-to", false);
-            } else if (event && this.isCtrlKey(event)) {
-                this.$emit("init-key-selection");
-                this.$emit("update:selected", !this.selected);
-            } else if (event && event.shiftKey) {
-                this.$emit("selected-to", true);
-            } else if (this.isPlaceholder) {
-                this.$emit("init-key-selection");
-            } else if (this.isDataset) {
-                this.$emit("init-key-selection");
-                this.$emit("update:expand-dataset", !this.expandDataset);
-            } else {
-                this.$emit("view-collection", this.item, this.name);
-            }
-        },
-        onDisplay() {
-            const entryPointStore = useEntryPointStore();
-            const entryPointsForHda = entryPointStore.entryPointsForHda(this.item.id);
-            if (entryPointsForHda && entryPointsForHda.length > 0) {
-                // there can be more than one entry point, choose the first
-                const url = entryPointsForHda[0].target;
-                window.open(url, "_blank");
-            } else {
-                // vue-router 4 supports a native force push with clean URLs,
-                // but we're using a workaround with a __vkey__ bit as a workaround
-                // Only conditionally force to keep urls clean most of the time.
-                if (this.$router.currentRoute.path === this.itemUrls.display) {
-                    this.$router.push(this.itemUrls.display, { title: this.name, force: true });
-                } else {
-                    this.$router.push(this.itemUrls.display, { title: this.name });
-                }
-            }
-        },
-        onDelete(recursive = false) {
-            this.$emit("delete", this.item, recursive);
-            this.$emit("update:selected", false);
-            this.$emit("init-key-selection");
-        },
-        onUndelete() {
-            this.$emit("undelete");
-            this.$emit("update:selected", false);
-            this.$emit("init-key-selection");
-        },
-        onDragStart(evt) {
-            this.$emit("drag-start", evt);
-        },
-        onDragEnd() {
-            clearDrag();
-        },
-        onEdit() {
-            this.$router.push(this.itemUrls.edit);
-        },
-        onShowCollectionInfo() {
-            this.$router.push(this.itemUrls.showDetails);
-        },
-        onTags(newTags) {
-            this.$emit("tag-change", this.item, newTags);
-            updateContentFields(this.item, { tags: newTags });
-        },
-        onTagClick(tag) {
-            if (this.filterable) {
-                this.$emit("tag-click", tag);
-            }
-        },
-        toggleHighlights() {
-            this.$emit("toggleHighlights", this.item);
-        },
-    },
-};
-</script>
 
 <style lang="scss" scoped>
 @import "~bootstrap/scss/_functions.scss";

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -66,7 +66,6 @@
                     :is-visible="item.visible"
                     :state="state"
                     :item-urls="itemUrls"
-                    :keyboard-selectable="isCollection || expandDataset"
                     @delete="onDelete"
                     @display="onDisplay"
                     @showCollectionInfo="onShowCollectionInfo"

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -229,6 +229,10 @@ export default {
         },
     },
     methods: {
+        isCtrlKey(event) {
+            const isMac = navigator.userAgent.indexOf("Mac") >= 0;
+            return isMac ? event.metaKey : event.ctrlKey;
+        },
         onKeyDown(event) {
             if (!event.target.classList.contains("content-item")) {
                 return;
@@ -248,13 +252,13 @@ export default {
             } else if (event.key === "Escape") {
                 event.preventDefault();
                 this.$emit("hide-selection");
-            } else if (event.key === "a" && event.ctrlKey) {
+            } else if (event.key === "a" && this.isCtrlKey(event)) {
                 event.preventDefault();
                 this.$emit("select-all");
             }
         },
         onClick(event) {
-            if (event && event.ctrlKey) {
+            if (event && this.isCtrlKey(event)) {
                 this.$emit("update:selected", !this.selected);
             } else if (this.isPlaceholder) {
                 return;

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -70,7 +70,7 @@
                     @display="onDisplay"
                     @showCollectionInfo="onShowCollectionInfo"
                     @edit="onEdit"
-                    @undelete="$emit('undelete')"
+                    @undelete="onUndelete"
                     @unhide="$emit('unhide')" />
             </div>
         </div>
@@ -288,6 +288,11 @@ export default {
         },
         onDelete(recursive = false) {
             this.$emit("delete", this.item, recursive);
+            this.$emit("update:selected", false);
+        },
+        onUndelete() {
+            this.$emit("undelete");
+            this.$emit("update:selected", false);
         },
         onDragStart(evt) {
             this.$emit("drag-start", evt);

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -10,6 +10,7 @@ import { useRoute, useRouter } from "vue-router/composables";
 import type { ItemUrls } from "@/components/History/Content/Dataset/index";
 import { updateContentFields } from "@/components/History/model/queries";
 import { useEntryPointStore } from "@/stores/entryPointStore";
+import { useEventStore } from "@/stores/eventStore";
 import { clearDrag } from "@/utils/setDrag";
 
 import { JobStateSummary } from "./Collection/JobStateSummary";
@@ -75,6 +76,7 @@ const emit = defineEmits<{
 }>();
 
 const entryPointStore = useEntryPointStore();
+const eventStore = useEventStore();
 
 const jobState = computed(() => {
     return new JobStateSummary(props.item);
@@ -170,9 +172,11 @@ const isBeingUsed = computed(() => {
     return Object.values(itemUrls.value).includes(route.path) ? "being-used" : "";
 });
 
-function isCtrlKey(event: KeyboardEvent) {
-    const isMac = navigator.userAgent.indexOf("Mac") >= 0;
-    return isMac ? event.metaKey : event.ctrlKey;
+/** Based on the user's keyboard platform, checks if it is the
+ * typical key for selection (ctrl for windows/linux, cmd for mac)
+ */
+function isSelectKey(event: KeyboardEvent) {
+    return eventStore.isMac ? event.metaKey : event.ctrlKey;
 }
 
 function onKeyDown(event: KeyboardEvent) {
@@ -197,16 +201,16 @@ function onKeyDown(event: KeyboardEvent) {
     } else if (event.key === "Escape") {
         event.preventDefault();
         emit("hide-selection");
-    } else if (event.key === "a" && isCtrlKey(event)) {
+    } else if (event.key === "a" && isSelectKey(event)) {
         event.preventDefault();
         emit("select-all");
     }
 }
 
 function onClick(event: KeyboardEvent) {
-    if (event && event.shiftKey && isCtrlKey(event)) {
+    if (event && event.shiftKey && isSelectKey(event)) {
         emit("selected-to", false);
-    } else if (event && isCtrlKey(event)) {
+    } else if (event && isSelectKey(event)) {
         emit("init-key-selection");
         emit("update:selected", !props.selected);
     } else if (event && event.shiftKey) {

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -6,7 +6,8 @@
         :data-state="dataState"
         tabindex="0"
         role="button"
-        @keydown="onKeyDown">
+        @keydown="onKeyDown"
+        @focus="$emit('update:item-focused')">
         <div class="p-1 cursor-pointer" draggable @dragstart="onDragStart" @dragend="onDragEnd" @click.stop="onClick">
             <div class="d-flex justify-content-between">
                 <span class="p-1" data-description="content item header info">
@@ -245,7 +246,10 @@ export default {
                 this.$emit("shift-select", event.key);
             } else if (event.key === "ArrowUp" || event.key === "ArrowDown") {
                 event.preventDefault();
+                this.$emit("init-key-selection");
                 this.$emit("arrow-navigate", event.key);
+            } else if (event.key === "Tab") {
+                this.$emit("init-key-selection");
             } else if (event.key === "Delete" && !this.selected && !this.item.deleted) {
                 event.preventDefault();
                 this.onDelete(event.shiftKey);
@@ -258,11 +262,17 @@ export default {
             }
         },
         onClick(event) {
-            if (event && this.isCtrlKey(event)) {
+            if (event && event.shiftKey && this.isCtrlKey(event)) {
+                this.$emit("selected-to", false);
+            } else if (event && this.isCtrlKey(event)) {
+                this.$emit("init-key-selection");
                 this.$emit("update:selected", !this.selected);
+            } else if (event && event.shiftKey) {
+                this.$emit("selected-to", true);
             } else if (this.isPlaceholder) {
-                return;
+                this.$emit("init-key-selection");
             } else if (this.isDataset) {
+                this.$emit("init-key-selection");
                 this.$emit("update:expand-dataset", !this.expandDataset);
             } else {
                 this.$emit("view-collection", this.item, this.name);
@@ -289,10 +299,12 @@ export default {
         onDelete(recursive = false) {
             this.$emit("delete", this.item, recursive);
             this.$emit("update:selected", false);
+            this.$emit("init-key-selection");
         },
         onUndelete() {
             this.$emit("undelete");
             this.$emit("update:selected", false);
+            this.$emit("init-key-selection");
         },
         onDragStart(evt) {
             this.$emit("drag-start", evt);

--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -12,7 +12,6 @@ const props = defineProps({
     isVisible: { type: Boolean, default: true },
     state: { type: String, default: "" },
     itemUrls: { type: Object, required: true },
-    keyboardSelectable: { type: Boolean, default: true },
 });
 
 const emit = defineEmits<{
@@ -45,8 +44,6 @@ const isCollection = computed(() => !props.isDataset);
 const canShowCollectionDetails = computed(() => props.itemUrls.showDetails);
 
 const showCollectionDetailsUrl = computed(() => prependPath(props.itemUrls.showDetails));
-
-const tabindex = computed(() => (props.keyboardSelectable ? "0" : "-1"));
 
 function onDelete($event: MouseEvent) {
     if (isCollection.value) {
@@ -94,7 +91,7 @@ function onDisplay($event: MouseEvent) {
             v-if="isDataset"
             :disabled="displayDisabled"
             :title="displayButtonTitle"
-            :tabindex="tabindex"
+            tabindex="0"
             class="display-btn px-1"
             size="sm"
             variant="link"
@@ -106,7 +103,7 @@ function onDisplay($event: MouseEvent) {
             v-if="writable && isHistoryItem"
             :disabled="editDisabled"
             :title="editButtonTitle"
-            :tabindex="tabindex"
+            tabindex="0"
             class="edit-btn px-1"
             size="sm"
             variant="link"
@@ -116,7 +113,7 @@ function onDisplay($event: MouseEvent) {
         </b-button>
         <b-button
             v-if="writable && isHistoryItem && !isDeleted"
-            :tabindex="tabindex"
+            :tabindex="isDataset ? '0' : '-1'"
             class="delete-btn px-1"
             title="Delete"
             size="sm"
@@ -139,7 +136,7 @@ function onDisplay($event: MouseEvent) {
         </b-button>
         <b-button
             v-if="writable && isHistoryItem && isDeleted"
-            :tabindex="tabindex"
+            tabindex="0"
             class="undelete-btn px-1"
             title="Undelete"
             size="sm"
@@ -149,7 +146,7 @@ function onDisplay($event: MouseEvent) {
         </b-button>
         <b-button
             v-if="writable && isHistoryItem && !isVisible"
-            :tabindex="tabindex"
+            tabindex="0"
             class="unhide-btn px-1"
             title="Unhide"
             size="sm"

--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -58,16 +58,16 @@ const showVisualizations = computed(() => {
     return !props.item.purged && ["ok", "failed_metadata", "error"].includes(props.item.state);
 });
 const reportErrorUrl = computed(() => {
-    return prependPath(props.itemUrls.reportError);
+    return prependPath(props.itemUrls.reportError!);
 });
 const showDetailsUrl = computed(() => {
-    return prependPath(props.itemUrls.showDetails);
+    return prependPath(props.itemUrls.showDetails!);
 });
 const rerunUrl = computed(() => {
-    return prependPath(props.itemUrls.rerun);
+    return prependPath(props.itemUrls.rerun!);
 });
 const visualizeUrl = computed(() => {
-    return prependPath(props.itemUrls.visualize);
+    return prependPath(props.itemUrls.visualize!);
 });
 const downloadUrl = computed(() => {
     return prependPath(`api/datasets/${props.item.id}/display?to_ext=${props.item.extension}`);
@@ -83,11 +83,11 @@ function onDownload(resource: string) {
 }
 
 function onError() {
-    router.push(props.itemUrls.reportError);
+    router.push(props.itemUrls.reportError!);
 }
 
 function onInfo() {
-    router.push(props.itemUrls.showDetails);
+    router.push(props.itemUrls.showDetails!);
 }
 
 function onRerun() {
@@ -95,7 +95,7 @@ function onRerun() {
 }
 
 function onVisualize() {
-    router.push(props.itemUrls.visualize);
+    router.push(props.itemUrls.visualize!);
 }
 
 function onHighlight() {

--- a/client/src/components/History/Content/Dataset/index.ts
+++ b/client/src/components/History/Content/Dataset/index.ts
@@ -1,6 +1,8 @@
 export type ItemUrls = {
-    rerun: string;
-    visualize: string;
-    reportError: string;
-    showDetails: string;
+    display?: string;
+    edit: string;
+    rerun?: string;
+    visualize?: string;
+    reportError?: string;
+    showDetails: string | null;
 };

--- a/client/src/components/History/Content/GenericElement.test.js
+++ b/client/src/components/History/Content/GenericElement.test.js
@@ -1,3 +1,4 @@
+import { createTestingPinia } from "@pinia/testing";
 import { mount } from "@vue/test-utils";
 import { getLocalVue } from "tests/jest/helpers";
 import VueRouter from "vue-router";
@@ -60,6 +61,7 @@ describe("GenericElement", () => {
             },
             localVue,
             router,
+            pinia: createTestingPinia(),
         });
     });
 

--- a/client/src/components/History/Content/SelectedItems.js
+++ b/client/src/components/History/Content/SelectedItems.js
@@ -36,7 +36,12 @@ export default {
         setShowSelection(val) {
             this.showSelection = val;
         },
-        selectAllInCurrentQuery(loadedItems = []) {
+        selectAllInCurrentQuery(loadedItems = [], force = true) {
+            // if we are not forcing selectAll, and all items are already selected; deselect them
+            if (!force && this.allSelected) {
+                this.setShowSelection(false);
+                return;
+            }
             this.selectItems(loadedItems);
             this.allSelected = true;
         },

--- a/client/src/components/History/Content/SelectedItems.js
+++ b/client/src/components/History/Content/SelectedItems.js
@@ -17,7 +17,7 @@ export default {
             items: new Map(),
             showSelection: false,
             allSelected: false,
-            initSelectedKey: null,
+            initSelectedItem: null,
             initDirection: null,
         };
     },
@@ -30,6 +30,9 @@ export default {
         },
         currentFilters() {
             return HistoryFilters.getFiltersForText(this.filterText);
+        },
+        initSelectedKey() {
+            return this.initSelectedItem ? this.getItemKey(this.initSelectedItem) : null;
         },
     },
     methods: {
@@ -59,10 +62,10 @@ export default {
             this.items = newSelected;
             this.breakQuerySelection();
         },
-        shiftSelect({ item, nextItem, eventKey }) {
+        shiftSelect(item, nextItem, eventKey) {
             const currentItemKey = this.getItemKey(item);
-            if (!this.initDirection) {
-                this.initSelectedKey = currentItemKey;
+            if (!this.initSelectedKey) {
+                this.initSelectedItem = item;
                 this.initDirection = eventKey;
                 this.setSelected(item, true);
             }
@@ -82,8 +85,39 @@ export default {
                 this.setSelected(nextItem, true);
             }
         },
+        selectTo(item, prevItem, allItems, reset = true) {
+            if (prevItem && item) {
+                // we are staring a new shift+click selectTo from `prevItem`
+                if (!this.initSelectedKey) {
+                    this.initSelectedItem = prevItem;
+                }
+
+                // `reset = false` in the case user is holding shift+ctrl key
+                if (reset) {
+                    // clear this.items of any other selections
+                    this.items = new Map();
+                }
+                this.setSelected(this.initSelectedItem, true);
+
+                const initItemIndex = allItems.indexOf(this.initSelectedItem);
+                const currentItemIndex = allItems.indexOf(item);
+
+                let selections = [];
+                // from allItems, get the items between the init item and the current item
+                if (initItemIndex < currentItemIndex) {
+                    this.initDirection = "ArrowDown";
+                    selections = allItems.slice(initItemIndex + 1, currentItemIndex + 1);
+                } else if (initItemIndex > currentItemIndex) {
+                    this.initDirection = "ArrowUp";
+                    selections = allItems.slice(currentItemIndex, initItemIndex);
+                }
+                this.selectItems(selections);
+            } else {
+                this.setSelected(item, true);
+            }
+        },
         initKeySelection() {
-            this.initSelectedKey = null;
+            this.initSelectedItem = null;
             this.initDirection = null;
         },
         selectItems(items = []) {
@@ -142,6 +176,7 @@ export default {
             setShowSelection: this.setShowSelection,
             selectAllInCurrentQuery: this.selectAllInCurrentQuery,
             selectItems: this.selectItems,
+            selectTo: this.selectTo,
             isSelected: this.isSelected,
             setSelected: this.setSelected,
             resetSelection: this.reset,

--- a/client/src/components/History/Content/model/states.ts
+++ b/client/src/components/History/Content/model/states.ts
@@ -12,7 +12,7 @@ interface StateRepresentation {
     nonDb?: boolean;
 }
 
-type StateMap = {
+export type StateMap = {
     [__ in State]: StateRepresentation;
 };
 

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -82,6 +82,8 @@ const contentItemRefs = computed(() => {
         return acc;
     }, {});
 });
+const currItemFocused = ref<HistoryItem | null>(null);
+const lastItemFocused = ref<HistoryItem | null>(null);
 
 const { currentFilterText, currentHistoryId } = storeToRefs(useHistoryStore());
 const { lastCheckedTime, totalMatchesCount, isWatching } = storeToRefs(useHistoryItemsStore());
@@ -149,6 +151,8 @@ watch(
         invisibleHistoryItems.value = {};
         offsetQueryParam.value = 0;
         loadHistoryItems();
+        currItemFocused.value = null;
+        lastItemFocused.value = null;
     }
 );
 
@@ -176,6 +180,8 @@ watch(
     (newValue, currentValue) => {
         if (newValue !== currentValue) {
             operationRunning.value = null;
+            currItemFocused.value = null;
+            lastItemFocused.value = null;
         }
     }
 );
@@ -192,6 +198,15 @@ watch(historyItems, (newHistoryItems) => {
         }
     }
 });
+
+watch(
+    () => currItemFocused.value,
+    (newItem, oldItem) => {
+        if (newItem) {
+            lastItemFocused.value = oldItem;
+        }
+    }
+);
 
 function getHighlight(item: HistoryItem) {
     if (unref(isLoading)) {
@@ -389,15 +404,6 @@ onMounted(async () => {
     await loadHistoryItems();
 });
 
-function nextSelections(item: HistoryItem, eventKey: string) {
-    const nextItem = arrowNavigate(item, eventKey);
-    return {
-        item,
-        nextItem,
-        eventKey,
-    };
-}
-
 function arrowNavigate(item: HistoryItem, eventKey: string) {
     let nextItem = null;
     if (eventKey === "ArrowDown") {
@@ -444,6 +450,7 @@ function setItemDragstart(
                 setShowSelection,
                 selectAllInCurrentQuery,
                 isSelected,
+                selectTo,
                 setSelected,
                 shiftSelect,
                 initKeySelection,
@@ -574,10 +581,7 @@ function setItemDragstart(
                                     :selected="isSelected(item)"
                                     :selectable="showSelection"
                                     :filterable="filterable"
-                                    @arrow-navigate="
-                                        arrowNavigate(item, $event);
-                                        initKeySelection();
-                                    "
+                                    @arrow-navigate="arrowNavigate(item, $event)"
                                     @drag-start="
                                         setItemDragstart(
                                             item,
@@ -588,12 +592,17 @@ function setItemDragstart(
                                         )
                                     "
                                     @hide-selection="setShowSelection(false)"
-                                    @shift-select="(eventKey) => shiftSelect(nextSelections(item, eventKey))"
+                                    @init-key-selection="initKeySelection"
+                                    @shift-select="
+                                        (eventKey) => shiftSelect(item, arrowNavigate(item, eventKey), eventKey)
+                                    "
                                     @select-all="selectAllInCurrentQuery(historyItems, false)"
+                                    @selected-to="(reset) => selectTo(item, lastItemFocused, historyItems, reset)"
                                     @tag-click="updateFilterValue('tag', $event)"
                                     @tag-change="onTagChange"
                                     @toggleHighlights="updateFilterValue('related', item.hid)"
                                     @update:expand-dataset="setExpanded(item, $event)"
+                                    @update:item-focused="currItemFocused = item"
                                     @update:selected="setSelected(item, $event)"
                                     @view-collection="$emit('view-collection', item, currentOffset)"
                                     @delete="onDelete"

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -361,10 +361,10 @@ async function onDrop(evt: any) {
         }
 
         if (multiple && datasetCount > 0) {
-            Toast.info(`${datasetCount} datasets copied to history`);
+            Toast.info(`${datasetCount} dataset${datasetCount > 1 ? "s" : ""} copied to new history`);
         }
         if (multiple && collectionCount > 0) {
-            Toast.info(`${collectionCount} collections copied to history`);
+            Toast.info(`${collectionCount} collection${collectionCount > 1 ? "s" : ""} copied to new history`);
         }
         historyStore.loadHistoryById(props.history.id);
     } catch (error) {

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -350,7 +350,10 @@ async function onDrop(evt: any) {
         // this was not a valid object for this dropzone, ignore
     }
 
-    if (!data || historyId === props.history.id) {
+    if (!data) {
+        return;
+    } else if (historyId === props.history.id) {
+        Toast.error("Cannot copy to the same history");
         return;
     }
 

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -589,7 +589,7 @@ function setItemDragstart(
                                     "
                                     @hide-selection="setShowSelection(false)"
                                     @shift-select="(eventKey) => shiftSelect(nextSelections(item, eventKey))"
-                                    @select-all="selectAllInCurrentQuery(historyItems)"
+                                    @select-all="selectAllInCurrentQuery(historyItems, false)"
                                     @tag-click="updateFilterValue('tag', $event)"
                                     @tag-change="onTagChange"
                                     @toggleHighlights="updateFilterValue('related', item.hid)"

--- a/client/src/stores/eventStore.ts
+++ b/client/src/stores/eventStore.ts
@@ -4,13 +4,14 @@
  */
 
 import { defineStore } from "pinia";
-import { type Ref, ref } from "vue";
+import { computed, type Ref, ref } from "vue";
 
 export type EventData = { [key: string]: unknown };
 
 export const useEventStore = defineStore("eventStore", () => {
     const dragData: Ref<EventData | null> = ref(null);
     const multipleDragData: Ref<boolean> = ref(false);
+    const isMac = computed(() => navigator.userAgent.toUpperCase().indexOf("MAC") >= 0);
 
     function clearDragData() {
         dragData.value = null;
@@ -27,6 +28,7 @@ export const useEventStore = defineStore("eventStore", () => {
     }
 
     return {
+        isMac,
         multipleDragData,
         clearDragData,
         getDragData,


### PR DESCRIPTION
Adds cross platform Ctrl/Cmd(Metakey) compatibility for features added in https://github.com/galaxyproject/galaxy/pull/17502

**Also adds a minor Shift+Click select feature (on top of the existing Shift+Arrowkey feature)**:

https://github.com/galaxyproject/galaxy/assets/78516064/b18f50ec-659f-431f-ad7b-b8d4b4fa56df

Here, the user first selects individual items using `Ctrl+Click`, and selects batches of items using `Shift+Ctrl+Click`, to be able to select batch items while maintaining prior selections.
Then, they select items using only` Shift+Click`, which restricts the selection to the initial item and the range.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Select an initial item using Ctrl/Shift + Click
  2. Then `Shift+Click` another item above or below the initial one to select the ones in the range
  3. Also, try out `Shift+Ctrl+Click` to select items in multiple batches

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
