### PR TITLE
[24.0] Fix histories API index_query serialization

### DIFF
--- a/client/src/components/Grid/configs/histories.ts
+++ b/client/src/components/Grid/configs/histories.ts
@@ -32,6 +32,7 @@ type SortKeyLiteral = "create_time" | "name" | "update_time" | undefined;
  */
 async function getData(offset: number, limit: number, search: string, sort_by: string, sort_desc: boolean) {
     const { data, headers } = await historiesFetcher({
+        view: "summary",
         limit,
         offset,
         search,

--- a/client/src/components/Grid/configs/historiesShared.ts
+++ b/client/src/components/Grid/configs/historiesShared.ts
@@ -22,6 +22,7 @@ type SortKeyLiteral = "create_time" | "name" | "update_time" | undefined;
  */
 async function getData(offset: number, limit: number, search: string, sort_by: string, sort_desc: boolean) {
     const { data, headers } = await historiesFetcher({
+        view: "summary",
         limit,
         offset,
         search,

--- a/client/src/components/Grid/configs/historiesShared.ts
+++ b/client/src/components/Grid/configs/historiesShared.ts
@@ -23,6 +23,7 @@ type SortKeyLiteral = "create_time" | "name" | "update_time" | undefined;
 async function getData(offset: number, limit: number, search: string, sort_by: string, sort_desc: boolean) {
     const { data, headers } = await historiesFetcher({
         view: "summary",
+        keys: "username,create_time",
         limit,
         offset,
         search,

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -191,7 +191,7 @@ class FastAPIHistories:
                 trans, serialization_params, filter_query_params, deleted_only=deleted, all_histories=all
             )
         else:
-            payload = HistoryIndexQueryPayload.construct(
+            payload = HistoryIndexQueryPayload.model_construct(
                 show_own=show_own,
                 show_published=show_published,
                 show_shared=show_shared,

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -201,7 +201,9 @@ class FastAPIHistories:
                 offset=offset,
                 search=search,
             )
-            entries, total_matches = self.service.index_query(trans, payload, include_total_count=True)
+            entries, total_matches = self.service.index_query(
+                trans, payload, serialization_params, include_total_count=True
+            )
             response.headers["total_matches"] = str(total_matches)
             return entries
 

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -216,6 +216,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         self,
         trans,
         payload: HistoryIndexQueryPayload,
+        serialization_params: SerializationParams,
         include_total_count: bool = False,
     ) -> Tuple[List[AnyHistoryView], int]:
         """Return a list of History accessible by the user
@@ -223,7 +224,6 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         :rtype:     list
         :returns:   dictionaries containing History details
         """
-        serialization_params = SerializationParams(default_view="detailed")
         entries, total_matches = self.manager.index_query(trans, payload, include_total_count)
         return (
             [self._serialize_history(trans, entry, serialization_params) for entry in entries],

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -226,7 +226,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         """
         entries, total_matches = self.manager.index_query(trans, payload, include_total_count)
         return (
-            [self._serialize_history(trans, entry, serialization_params) for entry in entries],
+            [self._serialize_history(trans, entry, serialization_params, default_view="summary") for entry in entries],
             total_matches,
         )
 

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -155,7 +155,7 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
 
         # Expect only specific keys
         expected_keys = ["name"]
-        unexpected_keys = ["id", "deleted", "state"]
+        unexpected_keys = ["deleted", "state"]
         index_response = self._get(f"histories?keys={','.join(expected_keys)}").json()
         for history in index_response:
             for key in expected_keys:
@@ -181,7 +181,7 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
 
         # Expect only specific keys
         expected_keys = ["name"]
-        unexpected_keys = ["id", "deleted", "state"]
+        unexpected_keys = ["deleted", "state"]
         data = dict(search=expected_name_contains, show_published=False, keys=",".join(expected_keys))
         index_response = self._get("histories", data=data).json()
         for history in index_response:


### PR DESCRIPTION
Follow up to #17717
Fixes #17723

The alternative "index_query" was missing the "serialization_params".
It also adds the "summary" view to the rest of the History Grid listings and it makes this the default serialization view for histories retrieved in "query" mode for consistency with the original "index" endpoint.

Hopefully this time it should make a little difference.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
