### PR TITLE
[24.0] Fix incorrect miscinfo 'fix this' display

### DIFF
--- a/client/src/components/History/Content/Dataset/DatasetMiscInfo.vue
+++ b/client/src/components/History/Content/Dataset/DatasetMiscInfo.vue
@@ -16,21 +16,21 @@ const knownErrors = [{ regex: sharingErrorRex, modalRef: sharingError }];
 const props = defineProps<Props>();
 
 const fixable = computed(() => {
-    return true;
+    // Assume the intent is to branch this out to other types of errors, so
+    // leaving the computed in.
+    return sharingError.value;
 });
 
-watch(
-    props,
-    () => {
-        for (const knownError of knownErrors) {
-            const regex = knownError.regex;
-            if (props.miscInfo.match(regex)) {
-                knownError.modalRef.value = true;
-            }
+function checkForKnownErrors() {
+    for (const knownError of knownErrors) {
+        const regex = knownError.regex;
+        if (props.miscInfo.match(regex)) {
+            knownError.modalRef.value = true;
         }
-    },
-    { immediate: true }
-);
+    }
+}
+
+watch(props, checkForKnownErrors, { immediate: true });
 
 function showHelp() {
     showErrorHelp.value = true;

--- a/client/src/components/History/Content/Dataset/DatasetMiscInfo.vue
+++ b/client/src/components/History/Content/Dataset/DatasetMiscInfo.vue
@@ -16,9 +16,7 @@ const knownErrors = [{ regex: sharingErrorRex, modalRef: sharingError }];
 const props = defineProps<Props>();
 
 const fixable = computed(() => {
-    // Assume the intent is to branch this out to other types of errors, so
-    // leaving the computed in.
-    return sharingError.value;
+    return knownErrors.some((error) => error.modalRef.value);
 });
 
 function checkForKnownErrors() {


### PR DESCRIPTION
Noticed this was always showing up, even for green datasets:

![image](https://github.com/galaxyproject/galaxy/assets/155398/a3f09478-68b3-4966-8337-2db297029f60)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
