### PR TITLE
[24.0] Prevent dragover for item from same history in history panel

### DIFF
--- a/client/src/components/DragGhost.vue
+++ b/client/src/components/DragGhost.vue
@@ -25,7 +25,7 @@ const name = computed(() => {
 
 <template>
     <span id="drag-ghost" class="py-2 px-3 rounded">
-        <FontAwesomeIcon icon="paper-plane" class="mr-1" />
+        <FontAwesomeIcon :icon="faPaperPlane" class="mr-1" />
         <TextShort class="font-weight-bold" :text="name" />
     </span>
 </template>

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -317,9 +317,12 @@ function unexpandedClick(event: Event) {
         :data-state="dataState"
         tabindex="0"
         role="button"
+        draggable
+        @dragstart="onDragStart"
+        @dragend="onDragEnd"
         @keydown="onKeyDown">
         <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/no-static-element-interactions -->
-        <div class="p-1 cursor-pointer" draggable @dragstart="onDragStart" @dragend="onDragEnd" @click.stop="onClick">
+        <div class="p-1 cursor-pointer" @click.stop="onClick">
             <div class="d-flex justify-content-between">
                 <span class="p-1" data-description="content item header info">
                     <BButton v-if="selectable" class="selector p-0" @click.stop="emit('update:selected', !selected)">


### PR DESCRIPTION
We would allow users to dragover items from the same history over its panel and render the dropzone, this prevents that entirely. Fixes https://github.com/galaxyproject/galaxy/issues/17743

### Before:

https://github.com/galaxyproject/galaxy/assets/78516064/d58bcc04-67bb-4a03-b440-736ccfe9f642

### Now:

https://github.com/galaxyproject/galaxy/assets/78516064/335e7c60-cc96-41fe-9953-585928cc1c54

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
