### PR TITLE
[24.0] Avoid showing a shareable URL with the default slug/username.

### DIFF
--- a/client/src/components/Sharing/SharingPage.vue
+++ b/client/src/components/Sharing/SharingPage.vue
@@ -273,7 +273,7 @@ const embedable = computed(() => item.value.importable && props.modelClass.toLoc
                         @submit="onSubmitSlug" />
                 </div>
                 <div v-else>
-                    <p>Currently publishing {{ modelClass }}.  A shareable URL will be available here momentarily.</p>
+                    <p>Currently publishing {{ modelClass }}. A shareable URL will be available here momentarily.</p>
                 </div>
             </div>
             <div v-else class="mb-4">

--- a/client/src/components/Sharing/SharingPage.vue
+++ b/client/src/components/Sharing/SharingPage.vue
@@ -208,6 +208,8 @@ function onPublish(published: boolean) {
 const hasUsername = ref(Boolean(getGalaxyInstance().user.get("username")));
 const newUsername = ref("");
 
+const slugSet = computed(() => itemUrl.slug != "slug" && itemUrl.prefix != "username");
+
 async function setUsername() {
     axios
         .put(`${getAppRoot()}api/users/${getGalaxyInstance().user.id}/information/inputs`, {
@@ -258,13 +260,21 @@ const embedable = computed(() => item.value.importable && props.modelClass.toLoc
             </div>
 
             <div v-if="item.importable" class="mb-4">
-                <div>This {{ modelClass }} is currently {{ itemStatus }}.</div>
-                <p>Anyone can view and import this {{ modelClass }} by visiting the following URL:</p>
-                <EditableUrl
-                    :prefix="itemUrl.prefix"
-                    :slug="itemUrl.slug"
-                    @change="onChangeSlug"
-                    @submit="onSubmitSlug" />
+                <div v-if="slugSet">
+                    <p>
+                        This {{ modelClass }} is currently {{ itemStatus }}.
+                        <br />
+                        Anyone can view and import this {{ modelClass }} by visiting the following URL:
+                    </p>
+                    <EditableUrl
+                        :prefix="itemUrl.prefix"
+                        :slug="itemUrl.slug"
+                        @change="onChangeSlug"
+                        @submit="onSubmitSlug" />
+                </div>
+                <div v-else>
+                    <p>Currently publishing {{ modelClass }}, a shareable URL will be available here momentarily.</p>
+                </div>
             </div>
             <div v-else class="mb-4">
                 Access to this {{ modelClass }} is currently restricted so that only you and the users listed below can

--- a/client/src/components/Sharing/SharingPage.vue
+++ b/client/src/components/Sharing/SharingPage.vue
@@ -45,7 +45,7 @@ const defaultExtra = () =>
 
 const item = ref<Item>({
     title: "title",
-    username_and_slug: "username/slug",
+    username_and_slug: "__username__/__slug__",
     importable: false,
     published: false,
     users_shared_with: [],
@@ -208,7 +208,7 @@ function onPublish(published: boolean) {
 const hasUsername = ref(Boolean(getGalaxyInstance().user.get("username")));
 const newUsername = ref("");
 
-const slugSet = computed(() => itemUrl.slug != "slug" && itemUrl.prefix != "username");
+const slugSet = computed(() => itemUrl.slug != "__slug__" && itemUrl.prefix != "__username__");
 
 async function setUsername() {
     axios
@@ -273,7 +273,7 @@ const embedable = computed(() => item.value.importable && props.modelClass.toLoc
                         @submit="onSubmitSlug" />
                 </div>
                 <div v-else>
-                    <p>Currently publishing {{ modelClass }}, a shareable URL will be available here momentarily.</p>
+                    <p>Currently publishing {{ modelClass }}.  A shareable URL will be available here momentarily.</p>
                 </div>
             </div>
             <div v-else class="mb-4">


### PR DESCRIPTION
We optimistically flip the 'published' display on the sharing page as soon as the toggle is clicked clientside but the initial URL prior to server response uses 'username/slug' (which is better than the old `null`, but still an invalid link to share).  This has been reported by users to be confusing, especially when a history can take ~10s to actually publish and return with the valid, new slug.

Thanks @abueg!

Fixes https://github.com/galaxyproject/galaxy/issues/16275

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
