### PR TITLE
Add logrotate to the Docker image

### DIFF
--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -162,15 +162,18 @@ RUN set -xe; \
     && echo "$LANG UTF-8" > /etc/locale.gen \
     && locale-gen $LANG && update-locale LANG=$LANG \
     && curl -L https://github.com/galaxyproject/gxadmin/releases/latest/download/gxadmin > /usr/bin/gxadmin \
-    && chmod +x /usr/bin/gxadmin \
-    && apt-get autoremove -y && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/*
+    && chmod +x /usr/bin/gxadmin
 
 # Create Galaxy user, group, directory; chown
 RUN set -xe; \
       adduser --system --group --uid 101 $GALAXY_USER \
       && mkdir -p $SERVER_DIR \
       && chown $GALAXY_USER:$GALAXY_USER $ROOT_DIR -R
+
+RUN set -xe; \
+    apt-get install -y logrotate \
+    && apt-get autoremove -y && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /etc/logrotate.d/*
 
 WORKDIR $ROOT_DIR
 # Copy galaxy files to final image


### PR DESCRIPTION
Add logrotate to the Docker image build.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Build the Docker image
  2. Launch Galaxy using the new image
  3. Login to one of Galaxy pods
  4. Ensure `which logrotate` returns `/usr/sbin/logrotate` and the `/etc/logrotate.d` directory is empty.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
