### PR TITLE
[24.0] Restore histories API behavior for `keys` query parameter

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -125,3 +125,26 @@ export function hasDetails(entry: DatasetEntry): entry is DatasetDetails {
  * Contains dataset metadata information.
  */
 export type MetadataFiles = components["schemas"]["MetadataFile"][];
+
+type QuotaUsageResponse = components["schemas"]["UserQuotaUsage"];
+
+export interface User extends QuotaUsageResponse {
+    id: string;
+    email: string;
+    tags_used: string[];
+    isAnonymous: false;
+    is_admin?: boolean;
+    username?: string;
+}
+
+export interface AnonymousUser {
+    isAnonymous: true;
+    username?: string;
+    is_admin?: false;
+}
+
+export type GenericUser = User | AnonymousUser;
+
+export function isRegisteredUser(user: User | AnonymousUser | null): user is User {
+    return !user?.isAnonymous;
+}

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -7,10 +7,18 @@ import { components } from "@/api/schema";
  */
 export type HistorySummary = components["schemas"]["HistorySummary"];
 
+export interface HistorySummaryExtended extends HistorySummary {
+    size: number;
+    contents_active: components["schemas"]["HistoryActiveContentCounts"];
+    user_id: string;
+}
+
 /**
  * Contains additional details about a History.
  */
 export type HistoryDetailed = components["schemas"]["HistoryDetailed"];
+
+export type AnyHistory = HistorySummary | HistorySummaryExtended | HistoryDetailed;
 
 /**
  * Contains minimal information about a HistoryContentItem.
@@ -126,6 +134,14 @@ export function hasDetails(entry: DatasetEntry): entry is DatasetDetails {
  */
 export type MetadataFiles = components["schemas"]["MetadataFile"][];
 
+export function isHistorySummary(history: AnyHistory): history is HistorySummary {
+    return !("user_id" in history);
+}
+
+export function isHistorySummaryExtended(history: AnyHistory): history is HistorySummaryExtended {
+    return "contents_active" in history && "user_id" in history;
+}
+
 type QuotaUsageResponse = components["schemas"]["UserQuotaUsage"];
 
 export interface User extends QuotaUsageResponse {
@@ -147,4 +163,16 @@ export type GenericUser = User | AnonymousUser;
 
 export function isRegisteredUser(user: User | AnonymousUser | null): user is User {
     return !user?.isAnonymous;
+}
+
+export function userOwnsHistory(user: User | AnonymousUser | null, history: AnyHistory) {
+    return (
+        // Assuming histories without user_id are owned by the current user
+        (isRegisteredUser(user) && !hasOwner(history)) ||
+        (isRegisteredUser(user) && hasOwner(history) && user.id === history.user_id)
+    );
+}
+
+function hasOwner(history: AnyHistory): history is HistorySummaryExtended {
+    return "user_id" in history;
 }

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -3597,6 +3597,142 @@ export interface components {
         CustomHistoryItem: {
             [key: string]: unknown | undefined;
         };
+        /** CustomHistoryView */
+        CustomHistoryView: {
+            /**
+             * Annotation
+             * @description An annotation to provide details or to help understand the purpose and usage of this item.
+             */
+            annotation?: string | null;
+            /**
+             * Archived
+             * @description Whether this item has been archived and is no longer active.
+             */
+            archived?: boolean | null;
+            /**
+             * Contents Active
+             * @description Contains the number of active, deleted or hidden items in a History.
+             */
+            contents_active?: components["schemas"]["HistoryActiveContentCounts"] | null;
+            /**
+             * Contents URL
+             * @description The relative URL to access the contents of this History.
+             */
+            contents_url?: string | null;
+            /**
+             * Count
+             * @description The number of items in the history.
+             */
+            count?: number | null;
+            /**
+             * Create Time
+             * @description The time and date this item was created.
+             */
+            create_time?: string | null;
+            /**
+             * Deleted
+             * @description Whether this item is marked as deleted.
+             */
+            deleted?: boolean | null;
+            /**
+             * Genome Build
+             * @description TODO
+             */
+            genome_build?: string | null;
+            /**
+             * History ID
+             * @example 0123456789ABCDEF
+             */
+            id?: string;
+            /**
+             * Importable
+             * @description Whether this History can be imported by other users with a shared link.
+             */
+            importable?: boolean | null;
+            /**
+             * Model class
+             * @description The name of the database model class.
+             * @constant
+             */
+            model_class?: "History";
+            /**
+             * Name
+             * @description The name of the history.
+             */
+            name?: string | null;
+            /**
+             * Preferred Object Store ID
+             * @description The ID of the object store that should be used to store new datasets in this history.
+             */
+            preferred_object_store_id?: string | null;
+            /**
+             * Published
+             * @description Whether this resource is currently publicly available to all users.
+             */
+            published?: boolean | null;
+            /**
+             * Purged
+             * @description Whether this item has been permanently removed.
+             */
+            purged?: boolean | null;
+            /**
+             * Size
+             * @description The total size of the contents of this history in bytes.
+             */
+            size?: number | null;
+            /**
+             * Slug
+             * @description Part of the URL to uniquely identify this History by link in a readable way.
+             */
+            slug?: string | null;
+            /**
+             * State
+             * @description The current state of the History based on the states of the datasets it contains.
+             */
+            state?: components["schemas"]["DatasetState"] | null;
+            /**
+             * State Counts
+             * @description A dictionary keyed to possible dataset states and valued with the number of datasets in this history that have those states.
+             */
+            state_details?: {
+                [key: string]: number | undefined;
+            } | null;
+            /**
+             * State IDs
+             * @description A dictionary keyed to possible dataset states and valued with lists containing the ids of each HDA in that state.
+             */
+            state_ids?: {
+                [key: string]: string[] | undefined;
+            } | null;
+            tags?: components["schemas"]["TagCollection"] | null;
+            /**
+             * Update Time
+             * @description The last time and date this item was updated.
+             */
+            update_time?: string | null;
+            /**
+             * URL
+             * @deprecated
+             * @description The relative URL to access this item.
+             */
+            url?: string | null;
+            /**
+             * User ID
+             * @description The encoded ID of the user that owns this History.
+             */
+            user_id?: string | null;
+            /**
+             * Username
+             * @description Owner of the history
+             */
+            username?: string | null;
+            /**
+             * Username and slug
+             * @description The relative URL in the form of /u/{username}/h/{slug}
+             */
+            username_and_slug?: string | null;
+            [key: string]: unknown | undefined;
+        };
         /**
          * DCESummary
          * @description Dataset Collection Element summary information.
@@ -6378,6 +6514,27 @@ export interface components {
         HelpForumUser: {
             [key: string]: unknown | undefined;
         };
+        /**
+         * HistoryActiveContentCounts
+         * @description Contains the number of active, deleted or hidden items in a History.
+         */
+        HistoryActiveContentCounts: {
+            /**
+             * Active
+             * @description Number of active datasets.
+             */
+            active: number;
+            /**
+             * Deleted
+             * @description Number of deleted datasets.
+             */
+            deleted: number;
+            /**
+             * Hidden
+             * @description Number of hidden datasets.
+             */
+            hidden: number;
+        };
         /** HistoryContentBulkOperationPayload */
         HistoryContentBulkOperationPayload: {
             /** Items */
@@ -6612,26 +6769,6 @@ export interface components {
              * @description The relative URL in the form of /u/{username}/h/{slug}
              */
             username_and_slug?: string | null;
-            [key: string]: unknown | undefined;
-        };
-        /**
-         * HistoryMinimal
-         * @description Minimal History Response with optional fields
-         */
-        HistoryMinimal: {
-            /** Id */
-            id?: string | null;
-            /**
-             * Model class
-             * @description The name of the database model class.
-             * @constant
-             */
-            model_class: "History";
-            /**
-             * User ID
-             * @description The encoded ID of the user that owns this History.
-             */
-            user_id?: string | null;
             [key: string]: unknown | undefined;
         };
         /**
@@ -15139,9 +15276,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json": (
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryMinimal"]
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["CustomHistoryView"]
                     )[];
                 };
             };
@@ -15181,9 +15318,9 @@ export interface operations {
                 content: {
                     "application/json":
                         | components["schemas"]["JobImportHistoryResponse"]
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryMinimal"];
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["CustomHistoryView"];
                 };
             };
             /** @description Validation Error */
@@ -15267,9 +15404,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json": (
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryMinimal"]
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["CustomHistoryView"]
                     )[];
                 };
             };
@@ -15305,9 +15442,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json": (
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryMinimal"]
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["CustomHistoryView"]
                     )[];
                 };
             };
