### PR TITLE
[24.0] Moves archived histories from Masthead to Histories Grid

### DIFF
--- a/client/src/components/Grid/GridHistory.vue
+++ b/client/src/components/Grid/GridHistory.vue
@@ -17,7 +17,7 @@ const userStore = useUserStore();
 library.add(faPlus);
 
 interface Props {
-    activeList?: "my" | "shared" | "published";
+    activeList?: "archived" | "my" | "shared" | "published";
     username?: string;
 }
 
@@ -63,6 +63,9 @@ const props = withDefaults(defineProps<Props>(), {
             </BNavItem>
             <BNavItem id="histories-published-tab" :active="activeList === 'published'" to="/histories/list_published">
                 Public Histories
+            </BNavItem>
+            <BNavItem id="histories-published-tab" :active="activeList === 'archived'" to="/histories/archived">
+                Archived Histories
             </BNavItem>
         </BNav>
         <GridList v-if="activeList === 'my'" :grid-config="historiesGridConfig" embedded />

--- a/client/src/components/Grid/GridHistory.vue
+++ b/client/src/components/Grid/GridHistory.vue
@@ -11,6 +11,7 @@ import { useUserStore } from "@/stores/userStore";
 import Heading from "@/components/Common/Heading.vue";
 import LoginRequired from "@/components/Common/LoginRequired.vue";
 import GridList from "@/components/Grid/GridList.vue";
+import HistoryArchive from "@/components/History/Archiving/HistoryArchive.vue";
 
 const userStore = useUserStore();
 
@@ -70,6 +71,11 @@ const props = withDefaults(defineProps<Props>(), {
         </BNav>
         <GridList v-if="activeList === 'my'" :grid-config="historiesGridConfig" embedded />
         <GridList v-else-if="activeList === 'shared'" :grid-config="historiesSharedGridConfig" embedded />
-        <GridList v-else :grid-config="historiesPublishedGridConfig" :username-search="props.username" embedded />
+        <GridList
+            v-else-if="activeList === 'published'"
+            :grid-config="historiesPublishedGridConfig"
+            :username-search="props.username"
+            embedded />
+        <HistoryArchive v-else />
     </div>
 </template>

--- a/client/src/components/History/Archiving/HistoryArchive.vue
+++ b/client/src/components/History/Archiving/HistoryArchive.vue
@@ -135,7 +135,6 @@ async function onImportCopy(history: ArchivedHistorySummary) {
 </script>
 <template>
     <section id="archived-histories" class="d-flex flex-column">
-        <h1>Archived Histories</h1>
         <div>
             <DelayedInput
                 :query="searchText"

--- a/client/src/components/History/Archiving/HistoryArchive.vue
+++ b/client/src/components/History/Archiving/HistoryArchive.vue
@@ -139,7 +139,7 @@ async function onImportCopy(history: ArchivedHistorySummary) {
             <DelayedInput
                 :query="searchText"
                 class="m-1 mb-3"
-                placeholder="Search by name"
+                placeholder="search by name"
                 @change="updateSearchQuery" />
             <BAlert v-if="isLoading" variant="info" show>
                 <LoadingSpan v-if="isLoading" message="Loading archived histories" />

--- a/client/src/entry/analysis/menu.js
+++ b/client/src/entry/analysis/menu.js
@@ -243,10 +243,6 @@ export function fetchMenu(options = {}) {
                 url: "/interactivetool_entry_points/list",
             });
         }
-        userTab.menu.push({
-            title: _l("Archived Histories"),
-            url: "/histories/archived",
-        });
         if (Galaxy.config.enable_notification_system) {
             userTab.menu.push({
                 title: _l("Notifications"),

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -63,7 +63,6 @@ import { patchRouterPush } from "./router-push";
 
 import AboutGalaxy from "@/components/AboutGalaxy.vue";
 import GridVisualization from "@/components/Grid/GridVisualization.vue";
-import HistoryArchive from "@/components/History/Archiving/HistoryArchive.vue";
 import HistoryArchiveWizard from "@/components/History/Archiving/HistoryArchiveWizard.vue";
 import HistoryDatasetPermissions from "@/components/History/HistoryDatasetPermissions.vue";
 import NotificationsList from "@/components/Notifications/NotificationsList.vue";
@@ -288,7 +287,10 @@ export function getRouter(Galaxy) {
                     },
                     {
                         path: "histories/archived",
-                        component: HistoryArchive,
+                        component: GridHistory,
+                        props: {
+                            activeList: "archived",
+                        },
                     },
                     {
                         path: "histories/list",


### PR DESCRIPTION
Moves the archived histories link from the Mastheads User tab to the new Grid History tabs.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
