### PR TITLE
[24.0] Add ``require_default_history`` route argument 

### DIFF
--- a/lib/galaxy/managers/session.py
+++ b/lib/galaxy/managers/session.py
@@ -6,9 +6,33 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import joinedload
 
+from galaxy.model import (
+    GalaxySession,
+    History,
+)
 from galaxy.model.base import SharedModelMapping
+from galaxy.model.security import GalaxyRBACAgent
 
 log = logging.getLogger(__name__)
+
+
+def new_history(galaxy_session: GalaxySession, security_agent: GalaxyRBACAgent):
+    """
+    Create a new history and associate it with the current session and
+    its associated user (if set).
+    """
+    # Create new history
+    history = History()
+    # Associate with session
+    history.add_galaxy_session(galaxy_session)
+    # Make it the session's current history
+    galaxy_session.current_history = history
+    # Associate with user
+    if galaxy_session.user:
+        history.user = galaxy_session.user
+    # Set the user's default history permissions
+    security_agent.history_set_default_permissions(history)
+    return history
 
 
 class GalaxySessionManager:
@@ -17,6 +41,34 @@ class GalaxySessionManager:
     def __init__(self, model: SharedModelMapping):
         self.model = model
         self.sa_session = model.context
+
+    def get_or_create_default_history(self, galaxy_session: GalaxySession, security_agent: GalaxyRBACAgent):
+        default_history = galaxy_session.current_history
+        if default_history and not default_history.deleted:
+            return default_history
+        # history might be deleted, reset to None
+        default_history = None
+        user = galaxy_session.user
+        if user:
+            # Look for default history that (a) has default name + is not deleted and
+            # (b) has no datasets. If suitable history found, use it; otherwise, create
+            # new history.
+            stmt = select(History).filter_by(user=user, name=History.default_name, deleted=False)
+            unnamed_histories = self.sa_session.scalars(stmt)
+            for history in unnamed_histories:
+                if history.empty:
+                    # Found suitable default history.
+                    default_history = history
+                    break
+
+            # Set or create history.
+            if default_history:
+                galaxy_session.current_history = default_history
+        if not default_history:
+            default_history = new_history(galaxy_session, security_agent)
+            self.sa_session.add_all((default_history, galaxy_session))
+        self.sa_session.commit()
+        return default_history
 
     def get_session_from_session_key(self, session_key: str):
         """Returns GalaxySession if session_key is valid."""

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -363,8 +363,8 @@ def get_or_create_default_history(
     trans: SessionRequestContext = DependsOnTrans,
     session_manager=cast(GalaxySessionManager, Depends(get_session_manager)),
 ):
-    if not trans.galaxy_session:
-        raise RequestParameterMissingException("No galaxysession cookie provided")
+    if not trans.user and not trans.galaxy_session:
+        raise RequestParameterMissingException("Cannot fetch or create history for unknown user session")
     history = session_manager.get_or_create_default_history(trans.galaxy_session, trans.app.security_agent)
     trans.history = history
     return history

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -641,6 +641,7 @@ class FastAPIUsers:
         "/api/users/{user_id}",
         name="get_user",
         summary="Return information about a specified or the current user. Only admin can see deleted or other users",
+        require_default_history=True,
     )
     def show(
         self,

--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -70,6 +70,10 @@ class WorkRequestContext(ProvidesHistoryContext):
     def history(self):
         return self.get_history()
 
+    @history.setter
+    def history(self, history):
+        self.__history = history
+
     def get_user(self):
         """Return the current user if logged in or None."""
         return self.__user

--- a/lib/galaxy_test/api/test_authenticate.py
+++ b/lib/galaxy_test/api/test_authenticate.py
@@ -75,3 +75,28 @@ class TestAuthenticateApi(ApiTestCase):
             cookies=cookie,
         )
         assert second_histories_response.json()
+
+    def test_anon_history_creation_api(self):
+        # First request:
+        # We don't create any histories, just return a session cookie
+        response = get(self.url)
+        cookie = {"galaxysession": response.cookies["galaxysession"]}
+        # Check that we don't have any histories (API doesn't auto-create new histories)
+        histories_response = get(
+            urljoin(
+                self.url,
+                "api/histories",
+            )
+        )
+        assert not histories_response.json()
+        # Second request, we know client follows conventions by including cookies,
+        # default history is created.
+        get(urljoin(self.url, "api/users/current"), cookies=cookie).raise_for_status()
+        histories_response = get(
+            urljoin(
+                self.url,
+                "api/histories",
+            ),
+            cookies=cookie,
+        )
+        assert histories_response.json()

--- a/lib/tool_shed/webapp/buildapp.py
+++ b/lib/tool_shed/webapp/buildapp.py
@@ -37,10 +37,6 @@ class ToolShedGalaxyWebTransaction(GalaxyWebTransaction):
     def repositories_hostname(self) -> str:
         return url_for("/", qualified=True).rstrip("/")
 
-    def get_or_create_default_history(self):
-        # tool shed has no concept of histories
-        raise NotImplementedError
-
 
 class CommunityWebApplication(galaxy.webapps.base.webapp.WebApplication):
     injection_aware: bool = True


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/17703. The strategy introduced in https://github.com/galaxyproject/galaxy/pull/17657 started failing when applied to 24.0, since `/api/users/current` was ported to FastAPI and so didn't result in the creation of a history. The effect of this was that if you didn't have a session cookie your first visit would fail to load the history panel.

Going forward I think this is a nice way to provide resources conditionally per endpoint, instead of setting up everything in trans, whether it is needed or not for a given route.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
