### PR TITLE
[24.0] Make WorkflowInput label, value and uuid optional

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -12107,18 +12107,17 @@ export interface components {
              * Label
              * @description Label of the input.
              */
-            label: string;
+            label: string | null;
             /**
              * UUID
-             * Format: uuid4
              * @description Universal unique identifier of the input.
              */
-            uuid: string;
+            uuid: string | null;
             /**
              * Value
              * @description TODO
              */
-            value: string;
+            value: Record<string, never> | null;
         };
         /** WorkflowInvocationCollectionView */
         WorkflowInvocationCollectionView: {

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2154,17 +2154,17 @@ class StoredWorkflowSummary(Model, WithModelClass):
 
 
 class WorkflowInput(Model):
-    label: str = Field(
+    label: Optional[str] = Field(
         ...,
         title="Label",
         description="Label of the input.",
     )
-    value: str = Field(
+    value: Optional[Any] = Field(
         ...,
         title="Value",
         description="TODO",
     )
-    uuid: UUID4 = Field(
+    uuid: Optional[UUID4] = Field(
         ...,
         title="UUID",
         description="Universal unique identifier of the input.",


### PR DESCRIPTION
Fixes:
```
ValidationError
2 validation errors for StoredWorkflowDetailed
inputs.0.uuid
  UUID input should be a string, bytes or UUID object [type=uuid_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.5/v/uuid_type
inputs.1.uuid
  UUID input should be a string, bytes or UUID object [type=uuid_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.5/v/uuid_type
```
https://sentry.galaxyproject.org/share/issue/dd0fa7dec206415f82eefb876de1ca1e/

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
