### PR TITLE
Place invocation state in list

### DIFF
--- a/client/src/api/invocations.ts
+++ b/client/src/api/invocations.ts
@@ -2,6 +2,7 @@ import { type components } from "./schema";
 
 export type WorkflowInvocationElementView = components["schemas"]["WorkflowInvocationElementView"];
 export type WorkflowInvocationCollectionView = components["schemas"]["WorkflowInvocationCollectionView"];
+export type WorkflowInvocationStepStatesView = components["schemas"]["WorkflowInvocationStepStatesView"];
 export type InvocationJobsSummary = components["schemas"]["InvocationJobsResponse"];
 export type InvocationStep = components["schemas"]["InvocationStep"];
 export type InvocationMessage = components["schemas"]["InvocationMessageResponseUnion"];

--- a/client/src/api/invocations.ts
+++ b/client/src/api/invocations.ts
@@ -1,10 +1,12 @@
 import { type components } from "./schema";
 
 export type WorkflowInvocationElementView = components["schemas"]["WorkflowInvocationElementView"];
+export type LegacyWorkflowInvocationElementView = components["schemas"]["LegacyWorkflowInvocationElementView"];
 export type WorkflowInvocationCollectionView = components["schemas"]["WorkflowInvocationCollectionView"];
 export type WorkflowInvocationStepStatesView = components["schemas"]["WorkflowInvocationStepStatesView"];
 export type InvocationJobsSummary = components["schemas"]["InvocationJobsResponse"];
 export type InvocationStep = components["schemas"]["InvocationStep"];
