### PR TITLE
Sniff den_fmt files where END header is on one line

### DIFF
--- a/lib/galaxy/datatypes/test/Fe.den_fmt
+++ b/lib/galaxy/datatypes/test/Fe.den_fmt
@@ -1,0 +1,12 @@
+ BEGIN header
+  
+           Real Lattice(A)               Lattice parameters(A)    Cell Angles
+     2.8335126     0.0000000     0.0000000     a =    2.833513  alpha =   90.000000
+     0.0000000     2.8335126     0.0000000     b =    2.833513  beta  =   90.000000
+     0.0000000     0.0000000     2.8335126     c =    2.833513  gamma =   90.000000
+  
+   1   F                        ! nspins, non-collinear spin
+  24    24    24                ! fine FFT grid along <a,b,c>
+ END header: data is "<a b c> charge" in units of electrons/grid_point * number of grid_points
+  
+     1     1     1          290.606525

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -1394,18 +1394,22 @@ class FormattedDensity(Text):
         >>> fname = get_test_fname('YbCuAs2.den_fmt')
         >>> FormattedDensity().sniff(fname)
         True
+        >>> fname = get_test_fname('Fe.den_fmt')
+        >>> FormattedDensity().sniff(fname)
+        True
         >>> fname = get_test_fname('Si.param')
         >>> FormattedDensity().sniff(fname)
         False
         """
         begin_header = "BEGIN header"
-        end_header = 'END header: data is "<a b c> charge" in units of electrons/grid_point * number'
-        grid_points = "of grid_points"
-        end_header_spin = 'END header: data is "<a b c> charge spin" in units of electrons/grid_point * nu'
-        grid_points_spin = "mber of grid_points"
+        end_header = 'END header: data is "<a b c> charge'
+        end_header_units = '" in units of electrons/grid_point * number of grid_points'
+        end_headers = (
+            f"{end_header}{end_header_units}".replace(" ", ""),
+            f"{end_header} spin{end_header_units}".replace(" ", ""),
+        )
         handle = file_prefix.string_io()
         lines = handle.readlines()
-        return lines[0].strip() == begin_header and (
-            (lines[9].strip() == end_header and lines[10].strip() == grid_points)
-            or (lines[9].strip() == end_header_spin and lines[10].strip() == grid_points_spin)
-        )
+        begin_line = lines[0].strip()
+        end_line = lines[9].strip() + lines[10].strip()
+        return begin_line == begin_header and end_line.replace(" ", "") in end_headers


### PR DESCRIPTION
`sniff_prefix` for the CASTEP den_fmt datatype checks for a particular phrase to appear in the file header. However, in files generated with more recent versions of CASTEP, this phrase appears on one single line whereas before it was split over two lines.

To correctly sniff all versions of the file, concat the two possible lines the phrase can be spread over and remove whitespace/newlines and compare using that.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
  - Added new test file with the "one line" `END header: ...`
- [x] This is a refactoring of components with existing test coverage.
  - Existing tests with `Si.den_fmt` and `YbCuAs2.den_fmt` should still pass
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
