### PR TITLE
[24.0] Improve published histories listing performance in UI

### DIFF
--- a/client/src/components/Grid/configs/historiesPublished.ts
+++ b/client/src/components/Grid/configs/historiesPublished.ts
@@ -20,6 +20,7 @@ type SortKeyLiteral = "name" | "update_time" | undefined;
  */
 async function getData(offset: number, limit: number, search: string, sort_by: string, sort_desc: boolean) {
     const { data, headers } = await historiesFetcher({
+        view: "summary",
         limit,
         offset,
         search,


### PR DESCRIPTION
Fixes #17665

Initially load only summary views, as the additional details are requested for each history after loading anyway.

Tested with `CHANGE_ORIGIN=true GALAXY_URL="https://usegalaxy.org/" make client-dev-server`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
