### PR TITLE
[24.0] Don't require history to calculate anon disk usage

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -122,10 +122,9 @@ class UsersService(ServiceBase):
     def _anon_user_api_value(self, trans: ProvidesHistoryContext):
         """Return data for an anonymous user, truncated to only usage and quota_percent"""
         if not trans.user and not trans.history:
-            # Can't return info about this user, may not have a history yet.
-            # return {}
-            raise glx_exceptions.MessageException(err_msg="The user has no history, which should always be the case.")
-        usage = self.quota_agent.get_usage(trans, history=trans.history)
+            usage = None
+        else:
+            usage = self.quota_agent.get_usage(trans, history=trans.history)
         percent = self.quota_agent.get_percent(trans=trans, usage=usage)
         usage = usage or 0
         return {

--- a/test/integration/oidc/test_auth_oidc.py
+++ b/test/integration/oidc/test_auth_oidc.py
@@ -296,7 +296,8 @@ class TestGalaxyOIDCLoginIntegration(AbstractTestCases.BaseKeycloakIntegrationTe
         response = session.get(response.json()["redirect_uri"], verify=False)
         # make sure we can no longer request the user
         response = session.get(self._api_url("users/current"))
-        self._assert_status_code_is(response, 400)
+        self._assert_status_code_is(response, 200)
+        assert "email" not in response.json()
 
     def test_auth_by_access_token_logged_in_once(self):
         # login at least once


### PR DESCRIPTION
This is probably the simplest way to fix the anon user issue. If we don't have a history the size is 0, that's fairly simple.

We might still want to do https://github.com/galaxyproject/galaxy/pull/17755 for those FastAPI endpoints that do actually require a default history.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
