### PR TITLE
[24.0] default sort all grid histories the same

### DIFF
--- a/client/src/components/Grid/configs/historiesShared.ts
+++ b/client/src/components/Grid/configs/historiesShared.ts
@@ -112,7 +112,7 @@ const gridConfig: GridConfig = {
     filtering: new Filtering(validFilters, undefined, false, false),
     getData: getData,
     plural: "Histories",
-    sortBy: "name",
+    sortBy: "update_time",
     sortDesc: true,
     sortKeys: ["create_time", "name", "update_time", "username"],
     title: "Shared Histories",


### PR DESCRIPTION
closes https://github.com/galaxyproject/galaxy/issues/17623

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
