### PR TITLE
[24.0] Embed fix

### DIFF
--- a/client/src/components/Sharing/Embeds/WorkflowEmbed.vue
+++ b/client/src/components/Sharing/Embeds/WorkflowEmbed.vue
@@ -27,6 +27,7 @@ const settings = reactive({
     initialX: -20,
     initialY: -20,
     zoom: 1,
+    applyStyle: true,
 });
 
 function onChangePosition(event: Event, xy: "x" | "y") {
@@ -55,7 +56,16 @@ const embedUrl = computed(() => {
     return url;
 });
 
-const embed = computed(() => `<iframe title="Galaxy Workflow Embed" src="${embedUrl.value}" />`);
+const embedStyle = computed(() => {
+    if (settings.applyStyle) {
+        return ' style="width: 100%; height: 700px; border: none;" ';
+    } else {
+        return " ";
+    }
+});
+const embed = computed(
+    () => `<iframe title="Galaxy Workflow Embed"${embedStyle.value}src="${embedUrl.value}"></iframe>`
+);
 
 // These Embed settings are not reactive, to we have to key them
 const embedKey = computed(() => `zoom: ${settings.zoom}, x: ${settings.initialX}, y: ${settings.initialY}`);
@@ -117,6 +127,12 @@ const clipboardTitle = computed(() => (copied.value ? "Copied!" : "Copy URL"));
                     class="zoom-control"
                     @onZoom="(level) => (settings.zoom = level)" />
             </label>
+
+            <BFormCheckbox
+                v-model="settings.applyStyle"
+                title="adds a width, height, and removes the border of the iframe">
+                Add basic styling
+            </BFormCheckbox>
         </div>
         <div class="preview">
             <label for="embed-code" class="w-100">


### PR DESCRIPTION
The iframe generated by the embed settings was broken. Turns out iframes can't be self-closing, til!
Also added some base styles, which are likely required quite often.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
