### PR TITLE
[23.1] Fix DataResult type

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -884,7 +884,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
             # If stats were requested, return them.
             if "stats" in kwargs:
                 if stats["data"]["max"] == 0:
-                    return DataResult(dataset_type=indexer.dataset_type, data=None)
+                    return DataResult(dataset_type=indexer.dataset_type, data=[])
                 else:
                     return stats
 


### PR DESCRIPTION
None isn't valid for `List[Any]`.
Fixes:
```
ValidationError

1 validation error for DataResult
data
  Input should be a valid list [type=list_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.5/v/list_type
```

from https://sentry.galaxyproject.org/share/issue/ed6da4c9029649cc9cc4b9a30e5144fe/

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
