### PR TITLE
Fix bug in galaxy.xsd

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2858,7 +2858,7 @@ $attribute_list::5
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
 Asserts the output is an image and has a specific mean intensity value,
-plus/minus ``eps`` (e.g., ``<image_has_mean_intensity mean_intensity="0.83" />``).
+plus/minus ``eps`` (e.g., ``<has_image_mean_intensity mean_intensity="0.83" />``).
 Alternatively the range of the expected mean intensity value can be specified by ``min`` and/or ``max``.
 
 $attribute_list::5


### PR DESCRIPTION
There is a bug in the XSD introduced in #17581:

The assertion tag `<image_has_mean_intensity>` is misnamed, and should be corrected to `<has_image_mean_intensity>`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
