### PR TITLE
Add invocation filters to history contents

### DIFF
--- a/client/src/components/History/HistoryFilters.js
+++ b/client/src/components/History/HistoryFilters.js
@@ -29,6 +29,7 @@ const validFilters = {
     genome_build: { placeholder: "database", type: String, handler: contains("genome_build"), menuItem: true },
     genome_build_eq: { handler: equals("genome_build"), menuItem: false },
     related: { placeholder: "related", type: Number, handler: equals("related"), menuItem: true },
+    invocation_id: { placeholder: "invocation id", type: String, handler: equals("invocation_id"), menuItem: true },
     object_store_id: {
         placeholder: "object store",
         type: "ObjectStore",

--- a/client/src/store/historyStore/model/utilities.js
+++ b/client/src/store/historyStore/model/utilities.js
@@ -1,7 +1,7 @@
 import { set } from "vue";
 
 /* This function merges the existing data with new incoming data. */
-export function mergeArray(id, payload, items, itemKey) {
+export function mergeArray(id, payload, items, itemKey, nonKeyedValues = {}) {
     if (!items[id]) {
         set(items, id, []);
     }
@@ -14,9 +14,19 @@ export function mergeArray(id, payload, items, itemKey) {
                 Object.keys(localItem).forEach((key) => {
                     localItem[key] = item[key];
                 });
+
+                // for each non-keyed value, create a new key in the local item
+                Object.keys(nonKeyedValues).forEach((key) => {
+                    set(localItem, key, nonKeyedValues[key]);
+                });
             }
         } else {
             set(itemArray, itemIndex, item);
+            const localItem = itemArray[itemIndex];
+            // for each non-keyed value, create a new key in the local item
+            Object.keys(nonKeyedValues).forEach((key) => {
+                set(localItem, key, nonKeyedValues[key]);
+            });
         }
     }
 }

--- a/client/src/stores/historyItemsStore.ts
+++ b/client/src/stores/historyItemsStore.ts
@@ -6,7 +6,7 @@
 
 import { reverse } from "lodash";
 import { defineStore } from "pinia";
-import { computed, ref, set } from "vue";
+import { computed, ref } from "vue";
 
 import type { HistoryItemSummary } from "@/api";
 import { HistoryFilters } from "@/components/History/HistoryFilters";
@@ -25,25 +25,17 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", () => {
     const totalMatchesCount = ref<number | undefined>(undefined);
     const lastCheckedTime = ref(new Date());
     const lastUpdateTime = ref(new Date());
-    const relatedItems = ref<Record<string, boolean>>({});
     const isWatching = ref(false);
 
     const getHistoryItems = computed(() => {
         return (historyId: string, filterText: string) => {
             const itemArray = items.value[historyId] || [];
-            const filters = HistoryFilters.getFiltersForText(filterText).filter(
-                (filter: [string, string]) => !filter[0].includes("related")
-            );
-            const relatedHid = HistoryFilters.getFilterValue(filterText, "related");
+            const filters = HistoryFilters.getFiltersForText(filterText);
             const filtered = itemArray.filter((item: HistoryItemSummary) => {
                 if (!item) {
                     return false;
                 }
                 if (!HistoryFilters.testFilters(filters, item)) {
-                    return false;
-                }
-                const relationKey = `${historyId}-${relatedHid}-${item.hid}`;
-                if (relatedHid && !relatedItems.value[relationKey]) {
                     return false;
                 }
                 return true;
@@ -63,8 +55,17 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", () => {
             const stats = (data as ExpectedReturn).stats;
             totalMatchesCount.value = stats.total_matches;
             const payload = (data as ExpectedReturn).contents;
-            const relatedHid = HistoryFilters.getFilterValue(filterText, "related");
-            saveHistoryItems(historyId, payload, relatedHid);
+
+            /** filters that are not keys in history items **/
+            const nonKeyedFilterValues: Record<string, string | null> = { related: null, invocation_id: null };
+            for (const key of Object.keys(nonKeyedFilterValues)) {
+                const filterValue = HistoryFilters.getFilterValue(filterText, key);
+                if (filterValue) {
+                    nonKeyedFilterValues[key] = filterValue;
+                }
+            }
+
+            saveHistoryItems(historyId, payload, nonKeyedFilterValues);
         } catch (e) {
             if (!(e instanceof ActionSkippedError)) {
                 throw e;
@@ -72,17 +73,13 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", () => {
         }
     }
 
-    function saveHistoryItems(historyId: string, payload: HistoryItemSummary[], relatedHid = null) {
+    function saveHistoryItems(
+        historyId: string,
+        payload: HistoryItemSummary[],
+        nonKeyedFilterValues: Record<string, string | null>
+    ) {
         // merges incoming payload into existing state
-        mergeArray(historyId, payload, items.value, itemKey.value);
-        // if related filter is included, set keys in state
-        if (relatedHid) {
-            payload.forEach((item: HistoryItemSummary) => {
-                // current `item.hid` is related to item with hid = `relatedHid`
-                const relationKey = `${historyId}-${relatedHid}-${item.hid}`;
-                set(relatedItems.value, relationKey, true);
-            });
-        }
+        mergeArray(historyId, payload, items.value, itemKey.value, nonKeyedFilterValues);
     }
 
     function setLastUpdateTime(lastUpdated = new Date()) {

--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -635,6 +635,16 @@ class HistoryContentsFilters(
         """
         return [self.decode_type_id(type_id) for type_id in type_id_list_string.split(sep)]
 
+    def create_invocation_filter(self, attr, op, val):
+
+        def _invocation_filter(model_class=None):
+            value = self.app.security.decode_id(val)
+            if op != "eq":
+                raise_filter_err(attr, op, val, "bad op in filter")
+            return model_class.invocation_id == value
+
+        return _invocation_filter
+
     def _add_parsers(self):
         super()._add_parsers()
         database_connection: str = self.app.config.database_connection
@@ -657,5 +667,6 @@ class HistoryContentsFilters(
                 "visible": {"op": ("eq"), "val": parse_bool},
                 "create_time": {"op": ("le", "ge", "lt", "gt"), "val": self.parse_date},
                 "update_time": {"op": ("le", "ge", "lt", "gt"), "val": self.parse_date},
+                "invocation_id": self.create_invocation_filter,
             }
         )

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -1605,7 +1605,7 @@ class TestHistoryContentsApiBulkOperation(ApiTestCase):
         return collection_ids
 
     def _get_history_contents(self, history_id: str, query: str = ""):
-        return self._get(f"histories/{history_id}/contents{query}").json()
+        return self.dataset_populator._get_history_contents(history_id, query)
 
     def _get_hidden_items_from_history_contents(self, history_contents) -> List[Any]:
         return [content for content in history_contents if not content["visible"]]

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3454,6 +3454,65 @@ input_c:
             )
             assert output_filtered["element_count"] == 2, output_filtered
 
+    def test_workflow_invocation_content_filter_simple_output(self):
+        with self.dataset_populator.test_history() as history_id:
+            # Add a collection so that we can check that filter really works
+            self.dataset_collection_populator.create_list_in_history(history_id)
+            # Run a workflow
+            summary = self.workflow_populator.run_workflow(
+                WORKFLOW_SIMPLE, history_id=history_id, test_data={"input1": "abcdef"}
+            )
+            all_contents = self.dataset_populator._get_history_contents(history_id, query="?v=dev&q=visible&qv=true")
+            invocation_contents = self.dataset_populator._get_history_contents(
+                history_id, query=f"?v=dev&q=visible&qv=true&q=invocation_id-eq&qv={summary.invocation_id}"
+            )
+            assert len(all_contents) == 3  # 1 HDCA 1 workflow input + 1 workflow output
+            assert len(invocation_contents) == 1  # 1 regular step output
+
+    def test_workflow_invocation_content_filter_mapped_output(self):
+        with self.dataset_populator.test_history() as history_id:
+            # Add a collection so that we can check that filter really works
+            self.dataset_collection_populator.create_list_in_history(history_id)
+            # Run a workflow
+            summary = self.workflow_populator.run_workflow(
+                WORKFLOW_WITH_MAPPED_OUTPUT_COLLECTION,
+                history_id=history_id,
+                test_data="""
+input1:
+  collection_type: list
+  name: the_dataset_list
+  elements:
+    - identifier: el1
+      value: 1.fastq
+      type: File
+""",
+            )
+            all_contents = self.dataset_populator._get_history_contents(history_id, query="?v=dev&q=visible&qv=true")
+            invocation_contents = self.dataset_populator._get_history_contents(
+                history_id, query=f"?v=dev&q=visible&qv=true&q=invocation_id-eq&qv={summary.invocation_id}"
+            )
+            self.workflow_populator.wait_for_invocation_and_jobs(history_id, summary.workflow_id, summary.invocation_id)
+            assert (
+                len(all_contents) == 3
+            )  # 3 HDCAs (unrelated collection, input dataset collection and output dataset collection)
+            assert len(invocation_contents) == 1  # 1 mapped over step output HDCA
+
+    def test_workflow_invocation_content_filter_collection_output(self):
+        with self.dataset_populator.test_history() as history_id:
+            # Add a collection so that we can check that filter really works
+            self.dataset_collection_populator.create_list_in_history(history_id)
+            # Run a workflow
+            summary = self.workflow_populator.run_workflow(WORKFLOW_WITH_OUTPUT_COLLECTION, history_id=history_id)
+            self.workflow_populator.wait_for_invocation_and_jobs(history_id, summary.workflow_id, summary.invocation_id)
+            all_contents = self.dataset_populator._get_history_contents(history_id, query="?v=dev&q=visible&qv=true")
+            invocation_contents = self.dataset_populator._get_history_contents(
+                history_id, query=f"?v=dev&q=visible&qv=true&q=invocation_id-eq&qv={summary.invocation_id}"
+            )
+            assert (
+                len(all_contents) == 4
+            )  # 4 HDCAs (unrelated collection, input dataset collection and 2 output dataset collections)
+            assert len(invocation_contents) == 2  # 2 output collection
+
     def test_workflow_request(self):
         workflow = self.workflow_populator.load_workflow(name="test_for_queue")
         workflow_request, history_id, workflow_id = self._setup_workflow_run(workflow)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -707,6 +707,9 @@ class BaseDatasetPopulator(BasePopulator):
         ]
         return active_jobs
 
+    def _get_history_contents(self, history_id: str, query: str = ""):
+        return self._get(f"histories/{history_id}/contents{query}").json()
+
     def cancel_job(self, job_id: str) -> Response:
         return self._delete(f"jobs/{job_id}")
 


### PR DESCRIPTION
This is a basic filter that should cover
https://github.com/galaxyproject/galaxy/issues/17103, but we should also add invocation step and invocation output filters.

Subworkflows and hidden datasets are still a TODO.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
