### PR TITLE
[24.0] fix shared item details and initial filters

### DIFF
--- a/client/src/components/Common/PublishedItem.vue
+++ b/client/src/components/Common/PublishedItem.vue
@@ -82,11 +82,11 @@ const { showActivityBar, showToolbox } = usePanels();
                 <h2 class="h-sm">Related Pages</h2>
 
                 <div>
-                    <router-link :to="urlAll">All published {{ plural }}.</router-link>
+                    <router-link :to="urlAll">All published {{ plural }}</router-link>
                 </div>
 
                 <div>
-                    <router-link :to="publishedByUser"> Published {{ plural }} by {{ owner }}. </router-link>
+                    <router-link :to="publishedByUser"> Published {{ plural }} by {{ owner }}</router-link>
                 </div>
             </div>
             <LoadingSpan v-else message="Loading item details" />

--- a/client/src/components/Grid/GridHistory.vue
+++ b/client/src/components/Grid/GridHistory.vue
@@ -18,9 +18,10 @@ library.add(faPlus);
 
 interface Props {
     activeList?: "my" | "shared" | "published";
+    username?: string;
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
     activeList: "my",
 });
 </script>
@@ -66,6 +67,6 @@ withDefaults(defineProps<Props>(), {
         </BNav>
         <GridList v-if="activeList === 'my'" :grid-config="historiesGridConfig" embedded />
         <GridList v-else-if="activeList === 'shared'" :grid-config="historiesSharedGridConfig" embedded />
-        <GridList v-else :grid-config="historiesPublishedGridConfig" embedded />
+        <GridList v-else :grid-config="historiesPublishedGridConfig" :username-search="props.username" embedded />
     </div>
 </template>

--- a/client/src/components/Grid/GridList.vue
+++ b/client/src/components/Grid/GridList.vue
@@ -37,6 +37,8 @@ interface Props {
     embedded?: boolean;
     // rows per page to be shown
     limit?: number;
+    // username for initial search
+    usernameSearch?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -213,6 +215,11 @@ function onSelectAll(current: boolean): void {
  * Initialize grid data
  */
 onMounted(() => {
+    if (props.usernameSearch) {
+        const search_query = `user:${props.usernameSearch}`.trim();
+        filterText.value = search_query;
+        onSearch(search_query);
+    }
     getGridData();
     eventBus.on(onRouterPush);
     displayInitialMessage();

--- a/client/src/components/Grid/GridPage.vue
+++ b/client/src/components/Grid/GridPage.vue
@@ -17,9 +17,10 @@ library.add(faPlus);
 
 interface Props {
     activeList?: "my" | "published";
+    username?: string;
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
     activeList: "my",
 });
 </script>
@@ -47,6 +48,6 @@ withDefaults(defineProps<Props>(), {
             <BNavItem :active="activeList === 'published'" to="/pages/list_published"> Public Pages </BNavItem>
         </BNav>
         <GridList v-if="activeList === 'my'" :grid-config="pagesGridConfig" embedded />
-        <GridList v-else :grid-config="pagesPublishedGridConfig" embedded />
+        <GridList v-else :grid-config="pagesPublishedGridConfig" :username-search="props.username" embedded />
     </div>
 </template>

--- a/client/src/components/History/HistoryPublished.vue
+++ b/client/src/components/History/HistoryPublished.vue
@@ -14,9 +14,8 @@ const props = defineProps<Props>();
 const history = ref({});
 
 onMounted(async () => {
-    const result = await historyFetcher({ history_id: props.id });
-
-    history.value = result;
+    const { data } = await historyFetcher({ history_id: props.id });
+    history.value = data;
 });
 </script>
 

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -281,9 +281,10 @@ export function getRouter(Galaxy) {
                     {
                         path: "histories/list_published",
                         component: GridHistory,
-                        props: {
+                        props: (route) => ({
                             activeList: "published",
-                        },
+                            username: route.query["f-username"],
+                        }),
                     },
                     {
                         path: "histories/archived",
@@ -381,9 +382,10 @@ export function getRouter(Galaxy) {
                     {
                         path: "pages/list_published",
                         component: GridPage,
-                        props: {
+                        props: (route) => ({
                             activeList: "published",
-                        },
+                            username: route.query["f-username"],
+                        }),
                     },
                     {
                         path: "storage/history/:historyId",


### PR DESCRIPTION
- fix incorrect loading of information for object detail panel (screenshot below)
![Screenshot 2024-03-08 at 1 52 24 PM](https://github.com/galaxyproject/galaxy/assets/1814954/0ef5f69e-f405-4b2a-8d42-7cc66f07703d)


- fixes https://github.com/galaxyproject/galaxy/issues/15973 -- for this I was contemplating whether to support the `f-username` legacy filter, but I suspect these are URLs that could actually be shared outside of Galaxy so we should probably not break them



## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
