### PR TITLE
[24.0] change user-facing language from "object store" to "storage location"

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -206,7 +206,7 @@ onMounted(() => {
 
             <BModal
                 v-model="showPreferredObjectStoreModal"
-                title="History Preferred Object Store"
+                title="History Preferred Storage Location"
                 modal-class="history-preferred-object-store-modal"
                 title-tag="h3"
                 size="sm"

--- a/client/src/components/History/CurrentHistory/PreferredStorePopover.vue
+++ b/client/src/components/History/CurrentHistory/PreferredStorePopover.vue
@@ -23,14 +23,14 @@ const preferredObjectStoreId = computed(() => {
 
 <template>
     <BPopover :target="`history-storage-${historyId}`" triggers="hover" placement="bottomleft" boundary="window">
-        <template v-slot:title>Preferred Target Object Store</template>
+        <template v-slot:title>Preferred Storage Location</template>
         <div class="popover-wide">
             <p v-if="historyPreferredObjectStoreId" class="history-preferred-object-store-inherited">
-                This target object store has been set at the history level.
+                This storage location has been set at the history level.
             </p>
             <p v-else class="history-preferred-object-store-not-inherited">
-                This target object store has been inherited from your user preferences (set in User -> Preferences ->
-                Preferred Object Store). If that option is updated, this history will target that new default.
+                This storage location has been inherited from your user preferences (set in User -> Preferences ->
+                Preferred Storage Location). If that option is updated, this history will target that new default.
             </p>
 
             <ShowSelectedObjectStore
@@ -39,7 +39,7 @@ const preferredObjectStoreId = computed(() => {
                 for-what="Galaxy will default to storing this history's datasets in " />
 
             <div v-localize>
-                Change this preference object store target by clicking on the storage button in the history panel.
+                Change preferred storage location by clicking on the storage button in the history panel.
             </div>
         </div>
     </BPopover>

--- a/client/src/components/ObjectStore/ConfigurationMarkdown.test.ts
+++ b/client/src/components/ObjectStore/ConfigurationMarkdown.test.ts
@@ -16,7 +16,7 @@ describe("ConfigurationMarkdown.vue", () => {
         expect(wrapper.html()).toContain("<em>content</em>");
     });
 
-    it("should allow HTML in configuration markdup explicitly set by the admin", () => {
+    it("should allow HTML in configuration markup explicitly set by the admin", () => {
         wrapper = shallowMount(ConfigurationMarkdown, {
             propsData: { markdown: "the <b>content</b>", admin: true },
             localVue,

--- a/client/src/components/ObjectStore/DescribeObjectStore.vue
+++ b/client/src/components/ObjectStore/DescribeObjectStore.vue
@@ -46,15 +46,15 @@ export default {
         <div>
             <span v-localize>{{ what }}</span>
             <span v-if="storageInfo.name" class="display-os-by-name">
-                a Galaxy <ObjectStoreRestrictionSpan :is-private="isPrivate" /> object store named
+                a Galaxy <ObjectStoreRestrictionSpan :is-private="isPrivate" /> storage location named
                 <b>{{ storageInfo.name }}</b>
             </span>
             <span v-else-if="storageInfo.object_store_id" class="display-os-by-id">
-                a Galaxy <ObjectStoreRestrictionSpan :is-private="isPrivate" /> object store with id
+                a Galaxy <ObjectStoreRestrictionSpan :is-private="isPrivate" /> storage location with id
                 <b>{{ storageInfo.object_store_id }}</b>
             </span>
             <span v-else class="display-os-default">
-                the default configured Galaxy <ObjectStoreRestrictionSpan :is-private="isPrivate" /> object store </span
+                the default configured Galaxy <ObjectStoreRestrictionSpan :is-private="isPrivate" /> storage location </span
             >.
         </div>
         <ObjectStoreBadges :badges="badges"> </ObjectStoreBadges>
@@ -66,7 +66,7 @@ export default {
             <b-spinner v-if="isLoadingUsage" />
             <QuotaUsageBar v-else-if="quotaUsage" :quota-usage="quotaUsage" :embedded="true" />
         </QuotaSourceUsageProvider>
-        <div v-else>Galaxy has no quota configured for this object store.</div>
+        <div v-else>Galaxy has no quota configured for this storage location.</div>
         <ConfigurationMarkdown v-if="storageInfo.description" :markdown="storageInfo.description" :admin="true" />
     </div>
 </template>

--- a/client/src/components/ObjectStore/ObjectStoreBadge.vue
+++ b/client/src/components/ObjectStore/ObjectStoreBadge.vue
@@ -14,8 +14,8 @@ const MESSAGES = {
     restricted:
         "This dataset is stored on storage restricted to a single user. It can not be shared, published, or added to Galaxy data libraries.",
     user_defined: "This storage was user defined and is not managed by the Galaxy administrator.",
-    quota: "A Galaxy quota is enabled for this object store.",
-    no_quota: "No Galaxy quota is enabled for this object store.",
+    quota: "A Galaxy quota is enabled for this storage location.",
+    no_quota: "No Galaxy quota is enabled for this storage location.",
     faster: "This storage has been marked as a faster option by the Galaxy administrator.",
     slower: "This storage has been marked as a slower option by the Galaxy administrator.",
     short_term: "This storage has been marked as routinely purged by the Galaxy administrator.",

--- a/client/src/components/ObjectStore/ObjectStoreBadge.vue
+++ b/client/src/components/ObjectStore/ObjectStoreBadge.vue
@@ -18,7 +18,7 @@ const MESSAGES = {
     no_quota: "No Galaxy quota is enabled for this object store.",
     faster: "This storage has been marked as a faster option by the Galaxy administrator.",
     slower: "This storage has been marked as a slower option by the Galaxy administrator.",
-    short_term: "This storage has been marked routinely purged by the Galaxy administrator.",
+    short_term: "This storage has been marked as routinely purged by the Galaxy administrator.",
     backed_up: "This storage has been marked as backed up by the Galaxy administrator.",
     not_backed_up: "This storage has been marked as not backed up by the Galaxy administrator.",
     more_secure:

--- a/client/src/components/ObjectStore/ObjectStoreBadge.vue
+++ b/client/src/components/ObjectStore/ObjectStoreBadge.vue
@@ -136,6 +136,7 @@ const message = computed(() => {
             "
             triggers="hover"
             placement="bottom"
+            variant="secondary"
             class="object-store-badge-popover">
             <p v-localize>{{ stockMessage }}</p>
             <ConfigurationMarkdown v-if="message" :markdown="message" :admin="true" />

--- a/client/src/components/ObjectStore/SelectObjectStore.vue
+++ b/client/src/components/ObjectStore/SelectObjectStore.vue
@@ -27,12 +27,10 @@ const { isLoading, loadErrorMessage, selectableObjectStores } = storeToRefs(stor
 
 const loadingObjectStoreInfoMessage = ref("Loading object store information");
 const whyIsSelectionPreferredText = ref(`
-Selecting this will reset Galaxy to default behaviors configured by your Galaxy administrator.
-Select a preferred object store for new datasets. This is should be thought of as a preferred
-object store because depending the job and workflow configuration execution configuration of
-this Galaxy instance - a different object store may be selected. After a dataset is created,
+Select a preferred object store for new datasets. Depending on the job and workflow execution configuration of
+this Galaxy a different object store may be ultimately used. After a dataset is created,
 click on the info icon in the history panel to view information about where it is stored. If it
-is not stored in the correct place, contact your Galaxy administrator for more information.
+is not stored in the place you want, contact Galaxy administrator for more information.
 `);
 
 function variant(objectStoreId: string) {

--- a/client/src/components/ObjectStore/SelectObjectStore.vue
+++ b/client/src/components/ObjectStore/SelectObjectStore.vue
@@ -25,10 +25,10 @@ const props = withDefaults(defineProps<SelectObjectStoreProps>(), {
 const store = useObjectStoreStore();
 const { isLoading, loadErrorMessage, selectableObjectStores } = storeToRefs(store);
 
-const loadingObjectStoreInfoMessage = ref("Loading object store information");
+const loadingObjectStoreInfoMessage = ref("Loading storage location information");
 const whyIsSelectionPreferredText = ref(`
-Select a preferred object store for new datasets. Depending on the job and workflow execution configuration of
-this Galaxy a different object store may be ultimately used. After a dataset is created,
+Select a preferred storage location for new datasets. Depending on the job and workflow execution configuration of
+this Galaxy a different storage location may be ultimately used. After a dataset is created,
 click on the info icon in the history panel to view information about where it is stored. If it
 is not stored in the place you want, contact Galaxy administrator for more information.
 `);

--- a/client/src/components/ObjectStore/ShowSelectedObjectStore.test.js
+++ b/client/src/components/ObjectStore/ShowSelectedObjectStore.test.js
@@ -30,7 +30,7 @@ describe("ShowSelectedObjectStore", () => {
         });
         let loadingEl = wrapper.findComponent(LoadingSpan);
         expect(loadingEl.exists()).toBeTruthy();
-        expect(loadingEl.find(".loading-message").text()).toContainLocalizationOf("Loading object store details");
+        expect(loadingEl.find(".loading-message").text()).toContainLocalizationOf("Loading storage location details");
         await flushPromises();
         loadingEl = wrapper.findComponent(LoadingSpan);
         expect(loadingEl.exists()).toBeFalsy();

--- a/client/src/components/ObjectStore/ShowSelectedObjectStore.vue
+++ b/client/src/components/ObjectStore/ShowSelectedObjectStore.vue
@@ -38,7 +38,7 @@ watch(
     }
 );
 fetch();
-const loadingMessage = "Loading object store details";
+const loadingMessage = "Loading storage location details";
 </script>
 
 <template>

--- a/client/src/components/ObjectStore/showTargetPopoverMixin.js
+++ b/client/src/components/ObjectStore/showTargetPopoverMixin.js
@@ -12,7 +12,7 @@ export default {
     },
     computed: {
         title() {
-            return this.l(`Preferred Target Object Store ${this.titleSuffix || ""}`);
+            return this.l(`Preferred Target Storage Location ${this.titleSuffix || ""}`);
         },
     },
 };

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -148,7 +148,7 @@ const showHelpForum = computed(() => isConfigLoaded.value && config.value.enable
                         </ToolTargetPreferredObjectStorePopover>
                         <b-modal
                             v-model="showPreferredObjectStoreModal"
-                            title="Tool Execution Preferred Object Store"
+                            title="Tool Execution Preferred Storage Location"
                             modal-class="tool-preferred-object-store-modal"
                             title-tag="h3"
                             size="sm"

--- a/client/src/components/Tool/ToolSelectPreferredObjectStore.vue
+++ b/client/src/components/Tool/ToolSelectPreferredObjectStore.vue
@@ -12,7 +12,7 @@ const props = withDefaults(defineProps<ToolSelectProps>(), {
 });
 
 const selectedObjectStoreId = ref<String | null>(props.toolPreferredObjectStoreId);
-const newDatasetsDescription = "The default object store for the outputs of this tool";
+const newDatasetsDescription = "The default storage location for the outputs of this tool";
 const defaultOptionTitle = "Use Defaults";
 const defaultOptionDescription =
     "If the history has a default set, that will be used. If instead, you've set an option in your user preferences - that will be assumed to be your default selection. Finally, the Galaxy configuration will be used.";

--- a/client/src/components/Tool/ToolTargetPreferredObjectStorePopover.vue
+++ b/client/src/components/Tool/ToolTargetPreferredObjectStorePopover.vue
@@ -3,8 +3,8 @@
         <template v-slot:title>{{ title }}</template>
         <div class="popover-wide">
             <p v-if="toolPreferredObjectStoreId">
-                This target object store has been set at the tool level, by default history or user preferences will be
-                used and if those are not set Galaxy will pick an adminstrator configured default.
+                Preferred storage location has been set at the tool level, by default history or user preferences will
+                be used and if those are not set Galaxy will pick an administrator-configured default.
             </p>
             <ShowSelectedObjectStore
                 v-if="toolPreferredObjectStoreId"
@@ -15,7 +15,7 @@
                 No selection has been made for this tool execution. Defaults from history, user, or Galaxy will be used.
             </div>
             <div v-localize>
-                Change this preference object store target by clicking on the storage button in the tool header.
+                Change preferred storage location by clicking on the storage button in the tool header.
             </div>
         </div>
     </b-popover>

--- a/client/src/components/User/DiskUsage/Quota/ProvidedQuotaSourceUsageBar.vue
+++ b/client/src/components/User/DiskUsage/Quota/ProvidedQuotaSourceUsageBar.vue
@@ -36,7 +36,7 @@ export default {
     },
     data() {
         return {
-            loadingMessage: "Loading object store information",
+            loadingMessage: "Loading storage location information",
         };
     },
 };

--- a/client/src/components/User/UserPreferredObjectStore.test.js
+++ b/client/src/components/User/UserPreferredObjectStore.test.js
@@ -40,7 +40,7 @@ describe("UserPreferredObjectStore.vue", () => {
         const wrapper = mountComponent();
         expect(wrapper.vm.$refs["modal"].isHidden).toBeTruthy();
         const el = await wrapper.find(ROOT_COMPONENT.preferences.object_store.selector);
-        expect(el.text()).toBeLocalizationOf("Preferred Object Store");
+        expect(el.text()).toBeLocalizationOf("Preferred Storage Location");
         await el.trigger("click");
         expect(wrapper.vm.$refs["modal"].isHidden).toBeFalsy();
     });

--- a/client/src/components/User/UserPreferredObjectStore.vue
+++ b/client/src/components/User/UserPreferredObjectStore.vue
@@ -7,17 +7,17 @@
                 v-b-modal.modal-select-preferred-object-store
                 class="preferred-storage"
                 href="javascript:void(0)"
-                ><b v-localize>Preferred Object Store</b></a
+                ><b v-localize>Preferred Storage Location</b></a
             >
             <div v-localize class="form-text text-muted">
-                Select a preferred default object store for the outputs of new jobs to be created in.
+                Select a preferred storage location for the outputs of new jobs.
             </div>
             <BModal
                 id="modal-select-preferred-object-store"
                 ref="modal"
                 v-model="showModal"
                 centered
-                title="Preferred Object Store"
+                title="Preferred Storage Location"
                 :title-tag="titleTag"
                 hide-footer
                 static

--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -33,7 +33,7 @@
                     <b-form-checkbox
                         v-if="isConfigLoaded && config.object_store_allows_id_selection"
                         v-model="splitObjectStore">
-                        Send outputs and intermediate to different object stores?
+                        Send outputs and intermediate to different storage locations?
                     </b-form-checkbox>
                     <WorkflowStorageConfiguration
                         v-if="isConfigLoaded && config.object_store_allows_id_selection"

--- a/client/src/components/Workflow/Run/WorkflowSelectPreferredObjectStore.vue
+++ b/client/src/components/Workflow/Run/WorkflowSelectPreferredObjectStore.vue
@@ -16,10 +16,10 @@ const emit = defineEmits<{
 }>();
 
 const selectedObjectStoreId = ref<String | null>(props.invocationPreferredObjectStoreId);
-const newDatasetsDescription = "The default object store for the outputs of this workflow invocation";
+const newDatasetsDescription = "The default storage location for the outputs of this workflow invocation";
 const defaultOptionTitle = "Use Defaults";
 const defaultOptionDescription =
-    "If the history has a default set, that will be used. If instead, you've set an option in your user preferences - that will be assumed to be your default selection. Finally, the Galaxy configuration will be used.";
+    "If the history has a preference set, that will be used. If instead, you've set an option in your user preferences - that will be assumed to be your default selection. Finally, the Galaxy configuration will be used.";
 
 async function handleSubmit(preferredObjectStoreId: string | null) {
     selectedObjectStoreId.value = preferredObjectStoreId;

--- a/client/src/components/Workflow/Run/WorkflowStorageConfiguration.vue
+++ b/client/src/components/Workflow/Run/WorkflowStorageConfiguration.vue
@@ -14,7 +14,7 @@
         </WorkflowTargetPreferredObjectStorePopover>
         <b-modal
             v-model="showPreferredObjectStoreModal"
-            title="Invocation Preferred Object Store"
+            title="Invocation Preferred Storage Location"
             v-bind="modalProps"
             hide-footer>
             <WorkflowSelectPreferredObjectStore
@@ -37,7 +37,7 @@
         </WorkflowTargetPreferredObjectStorePopover>
         <b-modal
             v-model="showIntermediatePreferredObjectStoreModal"
-            title="Invocation Preferred Object Store (Intermediate Datasets)"
+            title="Invocation Preferred Storage Location (Intermediate Datasets)"
             v-bind="modalProps"
             hide-footer>
             <WorkflowSelectPreferredObjectStore

--- a/client/src/components/Workflow/Run/WorkflowTargetPreferredObjectStorePopover.vue
+++ b/client/src/components/Workflow/Run/WorkflowTargetPreferredObjectStorePopover.vue
@@ -2,9 +2,7 @@
     <b-popover :target="target" triggers="hover" placement="bottomleft" boundary="window">
         <template v-slot:title>{{ title }}</template>
         <div class="popover-wide">
-            <p v-if="invocationPreferredObjectStoreId">
-                This target object store has been set at the invocation level.
-            </p>
+            <p v-if="invocationPreferredObjectStoreId">Storage location has been set at the invocation level.</p>
             <ShowSelectedObjectStore
                 v-if="invocationPreferredObjectStoreId"
                 :preferred-object-store-id="invocationPreferredObjectStoreId"
@@ -15,7 +13,7 @@
                 used.
             </div>
             <div v-localize>
-                Change this preference object store target by clicking on the storage button in the worklfow run header.
+                Change preferred storage location by clicking on the storage button in the worklfow run header.
             </div>
         </div>
     </b-popover>


### PR DESCRIPTION
"object store" is a technical and admin-focused term that will be communicated better by "storage location" to the user.

Plus some minor ux touchups.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
