### PR TITLE
[23.2] Proxy Access-Control-* headers when using x-accel-redirect

### DIFF
--- a/doc/source/admin/nginx.md
+++ b/doc/source/admin/nginx.md
@@ -248,6 +248,9 @@ To enable it, add the following to your Galaxy's `server {}` block:
         location /_x_accel_redirect/ {
             internal;
             alias /;
+            # Add upstream response headers that would otherwise be omitted
+            add_header Access-Control-Allow-Origin $upstream_http_access_control_allow_origin;
+            add_header Access-Control-Allow-Methods $upstream_http_access_control_allow_methods;
         }
 ```
 


### PR DESCRIPTION
That means we don't need to explicitly add static headers for display applications.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
