### PR TITLE
[24.0] Fix datasets API custom keys encoding

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -3585,384 +3585,6 @@ export interface components {
              */
             installed_builds: components["schemas"]["LabelValuePair"][];
         };
-        /** CustomHistoryHDA */
-        CustomHistoryHDA: {
-            /**
-             * Accessible
-             * @description Whether this item is accessible to the current user due to permissions.
-             */
-            accessible?: boolean | null;
-            /**
-             * Annotation
-             * @description An annotation to provide details or to help understand the purpose and usage of this item.
-             */
-            annotation?: string | null;
-            /**
-             * API Type
-             * @deprecated
-             * @description TODO
-             */
-            api_type?: "file" | null;
-            /** Copied From Ldda Id */
-            copied_from_ldda_id?: string | null;
-            /**
-             * Create Time
-             * @description The time and date this item was created.
-             */
-            create_time?: string | null;
-            /**
-             * Created from basename
-             * @description The basename of the output that produced this dataset.
-             */
-            created_from_basename?: string | null;
-            /**
-             * Creating Job ID
-             * @description The encoded ID of the job that created this dataset.
-             */
-            creating_job?: string | null;
-            /**
-             * Data Type
-             * @description The fully qualified name of the class implementing the data type of this dataset.
-             */
-            data_type?: string | null;
-            /**
-             * Dataset ID
-             * @description The encoded ID of the dataset associated with this item.
-             * @example 0123456789ABCDEF
-             */
-            dataset_id?: string;
-            /**
-             * Deleted
-             * @description Whether this item is marked as deleted.
-             */
-            deleted?: boolean | null;
-            /**
-             * Display Applications
-             * @description Contains new-style display app urls.
-             */
-            display_apps?: components["schemas"]["DisplayApp"][] | null;
-            /**
-             * Legacy Display Applications
-             * @description Contains old-style display app urls.
-             */
-            display_types?: components["schemas"]["DisplayApp"][] | null;
-            /**
-             * Download URL
-             * @description The URL to download this item from the server.
-             */
-            download_url?: string | null;
-            /**
-             * DRS ID
-             * @description The DRS ID of the dataset.
-             */
-            drs_id?: string | null;
-            /**
-             * Extension
-             * @description The extension of the dataset.
-             */
-            extension?: string | null;
-            /**
-             * File extension
-             * @description The extension of the file.
-             */
-            file_ext?: string | null;
-            /**
-             * File Name
-             * @description The full path to the dataset file.
-             */
-            file_name?: string | null;
-            /**
-             * File Size
-             * @description The file size in bytes.
-             */
-            file_size?: number | null;
-            /**
-             * Genome Build
-             * @description TODO
-             */
-            genome_build?: string | null;
-            /**
-             * Hashes
-             * @description The list of hashes associated with this dataset.
-             */
-            hashes?: components["schemas"]["DatasetHash"][] | null;
-            /**
-             * HDA or LDDA
-             * @description Whether this dataset belongs to a history (HDA) or a library (LDDA).
-             */
-            hda_ldda?: components["schemas"]["DatasetSourceType"] | null;
-            /**
-             * HID
-             * @description The index position of this item in the History.
-             */
-            hid?: number | null;
-            /**
-             * History Content Type
-             * @description This is always `dataset` for datasets.
-             */
-            history_content_type?: "dataset" | null;
-            /**
-             * History ID
-             * @example 0123456789ABCDEF
-             */
-            history_id?: string;
-            /**
-             * Id
-             * @example 0123456789ABCDEF
-             */
-            id?: string;
-            /**
-             * Metadata Files
-             * @description Collection of metadata files associated with this dataset.
-             */
-            meta_files?: components["schemas"]["MetadataFile"][] | null;
-            /**
-             * Metadata
-             * @description The metadata associated with this dataset.
-             */
-            metadata?: Record<string, never> | null;
-            /**
-             * Metadata Data Lines
-             * @description TODO
-             */
-            metadata_data_lines?: number | null;
-            /**
-             * Metadata DBKey
-             * @description TODO
-             */
-            metadata_dbkey?: string | null;
-            /**
-             * Miscellaneous Blurb
-             * @description TODO
-             */
-            misc_blurb?: string | null;
-            /**
-             * Miscellaneous Information
-             * @description TODO
-             */
-            misc_info?: string | null;
-            /**
-             * Model class
-             * @description The name of the database model class.
-             * @constant
-             */
-            model_class?: "HistoryDatasetAssociation";
-            /**
-             * Name
-             * @description The name of the item.
-             */
-            name?: string | null;
-            /**
-             * Peek
-             * @description A few lines of contents from the start of the file.
-             */
-            peek?: string | null;
-            /**
-             * Permissions
-             * @description Role-based access and manage control permissions for the dataset.
-             */
-            permissions?: components["schemas"]["DatasetPermissions"] | null;
-            /**
-             * Purged
-             * @description Whether this dataset has been removed from disk.
-             */
-            purged?: boolean | null;
-            /**
-             * Rerunnable
-             * @description Whether the job creating this dataset can be run again.
-             */
-            rerunnable?: boolean | null;
-            /**
-             * Resubmitted
-             * @description Whether the job creating this dataset has been resubmitted.
-             */
-            resubmitted?: boolean | null;
-            /**
-             * State
-             * @description The current state of this dataset.
-             */
-            state?: components["schemas"]["DatasetState"] | null;
-            tags?: components["schemas"]["TagCollection"] | null;
-            /**
-             * Type
-             * @description This is always `file` for datasets.
-             */
-            type?: "file" | null;
-            /**
-             * Type - ID
-             * @description The type and the encoded ID of this item. Used for caching.
-             */
-            type_id?: string | null;
-            /**
-             * Update Time
-             * @description The last time and date this item was updated.
-             */
-            update_time?: string | null;
-            /**
-             * URL
-             * @deprecated
-             * @description The relative URL to access this item.
-             */
-            url?: string | null;
-            /** Uuid */
-            uuid?: string | null;
-            /**
-             * Validated State
-             * @description The state of the datatype validation for this dataset.
-             */
-            validated_state?: components["schemas"]["DatasetValidatedState"] | null;
-            /**
-             * Validated State Message
-             * @description The message with details about the datatype validation result for this dataset.
-             */
-            validated_state_message?: string | null;
-            /**
-             * Visible
-             * @description Whether this item is visible or hidden to the user by default.
-             */
-            visible?: boolean | null;
-            /**
-             * Visualizations
-             * @description The collection of visualizations that can be applied to this dataset.
-             */
-            visualizations?: components["schemas"]["Visualization"][] | null;
-        };
-        /** CustomHistoryHDCA */
-        CustomHistoryHDCA: {
-            /**
-             * Dataset Collection ID
-             * @example 0123456789ABCDEF
-             */
-            collection_id?: string;
-            /**
-             * Collection Type
-             * @description The type of the collection, can be `list`, `paired`, or define subcollections using `:` as separator like `list:paired` or `list:list`.
-             */
-            collection_type?: string | null;
-            /**
-             * Contents URL
-             * @description The relative URL to access the contents of this History.
-             */
-            contents_url?: string | null;
-            /**
-             * Create Time
-             * @description The time and date this item was created.
-             */
-            create_time?: string | null;
-            /**
-             * Deleted
-             * @description Whether this item is marked as deleted.
-             */
-            deleted?: boolean | null;
-            /**
-             * Element Count
-             * @description The number of elements contained in the dataset collection. It may be None or undefined if the collection could not be populated.
-             */
-            element_count?: number | null;
-            /**
-             * Elements
-             * @description The summary information of each of the elements inside the dataset collection.
-             */
-            elements?: components["schemas"]["DCESummary"][] | null;
-            /**
-             * Elements Datatypes
-             * @description A set containing all the different element datatypes in the collection.
-             */
-            elements_datatypes?: string[] | null;
-            /**
-             * HID
-             * @description The index position of this item in the History.
-             */
-            hid?: number | null;
-            /**
-             * History Content Type
-             * @description This is always `dataset_collection` for dataset collections.
-             */
-            history_content_type?: "dataset_collection" | null;
-            /**
-             * History ID
-             * @example 0123456789ABCDEF
-             */
-            history_id?: string;
-            /**
-             * Id
-             * @example 0123456789ABCDEF
-             */
-            id?: string;
-            /**
-             * Implicit Collection Jobs Id
-             * @description Encoded ID for the ICJ object describing the collection of jobs corresponding to this collection
-             */
-            implicit_collection_jobs_id?: string | null;
-            /**
-             * Job Source ID
-             * @description The encoded ID of the Job that produced this dataset collection. Used to track the state of the job.
-             */
-            job_source_id?: string | null;
-            /**
-             * Job Source Type
-             * @description The type of job (model class) that produced this dataset collection. Used to track the state of the job.
-             */
-            job_source_type?: components["schemas"]["JobSourceType"] | null;
-            /**
-             * Job State Summary
-             * @description Overview of the job states working inside the dataset collection.
-             */
-            job_state_summary?: components["schemas"]["HDCJobStateSummary"] | null;
-            /**
-             * Model class
-             * @description The name of the database model class.
-             * @constant
-             */
-            model_class?: "HistoryDatasetCollectionAssociation";
-            /**
-             * Name
-             * @description The name of the item.
-             */
-            name?: string | null;
-            /**
-             * Populated
-             * @description Whether the dataset collection elements (and any subcollections elements) were successfully populated.
-             */
-            populated?: boolean | null;
-            /**
-             * Populated State
-             * @description Indicates the general state of the elements in the dataset collection:- 'new': new dataset collection, unpopulated elements.- 'ok': collection elements populated (HDAs may or may not have errors).- 'failed': some problem populating, won't be populated.
-             */
-            populated_state?: components["schemas"]["DatasetCollectionPopulatedState"] | null;
-            /**
-             * Populated State Message
-             * @description Optional message with further information in case the population of the dataset collection failed.
-             */
-            populated_state_message?: string | null;
-            tags?: components["schemas"]["TagCollection"] | null;
-            /**
-             * Type
-             * @description This is always `collection` for dataset collections.
-             */
-            type?: "collection" | null;
-            /**
-             * Type - ID
-             * @description The type and the encoded ID of this item. Used for caching.
-             */
-            type_id?: string | null;
-            /**
-             * Update Time
-             * @description The last time and date this item was updated.
-             */
-            update_time?: string | null;
-            /**
-             * URL
-             * @deprecated
-             * @description The relative URL to access this item.
-             */
-            url?: string | null;
-            /**
-             * Visible
-             * @description Whether this item is visible or hidden to the user by default.
-             */
-            visible?: boolean | null;
-        };
         /** CustomHistoryView */
         CustomHistoryView: {
             /**
@@ -4393,6 +4015,30 @@ export interface components {
              * @default []
              */
             manage?: string[];
+        };
+        /** DatasetSource */
+        DatasetSource: {
+            /**
+             * Extra Files Path
+             * @description The path to the extra files.
+             */
+            extra_files_path?: string | null;
+            /**
+             * ID
+             * @description Encoded ID of the dataset source.
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /**
+             * Source URI
+             * @description The URI of the dataset source.
+             */
+            source_uri: string;
+            /**
+             * Transform
+             * @description The transformations applied to the dataset source.
+             */
+            transform?: Record<string, never>[] | null;
         };
         /** DatasetSourceId */
         DatasetSourceId: {
@@ -5867,6 +5513,244 @@ export interface components {
             /** Name */
             name: string;
         };
+        /** HDACustom */
+        HDACustom: {
+            /**
+             * Accessible
+             * @description Whether this item is accessible to the current user due to permissions.
+             */
+            accessible?: boolean | null;
+            /**
+             * Annotation
+             * @description An annotation to provide details or to help understand the purpose and usage of this item.
+             */
+            annotation?: string | null;
+            /**
+             * API Type
+             * @deprecated
+             * @description TODO
+             */
+            api_type?: "file" | null;
+            /** Copied From Ldda Id */
+            copied_from_ldda_id?: string | null;
+            /**
+             * Create Time
+             * @description The time and date this item was created.
+             */
+            create_time?: string | null;
+            /**
+             * Created from basename
+             * @description The basename of the output that produced this dataset.
+             */
+            created_from_basename?: string | null;
+            /**
+             * Creating Job ID
+             * @description The encoded ID of the job that created this dataset.
+             */
+            creating_job?: string | null;
+            /**
+             * Data Type
+             * @description The fully qualified name of the class implementing the data type of this dataset.
+             */
+            data_type?: string | null;
+            /**
+             * Dataset ID
+             * @description The encoded ID of the dataset associated with this item.
+             * @example 0123456789ABCDEF
+             */
+            dataset_id?: string;
+            /**
+             * Deleted
+             * @description Whether this item is marked as deleted.
+             */
+            deleted?: boolean | null;
+            /**
+             * Display Applications
+             * @description Contains new-style display app urls.
+             */
+            display_apps?: components["schemas"]["DisplayApp"][] | null;
+            /**
+             * Legacy Display Applications
+             * @description Contains old-style display app urls.
+             */
+            display_types?: components["schemas"]["DisplayApp"][] | null;
+            /**
+             * Download URL
+             * @description The URL to download this item from the server.
+             */
+            download_url?: string | null;
+            /**
+             * DRS ID
+             * @description The DRS ID of the dataset.
+             */
+            drs_id?: string | null;
+            /**
+             * Extension
+             * @description The extension of the dataset.
+             */
+            extension?: string | null;
+            /**
+             * File extension
+             * @description The extension of the file.
+             */
+            file_ext?: string | null;
+            /**
+             * File Name
+             * @description The full path to the dataset file.
+             */
+            file_name?: string | null;
+            /**
+             * File Size
+             * @description The file size in bytes.
+             */
+            file_size?: number | null;
+            /**
+             * Genome Build
+             * @description TODO
+             */
+            genome_build?: string | null;
+            /**
+             * Hashes
+             * @description The list of hashes associated with this dataset.
+             */
+            hashes?: components["schemas"]["DatasetHash"][] | null;
+            /**
+             * HDA or LDDA
+             * @description Whether this dataset belongs to a history (HDA) or a library (LDDA).
+             */
+            hda_ldda?: components["schemas"]["DatasetSourceType"] | null;
+            /**
+             * HID
+             * @description The index position of this item in the History.
+             */
+            hid?: number | null;
+            /**
+             * History Content Type
+             * @description This is always `dataset` for datasets.
+             */
+            history_content_type?: "dataset" | null;
+            /**
+             * History ID
+             * @example 0123456789ABCDEF
+             */
+            history_id?: string;
+            /**
+             * Id
+             * @example 0123456789ABCDEF
+             */
+            id?: string;
+            /**
+             * Metadata Files
+             * @description Collection of metadata files associated with this dataset.
+             */
+            meta_files?: components["schemas"]["MetadataFile"][] | null;
+            /**
+             * Metadata
+             * @description The metadata associated with this dataset.
+             */
+            metadata?: Record<string, never> | null;
+            /**
+             * Miscellaneous Blurb
+             * @description TODO
+             */
+            misc_blurb?: string | null;
+            /**
+             * Miscellaneous Information
+             * @description TODO
+             */
+            misc_info?: string | null;
+            /**
+             * Model class
+             * @description The name of the database model class.
+             * @constant
+             */
+            model_class?: "HistoryDatasetAssociation";
+            /**
+             * Name
+             * @description The name of the item.
+             */
+            name?: string | null;
+            /**
+             * Peek
+             * @description A few lines of contents from the start of the file.
+             */
+            peek?: string | null;
+            /**
+             * Permissions
+             * @description Role-based access and manage control permissions for the dataset.
+             */
+            permissions?: components["schemas"]["DatasetPermissions"] | null;
+            /**
+             * Purged
+             * @description Whether this dataset has been removed from disk.
+             */
+            purged?: boolean | null;
+            /**
+             * Rerunnable
+             * @description Whether the job creating this dataset can be run again.
+             */
+            rerunnable?: boolean | null;
+            /**
+             * Resubmitted
+             * @description Whether the job creating this dataset has been resubmitted.
+             */
+            resubmitted?: boolean | null;
+            /**
+             * Sources
+             * @description The list of sources associated with this dataset.
+             */
+            sources?: components["schemas"]["DatasetSource"][] | null;
+            /**
+             * State
+             * @description The current state of this dataset.
+             */
+            state?: components["schemas"]["DatasetState"] | null;
+            tags?: components["schemas"]["TagCollection"] | null;
+            /**
+             * Type
+             * @description This is always `file` for datasets.
+             */
+            type?: "file" | null;
+            /**
+             * Type - ID
+             * @description The type and the encoded ID of this item. Used for caching.
+             */
+            type_id?: string | null;
+            /**
+             * Update Time
+             * @description The last time and date this item was updated.
+             */
+            update_time?: string | null;
+            /**
+             * URL
+             * @deprecated
+             * @description The relative URL to access this item.
+             */
+            url?: string | null;
+            /** Uuid */
+            uuid?: string | null;
+            /**
+             * Validated State
+             * @description The state of the datatype validation for this dataset.
+             */
+            validated_state?: components["schemas"]["DatasetValidatedState"] | null;
+            /**
+             * Validated State Message
+             * @description The message with details about the datatype validation result for this dataset.
+             */
+            validated_state_message?: string | null;
+            /**
+             * Visible
+             * @description Whether this item is visible or hidden to the user by default.
+             */
+            visible?: boolean | null;
+            /**
+             * Visualizations
+             * @description The collection of visualizations that can be applied to this dataset.
+             */
+            visualizations?: components["schemas"]["Visualization"][] | null;
+            [key: string]: unknown | undefined;
+        };
         /**
          * HDADetailed
          * @description History Dataset Association detailed information.
@@ -6012,18 +5896,6 @@ export interface components {
              */
             metadata?: Record<string, never> | null;
             /**
-             * Metadata Data Lines
-             * @description TODO
-             * @default 0
-             */
-            metadata_data_lines?: number;
-            /**
-             * Metadata DBKey
-             * @description TODO
-             * @default ?
-             */
-            metadata_dbkey?: string | null;
-            /**
              * Miscellaneous Blurb
              * @description TODO
              */
@@ -6069,6 +5941,11 @@ export interface components {
              * @description Whether the job creating this dataset has been resubmitted.
              */
             resubmitted: boolean;
+            /**
+             * Sources
+             * @description The list of sources associated with this dataset.
+             */
+            sources: components["schemas"]["DatasetSource"][];
             /**
              * State
              * @description The current state of this dataset.
@@ -6119,11 +5996,6 @@ export interface components {
              * @description Whether this item is visible or hidden to the user by default.
              */
             visible: boolean;
-            /**
-             * Visualizations
-             * @description The collection of visualizations that can be applied to this dataset.
-             */
-            visualizations: components["schemas"]["Visualization"][];
         };
         /**
          * HDAObject
@@ -6192,6 +6064,12 @@ export interface components {
              */
             extension: string | null;
             /**
+             * Genome Build
+             * @description TODO
+             * @default ?
+             */
+            genome_build?: string | null;
+            /**
              * HID
              * @description The index position of this item in the History.
              */
@@ -6254,6 +6132,142 @@ export interface components {
              * @description Whether this item is visible or hidden to the user by default.
              */
             visible: boolean;
+        };
+        /** HDCACustom */
+        HDCACustom: {
+            /**
+             * Dataset Collection ID
+             * @example 0123456789ABCDEF
+             */
+            collection_id?: string;
+            /**
+             * Collection Type
+             * @description The type of the collection, can be `list`, `paired`, or define subcollections using `:` as separator like `list:paired` or `list:list`.
+             */
+            collection_type?: string | null;
+            /**
+             * Contents URL
+             * @description The relative URL to access the contents of this History.
+             */
+            contents_url?: string | null;
+            /**
+             * Create Time
+             * @description The time and date this item was created.
+             */
+            create_time?: string | null;
+            /**
+             * Deleted
+             * @description Whether this item is marked as deleted.
+             */
+            deleted?: boolean | null;
+            /**
+             * Element Count
+             * @description The number of elements contained in the dataset collection. It may be None or undefined if the collection could not be populated.
+             */
+            element_count?: number | null;
+            /**
+             * Elements
+             * @description The summary information of each of the elements inside the dataset collection.
+             */
+            elements?: components["schemas"]["DCESummary"][] | null;
+            /**
+             * Elements Datatypes
+             * @description A set containing all the different element datatypes in the collection.
+             */
+            elements_datatypes?: string[] | null;
+            /**
+             * HID
+             * @description The index position of this item in the History.
+             */
+            hid?: number | null;
+            /**
+             * History Content Type
+             * @description This is always `dataset_collection` for dataset collections.
+             */
+            history_content_type?: "dataset_collection" | null;
+            /**
+             * History ID
+             * @example 0123456789ABCDEF
+             */
+            history_id?: string;
+            /**
+             * Id
+             * @example 0123456789ABCDEF
+             */
+            id?: string;
+            /**
+             * Implicit Collection Jobs Id
+             * @description Encoded ID for the ICJ object describing the collection of jobs corresponding to this collection
+             */
+            implicit_collection_jobs_id?: string | null;
+            /**
+             * Job Source ID
+             * @description The encoded ID of the Job that produced this dataset collection. Used to track the state of the job.
+             */
+            job_source_id?: string | null;
+            /**
+             * Job Source Type
+             * @description The type of job (model class) that produced this dataset collection. Used to track the state of the job.
+             */
+            job_source_type?: components["schemas"]["JobSourceType"] | null;
+            /**
+             * Job State Summary
+             * @description Overview of the job states working inside the dataset collection.
+             */
+            job_state_summary?: components["schemas"]["HDCJobStateSummary"] | null;
+            /**
+             * Model class
+             * @description The name of the database model class.
+             * @constant
+             */
+            model_class?: "HistoryDatasetCollectionAssociation";
+            /**
+             * Name
+             * @description The name of the item.
+             */
+            name?: string | null;
+            /**
+             * Populated
+             * @description Whether the dataset collection elements (and any subcollections elements) were successfully populated.
+             */
+            populated?: boolean | null;
+            /**
+             * Populated State
+             * @description Indicates the general state of the elements in the dataset collection:- 'new': new dataset collection, unpopulated elements.- 'ok': collection elements populated (HDAs may or may not have errors).- 'failed': some problem populating, won't be populated.
+             */
+            populated_state?: components["schemas"]["DatasetCollectionPopulatedState"] | null;
+            /**
+             * Populated State Message
+             * @description Optional message with further information in case the population of the dataset collection failed.
+             */
+            populated_state_message?: string | null;
+            tags?: components["schemas"]["TagCollection"] | null;
+            /**
+             * Type
+             * @description This is always `collection` for dataset collections.
+             */
+            type?: "collection" | null;
+            /**
+             * Type - ID
+             * @description The type and the encoded ID of this item. Used for caching.
+             */
+            type_id?: string | null;
+            /**
+             * Update Time
+             * @description The last time and date this item was updated.
+             */
+            update_time?: string | null;
+            /**
+             * URL
+             * @deprecated
+             * @description The relative URL to access this item.
+             */
+            url?: string | null;
+            /**
+             * Visible
+             * @description Whether this item is visible or hidden to the user by default.
+             */
+            visible?: boolean | null;
         };
         /**
          * HDCADetailed
@@ -7024,10 +7038,10 @@ export interface components {
          * Can contain different views and kinds of items.
          */
         HistoryContentsResult: (
-            | components["schemas"]["CustomHistoryHDA"]
-            | components["schemas"]["CustomHistoryHDCA"]
+            | components["schemas"]["HDACustom"]
             | components["schemas"]["HDADetailed"]
             | components["schemas"]["HDASummary"]
+            | components["schemas"]["HDCACustom"]
             | components["schemas"]["HDCADetailed"]
             | components["schemas"]["HDCASummary"]
         )[];
@@ -7041,10 +7055,10 @@ export interface components {
              * @description The items matching the search query. Only the items fitting in the current page limit will be returned.
              */
             contents: (
-                | components["schemas"]["CustomHistoryHDA"]
-                | components["schemas"]["CustomHistoryHDCA"]
+                | components["schemas"]["HDACustom"]
                 | components["schemas"]["HDADetailed"]
                 | components["schemas"]["HDASummary"]
+                | components["schemas"]["HDCACustom"]
                 | components["schemas"]["HDCADetailed"]
                 | components["schemas"]["HDCASummary"]
             )[];
@@ -7266,9 +7280,8 @@ export interface components {
          */
         Hyperlink: {
             /**
-             * HRef
-             * Format: uri
-             * @description Specifies the linked document, resource, or location.
+             * Href
+             * @description The URL of the linked document.
              */
             href: string;
             /**
@@ -13633,10 +13646,10 @@ export interface operations {
             200: {
                 content: {
                     "application/json": (
-                        | components["schemas"]["CustomHistoryHDA"]
-                        | components["schemas"]["CustomHistoryHDCA"]
+                        | components["schemas"]["HDACustom"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
+                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
                     )[];
@@ -13814,7 +13827,10 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["HDADetailed"] | components["schemas"]["HDASummary"];
+                    "application/json":
+                        | components["schemas"]["HDACustom"]
+                        | components["schemas"]["HDADetailed"]
+                        | components["schemas"]["HDASummary"];
                 };
             };
             /** @description Validation Error */
@@ -16561,17 +16577,17 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["CustomHistoryHDA"]
-                        | components["schemas"]["CustomHistoryHDCA"]
+                        | components["schemas"]["HDACustom"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
+                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
                         | (
-                              | components["schemas"]["CustomHistoryHDA"]
-                              | components["schemas"]["CustomHistoryHDCA"]
+                              | components["schemas"]["HDACustom"]
                               | components["schemas"]["HDADetailed"]
                               | components["schemas"]["HDASummary"]
+                              | components["schemas"]["HDCACustom"]
                               | components["schemas"]["HDCADetailed"]
                               | components["schemas"]["HDCASummary"]
                           )[];
@@ -17152,10 +17168,10 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["CustomHistoryHDA"]
-                        | components["schemas"]["CustomHistoryHDCA"]
+                        | components["schemas"]["HDACustom"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
+                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"];
                 };
@@ -17204,10 +17220,10 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["CustomHistoryHDA"]
-                        | components["schemas"]["CustomHistoryHDCA"]
+                        | components["schemas"]["HDACustom"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
+                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"];
                 };
@@ -17437,17 +17453,17 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["CustomHistoryHDA"]
-                        | components["schemas"]["CustomHistoryHDCA"]
+                        | components["schemas"]["HDACustom"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
+                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
                         | (
-                              | components["schemas"]["CustomHistoryHDA"]
-                              | components["schemas"]["CustomHistoryHDCA"]
+                              | components["schemas"]["HDACustom"]
                               | components["schemas"]["HDADetailed"]
                               | components["schemas"]["HDASummary"]
+                              | components["schemas"]["HDCACustom"]
                               | components["schemas"]["HDCADetailed"]
                               | components["schemas"]["HDCASummary"]
                           )[];
@@ -17495,10 +17511,10 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["CustomHistoryHDA"]
-                        | components["schemas"]["CustomHistoryHDCA"]
+                        | components["schemas"]["HDACustom"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
+                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"];
                 };
@@ -17546,10 +17562,10 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
-                        | components["schemas"]["CustomHistoryHDA"]
-                        | components["schemas"]["CustomHistoryHDCA"]
+                        | components["schemas"]["HDACustom"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
+                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"];
                 };
@@ -17778,10 +17794,10 @@ export interface operations {
             200: {
                 content: {
                     "application/json": (
-                        | components["schemas"]["CustomHistoryHDA"]
-                        | components["schemas"]["CustomHistoryHDCA"]
+                        | components["schemas"]["HDACustom"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
+                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
                     )[];

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6133,142 +6133,6 @@ export interface components {
              */
             visible: boolean;
         };
-        /** HDCACustom */
-        HDCACustom: {
-            /**
-             * Dataset Collection ID
-             * @example 0123456789ABCDEF
-             */
-            collection_id?: string;
-            /**
-             * Collection Type
-             * @description The type of the collection, can be `list`, `paired`, or define subcollections using `:` as separator like `list:paired` or `list:list`.
-             */
-            collection_type?: string | null;
-            /**
-             * Contents URL
-             * @description The relative URL to access the contents of this History.
-             */
-            contents_url?: string | null;
-            /**
-             * Create Time
-             * @description The time and date this item was created.
-             */
-            create_time?: string | null;
-            /**
-             * Deleted
-             * @description Whether this item is marked as deleted.
-             */
-            deleted?: boolean | null;
-            /**
-             * Element Count
-             * @description The number of elements contained in the dataset collection. It may be None or undefined if the collection could not be populated.
-             */
-            element_count?: number | null;
-            /**
-             * Elements
-             * @description The summary information of each of the elements inside the dataset collection.
-             */
-            elements?: components["schemas"]["DCESummary"][] | null;
-            /**
-             * Elements Datatypes
-             * @description A set containing all the different element datatypes in the collection.
-             */
-            elements_datatypes?: string[] | null;
-            /**
-             * HID
-             * @description The index position of this item in the History.
-             */
-            hid?: number | null;
-            /**
-             * History Content Type
-             * @description This is always `dataset_collection` for dataset collections.
-             */
-            history_content_type?: "dataset_collection" | null;
-            /**
-             * History ID
-             * @example 0123456789ABCDEF
-             */
-            history_id?: string;
-            /**
-             * Id
-             * @example 0123456789ABCDEF
-             */
-            id?: string;
-            /**
-             * Implicit Collection Jobs Id
-             * @description Encoded ID for the ICJ object describing the collection of jobs corresponding to this collection
-             */
-            implicit_collection_jobs_id?: string | null;
-            /**
-             * Job Source ID
-             * @description The encoded ID of the Job that produced this dataset collection. Used to track the state of the job.
-             */
-            job_source_id?: string | null;
-            /**
-             * Job Source Type
-             * @description The type of job (model class) that produced this dataset collection. Used to track the state of the job.
-             */
-            job_source_type?: components["schemas"]["JobSourceType"] | null;
-            /**
-             * Job State Summary
-             * @description Overview of the job states working inside the dataset collection.
-             */
-            job_state_summary?: components["schemas"]["HDCJobStateSummary"] | null;
-            /**
-             * Model class
-             * @description The name of the database model class.
-             * @constant
-             */
-            model_class?: "HistoryDatasetCollectionAssociation";
-            /**
-             * Name
-             * @description The name of the item.
-             */
-            name?: string | null;
-            /**
-             * Populated
-             * @description Whether the dataset collection elements (and any subcollections elements) were successfully populated.
-             */
-            populated?: boolean | null;
-            /**
-             * Populated State
-             * @description Indicates the general state of the elements in the dataset collection:- 'new': new dataset collection, unpopulated elements.- 'ok': collection elements populated (HDAs may or may not have errors).- 'failed': some problem populating, won't be populated.
-             */
-            populated_state?: components["schemas"]["DatasetCollectionPopulatedState"] | null;
-            /**
-             * Populated State Message
-             * @description Optional message with further information in case the population of the dataset collection failed.
-             */
-            populated_state_message?: string | null;
-            tags?: components["schemas"]["TagCollection"] | null;
-            /**
-             * Type
-             * @description This is always `collection` for dataset collections.
-             */
-            type?: "collection" | null;
-            /**
-             * Type - ID
-             * @description The type and the encoded ID of this item. Used for caching.
-             */
-            type_id?: string | null;
-            /**
-             * Update Time
-             * @description The last time and date this item was updated.
-             */
-            update_time?: string | null;
-            /**
-             * URL
-             * @deprecated
-             * @description The relative URL to access this item.
-             */
-            url?: string | null;
-            /**
-             * Visible
-             * @description Whether this item is visible or hidden to the user by default.
-             */
-            visible?: boolean | null;
-        };
         /**
          * HDCADetailed
          * @description History Dataset Collection Association detailed information.
@@ -7041,7 +6905,6 @@ export interface components {
             | components["schemas"]["HDACustom"]
             | components["schemas"]["HDADetailed"]
             | components["schemas"]["HDASummary"]
-            | components["schemas"]["HDCACustom"]
             | components["schemas"]["HDCADetailed"]
             | components["schemas"]["HDCASummary"]
         )[];
@@ -7058,7 +6921,6 @@ export interface components {
                 | components["schemas"]["HDACustom"]
                 | components["schemas"]["HDADetailed"]
                 | components["schemas"]["HDASummary"]
-                | components["schemas"]["HDCACustom"]
                 | components["schemas"]["HDCADetailed"]
                 | components["schemas"]["HDCASummary"]
             )[];
@@ -13649,7 +13511,6 @@ export interface operations {
                         | components["schemas"]["HDACustom"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
-                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
                     )[];
@@ -16580,14 +16441,12 @@ export interface operations {
                         | components["schemas"]["HDACustom"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
-                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
                         | (
                               | components["schemas"]["HDACustom"]
                               | components["schemas"]["HDADetailed"]
                               | components["schemas"]["HDASummary"]
-                              | components["schemas"]["HDCACustom"]
                               | components["schemas"]["HDCADetailed"]
                               | components["schemas"]["HDCASummary"]
                           )[];
@@ -17171,7 +17030,6 @@ export interface operations {
                         | components["schemas"]["HDACustom"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
-                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"];
                 };
@@ -17223,7 +17081,6 @@ export interface operations {
                         | components["schemas"]["HDACustom"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
-                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"];
                 };
@@ -17456,14 +17313,12 @@ export interface operations {
                         | components["schemas"]["HDACustom"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
-                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
                         | (
                               | components["schemas"]["HDACustom"]
                               | components["schemas"]["HDADetailed"]
                               | components["schemas"]["HDASummary"]
-                              | components["schemas"]["HDCACustom"]
                               | components["schemas"]["HDCADetailed"]
                               | components["schemas"]["HDCASummary"]
                           )[];
@@ -17514,7 +17369,6 @@ export interface operations {
                         | components["schemas"]["HDACustom"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
-                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"];
                 };
@@ -17565,7 +17419,6 @@ export interface operations {
                         | components["schemas"]["HDACustom"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
-                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"];
                 };
@@ -17797,7 +17650,6 @@ export interface operations {
                         | components["schemas"]["HDACustom"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
-                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
                     )[];

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -3652,6 +3652,11 @@ export interface components {
              */
             download_url?: string | null;
             /**
+             * DRS ID
+             * @description The DRS ID of the dataset.
+             */
+            drs_id?: string | null;
+            /**
              * Extension
              * @description The extension of the dataset.
              */
@@ -5933,6 +5938,11 @@ export interface components {
              * @description The URL to download this item from the server.
              */
             download_url: string;
+            /**
+             * DRS ID
+             * @description The DRS ID of the dataset.
+             */
+            drs_id: string;
             /**
              * Extension
              * @description The extension of the dataset.

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -3677,6 +3677,11 @@ export interface components {
              */
             genome_build?: string | null;
             /**
+             * Hashes
+             * @description The list of hashes associated with this dataset.
+             */
+            hashes?: components["schemas"]["DatasetHash"][] | null;
+            /**
              * HDA or LDDA
              * @description Whether this dataset belongs to a history (HDA) or a library (LDDA).
              */
@@ -4318,6 +4323,36 @@ export interface components {
          * @description A list of extra files associated with a dataset.
          */
         DatasetExtraFiles: components["schemas"]["ExtraFileEntry"][];
+        /** DatasetHash */
+        DatasetHash: {
+            /**
+             * Extra Files Path
+             * @description The path to the extra files used to generate the hash.
+             */
+            extra_files_path?: string | null;
+            /**
+             * Hash Function
+             * @description The hash function used to generate the hash.
+             */
+            hash_function: components["schemas"]["HashFunctionNames"];
+            /**
+             * Hash Value
+             * @description The hash value.
+             */
+            hash_value: string;
+            /**
+             * ID
+             * @description Encoded ID of the dataset hash.
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /**
+             * Model class
+             * @description The name of the database model class.
+             * @constant
+             */
+            model_class: "DatasetHash";
+        };
         /**
          * DatasetInheritanceChain
          * @default []
@@ -5925,6 +5960,11 @@ export interface components {
              */
             genome_build?: string | null;
             /**
+             * Hashes
+             * @description The list of hashes associated with this dataset.
+             */
+            hashes: components["schemas"]["DatasetHash"][];
+            /**
              * HDA or LDDA
              * @description Whether this dataset belongs to a history (HDA) or a library (LDDA).
              * @default hda
@@ -6571,6 +6611,12 @@ export interface components {
          * @enum {string}
          */
         HashFunctionNameEnum: "MD5" | "SHA-1" | "SHA-256" | "SHA-512";
+        /**
+         * HashFunctionNames
+         * @description Hash function names that can be used to generate checksums for datasets.
+         * @enum {string}
+         */
+        HashFunctionNames: "MD5" | "SHA-1" | "SHA-256" | "SHA-512";
         /** HdaDestination */
         HdaDestination: {
             /**

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6968,12 +6968,12 @@ export interface components {
          * Can contain different views and kinds of items.
          */
         HistoryContentsResult: (
+            | components["schemas"]["CustomHistoryHDA"]
+            | components["schemas"]["CustomHistoryHDCA"]
             | components["schemas"]["HDADetailed"]
             | components["schemas"]["HDASummary"]
             | components["schemas"]["HDCADetailed"]
             | components["schemas"]["HDCASummary"]
-            | components["schemas"]["CustomHistoryHDA"]
-            | components["schemas"]["CustomHistoryHDCA"]
         )[];
         /**
          * HistoryContentsWithStatsResult
@@ -6985,12 +6985,12 @@ export interface components {
              * @description The items matching the search query. Only the items fitting in the current page limit will be returned.
              */
             contents: (
+                | components["schemas"]["CustomHistoryHDA"]
+                | components["schemas"]["CustomHistoryHDCA"]
                 | components["schemas"]["HDADetailed"]
                 | components["schemas"]["HDASummary"]
                 | components["schemas"]["HDCADetailed"]
                 | components["schemas"]["HDCASummary"]
-                | components["schemas"]["CustomHistoryHDA"]
-                | components["schemas"]["CustomHistoryHDCA"]
             )[];
             /**
              * Stats
@@ -13577,12 +13577,12 @@ export interface operations {
             200: {
                 content: {
                     "application/json": (
+                        | components["schemas"]["CustomHistoryHDA"]
+                        | components["schemas"]["CustomHistoryHDCA"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
-                        | components["schemas"]["CustomHistoryHDA"]
-                        | components["schemas"]["CustomHistoryHDCA"]
                     )[];
                 };
             };
@@ -16505,19 +16505,19 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
+                        | components["schemas"]["CustomHistoryHDA"]
+                        | components["schemas"]["CustomHistoryHDCA"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
-                        | components["schemas"]["CustomHistoryHDA"]
-                        | components["schemas"]["CustomHistoryHDCA"]
                         | (
+                              | components["schemas"]["CustomHistoryHDA"]
+                              | components["schemas"]["CustomHistoryHDCA"]
                               | components["schemas"]["HDADetailed"]
                               | components["schemas"]["HDASummary"]
                               | components["schemas"]["HDCADetailed"]
                               | components["schemas"]["HDCASummary"]
-                              | components["schemas"]["CustomHistoryHDA"]
-                              | components["schemas"]["CustomHistoryHDCA"]
                           )[];
                 };
             };
@@ -17096,12 +17096,12 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
+                        | components["schemas"]["CustomHistoryHDA"]
+                        | components["schemas"]["CustomHistoryHDCA"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDCADetailed"]
-                        | components["schemas"]["HDCASummary"]
-                        | components["schemas"]["CustomHistoryHDA"]
-                        | components["schemas"]["CustomHistoryHDCA"];
+                        | components["schemas"]["HDCASummary"];
                 };
             };
             /** @description Validation Error */
@@ -17148,12 +17148,12 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
+                        | components["schemas"]["CustomHistoryHDA"]
+                        | components["schemas"]["CustomHistoryHDCA"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDCADetailed"]
-                        | components["schemas"]["HDCASummary"]
-                        | components["schemas"]["CustomHistoryHDA"]
-                        | components["schemas"]["CustomHistoryHDCA"];
+                        | components["schemas"]["HDCASummary"];
                 };
             };
             /** @description Validation Error */
@@ -17381,19 +17381,19 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
+                        | components["schemas"]["CustomHistoryHDA"]
+                        | components["schemas"]["CustomHistoryHDCA"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
-                        | components["schemas"]["CustomHistoryHDA"]
-                        | components["schemas"]["CustomHistoryHDCA"]
                         | (
+                              | components["schemas"]["CustomHistoryHDA"]
+                              | components["schemas"]["CustomHistoryHDCA"]
                               | components["schemas"]["HDADetailed"]
                               | components["schemas"]["HDASummary"]
                               | components["schemas"]["HDCADetailed"]
                               | components["schemas"]["HDCASummary"]
-                              | components["schemas"]["CustomHistoryHDA"]
-                              | components["schemas"]["CustomHistoryHDCA"]
                           )[];
                 };
             };
@@ -17439,12 +17439,12 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
+                        | components["schemas"]["CustomHistoryHDA"]
+                        | components["schemas"]["CustomHistoryHDCA"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDCADetailed"]
-                        | components["schemas"]["HDCASummary"]
-                        | components["schemas"]["CustomHistoryHDA"]
-                        | components["schemas"]["CustomHistoryHDCA"];
+                        | components["schemas"]["HDCASummary"];
                 };
             };
             /** @description Validation Error */
@@ -17490,12 +17490,12 @@ export interface operations {
             200: {
                 content: {
                     "application/json":
+                        | components["schemas"]["CustomHistoryHDA"]
+                        | components["schemas"]["CustomHistoryHDCA"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDCADetailed"]
-                        | components["schemas"]["HDCASummary"]
-                        | components["schemas"]["CustomHistoryHDA"]
-                        | components["schemas"]["CustomHistoryHDCA"];
+                        | components["schemas"]["HDCASummary"];
                 };
             };
             /** @description Validation Error */
@@ -17722,12 +17722,12 @@ export interface operations {
             200: {
                 content: {
                     "application/json": (
+                        | components["schemas"]["CustomHistoryHDA"]
+                        | components["schemas"]["CustomHistoryHDCA"]
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
-                        | components["schemas"]["CustomHistoryHDA"]
-                        | components["schemas"]["CustomHistoryHDCA"]
                     )[];
                 };
             };

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -3585,15 +3585,373 @@ export interface components {
              */
             installed_builds: components["schemas"]["LabelValuePair"][];
         };
-        /**
-         * CustomHistoryItem
-         * @description Can contain any serializable property of the item.
-         *
-         * Allows arbitrary custom keys to be specified in the serialization
-         * parameters without a particular view (predefined set of keys).
-         */
-        CustomHistoryItem: {
-            [key: string]: unknown | undefined;
+        /** CustomHistoryHDA */
+        CustomHistoryHDA: {
+            /**
+             * Accessible
+             * @description Whether this item is accessible to the current user due to permissions.
+             */
+            accessible?: boolean | null;
+            /**
+             * Annotation
+             * @description An annotation to provide details or to help understand the purpose and usage of this item.
+             */
+            annotation?: string | null;
+            /**
+             * API Type
+             * @deprecated
+             * @description TODO
+             */
+            api_type?: "file" | null;
+            /** Copied From Ldda Id */
+            copied_from_ldda_id?: string | null;
+            /**
+             * Create Time
+             * @description The time and date this item was created.
+             */
+            create_time?: string | null;
+            /**
+             * Created from basename
+             * @description The basename of the output that produced this dataset.
+             */
+            created_from_basename?: string | null;
+            /**
+             * Creating Job ID
+             * @description The encoded ID of the job that created this dataset.
+             */
+            creating_job?: string | null;
+            /**
+             * Data Type
+             * @description The fully qualified name of the class implementing the data type of this dataset.
+             */
+            data_type?: string | null;
+            /**
+             * Dataset ID
+             * @description The encoded ID of the dataset associated with this item.
+             * @example 0123456789ABCDEF
+             */
+            dataset_id?: string;
+            /**
+             * Deleted
+             * @description Whether this item is marked as deleted.
+             */
+            deleted?: boolean | null;
+            /**
+             * Display Applications
+             * @description Contains new-style display app urls.
+             */
+            display_apps?: components["schemas"]["DisplayApp"][] | null;
+            /**
+             * Legacy Display Applications
+             * @description Contains old-style display app urls.
+             */
+            display_types?: components["schemas"]["DisplayApp"][] | null;
+            /**
+             * Download URL
+             * @description The URL to download this item from the server.
+             */
+            download_url?: string | null;
+            /**
+             * Extension
+             * @description The extension of the dataset.
+             */
+            extension?: string | null;
+            /**
+             * File extension
+             * @description The extension of the file.
+             */
+            file_ext?: string | null;
+            /**
+             * File Name
+             * @description The full path to the dataset file.
+             */
+            file_name?: string | null;
+            /**
+             * File Size
+             * @description The file size in bytes.
+             */
+            file_size?: number | null;
+            /**
+             * Genome Build
+             * @description TODO
+             */
+            genome_build?: string | null;
+            /**
+             * HDA or LDDA
+             * @description Whether this dataset belongs to a history (HDA) or a library (LDDA).
+             */
+            hda_ldda?: components["schemas"]["DatasetSourceType"] | null;
+            /**
+             * HID
+             * @description The index position of this item in the History.
+             */
+            hid?: number | null;
+            /**
+             * History Content Type
+             * @description This is always `dataset` for datasets.
+             */
+            history_content_type?: "dataset" | null;
+            /**
+             * History ID
+             * @example 0123456789ABCDEF
+             */
+            history_id?: string;
+            /**
+             * Id
+             * @example 0123456789ABCDEF
+             */
+            id?: string;
+            /**
+             * Metadata Files
+             * @description Collection of metadata files associated with this dataset.
+             */
+            meta_files?: components["schemas"]["MetadataFile"][] | null;
+            /**
+             * Metadata
+             * @description The metadata associated with this dataset.
+             */
+            metadata?: Record<string, never> | null;
+            /**
+             * Metadata Data Lines
+             * @description TODO
+             */
+            metadata_data_lines?: number | null;
+            /**
+             * Metadata DBKey
+             * @description TODO
+             */
+            metadata_dbkey?: string | null;
+            /**
+             * Miscellaneous Blurb
+             * @description TODO
+             */
+            misc_blurb?: string | null;
+            /**
+             * Miscellaneous Information
+             * @description TODO
+             */
+            misc_info?: string | null;
+            /**
+             * Model class
+             * @description The name of the database model class.
+             * @constant
+             */
+            model_class?: "HistoryDatasetAssociation";
+            /**
+             * Name
+             * @description The name of the item.
+             */
+            name?: string | null;
+            /**
+             * Peek
+             * @description A few lines of contents from the start of the file.
+             */
+            peek?: string | null;
+            /**
+             * Permissions
+             * @description Role-based access and manage control permissions for the dataset.
+             */
+            permissions?: components["schemas"]["DatasetPermissions"] | null;
+            /**
+             * Purged
+             * @description Whether this dataset has been removed from disk.
+             */
+            purged?: boolean | null;
+            /**
+             * Rerunnable
+             * @description Whether the job creating this dataset can be run again.
+             */
+            rerunnable?: boolean | null;
+            /**
+             * Resubmitted
+             * @description Whether the job creating this dataset has been resubmitted.
+             */
+            resubmitted?: boolean | null;
+            /**
+             * State
+             * @description The current state of this dataset.
+             */
+            state?: components["schemas"]["DatasetState"] | null;
+            tags?: components["schemas"]["TagCollection"] | null;
+            /**
+             * Type
+             * @description This is always `file` for datasets.
+             */
+            type?: "file" | null;
+            /**
+             * Type - ID
+             * @description The type and the encoded ID of this item. Used for caching.
+             */
+            type_id?: string | null;
+            /**
+             * Update Time
+             * @description The last time and date this item was updated.
+             */
+            update_time?: string | null;
+            /**
+             * URL
+             * @deprecated
+             * @description The relative URL to access this item.
+             */
+            url?: string | null;
+            /** Uuid */
+            uuid?: string | null;
+            /**
+             * Validated State
+             * @description The state of the datatype validation for this dataset.
+             */
+            validated_state?: components["schemas"]["DatasetValidatedState"] | null;
+            /**
+             * Validated State Message
+             * @description The message with details about the datatype validation result for this dataset.
+             */
+            validated_state_message?: string | null;
+            /**
+             * Visible
+             * @description Whether this item is visible or hidden to the user by default.
+             */
+            visible?: boolean | null;
+            /**
+             * Visualizations
+             * @description The collection of visualizations that can be applied to this dataset.
+             */
+            visualizations?: components["schemas"]["Visualization"][] | null;
+        };
+        /** CustomHistoryHDCA */
+        CustomHistoryHDCA: {
+            /**
+             * Dataset Collection ID
+             * @example 0123456789ABCDEF
+             */
+            collection_id?: string;
+            /**
+             * Collection Type
+             * @description The type of the collection, can be `list`, `paired`, or define subcollections using `:` as separator like `list:paired` or `list:list`.
+             */
+            collection_type?: string | null;
+            /**
+             * Contents URL
+             * @description The relative URL to access the contents of this History.
+             */
+            contents_url?: string | null;
+            /**
+             * Create Time
+             * @description The time and date this item was created.
+             */
+            create_time?: string | null;
+            /**
+             * Deleted
+             * @description Whether this item is marked as deleted.
+             */
+            deleted?: boolean | null;
+            /**
+             * Element Count
+             * @description The number of elements contained in the dataset collection. It may be None or undefined if the collection could not be populated.
+             */
+            element_count?: number | null;
+            /**
+             * Elements
+             * @description The summary information of each of the elements inside the dataset collection.
+             */
+            elements?: components["schemas"]["DCESummary"][] | null;
+            /**
+             * Elements Datatypes
+             * @description A set containing all the different element datatypes in the collection.
+             */
+            elements_datatypes?: string[] | null;
+            /**
+             * HID
+             * @description The index position of this item in the History.
+             */
+            hid?: number | null;
+            /**
+             * History Content Type
+             * @description This is always `dataset_collection` for dataset collections.
+             */
+            history_content_type?: "dataset_collection" | null;
+            /**
+             * History ID
+             * @example 0123456789ABCDEF
+             */
+            history_id?: string;
+            /**
+             * Id
+             * @example 0123456789ABCDEF
+             */
+            id?: string;
+            /**
+             * Implicit Collection Jobs Id
+             * @description Encoded ID for the ICJ object describing the collection of jobs corresponding to this collection
+             */
+            implicit_collection_jobs_id?: string | null;
+            /**
+             * Job Source ID
+             * @description The encoded ID of the Job that produced this dataset collection. Used to track the state of the job.
+             */
+            job_source_id?: string | null;
+            /**
+             * Job Source Type
+             * @description The type of job (model class) that produced this dataset collection. Used to track the state of the job.
+             */
+            job_source_type?: components["schemas"]["JobSourceType"] | null;
+            /**
+             * Job State Summary
+             * @description Overview of the job states working inside the dataset collection.
+             */
+            job_state_summary?: components["schemas"]["HDCJobStateSummary"] | null;
+            /**
+             * Model class
+             * @description The name of the database model class.
+             * @constant
+             */
+            model_class?: "HistoryDatasetCollectionAssociation";
+            /**
+             * Name
+             * @description The name of the item.
+             */
+            name?: string | null;
+            /**
+             * Populated
+             * @description Whether the dataset collection elements (and any subcollections elements) were successfully populated.
+             */
+            populated?: boolean | null;
+            /**
+             * Populated State
+             * @description Indicates the general state of the elements in the dataset collection:- 'new': new dataset collection, unpopulated elements.- 'ok': collection elements populated (HDAs may or may not have errors).- 'failed': some problem populating, won't be populated.
+             */
+            populated_state?: components["schemas"]["DatasetCollectionPopulatedState"] | null;
+            /**
+             * Populated State Message
+             * @description Optional message with further information in case the population of the dataset collection failed.
+             */
+            populated_state_message?: string | null;
+            tags?: components["schemas"]["TagCollection"] | null;
+            /**
+             * Type
+             * @description This is always `collection` for dataset collections.
+             */
+            type?: "collection" | null;
+            /**
+             * Type - ID
+             * @description The type and the encoded ID of this item. Used for caching.
+             */
+            type_id?: string | null;
+            /**
+             * Update Time
+             * @description The last time and date this item was updated.
+             */
+            update_time?: string | null;
+            /**
+             * URL
+             * @deprecated
+             * @description The relative URL to access this item.
+             */
+            url?: string | null;
+            /**
+             * Visible
+             * @description Whether this item is visible or hidden to the user by default.
+             */
+            visible?: boolean | null;
         };
         /** CustomHistoryView */
         CustomHistoryView: {
@@ -4377,7 +4735,6 @@ export interface components {
              * @description True if the item was successfully removed from disk.
              */
             purged?: boolean | null;
-            [key: string]: unknown | undefined;
         };
         /** DeleteHistoryPayload */
         DeleteHistoryPayload: {
@@ -5717,7 +6074,6 @@ export interface components {
              * @description The collection of visualizations that can be applied to this dataset.
              */
             visualizations: components["schemas"]["Visualization"][];
-            [key: string]: unknown | undefined;
         };
         /**
          * HDAObject
@@ -5848,7 +6204,6 @@ export interface components {
              * @description Whether this item is visible or hidden to the user by default.
              */
             visible: boolean;
-            [key: string]: unknown | undefined;
         };
         /**
          * HDCADetailed
@@ -5992,7 +6347,6 @@ export interface components {
              * @description Whether this item is visible or hidden to the user by default.
              */
             visible: boolean;
-            [key: string]: unknown | undefined;
         };
         /**
          * HDCASummary
@@ -6115,7 +6469,6 @@ export interface components {
              * @description Whether this item is visible or hidden to the user by default.
              */
             visible: boolean;
-            [key: string]: unknown | undefined;
         };
         /**
          * HDCJobStateSummary
@@ -6619,7 +6972,8 @@ export interface components {
             | components["schemas"]["HDASummary"]
             | components["schemas"]["HDCADetailed"]
             | components["schemas"]["HDCASummary"]
-            | components["schemas"]["CustomHistoryItem"]
+            | components["schemas"]["CustomHistoryHDA"]
+            | components["schemas"]["CustomHistoryHDCA"]
         )[];
         /**
          * HistoryContentsWithStatsResult
@@ -6635,7 +6989,8 @@ export interface components {
                 | components["schemas"]["HDASummary"]
                 | components["schemas"]["HDCADetailed"]
                 | components["schemas"]["HDCASummary"]
-                | components["schemas"]["CustomHistoryItem"]
+                | components["schemas"]["CustomHistoryHDA"]
+                | components["schemas"]["CustomHistoryHDCA"]
             )[];
             /**
              * Stats
@@ -13226,7 +13581,8 @@ export interface operations {
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
-                        | components["schemas"]["CustomHistoryItem"]
+                        | components["schemas"]["CustomHistoryHDA"]
+                        | components["schemas"]["CustomHistoryHDCA"]
                     )[];
                 };
             };
@@ -16153,13 +16509,15 @@ export interface operations {
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
-                        | components["schemas"]["CustomHistoryItem"]
+                        | components["schemas"]["CustomHistoryHDA"]
+                        | components["schemas"]["CustomHistoryHDCA"]
                         | (
                               | components["schemas"]["HDADetailed"]
                               | components["schemas"]["HDASummary"]
                               | components["schemas"]["HDCADetailed"]
                               | components["schemas"]["HDCASummary"]
-                              | components["schemas"]["CustomHistoryItem"]
+                              | components["schemas"]["CustomHistoryHDA"]
+                              | components["schemas"]["CustomHistoryHDCA"]
                           )[];
                 };
             };
@@ -16742,7 +17100,8 @@ export interface operations {
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
-                        | components["schemas"]["CustomHistoryItem"];
+                        | components["schemas"]["CustomHistoryHDA"]
+                        | components["schemas"]["CustomHistoryHDCA"];
                 };
             };
             /** @description Validation Error */
@@ -16793,7 +17152,8 @@ export interface operations {
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
-                        | components["schemas"]["CustomHistoryItem"];
+                        | components["schemas"]["CustomHistoryHDA"]
+                        | components["schemas"]["CustomHistoryHDCA"];
                 };
             };
             /** @description Validation Error */
@@ -17025,13 +17385,15 @@ export interface operations {
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
-                        | components["schemas"]["CustomHistoryItem"]
+                        | components["schemas"]["CustomHistoryHDA"]
+                        | components["schemas"]["CustomHistoryHDCA"]
                         | (
                               | components["schemas"]["HDADetailed"]
                               | components["schemas"]["HDASummary"]
                               | components["schemas"]["HDCADetailed"]
                               | components["schemas"]["HDCASummary"]
-                              | components["schemas"]["CustomHistoryItem"]
+                              | components["schemas"]["CustomHistoryHDA"]
+                              | components["schemas"]["CustomHistoryHDCA"]
                           )[];
                 };
             };
@@ -17081,7 +17443,8 @@ export interface operations {
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
-                        | components["schemas"]["CustomHistoryItem"];
+                        | components["schemas"]["CustomHistoryHDA"]
+                        | components["schemas"]["CustomHistoryHDCA"];
                 };
             };
             /** @description Validation Error */
@@ -17131,7 +17494,8 @@ export interface operations {
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
-                        | components["schemas"]["CustomHistoryItem"];
+                        | components["schemas"]["CustomHistoryHDA"]
+                        | components["schemas"]["CustomHistoryHDCA"];
                 };
             };
             /** @description Validation Error */
@@ -17362,7 +17726,8 @@ export interface operations {
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
-                        | components["schemas"]["CustomHistoryItem"]
+                        | components["schemas"]["CustomHistoryHDA"]
+                        | components["schemas"]["CustomHistoryHDCA"]
                     )[];
                 };
             };

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -498,7 +498,6 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
                 # TODO: accessible needs to go away
                 "accessible",
                 # remapped
-                "genome_build",
                 "misc_info",
                 "misc_blurb",
                 "file_ext",

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -272,7 +272,6 @@ class HDCASerializer(DCASerializer, taggable.TaggableSerializerMixin, annotatabl
                 "job_source_type",
                 "job_state_summary",
                 "name",
-                "type_id",
                 "deleted",
                 "visible",
                 "type",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -629,8 +629,6 @@ class HistoryItemBase(Model):
 class HistoryItemCommon(HistoryItemBase):
     """Common information provided by items contained in a History."""
 
-    model_config = ConfigDict(extra="allow")
-
     type_id: Optional[str] = Field(
         default=None,
         title="Type - ID",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -573,11 +573,7 @@ class Hyperlink(Model):
     target: str = Field(
         ..., title="Target", description="Specifies where to open the linked document.", examples=["_blank"]
     )
-    href: AnyUrl = Field(
-        ...,
-        title="HRef",
-        description="Specifies the linked document, resource, or location.",
-    )
+    href: Annotated[RelativeUrl, Field(..., title="Href", description="The URL of the linked document.")]
     text: str = Field(
         ...,
         title="Text",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3266,6 +3266,10 @@ class HDACustom(HDADetailed):
         ),
     ]
 
+    # We need to allow extra fields so we can have the metadata_* fields serialized.
+    # TODO: try to find a better way to handle this.
+    model_config = ConfigDict(extra="allow")
+
 
 @partial_model()
 class HDCACustom(HDCADetailed):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3195,6 +3195,12 @@ class CustomHistoryHDA(HDADetailed):
     parameters without a particular view (predefined set of keys).
     """
 
+    # TODO: Fix this workaround for partial_model not supporting UUID fields for some reason.
+    # The error otherwise is: `PydanticUserError: 'UuidVersion' cannot annotate 'nullable'.`
+    # Also ignoring mypy complaints about the type redefinition.
+    uuid: Optional[UUID4]  # type: ignore
+
+
 @partial_model()
 class CustomHistoryHDCA(HDCADetailed):
     """Can contain any serializable property of an HDCA.

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -729,6 +729,26 @@ class DatasetHash(Model):
     )
 
 
+class DatasetSource(Model):
+    id: EncodedDatabaseIdField = Field(
+        ...,
+        title="ID",
+        description="Encoded ID of the dataset source.",
+    )
+    source_uri: Annotated[RelativeUrl, Field(..., title="Source URI", description="The URI of the dataset source.")]
+    extra_files_path: Annotated[
+        Optional[str], Field(None, title="Extra Files Path", description="The path to the extra files.")
+    ]
+    transform: Annotated[
+        Optional[List[Any]],  # TODO: type this
+        Field(
+            None,
+            title="Transform",
+            description="The transformations applied to the dataset source.",
+        ),
+    ]
+
+
 class HDADetailed(HDASummary, WithModelClass):
     """History Dataset Association detailed information."""
 
@@ -877,6 +897,14 @@ class HDADetailed(HDASummary, WithModelClass):
             ...,
             title="DRS ID",
             description="The DRS ID of the dataset.",
+        ),
+    ]
+    sources: Annotated[
+        List[DatasetSource],
+        Field(
+            ...,
+            title="Sources",
+            description="The list of sources associated with this dataset.",
         ),
     ]
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -844,11 +844,6 @@ class HDADetailed(HDASummary, WithModelClass):
         # https://github.com/pydantic/pydantic/issues/2255
         # deprecated=False,  # TODO: Should this field be deprecated in favor of display_apps?
     )
-    visualizations: List[Visualization] = Field(
-        ...,
-        title="Visualizations",
-        description="The collection of visualizations that can be applied to this dataset.",
-    )
     validated_state: DatasetValidatedState = Field(
         ...,
         title="Validated State",
@@ -3270,6 +3265,16 @@ class CustomHistoryHDA(HDADetailed):
     # The error otherwise is: `PydanticUserError: 'UuidVersion' cannot annotate 'nullable'.`
     # Also ignoring mypy complaints about the type redefinition.
     uuid: Optional[UUID4]  # type: ignore
+
+    # Add fields that are not part of any view here
+    visualizations: Annotated[
+        Optional[List[Visualization]],
+        Field(
+            None,
+            title="Visualizations",
+            description="The collection of visualizations that can be applied to this dataset.",
+        ),
+    ]
 
 
 @partial_model()

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3254,7 +3254,7 @@ class UpdateDatasetPermissionsPayload(Model):
 
 
 @partial_model()
-class CustomHistoryHDA(HDADetailed):
+class HDACustom(HDADetailed):
     """Can contain any serializable property of an HDA.
 
     Allows arbitrary custom keys to be specified in the serialization
@@ -3278,7 +3278,7 @@ class CustomHistoryHDA(HDADetailed):
 
 
 @partial_model()
-class CustomHistoryHDCA(HDCADetailed):
+class HDCACustom(HDCADetailed):
     """Can contain any serializable property of an HDCA.
 
     Allows arbitrary custom keys to be specified in the serialization
@@ -3288,13 +3288,10 @@ class CustomHistoryHDCA(HDCADetailed):
     pass
 
 
-AnyCustomHistoryItem = Union[CustomHistoryHDA, CustomHistoryHDCA]
-
-AnyHDA = Union[HDADetailed, HDASummary]
-AnyHDCA = Union[HDCADetailed, HDCASummary]
+AnyHDA = Union[HDACustom, HDADetailed, HDASummary]
+AnyHDCA = Union[HDCACustom, HDCADetailed, HDCASummary]
 AnyHistoryContentItem = Annotated[
     Union[
-        AnyCustomHistoryItem,
         AnyHDA,
         AnyHDCA,
     ],

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3271,19 +3271,8 @@ class HDACustom(HDADetailed):
     model_config = ConfigDict(extra="allow")
 
 
-@partial_model()
-class HDCACustom(HDCADetailed):
-    """Can contain any serializable property of an HDCA.
-
-    Allows arbitrary custom keys to be specified in the serialization
-    parameters without a particular view (predefined set of keys).
-    """
-
-    pass
-
-
 AnyHDA = Union[HDACustom, HDADetailed, HDASummary]
-AnyHDCA = Union[HDCACustom, HDCADetailed, HDCASummary]
+AnyHDCA = Union[HDCADetailed, HDCASummary]
 AnyHistoryContentItem = Annotated[
     Union[
         AnyHDA,

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3187,15 +3187,26 @@ class UpdateDatasetPermissionsPayload(Model):
     )
 
 
-class CustomHistoryItem(Model):
-    """Can contain any serializable property of the item.
+@partial_model()
+class CustomHistoryHDA(HDADetailed):
+    """Can contain any serializable property of an HDA.
 
     Allows arbitrary custom keys to be specified in the serialization
     parameters without a particular view (predefined set of keys).
     """
 
-    model_config = ConfigDict(extra="allow")
+@partial_model()
+class CustomHistoryHDCA(HDCADetailed):
+    """Can contain any serializable property of an HDCA.
 
+    Allows arbitrary custom keys to be specified in the serialization
+    parameters without a particular view (predefined set of keys).
+    """
+
+    pass
+
+
+AnyCustomHistoryItem = Union[CustomHistoryHDA, CustomHistoryHDCA]
 
 AnyHDA = Union[HDADetailed, HDASummary]
 AnyHDCA = Union[HDCADetailed, HDCASummary]
@@ -3203,7 +3214,7 @@ AnyHistoryContentItem = Annotated[
     Union[
         AnyHDA,
         AnyHDCA,
-        CustomHistoryItem,
+        AnyCustomHistoryItem,
     ],
     Field(union_mode="left_to_right"),
 ]
@@ -3240,7 +3251,7 @@ class DeleteHistoryContentPayload(Model):
     )
 
 
-class DeleteHistoryContentResult(CustomHistoryItem):
+class DeleteHistoryContentResult(Model):
     """Contains minimum information about the deletion state of a history item.
 
     Can also contain any other properties of the item."""

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3216,9 +3216,9 @@ AnyHDA = Union[HDADetailed, HDASummary]
 AnyHDCA = Union[HDCADetailed, HDCASummary]
 AnyHistoryContentItem = Annotated[
     Union[
+        AnyCustomHistoryItem,
         AnyHDA,
         AnyHDCA,
-        AnyCustomHistoryItem,
     ],
     Field(union_mode="left_to_right"),
 ]

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -785,16 +785,6 @@ class HDADetailed(HDASummary, WithModelClass):
         title="Metadata",
         description="The metadata associated with this dataset.",
     )
-    metadata_dbkey: Optional[str] = Field(
-        "?",
-        title="Metadata DBKey",
-        description="TODO",
-    )
-    metadata_data_lines: int = Field(
-        0,
-        title="Metadata Data Lines",
-        description="TODO",
-    )
     meta_files: List[MetadataFile] = Field(
         ...,
         title="Metadata Files",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -875,6 +875,14 @@ class HDADetailed(HDASummary, WithModelClass):
             description="The list of hashes associated with this dataset.",
         ),
     ]
+    drs_id: Annotated[
+        str,
+        Field(
+            ...,
+            title="DRS ID",
+            description="The DRS ID of the dataset.",
+        ),
+    ]
 
 
 class HDAExtended(HDADetailed):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -686,6 +686,7 @@ class HDASummary(HDACommon):
         title="Purged",
         description="Whether this dataset has been removed from disk.",
     )
+    genome_build: Optional[str] = GenomeBuildField
 
 
 class HDAInaccessible(HDACommon):
@@ -738,7 +739,6 @@ class HDADetailed(HDASummary, WithModelClass):
     model_class: Annotated[HDA_MODEL_CLASS, ModelClassField(HDA_MODEL_CLASS)]
     hda_ldda: DatasetSourceType = HdaLddaField
     accessible: bool = AccessibleField
-    genome_build: Optional[str] = GenomeBuildField
     misc_info: Optional[str] = Field(
         default=None,
         title="Miscellaneous Information",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -116,6 +116,15 @@ class DatasetCollectionPopulatedState(str, Enum):
     FAILED = "failed"  # some problem populating state, won't be populated
 
 
+class HashFunctionNames(str, Enum):
+    """Hash function names that can be used to generate checksums for datasets."""
+
+    md5 = "MD5"
+    sha1 = "SHA-1"
+    sha256 = "SHA-256"
+    sha512 = "SHA-512"
+
+
 # Generic and common Field annotations that can be reused across models
 
 RelativeUrlField = Annotated[
@@ -699,6 +708,30 @@ class DatasetValidatedState(str, Enum):
     OK = "ok"
 
 
+class DatasetHash(Model):
+    model_class: Literal["DatasetHash"] = ModelClassField(Literal["DatasetHash"])
+    id: EncodedDatabaseIdField = Field(
+        ...,
+        title="ID",
+        description="Encoded ID of the dataset hash.",
+    )
+    hash_function: HashFunctionNames = Field(
+        ...,
+        title="Hash Function",
+        description="The hash function used to generate the hash.",
+    )
+    hash_value: str = Field(
+        ...,
+        title="Hash Value",
+        description="The hash value.",
+    )
+    extra_files_path: Optional[str] = Field(
+        None,
+        title="Extra Files Path",
+        description="The path to the extra files used to generate the hash.",
+    )
+
+
 class HDADetailed(HDASummary, WithModelClass):
     """History Dataset Association detailed information."""
 
@@ -834,6 +867,14 @@ class HDADetailed(HDASummary, WithModelClass):
         title="Created from basename",
         description="The basename of the output that produced this dataset.",  # TODO: is that correct?
     )
+    hashes: Annotated[
+        List[DatasetHash],
+        Field(
+            ...,
+            title="Hashes",
+            description="The list of hashes associated with this dataset.",
+        ),
+    ]
 
 
 class HDAExtended(HDADetailed):

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -141,6 +141,7 @@ class FastAPIDatasets:
     @router.get(
         "/api/datasets",
         summary="Search datasets or collections using a query system.",
+        response_model_exclude_unset=True,
     )
     def index(
         self,

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -496,6 +496,7 @@ class FastAPIHistoryContents:
         name="history_content_typed",
         summary="Return detailed information about a specific HDA or HDCA with the given `ID` within a history.",
         operation_id="history_contents__show",
+        response_model_exclude_unset=True,
     )
     def show(
         self,
@@ -525,6 +526,7 @@ class FastAPIHistoryContents:
         summary="Return detailed information about an HDA within a history. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.",
         deprecated=True,
         operation_id="history_contents__show_legacy",
+        response_model_exclude_unset=True,
     )
     def show_legacy(
         self,
@@ -674,6 +676,7 @@ class FastAPIHistoryContents:
         "/api/histories/{history_id}/contents/{type}s",
         summary="Create a new `HDA` or `HDCA` in the given History.",
         operation_id="history_contents__create_typed",
+        response_model_exclude_unset=True,
     )
     def create_typed(
         self,
@@ -691,6 +694,7 @@ class FastAPIHistoryContents:
         summary="Create a new `HDA` or `HDCA` in the given History.",
         deprecated=True,
         operation_id="history_contents__create",
+        response_model_exclude_unset=True,
     )
     def create(
         self,
@@ -787,6 +791,7 @@ class FastAPIHistoryContents:
         "/api/histories/{history_id}/contents/{type}s/{id}",
         summary="Updates the values for the history content item with the given ``ID`` and path specified type.",
         operation_id="history_contents__update_typed",
+        response_model_exclude_unset=True,
     )
     def update_typed(
         self,
@@ -807,6 +812,7 @@ class FastAPIHistoryContents:
         summary="Updates the values for the history content item with the given ``ID`` and query specified type. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.",
         deprecated=True,
         operation_id="history_contents__update_legacy",
+        response_model_exclude_unset=True,
     )
     def update_legacy(
         self,
@@ -970,7 +976,11 @@ class FastAPIHistoryContents:
             return archive
         return StreamingResponse(archive.response(), headers=archive.get_headers())
 
-    @router.post("/api/histories/{history_id}/contents_from_store", summary="Create contents from store.")
+    @router.post(
+        "/api/histories/{history_id}/contents_from_store",
+        summary="Create contents from store.",
+        response_model_exclude_unset=True,
+    )
     def create_from_store(
         self,
         history_id: HistoryIDPathParam,

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -384,6 +384,7 @@ class FastAPIHistoryContents:
         "/api/histories/{history_id}/contents/{type}s",
         summary="Returns the contents of the given history filtered by type.",
         operation_id="history_contents__index_typed",
+        response_model_exclude_unset=True,
     )
     def index_typed(
         self,
@@ -438,6 +439,7 @@ class FastAPIHistoryContents:
             },
         },
         operation_id="history_contents__index",
+        response_model_exclude_unset=True,
     )
     def index(
         self,
@@ -741,6 +743,7 @@ class FastAPIHistoryContents:
     @router.put(
         "/api/histories/{history_id}/contents",
         summary="Batch update specific properties of a set items contained in the given History.",
+        response_model_exclude_unset=True,
     )
     def update_batch(
         self,

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -265,10 +265,13 @@ class TestHistoryContentsApi(ApiTestCase):
 
         # Expect only specific keys to be returned.
         view = None
-        keys = detailed_view_only_keys
+        keys = detailed_view_only_keys + ["id"]
         item = self._get_history_item_with_custom_serialization(history_id, hda_id, item_type, view, keys)
         self._assert_has_keys(item, *keys)
         assert len(item) == len(keys)
+        # Make sure the id is encoded in the response.
+        assert isinstance(item["id"], str)
+        assert item["id"] == hda_id
 
         # Expect combined view and keys to be returned.
         view = "summary"


### PR DESCRIPTION
Requires #17779
Fixes #17729 since the custom keys will be serialized correctly after this.

This is similar to #17779 but this time addressing history contents.

## TODO
- [x] Add potential missing fields to models
- [x] Increase test coverage for the use of `view` and `keys` query parameters for HDAs and HDCAs.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
