### PR TITLE
[24.0] Increase ContentItem clickable area

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -184,6 +184,7 @@ function onKeyDown(event: KeyboardEvent) {
     }
 
     if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
         onClick(event);
     } else if ((event.key === "ArrowUp" || event.key === "ArrowDown") && event.shiftKey) {
         event.preventDefault();
@@ -206,7 +207,8 @@ function onKeyDown(event: KeyboardEvent) {
     }
 }
 
-function onClick(event: KeyboardEvent) {
+function onClick(e: Event) {
+    const event = e as KeyboardEvent;
     if (event && event.shiftKey && isSelectKey(event)) {
         emit("selected-to", false);
     } else if (event && isSelectKey(event)) {
@@ -284,6 +286,12 @@ function onTagClick(tag: string) {
 
 function toggleHighlights() {
     emit("toggleHighlights", props.item);
+}
+
+function unexpandedClick(event: Event) {
+    if (!props.expandDataset) {
+        onClick(event);
+    }
 }
 </script>
 
@@ -364,22 +372,26 @@ function toggleHighlights() {
                     @unhide="emit('unhide')" />
             </div>
         </div>
-        <CollectionDescription
-            v-if="!isDataset"
-            class="px-2 pb-2"
-            :job-state-summary="jobState"
-            :collection-type="item.collection_type"
-            :element-count="item.element_count"
-            :elements-datatypes="item.elements_datatypes" />
-        <StatelessTags
-            v-if="!tagsDisabled || hasTags"
-            class="px-2 pb-2"
-            :value="tags"
-            :disabled="tagsDisabled"
-            :clickable="filterable"
-            :use-toggle-link="false"
-            @input="onTags"
-            @tag-click="onTagClick" />
+        <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/no-static-element-interactions -->
+        <span @click.stop="unexpandedClick">
+            <CollectionDescription
+                v-if="!isDataset"
+                class="px-2 pb-2 cursor-pointer"
+                :job-state-summary="jobState"
+                :collection-type="item.collection_type"
+                :element-count="item.element_count"
+                :elements-datatypes="item.elements_datatypes" />
+            <StatelessTags
+                v-if="!tagsDisabled || hasTags"
+                class="px-2 pb-2"
+                :class="{ 'cursor-pointer': !expandDataset }"
+                :value="tags"
+                :disabled="tagsDisabled"
+                :clickable="filterable"
+                :use-toggle-link="false"
+                @input="onTags"
+                @tag-click="onTagClick" />
+        </span>
         <!-- collections are not expandable, so we only need the DatasetDetails component here -->
         <BCollapse :visible="expandDataset" class="px-2 pb-2">
             <DatasetDetails

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -72,7 +72,6 @@ const emit = defineEmits<{
     (e: "tag-change", item: any, newTags: Array<string>): void;
     (e: "tag-click", tag: string): void;
     (e: "toggleHighlights", item: any): void;
-    (e: "update:item-focused"): void;
 }>();
 
 const entryPointStore = useEntryPointStore();
@@ -296,8 +295,7 @@ function toggleHighlights() {
         :data-state="dataState"
         tabindex="0"
         role="button"
-        @keydown="onKeyDown"
-        @focus="emit('update:item-focused')">
+        @keydown="onKeyDown">
         <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/no-static-element-interactions -->
         <div class="p-1 cursor-pointer" draggable @dragstart="onDragStart" @dragend="onDragEnd" @click.stop="onClick">
             <div class="d-flex justify-content-between">

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { BAlert } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
-import { computed, onMounted, ref, set as VueSet, unref, watch } from "vue";
+import { computed, onMounted, type Ref, ref, set as VueSet, unref, watch } from "vue";
 
 import type { HistorySummary } from "@/api";
 import { copyDataset } from "@/api/datasets";
@@ -55,6 +55,8 @@ interface Props {
     isMultiViewItem?: boolean;
 }
 
+type ContentItemRef = Record<string, Ref<InstanceType<typeof ContentItem> | null>>;
+
 const props = withDefaults(defineProps<Props>(), {
     listOffset: 0,
     filter: "",
@@ -77,9 +79,8 @@ const operationError = ref(null);
 const querySelectionBreak = ref(false);
 const dragTarget = ref<EventTarget | null>(null);
 const contentItemRefs = computed(() => {
-    return historyItems.value.reduce((acc: any, item) => {
-        // TODO: type `any` properly
-        acc[`item-${item.hid}`] = ref(null);
+    return historyItems.value.reduce((acc: ContentItemRef, item) => {
+        acc[`item-${item.id}`] = ref(null);
         return acc;
     }, {});
 });
@@ -410,6 +411,12 @@ onMounted(async () => {
         filterText.value = storeFilterText.value;
     }
     await loadHistoryItems();
+    // if there is a listOffset, we are coming from a collection view, so focus on item at that offset
+    if (props.listOffset) {
+        const itemId = historyItems.value[props.listOffset]?.id;
+        const itemElement = contentItemRefs.value[`item-${itemId}`]?.value?.$el as HTMLElement;
+        itemElement?.focus();
+    }
 });
 
 function arrowNavigate(item: HistoryItem, eventKey: string) {
@@ -420,7 +427,8 @@ function arrowNavigate(item: HistoryItem, eventKey: string) {
         nextItem = historyItems.value[historyItems.value.indexOf(item) - 1];
     }
     if (nextItem) {
-        contentItemRefs.value[`item-${nextItem.hid}`].value.$el.focus();
+        const itemElement = contentItemRefs.value[`item-${nextItem.id}`]?.value?.$el as HTMLElement;
+        itemElement?.focus();
     }
     return nextItem;
 }
@@ -578,7 +586,7 @@ function setItemDragstart(
                             <template v-slot:item="{ item, currentOffset }">
                                 <ContentItem
                                     :id="item.hid"
-                                    :ref="contentItemRefs[`item-${item.hid}`]"
+                                    :ref="contentItemRefs[`item-${item.id}`]"
                                     is-history-item
                                     :item="item"
                                     :name="item.name"


### PR DESCRIPTION
Fixes #17620 
| Before | After |
| ------ | ----- |
| <video src="https://github.com/galaxyproject/galaxy/assets/78516064/6fe739ea-3b61-4013-9aa8-3a000a29cf6b" /> | <video src="https://github.com/galaxyproject/galaxy/assets/78516064/12f9dd3d-d468-4835-bd91-1d992555aff6" /> |

Also adds a minor enhancement where if you might have entered a collection view by clicking or keyboard, when you return to the panel, the collection is focused so that you can continue navigating the history with the arrow keys etc.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
