### PR TITLE
Issue #17631: Make it possible to use custom invfile.lua if needed

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -222,6 +222,7 @@ def mull_targets(
     singularity_image_dir="singularity_import",
     base_image=None,
     determine_base_image=True,
+    invfile=INVFILE,
 ):
     if involucro_context is None:
         involucro_context = InvolucroContext()
@@ -266,7 +267,7 @@ def mull_targets(
     bind_str = ",".join(binds)
     involucro_args = [
         "-f",
-        f"{INVFILE}",
+        invfile,
         "-set",
         f"CHANNELS={channels_str}",
         "-set",
@@ -470,6 +471,7 @@ def add_build_arguments(parser):
     parser.add_argument(
         "--singularity-image-dir", dest="singularity_image_dir", help="Directory to write singularity images too."
     )
+    parser.add_argument("--involucro-lua-file", dest="invfile", default=INVFILE, help="Path to invfile.lua")
     parser.add_argument("-n", "--namespace", dest="namespace", default="biocontainers", help="quay.io namespace.")
     parser.add_argument(
         "-r",
@@ -580,6 +582,8 @@ def args_to_mull_targets_kwds(args):
         kwds["hash_func"] = args.hash
     if hasattr(args, "singularity_image_dir") and args.singularity_image_dir:
         kwds["singularity_image_dir"] = args.singularity_image_dir
+    if hasattr(args, "invfile"):
+        kwds["invfile"] = args.invfile
 
     kwds["involucro_context"] = context_from_args(args)
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -57,7 +57,7 @@ from ..conda_compat import MetaData
 
 log = logging.getLogger(__name__)
 
-DIRNAME = os.path.dirname(__file__)
+DIRNAME = os.environ.get("INVFILE_DIRNAME", os.path.dirname(__file__))
 DEFAULT_BASE_IMAGE = os.environ.get("DEFAULT_BASE_IMAGE", "quay.io/bioconda/base-glibc-busybox-bash:latest")
 DEFAULT_EXTENDED_BASE_IMAGE = os.environ.get(
     "DEFAULT_EXTENDED_BASE_IMAGE", "quay.io/bioconda/base-glibc-debian-bash:latest"

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -57,7 +57,7 @@ from ..conda_compat import MetaData
 
 log = logging.getLogger(__name__)
 
-DIRNAME = os.environ.get("INVFILE_DIRNAME", os.path.dirname(__file__))
+INVFILE = os.environ.get("INVFILE", os.path.join(os.path.dirname(__file__), "invfile.lua"))
 DEFAULT_BASE_IMAGE = os.environ.get("DEFAULT_BASE_IMAGE", "quay.io/bioconda/base-glibc-busybox-bash:latest")
 DEFAULT_EXTENDED_BASE_IMAGE = os.environ.get(
     "DEFAULT_EXTENDED_BASE_IMAGE", "quay.io/bioconda/base-glibc-debian-bash:latest"
@@ -266,7 +266,7 @@ def mull_targets(
     bind_str = ",".join(binds)
     involucro_args = [
         "-f",
-        f"{DIRNAME}/invfile.lua",
+        f"{INVFILE}",
         "-set",
         f"CHANNELS={channels_str}",
         "-set",


### PR DESCRIPTION
mulled-build.py uses invfile.lua that comes pre-packaged with galaxy-tool-util.
It would be nice if the user could specify a custom invfile.lua when (s)he needs to use a modified recipe for the image creation

## How to test the changes?

Export `INVFILE_DIRNAME` env var that points to a folder with `invfile.lua` in it and try to use `mulled-build` too. It should use the custom `invfile.lua` instead of the one coming with `galaxy-tool-util`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
