### PR TITLE
Fix syntax for SA2.0

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7500,7 +7500,7 @@ class StoredWorkflow(Base, HasTags, Dictifiable, RepresentById):
     def invocation_counts(self) -> InvocationsStateCounts:
         sa_session = object_session(self)
         stmt = (
-            select([WorkflowInvocation.state, func.count(WorkflowInvocation.state)])
+            select(WorkflowInvocation.state, func.count(WorkflowInvocation.state))
             .select_from(StoredWorkflow)
             .join(Workflow, Workflow.stored_workflow_id == StoredWorkflow.id)
             .join(WorkflowInvocation, WorkflowInvocation.workflow_id == Workflow.id)


### PR DESCRIPTION
This will break under SQLAlchemy 2.0. New select syntax: `select(foo, bar)`, not `select([foo, bar])`.

(Just noticed: was added in #17488)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
