### PR TITLE
[24.0] More efficient change_state queries, maybe fix deadlock

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1633,7 +1633,10 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
 
     def add_output_dataset(self, name, dataset):
         joda = JobToOutputDatasetAssociation(name, dataset)
-        dataset.dataset.job = self
+        if dataset.dataset.job is None:
+            # Only set job if dataset doesn't already have associated job.
+            # database operation tools that make copies should not modify the job here.
+            dataset.dataset.job = self
         add_object_to_object_session(self, joda)
         self.output_datasets.append(joda)
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1633,6 +1633,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
 
     def add_output_dataset(self, name, dataset):
         joda = JobToOutputDatasetAssociation(name, dataset)
+        dataset.dataset.job = self
         add_object_to_object_session(self, joda)
         self.output_datasets.append(joda)
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1996,24 +1996,8 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
             SET
                 state = :state,
                 update_time = :update_time
-            WHERE id IN (
-                SELECT hda.dataset_id FROM history_dataset_association hda
-                INNER JOIN job_to_output_dataset jtod
-                ON jtod.dataset_id = hda.id AND jtod.job_id = :job_id
-            );
-        """
-            ),
-            text(
-                """
-            UPDATE dataset
-            SET
-                state = :state,
-                update_time = :update_time
-            WHERE id IN (
-                SELECT ldda.dataset_id FROM library_dataset_dataset_association ldda
-                INNER JOIN job_to_output_library_dataset jtold
-                ON jtold.ldda_id = ldda.id AND jtold.job_id = :job_id
-            );
+            WHERE
+                dataset.job_id = :job_id
         """
             ),
             text(
@@ -2022,11 +2006,10 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
             SET
                 info = :info,
                 update_time = :update_time
-            WHERE id IN (
-                SELECT jtod.dataset_id
-                FROM job_to_output_dataset jtod
-                WHERE jtod.job_id = :job_id
-            );
+            FROM dataset
+            WHERE
+                history_dataset_association.dataset_id = dataset.id
+                AND dataset.job_id = :job_id;
         """
             ),
             text(
@@ -2035,11 +2018,10 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
             SET
                 info = :info,
                 update_time = :update_time
-            WHERE id IN (
-                SELECT jtold.ldda_id
-                FROM job_to_output_library_dataset jtold
-                WHERE jtold.job_id = :job_id
-            );
+            FROM dataset
+            WHERE
+                library_dataset_dataset_association.dataset_id = dataset.id
+                AND dataset.job_id = :job_id;
         """
             ),
         ]

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -175,11 +175,6 @@ def execute(
             history = execution_slice.history or history
             jobs_executed += 1
 
-    if job_datasets:
-        for job, datasets in job_datasets.items():
-            for dataset_instance in datasets:
-                dataset_instance.dataset.job = job
-
     if execution_slice:
         history.add_pending_items()
     # Make sure collections, implicit jobs etc are flushed even if there are no precreated output datasets

--- a/test/unit/app/managers/test_JobConnectionsManager.py
+++ b/test/unit/app/managers/test_JobConnectionsManager.py
@@ -25,10 +25,10 @@ def job_connections_manager(sa_session) -> JobConnectionsManager:
 
 # =============================================================================
 def setup_connected_dataset(sa_session: galaxy_scoped_session):
-    center_hda = HistoryDatasetAssociation(sa_session=sa_session)
-    input_hda = HistoryDatasetAssociation(sa_session=sa_session)
+    center_hda = HistoryDatasetAssociation(sa_session=sa_session, create_dataset=True)
+    input_hda = HistoryDatasetAssociation(sa_session=sa_session, create_dataset=True)
     input_hdca = HistoryDatasetCollectionAssociation()
-    output_hda = HistoryDatasetAssociation(sa_session=sa_session)
+    output_hda = HistoryDatasetAssociation(sa_session=sa_session, create_dataset=True)
     output_hdca = HistoryDatasetCollectionAssociation()
     input_job = Job()
     output_job = Job()
@@ -56,10 +56,10 @@ def setup_connected_dataset(sa_session: galaxy_scoped_session):
 
 def setup_connected_dataset_collection(sa_session: galaxy_scoped_session):
     center_hdca = HistoryDatasetCollectionAssociation()
-    input_hda1 = HistoryDatasetAssociation(sa_session=sa_session)
-    input_hda2 = HistoryDatasetAssociation(sa_session=sa_session)
+    input_hda1 = HistoryDatasetAssociation(sa_session=sa_session, create_dataset=True)
+    input_hda2 = HistoryDatasetAssociation(sa_session=sa_session, create_dataset=True)
     input_hdca = HistoryDatasetCollectionAssociation()
-    output_hda = HistoryDatasetAssociation(sa_session=sa_session)
+    output_hda = HistoryDatasetAssociation(sa_session=sa_session, create_dataset=True)
     output_hdca = HistoryDatasetCollectionAssociation()
     input_job = Job()
     output_job = Job()


### PR DESCRIPTION
Here's the deadlock:

```
Traceback (most recent call last):
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1910, in _execute_context
    self.dialect.do_execute(
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.DeadlockDetected: deadlock detected
DETAIL:  Process 317 waits for ShareLock on transaction 1057; blocked by process 318.
Process 318 waits for ShareLock on transaction 1056; blocked by process 317.
HINT:  See server log for query details.
CONTEXT:  while updating tuple (0,7) in relation "dataset"

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/jobs/runners/__init__.py", line 203, in put
    queue_job = job_wrapper.enqueue()
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/jobs/__init__.py", line 1589, in enqueue
    self.change_state(model.Job.states.QUEUED, flush=False, job=job)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/jobs/__init__.py", line 1547, in change_state
    job.update_output_states(self.app.application_stack.supports_skip_locked())
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/__init__.py", line 2053, in update_output_states
    sa_session.execute(statement, params)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/sqlalchemy/orm/session.py", line 1717, in execute
    result = conn._execute_20(statement, params or {}, execution_options)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1710, in _execute_20
    return meth(self, args_10style, kwargs_10style, execution_options)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/sqlalchemy/sql/elements.py", line 334, in _execute_on_connection
    return connection._execute_clauseelement(
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1577, in _execute_clauseelement
    ret = self._execute_context(
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1953, in _execute_context
    self._handle_dbapi_exception(
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 2134, in _handle_dbapi_exception
    util.raise_(
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1910, in _execute_context
    self.dialect.do_execute(
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.OperationalError: (psycopg2.errors.DeadlockDetected) deadlock detected
DETAIL:  Process 317 waits for ShareLock on transaction 1057; blocked by process 318.
Process 318 waits for ShareLock on transaction 1056; blocked by process 317.
HINT:  See server log for query details.
CONTEXT:  while updating tuple (0,7) in relation "dataset"

[SQL:
            UPDATE dataset
            SET
                state = %(state)s,
                update_time = %(update_time)s
            WHERE id IN (
                SELECT hda.dataset_id FROM history_dataset_association hda
                INNER JOIN job_to_output_dataset jtod
                ON jtod.dataset_id = hda.id AND jtod.job_id = %(job_id)s
            );
        ]
[parameters: {'state': 'queued', 'update_time': datetime.datetime(2024, 3, 7, 12, 29, 10, 229364), 'job_id': 3}]
(Background on this error at: https://sqlalche.me/e/14/e3q8)

```

The likely culprit for the deadlock  is that `__EXTRACT_DATASET__` deals with the same dataset as the tool that created the collection `__EXTRACT_DATASET__` is running on, they might both be attempting to update the output state.

My thinking is that by filtering on the job_id we're not going to change state for the `__EXTRACT_DATASET__` change_state method.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
