### PR TITLE
[24.0] do not link to invocations for workflow that has never run

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -7,11 +7,11 @@ import {
     faExchangeAlt,
     faFileArchive,
     faFileExport,
+    faList,
     faLock,
     faPlay,
     faPlus,
     faShareAlt,
-    faSitemap,
     faStream,
     faTrash,
     faUserLock,
@@ -50,7 +50,7 @@ library.add(
     faPlay,
     faPlus,
     faShareAlt,
-    faSitemap,
+    faList,
     faStream,
     faTrash,
     faUserLock
@@ -204,7 +204,7 @@ function userTitle(title: string) {
                         :disabled="isAnonymous"
                         :title="userTitle('Display Workflow Invocations')"
                         @click="$router.push(`/histories/${history.id}/invocations`)">
-                        <FontAwesomeIcon fixed-width :icon="faSitemap" class="fa-rotate-270 mr-1" />
+                        <FontAwesomeIcon fixed-width :icon="faList" class="mr-1" />
                         <span v-localize>Show Invocations</span>
                     </BDropdownItem>
 

--- a/client/src/components/Workflow/WorkflowInvocationsCount.vue
+++ b/client/src/components/Workflow/WorkflowInvocationsCount.vue
@@ -33,22 +33,24 @@ onMounted(initCounts);
 
 <template>
     <div class="workflow-invocations-count d-flex align-items-center flex-gapx-1">
+        <BBadge v-if="count != undefined && count === 0" pill class="list-view">
+            <FontAwesomeIcon :icon="faClock" fixed-width />
+            <span>never run</span>
+        </BBadge>
         <BBadge
-            v-if="count != undefined"
+            v-else-if="count != undefined && count > 0"
             v-b-tooltip.hover.noninteractive
             pill
             :title="localize('View workflow invocations')"
             class="outline-badge cursor-pointer list-view"
             :to="`/workflows/${props.workflow.id}/invocations`">
-            <FontAwesomeIcon :icon="faSitemap" fixed-width />
+            <FontAwesomeIcon :icon="faClock" fixed-width />
 
-            <span v-if="count > 0">
+            <span>
                 workflow runs:
                 {{ count }}
             </span>
-            <span v-else> workflow never run </span>
         </BBadge>
-
         <BButton
             v-else
             v-b-tooltip.hover.noninteractive
@@ -57,7 +59,7 @@ onMounted(initCounts);
             variant="link"
             size="sm"
             :to="`/workflows/${props.workflow.id}/invocations`">
-            <FontAwesomeIcon :icon="faSitemap" fixed-width />
+            <FontAwesomeIcon :icon="faClock" fixed-width />
         </BButton>
     </div>
 </template>

--- a/client/src/components/Workflow/WorkflowInvocationsCount.vue
+++ b/client/src/components/Workflow/WorkflowInvocationsCount.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faClock, faSitemap } from "@fortawesome/free-solid-svg-icons";
+import { faList } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { onMounted, ref } from "vue";
 
 import { invocationCountsFetcher } from "@/api/workflows";
 import localize from "@/utils/localization";
 
-library.add(faClock, faSitemap);
+library.add(faList);
 
 interface Props {
     workflow: any;
@@ -34,7 +34,6 @@ onMounted(initCounts);
 <template>
     <div class="workflow-invocations-count d-flex align-items-center flex-gapx-1">
         <BBadge v-if="count != undefined && count === 0" pill class="list-view">
-            <FontAwesomeIcon :icon="faClock" fixed-width />
             <span>never run</span>
         </BBadge>
         <BBadge
@@ -44,7 +43,7 @@ onMounted(initCounts);
             :title="localize('View workflow invocations')"
             class="outline-badge cursor-pointer list-view"
             :to="`/workflows/${props.workflow.id}/invocations`">
-            <FontAwesomeIcon :icon="faClock" fixed-width />
+            <FontAwesomeIcon :icon="faList" fixed-width />
 
             <span>
                 workflow runs:
@@ -59,7 +58,7 @@ onMounted(initCounts);
             variant="link"
             size="sm"
             :to="`/workflows/${props.workflow.id}/invocations`">
-            <FontAwesomeIcon :icon="faClock" fixed-width />
+            <FontAwesomeIcon :icon="faList" fixed-width />
         </BButton>
     </div>
 </template>


### PR DESCRIPTION
We know it never run so there is little point to linking to an empty search.

plus switch icon, tweak wording 

|before|after|
|-|-|
|![Screenshot 2024-03-06 at 3 12 24 PM](https://github.com/galaxyproject/galaxy/assets/1814954/37b0c146-2ce8-449a-b515-bfe3cf9ed718)|![Screenshot 2024-03-06 at 3 11 25 PM](https://github.com/galaxyproject/galaxy/assets/1814954/d74fbb04-b8a8-4d05-bc43-906838e444d5)




## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
