### PR TITLE
[24.0] Fix archived histories mixing with active in histories list

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -15519,6 +15519,7 @@ export interface operations {
         parameters?: {
             /** @description The maximum number of items to return. */
             /** @description Starts at the beginning skip the first ( offset - 1 ) items and begin returning at the Nth item */
+            /** @description Whether to include archived histories. */
             /** @description Sort index by this specified attribute */
             /** @description Sort in descending order? */
             /**
@@ -15570,6 +15571,7 @@ export interface operations {
                 show_own?: boolean;
                 show_published?: boolean;
                 show_shared?: boolean;
+                show_archived?: boolean | null;
                 sort_by?: "create_time" | "name" | "update_time" | "username";
                 sort_desc?: boolean;
                 search?: string | null;

--- a/client/src/components/Grid/configs/historiesPublished.ts
+++ b/client/src/components/Grid/configs/historiesPublished.ts
@@ -30,6 +30,7 @@ async function getData(offset: number, limit: number, search: string, sort_by: s
         show_own: false,
         show_published: true,
         show_shared: false,
+        show_archived: true,
     });
     const totalMatches = parseInt(headers.get("total_matches") ?? "0");
     return [data, totalMatches];

--- a/client/src/components/Grid/configs/historiesShared.ts
+++ b/client/src/components/Grid/configs/historiesShared.ts
@@ -32,6 +32,7 @@ async function getData(offset: number, limit: number, search: string, sort_by: s
         show_own: false,
         show_published: false,
         show_shared: true,
+        show_archived: true,
     });
     const totalMatches = parseInt(headers.get("total_matches") ?? "0");
     return [data, totalMatches];

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -208,8 +208,10 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
                 self.model_class.deleted == (true() if show_deleted else false())
             )
 
-        # By default, only return non-archived histories
-        if not show_archived:
+        # By default, only return non-archived histories when we are showing the current user's histories
+        # if listing other users' histories, we don't filter out archived histories as they may be
+        # public or shared with the current user
+        if not show_archived and show_own:
             stmt = stmt.where(self.model_class.archived == false())
 
         stmt = stmt.distinct()

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -127,6 +127,7 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         show_published = payload.show_published
         show_purged = False
         show_shared = payload.show_shared
+        show_archived = payload.show_archived
         is_admin = trans.user_is_admin
         user = trans.user
 
@@ -207,15 +208,8 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
                 self.model_class.deleted == (true() if show_deleted else false())
             )
 
-        # Handle archived histories
-        if show_published:
-            # Someone published a history and then archived it, it should still be returned
-            stmt = stmt.where(or_(self.model_class.archived == false(), self.model_class.published == true()))
-        elif show_shared:
-            # Someone shared a history with the current user and then archived it, it should still be returned
-            stmt = stmt.where(or_(self.model_class.archived == false(), self.user_share_model.user == user))
-        else:
-            # By default, only return non-archived histories
+        # By default, only return non-archived histories
+        if not show_archived:
             stmt = stmt.where(self.model_class.archived == false())
 
         stmt = stmt.distinct()

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -208,10 +208,10 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
                 self.model_class.deleted == (true() if show_deleted else false())
             )
 
-        # By default, only return non-archived histories when we are showing the current user's histories
+        # By default, return only non-archived histories when we are showing the current user's histories
         # if listing other users' histories, we don't filter out archived histories as they may be
         # public or shared with the current user
-        if not show_archived and show_own:
+        if show_own and not show_archived:
             stmt = stmt.where(self.model_class.archived == false())
 
         stmt = stmt.distinct()

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -207,6 +207,17 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
                 self.model_class.deleted == (true() if show_deleted else false())
             )
 
+        # Handle archived histories
+        if show_published:
+            # Someone published a history and then archived it, it should still be returned
+            stmt = stmt.where(or_(self.model_class.archived == false(), self.model_class.published == true()))
+        elif show_shared:
+            # Someone shared a history with the current user and then archived it, it should still be returned
+            stmt = stmt.where(or_(self.model_class.archived == false(), self.user_share_model.user == user))
+        else:
+            # By default, only return non-archived histories
+            stmt = stmt.where(self.model_class.archived == false())
+
         stmt = stmt.distinct()
 
         if include_total_count:

--- a/lib/galaxy/schema/history.py
+++ b/lib/galaxy/schema/history.py
@@ -26,6 +26,7 @@ class HistoryIndexQueryPayload(Model):
     show_own: Optional[bool] = None
     show_published: Optional[bool] = None
     show_shared: Optional[bool] = None
+    show_archived: Optional[bool] = None
     sort_by: HistorySortByEnum = Field("update_time", title="Sort By", description="Sort by this attribute.")
     sort_desc: Optional[bool] = Field(default=True, title="Sort descending", description="Sort in descending order.")
     search: Optional[str] = Field(default=None, title="Filter text", description="Freetext to search.")

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -121,6 +121,12 @@ ShowSharedQueryParam: bool = Query(
     default=False, title="Include histories shared with authenticated user.", description=""
 )
 
+ShowArchivedQueryParam: Optional[bool] = Query(
+    default=None,
+    title="Show Archived",
+    description="Whether to include archived histories.",
+)
+
 SortByQueryParam: HistorySortByEnum = Query(
     default="update_time",
     title="Sort attribute",
@@ -174,6 +180,7 @@ class FastAPIHistories:
         show_own: bool = ShowOwnQueryParam,
         show_published: bool = ShowPublishedQueryParam,
         show_shared: bool = ShowSharedQueryParam,
+        show_archived: Optional[bool] = ShowArchivedQueryParam,
         sort_by: HistorySortByEnum = SortByQueryParam,
         sort_desc: bool = SortDescQueryParam,
         search: Optional[str] = SearchQueryParam,
@@ -196,6 +203,7 @@ class FastAPIHistories:
                 show_own=show_own,
                 show_published=show_published,
                 show_shared=show_shared,
+                show_archived=show_archived,
                 sort_by=sort_by,
                 sort_desc=sort_desc,
                 limit=limit,

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -304,6 +304,40 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
             index_response = self._get("histories", data=data).json()
             assert len(index_response) == 1
 
+            archived_history_id = self._create_history(f"Archived history_{uuid4()}")["id"]
+            name_contains = "history"
+            data = dict(search=name_contains, show_published=False)
+            index_response = self._get("histories", data=data).json()
+            assert len(index_response) == 4
+
+            # Archived histories should not be included in the index
+            self.dataset_populator.archive_history(archived_history_id)
+            data = dict(search=name_contains, show_published=False)
+            index_response = self._get("histories", data=data).json()
+            assert len(index_response) == 3
+
+            archived_public_history_id = self._create_history(f"Public Archived history_{uuid4()}")["id"]
+            self._update(archived_public_history_id, {"published": True})
+            self.dataset_populator.archive_history(archived_public_history_id)
+            data = dict(search=name_contains, show_published=False)
+            index_response = self._get("histories", data=data).json()
+            assert len(index_response) == 3
+
+            name_contains = "Archived"
+            data = dict(search=name_contains, show_published=False)
+            index_response = self._get("histories", data=data).json()
+            assert len(index_response) == 0
+
+            # Archived public histories should be included when filtering by published
+            data = dict(search="is:published")
+            index_response = self._get("histories", data=data).json()
+            assert len(index_response) == 2
+
+            name_contains = "Archived"
+            data = dict(search=name_contains, show_published=True)
+            index_response = self._get("histories", data=data).json()
+            assert len(index_response) == 1
+
     def test_delete(self):
         # Setup a history and ensure it is in the index
         history_id = self._create_history("TestHistoryForDelete")["id"]

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -310,7 +310,7 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
             index_response = self._get("histories", data=data).json()
             assert len(index_response) == 4
 
-            # Archived histories should not be included in the index
+            # Archived histories should not be included by default
             self.dataset_populator.archive_history(archived_history_id)
             data = dict(search=name_contains, show_published=False)
             index_response = self._get("histories", data=data).json()
@@ -328,13 +328,13 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
             index_response = self._get("histories", data=data).json()
             assert len(index_response) == 0
 
-            # Archived public histories should be included when filtering by published
-            data = dict(search="is:published")
+            # Archived public histories should be included when filtering by show_published and show_archived
+            data = dict(search="is:published", show_archived=True)
             index_response = self._get("histories", data=data).json()
             assert len(index_response) == 2
 
             name_contains = "Archived"
-            data = dict(search=name_contains, show_published=True)
+            data = dict(search=name_contains, show_published=True, show_archived=True)
             index_response = self._get("histories", data=data).json()
             assert len(index_response) == 1
 


### PR DESCRIPTION
Fixes #17807

This should return archived histories only if they are public or shared with the user. The query could use another pair of :eyes: to make it prettier :sweat_smile: 

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
