### PR TITLE
[24.0] Fix history panel arrow navigate by id bug, add `HistoryOperations` to `HistoryView` and prevent item selection in unowned histories

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -185,41 +185,54 @@ function onKeyDown(event: KeyboardEvent) {
 
     if (event.key === "Enter" || event.key === " ") {
         event.preventDefault();
-        onClick(event);
-    } else if ((event.key === "ArrowUp" || event.key === "ArrowDown") && event.shiftKey) {
+        onClick();
+    } else if ((event.key === "ArrowUp" || event.key === "ArrowDown") && !event.shiftKey) {
         event.preventDefault();
-        emit("shift-select", event.key);
-    } else if (event.key === "ArrowUp" || event.key === "ArrowDown") {
-        event.preventDefault();
-        emit("init-key-selection");
         emit("arrow-navigate", event.key);
-    } else if (event.key === "Tab") {
-        emit("init-key-selection");
-    } else if (event.key === "Delete" && !props.selected && !props.item.deleted) {
-        event.preventDefault();
-        onDelete(event.shiftKey);
-    } else if (event.key === "Escape") {
-        event.preventDefault();
-        emit("hide-selection");
-    } else if (event.key === "a" && isSelectKey(event)) {
-        event.preventDefault();
-        emit("select-all");
+    }
+
+    if (props.writable) {
+        if (event.key === "Tab") {
+            emit("init-key-selection");
+        } else {
+            event.preventDefault();
+            if ((event.key === "ArrowUp" || event.key === "ArrowDown") && event.shiftKey) {
+                emit("shift-select", event.key);
+            } else if (event.key === "ArrowUp" || event.key === "ArrowDown") {
+                emit("init-key-selection");
+            } else if (event.key === "Delete" && !props.selected && !props.item.deleted) {
+                onDelete(event.shiftKey);
+                emit("arrow-navigate", "ArrowDown");
+            } else if (event.key === "Escape") {
+                emit("hide-selection");
+            } else if (event.key === "a" && isSelectKey(event)) {
+                emit("select-all");
+            }
+        }
     }
 }
 
