### PR TITLE
[24.0] Fix Collection Scrolling not showing all items

### DIFF
--- a/client/src/components/History/CurrentCollection/CollectionPanel.vue
+++ b/client/src/components/History/CurrentCollection/CollectionPanel.vue
@@ -43,7 +43,16 @@ const dsc = computed(() => {
     }
     return currentCollection;
 });
-const collectionElements = computed(() => collectionElementsStore.getCollectionElements(dsc.value, offset.value));
+
+watch(
+    () => [dsc.value, offset.value],
+    () => {
+        collectionElementsStore.fetchMissingElements(dsc.value, offset.value);
+    },
+    { immediate: true }
+);
+
+const collectionElements = computed(() => collectionElementsStore.getCollectionElements(dsc.value));
 const loading = computed(() => collectionElementsStore.isLoadingCollectionElements(dsc.value));
 const jobState = computed(() => ("job_state_summary" in dsc.value ? dsc.value.job_state_summary : undefined));
 const populatedStateMsg = computed(() =>

--- a/client/src/components/History/CurrentCollection/CollectionPanel.vue
+++ b/client/src/components/History/CurrentCollection/CollectionPanel.vue
@@ -52,7 +52,7 @@ watch(
     { immediate: true }
 );
 
-const collectionElements = computed(() => collectionElementsStore.getCollectionElements(dsc.value));
+const collectionElements = computed(() => collectionElementsStore.getCollectionElements(dsc.value) ?? []);
 const loading = computed(() => collectionElementsStore.isLoadingCollectionElements(dsc.value));
 const jobState = computed(() => ("job_state_summary" in dsc.value ? dsc.value.job_state_summary : undefined));
 const populatedStateMsg = computed(() =>
@@ -108,7 +108,7 @@ watch(
 watch(
     jobState,
     () => {
-        collectionElementsStore.loadCollectionElements(dsc.value);
+        collectionElementsStore.invalidateCollectionElements(dsc.value);
     },
     { deep: true }
 );

--- a/client/src/components/History/CurrentCollection/CollectionPanel.vue
+++ b/client/src/components/History/CurrentCollection/CollectionPanel.vue
@@ -109,6 +109,7 @@ watch(
     jobState,
     () => {
         collectionElementsStore.invalidateCollectionElements(dsc.value);
+        collectionElementsStore.fetchMissingElements(dsc.value, offset.value);
     },
     { deep: true }
 );

--- a/client/src/store/historyStore/model/utilities.js
+++ b/client/src/store/historyStore/model/utilities.js
@@ -1,9 +1,9 @@
-import Vue from "vue";
+import { set } from "vue";
 
 /* This function merges the existing data with new incoming data. */
 export function mergeArray(id, payload, items, itemKey) {
     if (!items[id]) {
-        Vue.set(items, id, []);
+        set(items, id, []);
     }
     const itemArray = items[id];
     for (const item of payload) {
@@ -16,7 +16,7 @@ export function mergeArray(id, payload, items, itemKey) {
                 });
             }
         } else {
-            Vue.set(itemArray, itemIndex, item);
+            set(itemArray, itemIndex, item);
         }
     }
 }

--- a/client/src/stores/collectionElementsStore.ts
+++ b/client/src/stores/collectionElementsStore.ts
@@ -124,7 +124,7 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
                 const to = from + data.fetchedElements.length;
 
                 for (let index = from; index < to; index++) {
-                    storedElements[index] = ensureDefined(data.fetchedElements[index - from]);
+                    set(storedElements, index, ensureDefined(data.fetchedElements[index - from]));
                 }
 
                 set(storedCollectionElements.value, key, storedElements);

--- a/client/src/stores/collectionElementsStore.ts
+++ b/client/src/stores/collectionElementsStore.ts
@@ -74,7 +74,7 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
         const collectionKey = getCollectionKey(collection);
 
         try {
-            if (storedElements.length !== 0) {
+            if (collection.element_count !== null) {
                 // We should fetch only missing (placeholder) elements from the range
                 const firstMissingIndexInRange = storedElements
                     .slice(offset, offset + limit)

--- a/client/src/stores/collectionElementsStore.ts
+++ b/client/src/stores/collectionElementsStore.ts
@@ -62,8 +62,6 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
         };
     });
 
-    const lastQueue = new LastQueue(1000, true);
-
     type FetchParams = {
         storedElements: DCEEntry[];
         collection: CollectionEntry;
@@ -106,6 +104,8 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
         }
     }
 
