### PR TITLE
[23.2] Fix switch to history in invocations list

### DIFF
--- a/client/src/components/History/SwitchToHistoryLink.test.ts
+++ b/client/src/components/History/SwitchToHistoryLink.test.ts
@@ -1,0 +1,100 @@
+import { createTestingPinia } from "@pinia/testing";
+import { getLocalVue } from "@tests/jest/helpers";
+import { shallowMount } from "@vue/test-utils";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+import flushPromises from "flush-promises";
+
+import { type HistorySummary } from "@/api";
+
+import SwitchToHistoryLink from "./SwitchToHistoryLink.vue";
+
+const localVue = getLocalVue(true);
+
+const selectors = {
+    historyLink: ".history-link",
+} as const;
+
+function mountSwitchToHistoryLinkForHistory(history: HistorySummary) {
+    const pinia = createTestingPinia();
+
+    const axiosMock = new MockAdapter(axios);
+    axiosMock.onGet(`/api/histories/${history.id}`).reply(200, history);
+
+    const wrapper = shallowMount(SwitchToHistoryLink as object, {
+        propsData: {
+            historyId: history.id,
+        },
+        localVue,
+        pinia,
+        stubs: {
+            FontAwesomeIcon: true,
+        },
+    });
+    return wrapper;
+}
+
+async function expectOptionForHistory(option: string, history: HistorySummary) {
+    const wrapper = mountSwitchToHistoryLinkForHistory(history);
+
+    // Wait for the history to be loaded
+    await flushPromises();
+
+    expect(wrapper.html()).toContain(option);
+    expect(wrapper.text()).toContain(history.name);
+}
+
+describe("SwitchToHistoryLink", () => {
+    it("loads the history information from the store", async () => {
+        const history = {
+            id: "history-id-to-load",
+            name: "History Name",
+            deleted: false,
+            archived: false,
+            purged: false,
+        } as HistorySummary;
+        const wrapper = mountSwitchToHistoryLinkForHistory(history);
+
+        expect(wrapper.find(selectors.historyLink).exists()).toBe(false);
+        expect(wrapper.html()).toContain("Loading");
+
+        // Wait for the history to be loaded
+        await flushPromises();
+
+        expect(wrapper.find(selectors.historyLink).exists()).toBe(true);
+        expect(wrapper.text()).toContain(history.name);
+    });
+
+    it("should display the Switch option when the history can be switched to", async () => {
+        const history = {
+            id: "active-history-id",
+            name: "History Active",
+            deleted: false,
+            purged: false,
+            archived: false,
+        } as HistorySummary;
+        await expectOptionForHistory("Switch", history);
+    });
+
+    it("should display the View option when the history is purged", async () => {
+        const history = {
+            id: "purged-history-id",
+            name: "History Purged",
+            deleted: false,
+            purged: true,
+            archived: false,
+        } as HistorySummary;
+        await expectOptionForHistory("View", history);
+    });
+
+    it("should display the View option when the history is archived", async () => {
+        const history = {
+            id: "archived-history-id",
+            name: "History Archived",
+            deleted: false,
+            purged: false,
+            archived: true,
+        } as HistorySummary;
+        await expectOptionForHistory("View", history);
+    });
+});

