### PR TITLE
[24.0] Swap history dropdown from using the tiny caret to faBars. 

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -127,8 +127,8 @@ function userTitle(title: string) {
                 </BButton>
 
                 <BDropdown
-                    no-caret
                     v-b-tooltip.top.hover.noninteractive
+                    no-caret
                     size="sm"
                     variant="link"
                     toggle-class="text-decoration-none"

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -2,6 +2,7 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import {
     faArchive,
+    faBars,
     faColumns,
     faCopy,
     faExchangeAlt,
@@ -42,6 +43,7 @@ import SelectorModal from "@/components/History/Modals/SelectorModal.vue";
 
 library.add(
     faArchive,
+    faBars,
     faColumns,
     faCopy,
     faExchangeAlt,
@@ -125,6 +127,7 @@ function userTitle(title: string) {
                 </BButton>
 
                 <BDropdown
+                    no-caret
                     v-b-tooltip.top.hover.noninteractive
                     size="sm"
                     variant="link"
@@ -133,6 +136,7 @@ function userTitle(title: string) {
                     title="History options"
                     data-description="history options">
                     <template v-slot:button-content>
+                        <FontAwesomeIcon fixed-width :icon="faBars" />
                         <span class="sr-only">History Options</span>
                     </template>
 


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/15444

The caret is too small, and bars communicate usage of the menu effectively here.  I tried both kebab and hamburger, liked hambuger more.  The intent here is a quick fix for 24.0, but we should audit other uses of dropdowns that don't have a customized slot and standardize this where appropriate -- likely few of them should use the default tiny caret, certainly not in small variant.

![image](https://github.com/galaxyproject/galaxy/assets/155398/6769784c-5987-4ebb-9283-baed295a777a)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
