### PR TITLE
[24.0] Fix source history update_time being updated when importing a public history

### DIFF
--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -100,6 +100,17 @@ function selectHistories() {
 function setFilterValue(newFilter: string, newValue: string) {
     filter.value = HistoriesFilters.setFilterValue(filter.value, newFilter, newValue);
 }
+
+// hacky workaround for popovers in date pickers being cutoff
+// https://github.com/galaxyproject/galaxy/issues/17711
+const modalBodyClasses = computed(() => {
+    return [
+        "history-selector-modal-body",
+        showAdvanced.value
+            ? "history-selector-modal-body-allow-overflow"
+            : "history-selector-modal-body-prevent-overflow",
+    ];
+});
 </script>
 
 <template>
@@ -107,9 +118,9 @@ function setFilterValue(newFilter: string, newValue: string) {
         <BModal
             ref="modal"
             v-model="propShowModal"
-            body-class="history-selector-modal-body"
             content-class="history-selector-modal-content"
             v-bind="$attrs"
+            :body-class="modalBodyClasses"
             static
             centered
             hide-footer
@@ -174,9 +185,16 @@ function setFilterValue(newFilter: string, newValue: string) {
 with scoped or lang="scss" */
 
 .history-selector-modal-body {
-    overflow: hidden;
     display: flex;
     flex-direction: column;
+}
+
+.history-selector-modal-body-allow-overflow {
+    overflow: visible;
+}
+
+.history-selector-modal-body-prevent-overflow {
+    overflow: hidden;
 }
 
 .history-selector-modal-content {

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5093,9 +5093,9 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
             visible=self.visible,
             deleted=self.deleted,
             parent_id=parent_id,
-            copied_from_history_dataset_association=self,
             flush=False,
         )
+        hda.copied_from_history_dataset_association_id = self.id
         # update init non-keywords as well
         hda.purged = self.purged
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5038,7 +5038,7 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
 
             # hist.deleted holds old value(s)
             changes[attr.key] = hist.deleted
-        if self.update_time and self.state == self.states.OK and not self.deleted:
+        if changes and self.update_time and self.state == self.states.OK and not self.deleted:
             # We only record changes to HDAs that exist in the database and have a update_time
             new_values = {}
             new_values["name"] = changes.get("name", self.name)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4999,8 +4999,10 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
         self.hid = hid
         # Relationships
         self.history = history
-        self.copied_from_history_dataset_association = copied_from_history_dataset_association
-        self.copied_from_library_dataset_dataset_association = copied_from_library_dataset_dataset_association
+        if copied_from_history_dataset_association:
+            self.copied_from_history_dataset_association_id = copied_from_history_dataset_association.id
+        if copied_from_library_dataset_dataset_association:
+            self.copied_from_library_dataset_dataset_association_id = copied_from_library_dataset_dataset_association.id
 
     def __strict_check_before_flush__(self):
         if self.extension != "len":
@@ -5093,9 +5095,9 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
             visible=self.visible,
             deleted=self.deleted,
             parent_id=parent_id,
+            copied_from_history_dataset_association=self,
             flush=False,
         )
-        hda.copied_from_history_dataset_association_id = self.id
         # update init non-keywords as well
         hda.purged = self.purged
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4364,6 +4364,8 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
     permitted_actions = Dataset.permitted_actions
     purged: bool
     creating_job_associations: List[Union[JobToOutputDatasetCollectionAssociation, JobToOutputDatasetAssociation]]
+    copied_from_history_dataset_association: Optional["HistoryDatasetAssociation"]
+    copied_from_library_dataset_dataset_association: Optional["LibraryDatasetDatasetAssociation"]
 
     validated_states = DatasetValidatedState
 
@@ -4393,6 +4395,8 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
         flush=True,
         metadata_deferred=False,
         creating_job_id=None,
+        copied_from_history_dataset_association=None,
+        copied_from_library_dataset_dataset_association=None,
     ):
         self.name = name or "Unnamed dataset"
         self.id = id
@@ -4416,6 +4420,10 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
         self.validated_state = validated_state
         self.validated_state_message = validated_state_message
         # Relationships
+        if copied_from_history_dataset_association:
+            self.copied_from_history_dataset_association_id = copied_from_history_dataset_association.id
+        if copied_from_library_dataset_dataset_association:
+            self.copied_from_library_dataset_dataset_association_id = copied_from_library_dataset_dataset_association.id
         if not dataset and create_dataset:
             # Had to pass the sqlalchemy session in order to create a new dataset
             dataset = Dataset(state=Dataset.states.NEW)
@@ -4985,8 +4993,6 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
         self,
         hid=None,
         history=None,
-        copied_from_history_dataset_association=None,
-        copied_from_library_dataset_dataset_association=None,
         sa_session=None,
         **kwd,
     ):
