### PR TITLE
[23.2] Yaml nested assertions: fix parsing

### DIFF
--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -35,7 +35,7 @@ NOT_IMPLEMENTED_MESSAGE = "Galaxy tool format does not yet support this tool fea
 class AssertionDict(TypedDict):
     tag: str
     attributes: Dict[str, Any]
-    children: Optional[List[Dict[str, Any]]]
+    children: "AssertionList"
 
 
 AssertionList = Optional[List[AssertionDict]]

--- a/lib/galaxy/tool_util/parser/yaml.py
+++ b/lib/galaxy/tool_util/parser/yaml.py
@@ -287,10 +287,7 @@ def to_test_assert_list(assertions) -> AssertionList:
                 new_assertion["that"] = assertion_key
                 new_assertion.update(assertion_value)
             assertion = new_assertion
-        children = []
-        if "children" in assertion:
-            children = assertion["children"]
-            del assertion["children"]
+        children = to_test_assert_list(assertion.pop("children", []))
         assert_dict: AssertionDict = dict(
             tag=assertion["that"],
             attributes=assertion,

--- a/lib/galaxy/tool_util/parser/yaml.py
+++ b/lib/galaxy/tool_util/parser/yaml.py
@@ -287,7 +287,11 @@ def to_test_assert_list(assertions) -> AssertionList:
                 new_assertion["that"] = assertion_key
                 new_assertion.update(assertion_value)
             assertion = new_assertion
-        children = to_test_assert_list(assertion.pop("children", []))
+        children = assertion.pop("asserts", assertion.pop("children", []))
+        # if there are no nested assertions then children should be []
+        # but to_test_assert_list would return None
+        if children:
+            children = to_test_assert_list(children)
         assert_dict: AssertionDict = dict(
             tag=assertion["that"],
             attributes=assertion,

--- a/test/unit/tool_util/test_test_parsing.py
+++ b/test/unit/tool_util/test_test_parsing.py
@@ -44,11 +44,11 @@ NESTED_ASSERT_LIST = yaml.safe_load(
     """
 - has_archive_member:
     path: ".*"
-    children:
-    - has_text:
-        text: "a text"
-    - has_text:
-        text: "another text"
+    asserts:
+      - has_text:
+          text: "a text"
+      - has_text:
+          text: "another text"
 """
 )
 

--- a/test/unit/tool_util/test_test_parsing.py
+++ b/test/unit/tool_util/test_test_parsing.py
@@ -55,9 +55,9 @@ NESTED_ASSERT_LIST = yaml.safe_load(
 
 def test_nested_asserts():
     asserts = to_test_assert_list(NESTED_ASSERT_LIST)
-    assert len(asserts) == 1
-    assert len(asserts[0]["children"]) == 2
-    assert asserts[0]["children"][0]["tag"] == "has_text"
-    assert asserts[0]["children"][0]["attributes"]["text"] == "a text"
-    assert asserts[0]["children"][1]["tag"] == "has_text"
-    assert asserts[0]["children"][1]["attributes"]["text"] == "another text"
+    assert asserts and len(asserts) == 1
+    assert asserts and asserts[0]["children"] and len(asserts[0]["children"]) == 2
+    assert asserts and asserts[0]["children"] and asserts[0]["children"][0]["tag"] == "has_text"
+    assert asserts and asserts[0]["children"] and asserts[0]["children"][0]["attributes"]["text"] == "a text"
+    assert asserts and asserts[0]["children"] and asserts[0]["children"][1]["tag"] == "has_text"
+    assert asserts and asserts[0]["children"] and asserts[0]["children"][1]["attributes"]["text"] == "another text"

--- a/test/unit/tool_util/test_test_parsing.py
+++ b/test/unit/tool_util/test_test_parsing.py
@@ -38,3 +38,26 @@ def test_simple_assert_to_test_assert_list():
 
 def test_assert_legacy_same_as_new_list_style():
     assert to_test_assert_list(ASSERT_THAT_LIST) == to_test_assert_list(ASSERT_THAT_LIST)
+
+
+NESTED_ASSERT_LIST = yaml.safe_load(
+    """
+- has_archive_member:
+    path: ".*"
+    children:
+    - has_text:
+        text: "a text"
+    - has_text:
+        text: "another text"
+"""
+)
+
+
+def test_nested_asserts():
+    asserts = to_test_assert_list(NESTED_ASSERT_LIST)
+    assert len(asserts) == 1
+    assert len(asserts[0]["children"]) == 2
+    assert asserts[0]["children"][0]["tag"] == "has_text"
+    assert asserts[0]["children"][0]["attributes"]["text"] == "a text"
+    assert asserts[0]["children"][1]["tag"] == "has_text"
+    assert asserts[0]["children"][1]["attributes"]["text"] == "another text"


### PR DESCRIPTION
Seems that the recursive call was forgotten.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
