### PR TITLE
[24.0] Fix incorrect history item count in histories lists

### DIFF
--- a/client/src/components/Grid/configs/histories.ts
+++ b/client/src/components/Grid/configs/histories.ts
@@ -241,7 +241,7 @@ const fields: FieldArray = [
         ],
     },
     {
-        key: "hid_counter",
+        key: "count",
         title: "Items",
         type: "text",
     },


### PR DESCRIPTION
Fixes #17671 

![Screenshot from 2024-03-14 13-00-45](https://github.com/galaxyproject/galaxy/assets/46503462/ef5ba606-0818-4e11-9753-781018d7dcdc)


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
