### PR TITLE
Add integration tests for galaxy packages against tpv

### DIFF
--- a/.github/workflows/test_galaxy_package_integration.yaml
+++ b/.github/workflows/test_galaxy_package_integration.yaml
@@ -50,7 +50,7 @@ jobs:
           # create local release
           echo "c" | ./scripts/release.sh -l
           # make requirements point to local wheels
-          sed -i'' -e '/^galaxy-/ s/-/_/g' -e 's|^galaxy_\(.*\)$|../packages/\1/build/\*.whl|' tpv/requirements_test.txt
+          sed -i'' -e '/^galaxy-/ s/-/_/g' -e 's|^galaxy_\(.*\)$|../packages/\1/dist/\*.whl|' tpv/requirements_test.txt
           cat tpv/requirements_test.txt
       - name: Install required packages
         run: pip install tox

--- a/.github/workflows/test_galaxy_package_integration.yaml
+++ b/.github/workflows/test_galaxy_package_integration.yaml
@@ -56,7 +56,7 @@ jobs:
             package_path=`echo $line | sed -e '/^galaxy-/ s/-/_/g' -e 's|^galaxy_\(.*\)$|../packages/\1|'`
             if [ -d "$package_path" ]; then
               # This is a local package. Replace it with the path to the local wheel
-              row=`find $package_path/dist -type d -exec find {} -depth -maxdepth 1 -type f -name '*.whl' -print -quit \;`
+              row=`find $package_path/dist -type f -name '*.whl'`
             else
               # pass original requirement line unchanged
               row="$line"

--- a/.github/workflows/test_galaxy_package_integration.yaml
+++ b/.github/workflows/test_galaxy_package_integration.yaml
@@ -50,8 +50,17 @@ jobs:
           # create local release
           echo "c" | ./scripts/release.sh -l
           # make requirements point to local wheels
-          sed -i'' -e '/^galaxy-/ s/-/_/g' -e 's|^galaxy_\(.*\)$|../packages/\1/dist/\*.whl|' tpv/requirements_test.txt
-          cat tpv/requirements_test.txt
+          while read -r line; do
+            package_path=`echo $line | sed -e '/^galaxy-/ s/-/_/g' -e 's|^galaxy_\(.*\)$|../packages/\1|'`
+            if [ -d $package_path ]; then
+              row=`find $package_path/dist -type d -exec find {} -depth -maxdepth 1 -type f -name '*.whl' -print -quit \;`
+            else
+              row=$line
+            fi
+            echo $row >> tpv/requirements_local.txt
+          done < "$file"
+          cat tpv/requirements_local.txt
+          mv tpv/requirements_local.txt tpv/requirements_test.txt
       - name: Install required packages
         run: pip install tox
       - name: Run tox

--- a/.github/workflows/test_galaxy_package_integration.yaml
+++ b/.github/workflows/test_galaxy_package_integration.yaml
@@ -30,9 +30,19 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache pip dir
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+      - name: Cache galaxy venv
+        uses: actions/cache@v3
+        with:
+          path: '.venv'
+          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('requirements.txt') }}-integration
       - name: replace tpv galaxy dependencies with package paths from local galaxy build
         run: |
-          make setup-venv
+          GALAXY_SKIP_CLIENT_BUILD=1 make setup-venv
           # create local release
           echo "c" | ./scripts/release.sh -l
           # make requirements point to local wheels

--- a/.github/workflows/test_galaxy_package_integration.yaml
+++ b/.github/workflows/test_galaxy_package_integration.yaml
@@ -61,7 +61,7 @@ jobs:
               row=$line
             fi
             echo $row >> tpv/requirements_local.txt
-          done < "$file"
+          done < "tpv/requirements_test.txt"
           cat tpv/requirements_local.txt
           mv tpv/requirements_local.txt tpv/requirements_test.txt
       - name: Install required packages

--- a/.github/workflows/test_galaxy_package_integration.yaml
+++ b/.github/workflows/test_galaxy_package_integration.yaml
@@ -35,6 +35,9 @@ jobs:
         run: cat tpv/requirements_test.txt | sed -e '/^galaxy-/ s/-/_/g' | sed -E 's/^galaxy_(.*)$/\.\.\/packages\/\1/g;' > requirements_local.txt
       - name: replace test requirements with updated requirements that point to local packages
         run: mv requirements_local.txt tpv/requirements_test.txt
