### PR TITLE
Per-host default_panel_view config

### DIFF
--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2831,6 +2831,7 @@ mapping:
         type: str
         default: default
         required: false
+        per_host: true
         desc: |
           Default tool panel view for the current Galaxy configuration. This should refer to an id of
           a panel view defined using the panel_views or panel_views_dir configuration options or an


### PR DESCRIPTION
Related to issue https://github.com/galaxyproject/galaxy/issues/17664.

This was intended to be a feature of https://github.com/galaxyproject/galaxy/pull/12328 but it was not included as a `per_host` config param. This PR should fix that.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
