### PR TITLE
[23.2] Limit new anon histories

### DIFF
--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -650,11 +650,11 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
             galaxy_session = self.__create_new_session(prev_galaxy_session, user_for_new_session)
             galaxy_session_requires_flush = True
             self.galaxy_session = galaxy_session
-            if self.webapp.name == "galaxy":
-                self.get_or_create_default_history()
             self.__update_session_cookie(name=session_cookie)
         else:
             self.galaxy_session = galaxy_session
+            if self.webapp.name == "galaxy":
+                self.get_or_create_default_history()
         # Do we need to flush the session?
         if galaxy_session_requires_flush:
             self.sa_session.add(galaxy_session)
@@ -799,10 +799,10 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
             and not users_last_session.current_history.deleted
         ):
             history = users_last_session.current_history
-        elif not history:
-            history = self.get_history(create=True, most_recent=True)
         if history not in self.galaxy_session.histories:
             self.galaxy_session.add_history(history)
+        if not history:
+            history = self.new_history()
         if history.user is None:
             history.user = user
         self.galaxy_session.current_history = history

--- a/lib/galaxy_test/api/test_authenticate.py
+++ b/lib/galaxy_test/api/test_authenticate.py
@@ -53,3 +53,25 @@ class TestAuthenticateApi(ApiTestCase):
         current_history_json_response.raise_for_status()
         current_history = current_history_json_response.json()
         assert current_history["contents_active"]["active"] == 1
+
+    def test_anon_history_creation(self):
+        # First request:
+        # We don't create any histories, just return a session cookie
+        response = get(self.url)
+        cookie = {"galaxysession": response.cookies["galaxysession"]}
+        # Check that we don't have any histories (API doesn't auto-create new histories)
+        histories_response = get(
+            urljoin(
+                self.url,
+                "api/histories",
+            )
+        )
+        assert not histories_response.json()
+        # Second request, we know client follows conventions by including cookies,
+        # default history is created.
+        get(self.url, cookies=cookie)
+        second_histories_response = get(
+            urljoin(self.url, "history/current_history_json"),
+            cookies=cookie,
+        )
+        assert second_histories_response.json()


### PR DESCRIPTION
This is a two-fold fix that should reduce the number of newly created histories.

- When we first create a new session (e.g. because an initial session cookie hasn't been provided or wasn't valid) we **don't** create a new history or associate an existing history. Scripts or spiders that don't include a session cookie will not be creating new histories that way.
- Do return the default history also for anon users in `get_or_create_default_history`

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
