### PR TITLE
[24.0] Improved error messages for runtime sharing problems.

### DIFF
--- a/client/src/components/History/Content/Dataset/DatasetDetails.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDetails.vue
@@ -8,6 +8,7 @@ import { useDatasetStore } from "@/stores/datasetStore";
 import { type ItemUrls } from ".";
 
 import DatasetActions from "./DatasetActions.vue";
+import DatasetMiscInfo from "./DatasetMiscInfo.vue";
 
 const datasetStore = useDatasetStore();
 
@@ -56,9 +57,7 @@ function toggleHighlights() {
                             result.genome_build
                         }}</BLink>
                     </span>
-                    <div v-if="result.misc_info" class="info">
-                        <span class="value">{{ result.misc_info }}</span>
-                    </div>
+                    <DatasetMiscInfo v-if="result.misc_info" :misc-info="result.misc_info" />
                 </div>
                 <DatasetActions
                     :item="result"

--- a/client/src/components/History/Content/Dataset/DatasetMiscInfo.vue
+++ b/client/src/components/History/Content/Dataset/DatasetMiscInfo.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+
+interface Props {
+    miscInfo: string;
+}
+
+const showErrorHelp = ref(false);
+const sharingError = ref(false);
+
+// old sharable error: Attempted to create shared output datasets in objectstore with sharing disabled
+// new sharable error: Job attempted to create sharable output datasets in a storage location with sharing disabled
+const sharingErrorRex: RegExp = /with sharing disabled/g;
+const knownErrors = [{ regex: sharingErrorRex, modalRef: sharingError }];
+
+const props = defineProps<Props>();
+
+const fixable = computed(() => {
+    return true;
+});
+
+watch(
+    props,
+    () => {
+        for (const knownError of knownErrors) {
+            const regex = knownError.regex;
+            if (props.miscInfo.match(regex)) {
+                knownError.modalRef.value = true;
+            }
+        }
+    },
+    { immediate: true }
+);
+
+function showHelp() {
+    showErrorHelp.value = true;
+}
+</script>
+
+<template>
+    <div class="info">
+        <b-modal v-if="sharingError" v-model="showErrorHelp" title="Dataset Sharing Misconfigured" ok-only>
+            <p>
+                This error message indicates that your history is setup to allow sharing but your job was run in a
+                configuration to target a storage location that explicitly disables sharing.
+            </p>
+            <p>
+                To fix this configure your history so that new datasets are private or target a different storage
+                location.
+            </p>
+            <p>
+                To re-configure your history, click the history menu and go to the "Set Permissions" option in the
+                dropdown. This should result in a toggle that allows you to configure the history so that new datasets
+                are created as private datasets.
+            </p>
+            <p>
+                There are many ways to instead target different storage for your job. This can be selected in the tool
+                or workflow form right before you execute your job or a different default for your history or user can
+                be chosen that allows for sharing.
+            </p>
+        </b-modal>
+        <span class="value">{{ miscInfo }} <a v-if="fixable" href="#" @click="showHelp">How do I fix this?</a></span>
+    </div>
+</template>

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -203,9 +203,10 @@ class BaseJobRunner:
             queue_job = job_wrapper.enqueue()
         except Exception as e:
             queue_job = False
-            # Required for exceptions thrown by object store incompatiblity.
+            # Required for exceptions thrown by object store incompatibility.
             # tested by test/integration/objectstore/test_private_handling.py
-            job_wrapper.fail(str(e), exception=e)
+            message = e.client_message if hasattr(e, "client_message") else str(e)
+            job_wrapper.fail(message, exception=e)
             log.debug(f"Job [{job_wrapper.job_id}] failed to queue {put_timer}")
             return
         if queue_job:

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -1609,6 +1609,22 @@ class QuotaSourceMap:
         return quota_sources
 
 
+class ObjectCreationProblem(Exception):
+    pass
+
+
+# Calling these client_message to make it clear they should use the language of the
+# Galaxy UI/UX - for instance "storage location" not "objectstore".
+class ObjectCreationProblemSharingDisabled(ObjectCreationProblem):
+    client_message = "Job attempted to create sharable output datasets in a storage location with sharing disabled"
+
+
+class ObjectCreationProblemStoreFull(ObjectCreationProblem):
+    client_message = (
+        "Job attempted to create output datasets in a full storage location, please contact your admin for more details"
+    )
+
+
 class ObjectStorePopulator:
     """Small helper for interacting with the object store and making sure all
     datasets from a job end up with the same object_store_id.
@@ -1635,9 +1651,9 @@ class ObjectStorePopulator:
             ensure_non_private = require_shareable
             concrete_store = self.object_store.create(dataset, ensure_non_private=ensure_non_private)
             if concrete_store.private and require_shareable:
-                raise Exception("Attempted to create shared output datasets in objectstore with sharing disabled")
+                raise ObjectCreationProblemSharingDisabled()
         except ObjectInvalid:
-            raise Exception("Unable to create output dataset: object store is full")
+            raise ObjectCreationProblemStoreFull()
         self.object_store_id = dataset.object_store_id  # these will be the same thing after the first output
 
 


### PR DESCRIPTION
<img width="1013" alt="Screenshot 2024-03-19 at 11 48 00 AM" src="https://github.com/galaxyproject/galaxy/assets/216771/ab2ef777-5d02-4f60-83fd-57e68b980cf3">

Improved the error message in the misc_info to reflect https://github.com/galaxyproject/galaxy/pull/17763. Kind argues the point that "user facing" language is impossible but lets do our best. Adds a little regex framework for scanning the misc_info and providing help if there are problems. I added regex for the old error message also so pre-24.0 dataset errors should get the same improved error message.

If we merge this - I can improve the modal to provide access to these activities inside the of the help text and links and such. But I want to see if we're okay with this a basis framework for handling such errors going forward.

There is also a bunch of things we can probably do pre-job execution to guess if there will be an error and prevent it before it happens. I'll research that but I want to have an abstraction the admin can configure to eliminate the "preferred" language by indicating the admin will always use the configured object store (dynamic destinations don't overwrite the object store id in unpredictable ways).

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Misconfigure it and look at the error message.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
