### PR TITLE
[24.0] Fix ``test_oidc_login_existing_user`` test

### DIFF
--- a/test/integration/oidc/test_auth_oidc.py
+++ b/test/integration/oidc/test_auth_oidc.py
@@ -225,6 +225,8 @@ class TestGalaxyOIDCLoginIntegration(AbstractTestCases.BaseKeycloakIntegrationTe
         parsed_url = parse.urlparse(response.url)
         provider = parse.parse_qs(parsed_url.query)["connect_external_provider"][0]
         assert "keycloak" == provider
+
+        # user should not have been logged in
         response = self._get("users/current")
         assert "id" not in response.json()
 

--- a/test/integration/oidc/test_auth_oidc.py
+++ b/test/integration/oidc/test_auth_oidc.py
@@ -226,7 +226,7 @@ class TestGalaxyOIDCLoginIntegration(AbstractTestCases.BaseKeycloakIntegrationTe
         provider = parse.parse_qs(parsed_url.query)["connect_external_provider"][0]
         assert "keycloak" == provider
         response = self._get("users/current")
-        self._assert_status_code_is(response, 400)
+        assert "id" not in response.json()
 
     def test_oidc_login_account_linkup(self):
         # pre-create a user account manually


### PR DESCRIPTION
Fix the following error:

```
self = <test_auth_oidc.TestGalaxyOIDCLoginIntegration object at 0x7f00ca129150>

    def test_oidc_login_existing_user(self):
        ...
        _, response = self._login_via_keycloak("gxyuser_existing", KEYCLOAK_TEST_PASSWORD, save_cookies=True)

        # Should prompt user to associate accounts
        parsed_url = parse.urlparse(response.url)
        provider = parse.parse_qs(parsed_url.query)["connect_external_provider"][0]
        assert "keycloak" == provider
        response = self._get("users/current")
>       self._assert_status_code_is(response, 400)

test/integration/oidc/test_auth_oidc.py:229:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
lib/galaxy_test/base/api.py:199: in _assert_status_code_is
    assert_status_code_is(response, expected_status_code)
lib/galaxy_test/base/api_asserts.py:21: in assert_status_code_is
    _report_status_code_error(response, expected_status_code, failure_message)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

response = <Response [200]>, expected_status_code = 400, failure_message = None

    def _report_status_code_error(
        response: Response, expected_status_code: Union[str, int], failure_message: Optional[str]
    ):
        try:
            body = response.json()
        except Exception:
            body = f"INVALID JSON RESPONSE <{response.text}>"
        assertion_message = "Request status code (%d) was not expected value %s. Body was %s" % (response.status_code, expected_status_code, body)
        if failure_message:
            assertion_message = f"{failure_message}. {assertion_message}"
>       raise AssertionError(assertion_message)
E       AssertionError: Request status code (200) was not expected value 400. Body was {'total_disk_usage': 0.0, 'nice_total_disk_usage': '0 bytes', 'quota_percent': None}

lib/galaxy_test/base/api_asserts.py:48: AssertionError
```

This broke when commit 85630e2ca90211bfaea459192a90b7070c0a024a was merged forward because now that the failed keycloak login session still gets a history, this check

```
        if not trans.user and not trans.history:
            # Can't return info about this user, may not have a history yet.
            # return {}
            raise glx_exceptions.MessageException(err_msg="The user has no history, which should always be the case.")
```

in `_anon_user_api_value()` inside `lib/galaxy/webapps/galaxy/services/users.py` does not raise the exception any more.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
