### PR TITLE
Fix bug in image_util.py

### DIFF
--- a/lib/galaxy/util/image_util.py
+++ b/lib/galaxy/util/image_util.py
@@ -10,7 +10,7 @@ from typing import (
 try:
     from PIL import Image
 except ImportError:
-    PIL = None
+    Image = None
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fix bug introduced in 3d3ad72dcff055d6b853b499e6fc953374397af0 (#17556).

When running `planemo test`:

> Traceback (most recent call last):
>   File "/home/void/miniconda3/envs/galaxy2024/bin/planemo", line 8, in <module>
>     sys.exit(planemo())
>   File "/home/void/miniconda3/envs/galaxy2024/lib/python3.8/site-packages/click/core.py", line 1157, in __call__
>     return self.main(*args, **kwargs)
>   File "/home/void/miniconda3/envs/galaxy2024/lib/python3.8/site-packages/galaxy/util/image_util.py", line 20, in image_type
>     if Image is not None:
> NameError: name 'Image' is not defined

We forgot to change `PIL = None` to `Image = None`. This is hereby done.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).