### PR TITLE
Issue #17631: Make it possible to pass custom options to mulled-build's shell

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/invfile.lua
+++ b/lib/galaxy/tool_util/deps/mulled/invfile.lua
@@ -14,6 +14,11 @@ function string:split( inSplitPattern, outResults )
   return outResults
 end
 
+local shell_opts = VAR.SHELL_OPTS
+if shell_opts == '' then
+    shell_opts = '-c'
+end
+
 local repo = VAR.REPO
 
 local channel_args = ''
@@ -87,7 +92,7 @@ inv.task('build')
         .run('rm', '-rf', '/data/dist')
     .using(conda_image)
         .withHostConfig({binds = bind_args})
-        .run('/bin/sh', '-c', preinstall
+        .run('/bin/sh', shell_opts, preinstall
             .. conda_bin .. ' install '
             .. channel_args .. ' '
             .. target_args
@@ -103,7 +108,7 @@ if VAR.SINGULARITY ~= '' then
     inv.task('singularity')
         .using(singularity_image)
         .withHostConfig({binds = {"build:/data", singularity_image_dir .. ":/import"}, privileged = true})
-        .withConfig({entrypoint = {'/bin/sh', '-c'}})
+        .withConfig({entrypoint = {'/bin/sh', shell_opts}})
         .run('mkdir -p /usr/local/var/singularity/mnt/container && '
             .. 'singularity build /import/' .. VAR.SINGULARITY_IMAGE_NAME .. ' /import/Singularity.def && '
             .. 'chown ' .. VAR.USER_ID .. ' /import/' .. VAR.SINGULARITY_IMAGE_NAME)
@@ -118,13 +123,13 @@ inv.task('cleanup')
 if VAR.TEST_BINDS == '' then
     inv.task('test')
         .using(repo)
-        .withConfig({entrypoint = {'/bin/sh', '-c'}})
+        .withConfig({entrypoint = {'/bin/sh', shell_opts}})
         .run(VAR.TEST)
 else
     inv.task('test')
         .using(repo)
         .withHostConfig({binds = test_bind_args})
-        .withConfig({entrypoint = {'/bin/sh', '-c'}})
+        .withConfig({entrypoint = {'/bin/sh', shell_opts}})
         .run(VAR.TEST)
 end
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -70,6 +70,7 @@ IS_OS_X = _platform == "darwin"
 INVOLUCRO_VERSION = "1.1.2"
 DEST_BASE_IMAGE = os.environ.get("DEST_BASE_IMAGE", None)
 CONDA_IMAGE = os.environ.get("CONDA_IMAGE", None)
+SHELL_OPTS = os.environ.get("SHELL_OPTS", '-c')
 
 SINGULARITY_TEMPLATE = """Bootstrap: docker
 From: %(base_image)s
@@ -290,6 +291,8 @@ def mull_targets(
         involucro_args.extend(["-set", f"DEST_BASE_IMAGE={dest_base_image}"])
     if CONDA_IMAGE:
         involucro_args.extend(["-set", f"CONDA_IMAGE={CONDA_IMAGE}"])
+    if SHELL_OPTS:
+        involucro_args.extend(["-set", f"SHELL_OPTS={SHELL_OPTS}"])
     if verbose:
         involucro_args.extend(["-set", "VERBOSE=1"])
     if singularity:


### PR DESCRIPTION
#17631 

By default mulled-build uses `/bin/sh -c` - a non-interactive, non-login shell. Because of this it does not load any rcfile, like `/etc/profile`.

By making the shell options configurable the user can pass `-set SHELL_OPTS="-lc"`, i.e. to make it a login shell and load the rcfile.

## How to test the changes?

Before the suggested changes executing the following on Linux ARM64 would fail with `Permission denied` because the `umask` is `0027` (inherited from the base image of `continuumio/miniconda3:latest`:
```
conda create -n test17631
conda activate test17631
conda install font-ttf-ubuntu involucro
mulled-build build 'font-ttf-ubuntu=0.83' --involucro-path $(which involucro) --verbose
ls -laR build/
```

After these changes the user could export `SHELL_OPTS=-lc` and this will tell `/bin/sh` to load `/etc/profile` that will make it possible to set custom umask, like `0022`.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
