### PR TITLE
[24.0] Prompt user to change default history permissions...

### DIFF
--- a/client/src/components/History/CurrentHistory/SelectPreferredStore.vue
+++ b/client/src/components/History/CurrentHistory/SelectPreferredStore.vue
@@ -2,6 +2,7 @@
 import axios from "axios";
 import { computed, ref } from "vue";
 
+import { getPermissions, isHistoryPrivate, makePrivate, type PermissionsResponse } from "@/components/History/services";
 import { prependPath } from "@/utils/redirect";
 import { errorMessageAsString } from "@/utils/simple-error";
 
@@ -48,7 +49,26 @@ const emit = defineEmits<{
     (e: "updated", id: string | null): void;
 }>();
 
-async function handleSubmit(preferredObjectStoreId: string | null) {
+async function handleSubmit(preferredObjectStoreId: string | null, isPrivate: boolean) {
+    if (isPrivate) {
+        const { data } = await getPermissions(props.history.id);
+        const permissionResponse = data as PermissionsResponse;
+        const historyPrivate = await isHistoryPrivate(permissionResponse);
+        if (!historyPrivate) {
+            if (
+                confirm(
+                    "Your history is set to create sharable datasets, but the target object store is private? Change the history configuration so new datasets are private by default?"
+                )
+            ) {
+                try {
+                    await makePrivate(props.history.id, permissionResponse);
+                } catch {
+                    error.value = "Failed to update default permissions for history.";
+                }
+            }
+        }
+    }
+
     const payload = { preferred_object_store_id: preferredObjectStoreId };
     const url = prependPath(`api/histories/${props.history.id}`);
     try {

--- a/client/src/components/History/CurrentHistory/SelectPreferredStore.vue
+++ b/client/src/components/History/CurrentHistory/SelectPreferredStore.vue
@@ -57,7 +57,7 @@ async function handleSubmit(preferredObjectStoreId: string | null, isPrivate: bo
         if (!historyPrivate) {
             if (
                 confirm(
-                    "Your history is set to create sharable datasets, but the target object store is private? Change the history configuration so new datasets are private by default?"
+                    "Your history is set to create sharable datasets, but the target storage location is private. Change the history configuration so new datasets are private by default?"
                 )
             ) {
                 try {

--- a/client/src/components/History/HistoryDatasetPermissions.vue
+++ b/client/src/components/History/HistoryDatasetPermissions.vue
@@ -1,9 +1,9 @@
 <script lang="ts" setup>
-import axios from "axios";
 import { computed, ref } from "vue";
 
 import { initRefs, updateRefs, useCallbacks } from "@/composables/datasetPermissions";
-import { withPrefix } from "@/utils/redirect";
+
+import { getPermissions, getPermissionsUrl, setPermissions } from "./services";
 
 import DatasetPermissionsForm from "@/components/Dataset/DatasetPermissionsForm.vue";
 
@@ -24,7 +24,7 @@ const {
 } = initRefs();
 
 const inputsUrl = computed(() => {
-    return `/history/permissions?id=${props.historyId}`;
+    return getPermissionsUrl(props.historyId);
 });
 
 const title = "Change default dataset permissions for history";
@@ -48,11 +48,11 @@ async function change(value: unknown) {
         DATASET_MANAGE_PERMISSIONS: [managePermissionValue],
         DATASET_ACCESS: access,
     };
-    axios.put(withPrefix(inputsUrl.value), formValue).then(onSuccess).catch(onError);
+    setPermissions(props.historyId, formValue).then(onSuccess).catch(onError);
 }
 
 async function init() {
-    const { data } = await axios.get(withPrefix(inputsUrl.value));
+    const { data } = await getPermissions(props.historyId);
     updateRefs(data.inputs, managePermissionsOptions, accessPermissionsOptions, managePermissions, accessPermissions);
     loading.value = false;
 }

--- a/client/src/components/History/services.ts
+++ b/client/src/components/History/services.ts
@@ -1,5 +1,9 @@
+import axios from "axios";
+
 import { fetcher } from "@/api/schema";
+import { type Input, permissionInputParts } from "@/composables/datasetPermissions";
 import type Filtering from "@/utils/filtering";
+import { withPrefix } from "@/utils/redirect";
 
 const publishedHistoriesFetcher = fetcher.path("/api/histories/published").method("get").create();
 export async function getPublishedHistories(
@@ -26,4 +30,38 @@ export async function getPublishedHistories(
     });
 
     return data;
+}
+
+export function getPermissionsUrl(historyId: string) {
+    return `/history/permissions?id=${historyId}`;
+}
+
+export interface PermissionsResponse {
+    inputs: Input[];
+}
+
+export function getPermissions(historyId: string) {
+    const permissionsUrl = getPermissionsUrl(historyId);
+    return axios.get(withPrefix(permissionsUrl));
+}
+
+export function setPermissions(historyId: string, formContents: object) {
+    const permissionsUrl = getPermissionsUrl(historyId);
+    return axios.put(withPrefix(permissionsUrl), formContents);
+}
+
+export function makePrivate(historyId: string, permissionResponse: PermissionsResponse) {
+    const { manageInput } = permissionInputParts(permissionResponse.inputs);
+    const managePermissionValue: number = manageInput.value[0] as number;
+    const access = [managePermissionValue];
+    const formValue = {
+        DATASET_MANAGE_PERMISSIONS: [managePermissionValue],
+        DATASET_ACCESS: access,
+    };
+    return setPermissions(historyId, formValue);
+}
+
+export async function isHistoryPrivate(permissionResponse: PermissionsResponse) {
+    const { accessInput } = permissionInputParts(permissionResponse.inputs);
+    return accessInput.value.length >= 1;
 }

--- a/client/src/components/ObjectStore/SelectObjectStore.vue
+++ b/client/src/components/ObjectStore/SelectObjectStore.vue
@@ -2,6 +2,7 @@
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 
+import { ConcreteObjectStoreModel } from "@/api";
 import { useObjectStoreStore } from "@/stores/objectStoreStore";
 
 import ObjectStoreSelectButton from "./ObjectStoreSelectButton.vue";
@@ -44,15 +45,17 @@ function variant(objectStoreId: string) {
 }
 
 const emit = defineEmits<{
-    (e: "onSubmit", id: string | null): void;
+    (e: "onSubmit", id: string | null, isPrivate: boolean): void;
 }>();
 
 const error = computed(() => {
     return props.parentError || loadErrorMessage.value;
 });
 
-async function handleSubmit(preferredObjectStoreId: string) {
-    emit("onSubmit", preferredObjectStoreId);
+async function handleSubmit(preferredObjectStore: ConcreteObjectStoreModel | null) {
+    const id: string | null = (preferredObjectStore ? preferredObjectStore.object_store_id : null) as string | null;
+    const isPrivate: boolean = preferredObjectStore ? preferredObjectStore.private : false;
+    emit("onSubmit", id, isPrivate);
 }
 </script>
 
@@ -81,7 +84,7 @@ async function handleSubmit(preferredObjectStoreId: string) {
                             :object-store="objectStore"
                             :variant="variant(objectStore.object_store_id)"
                             class="preferred-object-store-select-button"
-                            @click="handleSubmit(objectStore.object_store_id)" />
+                            @click="handleSubmit(objectStore)" />
                     </b-button-group>
                 </b-col>
                 <b-col cols="5">

--- a/client/src/composables/datasetPermissions.ts
+++ b/client/src/composables/datasetPermissions.ts
@@ -10,7 +10,7 @@ interface InputOption {
     roleValue: number;
 }
 
-interface Input {
+export interface Input {
     value: number[];
     options: [string, number][];
 }
@@ -46,6 +46,12 @@ export function initRefs() {
     };
 }
 
+export function permissionInputParts(inputs: Input[]) {
+    const manageInput: Input = inputs[0] as Input;
+    const accessInput: Input = inputs[1] as Input;
+    return { manageInput, accessInput };
+}
+
 export function updateRefs(
     inputs: Input[],
     managePermissionsOptions: Ref<InputOption[]>,
@@ -53,8 +59,7 @@ export function updateRefs(
     managePermissions: Ref<number[]>,
     accessPermissions: Ref<number[]>
 ) {
-    const manageInput: Input = inputs[0] as Input;
-    const accessInput: Input = inputs[1] as Input;
+    const { manageInput, accessInput } = permissionInputParts(inputs);
     managePermissionsOptions.value = manageInput.options.map((v: [string, number]) => {
         return <InputOption>{ roleName: v[0], roleValue: v[1] };
     });


### PR DESCRIPTION
... if picking a private object store for that history.

First and easiest of a series of changes to improve handling of private storage. The other tasks are:
- Do this same thing when changing the user's default permissions.
- Do the inverse check when changing the history permissions.
- Do the inverse check when changing the user's default history permissions.
- Provide a much nicer explanation when these don't line up and give the user the ability to fix the problem from the error message.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
   - Good luck! 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