@@ -15373,9 +15510,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json": (
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryMinimal"]
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["CustomHistoryView"]
                     )[];
                 };
             };
@@ -15410,9 +15547,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryMinimal"];
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["CustomHistoryView"];
                 };
             };
             /** @description Validation Error */
@@ -15447,9 +15584,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryMinimal"];
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["CustomHistoryView"];
                 };
             };
             /** @description Validation Error */
@@ -15507,9 +15644,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryMinimal"];
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["CustomHistoryView"];
                 };
             };
             /** @description Validation Error */
@@ -15549,9 +15686,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json": (
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryMinimal"]
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["CustomHistoryView"]
                     )[];
                 };
             };
@@ -15592,9 +15729,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json": (
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryMinimal"]
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["CustomHistoryView"]
                     )[];
                 };
             };
@@ -15629,9 +15766,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryMinimal"];
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["CustomHistoryView"];
                 };
             };
             /** @description Validation Error */
@@ -15670,9 +15807,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryMinimal"];
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["CustomHistoryView"];
                 };
             };
             /** @description Validation Error */
@@ -15712,9 +15849,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryMinimal"];
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["CustomHistoryView"];
                 };
             };
             /** @description Validation Error */
@@ -15806,9 +15943,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryMinimal"];
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["CustomHistoryView"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6522,18 +6522,21 @@ export interface components {
             /**
              * Active
              * @description Number of active datasets.
+             * @default 0
              */
-            active: number;
+            active?: number | null;
             /**
              * Deleted
              * @description Number of deleted datasets.
+             * @default 0
              */
-            deleted: number;
+            deleted?: number | null;
             /**
              * Hidden
              * @description Number of hidden datasets.
+             * @default 0
              */
-            hidden: number;
+            hidden?: number | null;
         };
         /** HistoryContentBulkOperationPayload */
         HistoryContentBulkOperationPayload: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -11701,6 +11701,7 @@ export interface components {
              * @description Whether this item is visible in the history.
              */
             visible?: boolean | null;
+            [key: string]: unknown | undefined;
         };
         /** UpdateLibraryFolderPayload */
         UpdateLibraryFolderPayload: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -11665,6 +11665,7 @@ export interface components {
              * @description A list of content items to update with the changes.
              */
             items: components["schemas"]["UpdateContentItem"][];
+            [key: string]: unknown | undefined;
         };
         /**
          * UpdateHistoryContentsPayload

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6531,21 +6531,18 @@ export interface components {
             /**
              * Active
              * @description Number of active datasets.
-             * @default 0
              */
-            active?: number | null;
+            active: number;
             /**
              * Deleted
              * @description Number of deleted datasets.
-             * @default 0
              */
-            deleted?: number | null;
+            deleted: number;
             /**
              * Hidden
              * @description Number of hidden datasets.
-             * @default 0
              */
-            hidden?: number | null;
+            hidden: number;
         };
         /** HistoryContentBulkOperationPayload */
         HistoryContentBulkOperationPayload: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -2336,7 +2336,6 @@ export interface components {
              * @description The relative URL in the form of /u/{username}/h/{slug}
              */
             username_and_slug?: string | null;
-            [key: string]: unknown | undefined;
         };
         /** ArchivedHistorySummary */
         ArchivedHistorySummary: {
@@ -2409,7 +2408,6 @@ export interface components {
              * @description The relative URL to access this item.
              */
             url: string;
-            [key: string]: unknown | undefined;
         };
         /** AsyncFile */
         AsyncFile: {
@@ -3615,6 +3613,13 @@ export interface components {
              */
             contents_active?: components["schemas"]["HistoryActiveContentCounts"] | null;
             /**
+             * Contents States
+             * @description A dictionary keyed to possible dataset states and valued with the number of datasets in this history that have those states.
+             */
+            contents_states?: {
+                [key: string]: number | undefined;
+            } | null;
+            /**
              * Contents URL
              * @description The relative URL to access the contents of this History.
              */
@@ -3660,6 +3665,11 @@ export interface components {
              * @description The name of the history.
              */
             name?: string | null;
+            /**
+             * Nice Size
+             * @description The total size of the contents of this history in a human-readable format.
+             */
+            nice_size?: string | null;
             /**
              * Preferred Object Store ID
              * @description The ID of the object store that should be used to store new datasets in this history.
@@ -3731,7 +3741,6 @@ export interface components {
              * @description The relative URL in the form of /u/{username}/h/{slug}
              */
             username_and_slug?: string | null;
-            [key: string]: unknown | undefined;
         };
         /**
          * DCESummary
@@ -6772,7 +6781,6 @@ export interface components {
              * @description The relative URL in the form of /u/{username}/h/{slug}
              */
             username_and_slug?: string | null;
-            [key: string]: unknown | undefined;
         };
         /**
          * HistorySummary
@@ -6843,7 +6851,6 @@ export interface components {
              * @description The relative URL to access this item.
              */
             url: string;
-            [key: string]: unknown | undefined;
         };
         /**
          * Hyperlink
@@ -11661,7 +11668,6 @@ export interface components {
              * @description A list of content items to update with the changes.
              */
             items: components["schemas"]["UpdateContentItem"][];
-            [key: string]: unknown | undefined;
         };
         /**
          * UpdateHistoryContentsPayload
@@ -11697,7 +11703,6 @@ export interface components {
              * @description Whether this item is visible in the history.
              */
             visible?: boolean | null;
