### PR TITLE
Improve usability of Directory datatype

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -288,13 +288,14 @@
       <display file="qiime/qiime2/q2view.xml"/>
     </datatype>
     <datatype extension='qiime2.tabular' type="galaxy.datatypes.qiime2:QIIME2Metadata" display_in_upload="true"/>
-    <datatype extension="zip" type="galaxy.datatypes.binary:CompressedZipArchive" display_in_upload="true"/>
+    <datatype extension="zip" type="galaxy.datatypes.binary:CompressedZipArchive" display_in_upload="true">
+        <converter file="archive_to_directory.xml" target_datatype="directory" />
+    </datatype>
     <datatype extension="ncbi_genome_dataset.zip" type="galaxy.datatypes.binary:CompressedZipArchive" subclass="true" display_in_upload="true"/>
     <datatype extension="tar" type="galaxy.datatypes.binary:CompressedArchive" subclass="true" display_in_upload="true">
-      <converter file="tar_to_directory.xml" target_datatype="directory"/>
+      <converter file="archive_to_directory.xml" target_datatype="directory"/>
     </datatype>
-    <datatype extension="directory" type="galaxy.datatypes.data:Directory">
-    </datatype>
+    <datatype extension="directory" type="galaxy.datatypes.data:Directory"/>
     <datatype extension="yaml" type="galaxy.datatypes.text:Yaml" display_in_upload="true" />
     <!-- Proteomics Datatypes -->
     <datatype extension="mrm" type="galaxy.datatypes.tabular:Tabular" display_in_upload="true" subclass="true"/>

--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -292,7 +292,7 @@
         <converter file="archive_to_directory.xml" target_datatype="directory" />
     </datatype>
     <datatype extension="ncbi_genome_dataset.zip" type="galaxy.datatypes.binary:CompressedZipArchive" subclass="true" display_in_upload="true"/>
-    <datatype extension="tar" type="galaxy.datatypes.binary:CompressedArchive" subclass="true" display_in_upload="true">
+    <datatype extension="tar" auto_compressed_types="gz,bz2" type="galaxy.datatypes.binary:CompressedArchive" subclass="true" display_in_upload="true">
       <converter file="archive_to_directory.xml" target_datatype="directory"/>
     </datatype>
     <datatype extension="directory" type="galaxy.datatypes.data:Directory"/>

--- a/lib/galaxy/datatypes/converters/archive_to_directory.xml
+++ b/lib/galaxy/datatypes/converters/archive_to_directory.xml
@@ -23,7 +23,7 @@
         </param>
     </inputs>
     <outputs provided_metadata_file="metadata_json">
-        <data format="auto" name="output1"/>
+        <data format="directory" name="output1"/>
     </outputs>
     <tests>
         <test>

