### PR TITLE
[24.0] Fix new default history creation when in remote or single user mode

### DIFF
--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -927,36 +927,28 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
         Gets or creates a default history and associates it with the current
         session.
         """
+
+        # Just return the current history if one exists and is not deleted.
         history = self.galaxy_session.current_history
         if history and not history.deleted:
             return history
 
+        # Look for an existing history that has the default name, is not
+        # deleted, and is empty. If this exists, we associate it with the
+        # current session and return it.
         user = self.galaxy_session.user
         if user:
-            # Look for default history that (a) has default name + is not deleted and
-            # (b) has no datasets. If suitable history found, use it; otherwise, create
-            # new history.
             stmt = select(self.app.model.History).filter_by(
                 user=user, name=self.app.model.History.default_name, deleted=False
             )
             unnamed_histories = self.sa_session.scalars(stmt)
-            default_history = None
             for history in unnamed_histories:
                 if history.empty:
-                    # Found suitable default history.
-                    default_history = history
-                    break
+                    self.set_history(history)
+                    return history
 
-            # Set or create history.
-            if default_history:
-                history = default_history
-                self.set_history(history)
-            else:
-                history = self.new_history()
-        else:
-            history = self.new_history()
-
-        return history
+        # No suitable history found, create a new one.
+        return self.new_history()
 
     def get_most_recent_history(self):
         """

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -953,6 +953,8 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
                 self.set_history(history)
             else:
                 history = self.new_history()
+        else:
+            history = self.new_history()
 
         return history
 

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -951,8 +951,8 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
             if default_history:
                 history = default_history
                 self.set_history(history)
-        else:
-            history = self.new_history()
+            else:
+                history = self.new_history()
 
         return history
 


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/17783

When using a new remote user, (i.e. a brand new anvil instance, or reproducible locally kicking a galaxy into singleuser mode with  a new identity) you can run into the situation where you do have a session, user, but no previous histories, so we must create one.

~~Leaving this draft because I want to look through and think about the rest of this stuff and recent related changes in the morning;~~

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