--- a/client/src/components/History/SwitchToHistoryLink.vue
+++ b/client/src/components/History/SwitchToHistoryLink.vue
@@ -23,7 +23,9 @@ interface Props {
 const props = defineProps<Props>();
 
 const history = computed(() => historyStore.getHistoryById(props.historyId));
+
 const canSwitch = computed(() => !!history.value && !history.value.archived && !history.value.purged);
+
 const actionText = computed(() => (canSwitch.value ? "Switch to" : "View in new tab"));
 
 function onClick(history: HistorySummary) {
@@ -46,12 +48,22 @@ function viewHistoryInNewTab(history: HistorySummary) {
 <template>
     <div>
         <LoadingSpan v-if="!history" />
-        <div v-else v-b-tooltip.hover.top.html :title="`<b>${actionText}</b><br>${history.name}`" class="truncate">
-            <FontAwesomeIcon v-if="history.purged" :icon="faBurn" title="This history has been purged" />
-            <FontAwesomeIcon v-if="history.archived" :icon="faArchive" title="This history has been archived" />
-            <BLink class="history-link" href="#" @click.stop="onClick(history)">
+        <div v-else v-b-tooltip.hover.top.html :title="`<b>${actionText}</b><br>${history.name}`" class="history-link">
+            <BLink class="truncate" href="#" @click.stop="onClick(history)">
                 {{ history.name }}
             </BLink>
+
+            <FontAwesomeIcon v-if="history.purged" :icon="faBurn" fixed-width />
+            <FontAwesomeIcon v-else-if="history.archived" :icon="faArchive" fixed-width />
         </div>
     </div>
 </template>
+
+<style scoped>
+.history-link {
+    display: flex;
+    gap: 1px;
+    align-items: center;
+    justify-content: space-between;
+}
+</style>

--- a/client/src/components/History/SwitchToHistoryLink.vue
+++ b/client/src/components/History/SwitchToHistoryLink.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { BLink } from "bootstrap-vue";
+import { computed } from "vue";
+import { useRouter } from "vue-router/composables";
+
+import { HistorySummary } from "@/api";
+import { useHistoryStore } from "@/stores/historyStore";
+
+import LoadingSpan from "@/components/LoadingSpan.vue";
+
+const router = useRouter();
+const historyStore = useHistoryStore();
+
+interface Props {
+    historyId: string;
+}
+
+const props = defineProps<Props>();
+
+const history = computed(() => historyStore.getHistoryById(props.historyId));
+const canSwitch = computed(() => !!history.value && !history.value.archived && !history.value.purged);
+const actionText = computed(() => (canSwitch.value ? "Switch to" : "View in new tab"));
+
+function onClick(history: HistorySummary) {
+    console.log("onClick", history);
+    if (canSwitch.value) {
+        console.log("setCurrentHistory", history.id);
+        historyStore.setCurrentHistory(history.id);
+        return;
+    }
+    console.log("viewHistoryInNewTab", history);
+    viewHistoryInNewTab(history);
+}
+
+function viewHistoryInNewTab(history: HistorySummary) {
+    const routeData = router.resolve(`/histories/view?id=${history.id}`);
+    window.open(routeData.href, "_blank");
+}
+</script>
+
+<template>
+    <div>
+        <LoadingSpan v-if="!history" />
+        <div v-else v-b-tooltip.hover.top.html :title="`<b>${actionText}</b><br>${history.name}`" class="truncate">
+            <BLink class="history-link" href="#" @click.stop="onClick(history)">
+                {{ history.name }}
+            </BLink>
+        </div>
+    </div>
+</template>

--- a/client/src/components/History/SwitchToHistoryLink.vue
+++ b/client/src/components/History/SwitchToHistoryLink.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faArchive, faBurn } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BLink } from "bootstrap-vue";
 import { computed } from "vue";
 import { useRouter } from "vue-router/composables";
@@ -7,6 +10,8 @@ import { HistorySummary } from "@/api";
 import { useHistoryStore } from "@/stores/historyStore";
 
 import LoadingSpan from "@/components/LoadingSpan.vue";
+
+library.add(faArchive, faBurn);
 
 const router = useRouter();
 const historyStore = useHistoryStore();
@@ -42,6 +47,8 @@ function viewHistoryInNewTab(history: HistorySummary) {
     <div>
         <LoadingSpan v-if="!history" />
         <div v-else v-b-tooltip.hover.top.html :title="`<b>${actionText}</b><br>${history.name}`" class="truncate">
+            <FontAwesomeIcon v-if="history.purged" :icon="faBurn" title="This history has been purged" />
+            <FontAwesomeIcon v-if="history.archived" :icon="faArchive" title="This history has been archived" />
             <BLink class="history-link" href="#" @click.stop="onClick(history)">
                 {{ history.name }}
             </BLink>

--- a/client/src/components/Workflow/InvocationsList.test.js
+++ b/client/src/components/Workflow/InvocationsList.test.js
@@ -173,7 +173,7 @@ describe("InvocationsList.vue", () => {
             const row = rows[0];
             const columns = row.findAll("td");
             expect(columns.at(1).text()).toBe("workflow name");
-            expect(columns.at(2).text()).toBe("history name");
+            expect(columns.at(2).text()).toBe("Loading..."); // Checking the actual name will be tested in its own component
             expect(columns.at(3).text()).toBe(
                 formatDistanceToNow(parseISO(`${mockInvocationData.create_time}Z`), { addSuffix: true })
             );
@@ -190,13 +190,6 @@ describe("InvocationsList.vue", () => {
             await wrapper.find(".toggle-invocation-details").trigger("click");
             rows = wrapper.findAll("tbody > tr").wrappers;
             expect(rows.length).toBe(1);
-        });
-
-        it("calls switchHistory", async () => {
-            const mockMethod = jest.fn();
-            wrapper.vm.switchHistory = mockMethod;
-            await wrapper.find("#switch-to-history").trigger("click");
-            expect(mockMethod).toHaveBeenCalled();
         });
 
         it("calls executeWorkflow", async () => {

--- a/client/src/components/Workflow/InvocationsList.vue
+++ b/client/src/components/Workflow/InvocationsList.vue
@@ -55,14 +55,7 @@
                 </div>
             </template>
             <template v-slot:cell(history_id)="data">
-                <div
-                    v-b-tooltip.hover.top.html
-                    :title="`<b>Switch to</b><br>${getHistoryNameById(data.item.history_id)}`"
-                    class="truncate">
-                    <b-link id="switch-to-history" href="#" @click.stop="switchHistory(data.item.history_id)">
-                        {{ getHistoryNameById(data.item.history_id) }}
-                    </b-link>
-                </div>
+                <SwitchToHistoryLink :history-id="data.value" />
             </template>
             <template v-slot:cell(create_time)="data">
                 <UtcDate :date="data.value" mode="elapsed" />
@@ -86,7 +79,6 @@
 </template>
 
 <script>
-import { getGalaxyInstance } from "app";
 import { invocationsProvider } from "components/providers/InvocationsProvider";
 import UtcDate from "components/UtcDate";
 import WorkflowInvocationState from "components/WorkflowInvocationState/WorkflowInvocationState";
@@ -98,12 +90,14 @@ import { useWorkflowStore } from "@/stores/workflowStore";
 import paginationMixin from "./paginationMixin";
 
 import WorkflowRunButton from "./WorkflowRunButton.vue";
+import SwitchToHistoryLink from "@/components/History/SwitchToHistoryLink.vue";
 
 export default {
     components: {
         UtcDate,
         WorkflowInvocationState,
         WorkflowRunButton,
+        SwitchToHistoryLink,
     },
     mixins: [paginationMixin],
     props: {
@@ -214,10 +208,6 @@ export default {
         },
         swapRowDetails(row) {
             row.toggleDetails();
-        },
-        switchHistory(historyId) {
-            const Galaxy = getGalaxyInstance();
-            Galaxy.currHistoryPanel.switchToHistory(historyId);
         },
     },
 };


### PR DESCRIPTION
Fixes #17604

When the associated history has been purged or archived, instead of trying to set it as the current it will open a new tab with the history view.

Includes icons to clarify the history status and manage expectations before switching or displaying it.

![FixInvocationHistoryLink](https://github.com/galaxyproject/galaxy/assets/46503462/63687b24-628a-49ee-9a1b-5aed65762d85)


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
