### PR TITLE
Npz sniffing: do not read the whole file

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -4299,9 +4299,7 @@ class Npz(CompressedArchive):
         try:
             npz = np.load(filename)
             if isinstance(npz, np.lib.npyio.NpzFile):
-                for f in npz.files:
-                    if isinstance(npz[f], np.ndarray):
-                        return True
+                return True
         except Exception:
             return False
         return False


### PR DESCRIPTION
I noticed that an upload of https://data.qiime2.org/2024.2/common/silva-138-99-nb-classifier.qza fails because of high memory load (for the file in question 18GB). One can try on usegalaxy.org. 

Reason was that the npz sniffer reads the whole file (npz seems to be just zip files). 

Also tried to use the `mmap_mode` for `load` (https://numpy.org/doc/stable/reference/generated/numpy.load.html) but this changed nothing.

Btw. I used [memray](https://github.com/bloomberg/memray) which showed me the problem in seconds.

Could also backport further if needed (https://github.com/galaxyproject/galaxy/pull/11957)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
