### PR TITLE
[24.0] Make latest_workflow_uuid optional

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -11005,10 +11005,9 @@ export interface components {
             };
             /**
              * Latest workflow UUID
-             * Format: uuid4
              * @description TODO
              */
-            latest_workflow_uuid: string;
+            latest_workflow_uuid?: string | null;
             /**
              * License
              * @description SPDX Identifier of the license associated with this workflow.

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2136,8 +2136,8 @@ class StoredWorkflowSummary(Model, WithModelClass):
         title="Owner",
         description="The name of the user who owns this workflow.",
     )
-    latest_workflow_uuid: UUID4 = Field(  # Is this really used?
-        ...,
+    latest_workflow_uuid: Optional[UUID4] = Field(
+        None,
         title="Latest workflow UUID",
         description="TODO",
     )


### PR DESCRIPTION
Old workflows don't have this.
Fixes https://sentry.galaxyproject.org/share/issue/dd0fa7dec206415f82eefb876de1ca1e/

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
