### PR TITLE
[24.0] Fix activity bar unreachable in some pages

### DIFF
--- a/client/src/entry/analysis/menu.js
+++ b/client/src/entry/analysis/menu.js
@@ -53,7 +53,6 @@ export function fetchMenu(options = {}) {
                 {
                     title: _l("Data Libraries"),
                     url: "/libraries",
-                    target: "_top",
                 },
                 {
                     title: _l("Datasets"),
@@ -91,7 +90,6 @@ export function fetchMenu(options = {}) {
                 {
                     title: _l("Data Libraries"),
                     url: "/libraries",
-                    target: "_top",
                 },
                 {
                     title: _l("Histories"),
@@ -123,7 +121,6 @@ export function fetchMenu(options = {}) {
             url: "/admin",
             tooltip: _l("Administer this Galaxy"),
             cls: "admin-only",
-            target: "_top",
         });
     }
 

--- a/client/src/entry/analysis/modules/Base.vue
+++ b/client/src/entry/analysis/modules/Base.vue
@@ -1,3 +1,3 @@
 <template>
-    <router-view :key="$route.fullPath" class="m-2" />
+    <router-view :key="$route.fullPath" />
 </template>

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -105,9 +105,6 @@ export function getRouter(Galaxy) {
         base: getAppRoot(),
         mode: "history",
         routes: [
-            ...AdminRoutes,
-            ...LibraryRoutes,
-            ...StorageDashboardRoutes,
             /** Login entry route */
             {
                 path: "/login/start",
@@ -171,6 +168,9 @@ export function getRouter(Galaxy) {
                 path: "/",
                 component: Analysis,
                 children: [
+                    ...AdminRoutes,
+                    ...LibraryRoutes,
+                    ...StorageDashboardRoutes,
                     {
                         path: "",
                         alias: "root",


### PR DESCRIPTION
Fixes #17617

The Admin Panel, Data Libraries, and Storage Dashboard will be displayed in the center panel so the Activity bar is always reachable.
In addition, Data Libraries and Admin Panel will no longer trigger a page reload.

![ActivityBarAlwaysVisible](https://github.com/galaxyproject/galaxy/assets/46503462/b0c9357a-d6ab-4cbf-8700-221f28ca84d0)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