+      - name: Display requirement contents
+        run: cat requirements_test.txt
+        working-directory: 'tpv'
       - name: Install required packages
         run: pip install tox
       - name: Run tox

--- a/.github/workflows/test_galaxy_package_integration.yaml
+++ b/.github/workflows/test_galaxy_package_integration.yaml
@@ -44,12 +44,12 @@ jobs:
         with:
           path: '.venv'
           key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('requirements.txt') }}-integration
-      - name: replace tpv galaxy dependencies with package paths from local galaxy build
+      - name: Replace tpv galaxy dependencies with package paths from local galaxy build
         run: |
           GALAXY_SKIP_NODE=1 GALAXY_SKIP_CLIENT_BUILD=1 make setup-venv
           # create local release
           echo "c" | ./scripts/release.sh -l
-          # make requirements point to local wheels
+          # make requirements point to local wheels where possible
           while read -r line; do
             package_path=`echo $line | sed -e '/^galaxy-/ s/-/_/g' -e 's|^galaxy_\(.*\)$|../packages/\1|'`            
             if [ -d $package_path ]; then

--- a/.github/workflows/test_galaxy_package_integration.yaml
+++ b/.github/workflows/test_galaxy_package_integration.yaml
@@ -46,15 +46,17 @@ jobs:
           key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('requirements.txt') }}-integration
       - name: replace tpv galaxy dependencies with package paths from local galaxy build
         run: |
-          GALAXY_SKIP_CLIENT_BUILD=1 make setup-venv
+          GALAXY_SKIP_NODE=1 GALAXY_SKIP_CLIENT_BUILD=1 make setup-venv
           # create local release
           echo "c" | ./scripts/release.sh -l
           # make requirements point to local wheels
           while read -r line; do
-            package_path=`echo $line | sed -e '/^galaxy-/ s/-/_/g' -e 's|^galaxy_\(.*\)$|../packages/\1|'`
+            package_path=`echo $line | sed -e '/^galaxy-/ s/-/_/g' -e 's|^galaxy_\(.*\)$|../packages/\1|'`            
             if [ -d $package_path ]; then
+              # This is a local package. Replace it with the path to the local wheel
               row=`find $package_path/dist -type d -exec find {} -depth -maxdepth 1 -type f -name '*.whl' -print -quit \;`
             else
+              # pass original requirement line unchanged
               row=$line
             fi
             echo $row >> tpv/requirements_local.txt

--- a/.github/workflows/test_galaxy_package_integration.yaml
+++ b/.github/workflows/test_galaxy_package_integration.yaml
@@ -30,11 +30,13 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: replace tpv galaxy dependencies with local package paths from galaxy source
+      - name: replace tpv galaxy dependencies with package paths from local galaxy build
         run: |
-          sed -i'' -e '/^galaxy-/ s/-/_/g' -e 's|^galaxy_\(.*\)$|../packages/\1|' tpv/requirements_test.txt
+          # create local release
+          echo "c" | ./scripts/release.sh -l
+          # make requirements point to local wheels
+          sed -i'' -e '/^galaxy-/ s/-/_/g' -e 's|^galaxy_\(.*\)$|../packages/\1/build/\*.whl|' tpv/requirements_test.txt
           cat tpv/requirements_test.txt
-        working-directory: 'tpv'
       - name: Install required packages
         run: pip install tox
       - name: Run tox

--- a/.github/workflows/test_galaxy_package_integration.yaml
+++ b/.github/workflows/test_galaxy_package_integration.yaml
@@ -20,14 +20,13 @@ jobs:
       matrix:
         python-version: ['3.10']
     steps:
+      - name: Checkout galaxy code
+        uses: actions/checkout@v3
       - name: Checkout tpv code
         uses: actions/checkout@v3
         with:
           repository: galaxyproject/total-perspective-vortex
           path: 'tpv'
-          persist-credentials: false
-      - name: Checkout galaxy code
-        uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -49,21 +48,23 @@ jobs:
         run: |
           GALAXY_SKIP_NODE=1 GALAXY_SKIP_CLIENT_BUILD=1 make setup-venv
           # create local release
