### PR TITLE
Fix bug in `assert_has_image_n_labels`

### DIFF
--- a/lib/galaxy/tool_util/verify/asserts/image.py
+++ b/lib/galaxy/tool_util/verify/asserts/image.py
@@ -241,6 +241,7 @@ def _get_image_labels(
 def assert_has_image_n_labels(
     output_bytes: bytes,
     channel: Optional[Union[int, str]] = None,
+    labels: Optional[Union[str, List[int]]] = None,
     exclude_labels: Optional[Union[str, List[int]]] = None,
     n: Optional[Union[int, str]] = None,
     delta: Union[int, str] = 0,
@@ -251,7 +252,7 @@ def assert_has_image_n_labels(
     """
     Asserts the specified output is an image and has the specified number of unique values (e.g., uniquely labeled objects).
     """
-    present_labels = _get_image_labels(output_bytes, channel, exclude_labels)[1]
+    present_labels = _get_image_labels(output_bytes, channel, labels, exclude_labels)[1]
     _assert_number(
         len(present_labels),
         n,

--- a/test/functional/tools/validation_image.xml
+++ b/test/functional/tools/validation_image.xml
@@ -102,6 +102,7 @@
                     <has_image_height height="32" />
                     <has_image_channels channels="1" />
                     <has_image_n_labels n="1" exclude_labels="0" />
+                    <has_image_n_labels n="0" exclude_labels="0,1" />
                     <has_image_mean_object_size mean_object_size="256" exclude_labels="0" />
                 </assert_contents>
             </output>


### PR DESCRIPTION
Fix bug introduced in #17581: The argument `labels` was missing in `assert_has_image_n_labels` and is now added.

A test which covers this bug is added (fails before the fix).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
