### PR TITLE
[24.0] Fix very slow user data table query

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -10910,7 +10910,7 @@ HistoryDatasetAssociation.table = Table(
     Column("blurb", TrimmedString(255)),
     Column("peek", TEXT, key="_peek"),
     Column("tool_version", TEXT),
-    Column("extension", TrimmedString(64)),
+    Column("extension", TrimmedString(64), index=True),
     Column("metadata", MetadataType, key="_metadata"),
     Column("metadata_deferred", Boolean, key="metadata_deferred"),
     Column("parent_id", Integer, ForeignKey("history_dataset_association.id"), nullable=True),

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/55f02fd8ab6c_add_index_on_hda_extension.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/55f02fd8ab6c_add_index_on_hda_extension.py
@@ -1,0 +1,32 @@
+"""Add index on history_dataset_association extension
+
+Revision ID: 55f02fd8ab6c
+Revises: 2dc3386d091f
+Create Date: 2024-03-25 11:14:40.005394
+
+"""
+
+from galaxy.model.database_object_names import build_index_name
+from galaxy.model.migrations.util import (
+    create_index,
+    drop_index,
+)
+
+# revision identifiers, used by Alembic.
+revision = "55f02fd8ab6c"
+down_revision = "2dc3386d091f"
+branch_labels = None
+depends_on = None
+
+
+hda_table_name = "history_dataset_association"
+hda_extension_column_name = "extension"
+hda_extension_index_name = build_index_name(hda_table_name, hda_extension_column_name)
+
+
+def upgrade():
+    create_index(hda_extension_index_name, hda_table_name, [hda_extension_column_name])
+
+
+def downgrade():
+    drop_index(hda_extension_index_name, hda_table_name)


### PR DESCRIPTION
by adding an index on extension.
Fixes extremely slow tool form building.


Before:
```
['Sort  (cost=11152.93..11152.94 rows=1 width=575) (actual time=151.608..152.636 rows=0 loops=1)',
 '  Sort Key: history_dataset_association.id',
 '  Sort Method: quicksort  Memory: 25kB',
 '  ->  Nested Loop  (cost=1001.26..11152.92 rows=1 width=575) (actual time=151.564..152.592 rows=0 loops=1)',
 '        ->  Nested Loop  (cost=1000.84..11144.46 rows=1 width=575) (actual time=151.564..152.592 rows=0 loops=1)',
 '              Join Filter: (history_dataset_association.dataset_id = dataset.id)',
 '              ->  Nested Loop  (cost=1000.42..11143.94 rows=1 width=575) (actual time=151.563..152.591 rows=0 loops=1)',
 '                    ->  Gather  (cost=1000.00..11135.50 rows=1 width=363) (actual time=151.563..152.590 rows=0 loops=1)',
 '                          Workers Planned: 2',
 '                          Workers Launched: 2',
 '                          ->  Parallel Seq Scan on history_dataset_association  (cost=0.00..10135.40 rows=1 width=363) (actual time=139.910..139.911 rows=0 loops=3)',
 "                                Filter: ((NOT deleted) AND (metadata ~~ '\\x2522616c6c5f66617374612225'::bytea) AND ((extension)::text = 'data_manager_json'::text))",
 '                                Rows Removed by Filter: 80928',
 '                    ->  Index Scan using dataset_pkey on dataset dataset_1  (cost=0.42..8.44 rows=1 width=212) (never executed)',
 '                          Index Cond: (id = history_dataset_association.dataset_id)',
 '              ->  Index Scan using dataset_pkey on dataset  (cost=0.42..0.51 rows=1 width=4) (never executed)',
 '                    Index Cond: (id = dataset_1.id)',
 "                    Filter: ((total_size <> file_size) AND ((state)::text = 'ok'::text))",
 '        ->  Index Scan using history_pkey on history  (cost=0.42..8.44 rows=1 width=4) (never executed)',
 '              Index Cond: (id = history_dataset_association.history_id)',
 '              Filter: (user_id = 1)',
 'Planning Time: 9.134 ms',
 'Execution Time: 152.984 ms']

```

After:
```
['Sort  (cost=352.72..352.73 rows=1 width=575) (actual time=3.429..3.432 rows=0 loops=1)',
 '  Sort Key: history_dataset_association.id',
 '  Sort Method: quicksort  Memory: 25kB',
 '  ->  Nested Loop  (cost=6.35..352.71 rows=1 width=575) (actual time=3.377..3.379 rows=0 loops=1)',
 '        ->  Nested Loop  (cost=5.93..344.25 rows=1 width=575) (actual time=3.377..3.378 rows=0 loops=1)',
 '              Join Filter: (history_dataset_association.dataset_id = dataset.id)',
 '              ->  Nested Loop  (cost=5.51..343.73 rows=1 width=575) (actual time=3.376..3.377 rows=0 loops=1)',
 '                    ->  Bitmap Heap Scan on history_dataset_association  (cost=5.09..335.29 rows=1 width=363) (actual time=3.376..3.376 rows=0 loops=1)',
 "                          Recheck Cond: ((extension)::text = 'data_manager_json'::text)",
 "                          Filter: ((NOT deleted) AND (metadata ~~ '\\x2522616c6c5f66617374612225'::bytea))",
 '                          Rows Removed by Filter: 126',
 '                          Heap Blocks: exact=55',
 '                          ->  Bitmap Index Scan on hda_ext  (cost=0.00..5.09 rows=89 width=0) (actual time=0.616..0.617 rows=126 loops=1)',
 "                                Index Cond: ((extension)::text = 'data_manager_json'::text)",
 '                    ->  Index Scan using dataset_pkey on dataset dataset_1  (cost=0.42..8.44 rows=1 width=212) (never executed)',
 '                          Index Cond: (id = history_dataset_association.dataset_id)',
 '              ->  Index Scan using dataset_pkey on dataset  (cost=0.42..0.51 rows=1 width=4) (never executed)',
 '                    Index Cond: (id = dataset_1.id)',
 "                    Filter: ((total_size <> file_size) AND ((state)::text = 'ok'::text))",
 '        ->  Index Scan using history_pkey on history  (cost=0.42..8.44 rows=1 width=4) (never executed)',
 '              Index Cond: (id = history_dataset_association.history_id)',
 '              Filter: (user_id = 1)',
 'Planning Time: 23.736 ms',
 'Execution Time: 3.594 ms']

```

This became important with https://github.com/galaxyproject/galaxy/pull/17435

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