-function onClick(e: Event) {
+function onClick(e?: Event) {
     const event = e as KeyboardEvent;
-    if (event && event.shiftKey && isSelectKey(event)) {
-        emit("selected-to", false);
-    } else if (event && isSelectKey(event)) {
-        emit("init-key-selection");
-        emit("update:selected", !props.selected);
-    } else if (event && event.shiftKey) {
-        emit("selected-to", true);
-    } else if (props.isPlaceholder) {
-        emit("init-key-selection");
-    } else if (props.isDataset) {
-        emit("init-key-selection");
+    if (event && props.writable) {
+        if (event.shiftKey && isSelectKey(event)) {
+            emit("selected-to", false);
+            return;
+        } else if (isSelectKey(event)) {
+            emit("init-key-selection");
+            emit("update:selected", !props.selected);
+            return;
+        } else if (event.shiftKey) {
+            emit("selected-to", true);
+            return;
+        } else {
+            emit("init-key-selection");
+        }
+    }
+    if (props.isPlaceholder) {
+        return;
+    }
+    if (props.isDataset) {
         emit("update:expand-dataset", !props.expandDataset);
     } else {
         emit("view-collection", props.item, props.name);

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -50,7 +50,6 @@ interface Props {
     history: HistorySummary;
     filter?: string;
     canEditHistory?: boolean;
-    shouldShowControls?: boolean;
     filterable?: boolean;
     isMultiViewItem?: boolean;
 }
@@ -61,7 +60,6 @@ const props = withDefaults(defineProps<Props>(), {
     listOffset: 0,
     filter: "",
     canEditHistory: true,
-    shouldShowControls: true,
     filterable: false,
     isMultiViewItem: false,
 });
@@ -510,13 +508,13 @@ function setItemDragstart(
                         :history="history"
                         :is-watching="isWatching"
                         :last-checked="lastCheckedTime"
-                        :show-controls="shouldShowControls"
+                        :show-controls="canEditHistory"
                         :filter-text.sync="filterText"
                         :hide-reload="isMultiViewItem"
                         @reloadContents="reloadContents" />
 
                     <HistoryOperations
-                        v-if="shouldShowControls"
+                        v-if="canEditHistory"
                         :history="history"
                         :show-selection="showSelection"
                         :expanded-count="expandedCount"

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -80,7 +80,7 @@ const querySelectionBreak = ref(false);
 const dragTarget = ref<EventTarget | null>(null);
 const contentItemRefs = computed(() => {
     return historyItems.value.reduce((acc: ContentItemRef, item) => {
-        acc[`item-${item.id}`] = ref(null);
+        acc[`item-${item.hid}`] = ref(null);
         return acc;
     }, {});
 });
@@ -413,8 +413,8 @@ onMounted(async () => {
     await loadHistoryItems();
     // if there is a listOffset, we are coming from a collection view, so focus on item at that offset
     if (props.listOffset) {
-        const itemId = historyItems.value[props.listOffset]?.id;
-        const itemElement = contentItemRefs.value[`item-${itemId}`]?.value?.$el as HTMLElement;
+        const itemHid = historyItems.value[props.listOffset]?.hid;
+        const itemElement = contentItemRefs.value[`item-${itemHid}`]?.value?.$el as HTMLElement;
         itemElement?.focus();
     }
 });
@@ -427,7 +427,7 @@ function arrowNavigate(item: HistoryItem, eventKey: string) {
         nextItem = historyItems.value[historyItems.value.indexOf(item) - 1];
     }
     if (nextItem) {
-        const itemElement = contentItemRefs.value[`item-${nextItem.id}`]?.value?.$el as HTMLElement;
+        const itemElement = contentItemRefs.value[`item-${nextItem.hid}`]?.value?.$el as HTMLElement;
         itemElement?.focus();
     }
     return nextItem;
@@ -586,7 +586,7 @@ function setItemDragstart(
                             <template v-slot:item="{ item, currentOffset }">
                                 <ContentItem
                                     :id="item.hid"
-                                    :ref="contentItemRefs[`item-${item.id}`]"
+                                    :ref="contentItemRefs[`item-${item.hid}`]"
                                     is-history-item
                                     :item="item"
                                     :name="item.name"

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -78,7 +78,7 @@ const querySelectionBreak = ref(false);
 const dragTarget = ref<EventTarget | null>(null);
 const contentItemRefs = computed(() => {
     return historyItems.value.reduce((acc: ContentItemRef, item) => {
-        acc[`item-${item.hid}`] = ref(null);
+        acc[itemUniqueKey(item)] = ref(null);
         return acc;
     }, {});
 });
@@ -403,6 +403,10 @@ function getItemKey(item: HistoryItem) {
     return item.type_id;
 }
 
+function itemUniqueKey(item: HistoryItem) {
+    return `${item.history_content_type}-${item.id}`;
+}
+
 onMounted(async () => {
     // `filterable` here indicates if this is the current history panel
     if (props.filterable && !props.filter) {
@@ -411,9 +415,11 @@ onMounted(async () => {
     await loadHistoryItems();
     // if there is a listOffset, we are coming from a collection view, so focus on item at that offset
     if (props.listOffset) {
-        const itemHid = historyItems.value[props.listOffset]?.hid;
-        const itemElement = contentItemRefs.value[`item-${itemHid}`]?.value?.$el as HTMLElement;
-        itemElement?.focus();
+        const itemAtOffset = historyItems.value[props.listOffset];
+        if (itemAtOffset) {
+            const itemElement = contentItemRefs.value[itemUniqueKey(itemAtOffset)]?.value?.$el as HTMLElement;
+            itemElement?.focus();
+        }
     }
 });
 
@@ -425,7 +431,7 @@ function arrowNavigate(item: HistoryItem, eventKey: string) {
         nextItem = historyItems.value[historyItems.value.indexOf(item) - 1];
     }
     if (nextItem) {
-        const itemElement = contentItemRefs.value[`item-${nextItem.hid}`]?.value?.$el as HTMLElement;
+        const itemElement = contentItemRefs.value[itemUniqueKey(nextItem)]?.value?.$el as HTMLElement;
         itemElement?.focus();
     }
     return nextItem;
@@ -584,7 +590,7 @@ function setItemDragstart(
                             <template v-slot:item="{ item, currentOffset }">
                                 <ContentItem
                                     :id="item.hid"
-                                    :ref="contentItemRefs[`item-${item.hid}`]"
+                                    :ref="contentItemRefs[itemUniqueKey(item)]"
                                     is-history-item
                                     :item="item"
                                     :name="item.name"

--- a/client/src/components/History/HistoryView.test.js
+++ b/client/src/components/History/HistoryView.test.js
@@ -94,10 +94,13 @@ describe("History center panel View", () => {
         expect(tags.text()).toContain("tag_1");
         expect(tags.text()).toContain("tag_2");
         // HistoryCounter
-        expect(wrapper.find("[data-description='storage dashboard button']").attributes("disabled")).toBeTruthy();
         expect(wrapper.find("[data-description='show active items button']").text()).toEqual("8");
         expect(wrapper.find("[data-description='include deleted items button']").text()).toEqual("1");
         expect(wrapper.find("[data-description='include hidden items button']").text()).toEqual("2");
+    }
+
+    function storageDashboardButtonDisabled(wrapper) {
+        return wrapper.find("[data-description='storage dashboard button']").attributes("disabled");
     }
 
     it("current user's current history", async () => {
@@ -116,6 +119,9 @@ describe("History center panel View", () => {
 
         // parts of the layout that should be similar for all cases
         expectCorrectLayout(wrapper);
+
+        // storage dashboard button should be enabled
+        expect(storageDashboardButtonDisabled(wrapper)).toBeFalsy();
 
         // make sure all history items show up
         const historyItems = wrapper.findAllComponents(ContentItem);
@@ -138,6 +144,9 @@ describe("History center panel View", () => {
         expect(switchButton.exists()).toBe(false);
         expect(importButton.attributes("disabled")).toBeFalsy();
 
+        // storage dashboard button should be disabled
+        expect(storageDashboardButtonDisabled(wrapper)).toBeTruthy();
+
         // parts of the layout that should be similar for all cases
         expectCorrectLayout(wrapper);
     });
@@ -152,6 +161,9 @@ describe("History center panel View", () => {
         const importButton = wrapper.find("[data-description='import history button']");
         expect(switchButton.attributes("disabled")).toBeFalsy();
         expect(importButton.exists()).toBe(false);
+
+        // storage dashboard button should be enabled
+        expect(storageDashboardButtonDisabled(wrapper)).toBeFalsy();
 
         // parts of the layout that should be similar for all cases
         expectCorrectLayout(wrapper);
@@ -168,6 +180,9 @@ describe("History center panel View", () => {
         expect(switchButton.attributes("disabled")).toBeTruthy();
         expect(importButton.exists()).toBe(false);
 
+        // storage dashboard button should be disabled
+        expect(storageDashboardButtonDisabled(wrapper)).toBeTruthy();
+
         // instead we have an alert
         expect(wrapper.find("[data-description='history state info']").text()).toBe("This history has been purged.");
     });
@@ -183,6 +198,9 @@ describe("History center panel View", () => {
         expect(importButton.exists()).toBe(true);
         expect(importButton.attributes("disabled")).toBeFalsy();
 
+        // storage dashboard button should be disabled
+        expect(storageDashboardButtonDisabled(wrapper)).toBeTruthy();
+
         expectCorrectLayout(wrapper);
         expect(wrapper.find("[data-description='history state info']").exists()).toBe(false);
     });
@@ -197,6 +215,9 @@ describe("History center panel View", () => {
         expect(switchButton.exists()).toBe(true);
         expect(switchButton.attributes("disabled")).toBeTruthy();
         expect(importButton.exists()).toBe(false);
+
+        // storage dashboard button should be disabled
+        expect(storageDashboardButtonDisabled(wrapper)).toBeTruthy();
 
         expectCorrectLayout(wrapper);
         expect(wrapper.find("[data-description='history state info']").text()).toBe("This history has been archived.");

--- a/client/src/components/History/HistoryView.vue
+++ b/client/src/components/History/HistoryView.vue
@@ -37,7 +37,6 @@
             v-else
             :history="history"
             :can-edit-history="canEditHistory"
-            :should-show-controls="false"
             filterable
             @view-collection="onViewCollection" />
 


### PR DESCRIPTION
## Fix history keyboard navigation bug:
For navigating history with arrow keys, we were tracking the next item by the `item.id` but items can have the same id and therefore, we were navigating across items. Changed it to `item.hid` instead because that is unique for the items visible for the current `historyId` and `filterText`.

## Add history operations to center panel history view:
Also, added the `HistoryOperations` to the center panel `HistoryView` for owned histories (while also preventing users to keyboard/mouse select items in unowned/published histories):
![image](https://github.com/galaxyproject/galaxy/assets/78516064/0fa1f303-e465-4d6b-9433-2558ae367306)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
