### PR TITLE
Fix permissions for temporary upload file for API uploads

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -72,6 +72,7 @@ class ToolsService(ServiceBase):
                     dir=trans.app.config.new_file_path, prefix="upload_file_data_", delete=False
                 ) as dest:
                     shutil.copyfileobj(upload_file.file, dest)  # type: ignore[misc]  # https://github.com/python/mypy/issues/15031
+                    util.umask_fix_perms(dest.name, trans.app.config.umask, 0o0666)
                 upload_file.file.close()
                 files_payload[f"files_{i}|file_data"] = FilesPayload(
                     filename=upload_file.filename, local_filename=dest.name


### PR DESCRIPTION
I noticed that workflow test upload jobs jobs fail when testing against my instance (which uses a real user setup). Problem is that the temporary upload file does not respect the `umask` (because  files created using tempfile just do not do this). 

The quick fix implemented here is fixing this by changing the permissions. Note that uploads via the web interface are not affected because they go [this](https://github.com/galaxyproject/galaxy/blob/6b96bb17b2099c527fd5e6b02699e8f6b81b6593/lib/galaxy/tools/actions/upload_common.py#L56) way. 

Ultimately: it might be better to store the files in the job working dir, but this task seems to be to large for me.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