--- a/lib/galaxy/datatypes/converters/archive_to_directory.xml
+++ b/lib/galaxy/datatypes/converters/archive_to_directory.xml
@@ -4,7 +4,6 @@
         <requirement type="package" version="23.2.1">galaxy-util</requirement>
     </requirements>
     <command><![CDATA[
-        cp '$metadata_json' galaxy.json &&
         mkdir '$output1.files_path' &&
         cd '$output1.files_path' &&
         python -c "from galaxy.util.compression_utils import CompressedFile; CompressedFile('$input1').extract('.')"
@@ -23,7 +22,7 @@
             <option value="directory">directory</option>
         </param>
     </inputs>
-    <outputs>
+    <outputs provided_metadata_file="metadata_json">
         <data format="auto" name="output1"/>
     </outputs>
     <tests>

--- a/lib/galaxy/datatypes/converters/archive_to_directory.xml
+++ b/lib/galaxy/datatypes/converters/archive_to_directory.xml
@@ -4,6 +4,7 @@
         <requirement type="package" version="23.2.1">galaxy-util</requirement>
     </requirements>
     <command><![CDATA[
+        cp '$metadata_json' galaxy.json &&
         mkdir '$output1.files_path' &&
         cd '$output1.files_path' &&
         python -c "from galaxy.util.compression_utils import CompressedFile; CompressedFile('$input1').extract('.')"
@@ -22,8 +23,8 @@
             <option value="directory">directory</option>
         </param>
     </inputs>
-    <outputs provided_metadata_file="metadata_json">
-        <data format="directory" name="output1"/>
+    <outputs>
+        <data format="auto" name="output1"/>
     </outputs>
     <tests>
         <test>

--- a/lib/galaxy/datatypes/converters/archive_to_directory.xml
+++ b/lib/galaxy/datatypes/converters/archive_to_directory.xml
@@ -1,0 +1,33 @@
+<tool id="CONVERTER_archive_to_directory" name="Unpack archive to directory" version="1.0.0" profile="21.09">
+    <!-- Use compression_utils instead of shell commands (tar/unzip) so we can verify safety of results -->
+    <requirements>
+        <requirement type="package" version="23.2.1">galaxy-util</requirement>
+    </requirements>
+    <command><![CDATA[
+        mkdir '$output1.files_path' &&
+        cd '$output1.files_path' &&
+        python -c "from galaxy.util.compression_utils import CompressedFile; CompressedFile('$input1').extract('.')"
+    ]]></command>
+    <configfiles>
+        <configfile filename="metadata_json"><![CDATA[{
+    "output1": {
+        "name": "$input1.name unpacked to $__target_datatype__",
+        "ext": "$__target_datatype__"
+    }
+}]]></configfile>
+    </configfiles>
+    <inputs>
+        <param format="tar,zip" name="input1" type="data"/>
+    </inputs>
+    <outputs provided_metadata_file="metadata_json">
+        <data format="auto" name="output1"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input1" ftype="tar" value="testdir1.tar"/>
+            <output name="output1" ftype="directory" value="testdir1.tar.directory"/>
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/lib/galaxy/datatypes/converters/archive_to_directory.xml
+++ b/lib/galaxy/datatypes/converters/archive_to_directory.xml
@@ -18,6 +18,9 @@
     </configfiles>
     <inputs>
         <param format="tar,zip" name="input1" type="data"/>
+        <param name="__target_datatype__" type="select" label="Target data type">
+            <option value="directory">directory</option>
+        </param>
     </inputs>
     <outputs provided_metadata_file="metadata_json">
         <data format="auto" name="output1"/>
@@ -25,6 +28,7 @@
     <tests>
         <test>
             <param name="input1" ftype="tar" value="testdir1.tar"/>
+            <param name="__target_datatype__" value="directory"/>
             <output name="output1" ftype="directory" value="testdir1.tar.directory"/>
         </test>
     </tests>

--- a/lib/galaxy/datatypes/converters/tar_to_directory.xml
+++ b/lib/galaxy/datatypes/converters/tar_to_directory.xml
@@ -1,7 +1,7 @@
 <tool id="CONVERTER_tar_to_directory" name="Convert tar to directory" version="1.0.1" profile="17.05">
     <!-- Don't use tar directly so we can verify safety of results - tar -xzf '$input1'; -->
     <requirements>
-        <requirement type="package" version="23.1">galaxy-util</requirement>
+        <requirement type="package" version="23.2.1">galaxy-util</requirement>
     </requirements>
     <command>
         mkdir '$output1.files_path';

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -1217,31 +1217,9 @@ class Directory(Data):
     # The behavior of this class is intended to be similar to that of
     # composite types, but with arbitrary structure of extra_files.
 
-    # Directories converted from archives, and possibly others, have a single
-    # root folder inside the directory. The root_folder attribute lets tools
-    # access that folder without first exploring the directory tree themselves.
-    # Will be set to the empty string for flat directories.
-    MetadataElement(
-        name="root_folder",
-        default=None,
-        desc="Name of the root folder of the directory",
-        readonly=True,
-        optional=False,
-        visible=False,
-    )
-
-    def set_meta(self, dataset: DatasetProtocol, **kwd):
-        efp = dataset.extra_files_path
-        efp_items = os.listdir(efp)
-        root_folder_name = efp_items[0]
-        if len(efp_items) == 1 and os.path.isdir(os.path.join(efp, root_folder_name)):
-            dataset.metadata.root_folder = root_folder_name
-        else:
-            dataset.metadata.root_folder = ""
-
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = f"{dataset.metadata.root_folder}"
+            dataset.peek = f"{dataset.extra_files_path}"
             dataset.blurb = nice_size(dataset.dataset.total_size)
         else:
             dataset.peek = "file does not exist"

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -1212,12 +1212,14 @@ class Text(Data):
 class Directory(Data):
     """Class representing a directory of files."""
 
+    file_ext = "directory"
+
     # The behavior of this class is intended to be similar to that of
     # composite types, but with arbitrary structure of extra_files.
 
     # A prioritized list of files in the directory that, if present, can serve
     # as a replacement for a composite type's primary dataset.
-    recognized_index_files = []
+    recognized_index_files: List[str] = []
 
     # Directories converted from archives, and possibly others, have a single
     # root folder inside the directory. The root_folder attribute lets tools

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -1219,7 +1219,6 @@ class Directory(Data):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = f"{dataset.extra_files_path}"
             dataset.blurb = nice_size(dataset.dataset.total_size)
         else:
             dataset.peek = "file does not exist"

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -1243,26 +1243,6 @@ class Directory(Data):
         visible=False,
     )
 
-    MetadataElement(
-        name="folder_size",
-        default=0,
-        desc="Total size of the folder in bytes",
-        readonly=True,
-        optional=False,
-        visible=False,
-    )
-
-    @classmethod
-    def _get_size(cls, root_path):
-        total_size = 0
-        for dirpath, dirnames, filenames in os.walk(root_path):
-            for f in filenames:
-                fp = os.path.join(dirpath, f)
-                # skip if it is symbolic link
-                if not os.path.islink(fp):
-                    total_size += os.path.getsize(fp)
-        return total_size
-
     def set_meta(self, dataset: DatasetProtocol, **kwd):
         efp = dataset.extra_files_path
         efp_items = os.listdir(efp)
@@ -1277,12 +1257,11 @@ class Directory(Data):
                 index_file = f
                 break
         dataset.metadata.index_file = index_file
-        dataset.metadata.folder_size = self._get_size(os.path.join(efp, dataset.metadata.root_folder))
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
             dataset.peek = f"{dataset.metadata.root_folder}"
-            dataset.blurb = nice_size(dataset.metadata.folder_size)
+            dataset.blurb = nice_size(dataset.dataset.total_size)
         else:
             dataset.peek = "file does not exist"
             dataset.blurb = "file purged from disk"

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -1214,16 +1214,6 @@ class Directory(Data):
 
     file_ext = "directory"
 
-    # The behavior of this class is intended to be similar to that of
-    # composite types, but with arbitrary structure of extra_files.
-
-    def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
-        if not dataset.dataset.purged:
-            dataset.blurb = nice_size(dataset.dataset.total_size)
-        else:
-            dataset.peek = "file does not exist"
-            dataset.blurb = "file purged from disk"
-
     def _archive_main_file(
         self, archive: ZipstreamWrapper, display_name: str, data_filename: str
     ) -> Tuple[bool, str, str]:

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -1315,7 +1315,7 @@ class Directory(Data):
                     filename = root_folder
                 else:
                     # No meaningful display available, show an info message instead
-                    self._clean_and_set_mime_type(trans, "text/plain", headers) # type: ignore[arg-type]
+                    self._clean_and_set_mime_type(trans, "text/plain", headers)  # type: ignore[arg-type]
                     if root_folder is None:
                         return util.smart_str("Cannot generate preview with incomplete metadata. Resetting metadata may help.")
                     elif self.recognized_index_files:

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -465,6 +465,7 @@ class Data(metaclass=DataMeta):
         composite_extensions = trans.app.datatypes_registry.get_composite_extensions()
         composite_extensions.append("html")  # for archiving composite datatypes
         composite_extensions.append("data_manager_json")  # for downloading bundles if bundled.
+        composite_extensions.append("directory")  # for downloading directories.
 
         if data.extension in composite_extensions:
             return self._archive_composite_dataset(trans, data, headers, do_action=kwd.get("do_action", "zip"))

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -1298,17 +1298,12 @@ class Directory(Data):
         if preview:
             root_folder = dataset.metadata.root_folder
             index_file = dataset.metadata.index_file
-            if not filename or filename == 'index':
+            if not filename or filename == "index":
                 if root_folder is not None and index_file:
                     # display the index file in lieu of the empty primary dataset
                     file_path = os.path.join(dataset.extra_files_path, root_folder, index_file)
                     self._clean_and_set_mime_type(trans, "text/plain", headers)  # type: ignore[arg-type]
-                    return self._yield_user_file_content(
-                        trans,
-                        dataset,
-                        file_path,
-                        headers
-                    ), headers
+                    return self._yield_user_file_content(trans, dataset, file_path, headers), headers
                 elif root_folder:
                     # delegate to the parent method, which knows how to display
                     # a directory
@@ -1317,9 +1312,13 @@ class Directory(Data):
                     # No meaningful display available, show an info message instead
                     self._clean_and_set_mime_type(trans, "text/plain", headers)  # type: ignore[arg-type]
                     if root_folder is None:
-                        return util.smart_str("Cannot generate preview with incomplete metadata. Resetting metadata may help.")
+                        return util.smart_str(
+                            "Cannot generate preview with incomplete metadata. Resetting metadata may help."
+                        )
                     elif self.recognized_index_files:
-                        return util.smart_str("None of the known key files for the datatype present. Is the datatype format set correctly?")
+                        return util.smart_str(
+                            "None of the known key files for the datatype present. Is the datatype format set correctly?"
+                        )
                     else:
                         return util.smart_str("No preview available for this dataset."), headers
 

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -1,5 +1,6 @@
 import json
 import os
+import tempfile
 import urllib.parse
 from base64 import b64encode
 from typing import cast
@@ -10,6 +11,7 @@ from tusclient import client
 from galaxy.tool_util.verify.test_data import TestDataResolver
 from galaxy.util import UNKNOWN
 from galaxy.util.compression_utils import decompress_bytes_to_directory
+from galaxy.util.hash_util import md5_hash_file
 from galaxy.util.unittest_utils import (
     skip_if_github_down,
     skip_if_site_down,
@@ -30,6 +32,14 @@ from ._framework import ApiTestCase
 
 B64_FOR_1_2_3 = b64encode(b"1 2 3").decode("utf-8")
 URI_FOR_1_2_3 = f"base64://{B64_FOR_1_2_3}"
+
+EXPECTED_TAR_CONTENTS = {
+    "testdir": "Directory",
+    "testdir/c": "Directory",
+    "testdir/a": "File",
+    "testdir/b": "File",
+    "testdir/c/d": "File",
+}
 
 
 class TestToolsUpload(ApiTestCase):
@@ -606,18 +616,11 @@ class TestToolsUpload(ApiTestCase):
         assert content.strip() == "Test123"
         extra_files = self.dataset_populator.get_history_dataset_extra_files(history_id, dataset_id=dataset["id"])
         assert len(extra_files) == 5, extra_files
-        expected_contents = {
-            "testdir": "Directory",
-            "testdir/c": "Directory",
-            "testdir/a": "File",
-            "testdir/b": "File",
-            "testdir/c/d": "File",
-        }
         found_files = set()
         for extra_file in extra_files:
             path = extra_file["path"]
-            assert path in expected_contents
-            assert extra_file["class"] == expected_contents[path]
+            assert path in EXPECTED_TAR_CONTENTS
+            assert extra_file["class"] == EXPECTED_TAR_CONTENTS[path]
             found_files.add(path)
 
         assert len(found_files) == 5, found_files
@@ -641,43 +644,73 @@ class TestToolsUpload(ApiTestCase):
             details = self.dataset_populator.get_history_dataset_details(history_id, dataset=dataset, assert_ok=False)
             assert details["state"] == "error"
 
-    def test_upload_zip_directory_roundtrip(self, history_id):
-        testdir = TestDataResolver().get_filename("testdir1.zip")
+    def test_upload_tar_roundtrip(self, history_id):
+        testdir = TestDataResolver().get_filename("testdir.tar")
+        expected_size = os.path.getsize(testdir)
         with open(testdir, "rb") as fh:
-            details = self._upload_and_get_details(fh, api="fetch", history_id=history_id, ext="zip", assert_ok=True)
-        assert details["file_ext"] == "zip"
-
-        # Convert/unpack zip to directory.
-        payload = {
-            "src": "hda",
-            "id": details["id"],
-            "source_type": "zip",
-            "target_type": "directory",
-            "history_id": history_id,
-        }
-        create_response = self._post("tools/CONVERTER_archive_to_directory/convert", data=payload)
-        self.dataset_populator.wait_for_job(create_response.json()["jobs"][0]["id"], assert_ok=True)
-        create_response.raise_for_status()
-        directory_dataset = create_response.json()["outputs"][0]
-
-        # Download (compressed) directory and verify structure.
-        content = self.dataset_populator.get_history_dataset_content(
-            history_id, dataset=directory_dataset, to_ext="directory", type="bytes"
+            details = self._upload_and_get_details(fh, api="fetch", history_id=history_id, assert_ok=True)
+        assert details["file_ext"] == "tar"
+        assert details["file_size"] == expected_size
+        content = cast(
+            bytes, self.dataset_populator.get_history_dataset_content(history_id, dataset=details, type="bytes")
         )
-        dir_path = decompress_bytes_to_directory(cast(bytes, content))
-        expected_directory_structure = {
+        # Make sure we got the expected content size.
+        assert len(content) == expected_size
+
+        # Make sure we get the expected contents.
+        dir_path = decompress_bytes_to_directory(content)
+        assert dir_path.endswith("testdir")
+        for path, entry_class in EXPECTED_TAR_CONTENTS.items():
+            path = os.path.join(dir_path, os.path.pardir, path)
+            if entry_class == "Directory":
+                assert os.path.isdir(path)
+            else:
+                assert os.path.isfile(path)
+
+        # Make sure the hash of the content matches the hash of the original file.
+        expected_hash = md5_hash_file(testdir)
+        assert expected_hash is not None
+        self._assert_content_matches_hash(content, expected_hash)
+
+    def _assert_content_matches_hash(self, content: bytes, expected_hash: str):
+        with tempfile.NamedTemporaryFile("wb") as temp:
+            temp.write(content)
+            actual_hash = md5_hash_file(temp.name)
+            assert actual_hash == expected_hash
+
+    def test_upload_zip_roundtrip(self, history_id):
+        testdir = TestDataResolver().get_filename("testdir1.zip")
+        expected_size = os.path.getsize(testdir)
+        with open(testdir, "rb") as fh:
+            details = self._upload_and_get_details(fh, api="fetch", history_id=history_id, assert_ok=True)
+        assert details["file_ext"] == "zip"
+        assert details["file_size"] == expected_size
+        content = cast(
+            bytes, self.dataset_populator.get_history_dataset_content(history_id, dataset=details, type="bytes")
+        )
+        # Make sure we got the expected content size.
+        assert len(content) == expected_size
+
+        # Make sure we get the expected contents.
+        dir_path = decompress_bytes_to_directory(content)
+        assert dir_path.endswith("testdir1")
+        EXPECTED_ZIP_CONTENTS = {
             "file1": "File",
             "file2": "File",
-            "dir1": "Directory",
+            "dir1/": "Directory",
             "dir1/file3": "File",
         }
-        assert dir_path.endswith("testdir1")
-        for path, entry_class in expected_directory_structure.items():
+        for path, entry_class in EXPECTED_ZIP_CONTENTS.items():
             path = os.path.join(dir_path, path)
             if entry_class == "Directory":
                 assert os.path.isdir(path)
             else:
                 assert os.path.isfile(path)
+
+        # Make sure the hash of the content matches the hash of the original file.
+        expected_hash = md5_hash_file(testdir)
+        assert expected_hash is not None
+        self._assert_content_matches_hash(content, expected_hash)
 
     def test_upload_dbkey(self):
         with self.dataset_populator.test_history() as history_id:

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -675,6 +675,7 @@ class TestToolsUpload(ApiTestCase):
     def _assert_content_matches_hash(self, content: bytes, expected_hash: str):
         with tempfile.NamedTemporaryFile("wb") as temp:
             temp.write(content)
+            temp.flush()
             actual_hash = md5_hash_file(temp.name)
             assert actual_hash == expected_hash
 


### PR DESCRIPTION
<del>This adds functionality to the Directory datatype class, which can now be displayed and downloaded as an archive.</del>
It also adds a new `archive_to_directory` converter that generalizes the existing tar_to_directory one to work with tar and zip archives. Also updates the older converter's requirement to an existing version of the galaxy-util package. Previously the exact requirement wasn't installable via conda.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. upload an archive as either zip or tar
  2. convert the datatype to directory
  3. explore

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
