### PR TITLE
[24.0] Fix Help Forum Integration uses Long ID

### DIFF
--- a/client/src/components/Tool/ToolHelpForum.vue
+++ b/client/src/components/Tool/ToolHelpForum.vue
@@ -5,6 +5,7 @@ import { computed, onMounted, ref } from "vue";
 
 import { fetcher } from "@/api/schema";
 import { useConfigStore } from "@/stores/configurationStore";
+import { getShortToolId } from "@/utils/tool";
 
 import { createTopicUrl, type HelpForumPost, type HelpForumTopic, useHelpURLs } from "./helpForumUrls";
 
@@ -26,7 +27,8 @@ const helpAvailable = computed(() => topics.value.length > 0);
 
 const root = ref(null);
 
-const query = computed(() => `tags:${props.toolId}+${toolHelpTag} status:solved`);
+const shortToolId = computed(() => getShortToolId(props.toolId));
+const query = computed(() => `tags:${shortToolId.value}+${toolHelpTag} status:solved`);
 
 onMounted(async () => {
     const response = await helpFetcher({ query: query.value });
@@ -49,7 +51,7 @@ function blurbForTopic(topicId: number): string {
 
 const { createNewTopicUrl, searchTopicUrl } = useHelpURLs({
     title: computed(() => props.toolName),
-    tags: computed(() => [props.toolId, toolHelpTag]),
+    tags: computed(() => [shortToolId.value, toolHelpTag]),
     query,
 });
 

--- a/client/src/components/ToolRecommendation.vue
+++ b/client/src/components/ToolRecommendation.vue
@@ -22,6 +22,8 @@ import { getCompatibleRecommendations } from "components/Workflow/Editor/modules
 import * as d3 from "d3";
 import { getAppRoot } from "onload/loadConfig";
 
+import { getShortToolId } from "@/utils/tool";
+
 export default {
     props: {
         toolId: {
@@ -38,12 +40,7 @@ export default {
     },
     computed: {
         getToolId() {
-            let toolId = this.toolId || "";
-            if (toolId.indexOf("/") > 0) {
-                const toolIdSlash = toolId.split("/");
-                toolId = toolIdSlash[toolIdSlash.length - 2];
-            }
-            return toolId;
+            return getShortToolId(this.toolId ?? "");
         },
     },
     created() {

--- a/client/src/components/Workflow/Editor/Recommendations.vue
+++ b/client/src/components/Workflow/Editor/Recommendations.vue
@@ -22,6 +22,7 @@ import LoadingSpan from "components/LoadingSpan";
 import _l from "utils/localization";
 
 import { useWorkflowStores } from "@/composables/workflowStores";
+import { getShortToolId } from "@/utils/tool";
 
 import { getToolPredictions } from "./modules/services";
 import { getCompatibleRecommendations } from "./modules/utilities";
@@ -59,11 +60,7 @@ export default {
     },
     methods: {
         getToolId(toolId) {
-            if (toolId !== undefined && toolId !== null && toolId.indexOf("/") > -1) {
-                const toolIdSlash = toolId.split("/");
-                toolId = toolIdSlash[toolIdSlash.length - 2];
-            }
-            return toolId;
+            return getShortToolId(toolId ?? "");
         },
         getWorkflowPath(currentNodeId) {
             const steps = {};

--- a/client/src/utils/tool.ts
+++ b/client/src/utils/tool.ts
@@ -1,0 +1,12 @@
+/**
+ * Converts a long tool ID to a short tool id.
+ * If the passed in ID is short already, returns it.
+ * @param longId long tool-id
+ * @returns short tool-id
+ */
+export function getShortToolId(longId: string): string {
+    const toolIdSlash = longId.split("/");
+    const shortId = toolIdSlash[toolIdSlash.length - 2];
+
+    return shortId ?? longId;
+}


### PR DESCRIPTION
The tool help forum integration was accidentally using the tools long ID to search for matching tools.
This PR changes the help forum integration to use the short ID instead.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
