### PR TITLE
Rename JupyTool to something more searchable (i.e. JupyterLab which includes the substring Jupyter) 

### DIFF
--- a/tools/interactive/interactivetool_jupyter_notebook_1.0.0.xml
+++ b/tools/interactive/interactivetool_jupyter_notebook_1.0.0.xml
@@ -1,4 +1,4 @@
-<tool id="interactive_tool_jupyter_notebook" tool_type="interactive" name="Interactive JupyTool and notebook" version="1.0.0" profile="22.01">
+<tool id="interactive_tool_jupyter_notebook" tool_type="interactive" name="Interactive JupyterLab Notebook" version="1.0.0" profile="22.01">
     <requirements>
         <container type="docker">quay.io/bgruening/docker-jupyter-notebook:2021-03-05</container>
     </requirements>


### PR DESCRIPTION
i keep looking for jupyter and only finding a QISkit and GPU enabled one which I don't need. I want jupyter(lab), but by the time I've typed jupyter it's already not findable due to the naming choice made in this IT. Jupyter/Lab are more standard and well known terms and will be better for end-users to look for.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