+export type LegacyInvocationStep = components["schemas"]["LegacyInvocationStep"];
 export type InvocationMessage = components["schemas"]["InvocationMessageResponseUnion"];
 
 export type StepJobSummary =

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -12161,7 +12161,7 @@ export interface components {
          * InvocationSerializationView
          * @enum {string}
          */
-        InvocationSerializationView: "element" | "collection";
+        InvocationSerializationView: "element" | "collection" | "step_states";
         /**
          * InvocationSortByEnum
          * @enum {string}
@@ -12179,10 +12179,7 @@ export interface components {
             | "cancelled"
             | "cancelling"
             | "failed";
-        /**
-         * InvocationStep
-         * @description Information about workflow invocation step
-         */
+        /** InvocationStep */
         InvocationStep: {
             /**
              * Action
@@ -12199,8 +12196,6 @@ export interface components {
              * @description The implicit collection job ID associated with the workflow invocation step.
              */
             implicit_collection_jobs_id?: string | null;
-            /** Job Id */
-            job_id: string | null;
             /**
              * Jobs
              * @description Jobs associated with the workflow invocation step.
@@ -13125,6 +13120,11 @@ export interface components {
              * @example 0123456789ABCDEF
              */
             id: string;
+            /**
+             * Implicit Collection Jobs ID
+             * @description The implicit collection job ID associated with the workflow invocation step.
+             */
+            implicit_collection_jobs_id?: string | null;
             /** Job Id */
             job_id: string | null;
             /**
@@ -13132,11 +13132,12 @@ export interface components {
              * @description Jobs associated with the workflow invocation step.
              * @default []
              */
-            jobs?: components["schemas"]["JobBaseModel"][];
+            jobs: components["schemas"]["JobBaseModel"][];
             /**
              * Model class
              * @description The name of the database model class.
              * @constant
+             * @enum {string}
              */
             model_class: "WorkflowInvocationStep";
             /**
@@ -13149,16 +13150,16 @@ export interface components {
              * @description The dataset collection outputs of the workflow invocation step.
              * @default {}
              */
-            output_collections?: {
-                [key: string]: components["schemas"]["InvocationStepCollectionOutput"] | undefined;
+            output_collections: {
+                [key: string]: components["schemas"]["InvocationStepCollectionOutput"];
             };
             /**
              * Outputs
              * @description The outputs of the workflow invocation step.
              * @default {}
              */
-            outputs?: {
-                [key: string]: components["schemas"]["InvocationStepOutput"] | undefined;
+            outputs: {
+                [key: string]: components["schemas"]["InvocationStepOutput"];
             };
             /**
              * State of the invocation step
@@ -13241,36 +13242,25 @@ export interface components {
              * @description Input step parameters of the workflow invocation.
              */
             input_step_parameters: {
-                [key: string]: components["schemas"]["InvocationInputParameter"] | undefined;
+                [key: string]: components["schemas"]["InvocationInputParameter"];
             };
             /**
              * Inputs
              * @description Input datasets/dataset collections of the workflow invocation.
              */
             inputs: {
-                [key: string]: components["schemas"]["InvocationInput"] | undefined;
+                [key: string]: components["schemas"]["InvocationInput"];
             };
             /**
              * Messages
              * @description A list of messages about why the invocation did not succeed.
              */
-            messages: (
-                | components["schemas"]["InvocationCancellationReviewFailedResponse"]
-                | components["schemas"]["InvocationCancellationHistoryDeletedResponse"]
-                | components["schemas"]["InvocationCancellationUserRequestResponse"]
-                | components["schemas"]["InvocationFailureDatasetFailedResponse"]
-                | components["schemas"]["InvocationFailureCollectionFailedResponse"]
-                | components["schemas"]["InvocationFailureJobFailedResponse"]
-                | components["schemas"]["InvocationFailureOutputNotFoundResponse"]
-                | components["schemas"]["InvocationFailureExpressionEvaluationFailedResponse"]
-                | components["schemas"]["InvocationFailureWhenNotBooleanResponse"]
-                | components["schemas"]["InvocationUnexpectedFailureResponse"]
-                | components["schemas"]["InvocationEvaluationWarningWorkflowOutputNotFoundResponse"]
-            )[];
+            messages: components["schemas"]["InvocationMessageResponseUnion"][];
             /**
              * Model class
              * @description The name of the database model class.
              * @constant
+             * @enum {string}
              */
             model_class: "WorkflowInvocation";
             /**
@@ -13278,7 +13268,7 @@ export interface components {
              * @description Output dataset collections of the workflow invocation.
              */
             output_collections: {
-                [key: string]: components["schemas"]["InvocationOutputCollection"] | undefined;
+                [key: string]: components["schemas"]["InvocationOutputCollection"];
             };
             /**
              * Output values
@@ -13290,7 +13280,7 @@ export interface components {
              * @description Output datasets of the workflow invocation.
              */
             outputs: {
-                [key: string]: components["schemas"]["InvocationOutput"] | undefined;
+                [key: string]: components["schemas"]["InvocationOutput"];
             };
             /**
              * Invocation state
@@ -13312,7 +13302,7 @@ export interface components {
              * UUID
              * @description Universal unique identifier of the workflow invocation.
              */
-            uuid?: string | string | null;
+            uuid?: string | null;
             /**
              * Workflow ID
              * @description The encoded Workflow ID associated with the invocation.
@@ -18498,7 +18488,8 @@ export interface components {
         WorkflowInvocationResponse:
             | components["schemas"]["WorkflowInvocationElementView"]
             | components["schemas"]["LegacyWorkflowInvocationElementView"]
-            | components["schemas"]["WorkflowInvocationCollectionView"];
+            | components["schemas"]["WorkflowInvocationCollectionView"]
+            | components["schemas"]["WorkflowInvocationStepStatesView"];
         /** WorkflowInvocationStateSummary */
         WorkflowInvocationStateSummary: {
             /**
@@ -18524,6 +18515,61 @@ export interface components {
             states: {
                 [key: string]: number;
             };
+        };
+        /** WorkflowInvocationStepStatesView */
+        WorkflowInvocationStepStatesView: {
+            /**
+             * Create Time
+             * Format: date-time
+             * @description The time and date this item was created.
+             */
+            create_time: string;
+            /**
+             * History ID
+             * @description The encoded ID of the history associated with the invocation.
+             * @example 0123456789ABCDEF
+             */
+            history_id: string;
+            /**
+             * ID
+             * @description The encoded ID of the workflow invocation.
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /**
+             * Model class
+             * @description The name of the database model class.
+             * @constant
+             * @enum {string}
+             */
+            model_class: "WorkflowInvocation";
+            /**
+             * Invocation state
+             * @description State of workflow invocation.
+             */
+            state: components["schemas"]["InvocationState"];
+            /**
+             * Steps
+             * @description Steps of the workflow invocation.
+             */
+            steps: components["schemas"]["InvocationStep"][];
+            /**
+             * Update Time
+             * Format: date-time
+             * @description The last time and date this item was updated.
+             */
+            update_time: string;
+            /**
+             * UUID
+             * @description Universal unique identifier of the workflow invocation.
+             */
+            uuid?: string | null;
+            /**
+             * Workflow ID
+             * @description The encoded Workflow ID associated with the invocation.
+             * @example 0123456789ABCDEF
+             */
+            workflow_id: string;
         };
         /**
          * WorkflowJobMetric
@@ -27127,6 +27173,8 @@ export interface operations {
     show_invocation_api_invocations__invocation_id__get: {
         parameters: {
             query?: {
+                /** @description View to be passed to the serializer */
+                view?: string | null;
                 /** @description Include details for individual invocation steps and populate a steps attribute in the resulting dictionary. */
                 step_details?: boolean;
                 /** @description Populate the invocation step state with the job state instead of the invocation step state.

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -12239,7 +12239,7 @@ export interface components {
              * State of the invocation step
              * @description Describes where in the scheduling process the workflow invocation step is.
              */
-            state: components["schemas"]["InvocationStepState"] | components["schemas"]["JobState"];
+            state: components["schemas"]["InvocationStepState"];
             /** Subworkflow Invocation Id */
             subworkflow_invocation_id: string | null;
             /**
@@ -13113,6 +13113,82 @@ export interface components {
          * @enum {string}
          */
         LandingRequestState: "unclaimed" | "claimed";
+        /** LegacyInvocationStep */
+        LegacyInvocationStep: {
+            /**
+             * Action
+             * @description Whether to take action on the invocation step.
+             */
+            action: boolean | null;
+            /**
+             * Invocation Step ID
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /** Job Id */
+            job_id: string | null;
+            /**
+             * Jobs
+             * @description Jobs associated with the workflow invocation step.
+             * @default []
+             */
+            jobs?: components["schemas"]["JobBaseModel"][];
+            /**
+             * Model class
+             * @description The name of the database model class.
+             * @constant
+             */
+            model_class: "WorkflowInvocationStep";
+            /**
+             * Order index
+             * @description The index of the workflow step in the workflow.
+             */
+            order_index: number;
+            /**
+             * Output collections
+             * @description The dataset collection outputs of the workflow invocation step.
+             * @default {}
+             */
+            output_collections?: {
+                [key: string]: components["schemas"]["InvocationStepCollectionOutput"] | undefined;
+            };
+            /**
+             * Outputs
+             * @description The outputs of the workflow invocation step.
+             * @default {}
+             */
+            outputs?: {
+                [key: string]: components["schemas"]["InvocationStepOutput"] | undefined;
+            };
+            /**
+             * State of the invocation step
+             * @description Describes the job state corresponding to this invocation step.
+             */
+            state: components["schemas"]["JobState"] | null;
+            /** Subworkflow Invocation Id */
+            subworkflow_invocation_id: string | null;
+            /**
+             * Update Time
+             * @description The last time and date this item was updated.
+             */
+            update_time: string | null;
+            /**
+             * Workflow step ID
+             * @description The encoded ID of the workflow step associated with this workflow invocation step.
+             * @example 0123456789ABCDEF
+             */
+            workflow_step_id: string;
+            /**
+             * Step label
+             * @description The label of the workflow step
+             */
+            workflow_step_label?: string | null;
+            /**
+             * UUID
+             * @description Universal unique identifier of the workflow step.
+             */
+            workflow_step_uuid?: string | null;
+        };
         /** LegacyLibraryPermissionsPayload */
         LegacyLibraryPermissionsPayload: {
             /**
@@ -13139,6 +13215,110 @@ export interface components {
              * @default []
              */
             LIBRARY_MODIFY_in: string[] | string | null;
+        };
+        /** LegacyWorkflowInvocationElementView */
+        LegacyWorkflowInvocationElementView: {
+            /**
+             * Create Time
+             * Format: date-time
+             * @description The time and date this item was created.
+             */
+            create_time: string;
+            /**
+             * History ID
+             * @description The encoded ID of the history associated with the invocation.
+             * @example 0123456789ABCDEF
+             */
+            history_id: string;
+            /**
+             * ID
+             * @description The encoded ID of the workflow invocation.
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /**
+             * Input step parameters
+             * @description Input step parameters of the workflow invocation.
+             */
+            input_step_parameters: {
+                [key: string]: components["schemas"]["InvocationInputParameter"] | undefined;
+            };
+            /**
+             * Inputs
+             * @description Input datasets/dataset collections of the workflow invocation.
+             */
+            inputs: {
+                [key: string]: components["schemas"]["InvocationInput"] | undefined;
+            };
+            /**
+             * Messages
+             * @description A list of messages about why the invocation did not succeed.
+             */
+            messages: (
+                | components["schemas"]["InvocationCancellationReviewFailedResponse"]
+                | components["schemas"]["InvocationCancellationHistoryDeletedResponse"]
+                | components["schemas"]["InvocationCancellationUserRequestResponse"]
+                | components["schemas"]["InvocationFailureDatasetFailedResponse"]
+                | components["schemas"]["InvocationFailureCollectionFailedResponse"]
+                | components["schemas"]["InvocationFailureJobFailedResponse"]
+                | components["schemas"]["InvocationFailureOutputNotFoundResponse"]
+                | components["schemas"]["InvocationFailureExpressionEvaluationFailedResponse"]
+                | components["schemas"]["InvocationFailureWhenNotBooleanResponse"]
+                | components["schemas"]["InvocationUnexpectedFailureResponse"]
+                | components["schemas"]["InvocationEvaluationWarningWorkflowOutputNotFoundResponse"]
+            )[];
+            /**
+             * Model class
+             * @description The name of the database model class.
+             * @constant
+             */
+            model_class: "WorkflowInvocation";
+            /**
+             * Output collections
+             * @description Output dataset collections of the workflow invocation.
+             */
+            output_collections: {
+                [key: string]: components["schemas"]["InvocationOutputCollection"] | undefined;
+            };
+            /**
+             * Output values
+             * @description Output values of the workflow invocation.
+             */
+            output_values: Record<string, never>;
+            /**
+             * Outputs
+             * @description Output datasets of the workflow invocation.
+             */
+            outputs: {
+                [key: string]: components["schemas"]["InvocationOutput"] | undefined;
+            };
+            /**
+             * Invocation state
+             * @description State of workflow invocation.
+             */
+            state: components["schemas"]["InvocationState"];
+            /**
+             * Steps
+             * @description Steps of the workflow invocation (legacy view using job state).
+             */
+            steps: components["schemas"]["LegacyInvocationStep"][];
+            /**
+             * Update Time
+             * Format: date-time
+             * @description The last time and date this item was updated.
+             */
+            update_time: string;
+            /**
+             * UUID
+             * @description Universal unique identifier of the workflow invocation.
+             */
+            uuid?: string | string | null;
+            /**
+             * Workflow ID
+             * @description The encoded Workflow ID associated with the invocation.
+             * @example 0123456789ABCDEF
+             */
+            workflow_id: string;
         };
         /** LibraryAvailablePermissions */
         LibraryAvailablePermissions: {
@@ -18317,6 +18497,7 @@ export interface components {
         /** WorkflowInvocationResponse */
         WorkflowInvocationResponse:
             | components["schemas"]["WorkflowInvocationElementView"]
+            | components["schemas"]["LegacyWorkflowInvocationElementView"]
             | components["schemas"]["WorkflowInvocationCollectionView"];
         /** WorkflowInvocationStateSummary */
         WorkflowInvocationStateSummary: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -12239,7 +12239,7 @@ export interface components {
              * State of the invocation step
              * @description Describes where in the scheduling process the workflow invocation step is.
              */
-            state?: components["schemas"]["InvocationStepState"] | components["schemas"]["JobState"] | null;
+            state: components["schemas"]["InvocationStepState"] | components["schemas"]["JobState"];
             /** Subworkflow Invocation Id */
             subworkflow_invocation_id: string | null;
             /**

--- a/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
+++ b/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
@@ -14,7 +14,7 @@ import { BAlert, BButton, BCard, BCardBody, BCardHeader } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, onUnmounted, ref, watch } from "vue";
 
-import type { WorkflowInvocationElementView } from "@/api/invocations";
+import type { LegacyWorkflowInvocationElementView } from "@/api/invocations";
 import { JobProvider } from "@/components/providers";
 import { useDatatypesMapper } from "@/composables/datatypesMapper";
 import { useInvocationGraph } from "@/composables/useInvocationGraph";
@@ -35,7 +35,7 @@ library.add(faArrowDown, faChevronDown, faChevronUp, faSignInAlt, faSitemap, faT
 
 interface Props {
     /** The invocation to display */
-    invocation: WorkflowInvocationElementView;
+    invocation: LegacyWorkflowInvocationElementView;
     /** The workflow which was run */
     workflow: Workflow;
     /** Whether the invocation is terminal */

--- a/client/src/components/Workflow/Invocation/Graph/WorkflowInvocationSteps.vue
+++ b/client/src/components/Workflow/Invocation/Graph/WorkflowInvocationSteps.vue
@@ -4,7 +4,7 @@ import { faChevronDown, faChevronUp, faSignInAlt } from "@fortawesome/free-solid
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed, nextTick, ref, watch } from "vue";
 
-import type { WorkflowInvocationElementView } from "@/api/invocations";
+import type { LegacyWorkflowInvocationElementView } from "@/api/invocations";
 import { isWorkflowInput } from "@/components/Workflow/constants";
 import type { GraphStep } from "@/composables/useInvocationGraph";
 import type { Workflow } from "@/stores/workflowStore";
@@ -19,7 +19,7 @@ interface Props {
     /** The store id for the invocation graph */
     storeId: string;
     /** The invocation to display */
-    invocation: WorkflowInvocationElementView;
+    invocation: LegacyWorkflowInvocationElementView;
     /** The workflow which was run */
     workflow: Workflow;
     /** Whether the invocation graph is hidden */

--- a/client/src/components/Workflow/InvocationsListState.vue
+++ b/client/src/components/Workflow/InvocationsListState.vue
@@ -1,14 +1,49 @@
 <script setup lang="ts">
+import { onBeforeUnmount, onMounted, toRef } from "vue";
+
+import { useInvocationState } from "@/components/WorkflowInvocationState/usesInvocationState";
+
 import HelpText from "@/components/Help/HelpText.vue";
+import InvocationJobsProgressBar from "@/components/WorkflowInvocationState/InvocationJobsProgressBar.vue";
+import InvocationStepsProgressBar from "@/components/WorkflowInvocationState/InvocationStepsProgressBar.vue";
 
 interface Props {
     invocationId: string;
     invocationState: string;
+    detailsShowing: boolean;
 }
 
-defineProps<Props>();
+const props = defineProps<Props>();
+
+const {
+    invocation,
+    invocationState,
+    invocationSchedulingTerminal,
+    invocationAndJobTerminal,
+    jobStatesSummary,
+    monitorState,
+    clearStateMonitor,
+} = useInvocationState(toRef(props, "invocationId"));
+
+onMounted(monitorState);
+onBeforeUnmount(clearStateMonitor);
 </script>
 
 <template>
-    <HelpText :uri="`galaxy.invocations.states.${invocationState}`" :text="invocationState" />
+    <span>
+        <HelpText
+            v-if="!invocation || detailsShowing"
+            :uri="`galaxy.invocations.states.${props.invocationState}`"
+            :text="props.invocationState" />
+        <template v-else>
+            <InvocationStepsProgressBar
+                :invocation="invocation"
+                :invocation-state="invocationState"
+                :invocation-scheduling-terminal="invocationSchedulingTerminal" />
+            <InvocationJobsProgressBar
+                :job-states-summary="jobStatesSummary"
+                :invocation-scheduling-terminal="invocationSchedulingTerminal"
+                :invocation-and-job-terminal="invocationAndJobTerminal" />
+        </template>
+    </span>
 </template>

--- a/client/src/components/Workflow/InvocationsListState.vue
+++ b/client/src/components/Workflow/InvocationsListState.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, toRef } from "vue";
+import { onBeforeUnmount, onMounted, toRef } from "vue";
 
-import type { WorkflowInvocationElementView } from "@/api/invocations";
 import { useInvocationState } from "@/components/WorkflowInvocationState/usesInvocationState";
 
 import HelpText from "@/components/Help/HelpText.vue";
@@ -17,17 +16,14 @@ interface Props {
 const props = defineProps<Props>();
 
 const {
-    invocation: invocationFromState,
+    invocation,
     invocationState,
     invocationSchedulingTerminal,
     invocationAndJobTerminal,
     jobStatesSummary,
     monitorState,
     clearStateMonitor,
-} = useInvocationState(toRef(props, "invocationId"), true);
-
-// TODO: This is a workaround to type invocation; I would've expected it to already be typed
-const invocation = computed(() => invocationFromState.value as WorkflowInvocationElementView | undefined);
+} = useInvocationState(toRef(props, "invocationId"), "step_states");
 
 onMounted(monitorState);
 onBeforeUnmount(clearStateMonitor);

--- a/client/src/components/Workflow/InvocationsListState.vue
+++ b/client/src/components/Workflow/InvocationsListState.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, toRef } from "vue";
+import { computed, onBeforeUnmount, onMounted, toRef } from "vue";
 
+import type { WorkflowInvocationElementView } from "@/api/invocations";
 import { useInvocationState } from "@/components/WorkflowInvocationState/usesInvocationState";
 
 import HelpText from "@/components/Help/HelpText.vue";
@@ -16,7 +17,7 @@ interface Props {
 const props = defineProps<Props>();
 
 const {
-    invocation,
+    invocation: invocationFromState,
     invocationState,
     invocationSchedulingTerminal,
     invocationAndJobTerminal,
@@ -24,6 +25,9 @@ const {
     monitorState,
     clearStateMonitor,
 } = useInvocationState(toRef(props, "invocationId"), true);
+
+// TODO: This is a workaround to type invocation; I would've expected it to already be typed
+const invocation = computed(() => invocationFromState.value as WorkflowInvocationElementView | undefined);
 
 onMounted(monitorState);
 onBeforeUnmount(clearStateMonitor);
@@ -41,6 +45,7 @@ onBeforeUnmount(clearStateMonitor);
                 :invocation-state="invocationState"
                 :invocation-scheduling-terminal="invocationSchedulingTerminal" />
             <InvocationJobsProgressBar
+                v-if="jobStatesSummary"
                 :job-states-summary="jobStatesSummary"
                 :invocation-scheduling-terminal="invocationSchedulingTerminal"
                 :invocation-and-job-terminal="invocationAndJobTerminal" />

--- a/client/src/components/Workflow/InvocationsListState.vue
+++ b/client/src/components/Workflow/InvocationsListState.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import HelpText from "@/components/Help/HelpText.vue";
+
+interface Props {
+    invocationId: string;
+    invocationState: string;
+}
+
+defineProps<Props>();
+</script>
+
+<template>
+    <HelpText :uri="`galaxy.invocations.states.${invocationState}`" :text="invocationState" />
+</template>

--- a/client/src/components/Workflow/InvocationsListState.vue
+++ b/client/src/components/Workflow/InvocationsListState.vue
@@ -23,7 +23,7 @@ const {
     jobStatesSummary,
     monitorState,
     clearStateMonitor,
-} = useInvocationState(toRef(props, "invocationId"));
+} = useInvocationState(toRef(props, "invocationId"), true);
 
 onMounted(monitorState);
 onBeforeUnmount(clearStateMonitor);

--- a/client/src/components/WorkflowInvocationState/InvocationJobsProgressBar.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationJobsProgressBar.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import { InvocationJobsSummary } from "@/api/invocations";
+import ProgressBar from "@/components/ProgressBar.vue";
+
+import {
+    errorCount as jobStatesSummaryErrorCount,
+    jobCount as jobStatesSummaryJobCount,
+    numTerminal,
+    okCount as jobStatesSummaryOkCount,
+    runningCount as jobStatesSummaryRunningCount,
+} from "./util";
+
+
+interface Props {
+    jobStatesSummary: InvocationJobsSummary;
+    invocationSchedulingTerminal: boolean;
+    invocationAndJobTerminal: boolean;
+}
+
+const props = defineProps<Props>();
+
+const jobCount = computed<number>(() => {
+    return jobStatesSummaryJobCount(props.jobStatesSummary);
+});
+
+const okCount = computed<number>(() => {
+    return jobStatesSummaryOkCount(props.jobStatesSummary);
+});
+
+const runningCount = computed<number>(() => {
+    return jobStatesSummaryRunningCount(props.jobStatesSummary);
+});
+
+const errorCount = computed<number>(() => {
+    return jobStatesSummaryErrorCount(props.jobStatesSummary);
+});
+
+const newCount = computed<number>(() => {
+    return jobCount.value - okCount.value - runningCount.value - errorCount.value;
+});
+
+const jobStatesStr = computed(() => {
+    let jobStr = `${numTerminal(props.jobStatesSummary) || 0} of ${jobCount.value} jobs complete`;
+    if (!props.invocationSchedulingTerminal) {
+        jobStr += " (total number of jobs will change until all steps fully scheduled)";
+    }
+    return `${jobStr}.`;
+});
+</script>
+
+<template>
+    <ProgressBar
+        :note="jobStatesStr"
+        :total="jobCount"
+        :ok-count="okCount"
+        :running-count="runningCount"
+        :new-count="newCount"
+        :error-count="errorCount"
+        :loading="!invocationAndJobTerminal"
+        class="jobs-progress" />
+</template>

--- a/client/src/components/WorkflowInvocationState/InvocationJobsProgressBar.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationJobsProgressBar.vue
@@ -12,7 +12,6 @@ import {
     runningCount as jobStatesSummaryRunningCount,
 } from "./util";
 
-
 interface Props {
     jobStatesSummary: InvocationJobsSummary;
     invocationSchedulingTerminal: boolean;

--- a/client/src/components/WorkflowInvocationState/InvocationJobsProgressBar.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationJobsProgressBar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-import { InvocationJobsSummary } from "@/api/invocations";
+import { type InvocationJobsSummary } from "@/api/invocations";
 
 import {
     errorCount as jobStatesSummaryErrorCount,

--- a/client/src/components/WorkflowInvocationState/InvocationJobsProgressBar.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationJobsProgressBar.vue
@@ -2,7 +2,6 @@
 import { computed } from "vue";
 
 import { InvocationJobsSummary } from "@/api/invocations";
-import ProgressBar from "@/components/ProgressBar.vue";
 
 import {
     errorCount as jobStatesSummaryErrorCount,
@@ -11,6 +10,8 @@ import {
     okCount as jobStatesSummaryOkCount,
     runningCount as jobStatesSummaryRunningCount,
 } from "./util";
+
+import ProgressBar from "@/components/ProgressBar.vue";
 
 interface Props {
     jobStatesSummary: InvocationJobsSummary;

--- a/client/src/components/WorkflowInvocationState/InvocationStepsProgressBar.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationStepsProgressBar.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-import { type InvocationStep, type WorkflowInvocationElementView } from "@/api/invocations";
+import {
+    type LegacyWorkflowInvocationElementView,
+    type WorkflowInvocationElementView,
+    type WorkflowInvocationStepStatesView,
+} from "@/api/invocations";
 
 import ProgressBar from "@/components/ProgressBar.vue";
 
 interface Props {
-    invocation?: WorkflowInvocationElementView;
+    invocation?: WorkflowInvocationElementView | WorkflowInvocationStepStatesView | LegacyWorkflowInvocationElementView;
     invocationState: string;
     invocationSchedulingTerminal: boolean;
 }
@@ -24,12 +28,12 @@ const stepStates = computed<StepStateType>(() => {
     if (!props.invocation) {
         return {};
     }
-    const steps: InvocationStep[] = props.invocation?.steps || [];
+    const steps = props.invocation?.steps || [];
     for (const step of steps) {
-        if (!step) {
+        const stepState = step.state;
+        if (!stepState) {
             continue;
         }
-        const stepState: string = step.state;
         if (!stepStates[stepState]) {
             stepStates[stepState] = 1;
         } else {

--- a/client/src/components/WorkflowInvocationState/InvocationStepsProgressBar.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationStepsProgressBar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-import { InvocationStep, WorkflowInvocationElementView } from "@/api/invocations";
+import { type InvocationStep, type WorkflowInvocationElementView } from "@/api/invocations";
 
 import ProgressBar from "@/components/ProgressBar.vue";
 

--- a/client/src/components/WorkflowInvocationState/InvocationStepsProgressBar.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationStepsProgressBar.vue
@@ -2,6 +2,7 @@
 import { computed } from "vue";
 
 import { InvocationStep, WorkflowInvocationElementView } from "@/api/invocations";
+
 import ProgressBar from "@/components/ProgressBar.vue";
 
 interface Props {
@@ -28,8 +29,7 @@ const stepStates = computed<StepStateType>(() => {
         if (!step) {
             continue;
         }
-        // the API defined state here allowing null and undefined is odd...
-        const stepState: string = step.state || "unknown";
+        const stepState: string = step.state;
         if (!stepStates[stepState]) {
             stepStates[stepState] = 1;
         } else {

--- a/client/src/components/WorkflowInvocationState/InvocationStepsProgressBar.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationStepsProgressBar.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import { InvocationStep, WorkflowInvocationElementView } from "@/api/invocations";
+import ProgressBar from "@/components/ProgressBar.vue";
+
+interface Props {
+    invocation?: WorkflowInvocationElementView;
+    invocationState: string;
+    invocationSchedulingTerminal: boolean;
+}
+
+const props = defineProps<Props>();
+
+const stepCount = computed<number>(() => {
+    return props.invocation?.steps.length || 0;
+});
+
+type StepStateType = { [state: string]: number };
+
+const stepStates = computed<StepStateType>(() => {
+    const stepStates: StepStateType = {};
+    if (!props.invocation) {
+        return {};
+    }
+    const steps: InvocationStep[] = props.invocation?.steps || [];
+    for (const step of steps) {
+        if (!step) {
+            continue;
+        }
+        // the API defined state here allowing null and undefined is odd...
+        const stepState: string = step.state || "unknown";
+        if (!stepStates[stepState]) {
+            stepStates[stepState] = 1;
+        } else {
+            stepStates[stepState] += 1;
+        }
+    }
+    return stepStates;
+});
+
+const stepStatesStr = computed<string>(() => {
+    return `${stepStates.value?.scheduled || 0} of ${stepCount.value} steps successfully scheduled.`;
+});
+</script>
+
+<template>
+    <span>
+        <ProgressBar v-if="!stepCount" note="Loading step state summary..." :loading="true" class="steps-progress" />
+        <ProgressBar
+            v-if="invocationState == 'cancelled'"
+            note="Invocation scheduling cancelled - expected jobs and outputs may not be generated."
+            :error-count="1"
+            class="steps-progress" />
+        <ProgressBar
+            v-else-if="invocationState == 'failed'"
+            note="Invocation scheduling failed - Galaxy administrator may have additional details in logs."
+            :error-count="1"
+            class="steps-progress" />
+        <ProgressBar
+            v-else
+            :note="stepStatesStr"
+            :total="stepCount"
+            :ok-count="stepStates.scheduled"
+            :loading="!invocationSchedulingTerminal"
+            class="steps-progress" />
+    </span>
+</template>

--- a/client/src/components/WorkflowInvocationState/InvocationStepsProgressBar.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationStepsProgressBar.vue
@@ -46,9 +46,9 @@ const stepStatesStr = computed<string>(() => {
 
 <template>
     <span>
-        <ProgressBar v-if="!stepCount" note="Loading step state summary..." :loading="true" class="steps-progress" />
+        <ProgressBar v-if="!invocation" note="Loading step state summary..." :loading="true" class="steps-progress" />
         <ProgressBar
-            v-if="invocationState == 'cancelled'"
+            v-else-if="invocationState == 'cancelled'"
             note="Invocation scheduling cancelled - expected jobs and outputs may not be generated."
             :error-count="1"
             class="steps-progress" />

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationHeader.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationHeader.vue
@@ -8,7 +8,7 @@ import { computed, ref } from "vue";
 import { RouterLink } from "vue-router";
 
 import { isRegisteredUser } from "@/api";
-import type { WorkflowInvocationElementView } from "@/api/invocations";
+import type { WorkflowInvocation } from "@/api/invocations";
 import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
 import { useUserStore } from "@/stores/userStore";
 import type { Workflow } from "@/stores/workflowStore";
@@ -25,7 +25,7 @@ import WorkflowInvocationsCount from "../Workflow/WorkflowInvocationsCount.vue";
 import WorkflowRunButton from "../Workflow/WorkflowRunButton.vue";
 
 interface Props {
-    invocation: WorkflowInvocationElementView;
+    invocation: WorkflowInvocation;
     fromPanel?: boolean;
 }
 

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationOverview.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationOverview.vue
@@ -37,7 +37,7 @@ const generatePdfTooltip = "Generate PDF report for this workflow invocation";
 
 const { workflow, loading, error } = useWorkflowInstance(props.invocation.workflow_id);
 
-const invocationId = computed<string | undefined>(() => props.invocation.id);
+const invocationId = computed<string>(() => props.invocation.id);
 
 const indexStr = computed(() => {
     if (props.index == undefined) {

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationOverview.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationOverview.vue
@@ -2,7 +2,7 @@
 import { BAlert, BButton } from "bootstrap-vue";
 import { computed } from "vue";
 
-import { type InvocationJobsSummary, type WorkflowInvocationElementView } from "@/api/invocations";
+import { type InvocationJobsSummary, type LegacyWorkflowInvocationElementView } from "@/api/invocations";
 import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
 import { getRootFromIndexLink } from "@/onload";
 import { withPrefix } from "@/utils/redirect";
@@ -22,7 +22,7 @@ function getUrl(path: string): string {
 }
 
 interface Props {
-    invocation: WorkflowInvocationElementView;
+    invocation: LegacyWorkflowInvocationElementView;
     invocationAndJobTerminal: boolean;
     invocationSchedulingTerminal: boolean;
     isFullPage?: boolean;

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -2,7 +2,7 @@
 import { BAlert, BTab, BTabs } from "bootstrap-vue";
 import { computed, onBeforeUnmount, onMounted, onUnmounted, ref, toRef, watch } from "vue";
 
-import { type InvocationJobsSummary, type WorkflowInvocationElementView } from "@/api/invocations";
+import { type InvocationJobsSummary } from "@/api/invocations";
 import { useAnimationFrameResizeObserver } from "@/composables/sensors/animationFrameResizeObserver";
 import { useInvocationStore } from "@/stores/invocationStore";
 import { useWorkflowStore } from "@/stores/workflowStore";
@@ -120,16 +120,13 @@ async function pollJobStatesUntilTerminal() {
 }
 
 const {
-    invocation: invocationFromState,
+    invocation,
     invocationSchedulingTerminal,
     invocationAndJobTerminal,
     jobStatesSummary,
     monitorState,
     clearStateMonitor,
-} = useInvocationState(toRef(props, "invocationId"));
-
-// TODO: This is a workaround to type invocation; I would've expected it to already be typed
-const invocation = computed(() => invocationFromState.value as WorkflowInvocationElementView | undefined);
+} = useInvocationState(toRef(props, "invocationId"), "legacy");
 
 onMounted(monitorState);
 onBeforeUnmount(clearStateMonitor);

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -128,6 +128,7 @@ const {
     clearStateMonitor,
 } = useInvocationState(toRef(props, "invocationId"));
 
+// TODO: This is a workaround to type invocation; I would've expected it to already be typed
 const invocation = computed(() => invocationFromState.value as WorkflowInvocationElementView | undefined);
 
 onMounted(monitorState);

--- a/client/src/components/WorkflowInvocationState/usesInvocationState.ts
+++ b/client/src/components/WorkflowInvocationState/usesInvocationState.ts
@@ -7,11 +7,15 @@ import { isTerminal, jobCount } from "./util";
 
 type OptionalInterval = ReturnType<typeof setInterval> | null;
 
-export function useInvocationState(invocationId: Ref<string>) {
+export function useInvocationState(invocationId: Ref<string>, fetchMinimal: boolean = false) {
     const invocationStore = useInvocationStore();
 
     const invocation = computed(() => {
-        return invocationStore.getInvocationById(invocationId.value);
+        if (fetchMinimal) {
+            return invocationStore.getInvocationWithStepStatesById(invocationId.value);
+        } else {
+            return invocationStore.getInvocationById(invocationId.value);
+        }
     });
 
     let stepStatesInterval: OptionalInterval = null;
@@ -47,7 +51,11 @@ export function useInvocationState(invocationId: Ref<string>) {
 
     async function pollStepStatesUntilTerminal() {
         if (!invocation.value || !invocationSchedulingTerminal.value) {
-            await invocationStore.fetchInvocationForId({ id: invocationId.value });
+            if (fetchMinimal) {
+                await invocationStore.fetchInvocationWithStepStatesForId({ id: invocationId.value });
+            } else {
+                await invocationStore.fetchInvocationForId({ id: invocationId.value });
+            }
             stepStatesInterval = setTimeout(pollStepStatesUntilTerminal, 3000);
         }
     }

--- a/client/src/components/WorkflowInvocationState/usesInvocationState.ts
+++ b/client/src/components/WorkflowInvocationState/usesInvocationState.ts
@@ -1,0 +1,85 @@
+import { computed, type Ref } from "vue";
+
+import { InvocationJobsSummary } from "@/api/invocations";
+import { useInvocationStore } from "@/stores/invocationStore";
+
+import { isTerminal, jobCount } from "./util";
+
+type OptionalInterval = ReturnType<typeof setInterval> | null;
+
+export function useInvocationState(invocationId: Ref<string>) {
+    const invocationStore = useInvocationStore();
+
+    const invocation = computed(() => {
+        return invocationStore.getInvocationById(invocationId.value);
+    });
+
+    let stepStatesInterval: OptionalInterval = null;
+    let jobStatesInterval: OptionalInterval = null;
+
+    const invocationState = computed(() => {
+        return invocation.value?.state || "new";
+    });
+
+    const invocationSchedulingTerminal = computed(() => {
+        const state = invocationState.value;
+        return state == "scheduled" || state == "cancelled" || state == "failed";
+    });
+
+    const invocationAndJobTerminal = computed(() => {
+        return !!(invocationSchedulingTerminal.value && jobStatesTerminal.value);
+    });
+
+    const jobStatesTerminal = computed(() => {
+        if (invocationSchedulingTerminal.value && jobCount(jobStatesSummary.value) === 0) {
+            // no jobs for this invocation (think subworkflow or just inputs)
+            return true;
+        }
+        return jobStatesSummary.value && isTerminal(jobStatesSummary.value);
+    });
+
+    const jobStatesSummary = computed<InvocationJobsSummary | null>(() => {
+        const jobsSummary: InvocationJobsSummary | null = invocationStore.getInvocationJobsSummaryById(
+            invocationId.value
+        );
+        return !jobsSummary ? null : jobsSummary;
+    });
+
+    async function pollStepStatesUntilTerminal() {
+        if (!invocation.value || !invocationSchedulingTerminal.value) {
+            await invocationStore.fetchInvocationForId({ id: invocationId.value });
+            stepStatesInterval = setTimeout(pollStepStatesUntilTerminal, 3000);
+        }
+    }
+
+    async function pollJobStatesUntilTerminal() {
+        if (!jobStatesTerminal.value) {
+            await invocationStore.fetchInvocationJobsSummaryForId({ id: invocationId.value });
+            jobStatesInterval = setTimeout(pollJobStatesUntilTerminal, 3000);
+        }
+    }
+
+    async function monitorState() {
+        pollStepStatesUntilTerminal();
+        pollJobStatesUntilTerminal();
+    }
+
+    async function clearStateMonitor() {
+        if (jobStatesInterval) {
+            clearTimeout(jobStatesInterval);
+        }
+        if (stepStatesInterval) {
+            clearTimeout(stepStatesInterval);
+        }
+    }
+
+    return {
+        invocation,
+        invocationState,
+        invocationSchedulingTerminal,
+        invocationAndJobTerminal,
+        jobStatesSummary,
+        monitorState,
+        clearStateMonitor,
+    };
+}

--- a/client/src/components/WorkflowInvocationState/usesInvocationState.ts
+++ b/client/src/components/WorkflowInvocationState/usesInvocationState.ts
@@ -1,6 +1,6 @@
 import { computed, type Ref } from "vue";
 
-import { InvocationJobsSummary } from "@/api/invocations";
+import { type InvocationJobsSummary } from "@/api/invocations";
 import { useInvocationStore } from "@/stores/invocationStore";
 
 import { isTerminal, jobCount } from "./util";

--- a/client/src/composables/useInvocationGraph.ts
+++ b/client/src/composables/useInvocationGraph.ts
@@ -11,7 +11,11 @@ import {
 import { computed, type Ref, ref, set } from "vue";
 
 import { GalaxyApi } from "@/api";
-import { type InvocationStep, type StepJobSummary, type WorkflowInvocationElementView } from "@/api/invocations";
+import {
+    type LegacyInvocationStep,
+    type LegacyWorkflowInvocationElementView,
+    type StepJobSummary,
+} from "@/api/invocations";
 import { isWorkflowInput } from "@/components/Workflow/constants";
 import { fromSimple } from "@/components/Workflow/Editor/modules/model";
 import { getWorkflowFull } from "@/components/Workflow/workflows.services";
@@ -67,7 +71,7 @@ const ALL_INSTANCES_STATES = ["deleted", "skipped", "new", "queued"];
  * @param workflowId - The id of the workflow that was invoked
  */
 export function useInvocationGraph(
-    invocation: Ref<WorkflowInvocationElementView>,
+    invocation: Ref<LegacyWorkflowInvocationElementView>,
     workflowId: string | undefined,
     workflowVersion: number | undefined
 ) {
@@ -169,7 +173,7 @@ export function useInvocationGraph(
                     invocationStepSummary = stepsJobsSummary.find((stepJobSummary: StepJobSummary) => {
                         if (stepJobSummary.model === "ImplicitCollectionJobs") {
                             return stepJobSummary.id === invocationStep.implicit_collection_jobs_id;
-                        } else {
+                        } else if (stepJobSummary.model === "Job") {
                             return stepJobSummary.id === invocationStep.job_id;
                         }
                     });
@@ -194,7 +198,7 @@ export function useInvocationGraph(
      */
     function updateStep(
         graphStep: GraphStep,
-        invocationStep: InvocationStep | undefined,
+        invocationStep: LegacyInvocationStep | undefined,
         invocationStepSummary: StepJobSummary | undefined
     ) {
         /** The new state for the graph step */
@@ -240,9 +244,11 @@ export function useInvocationGraph(
 
             // If the state still hasn't been set, set it based on the populated state
             if (!newState) {
-                if (populatedState === "scheduled" || populatedState === "ready") {
-                    newState = "queued";
-                } else if (populatedState === "resubmitted") {
+                // These states are apparently not in the schema anymore
+                // if (populatedState === "scheduled" || populatedState === "ready") {
+                //     newState = "queued";
+                // } else
+                if (populatedState === "resubmitted") {
                     newState = "new";
                 } else if (populatedState === "failed") {
                     newState = "error";

--- a/client/src/stores/invocationStore.ts
+++ b/client/src/stores/invocationStore.ts
@@ -1,7 +1,12 @@
 import { defineStore } from "pinia";
 
 import { GalaxyApi } from "@/api";
-import { type InvocationJobsSummary, type InvocationStep, type WorkflowInvocation } from "@/api/invocations";
+import {
+    type InvocationJobsSummary,
+    type InvocationStep,
+    type WorkflowInvocation,
+    type WorkflowInvocationStepStatesView,
+} from "@/api/invocations";
 import { type FetchParams, useKeyedCache } from "@/composables/keyedCache";
 import { rethrowSimple } from "@/utils/simple-error";
 
@@ -36,8 +41,21 @@ export const useInvocationStore = defineStore("invocationStore", () => {
         return data;
     }
 
+    async function fetchInvocationStepStateDetails(params: FetchParams): Promise<WorkflowInvocationStepStatesView> {
+        const { data, error } = await GalaxyApi().GET("/api/invocations/{invocation_id}", {
+            params: { path: { invocation_id: params.id }, view: "step_states" },
+        });
+        if (error) {
+            rethrowSimple(error);
+        }
+        return data;
+    }
+
     const { getItemById: getInvocationById, fetchItemById: fetchInvocationForId } =
         useKeyedCache<WorkflowInvocation>(fetchInvocationDetails);
+
+    const { getItemById: getInvocationWithStepStatesById, fetchItemById: fetchInvocationWithStepStatesForId } =
+        useKeyedCache<WorkflowInvocation>(fetchInvocationStepStateDetails);
 
     const { getItemById: getInvocationJobsSummaryById, fetchItemById: fetchInvocationJobsSummaryForId } =
         useKeyedCache<InvocationJobsSummary>(fetchInvocationJobsSummary);
@@ -52,5 +70,7 @@ export const useInvocationStore = defineStore("invocationStore", () => {
         fetchInvocationJobsSummaryForId,
         getInvocationStepById,
         fetchInvocationStepById,
+        getInvocationWithStepStatesById,
+        fetchInvocationWithStepStatesForId,
     };
 });

--- a/client/src/stores/invocationStore.ts
+++ b/client/src/stores/invocationStore.ts
@@ -48,7 +48,7 @@ export const useInvocationStore = defineStore("invocationStore", () => {
         if (error) {
             rethrowSimple(error);
         }
-        return data;
+        return data as WorkflowInvocationStepStatesView;
     }
 
     const { getItemById: getInvocationById, fetchItemById: fetchInvocationForId } =

--- a/client/src/stores/invocationStore.ts
+++ b/client/src/stores/invocationStore.ts
@@ -21,6 +21,16 @@ export const useInvocationStore = defineStore("invocationStore", () => {
         return data;
     }
 
+    async function fetchInvocationDetailsJobStepIds(params: FetchParams): Promise<WorkflowInvocation> {
+        const { data, error } = await GalaxyApi().GET("/api/invocations/{invocation_id}", {
+            params: { path: { invocation_id: params.id }, query: { legacy_job_state: true } },
+        });
+        if (error) {
+            rethrowSimple(error);
+        }
+        return data;
+    }
+
     async function fetchInvocationJobsSummary(params: FetchParams): Promise<InvocationJobsSummary> {
         const { data, error } = await GalaxyApi().GET("/api/invocations/{invocation_id}/jobs_summary", {
             params: { path: { invocation_id: params.id } },
@@ -43,7 +53,7 @@ export const useInvocationStore = defineStore("invocationStore", () => {
 
     async function fetchInvocationStepStateDetails(params: FetchParams): Promise<WorkflowInvocationStepStatesView> {
         const { data, error } = await GalaxyApi().GET("/api/invocations/{invocation_id}", {
-            params: { path: { invocation_id: params.id }, view: "step_states" },
+            params: { path: { invocation_id: params.id }, query: { view: "step_states" } },
         });
         if (error) {
             rethrowSimple(error);
@@ -53,6 +63,9 @@ export const useInvocationStore = defineStore("invocationStore", () => {
 
     const { getItemById: getInvocationById, fetchItemById: fetchInvocationForId } =
         useKeyedCache<WorkflowInvocation>(fetchInvocationDetails);
+
+    const { getItemById: getInvocationWithJobStepIdsById, fetchItemById: fetchInvocationWithJobStepIdsForId } =
+        useKeyedCache<WorkflowInvocation>(fetchInvocationDetailsJobStepIds);
 
     const { getItemById: getInvocationWithStepStatesById, fetchItemById: fetchInvocationWithStepStatesForId } =
         useKeyedCache<WorkflowInvocation>(fetchInvocationStepStateDetails);
@@ -66,6 +79,8 @@ export const useInvocationStore = defineStore("invocationStore", () => {
     return {
         getInvocationById,
         fetchInvocationForId,
+        getInvocationWithJobStepIdsById,
+        fetchInvocationWithJobStepIdsForId,
         getInvocationJobsSummaryById,
         fetchInvocationJobsSummaryForId,
         getInvocationStepById,

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9020,11 +9020,12 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
         return invocation_attrs
 
     def to_dict(self, view="collection", value_mapper=None, step_details=False, legacy_job_state=False):
-        rval = super().to_dict(view=view, value_mapper=value_mapper)
+        base_view = view if view != "step_states" else "collection"
+        rval = super().to_dict(view=base_view, value_mapper=value_mapper)
         if rval["state"] is None:
             # bugs could result in no state being set
             rval["state"] = self.states.FAILED
-        if view == "element":
+        if view in ["element", "step_states"]:
             steps = []
             for step in self.steps:
                 if step_details:
@@ -9046,7 +9047,7 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
                     v["implicit_collection_jobs_id"] = step.implicit_collection_jobs_id
                     steps.append(v)
             rval["steps"] = steps
-
+        if view == "element":
             inputs = {}
             for input_item_association in self.input_datasets + self.input_dataset_collections:
                 if input_item_association.history_content_type == "dataset":

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9519,8 +9519,6 @@ class WorkflowInvocationStep(Base, Dictifiable, Serializable):
         rval["order_index"] = self.workflow_step.order_index
         rval["workflow_step_label"] = self.workflow_step.label
         rval["workflow_step_uuid"] = str(self.workflow_step.uuid)
-        # Following no longer makes sense...
-        # rval['state'] = self.job.state if self.job is not None else None
         if view == "element":
             jobs = []
             for job in self.jobs:

--- a/lib/galaxy/schema/invocation.py
+++ b/lib/galaxy/schema/invocation.py
@@ -375,8 +375,8 @@ class InvocationStep(Model, WithModelClass):
             ),
         ]
     ]
-    state: Optional[Union[InvocationStepState, JobState]] = Field(
-        default=None,
+    state: Union[InvocationStepState, JobState] = Field(
+        ...,
         title="State of the invocation step",
         description="Describes where in the scheduling process the workflow invocation step is.",
     )

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1445,11 +1445,12 @@ class FastAPIInvocations:
         self,
         invocation_id: InvocationIDPathParam,
         trans: ProvidesUserContext = DependsOnTrans,
+        view: SerializationViewQueryParam = None,
         step_details: StepDetailQueryParam = False,
         legacy_job_state: LegacyJobStateQueryParam = False,
     ) -> WorkflowInvocationResponse:
         serialization_params = InvocationSerializationParams(
-            step_details=step_details, legacy_job_state=legacy_job_state
+            view=view, step_details=step_details, legacy_job_state=legacy_job_state
         )
         return self.invocations_service.show(trans, invocation_id, serialization_params, eager=True)
 

--- a/lib/galaxy/webapps/galaxy/services/invocations.py
+++ b/lib/galaxy/webapps/galaxy/services/invocations.py
@@ -260,7 +260,7 @@ class InvocationsService(ServiceBase, ConsumesModelStores):
         legacy_job_state = params.legacy_job_state
         as_dict = invocation.to_dict(view.value, step_details=step_details, legacy_job_state=legacy_job_state)
         as_dict["messages"] = invocation.messages
-        return WorkflowInvocationResponse(**as_dict)
+        return WorkflowInvocationResponse.from_dict(as_dict, view, legacy_job_state)
 
     def serialize_workflow_invocations(
         self,

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -7330,29 +7330,20 @@ steps: []
         usage_details = self._invocation_details(workflow_id, invocation_id)
 
         invocation_steps = usage_details["steps"]
-        invocation_input_step, invocation_tool_step = {}, {}
+        invocation_tool_step = {}
         for invocation_step in invocation_steps:
             self._assert_has_keys(invocation_step, "workflow_step_id", "order_index", "id")
             order_index = invocation_step["order_index"]
             assert order_index in [0, 1, 2], order_index
-            if order_index == 0:
-                invocation_input_step = invocation_step
-            elif order_index == 2:
+            if order_index == 2:
                 invocation_tool_step = invocation_step
-
-        # Tool steps have non-null job_ids (deprecated though they may be)
-        assert invocation_input_step.get("job_id", None) is None
-        job_id = invocation_tool_step.get("job_id", None)
-        assert job_id is not None
 
         invocation_tool_step_id = invocation_tool_step["id"]
         invocation_tool_step_response = self._get(
             f"workflows/{workflow_id}/invocations/{invocation_id}/steps/{invocation_tool_step_id}"
         )
         self._assert_status_code_is(invocation_tool_step_response, 200)
-        self._assert_has_keys(invocation_tool_step_response.json(), "id", "order_index", "job_id")
-
-        assert invocation_tool_step_response.json()["job_id"] == job_id
+        self._assert_has_keys(invocation_tool_step_response.json(), "id", "order_index")
 
     def test_invocation_with_collection_mapping(self):
         workflow_id, invocation_id = self._run_mapping_workflow()


### PR DESCRIPTION
The actual invocation state we decided wasn't very useful at the team meeting. Foregrounding the progress bars is a potential improvement. I've done some query optimization for this.

https://github.com/galaxyproject/galaxy/assets/216771/a1ec1dda-924c-4c61-ae56-6149d326d848

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Load up some invocations and look at the grid.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