-          echo "c" | ./scripts/release.sh -l
+          echo "c" | UPSTREAM_REMOTE_URL="https://github.com/galaxyproject/galaxy.git" ./scripts/release.sh -l
           # make requirements point to local wheels where possible
-          while read -r line; do
-            package_path=`echo $line | sed -e '/^galaxy-/ s/-/_/g' -e 's|^galaxy_\(.*\)$|../packages/\1|'`            
-            if [ -d $package_path ]; then
+          cd tpv
+          while IFS= read -r line; do
+            # Handle galaxy- packages specifically
+            package_path=`echo $line | sed -e '/^galaxy-/ s/-/_/g' -e 's|^galaxy_\(.*\)$|../packages/\1|'`
+            if [ -d "$package_path" ]; then
               # This is a local package. Replace it with the path to the local wheel
               row=`find $package_path/dist -type d -exec find {} -depth -maxdepth 1 -type f -name '*.whl' -print -quit \;`
             else
               # pass original requirement line unchanged
-              row=$line
+              row="$line"
             fi
-            echo $row >> tpv/requirements_local.txt
-          done < "tpv/requirements_test.txt"
-          cat tpv/requirements_local.txt
-          mv tpv/requirements_local.txt tpv/requirements_test.txt
+            echo "$row" >> requirements_local.txt
+          done < "requirements_test.txt"
+          cat requirements_local.txt
+          mv requirements_local.txt requirements_test.txt
       - name: Install required packages
         run: pip install tox
       - name: Run tox

--- a/.github/workflows/test_galaxy_package_integration.yaml
+++ b/.github/workflows/test_galaxy_package_integration.yaml
@@ -20,13 +20,14 @@ jobs:
       matrix:
         python-version: ['3.10']
     steps:
-      - name: Checkout galaxy code
-        uses: actions/checkout@v3
       - name: Checkout tpv code
         uses: actions/checkout@v3
         with:
           repository: galaxyproject/total-perspective-vortex
           path: 'tpv'
+          persist-credentials: false
+      - name: Checkout galaxy code
+        uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test_galaxy_package_integration.yaml
+++ b/.github/workflows/test_galaxy_package_integration.yaml
@@ -1,0 +1,44 @@
+name: Test Galaxy package integration with TPV
+on:
+  push:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10']
+    steps:
+      - name: Checkout galaxy code
+        uses: actions/checkout@v3
+      - name: Checkout tpv code
+        uses: actions/checkout@v3
+        with:
+          repository: galaxyproject/total-perspective-vortex
+          path: 'tpv'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: replace tpv galaxy dependencies with local package paths from galaxy source
+        shell: bash
+        run: cat tpv/requirements_test.txt | sed -e '/^galaxy-/ s/-/_/g' | sed -E 's/^galaxy_(.*)$/\.\.\/packages\/\1/g;' > requirements_local.txt
+      - name: replace test requirements with updated requirements that point to local packages
+        run: mv requirements_local.txt tpv/requirements_test.txt
+      - name: Install required packages
+        run: pip install tox
+      - name: Run tox
+        run: tox -e py${{ matrix.python-version }}
+        env:
+          PYTHONUNBUFFERED: "True"
+        working-directory: 'tpv'

--- a/.github/workflows/test_galaxy_package_integration.yaml
+++ b/.github/workflows/test_galaxy_package_integration.yaml
@@ -32,6 +32,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: replace tpv galaxy dependencies with package paths from local galaxy build
         run: |
+          make setup-venv
           # create local release
           echo "c" | ./scripts/release.sh -l
           # make requirements point to local wheels

--- a/.github/workflows/test_galaxy_package_integration.yaml
+++ b/.github/workflows/test_galaxy_package_integration.yaml
@@ -30,6 +30,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Get full Python version
+        id: full-python-version
+        shell: bash
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test_galaxy_package_integration.yaml
+++ b/.github/workflows/test_galaxy_package_integration.yaml
@@ -34,21 +34,21 @@ jobs:
         id: full-python-version
         shell: bash
         run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
