### PR TITLE
[24.0] Return published histories first in display_by_username_and_slug

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -100,6 +100,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
         history = session.scalars(
             select(model.History)
             .filter_by(user=user, slug=slug, deleted=False)
+            # return public histories first if slug is not unique
             .order_by(model.History.importable.desc())
             .limit(1)
         ).first()

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -97,7 +97,12 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
         session = trans.sa_session
 
         user = session.scalars(select(model.User).filter_by(username=username).limit(1)).first()
-        history = session.scalars(select(model.History).filter_by(user=user, slug=slug, deleted=False).limit(1)).first()
+        history = session.scalars(
+            select(model.History)
+            .filter_by(user=user, slug=slug, deleted=False)
+            .order_by(model.History.importable.desc())
+            .limit(1)
+        ).first()
 
         if history is None:
             raise web.httpexceptions.HTTPNotFound()


### PR DESCRIPTION
slugs are not necessarily unique, but they are for published items.  by returning the published histories first we return the intended history first, while making it possible for owners to retrieve their now unpublished histories by the old slug.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
