### PR TITLE
[24.0] Embed download fix

### DIFF
--- a/client/src/components/Workflow/Published/WorkflowPublished.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublished.vue
@@ -187,7 +187,7 @@ const viewUrl = computed(() => withPrefix(`/published/workflow?id=${props.id}`))
                         </Heading>
 
                         <span v-if="props.showButtons">
-                            <b-button :to="downloadUrl" title="Download Workflow" variant="secondary" size="md">
+                            <b-button :href="downloadUrl" title="Download Workflow" variant="secondary" size="md">
                                 <FontAwesomeIcon icon="fa-download" />
                                 Download
                             </b-button>


### PR DESCRIPTION
The "to" prop does not work inside iframes. Changing the download button to use an href fixes this.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
