### PR TITLE
[24.0] Grid filtering bug fixes

### DIFF
--- a/client/src/components/Common/FilterMenu.vue
+++ b/client/src/components/Common/FilterMenu.vue
@@ -4,7 +4,7 @@ import { faAngleDoubleUp, faQuestion, faRedo, faSearch } from "@fortawesome/free
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton, BModal } from "bootstrap-vue";
 import { kebabCase } from "lodash";
-import { computed, ref, watch } from "vue";
+import { computed, ref } from "vue";
 
 import type Filtering from "@/utils/filtering";
 import { type Alias, getOperatorForAlias } from "@/utils/filtering";
@@ -68,7 +68,6 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{
     (e: "update:filter-text", filter: string): void;
-    (e: "on-backend-filter", filter: string): void;
     (e: "update:show-advanced", showAdvanced: boolean): void;
     (e: "on-search", filters: Record<string, string | boolean>, filterText?: string, backendFilter?: string): void;
 }>();
@@ -127,25 +126,6 @@ function onToggle() {
 function updateFilterText(newFilterText: string) {
     emit("update:filter-text", newFilterText);
 }
-
-// as the filterText changes, emit a backend-filter that can be used as a backend query
-watch(
-    () => props.filterText,
-    (newFilterText: string) => {
-        const defaultBackendFilter = props.filterClass.getFilterText(props.filterClass.defaultFilters, true);
-        const currentBackendFilter = props.filterClass.getFilterText(filters.value, true);
-
-        const backendFilter =
-            defaultBackendFilter === currentBackendFilter
-                ? `${
-                      defaultBackendFilter && !newFilterText.includes(defaultBackendFilter)
-                          ? defaultBackendFilter + " "
-                          : ""
-                  }` + newFilterText
-                : props.filterClass.getFilterText(filters.value, true);
-        emit("on-backend-filter", backendFilter);
-    }
-);
 </script>
 
 <template>

--- a/client/src/components/Grid/GridList.vue
+++ b/client/src/components/Grid/GridList.vue
@@ -82,6 +82,7 @@ const filterClass = props.gridConfig.filtering;
 const rawFilters = computed(() => Object.fromEntries(filterClass.getFiltersForText(filterText.value, true, false)));
 const validFilters = computed(() => filterClass.getValidFilters(rawFilters.value, true).validFilters);
 const invalidFilters = computed(() => filterClass.getValidFilters(rawFilters.value, true).invalidFilters);
+const hasInvalidFilters = computed(() => Object.keys(invalidFilters.value).length > 0);
 
 // hide message helper
 const hideMessage = useDebounceFn(() => {
@@ -116,7 +117,7 @@ async function getGridData() {
     resultsLoading.value = true;
     selected.value = new Set();
     if (props.gridConfig) {
-        if (Object.keys(invalidFilters.value).length > 0) {
+        if (hasInvalidFilters.value) {
             // there are invalid filters, so we don't want to search
             initDataLoading.value = false;
             resultsLoading.value = false;
@@ -291,8 +292,8 @@ watch(operationMessage, () => {
             <hr v-if="showAdvanced" />
         </div>
         <LoadingSpan v-if="initDataLoading" />
-        <span v-else-if="!isAvailable || Object.keys(invalidFilters).length > 0" variant="info" show>
-            <BAlert v-if="Object.keys(invalidFilters).length === 0" variant="info" show>
+        <span v-else-if="!isAvailable || hasInvalidFilters" variant="info" show>
+            <BAlert v-if="!hasInvalidFilters" variant="info" show>
                 <span v-if="filterText">
                     <span v-localize>Nothing found with:</span>
                     <b>{{ filterText }}</b>

--- a/client/src/components/Grid/GridList.vue
+++ b/client/src/components/Grid/GridList.vue
@@ -378,7 +378,7 @@ watch(operationMessage, () => {
                             :value="rowData[fieldEntry.key]"
                             :disabled="fieldEntry.disabled"
                             @input="onTagInput(rowData, $event, fieldEntry.handler)"
-                            @tag-click="applyFilter('tag', $event)" />
+                            @tag-click="applyFilter('tag', $event, true)" />
                         <span v-else v-localize> Not available. </span>
                     </div>
                     <FontAwesomeIcon v-else icon="fa-shield-alt" />

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -412,9 +412,9 @@ async function onDrop() {
     }
 }
 
-function updateFilterValue(newFilterText: string, newValue: any) {
+function updateFilterValue(filterKey: string, newValue: any) {
     const currentFilterText = filterText.value;
-    filterText.value = filterClass.setFilterValue(currentFilterText, newFilterText, newValue);
+    filterText.value = filterClass.setFilterValue(currentFilterText, filterKey, newValue);
 }
 
 function getItemKey(item: HistoryItem) {

--- a/client/src/components/Panels/Menus/PanelViewMenu.vue
+++ b/client/src/components/Panels/Menus/PanelViewMenu.vue
@@ -2,7 +2,7 @@
     <b-button
         v-if="showAdvanced"
         variant="link"
-        class="w-100"
+        class="w-100 text-decoration-none"
         size="sm"
         @click="$emit('update:show-advanced', !showAdvanced)">
         <slot name="panel-view-selector"></slot><span class="sr-only">Close advanced tool search menu</span>

--- a/client/src/components/Workflow/WorkflowCard.vue
+++ b/client/src/components/Workflow/WorkflowCard.vue
@@ -125,7 +125,10 @@ async function onTagClick(tag: string) {
                 'workflow-shared': workflow.published,
             }">
             <div class="workflow-card-header">
-                <WorkflowIndicators :workflow="workflow" :published-view="publishedView" @update-filter="(k, v) => emit('update-filter', k, v)" />
+                <WorkflowIndicators
+                    :workflow="workflow"
+                    :published-view="publishedView"
+                    @update-filter="(k, v) => emit('update-filter', k, v)" />
 
                 <div class="workflow-count-actions">
                     <WorkflowInvocationsCount v-if="!isAnonymous && !shared" class="mx-1" :workflow="workflow" />

--- a/client/src/components/Workflow/WorkflowCard.vue
+++ b/client/src/components/Workflow/WorkflowCard.vue
@@ -37,6 +37,7 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
     (e: "tagClick", tag: string): void;
     (e: "refreshList", overlayLoading?: boolean, b?: boolean): void;
+    (e: "update-filter", key: string, value: any): void;
 }>();
 
 const userStore = useUserStore();
@@ -124,7 +125,7 @@ async function onTagClick(tag: string) {
                 'workflow-shared': workflow.published,
             }">
             <div class="workflow-card-header">
-                <WorkflowIndicators :workflow="workflow" :published-view="publishedView" />
+                <WorkflowIndicators :workflow="workflow" :published-view="publishedView" @update-filter="(k, v) => emit('update-filter', k, v)" />
 
                 <div class="workflow-count-actions">
                     <WorkflowInvocationsCount v-if="!isAnonymous && !shared" class="mx-1" :workflow="workflow" />

--- a/client/src/components/Workflow/WorkflowFilters.js
+++ b/client/src/components/Workflow/WorkflowFilters.js
@@ -1,115 +1,167 @@
 import Filtering, { contains, equals, expandNameTag, toBool } from "utils/filtering";
 
-export const helpHtml = `<div>
-<p>This input can be used to filter the workflows displayed.</p>
+export function helpHtml(activeList = "my") {
+    let extra = "";
+    if (activeList === "my") {
+        extra = `<dt><code>is:published</code></dt>
+        <dd>
+            Shows published workflows.
+        </dd>
+        <dt><code>is:importable</code></dt>
+        <dd>
+            Shows importable workflows (this also means they are URL generated).
+        </dd>
+        <dt><code>is:shared_with_me</code></dt>
+        <dd>
+            Shows workflows shared by another user directly with you.
+        </dd>
+        <dt><code>is:deleted</code></dt>
+        <dd>Shows deleted workflows.</dd>`;
+    } else if (activeList === "shared_with_me") {
+        extra = `<dt><code>user:____</code></dt>
+        <dd>
+            Shows workflows owned by the given user.
+        </dd>
+        <dt><code>is:published</code></dt>
+        <dd>
+            Shows published workflows.
+        </dd>`;
+    } else {
+        extra = `<dt><code>user:____</code></dt>
+        <dd>
+            Shows workflows owned by the given user.
+        </dd>
+        <dt><code>is:shared_with_me</code></dt>
+        <dd>
+            Shows workflows shared by another user directly with you.
+        </dd>`;
+    }
 
-<p>
-    Text entered here will be searched against workflow names and workflow
-    tags. Additionally, advanced filtering tags can be used to refine the
-    search more precisely. Filtering tags are of the form
-    <code>&lt;tag_name&gt;:&lt;tag_value&gt;</code> or
-    <code>&lt;tag_name&gt;:'&lt;tag_value&gt;'</code>. For instance to
-    search just for RNAseq in the workflow name,
-    <code>name:rnsseq</code> can be used. Notice by default the search is
-    not case-sensitive. If the quoted version of tag is used, the search is
-    case sensitive and only full matches will be returned. So
-    <code>name:'RNAseq'</code> would show only workflows named exactly
-    <code>RNAseq</code>.
-</p>
+    const conditionalHelpHtml = `<div>
+        <p>This menu can be used to filter the workflows displayed.</p>
 
-<p>The available filtering tags are:</p>
-<dl>
-    <dt><code>name</code></dt>
-    <dd>
-        Shows workflows with the given sequence of characters in their names.
-    </dd>
-    <dt><code>tag</code></dt>
-    <dd>
-        Shows workflows with the given workflow tag. You may also click
-        on a tag to filter on that tag directly.
-    </dd>
-    <dt><code>is:published</code></dt>
-    <dd>
-        Shows published workflows.
-    </dd>
-    <dt><code>is:importable</code></dt>
-    <dd>
-        Shows importable workflows (this also means they are URL generated).
-    </dd>
-    <dt><code>is:shared_with_me</code></dt>
-    <dd>
-        Shows workflows shared by another user directly with you.
-    </dd>
-    <dt><code>is:deleted</code></dt>
-    <dd>Shows deleted workflows.</dd>
-</dl>
-</div>`;
+        <p>
+            Text entered here will be searched against workflow names and workflow
+            tags. Additionally, advanced filtering tags can be used to refine the
+            search more precisely. Filtering tags are of the form
+            <code>&lt;tag_name&gt;:&lt;tag_value&gt;</code> or
+            <code>&lt;tag_name&gt;:'&lt;tag_value&gt;'</code>. For instance to
+            search just for RNAseq in the workflow name,
+            <code>name:rnsseq</code> can be used. Notice by default the search is
+            not case-sensitive. If the quoted version of tag is used, the search is
+            case sensitive and only full matches will be returned. So
+            <code>name:'RNAseq'</code> would show only workflows named exactly
+            <code>RNAseq</code>.
+        </p>
 
-const validFilters = {
-    name: { placeholder: "name", type: String, handler: contains("name"), menuItem: true },
-    user: {
-        placeholder: "owner",
-        type: String,
-        handler: contains("user"),
-        menuItem: false,
-    },
-    tag: {
-        placeholder: "tag(s)",
-        type: "MultiTags",
-        handler: contains("tag", "tag", expandNameTag),
-        menuItem: true,
-    },
-    published: {
-        placeholder: "Filter on published workflows",
-        type: Boolean,
-        boolType: "is",
-        handler: equals("published", "published", toBool),
-        menuItem: true,
-    },
-    importable: {
-        placeholder: "Filter on importable workflows",
-        type: Boolean,
-        boolType: "is",
-        handler: equals("importable", "importable", toBool),
-        menuItem: true,
-    },
-    shared_with_me: {
-        placeholder: "Filter on workflows shared with me",
-        type: Boolean,
-        boolType: "is",
-        handler: equals("shared_with_me", "shared_with_me", toBool),
-        menuItem: true,
-    },
-    deleted: {
-        placeholder: "Filter on deleted workflows",
-        type: Boolean,
-        boolType: "is",
-        handler: equals("deleted", "deleted", toBool),
-        menuItem: true,
-    },
-};
+        <p>The available filtering tags are:</p>
+        <dl>
+            <dt><code>name:____</code></dt>
+            <dd>
+                Shows workflows with the given sequence of characters in their names.
+            </dd>
+            <dt><code>tag:____</code></dt>
+            <dd>
+                Shows workflows with the given workflow tag. You may also click
+                on a tag to filter on that tag directly.
+            </dd>
+            ${extra}
+        </dl>
+    </div>`;
+    return conditionalHelpHtml;
+}
 
-export const WorkflowFilters = new Filtering(validFilters, undefined, false, false);
+export function WorkflowFilters(activeList = "my") {
+    const commonFilters = {
+        name: { placeholder: "name", type: String, handler: contains("name"), menuItem: true },
+        tag: {
+            placeholder: "tag(s)",
+            type: "MultiTags",
+            handler: contains("tag", "tag", expandNameTag),
+            menuItem: true,
+        },
+    };
 
-const validPublishedFilters = {
-    ...validFilters,
-    user: {
-        ...validFilters.user,
-        menuItem: true,
-    },
-    published: {
-        ...validFilters.published,
-        default: true,
-        menuItem: false,
-    },
-    shared_with_me: {
-        ...validFilters.shared_with_me,
-        menuItem: false,
-    },
-    importable: {
-        ...validFilters.importable,
-        menuItem: false,
-    },
-};
-
-export const PublishedWorkflowFilters = new Filtering(validPublishedFilters, undefined, false, false);
+    if (activeList === "my") {
+        return new Filtering(
+            {
+                ...commonFilters,
+                published: {
+                    placeholder: "Filter on published workflows",
+                    type: Boolean,
+                    boolType: "is",
+                    handler: equals("published", "published", toBool),
+                    menuItem: true,
+                },
+                importable: {
+                    placeholder: "Filter on importable workflows",
+                    type: Boolean,
+                    boolType: "is",
+                    handler: equals("importable", "importable", toBool),
+                    menuItem: true,
+                },
+                shared_with_me: {
+                    placeholder: "Filter on workflows shared with me",
+                    type: Boolean,
+                    boolType: "is",
+                    handler: equals("shared_with_me", "shared_with_me", toBool),
+                    menuItem: true,
+                },
+                deleted: {
+                    placeholder: "Filter on deleted workflows",
+                    type: Boolean,
+                    boolType: "is",
+                    handler: equals("deleted", "deleted", toBool),
+                    menuItem: true,
+                },
+            },
+            undefined,
+            false,
+            false
+        );
+    } else if (activeList === "shared_with_me") {
+        return new Filtering(
+            {
+                ...commonFilters,
+                user: {
+                    placeholder: "owner",
+                    type: String,
+                    handler: contains("user"),
+                    menuItem: true,
+                },
+                published: {
+                    placeholder: "Filter on published workflows",
+                    type: Boolean,
+                    boolType: "is",
+                    handler: equals("published", "published", toBool),
+                    menuItem: true,
+                },
+            },
+            undefined,
+            false,
+            false
+        );
+    } else {
+        return new Filtering(
+            {
+                ...commonFilters,
+                user: {
+                    placeholder: "owner",
+                    type: String,
+                    handler: contains("user"),
+                    menuItem: true,
+                },
+                shared_with_me: {
+                    placeholder: "Filter on workflows shared with me",
+                    type: Boolean,
+                    boolType: "is",
+                    handler: equals("shared_with_me", "shared_with_me", toBool),
+                    menuItem: true,
+                },
+            },
+            undefined,
+            false,
+            false
+        );
+    }
+}

--- a/client/src/components/Workflow/WorkflowFilters.js
+++ b/client/src/components/Workflow/WorkflowFilters.js
@@ -74,12 +74,14 @@ export function helpHtml(activeList = "my") {
 export function WorkflowFilters(activeList = "my") {
     const commonFilters = {
         name: { placeholder: "name", type: String, handler: contains("name"), menuItem: true },
+        n: { handler: contains("n"), menuItem: false },
         tag: {
             placeholder: "tag(s)",
             type: "MultiTags",
             handler: contains("tag", "tag", expandNameTag),
             menuItem: true,
         },
+        t: { type: "MultiTags", handler: contains("t", "t", expandNameTag), menuItem: false },
     };
 
     if (activeList === "my") {
@@ -129,6 +131,7 @@ export function WorkflowFilters(activeList = "my") {
                     handler: contains("user"),
                     menuItem: true,
                 },
+                u: { handler: contains("u"), menuItem: false },
                 published: {
                     placeholder: "Filter on published workflows",
                     type: Boolean,
@@ -151,6 +154,7 @@ export function WorkflowFilters(activeList = "my") {
                     handler: contains("user"),
                     menuItem: true,
                 },
+                u: { handler: contains("u"), menuItem: false },
                 shared_with_me: {
                     placeholder: "Filter on workflows shared with me",
                     type: Boolean,

--- a/client/src/components/Workflow/WorkflowIndicators.vue
+++ b/client/src/components/Workflow/WorkflowIndicators.vue
@@ -79,7 +79,7 @@ function onViewUserPublished() {
 <template>
     <div>
         <BButton
-            v-if="workflow.published"
+            v-if="workflow.published && !publishedView"
             v-b-tooltip.noninteractive
             size="sm"
             class="workflow-published-icon inline-icon-button"
@@ -87,6 +87,7 @@ function onViewUserPublished() {
             title="Published workflow. Click to view all published workflows">
             <FontAwesomeIcon :icon="faGlobe" fixed-width />
         </BButton>
+        <FontAwesomeIcon v-else-if="workflow.published" :icon="faGlobe" fixed-width size="sm" />
 
         <BButton
             v-if="sourceType.includes('trs')"

--- a/client/src/components/Workflow/WorkflowIndicators.vue
+++ b/client/src/components/Workflow/WorkflowIndicators.vue
@@ -21,6 +21,10 @@ interface Props {
 
 const props = defineProps<Props>();
 
+const emit = defineEmits<{
+    (e: "update-filter", key: string, value: any): void;
+}>();
+
 const router = useRouter();
 const userStore = useUserStore();
 
@@ -69,10 +73,12 @@ function onCopyLink() {
 
 function onViewMySharedByUser() {
     router.push(`/workflows/list_shared_with_me?owner=${props.workflow.owner}`);
+    emit("update-filter", "user", `'${props.workflow.owner}'`);
 }
 
 function onViewUserPublished() {
     router.push(`/workflows/list_published?owner=${props.workflow.owner}`);
+    emit("update-filter", "user", `'${props.workflow.owner}'`);
 }
 </script>
 

--- a/client/src/components/Workflow/WorkflowIndicators.vue
+++ b/client/src/components/Workflow/WorkflowIndicators.vue
@@ -86,18 +86,18 @@ function onViewUserPublished() {
     <div>
         <BButton
             v-if="workflow.published && !publishedView"
-            v-b-tooltip.noninteractive
+            v-b-tooltip.noninteractive.hover
             size="sm"
             class="workflow-published-icon inline-icon-button"
-            to="/workflows/list_published"
-            title="Published workflow. Click to view all published workflows">
+            title="Published workflow. Click to filter published workflows"
+            @click="emit('update-filter', 'published', true)">
             <FontAwesomeIcon :icon="faGlobe" fixed-width />
         </BButton>
         <FontAwesomeIcon v-else-if="workflow.published" :icon="faGlobe" fixed-width size="sm" />
 
         <BButton
             v-if="sourceType.includes('trs')"
-            v-b-tooltip.noninteractive
+            v-b-tooltip.noninteractive.hover
             size="sm"
             class="workflow-trs-icon inline-icon-button"
             :title="sourceTitle">
@@ -106,7 +106,7 @@ function onViewUserPublished() {
 
         <BButton
             v-if="sourceType == 'url'"
-            v-b-tooltip.noninteractive
+            v-b-tooltip.noninteractive.hover
             size="sm"
             class="workflow-external-link inline-icon-button"
             :title="sourceTitle">
@@ -122,7 +122,7 @@ function onViewUserPublished() {
 
         <BBadge
             v-if="shared && !publishedView"
-            v-b-tooltip.noninteractive
+            v-b-tooltip.noninteractive.hover
             class="outline-badge cursor-pointer mx-1"
             :title="`'${workflow.owner}' shared this workflow with you. Click to view all workflows shared with you by '${workflow.owner}'`"
             @click="onViewMySharedByUser">
@@ -132,7 +132,7 @@ function onViewUserPublished() {
 
         <BBadge
             v-if="publishedView"
-            v-b-tooltip.noninteractive
+            v-b-tooltip.noninteractive.hover
             class="outline-badge cursor-pointer mx-1"
             :title="publishedTitle"
             @click="onViewUserPublished">

--- a/client/src/components/Workflow/WorkflowIndicators.vue
+++ b/client/src/components/Workflow/WorkflowIndicators.vue
@@ -93,7 +93,13 @@ function onViewUserPublished() {
             @click="emit('update-filter', 'published', true)">
             <FontAwesomeIcon :icon="faGlobe" fixed-width />
         </BButton>
-        <FontAwesomeIcon v-else-if="workflow.published" :icon="faGlobe" fixed-width size="sm" />
+        <FontAwesomeIcon
+            v-else-if="workflow.published"
+            v-b-tooltip.noninteractive.hover
+            title="Published workflow"
+            :icon="faGlobe"
+            fixed-width
+            size="sm" />
 
         <BButton
             v-if="sourceType.includes('trs')"

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -169,7 +169,7 @@ watch([filterText, sortBy, sortDesc, showBookmarked], async () => {
 
 onMounted(() => {
     if (router.currentRoute.query.owner) {
-        updateFilterValue("user", router.currentRoute.query.owner);
+        updateFilterValue("user", `'${router.currentRoute.query.owner}'`);
     }
     load();
 });
@@ -273,9 +273,9 @@ onMounted(() => {
                         >: {{ value }}
                     </li>
                 </ul>
-                <a href="javascript:void(0)" class="ui-link" @click="filterText = validatedFilterText()"
-                    >Remove invalid filters from query</a
-                >
+                <a href="javascript:void(0)" class="ui-link" @click="filterText = validatedFilterText()">
+                    Remove invalid filters from query
+                </a>
             </BAlert>
         </span>
 
@@ -294,7 +294,8 @@ onMounted(() => {
                 :grid-view="view === 'grid'"
                 :class="view === 'grid' ? 'grid-view' : 'list-view'"
                 @refreshList="load"
-                @tagClick="(tag) => updateFilterValue('tag', tag)" />
+                @tagClick="(tag) => updateFilterValue('tag', `'${tag}'`)"
+                @update-filter="updateFilterValue" />
 
             <BPagination
                 v-if="!loading && totalWorkflows > limit"

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -78,6 +78,7 @@ const rawFilters = computed(() =>
 );
 const validFilters = computed(() => workflowFilters.value.getValidFilters(rawFilters.value, true).validFilters);
 const invalidFilters = computed(() => workflowFilters.value.getValidFilters(rawFilters.value, true).invalidFilters);
+const hasInvalidFilters = computed(() => Object.keys(invalidFilters.value).length > 0);
 
 function updateFilterValue(filterKey: string, newValue: any) {
     const currentFilterText = filterText.value;
@@ -97,7 +98,7 @@ async function load(overlayLoading = false, silent = false) {
         }
     }
     let search;
-    if (Object.keys(invalidFilters.value).length === 0) {
+    if (!hasInvalidFilters.value) {
         search = validatedFilterText();
 
         // append default backend query filters for provided `props.activeList`
@@ -260,8 +261,8 @@ onMounted(() => {
         </BAlert>
 
         <!-- There are either `noResults` or `invalidFilters` -->
-        <span v-else-if="!loading && !overlay && (noResults || Object.keys(invalidFilters).length > 0)">
-            <BAlert v-if="Object.keys(invalidFilters).length === 0" id="no-workflow-found" variant="info" show>
+        <span v-else-if="!loading && !overlay && (noResults || hasInvalidFilters)">
+            <BAlert v-if="!hasInvalidFilters" id="no-workflow-found" variant="info" show>
                 No workflows found matching: <span class="font-weight-bold">{{ filterText }}</span>
             </BAlert>
 

--- a/client/src/utils/filterConversion.test.js
+++ b/client/src/utils/filterConversion.test.js
@@ -1,7 +1,9 @@
 import { HistoryFilters } from "components/History/HistoryFilters";
-import { PublishedWorkflowFilters } from "components/Workflow/WorkflowFilters";
+import { WorkflowFilters } from "components/Workflow/WorkflowFilters";
 
 describe("test filtering helpers to convert filters to filter text", () => {
+    const MyWorkflowFilters = WorkflowFilters("my");
+    const PublishedWorkflowFilters = WorkflowFilters("published");
     it("conversion from filters to new filter text", async () => {
         const normalized = HistoryFilters.defaultFilters;
         expect(Object.keys(normalized).length).toBe(2);
@@ -10,7 +12,7 @@ describe("test filtering helpers to convert filters to filter text", () => {
     });
 
     it("verify the existence of defaults", async () => {
-        let filters = {};
+        const filters = {};
         Object.entries(HistoryFilters.defaultFilters).forEach(([key, value]) => {
             filters[key] = value;
         });
@@ -22,13 +24,6 @@ describe("test filtering helpers to convert filters to filter text", () => {
         expect(HistoryFilters.containsDefaults(filters)).toBe(false);
         filters["visible"] = String(HistoryFilters.defaultFilters.visible).toUpperCase();
         expect(HistoryFilters.containsDefaults(filters)).toBe(true);
-        filters = {};
-        Object.entries(PublishedWorkflowFilters.defaultFilters).forEach(([key, value]) => {
-            filters[key] = value;
-        });
-        expect(PublishedWorkflowFilters.containsDefaults(filters)).toBe(true);
-        filters["published"] = !PublishedWorkflowFilters.defaultFilters.published;
-        expect(PublishedWorkflowFilters.containsDefaults(filters)).toBe(false);
     });
 
     it("verify correct conversion of filters", async () => {
@@ -37,14 +32,16 @@ describe("test filtering helpers to convert filters to filter text", () => {
             visible: HistoryFilters.defaultFilters.visible,
             name: "name",
             other: "other",
-            tag: ["tag1", "tag2"],
+            tag: ["tag1", "'tag2'", "'#tag3'"],
             genome_build: "",
-            published: PublishedWorkflowFilters.defaultFilters.published,
+            published: true,
         };
-        const validHistFilters = HistoryFilters.getValidFilters(filters);
+        const validHistFilters = HistoryFilters.getValidFilters(filters).validFilters;
         expect(Object.keys(validHistFilters)).toEqual(["deleted", "visible", "name"]);
-        const validWfFilters = PublishedWorkflowFilters.getValidFilters(filters);
-        expect(Object.keys(validWfFilters)).toEqual(["deleted", "name", "tag", "published"]);
+        const validMyWfFilters = MyWorkflowFilters.getValidFilters(filters).validFilters;
+        expect(Object.keys(validMyWfFilters)).toEqual(["deleted", "name", "tag", "published"]);
+        const validPubWfFilters = PublishedWorkflowFilters.getValidFilters(filters).validFilters;
+        expect(Object.keys(validPubWfFilters)).toEqual(["name", "tag"]);
 
         expect(HistoryFilters.getFilterText(filters)).toBe("name:name");
         filters["visible"] = !HistoryFilters.defaultFilters.visible;
@@ -52,15 +49,27 @@ describe("test filtering helpers to convert filters to filter text", () => {
         filters["visible"] = HistoryFilters.defaultFilters.visible;
         expect(HistoryFilters.getFilterText(filters)).toBe("name:name");
 
-        expect(PublishedWorkflowFilters.getFilterText(filters, true)).toBe("name:name tag:tag1 tag:tag2 is:published");
+        // non-backend filter text keeps filters as is
+        expect(MyWorkflowFilters.getFilterText(filters)).toBe("name:name tag:tag1 tag:'tag2' tag:'#tag3' is:published");
+
+        // backend filter text adjusts name tag by replacing `#` with `name:`
+        expect(MyWorkflowFilters.getFilterText(filters, true)).toBe(
+            "name:name tag:tag1 tag:'tag2' tag:'name:tag3' is:published"
+        );
+
+        expect(PublishedWorkflowFilters.getFilterText(filters, true)).toBe(
+            "name:name tag:tag1 tag:'tag2' tag:'name:tag3'"
+        );
         delete filters["published"];
-        expect(PublishedWorkflowFilters.getFilterText(filters, true)).toBe("name:name tag:tag1 tag:tag2");
+        expect(MyWorkflowFilters.getFilterText(filters, true)).toBe("name:name tag:tag1 tag:'tag2' tag:'name:tag3'");
     });
 });
 
 describe("test filtering helpers to convert filter text to filters", () => {
+    const PublishedWorkflowFilters = WorkflowFilters("published");
     function getFilters(filteringClass, filterText) {
-        return filteringClass.getValidFilters(Object.fromEntries(filteringClass.getFiltersForText(filterText)));
+        return filteringClass.getValidFilters(Object.fromEntries(filteringClass.getFiltersForText(filterText)))
+            .validFilters;
     }
 
     it("verify the existence of defaults", async () => {
@@ -74,11 +83,6 @@ describe("test filtering helpers to convert filter text to filters", () => {
         expect(HistoryFilters.containsDefaults(getFilters(HistoryFilters, filterText))).toBe(false);
         filterText = "deleted:false visible:true";
         expect(HistoryFilters.containsDefaults(getFilters(HistoryFilters, filterText))).toBe(true);
-
-        filterText = "";
-        expect(PublishedWorkflowFilters.containsDefaults(getFilters(PublishedWorkflowFilters, filterText))).toBe(true);
-        filterText = "is:published is:deleted";
-        expect(PublishedWorkflowFilters.containsDefaults(getFilters(PublishedWorkflowFilters, filterText))).toBe(true);
     });
 
     it("verify correct conversion of filterText (HistoryFilters)", async () => {
@@ -104,17 +108,14 @@ describe("test filtering helpers to convert filter text to filters", () => {
 
     it("verify correct conversion of filterText (PublishedWorkflowFilters)", async () => {
         const filters = {
-            published: PublishedWorkflowFilters.defaultFilters.published,
             name: "name",
         };
-        let filterText = "name:name";
+        let filterText = "name:name is:published";
         expect(getFilters(PublishedWorkflowFilters, filterText)).toEqual(filters);
         filterText = "published:false name:name";
-        // filters["visible"] = !PublishedWorkflowFilters.defaultFilters.visible;
-        // delete filters["deleted"];
         expect(getFilters(PublishedWorkflowFilters, filterText)).toEqual(filters);
-        filterText = "name:name invalid:invalid is:deleted";
-        filters["deleted"] = true;
+        filterText = "name:name invalid:invalid user:testUser";
+        filters["user"] = "testUser";
         expect(getFilters(PublishedWorkflowFilters, filterText)).toEqual(filters);
     });
 });

--- a/client/src/utils/filtering.test.js
+++ b/client/src/utils/filtering.test.js
@@ -14,6 +14,10 @@ const sampleFilters = [
         validFilters: {
             deleted: true,
         },
+        invalidFilters: {
+            invalid: "value",
+            visible: null,
+        },
         validText: "deleted:true visible:any",
     },
     {
@@ -27,6 +31,9 @@ const sampleFilters = [
             deleted: "any",
             related: 10,
             hid_gt: 5,
+        },
+        invalidFilters: {
+            hid_less_than: 20,
         },
         validText: "deleted:any related:10 hid>5 visible:any",
     },
@@ -90,7 +97,9 @@ describe("filtering", () => {
     });
     test("parse get valid filters and settings", () => {
         sampleFilters.forEach((sample) => {
-            expect(HistoryFilters.getValidFilters(sample.filters)).toEqual(sample.validFilters);
+            const { validFilters, invalidFilters } = HistoryFilters.getValidFilters(sample.filters);
+            expect(validFilters).toEqual(sample.validFilters);
+            expect(invalidFilters).toEqual(sample.invalidFilters);
             expect(HistoryFilters.getFilterText(sample.filters)).toEqual(sample.validText);
         });
     });

--- a/client/src/utils/filtering.ts
+++ b/client/src/utils/filtering.ts
@@ -104,7 +104,7 @@ export function toLowerNoQuotes<T>(value: T): string {
 
 /** Converts name tags starting with '#' to 'name:'
  * @param value
- * @returns Lowercase value with 'name:' replaced with '#'
+ * @returns String value with 'name:' replaced with '#'
  * */
 export function expandNameTag<T>(value: T): string {
     if (value && typeof value === "string") {
@@ -114,7 +114,7 @@ export function expandNameTag<T>(value: T): string {
             value = value.replace(/^#/, "name:") as T;
         }
     }
-    return toLower(value);
+    return value as string;
 }
 
 /** Converts string alias to string operator, e.g.: 'gt' to '>'
@@ -233,7 +233,9 @@ export function compare<T>(attribute: string, variant: string, converter?: Conve
  * @param validAliases: Array of valid aliases for filters
  * @param quoteStrings: Whether to auto quote filter strings in the query
  * @param nameMatching: Whether to apply name filter for unspecified filterText
- *                      (e.g. filterText = 'foo' -> 'name:foo')
+ *                      (e.g. filterText = 'foo' -> 'name:foo').
+ *                      Typically, when this is false, we index every field in
+ *                      the backend for unspecified filterText.
  * @returns Filtering object
  * */
 export default class Filtering<T> {
@@ -588,11 +590,10 @@ export default class Filtering<T> {
             if (converter) {
                 if (
                     (converter == toBool && filterValue == "any") ||
-                    (!backendFormatted && /^(['"]).*\1$/.test(filterValue as string))
+                    (!backendFormatted && /^(['"]).*\1$/.test(filterValue as string)) ||
+                    (!backendFormatted && ([expandNameTag, toDate] as Converter<T>[]).includes(converter))
                 ) {
                     return filterValue;
-                } else if (!backendFormatted && ([expandNameTag, toDate] as Converter<T>[]).includes(converter)) {
-                    return toLower(filterValue) as T;
                 }
                 return converter(filterValue);
             } else {

--- a/client/src/utils/filtering.ts
+++ b/client/src/utils/filtering.ts
@@ -341,7 +341,7 @@ export default class Filtering<T> {
      * @returns Parsed filter text string
      * */
     getFilterText(filters: Record<string, T>, backendFormatted = false): string {
-        filters = this.getValidFilters(filters, backendFormatted);
+        filters = this.getValidFilters(filters, backendFormatted).validFilters;
         const hasDefaults = this.containsDefaults(filters);
 
         let newFilterText = "";
@@ -385,10 +385,10 @@ export default class Filtering<T> {
 
     /** Parses single text input into a dict of field->value pairs.
      * @param filterText Raw filter text string
-     * @param removeAny default: `true` Whether to remove default filters if the are set to `any`
+     * @param removeAny default: `true` Whether to remove default filters if they are set to `any`
      * @returns Filters as 2D array of of [field, value] pairs
      * */
-    getFiltersForText(filterText: string, removeAny = true): [string, T][] {
+    getFiltersForText(filterText: string, removeAny = true, validate = true): [string, T][] {
         const pairSplitRE = this.quoteStrings
             ? /[^\s'"]+(?:['"][^'"]*['"][^\s'"]*)*|(?:['"][^'"]*['"][^\s'"]*)+/g
             : /(\S+):(.*?)(?=\s+\S+:|$)/g;
@@ -414,8 +414,8 @@ export default class Filtering<T> {
                     const normalizedField = field?.split("-").join("_");
                     if (
                         normalizedField &&
-                        this.validFilters[normalizedField] &&
-                        this.validFilters[normalizedField]?.boolType !== "is"
+                        this.validFilters[normalizedField]?.boolType !== "is" &&
+                        ((!validate && normalizedField !== "is") || this.validFilters[normalizedField])
                     ) {
                         // removes quotation and applies lower-case to filter value
                         const newVal = this.quoteStrings ? (toLowerNoQuotes(value) as T) : (value as T);
@@ -430,7 +430,12 @@ export default class Filtering<T> {
                             result[normalizedField] = newVal;
                         }
                         hasMatches = true;
-                    } else if (value && field === "is" && elg === ":" && this.validFilters[value]?.boolType === "is") {
+                    } else if (
+                        value &&
+                        field === "is" &&
+                        elg === ":" &&
+                        (!validate || this.validFilters[value]?.boolType === "is")
+                    ) {
                         // handle `is:filter` syntax
                         result[value] = true as T;
                         hasMatches = true;
@@ -471,7 +476,7 @@ export default class Filtering<T> {
      * @returns Parsed `filterText` string with added/removed filter(s)
      */
     applyFiltersToText(filters: Record<string, T>, existingText: string, remove = false) {
-        let validFilters = this.getValidFilters(filters);
+        let { validFilters } = this.getValidFilters(filters);
         const existingFilters = Object.fromEntries(this.getFiltersForText(existingText, false));
         if (remove) {
             validFilters = omit(existingFilters, Object.keys(validFilters));
@@ -485,10 +490,11 @@ export default class Filtering<T> {
      *
      * @param filters A filters object (e.g.: {hid: "3", name: "test", invalid: "x"}})
      * @param backendFormatted default: `false` Whether to convert the values to backend format
-     * @returns valid filters object (e.g.: {hid: "3", name: "test"}})
+     * @returns a _valid_ filters object (e.g.: {hid: "3", name: "test"}}) and one with invalid filters
      */
     getValidFilters(filters: Record<string, T>, backendFormatted = false) {
         const validFilters: Record<string, T> = {};
+        const invalidFilters: Record<string, T> = {};
         Object.entries(filters).forEach(([key, value]) => {
             if (this.validFilters[key]?.type === "MultiTags" && Array.isArray(value)) {
                 const validValues = value
@@ -497,14 +503,22 @@ export default class Filtering<T> {
                 if (validValues.length > 0) {
                     validFilters[key] = validValues as T;
                 }
+                const invalidValues = value.filter(
+                    (v) => !validValues.includes(this.getConvertedValue(key, v, backendFormatted))
+                );
+                if (invalidValues.length > 0) {
+                    invalidFilters[key] = invalidValues as T;
+                }
             } else {
                 const validValue = this.getConvertedValue(key, value, backendFormatted);
                 if (validValue !== undefined) {
                     validFilters[key] = validValue;
+                } else {
+                    invalidFilters[key] = value;
                 }
             }
         });
-        return validFilters;
+        return { validFilters, invalidFilters };
     }
 
     /** Convert a valid filter key (`filter`/`filter-gt`) to alias filter key (`filter:`/`filter>`)

--- a/test/integration_selenium/test_trs_import.py
+++ b/test/integration_selenium/test_trs_import.py
@@ -49,7 +49,8 @@ class TestTrsImport(SeleniumIntegrationTestCase):
         return cls.temp_config_dir("trs")
 
     def assert_workflow_imported(self, name):
-        self.workflow_index_search_for(name)
+        # surround name with quotes to consider case where name contains colons
+        self.workflow_index_search_for(f'"{name}"')
         assert len(self.workflow_card_elements()) == 1, f"workflow ${name} not imported"
 
     def test_import_workflow_by_url_dockstore(self):


### PR DESCRIPTION
Modified the `Filtering.getValidFilters` function to return an `invalidFilters` object as well, which can be used to tell the user which filters were invalid. Fixes https://github.com/galaxyproject/galaxy/issues/17668

https://github.com/galaxyproject/galaxy/assets/78516064/975e8e3b-9c40-4c4e-819e-a56144e72615

Also added a loading indicator that Fixes https://github.com/galaxyproject/galaxy/issues/17666

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Go to the Workflow List or any modernized grid (Histories, Pages etc.)
  2. Applying any filter not in the list of valid filters (seen in the advanced options) should produce an error and no results.
  3. Tag filtering should work as expected (with and without quotes; producing appropriate results)

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
