### PR TITLE
[24.0] Always display grid pagination on the right

### DIFF
--- a/client/src/components/Grid/GridList.vue
+++ b/client/src/components/Grid/GridList.vue
@@ -363,7 +363,7 @@ watch(operationMessage, () => {
         </table>
         <div class="flex-grow-1 h-100" />
         <div class="grid-footer">
-            <div v-if="isAvailable && gridConfig.batch" class="d-flex justify-content-between pt-3">
+            <div v-if="isAvailable" class="d-flex justify-content-between pt-3">
                 <div class="d-flex">
                     <div v-for="(batchOperation, batchIndex) in gridConfig.batch" :key="batchIndex">
                         <BButton
@@ -381,9 +381,6 @@ watch(operationMessage, () => {
                         </BButton>
                     </div>
                 </div>
-                <BPagination v-model="currentPage" :total-rows="totalRows" :per-page="limit" class="m-0" size="sm" />
-            </div>
-            <div v-else-if="isAvailable" class="d-flex justify-content-center pt-3">
                 <BPagination v-model="currentPage" :total-rows="totalRows" :per-page="limit" class="m-0" size="sm" />
             </div>
         </div>

--- a/client/src/components/Grid/GridList.vue
+++ b/client/src/components/Grid/GridList.vue
@@ -399,6 +399,7 @@ watch(operationMessage, () => {
     top: 0;
 }
 .grid-sticky {
+    left: 0;
     z-index: 2;
     background: $white;
     opacity: 0.95;


### PR DESCRIPTION
Partial fix for #17624. Always display the grid pagination on the right. Additionally preserves the position of the search field, pagination and batch operation buttons when scrolling on horizontally.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
