### PR TITLE
[24.0] Improve Shift+Click select in history panel and add it for `ContentItem` selector checkboxes as well

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -304,9 +304,10 @@ function onButtonSelect(e: Event) {
     const event = e as KeyboardEvent;
     if (event.shiftKey) {
         onClick(e);
+    } else {
+        emit("init-key-selection");
     }
     contentItem.value?.focus();
-    emit("init-key-selection");
     emit("update:selected", !props.selected);
 }
 

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -4,7 +4,7 @@ import { faCheckSquare, faSquare } from "@fortawesome/free-regular-svg-icons";
 import { faArrowCircleDown, faArrowCircleUp, faCheckCircle, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BBadge, BButton, BCollapse } from "bootstrap-vue";
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useRoute, useRouter } from "vue-router/composables";
 
 import type { ItemUrls } from "@/components/History/Content/Dataset/index";
@@ -76,6 +76,8 @@ const emit = defineEmits<{
 
 const entryPointStore = useEntryPointStore();
 const eventStore = useEventStore();
+
+const contentItem = ref<HTMLElement | null>(null);
 
 const jobState = computed(() => {
     return new JobStateSummary(props.item);
@@ -298,6 +300,16 @@ function onTagClick(tag: string) {
     }
 }
 
+function onButtonSelect(e: Event) {
+    const event = e as KeyboardEvent;
+    if (event.shiftKey) {
+        onClick(e);
+    }
+    contentItem.value?.focus();
+    emit("init-key-selection");
+    emit("update:selected", !props.selected);
+}
+
 function toggleHighlights() {
     emit("toggleHighlights", props.item);
 }
@@ -312,6 +324,7 @@ function unexpandedClick(event: Event) {
 <template>
     <div
         :id="contentId"
+        ref="contentItem"
         :class="['content-item m-1 p-0 rounded btn-transparent-background', contentCls, isBeingUsed]"
         :data-hid="id"
         :data-state="dataState"
@@ -322,7 +335,7 @@ function unexpandedClick(event: Event) {
         <div class="p-1 cursor-pointer" draggable @dragstart="onDragStart" @dragend="onDragEnd" @click.stop="onClick">
             <div class="d-flex justify-content-between">
                 <span class="p-1" data-description="content item header info">
-                    <BButton v-if="selectable" class="selector p-0" @click.stop="emit('update:selected', !selected)">
+                    <BButton v-if="selectable" class="selector p-0" @click.stop="onButtonSelect">
                         <FontAwesomeIcon v-if="selected" fixed-width size="lg" :icon="faCheckSquare" />
                         <FontAwesomeIcon v-else fixed-width size="lg" :icon="faSquare" />
                     </BButton>

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -35,6 +35,7 @@ interface Props {
     addHighlightBtn?: boolean;
     highlight?: string;
     isDataset?: boolean;
+    isRangeSelectAnchor?: boolean;
     isHistoryItem?: boolean;
     selected?: boolean;
     selectable?: boolean;
@@ -48,6 +49,7 @@ const props = withDefaults(defineProps<Props>(), {
     addHighlightBtn: false,
     highlight: undefined,
     isDataset: true,
+    isRangeSelectAnchor: false,
     isHistoryItem: false,
     selected: false,
     selectable: false,
@@ -58,12 +60,12 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
     (e: "update:selected", selected: boolean): void;
     (e: "update:expand-dataset", expand: boolean): void;
-    (e: "shift-select", direction: string): void;
+    (e: "shift-arrow-select", direction: string): void;
     (e: "init-key-selection"): void;
     (e: "arrow-navigate", direction: string): void;
     (e: "hide-selection"): void;
     (e: "select-all"): void;
-    (e: "selected-to", reset: boolean): void;
+    (e: "selected-to"): void;
     (e: "delete", item: any, recursive: boolean): void;
     (e: "undelete"): void;
     (e: "unhide"): void;
@@ -173,6 +175,10 @@ const isBeingUsed = computed(() => {
     return Object.values(itemUrls.value).includes(route.path) ? "being-used" : "";
 });
 
+const rangeSelectClass = computed(() => {
+    return props.isRangeSelectAnchor ? "range-select-anchor" : "";
+});
+
 /** Based on the user's keyboard platform, checks if it is the
  * typical key for selection (ctrl for windows/linux, cmd for mac)
  */
@@ -199,7 +205,7 @@ function onKeyDown(event: KeyboardEvent) {
         } else {
             event.preventDefault();
             if ((event.key === "ArrowUp" || event.key === "ArrowDown") && event.shiftKey) {
-                emit("shift-select", event.key);
+                emit("shift-arrow-select", event.key);
             } else if (event.key === "ArrowUp" || event.key === "ArrowDown") {
                 emit("init-key-selection");
             } else if (event.key === "Delete" && !props.selected && !props.item.deleted) {
@@ -217,15 +223,12 @@ function onKeyDown(event: KeyboardEvent) {
 function onClick(e?: Event) {
     const event = e as KeyboardEvent;
     if (event && props.writable) {
-        if (event.shiftKey && isSelectKey(event)) {
-            emit("selected-to", false);
-            return;
-        } else if (isSelectKey(event)) {
+        if (isSelectKey(event)) {
             emit("init-key-selection");
             emit("update:selected", !props.selected);
             return;
         } else if (event.shiftKey) {
-            emit("selected-to", true);
+            emit("selected-to");
             return;
         } else {
             emit("init-key-selection");
@@ -326,7 +329,7 @@ function unexpandedClick(event: Event) {
     <div
         :id="contentId"
         ref="contentItem"
-        :class="['content-item m-1 p-0 rounded btn-transparent-background', contentCls, isBeingUsed]"
+        :class="['content-item m-1 p-0 rounded btn-transparent-background', contentCls, isBeingUsed, rangeSelectClass]"
         :data-hid="id"
         :data-state="dataState"
         tabindex="0"
@@ -447,6 +450,10 @@ function unexpandedClick(event: Event) {
 
     // improve focus visibility
     &:deep(.btn:focus) {
+        box-shadow: 0 0 0 0.2rem transparentize($brand-primary, 0.75);
+    }
+
+    &.range-select-anchor {
         box-shadow: 0 0 0 0.2rem transparentize($brand-primary, 0.75);
     }
 

--- a/client/src/components/History/Content/SelectedItems.test.js
+++ b/client/src/components/History/Content/SelectedItems.test.js
@@ -6,16 +6,19 @@ import SelectedItems from "./SelectedItems";
 
 const localVue = getLocalVue();
 
-const DEFAULT_PROPS = {
-    scopeKey: "scope",
-    getItemKey: (item) => `item-key-${item.id}`,
-    filterText: "",
-    totalItemsInQuery: 100,
-};
-
 describe("History SelectedItems", () => {
     let wrapper;
     let slotProps;
+
+    const numberOfLoadedItems = 10;
+    const allItems = generateTestItems(numberOfLoadedItems);
+    const DEFAULT_PROPS = {
+        scopeKey: "scope",
+        getItemKey: (item) => `item-key-${item.id}`,
+        filterText: "",
+        totalItemsInQuery: 100,
+        allItems,
+    };
 
     beforeEach(async () => {
         wrapper = shallowMount(SelectedItems, {
@@ -79,10 +82,8 @@ describe("History SelectedItems", () => {
     describe("Query Selection Mode", () => {
         it("is considered a query selection when we select `all items` and the query contains more items than we have currently loaded", async () => {
             const expectedTotalItemsInQuery = 100;
-            const numberOfLoadedItems = 10;
-            const loadedItems = generateTestItems(numberOfLoadedItems);
 
-            await selectAllItemsInCurrentQuery(loadedItems);
+            await selectAllItemsInCurrentQuery();
 
             expect(slotProps.isQuerySelection).toBe(true);
             expect(slotProps.selectionSize).toBe(expectedTotalItemsInQuery);
@@ -90,11 +91,9 @@ describe("History SelectedItems", () => {
 
         it("shouldn't be a query selection when we already have all items loaded", async () => {
             const expectedTotalItemsInQuery = 10;
-            const numberOfLoadedItems = 10;
-            const loadedItems = generateTestItems(numberOfLoadedItems);
             await wrapper.setProps({ totalItemsInQuery: expectedTotalItemsInQuery });
 
-            await selectAllItemsInCurrentQuery(loadedItems);
+            await selectAllItemsInCurrentQuery();
 
             expect(slotProps.isQuerySelection).toBe(false);
             expect(slotProps.selectionSize).toBe(expectedTotalItemsInQuery);
@@ -102,14 +101,12 @@ describe("History SelectedItems", () => {
 
         it("should `break` query selection mode when we unselect an item", async () => {
             const expectedTotalItemsInQuery = 100;
-            const numberOfLoadedItems = 10;
-            const loadedItems = generateTestItems(numberOfLoadedItems);
-            await selectAllItemsInCurrentQuery(loadedItems);
+            await selectAllItemsInCurrentQuery();
             expect(slotProps.isQuerySelection).toBe(true);
             expect(slotProps.selectionSize).toBe(expectedTotalItemsInQuery);
             expect(wrapper.emitted()["query-selection-break"]).toBeUndefined();
 
-            await unselectItem(loadedItems[0]);
+            await unselectItem(allItems[0]);
 
             expect(slotProps.isQuerySelection).toBe(false);
             expect(slotProps.selectionSize).toBe(numberOfLoadedItems - 1);
@@ -117,9 +114,7 @@ describe("History SelectedItems", () => {
         });
 
         it("should `break` query selection mode when the total number of items changes", async () => {
-            const numberOfLoadedItems = 10;
-            const loadedItems = generateTestItems(numberOfLoadedItems);
-            await selectAllItemsInCurrentQuery(loadedItems);
+            await selectAllItemsInCurrentQuery();
             expect(slotProps.isQuerySelection).toBe(true);
             expect(wrapper.emitted()["query-selection-break"]).toBeUndefined();
 
@@ -146,8 +141,8 @@ describe("History SelectedItems", () => {
 
         it("should match the number of items in query when selecting all items", async () => {
             const expectedTotalItemsInQuery = 100;
-            const loadedItems = []; // Even if there are no explicit items selected
-            await selectAllItemsInCurrentQuery(loadedItems);
+            await wrapper.setProps({ allItems: generateTestItems(0) }); // Even if there are no explicit items selected
+            await selectAllItemsInCurrentQuery();
             expect(slotProps.isQuerySelection).toBe(true);
             expect(slotProps.selectionSize).toBe(expectedTotalItemsInQuery);
         });

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -470,15 +470,17 @@ function setItemDragstart(
                 setShowSelection,
                 selectAllInCurrentQuery,
                 isSelected,
-                selectTo,
+                rangeSelect,
                 setSelected,
-                shiftSelect,
+                shiftArrowKeySelect,
                 initKeySelection,
                 resetSelection,
+                initSelectedItem,
             }"
             :scope-key="queryKey"
             :get-item-key="getItemKey"
             :filter-text="filterText"
+            :all-items="historyItems"
             :total-items-in-query="totalMatchesCount"
             @query-selection-break="querySelectionBreak = true">
             <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
@@ -545,7 +547,7 @@ function setItemDragstart(
                             <HistorySelectionStatus
                                 v-if="showSelection"
                                 :selection-size="selectionSize"
-                                @select-all="selectAllInCurrentQuery(historyItems)"
+                                @select-all="selectAllInCurrentQuery()"
                                 @reset-selection="resetSelection" />
                         </template>
                     </HistoryOperations>
@@ -597,6 +599,9 @@ function setItemDragstart(
                                     :writable="canEditHistory"
                                     :expand-dataset="isExpanded(item)"
                                     :is-dataset="isDataset(item)"
+                                    :is-range-select-anchor="
+                                        initSelectedItem && itemUniqueKey(item) === itemUniqueKey(initSelectedItem)
+                                    "
                                     :highlight="getHighlight(item)"
                                     :selected="isSelected(item)"
                                     :selectable="showSelection"
@@ -613,11 +618,11 @@ function setItemDragstart(
                                     "
                                     @hide-selection="setShowSelection(false)"
                                     @init-key-selection="initKeySelection"
-                                    @shift-select="
-                                        (eventKey) => shiftSelect(item, arrowNavigate(item, eventKey), eventKey)
+                                    @shift-arrow-select="
+                                        (eventKey) => shiftArrowKeySelect(item, arrowNavigate(item, eventKey), eventKey)
                                     "
-                                    @select-all="selectAllInCurrentQuery(historyItems, false)"
-                                    @selected-to="(reset) => selectTo(item, lastItemFocused, historyItems, reset)"
+                                    @select-all="selectAllInCurrentQuery(false)"
+                                    @selected-to="rangeSelect(item, lastItemFocused)"
                                     @tag-click="updateFilterValue('tag', $event)"
                                     @tag-change="onTagChange"
                                     @toggleHighlights="updateFilterValue('related', item.hid)"


### PR DESCRIPTION
While keyboard select was added in https://github.com/galaxyproject/galaxy/pull/17502 (and polished/fixed in other PRs), the selector buttons did not allow for Shift+Click selection. This PR adds that and Fixes https://github.com/galaxyproject/galaxy/issues/17739.

## Minor Change in Functionality as well:
Modified `SelectedItems` so that for range select, we track the first and last item in a range, along with the anchor. This way, we can persist with a selected range even if the user deselects a few items within it, since we keep track of the beginning and end of the range.
Also, added a CSS indicator to `ContentItem`s which actually indicates which item is the Shift+click range select anchor.
This also removes the `Shift+Ctrl+Click` multiple range select.

https://github.com/galaxyproject/galaxy/assets/78516064/e455b5f3-4574-49ec-9c2b-39b60f29be40



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Select one item
  2. Then select a range using Shift+Click
  3. Deselect an item in the range
  4. Keep using Shift+Click to select items in any direction outside of the range and you will see the range select persist
  5. Keep note that content items get a border around them when they become range anchors
  - **Note:**
    - Selecting an item here can be done by either clicking on the whole item (Shift/Ctrl) or using the checkbox selector
    - **Ctrl** here can be translated to **Cmd** for Mac

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