-            [key: string]: unknown | undefined;
         };
         /** UpdateLibraryFolderPayload */
         UpdateLibraryFolderPayload: {
@@ -15279,9 +15284,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json": (
-                        | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["CustomHistoryView"]
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["HistorySummary"]
                     )[];
                 };
             };
@@ -15321,9 +15326,9 @@ export interface operations {
                 content: {
                     "application/json":
                         | components["schemas"]["JobImportHistoryResponse"]
-                        | components["schemas"]["HistorySummary"]
+                        | components["schemas"]["CustomHistoryView"]
                         | components["schemas"]["HistoryDetailed"]
-                        | components["schemas"]["CustomHistoryView"];
+                        | components["schemas"]["HistorySummary"];
                 };
             };
             /** @description Validation Error */
@@ -15407,9 +15412,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json": (
-                        | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["CustomHistoryView"]
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["HistorySummary"]
                     )[];
                 };
             };
@@ -15445,9 +15450,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json": (
-                        | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["CustomHistoryView"]
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["HistorySummary"]
                     )[];
                 };
             };
@@ -15513,9 +15518,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json": (
-                        | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["CustomHistoryView"]
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["HistorySummary"]
                     )[];
                 };
             };
@@ -15550,9 +15555,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["HistorySummary"]
+                        | components["schemas"]["CustomHistoryView"]
                         | components["schemas"]["HistoryDetailed"]
-                        | components["schemas"]["CustomHistoryView"];
+                        | components["schemas"]["HistorySummary"];
                 };
             };
             /** @description Validation Error */
@@ -15587,9 +15592,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["HistorySummary"]
+                        | components["schemas"]["CustomHistoryView"]
                         | components["schemas"]["HistoryDetailed"]
-                        | components["schemas"]["CustomHistoryView"];
+                        | components["schemas"]["HistorySummary"];
                 };
             };
             /** @description Validation Error */
@@ -15647,9 +15652,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["HistorySummary"]
+                        | components["schemas"]["CustomHistoryView"]
                         | components["schemas"]["HistoryDetailed"]
-                        | components["schemas"]["CustomHistoryView"];
+                        | components["schemas"]["HistorySummary"];
                 };
             };
             /** @description Validation Error */
@@ -15689,9 +15694,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json": (
-                        | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["CustomHistoryView"]
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["HistorySummary"]
                     )[];
                 };
             };
@@ -15732,9 +15737,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json": (
-                        | components["schemas"]["HistorySummary"]
-                        | components["schemas"]["HistoryDetailed"]
                         | components["schemas"]["CustomHistoryView"]
+                        | components["schemas"]["HistoryDetailed"]
+                        | components["schemas"]["HistorySummary"]
                     )[];
                 };
             };
@@ -15769,9 +15774,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["HistorySummary"]
+                        | components["schemas"]["CustomHistoryView"]
                         | components["schemas"]["HistoryDetailed"]
-                        | components["schemas"]["CustomHistoryView"];
+                        | components["schemas"]["HistorySummary"];
                 };
             };
             /** @description Validation Error */
@@ -15810,9 +15815,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["HistorySummary"]
+                        | components["schemas"]["CustomHistoryView"]
                         | components["schemas"]["HistoryDetailed"]
-                        | components["schemas"]["CustomHistoryView"];
+                        | components["schemas"]["HistorySummary"];
                 };
             };
             /** @description Validation Error */
@@ -15852,9 +15857,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["HistorySummary"]
+                        | components["schemas"]["CustomHistoryView"]
                         | components["schemas"]["HistoryDetailed"]
-                        | components["schemas"]["CustomHistoryView"];
+                        | components["schemas"]["HistorySummary"];
                 };
             };
             /** @description Validation Error */
