### PR TITLE
[24.0] Fix contentitem display routing. 

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -250,10 +250,11 @@ function onDisplay() {
         // but we're using a __vkey__ bit as a workaround
         // Only conditionally force to keep urls clean most of the time.
         if (route.path === itemUrls.value.display) {
-            // @ts-ignore
+            // @ts-ignore - monkeypatched router, drop with migration.
             router.push(itemUrls.value.display, { title: props.name, force: true });
         } else if (itemUrls.value.display) {
-            router.push({ path: itemUrls.value.display, params: { title: props.name } });
+            // @ts-ignore - monkeypatched router, drop with migration.
+            router.push(itemUrls.value.display, { title: props.name });
         }
     }
 }


### PR DESCRIPTION
Should fix selenium failures in 24.0 and dev.

Also documents the ts-ignore usage more explicitly.  We use a custom push method that has a different signature, hence the ts-ignores which can be removed with the migration to vue-router4 and native 'force' arg.  I guess we could jump through the hoops to declare the right types here, but the swap to vue-router4 is active in the vue3 branch and very limited, specific, short-lived use of ts-ignore seems fine here.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
