### PR TITLE
[24.0] Don't index tasks without task_uuid

### DIFF
--- a/lib/galaxy/managers/export_tracker.py
+++ b/lib/galaxy/managers/export_tracker.py
@@ -64,7 +64,11 @@ class StoreExportTracker:
                 StoreExportAssociation,
             )
             .where(
-                and_(StoreExportAssociation.object_type == object_type, StoreExportAssociation.object_id == object_id)
+                and_(
+                    StoreExportAssociation.object_type == object_type,
+                    StoreExportAssociation.object_id == object_id,
+                    StoreExportAssociation.task_uuid.is_not(None),
+                )
             )
             .order_by(StoreExportAssociation.create_time.desc())
         )


### PR DESCRIPTION
There's a brief window where we've committed a task to the database but it doesn't have a task uuid yet
(https://github.com/galaxyproject/galaxy/blob/474a0536fadcddc1f6b328955e0cda1d6a281787/lib/galaxy/webapps/galaxy/services/histories.py#L397-L408).

This fails response validation as in
https://sentry.galaxyproject.org/share/issue/e0d4080044754c8aa60dd6bd8667dfcf/:

```

ExceptionGroup: unhandled errors in a TaskGroup
  File "starlette/_utils.py", line 87, in collapse_excgroups
    yield
  File "starlette/middleware/base.py", line 190, in __call__
    async with anyio.create_task_group() as task_group:
  File "anyio/_backends/_asyncio.py", line 678, in __aexit__
    raise BaseExceptionGroup(
ValidationError: 1 validation error for ExportTaskListResponse
0.task_uuid
  UUID input should be a string, bytes or UUID object [type=uuid_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.5/v/uuid_type
  File "starlette/applications.py", line 123, in __call__
    await self.middleware_stack(scope, receive, send)
  File "starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "starlette_context/middleware/raw_middleware.py", line 92, in __call__
    await self.app(scope, receive, send_wrapper)
  File "starlette/middleware/base.py", line 189, in __call__
    with collapse_excgroups():
  File "contextlib.py", line 155, in __exit__
    self.gen.throw(typ, value, traceback)
  File "starlette/_utils.py", line 93, in collapse_excgroups
    raise exc
  File "starlette/middleware/base.py", line 191, in __call__
    response = await self.dispatch_func(request, call_next)
  File "galaxy/webapps/galaxy/fast_app.py", line 108, in add_x_frame_options
    response = await call_next(request)
  File "starlette/middleware/base.py", line 165, in call_next
    raise app_exc
  File "starlette/middleware/base.py", line 151, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "starlette/routing.py", line 758, in __call__
    await self.middleware_stack(scope, receive, send)
  File "starlette/routing.py", line 778, in app
    await route.handle(scope, receive, send)
  File "starlette/routing.py", line 299, in handle
    await self.app(scope, receive, send)
  File "starlette/routing.py", line 79, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "starlette/routing.py", line 74, in app
    response = await func(request)
  File "fastapi/routing.py", line 278, in app
    raw_response = await run_endpoint_function(
  File "fastapi/routing.py", line 193, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "starlette/concurrency.py", line 42, in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
  File "anyio/to_thread.py", line 56, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
  File "anyio/_backends/_asyncio.py", line 2144, in run_sync_in_worker_thread
    return await future
  File "anyio/_backends/_asyncio.py", line 851, in run
    result = context.run(func, *args)
  File "galaxy/webapps/galaxy/api/histories.py", line 503, in index_exports
    return ExportTaskListResponse(root=exports)
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