+    const lastQueue = new LastQueue<typeof fetchMissing>(1000, true);
+
     async function fetchMissingElements(collection: CollectionEntry, offset: number, limit = FETCH_LIMIT) {
         const key = getCollectionKey(collection);
         let storedElements = storedCollectionElements.value[key];
@@ -116,11 +116,7 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
         }
 
         try {
-            const data = await (lastQueue.enqueue(
-                fetchMissing,
-                { storedElements, collection, offset, limit },
-                key
-            ) as ReturnType<typeof fetchMissing>);
+            const data = await lastQueue.enqueue(fetchMissing, { storedElements, collection, offset, limit }, key);
 
             if (data) {
                 storedElements.splice(data.elementOffset, data.fetchedElements.length, ...data.fetchedElements);

--- a/client/src/stores/collectionElementsStore.ts
+++ b/client/src/stores/collectionElementsStore.ts
@@ -4,6 +4,7 @@ import { computed, del, ref, set } from "vue";
 import type { CollectionEntry, DCESummary, HDCASummary, HistoryContentItemBase } from "@/api";
 import { isHDCA } from "@/api";
 import { fetchCollectionDetails, fetchElementsFromCollection } from "@/api/datasetCollections";
+import { ensureDefined } from "@/utils/assertions";
 import { ActionSkippedError, LastQueue } from "@/utils/lastQueue";
 
 /**
@@ -119,7 +120,13 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
             const data = await lastQueue.enqueue(fetchMissing, { storedElements, collection, offset, limit }, key);
 
             if (data) {
-                storedElements.splice(data.elementOffset, data.fetchedElements.length, ...data.fetchedElements);
+                const from = data.elementOffset;
+                const to = from + data.fetchedElements.length;
+
+                for (let index = from; index < to; index++) {
+                    storedElements[index] = ensureDefined(data.fetchedElements[index - from]);
+                }
+
                 set(storedCollectionElements.value, key, storedElements);
             }
         } catch (e) {

--- a/client/src/utils/lastQueue.ts
+++ b/client/src/utils/lastQueue.ts
@@ -1,4 +1,4 @@
-type QueuedAction<T extends (...args: any) => R, R = unknown> = {
+type QueuedAction<T extends (...args: any) => R, R = ReturnType<T>> = {
     action: T;
     arg: Parameters<T>[0];
     resolve: (value: R) => void;
@@ -13,7 +13,7 @@ export class ActionSkippedError extends Error {}
  * This is useful when promises earlier enqueued become obsolete.
  * See also: https://stackoverflow.com/questions/53540348/js-async-await-tasks-queue
  */
-export class LastQueue<T extends (arg: any) => R, R = unknown> {
+export class LastQueue<T extends (arg: any) => R, R = ReturnType<T>> {
     throttlePeriod: number;
     /** Throw an error if a queued action is skipped. This avoids dangling promises */
     rejectSkipped: boolean;
@@ -34,7 +34,7 @@ export class LastQueue<T extends (arg: any) => R, R = unknown> {
         promise?.reject(new ActionSkippedError());
     }
 
-    async enqueue(action: T, arg: Parameters<T>[0], key: string | number = 0) {
+    async enqueue(action: T, arg: Parameters<T>[0], key: string | number = 0): Promise<R> {
         return new Promise((resolve, reject) => {
             this.skipPromise(key);
             this.queuedPromises[key] = { action, arg, resolve, reject };


### PR DESCRIPTION
fixes  #17677

~~I'm still not entirely sure why this happened. I suspect it happened due to the computed side-effect firing off multiple overlapping requests which could resolve out of order and break the store by splicing the wrong items out of the array.~~

~~This PR removes the side effect and denounces the requests. It also removes the splicing, instead using the mergeArray utility, to avoid accidentally removing items.~~

~~I cannot reproduce the issue anymore with this patch applied.~~

Figured out what caused this:

The store contained a `loadCollectionElements` function, which loads the first 50 elements of a collection and replaces all collection elements with the response, which is triggered on any deep changes to `jobState`.

I did not find out what caused the change to `jobState`, as there shouldn't be any, but regardless this function should not replace all collection contents with the first 50 elements of a collection.

I removed the function and replaced it with a new function which marks all collection elements as requiring a reload.

This PR still removes the side-effects and debounces the requests, which I originally thought to be causing this.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
