### PR TITLE
[24.0] Purge history from history panel

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -277,7 +277,7 @@ function userTitle(title: string) {
             @ok="onDelete"
             @show="purgeHistory = false">
             <p v-localize>
-                Do you also want to purge the history <i class="ml-1">{{ history.name }}</i>
+                Do you also want to permanently delete the history <i class="ml-1">{{ history.name }}</i>
             </p>
             <BFormCheckbox id="purge-history" v-model="purgeHistory">
                 <span v-localize>Purge history</span>

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -280,7 +280,7 @@ function userTitle(title: string) {
                 Do you also want to permanently delete the history <i class="ml-1">{{ history.name }}</i>
             </p>
             <BFormCheckbox id="purge-history" v-model="purgeHistory">
-                <span v-localize>Purge history</span>
+                <span v-localize>Yes, permanently delete this history.</span>
             </BFormCheckbox>
         </BModal>
     </div>

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -24,6 +24,7 @@ import {
     BDropdownDivider,
     BDropdownItem,
     BDropdownText,
+    BFormCheckbox,
     BModal,
     BSpinner,
 } from "bootstrap-vue";
@@ -63,18 +64,27 @@ interface Props {
     historiesLoading?: boolean;
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
     title: "Histories",
     historiesLoading: false,
 });
 
 const showSwitchModal = ref(false);
+const purgeHistory = ref(false);
 
 const userStore = useUserStore();
 const historyStore = useHistoryStore();
 
 const { isAnonymous } = storeToRefs(userStore);
 const { totalHistoryCount } = storeToRefs(historyStore);
+
+function onDelete() {
+    if (purgeHistory.value) {
+        historyStore.deleteHistory(props.history.id, true);
+    } else {
+        historyStore.deleteHistory(props.history.id, false);
+    }
+}
 
 function userTitle(title: string) {
     if (isAnonymous.value) {
@@ -264,8 +274,14 @@ function userTitle(title: string) {
             id="delete-history-modal"
             title="Delete History?"
             title-tag="h2"
-            @ok="historyStore.deleteHistory(history.id, false)">
-            <p v-localize>Really delete the current history?</p>
+            @ok="onDelete"
+            @show="purgeHistory = false">
+            <p v-localize>
+                Do you also want to purge the history <i class="ml-1">{{ history.name }}</i>
+            </p>
+            <BFormCheckbox id="purge-history" v-model="purgeHistory">
+                <span v-localize>Purge history</span>
+            </BFormCheckbox>
         </BModal>
 
         <BModal

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -283,13 +283,5 @@ function userTitle(title: string) {
                 <span v-localize>Purge history</span>
             </BFormCheckbox>
         </BModal>
-
-        <BModal
-            id="purge-history-modal"
-            title="Permanently Delete History?"
-            title-tag="h2"
-            @ok="historyStore.deleteHistory(history.id, true)">
-            <p v-localize>Really delete the current history permanently? This cannot be undone.</p>
-        </BModal>
     </div>
 </template>


### PR DESCRIPTION
Clicking on the `Delete History` option from the `HistoryNavigation` dropdown in the `HistoryPanel` now provides you the option to also purge the history from the modal. Fixes https://github.com/galaxyproject/galaxy/issues/17606

**Clicking here:**
![image](https://github.com/galaxyproject/galaxy/assets/78516064/721d9eca-32f2-498b-975c-3086c0368b4f)


| Used to do | Now does |
| -------- | ---------- |
| <img src="https://github.com/galaxyproject/galaxy/assets/78516064/7de37a82-af1b-49d8-9281-e8ff62337d49" /> | <img src="https://github.com/galaxyproject/galaxy/assets/78516064/72de9652-f901-4f8d-8b56-9eaf48ce14d2" /> |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