@@ -4999,10 +5005,6 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
         self.hid = hid
         # Relationships
         self.history = history
-        if copied_from_history_dataset_association:
-            self.copied_from_history_dataset_association_id = copied_from_history_dataset_association.id
-        if copied_from_library_dataset_dataset_association:
-            self.copied_from_library_dataset_dataset_association_id = copied_from_library_dataset_dataset_association.id
 
     def __strict_check_before_flush__(self):
         if self.extension != "len":
@@ -5772,10 +5774,9 @@ class LibraryDataset(Base, Serializable):
 
 
 class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, Serializable):
+
     def __init__(
         self,
-        copied_from_history_dataset_association=None,
-        copied_from_library_dataset_dataset_association=None,
         library_dataset=None,
         user=None,
         sa_session=None,
@@ -5784,10 +5785,6 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, Serializable):
         # FIXME: sa_session is must be passed to DataSetInstance if the create_dataset
         # parameter in kwd is True so that the new object can be flushed.  Is there a better way?
         DatasetInstance.__init__(self, sa_session=sa_session, **kwd)
-        if copied_from_history_dataset_association:
-            self.copied_from_history_dataset_association_id = copied_from_history_dataset_association.id
-        if copied_from_library_dataset_dataset_association:
-            self.copied_from_library_dataset_dataset_association_id = copied_from_library_dataset_dataset_association.id
         self.library_dataset = library_dataset
         self.user = user
 

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -2395,10 +2395,8 @@ class DirectoryModelExportStore(ModelExportStore):
                         f"Expected a HistoryDatasetAssociation or LibraryDatasetDatasetAssociation, but got a {type(hda)}: {hda}"
                     )
                 job_hda = hda
-                while getattr(
-                    job_hda, "copied_from_history_dataset_association", None
-                ):  # should this check library datasets as well?
-                    job_hda = job_hda.copied_from_history_dataset_association  # type: ignore[union-attr]
+                while job_hda.copied_from_history_dataset_association:  # should this check library datasets as well?
+                    job_hda = job_hda.copied_from_history_dataset_association
                 if not job_hda.creating_job_associations:
                     # No viable HDA found.
                     continue

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -346,6 +346,10 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
             history_id, contents=["Hello", "World"], direct_upload=True
         )
         dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_response.json())
+        history = self._show(history_id)
+        assert "update_time" in history
+        original_update_time = history["update_time"]
+
         copied_history_response = self.dataset_populator.copy_history(history_id)
         copied_history_response.raise_for_status()
         copied_history = copied_history_response.json()
@@ -365,6 +369,10 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
         assert source_hda["id"] != copied_hda["id"]
         assert source_hda["history_id"] != copied_hda["history_id"]
         assert source_hda["hid"] == copied_hda["hid"] == 2
+
+        history = self._show(history_id)
+        new_update_time = history["update_time"]
+        assert original_update_time == new_update_time
 
     # TODO: (CE) test_create_from_copy
     def test_import_from_model_store_dict(self):

--- a/test/unit/data/test_model_copy.py
+++ b/test/unit/data/test_model_copy.py
@@ -43,9 +43,18 @@ def test_history_dataset_copy(num_datasets=NUM_DATASETS, include_metadata_file=I
             session.commit()
 
         history_copy_timer = ExecutionTimer()
-        new_history = old_history.copy(target_user=old_history.user)
+        original_update_time = old_history.update_time
+        assert original_update_time
+        new_history = old_history.copy(name="new name", target_user=old_history.user, all_datasets=True)
+        session.add(new_history)
+        session.add(old_history)
+        with transaction(session):
+            session.commit()
+        session.refresh(old_history)
+        new_update_time = session.get(model.History, old_history.id).update_time
+        assert original_update_time == new_update_time
         print("history copied %s" % history_copy_timer)
-        assert new_history.name == "HistoryCopyHistory1"
+        assert new_history.name == "new name"
         assert new_history.user == old_history.user
         for hda in new_history.active_datasets:
             assert hda.get_size() == 3


### PR DESCRIPTION
Includes a failing test for history copying updating the history update_time.

I believe I've seen this behavior for a long time but I'm happy to work on a fix for it and a test is a good place to start.

Fixes https://github.com/galaxyproject/galaxy/issues/17702

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
