### PR TITLE
[24.0] Fix optional types in Help Forum API

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6656,19 +6656,38 @@ export interface components {
          * This model is based on the Discourse API response for the search endpoint.
          */
         HelpForumSearchResponse: {
-            /** Categories */
-            categories: components["schemas"]["HelpForumCategory"][] | null;
-            grouped_search_result: components["schemas"]["HelpForumGroupedSearchResult"] | null;
-            /** Groups */
-            groups: components["schemas"]["HelpForumGroup"][] | null;
-            /** Posts */
-            posts: components["schemas"]["HelpForumPost"][] | null;
-            /** Tags */
-            tags: components["schemas"]["HelpForumTag"][] | null;
-            /** Topics */
-            topics: components["schemas"]["HelpForumTopic"][] | null;
-            /** Users */
-            users: components["schemas"]["HelpForumUser"][] | null;
+            /**
+             * Categories
+             * @description The list of categories returned by the search.
+             */
+            categories?: components["schemas"]["HelpForumCategory"][] | null;
+            /** @description The grouped search result. */
+            grouped_search_result?: components["schemas"]["HelpForumGroupedSearchResult"] | null;
+            /**
+             * Groups
+             * @description The list of groups returned by the search.
+             */
+            groups?: components["schemas"]["HelpForumGroup"][] | null;
+            /**
+             * Posts
+             * @description The list of posts returned by the search.
+             */
+            posts?: components["schemas"]["HelpForumPost"][];
+            /**
+             * Tags
+             * @description The list of tags returned by the search.
+             */
+            tags?: components["schemas"]["HelpForumTag"][] | null;
+            /**
+             * Topics
+             * @description The list of topics returned by the search.
+             */
+            topics?: components["schemas"]["HelpForumTopic"][];
+            /**
+             * Users
+             * @description The list of users returned by the search.
+             */
+            users?: components["schemas"]["HelpForumUser"][] | null;
         };
         /**
          * HelpForumTag
@@ -6696,7 +6715,7 @@ export interface components {
              * Bookmarked
              * @description Whether the topic is bookmarked.
              */
-            bookmarked: boolean | null;
+            bookmarked?: boolean | null;
             /**
              * Bumped
              * @description Whether the topic was bumped.
@@ -6751,7 +6770,7 @@ export interface components {
              * Liked
              * @description Whether the topic is liked.
              */
-            liked: boolean | null;
+            liked?: boolean | null;
             /**
              * Pinned
              * @description Whether the topic is pinned.
@@ -6781,7 +6800,7 @@ export interface components {
              * Tags Descriptions
              * @description The descriptions of the tags of the topic.
              */
-            tags_descriptions: Record<string, never> | null;
+            tags_descriptions?: Record<string, never> | null;
             /**
              * Title
              * @description The title of the topic.
@@ -6791,7 +6810,7 @@ export interface components {
              * Unpinned
              * @description Whether the topic is unpinned.
              */
-            unpinned: boolean | null;
+            unpinned?: boolean | null;
             /**
              * Unseen
              * @description Whether the topic is unseen.

--- a/lib/galaxy/schema/help.py
+++ b/lib/galaxy/schema/help.py
@@ -54,14 +54,16 @@ class HelpForumTopic(Model):
     archetype: Annotated[Any, Field(description="The archetype of the topic.")]
     unseen: Annotated[bool, Field(description="Whether the topic is unseen.")]
     pinned: Annotated[bool, Field(description="Whether the topic is pinned.")]
-    unpinned: Annotated[Optional[bool], Field(description="Whether the topic is unpinned.")]
+    unpinned: Annotated[Optional[bool], Field(default=None, description="Whether the topic is unpinned.")]
     visible: Annotated[bool, Field(description="Whether the topic is visible.")]
     closed: Annotated[bool, Field(description="Whether the topic is closed.")]
     archived: Annotated[bool, Field(description="Whether the topic is archived.")]
-    bookmarked: Annotated[Optional[bool], Field(description="Whether the topic is bookmarked.")]
-    liked: Annotated[Optional[bool], Field(description="Whether the topic is liked.")]
+    bookmarked: Annotated[Optional[bool], Field(default=None, description="Whether the topic is bookmarked.")]
+    liked: Annotated[Optional[bool], Field(default=None, description="Whether the topic is liked.")]
     tags: Annotated[List[str], Field(description="The tags of the topic.")]
-    tags_descriptions: Annotated[Optional[Any], Field(description="The descriptions of the tags of the topic.")]
+    tags_descriptions: Annotated[
+        Optional[Any], Field(default=None, description="The descriptions of the tags of the topic.")
+    ]
     category_id: Annotated[int, Field(description="The ID of the category of the topic.")]
     has_accepted_answer: Annotated[bool, Field(description="Whether the topic has an accepted answer.")]
 
@@ -102,10 +104,23 @@ class HelpForumSearchResponse(Model):
     This model is based on the Discourse API response for the search endpoint.
     """
 
-    posts: Optional[List[HelpForumPost]]
-    topics: Optional[List[HelpForumTopic]]
-    users: Optional[List[HelpForumUser]]
-    categories: Optional[List[HelpForumCategory]]
-    tags: Optional[List[HelpForumTag]]
-    groups: Optional[List[HelpForumGroup]]
-    grouped_search_result: Optional[HelpForumGroupedSearchResult]
+    posts: Annotated[List[HelpForumPost], Field(default=None, description="The list of posts returned by the search.")]
+    topics: Annotated[
+        List[HelpForumTopic], Field(default=None, description="The list of topics returned by the search.")
+    ]
+    users: Annotated[
+        Optional[List[HelpForumUser]], Field(default=None, description="The list of users returned by the search.")
+    ]
+    categories: Annotated[
+        Optional[List[HelpForumCategory]],
+        Field(default=None, description="The list of categories returned by the search."),
+    ]
+    tags: Annotated[
+        Optional[List[HelpForumTag]], Field(default=None, description="The list of tags returned by the search.")
+    ]
+    groups: Annotated[
+        Optional[List[HelpForumGroup]], Field(default=None, description="The list of groups returned by the search.")
+    ]
+    grouped_search_result: Annotated[
+        Optional[HelpForumGroupedSearchResult], Field(default=None, description="The grouped search result.")
+    ]


### PR DESCRIPTION
Fixes:

```
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]: [2024-03-25 13:30:21 +0100] [2734708] [ERROR] Exception in ASGI application
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]: Traceback (most recent call last):
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/uvicorn/protocols/http/h11_impl.py", line 412, in run_asgi
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     result = await app(  # type: ignore[func-returns-value]
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 84, in __call__
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     return await self.app(scope, receive, send)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in __call__
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     await super().__call__(scope, receive, send)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/sentry_sdk/integrations/starlette.py", line 364, in _sentry_patched_asgi_app
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     return await middleware(scope, receive, send)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/sentry_sdk/integrations/asgi.py", line 146, in _run_asgi3
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     return await self._run_app(scope, receive, send, asgi_version=3)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/sentry_sdk/integrations/asgi.py", line 241, in _run_app
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     raise exc from None
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/sentry_sdk/integrations/asgi.py", line 234, in _run_app
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     return await self.app(
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:            ^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/starlette/applications.py", line 123, in __call__
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     await self.middleware_stack(scope, receive, send)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/sentry_sdk/integrations/starlette.py", line 157, in _create_span_call
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     return await old_call(app, scope, new_receive, new_send, **kwargs)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 186, in __call__
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     raise exc
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 164, in __call__
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     await self.app(scope, receive, _send)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/sentry_sdk/integrations/starlette.py", line 157, in _create_span_call
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     return await old_call(app, scope, new_receive, new_send, **kwargs)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/starlette_context/middleware/raw_middleware.py", line 92, in __call__
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     await self.app(scope, receive, send_wrapper)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/sentry_sdk/integrations/starlette.py", line 256, in _sentry_exceptionmiddleware_call
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     await old_call(self, scope, receive, send)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/sentry_sdk/integrations/starlette.py", line 157, in _create_span_call
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     return await old_call(app, scope, new_receive, new_send, **kwargs)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     raise exc
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     await app(scope, receive, sender)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/starlette/routing.py", line 758, in __call__
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     await self.middleware_stack(scope, receive, send)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/starlette/routing.py", line 778, in app
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     await route.handle(scope, receive, send)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/starlette/routing.py", line 299, in handle
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     await self.app(scope, receive, send)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/starlette/routing.py", line 79, in app
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     raise exc
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     await app(scope, receive, sender)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/starlette/routing.py", line 74, in app
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     response = await func(request)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:                ^^^^^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/sentry_sdk/integrations/fastapi.py", line 134, in _sentry_app
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     return await old_app(*args, **kwargs)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/fastapi/routing.py", line 278, in app
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     raw_response = await run_endpoint_function(
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/fastapi/routing.py", line 193, in run_endpoint_function
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     return await run_in_threadpool(dependant.call, **values)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/starlette/concurrency.py", line 42, in run_in_threadpool
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     return await anyio.to_thread.run_sync(func, *args)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/anyio/to_thread.py", line 56, in run_sync
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     return await get_async_backend().run_sync_in_worker_thread(
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 2144, in run_sync_in_worker_thread
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     return await future
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:            ^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 851, in run
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     result = context.run(func, *args)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:              ^^^^^^^^^^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/sentry_sdk/integrations/fastapi.py", line 88, in _sentry_call
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     return old_call(*args, **kwargs)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:            ^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/server/lib/galaxy/webapps/galaxy/api/help.py", line 38, in search_forum
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     return self.service.search_forum(query)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/server/lib/galaxy/webapps/galaxy/services/help.py", line 44, in search_forum
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     return HelpForumSearchResponse(**response.json())
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   File "/opt/galaxy/venv/lib/python3.11/site-packages/pydantic/main.py", line 171, in __init__
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     self.__pydantic_validator__.validate_python(data, self_instance=self)
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]: pydantic_core._pydantic_core.ValidationError: 1 validation error for HelpForumSearchResponse
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]: topics
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:   Field required [type=missing, input_value={'posts': [], 'users': []...': [], 'group_ids': []}}, input_type=dict]
Mar 25 13:30:21 sn06.galaxyproject.eu gunicorn[2578811]:     For further information visit https://errors.pydantic.dev/2.6/v/missing

```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