@@ -15946,9 +15951,9 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["HistorySummary"]
+                        | components["schemas"]["CustomHistoryView"]
                         | components["schemas"]["HistoryDetailed"]
-                        | components["schemas"]["CustomHistoryView"];
+                        | components["schemas"]["HistorySummary"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/components/History/CurrentHistory/HistoryMessages.vue
+++ b/client/src/components/History/CurrentHistory/HistoryMessages.vue
@@ -14,13 +14,13 @@ const props = defineProps<Props>();
 const userOverQuota = ref(false);
 
 const hasMessages = computed(() => {
-    return userOverQuota.value || props.history.isDeleted;
+    return userOverQuota.value || props.history.deleted;
 });
 </script>
 
 <template>
     <div v-if="hasMessages" class="mx-3 my-2">
-        <BAlert :show="history.isDeleted" variant="warning">
+        <BAlert :show="history.deleted" variant="warning">
             {{ localize("This history has been deleted") }}
         </BAlert>
 

--- a/client/src/components/History/Modals/CopyModal.vue
+++ b/client/src/components/History/Modals/CopyModal.vue
@@ -13,7 +13,7 @@ import {
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 
-import type { HistorySummary } from "@/api";
+import { type HistorySummary, userOwnsHistory } from "@/api";
 import { useHistoryStore } from "@/stores/historyStore";
 import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";
@@ -42,11 +42,11 @@ const saveTitle = computed(() => {
 const saveVariant = computed(() => {
     return loading.value ? "info" : formValid.value ? "primary" : "secondary";
 });
-const userOwnsHistory = computed(() => {
-    return userStore.isRegisteredUser(currentUser.value) && currentUser.value.id == props.history?.user_id;
+const isOwner = computed(() => {
+    return userOwnsHistory(currentUser.value, props.history);
 });
 const newNameValid = computed(() => {
-    if (userOwnsHistory.value && name.value == props.history.name) {
+    if (isOwner.value && name.value == props.history.name) {
         return false;
     }
     return name.value.length > 0;

--- a/client/src/components/History/Multiple/MultipleView.vue
+++ b/client/src/components/History/Multiple/MultipleView.vue
@@ -6,6 +6,7 @@ import { BAlert, BButton, BButtonGroup } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 
+import { userOwnsHistory } from "@/api";
 import { HistoryFilters } from "@/components/History/HistoryFilters";
 import { Toast } from "@/composables/toast";
 import { useHistoryStore } from "@/stores/historyStore";
@@ -38,7 +39,7 @@ const selectedHistories = computed<PinnedHistory[]>(() => {
     } else {
         // get the latest four histories
         return [...histories.value]
-            .filter((h) => !h.user_id || (!currentUser.value?.isAnonymous && h.user_id === currentUser.value?.id))
+            .filter((h) => userOwnsHistory(currentUser.value, h))
             .sort((a, b) => {
                 if (a.update_time < b.update_time) {
                     return 1;

--- a/client/src/composables/hashedUserId.ts
+++ b/client/src/composables/hashedUserId.ts
@@ -2,7 +2,8 @@ import { useLocalStorage } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import { computed, type Ref, ref, watch } from "vue";
 
-import { GenericUser, useUserStore } from "@/stores/userStore";
+import type { GenericUser } from "@/api";
+import { useUserStore } from "@/stores/userStore";
 
 async function hash32(value: string): Promise<string> {
     const valueUtf8 = new TextEncoder().encode(value);

--- a/client/src/composables/userLocalStorage.ts
+++ b/client/src/composables/userLocalStorage.ts
@@ -1,7 +1,7 @@
 import { useLocalStorage } from "@vueuse/core";
 import { computed, customRef, type Ref, ref } from "vue";
 
-import type { GenericUser } from "@/stores/userStore";
+import type { GenericUser } from "@/api";
 
 import { useHashedUserId } from "./hashedUserId";
 

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -241,12 +241,14 @@ export const useHistoryStore = defineStore("historyStore", () => {
     async function loadHistoryById(historyId: string) {
         if (!isLoadingHistory.has(historyId)) {
             isLoadingHistory.add(historyId);
-            await getHistoryByIdFromServer(historyId)
-                .then((history) => setHistory(history as HistorySummary))
-                .catch((error: Error) => console.warn(error))
-                .finally(() => {
+            try {
+                const history = await getHistoryByIdFromServer(historyId);
+                setHistory(history as HistorySummary);
+            } catch (error) {
+                console.error(error);
+            } finally {
                     isLoadingHistory.delete(historyId);
-                });
+            }
         }
     }
 

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import Vue, { computed, ref } from "vue";
+import { computed, del, ref, set } from "vue";
 
 import type { HistorySummary } from "@/api";
 import { archiveHistory, unarchiveHistory } from "@/api/histories.archived";
@@ -96,11 +96,11 @@ export const useHistoryStore = defineStore("historyStore", () => {
     }
 
     function setFilterText(historyId: string, filterText: string) {
-        Vue.set(storedFilterTexts.value, historyId, filterText);
+        set(storedFilterTexts.value, historyId, filterText);
     }
 
     function setHistory(history: HistorySummary) {
-        Vue.set(storedHistories.value, history.id, history);
+        set(storedHistories.value, history.id, history);
     }
 
     function setHistories(histories: HistorySummary[]) {
@@ -179,7 +179,7 @@ export const useHistoryStore = defineStore("historyStore", () => {
         } else {
             await createNewHistory();
         }
-        Vue.delete(storedHistories.value, deletedHistory.id);
+        del(storedHistories.value, deletedHistory.id);
         unpinHistories([deletedHistory.id]);
         await handleTotalCountChange(1, true);
     }
@@ -247,7 +247,7 @@ export const useHistoryStore = defineStore("historyStore", () => {
             } catch (error) {
                 console.error(error);
             } finally {
-                    isLoadingHistory.delete(historyId);
+                isLoadingHistory.delete(historyId);
             }
         }
     }

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -100,7 +100,12 @@ export const useHistoryStore = defineStore("historyStore", () => {
     }
 
     function setHistory(history: HistorySummary) {
-        set(storedHistories.value, history.id, history);
+        if (storedHistories.value[history.id] !== undefined) {
+            // Merge the incoming history with existing one to keep additional information
+            Object.assign(storedHistories.value[history.id]!, history);
+        } else {
+            set(storedHistories.value, history.id, history);
+        }
     }
 
     function setHistories(histories: HistorySummary[]) {

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 
-import type { components } from "@/api/schema";
+import type { AnonymousUser, User } from "@/api";
 import { useUserLocalStorage } from "@/composables/userLocalStorage";
 import { useHistoryStore } from "@/stores/historyStore";
 import {
@@ -10,25 +10,6 @@ import {
     removeFavoriteToolQuery,
     setCurrentThemeQuery,
 } from "@/stores/users/queries";
-
-type QuotaUsageResponse = components["schemas"]["UserQuotaUsage"];
-
-export interface User extends QuotaUsageResponse {
-    id: string;
-    email: string;
-    tags_used: string[];
-    isAnonymous: false;
-    is_admin?: boolean;
-    username?: string;
-}
-
-export interface AnonymousUser {
-    isAnonymous: true;
-    username?: string;
-    is_admin?: false;
-}
-
-export type GenericUser = User | AnonymousUser;
 
 interface Preferences {
     theme: string;
@@ -143,10 +124,6 @@ export const useUserStore = defineStore("userStore", () => {
         toggledSideBar.value = toggledSideBar.value === currentOpen ? "" : currentOpen;
     }
 
-    function isRegisteredUser(user: User | AnonymousUser | null): user is User {
-        return !user?.isAnonymous;
-    }
-
     return {
         currentUser,
         currentPreferences,
@@ -164,7 +141,6 @@ export const useUserStore = defineStore("userStore", () => {
         removeFavoriteTool,
         toggleActivityBar,
         toggleSideBar,
-        isRegisteredUser,
         $reset,
     };
 });

--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -183,9 +183,9 @@ class HistoryContentsManager(base.SortableManager):
         hdca_select = self._active_counts_statement(model.HistoryDatasetCollectionAssociation, history.id)
         subquery = hda_select.union_all(hdca_select).subquery()
         statement = select(
-            cast(func.sum(subquery.c.deleted), Integer).label("deleted"),
-            cast(func.sum(subquery.c.hidden), Integer).label("hidden"),
-            cast(func.sum(subquery.c.active), Integer).label("active"),
+            cast(func.coalesce(func.sum(subquery.c.deleted), 0), Integer).label("deleted"),
+            cast(func.coalesce(func.sum(subquery.c.hidden), 0), Integer).label("hidden"),
+            cast(func.coalesce(func.sum(subquery.c.active), 0), Integer).label("active"),
         )
         returned = self.app.model.context.execute(statement).one()
         return dict(returned._mapping)

--- a/lib/galaxy/schema/__init__.py
+++ b/lib/galaxy/schema/__init__.py
@@ -1,16 +1,23 @@
+import typing
+from copy import deepcopy
 from datetime import datetime
 from enum import Enum
 from typing import (
+    Any,
+    Callable,
     Dict,
     List,
     Optional,
+    TypeVar,
     Union,
 )
 
 from pydantic import (
     BaseModel,
+    create_model,
     Field,
 )
+from pydantic.fields import FieldInfo
 
 
 class BootstrapAdminUser(BaseModel):
@@ -110,3 +117,42 @@ class PdfDocumentType(str, Enum):
 class APIKeyModel(BaseModel):
     key: str = Field(..., title="Key", description="API key to interact with the Galaxy API")
     create_time: datetime = Field(..., title="Create Time", description="The time and date this API key was created.")
+
+
+T = TypeVar("T", bound="BaseModel")
+
+
+def partial_model(
+    include: Optional[list[str]] = None, exclude: Optional[list[str]] = None
+) -> Callable[[type[T]], type[T]]:
+    """Return a decorator to make model fields optional"""
+
+    if exclude is None:
+        exclude = []
+
+    @typing.no_type_check  # Mypy doesn't understand pydantic's create_model
+    def decorator(model: type[T]) -> type[T]:
+        def make_optional(field: FieldInfo, default: Any = None) -> tuple[Any, FieldInfo]:
+            new = deepcopy(field)
+            new.default = default
+            new.annotation = Optional[field.annotation or Any]
+            return new.annotation, new
+
+        fields = model.model_fields
+        if include is None:
+            fields = fields.items()
+        else:
+            fields = ((k, v) for k, v in fields.items() if k in include)
+
+        return create_model(
+            model.__name__,
+            __base__=model,
+            __module__=model.__module__,
+            **{
+                field_name: make_optional(field_info)
+                for field_name, field_info in fields
+                if exclude is None or field_name not in exclude
+            },
+        )
+
+    return decorator

--- a/lib/galaxy/schema/__init__.py
+++ b/lib/galaxy/schema/__init__.py
@@ -122,10 +122,13 @@ class APIKeyModel(BaseModel):
 T = TypeVar("T", bound="BaseModel")
 
 
+# TODO: This is a workaround to make all fields optional.
+#       It should be removed when Python/pydantic supports this feature natively.
+# https://github.com/pydantic/pydantic/issues/1673
 def partial_model(
     include: Optional[list[str]] = None, exclude: Optional[list[str]] = None
 ) -> Callable[[type[T]], type[T]]:
-    """Return a decorator to make model fields optional"""
+    """Decorator to make all model fields optional"""
 
     if exclude is None:
         exclude = []

--- a/lib/galaxy/schema/__init__.py
+++ b/lib/galaxy/schema/__init__.py
@@ -8,6 +8,8 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
+    Type,
     TypeVar,
     Union,
 )
@@ -126,16 +128,16 @@ T = TypeVar("T", bound="BaseModel")
 #       It should be removed when Python/pydantic supports this feature natively.
 # https://github.com/pydantic/pydantic/issues/1673
 def partial_model(
-    include: Optional[list[str]] = None, exclude: Optional[list[str]] = None
-) -> Callable[[type[T]], type[T]]:
+    include: Optional[List[str]] = None, exclude: Optional[List[str]] = None
+) -> Callable[[Type[T]], Type[T]]:
     """Decorator to make all model fields optional"""
 
     if exclude is None:
         exclude = []
 
     @typing.no_type_check  # Mypy doesn't understand pydantic's create_model
-    def decorator(model: type[T]) -> type[T]:
-        def make_optional(field: FieldInfo, default: Any = None) -> tuple[Any, FieldInfo]:
+    def decorator(model: Type[T]) -> Type[T]:
+        def make_optional(field: FieldInfo, default: Any = None) -> Tuple[Any, FieldInfo]:
             new = deepcopy(field)
             new.default = default
             new.annotation = Optional[field.annotation or Any]

--- a/lib/galaxy/schema/fields.py
+++ b/lib/galaxy/schema/fields.py
@@ -1,5 +1,9 @@
 import re
-from typing import TYPE_CHECKING
+from typing import (
+    get_origin,
+    TYPE_CHECKING,
+    Union,
+)
 
 from pydantic import (
     BeforeValidator,
@@ -110,6 +114,11 @@ def literal_to_value(arg):
     if len(val) > 1:
         raise Exception("Can't extract default argument for unions")
     return val[0]
+
+
+def is_optional(field):
+    args = get_args(field)
+    return get_origin(field) is Union and len(args) == 2 and type(None) in args
 
 
 def ModelClassField(default_value):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1069,10 +1069,6 @@ class HDCADetailed(HDCASummary):
     )
 
 
-class HistoryBase(Model):
-    """Provides basic configuration for all the History models."""
-
-
 class HistoryContentItemBase(Model):
     """Identifies a dataset or collection contained in a History."""
 
@@ -1209,7 +1205,7 @@ class UpdateHistoryContentsPayload(Model):
     )
 
 
-class HistorySummary(HistoryBase, WithModelClass):
+class HistorySummary(Model, WithModelClass):
     """History summary information."""
 
     model_class: HISTORY_MODEL_CLASS = ModelClassField(HISTORY_MODEL_CLASS)

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1271,8 +1271,12 @@ class HistoryActiveContentCounts(Model):
     )
 
 
+# TODO: https://github.com/galaxyproject/galaxy/issues/17785
 HistoryStateCounts = Dict[DatasetState, int]
 HistoryStateIds = Dict[DatasetState, List[DecodedDatabaseIdField]]
+
+HistoryContentStates = Union[DatasetState, DatasetCollectionPopulatedState]
+HistoryContentStateCounts = Dict[HistoryContentStates, int]
 
 
 class HistoryDetailed(HistorySummary):  # Equivalent to 'dev-detailed' view, which seems the default
@@ -1349,7 +1353,7 @@ class CustomHistoryView(HistoryDetailed):
         title="Contents Active",
         description=("Contains the number of active, deleted or hidden items in a History."),
     )
-    contents_states: Optional[HistoryStateCounts] = Field(
+    contents_states: Optional[HistoryContentStateCounts] = Field(
         default=None,
         title="Contents States",
         description="A dictionary keyed to possible dataset states and valued with the number of datasets in this history that have those states.",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1353,9 +1353,9 @@ class CustomHistoryView(HistoryDetailed):
 
 AnyHistoryView = Annotated[
     Union[
-        HistorySummary,
-        HistoryDetailed,
         CustomHistoryView,
+        HistoryDetailed,
+        HistorySummary,
     ],
     Field(union_mode="left_to_right"),
 ]

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1349,6 +1349,16 @@ class CustomHistoryView(HistoryDetailed):
         title="Contents Active",
         description=("Contains the number of active, deleted or hidden items in a History."),
     )
+    contents_states: Optional[HistoryStateCounts] = Field(
+        default=None,
+        title="Contents States",
+        description="A dictionary keyed to possible dataset states and valued with the number of datasets in this history that have those states.",
+    )
+    nice_size: Optional[str] = Field(
+        default=None,
+        title="Nice Size",
+        description="The total size of the contents of this history in a human-readable format.",
+    )
 
 
 AnyHistoryView = Annotated[

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1254,18 +1254,18 @@ class HistorySummary(HistoryBase, WithModelClass):
 class HistoryActiveContentCounts(Model):
     """Contains the number of active, deleted or hidden items in a History."""
 
-    active: int = Field(
-        ...,
+    active: Optional[int] = Field(
+        default=0,
         title="Active",
         description="Number of active datasets.",
     )
-    hidden: int = Field(
-        ...,
+    hidden: Optional[int] = Field(
+        default=0,
         title="Hidden",
         description="Number of hidden datasets.",
     )
-    deleted: int = Field(
-        ...,
+    deleted: Optional[int] = Field(
+        default=0,
         title="Deleted",
         description="Number of deleted datasets.",
     )

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1072,8 +1072,6 @@ class HDCADetailed(HDCASummary):
 class HistoryBase(Model):
     """Provides basic configuration for all the History models."""
 
-    model_config = ConfigDict(extra="allow")
-
 
 class HistoryContentItemBase(Model):
     """Identifies a dataset or collection contained in a History."""
@@ -1099,8 +1097,10 @@ class UpdateContentItem(HistoryContentItem):
     model_config = ConfigDict(use_enum_values=True, extra="allow")
 
 
-class UpdateHistoryContentsBatchPayload(HistoryBase):
+class UpdateHistoryContentsBatchPayload(Model):
     """Contains property values that will be updated for all the history `items` provided."""
+
+    model_config = ConfigDict(extra="allow")
 
     items: List[UpdateContentItem] = Field(
         ...,

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1170,7 +1170,7 @@ class HistoryContentBulkOperationResult(Model):
     errors: List[BulkOperationItemError]
 
 
-class UpdateHistoryContentsPayload(HistoryBase):
+class UpdateHistoryContentsPayload(Model):
     """Can contain arbitrary/dynamic fields that will be updated for a particular history item."""
 
     name: Optional[str] = Field(
@@ -1199,12 +1199,13 @@ class UpdateHistoryContentsPayload(HistoryBase):
         description="A list of tags to add to this item.",
     )
     model_config = ConfigDict(
+        extra="allow",
         json_schema_extra={
             "example": {
                 "visible": False,
                 "annotation": "Test",
             }
-        }
+        },
     )
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -39,6 +39,7 @@ from galaxy.schema.fields import (
     DecodedDatabaseIdField,
     EncodedDatabaseIdField,
     EncodedLibraryFolderDatabaseIdField,
+    is_optional,
     LibraryFolderDatabaseIdField,
     literal_to_value,
     ModelClassField,
@@ -313,8 +314,11 @@ class WithModelClass:
     def set_default(cls, data):
         if isinstance(data, dict):
             if "model_class" not in data and issubclass(cls, BaseModel):
+                model_class_annotation = cls.model_fields["model_class"].annotation
+                if is_optional(model_class_annotation):
+                    return data
                 data = data.copy()
-                data["model_class"] = literal_to_value(cls.model_fields["model_class"].annotation)
+                data["model_class"] = literal_to_value(model_class_annotation)
         return data
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1100,20 +1100,19 @@ class UpdateContentItem(HistoryContentItem):
 class UpdateHistoryContentsBatchPayload(Model):
     """Contains property values that will be updated for all the history `items` provided."""
 
-    model_config = ConfigDict(extra="allow")
-
     items: List[UpdateContentItem] = Field(
         ...,
         title="Items",
         description="A list of content items to update with the changes.",
     )
     model_config = ConfigDict(
+        extra="allow",
         json_schema_extra={
             "example": {
                 "items": [{"history_content_type": "dataset", "id": "string"}],
                 "visible": False,
             }
-        }
+        },
     )
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1254,18 +1254,18 @@ class HistorySummary(HistoryBase, WithModelClass):
 class HistoryActiveContentCounts(Model):
     """Contains the number of active, deleted or hidden items in a History."""
 
-    active: Optional[int] = Field(
-        default=0,
+    active: int = Field(
+        ...,
         title="Active",
         description="Number of active datasets.",
     )
-    hidden: Optional[int] = Field(
-        default=0,
+    hidden: int = Field(
+        ...,
         title="Hidden",
         description="Number of hidden datasets.",
     )
-    deleted: Optional[int] = Field(
-        default=0,
+    deleted: int = Field(
+        ...,
         title="Deleted",
         description="Number of deleted datasets.",
     )

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -221,6 +221,7 @@ class FastAPIHistories:
     @router.get(
         "/api/histories/deleted",
         summary="Returns deleted histories for the current user.",
+        response_model_exclude_unset=True,
     )
     def index_deleted(
         self,
@@ -236,6 +237,7 @@ class FastAPIHistories:
     @router.get(
         "/api/histories/published",
         summary="Return all histories that are published.",
+        response_model_exclude_unset=True,
     )
     def published(
         self,
@@ -248,6 +250,7 @@ class FastAPIHistories:
     @router.get(
         "/api/histories/shared_with_me",
         summary="Return all histories that are shared with the current user.",
+        response_model_exclude_unset=True,
     )
     def shared_with_me(
         self,
@@ -281,6 +284,7 @@ class FastAPIHistories:
     @router.get(
         "/api/histories/most_recently_used",
         summary="Returns the most recently used history of the user.",
+        response_model_exclude_unset=True,
     )
     def show_recent(
         self,
@@ -293,6 +297,7 @@ class FastAPIHistories:
         "/api/histories/{history_id}",
         name="history",
         summary="Returns the history with the given ID.",
+        response_model_exclude_unset=True,
     )
     def show(
         self,
@@ -348,6 +353,7 @@ class FastAPIHistories:
     @router.post(
         "/api/histories",
         summary="Creates a new history.",
+        response_model_exclude_unset=True,
     )
     def create(
         self,
@@ -370,6 +376,7 @@ class FastAPIHistories:
     @router.delete(
         "/api/histories/{history_id}",
         summary="Marks the history with the given ID as deleted.",
+        response_model_exclude_unset=True,
     )
     def delete(
         self,
@@ -386,6 +393,7 @@ class FastAPIHistories:
     @router.put(
         "/api/histories/batch/delete",
         summary="Marks several histories with the given IDs as deleted.",
+        response_model_exclude_unset=True,
     )
     def batch_delete(
         self,
@@ -405,6 +413,7 @@ class FastAPIHistories:
     @router.post(
         "/api/histories/deleted/{history_id}/undelete",
         summary="Restores a deleted history with the given ID (that hasn't been purged).",
+        response_model_exclude_unset=True,
     )
     def undelete(
         self,
@@ -417,6 +426,7 @@ class FastAPIHistories:
     @router.put(
         "/api/histories/batch/undelete",
         summary="Marks several histories with the given IDs as undeleted.",
+        response_model_exclude_unset=True,
     )
     def batch_undelete(
         self,
@@ -433,6 +443,7 @@ class FastAPIHistories:
     @router.put(
         "/api/histories/{history_id}",
         summary="Updates the values for the history with the given ID.",
+        response_model_exclude_unset=True,
     )
     def update(
         self,
@@ -449,6 +460,7 @@ class FastAPIHistories:
     @router.post(
         "/api/histories/from_store",
         summary="Create histories from a model store.",
+        response_model_exclude_unset=True,
     )
     def create_from_store(
         self,
@@ -620,6 +632,7 @@ class FastAPIHistories:
     @router.put(
         "/api/histories/{history_id}/archive/restore",
         summary="Restore an archived history.",
+        response_model_exclude_unset=True,
     )
     def restore_archived_history(
         self,

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -163,6 +163,7 @@ class FastAPIHistories:
     @router.get(
         "/api/histories",
         summary="Returns histories available to the current user.",
+        response_model_exclude_unset=True,
     )
     def index(
         self,

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -663,7 +663,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
                 hda_ids.append(item.id)
             else:
                 hdca_ids.append(item.id)
-        payload_dict = payload.dict(exclude_unset=True)
+        payload_dict = payload.model_dump(exclude_unset=True)
         hdas = self.__datasets_for_update(trans, history, hda_ids, payload_dict)
         rval = []
         for hda in hdas:

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -174,7 +174,7 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
             assert "state" in history
 
         # Expect only specific keys
-        expected_keys = ["name"]
+        expected_keys = ["nice_size", "contents_active", "contents_states"]
         unexpected_keys = ["id", "deleted", "state"]
         index_response = self._get(f"histories?keys={','.join(expected_keys)}").json()
         for history in index_response:
@@ -183,6 +183,16 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
                 assert key in history
             for key in unexpected_keys:
                 assert key not in history
+
+        # Expect combination of view and keys
+        view = "summary"
+        expected_keys = ["create_time", "count"]
+        data = dict(view=view, keys=",".join(expected_keys))
+        index_response = self._get("histories", data=data).json()
+        for history in index_response:
+            for key in expected_keys:
+                assert key in history
+            self._assert_has_keys(history, "id", "name", "url", "update_time", "deleted", "purged", "tags")
 
     def test_index_search_mode_views(self):
         # Make sure there is at least one history
@@ -201,7 +211,7 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
             assert "state" in history
 
         # Expect only specific keys
-        expected_keys = ["name"]
+        expected_keys = ["nice_size", "contents_active", "contents_states"]
         unexpected_keys = ["id", "deleted", "state"]
         data = dict(search=expected_name_contains, show_published=False, keys=",".join(expected_keys))
         index_response = self._get("histories", data=data).json()
@@ -211,6 +221,16 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
                 assert key in history
             for key in unexpected_keys:
                 assert key not in history
+
+        # Expect combination of view and keys
+        view = "summary"
+        expected_keys = ["create_time", "count"]
+        data = dict(search=expected_name_contains, show_published=False, view=view, keys=",".join(expected_keys))
+        index_response = self._get("histories", data=data).json()
+        for history in index_response:
+            for key in expected_keys:
+                assert key in history
+            self._assert_has_keys(history, "id", "name", "url", "update_time", "deleted", "purged", "tags")
 
     def test_index_case_insensitive_contains_query(self):
         # Create the histories with a different user to ensure the test

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -106,6 +106,26 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
         assert show_response["url"] == f"/api/histories/{history_id}"
         assert show_response["contents_url"] == f"/api/histories/{history_id}/contents"
 
+    def test_show_respects_view(self):
+        history_id = self._create_history(f"TestHistoryForShowView_{uuid4()}")["id"]
+        # By default the view is "detailed"
+        show_response = self._get(f"histories/{history_id}").json()
+        assert "state" in show_response
+
+        # Change the view to summary
+        show_response = self._get(f"histories/{history_id}", {"view": "summary"}).json()
+        assert "state" not in show_response
+
+        # Expect only specific keys
+        expected_keys = ["name"]
+        unexpected_keys = ["id", "deleted", "state"]
+        show_response = self._get(f"histories/{history_id}", {"keys": ",".join(expected_keys)}).json()
+        assert len(show_response) == len(expected_keys)
+        for key in expected_keys:
+            assert key in show_response
+        for key in unexpected_keys:
+            assert key not in show_response
+
     def test_show_most_recently_used(self):
         history_id = self._create_history("TestHistoryRecent")["id"]
         show_response = self._get("histories/most_recently_used").json()

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -155,9 +155,10 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
 
         # Expect only specific keys
         expected_keys = ["name"]
-        unexpected_keys = ["deleted", "state"]
+        unexpected_keys = ["id", "deleted", "state"]
         index_response = self._get(f"histories?keys={','.join(expected_keys)}").json()
         for history in index_response:
+            assert len(history) == len(expected_keys)
             for key in expected_keys:
                 assert key in history
             for key in unexpected_keys:
@@ -181,10 +182,11 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
 
         # Expect only specific keys
         expected_keys = ["name"]
-        unexpected_keys = ["deleted", "state"]
+        unexpected_keys = ["id", "deleted", "state"]
         data = dict(search=expected_name_contains, show_published=False, keys=",".join(expected_keys))
         index_response = self._get("histories", data=data).json()
         for history in index_response:
+            assert len(history) == len(expected_keys)
             for key in expected_keys:
                 assert key in history
             for key in unexpected_keys:


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/pull/17726#discussion_r1525223793 and addresses https://github.com/galaxyproject/galaxy/pull/17726#issuecomment-1999552966

as an example, when requesting `/api/histories?keys=name`:

## Before these changes
```json
[
  {
    "model_class": "History",
    "id": null,
    "user_id": null,
    "name": "Unnamed history"
  }
]
```


## After these changes
```json
[
  {
    "name": "Unnamed history"
  }
]
```

This PR adds a `partial_model` decorator [discussed in the Pydantic community](https://github.com/pydantic/pydantic/issues/1673) as a workaround to support partial (all fields optional) models until Python supports this concept natively.

The `CustomHistoryView` model now replaces `HistoryMinimal` by using this "partial_model" decorator and including any other fields the client might request. The "allow extra fields" configuration has been removed from the base model and now we need to be explicit about what the history response model can contain.

It also includes some refactorings/fixes around client model types since most components assumed the history objects contained all fields.

Finally, I increased the test coverage for using "view" and "keys" query parameters in histories.



## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