-      - name: Cache pip dir
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
-      - name: Cache galaxy venv
-        uses: actions/cache@v3
-        with:
-          path: '.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('requirements.txt') }}-integration
+      # - name: Cache pip dir
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/.cache/pip
+      #     key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+      # - name: Cache galaxy venv
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: '.venv'
+      #     key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('requirements.txt') }}-integration
       - name: Replace tpv galaxy dependencies with package paths from local galaxy build
         run: |
           GALAXY_SKIP_NODE=1 GALAXY_SKIP_CLIENT_BUILD=1 make setup-venv
           # create local release
-          echo "c" | UPSTREAM_REMOTE_URL="https://github.com/galaxyproject/galaxy.git" ./scripts/release.sh -l
+          echo "c" | UPSTREAM_REMOTE_URL="https://github.com/nuwang/galaxy.git" ./scripts/release.sh -l
           # make requirements point to local wheels where possible
           cd tpv
           while IFS= read -r line; do
@@ -68,7 +68,7 @@ jobs:
       - name: Install required packages
         run: pip install tox
       - name: Run tox
-        run: tox -e py${{ matrix.python-version }}
+        run: tox -e py${{ matrix.python-version }} -- --runslow
         env:
           PYTHONUNBUFFERED: "True"
         working-directory: 'tpv'

--- a/.github/workflows/test_galaxy_package_integration.yaml
+++ b/.github/workflows/test_galaxy_package_integration.yaml
@@ -31,12 +31,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: replace tpv galaxy dependencies with local package paths from galaxy source
-        shell: bash
-        run: cat tpv/requirements_test.txt | sed -e '/^galaxy-/ s/-/_/g' | sed -E 's/^galaxy_(.*)$/\.\.\/packages\/\1/g;' > requirements_local.txt
-      - name: replace test requirements with updated requirements that point to local packages
-        run: mv requirements_local.txt tpv/requirements_test.txt
-      - name: Display requirement contents
-        run: cat requirements_test.txt
+        run: |
+          sed -i'' -e '/^galaxy-/ s/-/_/g' -e 's|^galaxy_\(.*\)$|../packages/\1|' tpv/requirements_test.txt
+          cat tpv/requirements_test.txt
         working-directory: 'tpv'
       - name: Install required packages
         run: pip install tox

--- a/packages/app/MANIFEST.in
+++ b/packages/app/MANIFEST.in
@@ -1,5 +1,4 @@
 include *.rst *.txt LICENSE */py.typed
-include galaxy/carbon_emissions/carbon_intensity.csv
 include galaxy/dependencies/*.txt
 include galaxy/dependencies/*.sh
 include galaxy/jobs/runners/util/job_script/*.sh

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,7 +8,7 @@ shopt -s extglob
 : ${VENV:=.venv}
 : ${FORK_REMOTE:=origin}
 : ${UPSTREAM_REMOTE:=upstream}
-: ${UPSTREAM_REMOTE_URL:=https://github.com/galaxyproject/galaxy.git}
+: ${UPSTREAM_REMOTE_URL:=git@github.com:galaxyproject/galaxy.git}
 : ${DEV_BRANCH:=dev}
 : ${STABLE_BRANCH:=master}
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,7 +8,7 @@ shopt -s extglob
 : ${VENV:=.venv}
 : ${FORK_REMOTE:=origin}
 : ${UPSTREAM_REMOTE:=upstream}
-: ${UPSTREAM_REMOTE_URL:=git@github.com:galaxyproject/galaxy.git}
+: ${UPSTREAM_REMOTE_URL:=https://github.com/galaxyproject/galaxy.git}
 : ${DEV_BRANCH:=dev}
 : ${STABLE_BRANCH:=master}
 


### PR DESCRIPTION
In the past, we've run into issues with TPV testing due to PyPI packaging, normally because a file was overlooked while bundling galaxy PyPI packages.

https://github.com/galaxyproject/galaxy/pull/16308
https://github.com/galaxyproject/galaxy/pull/14018
https://github.com/galaxyproject/galaxy/pull/14020

Most recently, this: https://github.com/galaxyproject/galaxy/pull/17748

TPV uses a fairly comprehensive gamut of Galaxy packages, so it seems like a good integration test target to make sure PyPI packaging is not overlooking required files.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
