### PR TITLE
Update labels in Markdown editor when workflow labels change.

### DIFF
--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -74,14 +74,11 @@ import Vue from "vue";
 
 import { useWorkflowStore } from "@/stores/workflowStore";
 
+import { splitMarkdown as splitMarkdownUnrendered } from "./parse";
+
 import MarkdownContainer from "./MarkdownContainer.vue";
 import LoadingSpan from "components/LoadingSpan.vue";
 import StsDownloadButton from "components/StsDownloadButton.vue";
-
-const FUNCTION_VALUE_REGEX = `\\s*(?:[\\w_\\-]+|\\"[^\\"]+\\"|\\'[^\\']+\\')\\s*`;
-const FUNCTION_CALL = `\\s*[\\w\\|]+\\s*=` + FUNCTION_VALUE_REGEX;
-const FUNCTION_CALL_LINE = `\\s*(\\w+)\\s*\\(\\s*(?:(${FUNCTION_CALL})(,${FUNCTION_CALL})*)?\\s*\\)\\s*`;
-const FUNCTION_CALL_LINE_TEMPLATE = new RegExp(FUNCTION_CALL_LINE, "m");
 
 const mdNewline = markdownItRegexp(/<br>/, () => {
     return "<div style='clear:both;'/><br>";
@@ -195,69 +192,14 @@ export default {
             }
         },
         splitMarkdown(markdown) {
-            const sections = [];
-            let digest = markdown;
-            while (digest.length > 0) {
-                const galaxyStart = digest.indexOf("```galaxy");
-                if (galaxyStart != -1) {
-                    const galaxyEnd = digest.substr(galaxyStart + 1).indexOf("```");
-                    if (galaxyEnd != -1) {
-                        if (galaxyStart > 0) {
-                            const defaultContent = digest.substr(0, galaxyStart).trim();
-                            if (defaultContent) {
-                                sections.push({
-                                    name: "default",
-                                    content: md.render(defaultContent),
-                                });
-                            }
-                        }
-                        const galaxyEndIndex = galaxyEnd + 4;
-                        const galaxySection = digest.substr(galaxyStart, galaxyEndIndex);
-                        let args = null;
-                        try {
-                            args = this.getArgs(galaxySection);
-                            sections.push(args);
-                        } catch (e) {
-                            this.markdownErrors.push({
-                                error: "Found an unresolved tag.",
-                                line: galaxySection,
-                            });
-                        }
-                        digest = digest.substr(galaxyStart + galaxyEndIndex);
-                    } else {
-                        digest = digest.substr(galaxyStart + 1);
-                    }
-                } else {
-                    sections.push({
-                        name: "default",
-                        content: md.render(digest),
-                    });
-                    break;
+            const { sections, markdownErrors } = splitMarkdownUnrendered(markdown);
+            markdownErrors.forEach((error) => markdownErrors.push(error));
+            sections.forEach((section) => {
+                if (section.name == "default") {
+                    section.content = md.render(section.content);
                 }
-            }
+            });
             return sections;
-        },
-        getArgs(content) {
-            const galaxy_function = FUNCTION_CALL_LINE_TEMPLATE.exec(content);
-            const args = {};
-            const function_name = galaxy_function[1];
-            // we need [... ] to return empty string, if regex doesn't match
-            const function_arguments = [...content.matchAll(new RegExp(FUNCTION_CALL, "g"))];
-            for (let i = 0; i < function_arguments.length; i++) {
-                if (function_arguments[i] === undefined) {
-                    continue;
-                }
-                const arguments_str = function_arguments[i].toString().replace(/,/g, "").trim();
-                if (arguments_str) {
-                    const [key, val] = arguments_str.split("=");
-                    args[key.trim()] = val.replace(/['"]+/g, "").trim();
-                }
-            }
-            return {
-                name: function_name,
-                args: args,
-                content: content,
-            };
         },
     },
 };

--- a/client/src/components/Markdown/parse.test.js
+++ b/client/src/components/Markdown/parse.test.js
@@ -1,10 +1,112 @@
-import { getArgs } from "./parse";
+import { getArgs, replaceLabel, splitMarkdown } from "./parse";
 
 describe("parse.ts", () => {
     describe("getArgs", () => {
         it("parses simple directive expression", () => {
             const args = getArgs("job_metrics(job_id=THISFAKEID)");
             expect(args.name).toBe("job_metrics");
+        });
+    });
+
+    describe("splitMarkdown", () => {
+        it("strip leading whitespace by default", () => {
+            const { sections } = splitMarkdown("\n```galaxy\njob_metrics(job_id=THISFAKEID)\n```");
+            expect(sections.length).toBe(1);
+        });
+
+        it("should not strip leading whitespace if disabled", () => {
+            const { sections } = splitMarkdown("\n```galaxy\njob_metrics(job_id=THISFAKEID)\n```", true);
+            expect(sections.length).toBe(2);
+            expect(sections[0].content).toBe("\n");
+        });
+    });
+
+    describe("replaceLabel", () => {
+        it("should leave unaffected markdown alone", () => {
+            const input = "some random\n`markdown content`\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(result);
+        });
+
+        it("should leave unaffected galaxy directives alone", () => {
+            const input = "some random\n`markdown content`\n```galaxy\ncurrent_time()\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(result);
+        });
+
+        it("should leave galaxy directives of same type with other labels alone", () => {
+            const input = "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(output=moo)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(result);
+        });
+
+        it("should leave galaxy directives of other types with same labels alone", () => {
+            const input = "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(input=from)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(result);
+        });
+
+        it("should swap simple directives of specified type", () => {
+            const input = "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(output=from)\n```\n";
+            const output = "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(output=to)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(output);
+        });
+
+        it("should swap single quoted directives of specified type", () => {
+            const input = "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(output='from')\n```\n";
+            const output = "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(output=to)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(output);
+        });
+
+        it("should swap single quoted directives of specified type with extra args", () => {
+            const input =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output='from', title=dog)\n```\n";
+            const output =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output=to, title=dog)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(output);
+        });
+
+        it("should swap double quoted directives of specified type", () => {
+            const input = 'some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(output="from")\n```\n';
+            const output = "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(output=to)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(output);
+        });
+
+        it("should swap double quoted directives of specified type with extra args", () => {
+            const input =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output=\"from\", title=dog)\n```\n";
+            const output =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output=to, title=dog)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(output);
+        });
+
+        it("should leave non-arguments alone", () => {
+            const input =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(title='cow from farm', output=from)\n```\n";
+            const output =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(title='cow from farm', output=to)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(output);
+        });
+
+        // not a valid workflow label per se but make sure we're escaping the regex to be safe
+        it("should not be messed up by labels containing regexp content", () => {
+            const input = "```galaxy\nhistory_dataset_embedded(output='from(')\n```\n";
+            const output = "```galaxy\nhistory_dataset_embedded(output=to$1)\n```\n";
+            const result = replaceLabel(input, "output", "from(", "to$1");
+            expect(result).toBe(output);
+        });
+
+        it("should not swallow leading newlines", () => {
+            const input = "\n```galaxy\nhistory_dataset_embedded(output='from')\n```\n";
+            const output = "\n```galaxy\nhistory_dataset_embedded(output=to)\n```\n";
+            const result = replaceLabel(input, "output", "from", "to");
+            expect(result).toBe(output);
         });
     });
 });

--- a/client/src/components/Markdown/parse.test.js
+++ b/client/src/components/Markdown/parse.test.js
@@ -6,6 +6,18 @@ describe("parse.ts", () => {
             const args = getArgs("job_metrics(job_id=THISFAKEID)");
             expect(args.name).toBe("job_metrics");
         });
+
+        it("parses labels spaces at the end with single quotes", () => {
+            const args = getArgs("job_metrics(step=' fakestepname ')");
+            expect(args.name).toBe("job_metrics");
+            expect(args.args.step).toBe(" fakestepname ");
+        });
+
+        it("parses labels spaces at the end with double quotes", () => {
+            const args = getArgs('job_metrics(step=" fakestepname ")');
+            expect(args.name).toBe("job_metrics");
+            expect(args.args.step).toBe(" fakestepname ");
+        });
     });
 
     describe("splitMarkdown", () => {
@@ -16,6 +28,12 @@ describe("parse.ts", () => {
 
         it("should not strip leading whitespace if disabled", () => {
             const { sections } = splitMarkdown("\n```galaxy\njob_metrics(job_id=THISFAKEID)\n```", true);
+            expect(sections.length).toBe(2);
+            expect(sections[0].content).toBe("\n");
+        });
+
+        it("should parse labels with leading spaces", () => {
+            const { sections } = splitMarkdown("\n```galaxy\njob_metrics(step='THISFAKEID ')\n```", true);
             expect(sections.length).toBe(2);
             expect(sections[0].content).toBe("\n");
         });
@@ -103,12 +121,30 @@ describe("parse.ts", () => {
             expect(result).toBe(output);
         });
 
+        it("should work with single quotes for labels and spaces in the quotes including end", () => {
+            const input =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output='from this ', title=dog)\n```\n";
+            const output =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output='to thatx ', title=dog)\n```\n";
+            const result = replaceLabel(input, "output", "from this ", "to thatx ");
+            expect(result).toBe(output);
+        });
+
         it("should add quotes when refactoring to labels with spaces", () => {
             const input =
                 "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output=fromthis, title=dog)\n```\n";
             const output =
                 "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output='to that', title=dog)\n```\n";
             const result = replaceLabel(input, "output", "fromthis", "to that");
+            expect(result).toBe(output);
+        });
+
+        it("should add quotes when refactoring to labels with spaces including end space", () => {
+            const input =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output=fromthis, title=dog)\n```\n";
+            const output =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output='to that ', title=dog)\n```\n";
+            const result = replaceLabel(input, "output", "fromthis", "to that ");
             expect(result).toBe(output);
         });
 

--- a/client/src/components/Markdown/parse.test.js
+++ b/client/src/components/Markdown/parse.test.js
@@ -1,0 +1,10 @@
+import { getArgs } from "./parse";
+
+describe("parse.ts", () => {
+    describe("getArgs", () => {
+        it("parses simple directive expression", () => {
+            const args = getArgs("job_metrics(job_id=THISFAKEID)");
+            expect(args.name).toBe("job_metrics");
+        });
+    });
+});

--- a/client/src/components/Markdown/parse.test.js
+++ b/client/src/components/Markdown/parse.test.js
@@ -85,6 +85,33 @@ describe("parse.ts", () => {
             expect(result).toBe(output);
         });
 
+        it("should work with double quotes for labels and spaces in the quotes", () => {
+            const input =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output=\"from this\", title=dog)\n```\n";
+            const output =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output=\"to that\", title=dog)\n```\n";
+            const result = replaceLabel(input, "output", "from this", "to that");
+            expect(result).toBe(output);
+        });
+
+        it("should work with single quotes for labels and spaces in the quotes", () => {
+            const input =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output='from this', title=dog)\n```\n";
+            const output =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output='to that', title=dog)\n```\n";
+            const result = replaceLabel(input, "output", "from this", "to that");
+            expect(result).toBe(output);
+        });
+
+        it("should add quotes when refactoring to labels with spaces", () => {
+            const input =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output=fromthis, title=dog)\n```\n";
+            const output =
+                "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(footer='cow', output='to that', title=dog)\n```\n";
+            const result = replaceLabel(input, "output", "fromthis", "to that");
+            expect(result).toBe(output);
+        });
+
         it("should leave non-arguments alone", () => {
             const input =
                 "some random\n`markdown content`\n```galaxy\nhistory_dataset_embedded(title='cow from farm', output=from)\n```\n";

--- a/client/src/components/Markdown/parse.ts
+++ b/client/src/components/Markdown/parse.ts
@@ -3,8 +3,14 @@ const FUNCTION_ARGUMENT_REGEX = `\\s*[\\w\\|]+\\s*=` + FUNCTION_ARGUMENT_VALUE_R
 const FUNCTION_CALL_LINE = `\\s*(\\w+)\\s*\\(\\s*(?:(${FUNCTION_ARGUMENT_REGEX})(,${FUNCTION_ARGUMENT_REGEX})*)?\\s*\\)\\s*`;
 const FUNCTION_CALL_LINE_TEMPLATE = new RegExp(FUNCTION_CALL_LINE, "m");
 
-export function splitMarkdown(markdown: string) {
-    const sections = [];
+type DefaultSection = { name: "default"; content: string };
+type GalaxyDirectiveSection = { name: string; content: string; args: { [key: string]: string } };
+type Section = DefaultSection | GalaxyDirectiveSection;
+
+type WorkflowLabelKind = "input" | "output" | "step";
+
+export function splitMarkdown(markdown: string, preserveWhitespace: boolean = false) {
+    const sections: Section[] = [];
     const markdownErrors = [];
     let digest = markdown;
     while (digest.length > 0) {
@@ -13,11 +19,12 @@ export function splitMarkdown(markdown: string) {
             const galaxyEnd = digest.substr(galaxyStart + 1).indexOf("```");
             if (galaxyEnd != -1) {
                 if (galaxyStart > 0) {
-                    const defaultContent = digest.substr(0, galaxyStart).trim();
-                    if (defaultContent) {
+                    const rawContent = digest.substr(0, galaxyStart);
+                    const defaultContent = rawContent.trim();
+                    if (preserveWhitespace || defaultContent) {
                         sections.push({
                             name: "default",
-                            content: defaultContent,
+                            content: preserveWhitespace ? rawContent : defaultContent,
                         });
                     }
                 }
@@ -48,14 +55,54 @@ export function splitMarkdown(markdown: string) {
     return { sections, markdownErrors };
 }
 
-export function getArgs(content: string) {
+export function replaceLabel(
+    markdown: string,
+    labelType: WorkflowLabelKind,
+    fromLabel: string,
+    toLabel: string
+): string {
+    const { sections } = splitMarkdown(markdown, true);
+
+    function rewriteSection(section: Section) {
+        if ("args" in section) {
+            const directiveSection = section as GalaxyDirectiveSection;
+            const args = directiveSection.args;
+            if (!(labelType in args)) {
+                return section;
+            }
+            const labelValue = args[labelType];
+            if (labelValue != fromLabel) {
+                return section;
+            }
+            // we've got a section with a matching label and type...
+            const newArgs = { ...args };
+            newArgs[labelType] = toLabel;
+            const argRexExp = namedArgumentRegex(labelType);
+            const escapedToLabel = escapeRegExpReplacement(toLabel);
+            const content = directiveSection.content.replace(argRexExp, `$1${escapedToLabel}`);
+            return {
+                name: directiveSection.name,
+                args: newArgs,
+                content: content,
+            };
+        } else {
+            return section;
+        }
+    }
+
+    const rewrittenSections = sections.map(rewriteSection);
+    const rewrittenMarkdown = rewrittenSections.map((section) => section.content).join("");
+    return rewrittenMarkdown;
+}
+
+export function getArgs(content: string): GalaxyDirectiveSection {
     const galaxy_function = FUNCTION_CALL_LINE_TEMPLATE.exec(content);
     if (galaxy_function == null) {
         throw Error("Failed to parse galaxy directive");
     }
     type ArgsType = { [key: string]: string };
     const args: ArgsType = {};
-    const function_name = galaxy_function[1];
+    const function_name = galaxy_function[1] as string;
     // we need [... ] to return empty string, if regex doesn't match
     const function_arguments = [...content.matchAll(new RegExp(FUNCTION_ARGUMENT_REGEX, "g"))];
     for (let i = 0; i < function_arguments.length; i++) {
@@ -76,4 +123,13 @@ export function getArgs(content: string) {
         args: args,
         content: content,
     };
+}
+
+function namedArgumentRegex(argument: string): RegExp {
+    return new RegExp(`(\\s*${argument}\\s*=)` + FUNCTION_ARGUMENT_VALUE_REGEX);
+}
+
+// https://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
+function escapeRegExpReplacement(value: string): string {
+    return value.replace(/\$/g, "$$$$");
 }

--- a/client/src/components/Markdown/parse.ts
+++ b/client/src/components/Markdown/parse.ts
@@ -138,7 +138,7 @@ export function getArgs(content: string): GalaxyDirectiveSection {
         const arguments_str = function_arguments[i]?.toString().replace(/,/g, "").trim();
         if (arguments_str) {
             const [keyStr, valStr] = arguments_str.split("=");
-            if (keyStr == undefined || keyStr == undefined) {
+            if (keyStr == undefined || valStr == undefined) {
                 throw Error("Failed to parse galaxy directive");
             }
             const key = keyStr.trim();

--- a/client/src/components/Markdown/parse.ts
+++ b/client/src/components/Markdown/parse.ts
@@ -1,6 +1,6 @@
-const FUNCTION_VALUE_REGEX = `\\s*(?:[\\w_\\-]+|\\"[^\\"]+\\"|\\'[^\\']+\\')\\s*`;
-const FUNCTION_CALL = `\\s*[\\w\\|]+\\s*=` + FUNCTION_VALUE_REGEX;
-const FUNCTION_CALL_LINE = `\\s*(\\w+)\\s*\\(\\s*(?:(${FUNCTION_CALL})(,${FUNCTION_CALL})*)?\\s*\\)\\s*`;
+const FUNCTION_ARGUMENT_VALUE_REGEX = `\\s*(?:[\\w_\\-]+|\\"[^\\"]+\\"|\\'[^\\']+\\')\\s*`;
+const FUNCTION_ARGUMENT_REGEX = `\\s*[\\w\\|]+\\s*=` + FUNCTION_ARGUMENT_VALUE_REGEX;
+const FUNCTION_CALL_LINE = `\\s*(\\w+)\\s*\\(\\s*(?:(${FUNCTION_ARGUMENT_REGEX})(,${FUNCTION_ARGUMENT_REGEX})*)?\\s*\\)\\s*`;
 const FUNCTION_CALL_LINE_TEMPLATE = new RegExp(FUNCTION_CALL_LINE, "m");
 
 export function splitMarkdown(markdown: string) {
@@ -57,7 +57,7 @@ export function getArgs(content: string) {
     const args: ArgsType = {};
     const function_name = galaxy_function[1];
     // we need [... ] to return empty string, if regex doesn't match
-    const function_arguments = [...content.matchAll(new RegExp(FUNCTION_CALL, "g"))];
+    const function_arguments = [...content.matchAll(new RegExp(FUNCTION_ARGUMENT_REGEX, "g"))];
     for (let i = 0; i < function_arguments.length; i++) {
         if (function_arguments[i] === undefined) {
             continue;

--- a/client/src/components/Markdown/parse.ts
+++ b/client/src/components/Markdown/parse.ts
@@ -1,0 +1,79 @@
+const FUNCTION_VALUE_REGEX = `\\s*(?:[\\w_\\-]+|\\"[^\\"]+\\"|\\'[^\\']+\\')\\s*`;
+const FUNCTION_CALL = `\\s*[\\w\\|]+\\s*=` + FUNCTION_VALUE_REGEX;
+const FUNCTION_CALL_LINE = `\\s*(\\w+)\\s*\\(\\s*(?:(${FUNCTION_CALL})(,${FUNCTION_CALL})*)?\\s*\\)\\s*`;
+const FUNCTION_CALL_LINE_TEMPLATE = new RegExp(FUNCTION_CALL_LINE, "m");
+
+export function splitMarkdown(markdown: string) {
+    const sections = [];
+    const markdownErrors = [];
+    let digest = markdown;
+    while (digest.length > 0) {
+        const galaxyStart = digest.indexOf("```galaxy");
+        if (galaxyStart != -1) {
+            const galaxyEnd = digest.substr(galaxyStart + 1).indexOf("```");
+            if (galaxyEnd != -1) {
+                if (galaxyStart > 0) {
+                    const defaultContent = digest.substr(0, galaxyStart).trim();
+                    if (defaultContent) {
+                        sections.push({
+                            name: "default",
+                            content: defaultContent,
+                        });
+                    }
+                }
+                const galaxyEndIndex = galaxyEnd + 4;
+                const galaxySection = digest.substr(galaxyStart, galaxyEndIndex);
+                let args = null;
+                try {
+                    args = getArgs(galaxySection);
+                    sections.push(args);
+                } catch (e) {
+                    markdownErrors.push({
+                        error: "Found an unresolved tag.",
+                        line: galaxySection,
+                    });
+                }
+                digest = digest.substr(galaxyStart + galaxyEndIndex);
+            } else {
+                digest = digest.substr(galaxyStart + 1);
+            }
+        } else {
+            sections.push({
+                name: "default",
+                content: digest,
+            });
+            break;
+        }
+    }
+    return { sections, markdownErrors };
+}
+
+export function getArgs(content: string) {
+    const galaxy_function = FUNCTION_CALL_LINE_TEMPLATE.exec(content);
+    if (galaxy_function == null) {
+        throw Error("Failed to parse galaxy directive");
+    }
+    type ArgsType = { [key: string]: string };
+    const args: ArgsType = {};
+    const function_name = galaxy_function[1];
+    // we need [... ] to return empty string, if regex doesn't match
+    const function_arguments = [...content.matchAll(new RegExp(FUNCTION_CALL, "g"))];
+    for (let i = 0; i < function_arguments.length; i++) {
+        if (function_arguments[i] === undefined) {
+            continue;
+        }
+        const arguments_str = function_arguments[i]?.toString().replace(/,/g, "").trim();
+        if (arguments_str) {
+            const [key, val] = arguments_str.split("=");
+            if (key == undefined || val == undefined) {
+                throw Error("Failed to parse galaxy directive");
+            }
+            args[key.trim()] = val.replace(/['"]+/g, "").trim();
+        }
+    }
+    return {
+        name: function_name,
+        args: args,
+        content: content,
+    };
+}

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -51,7 +51,8 @@
                     :key="index"
                     :name="output.name"
                     :step="step"
-                    :show-details="true" />
+                    :show-details="true"
+                    @onOutputLabel="onOutputLabel" />
             </div>
         </template>
     </FormCard>
@@ -78,7 +79,14 @@ const props = defineProps<{
     step: Step;
     datatypes: DatatypesMapperModel["datatypes"];
 }>();
-const emit = defineEmits(["onAnnotation", "onLabel", "onAttemptRefactor", "onEditSubworkflow", "onSetData"]);
+const emit = defineEmits([
+    "onAnnotation",
+    "onLabel",
+    "onAttemptRefactor",
+    "onEditSubworkflow",
+    "onSetData",
+    "onOutputLabel",
+]);
 const stepRef = toRef(props, "step");
 const { stepId, contentId, annotation, label, name, type, configForm } = useStepProps(stepRef);
 const { stepStore } = useWorkflowStores();
@@ -116,5 +124,8 @@ function onChange(values: any) {
         content_id: contentId!.value,
         inputs: values,
     });
+}
+function onOutputLabel(oldValue: string | null, newValue: string | null) {
+    emit("onOutputLabel", oldValue, newValue);
 }
 </script>

--- a/client/src/components/Workflow/Editor/Forms/FormOutput.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormOutput.vue
@@ -1,7 +1,7 @@
 <template>
     <FormCard :title="outputTitle" collapsible :expanded.sync="expanded">
         <template v-slot:body>
-            <FormOutputLabel :name="outputName" :step="step" />
+            <FormOutputLabel :name="outputName" :step="step" @onOutputLabel="onOutputLabel" />
             <FormElement
                 :id="actionNames.RenameDatasetAction__newname"
                 :value="formData[actionNames.RenameDatasetAction__newname]"
@@ -203,6 +203,9 @@ export default {
         },
         onInput(value, pjaKey) {
             this.$emit("onInput", value, pjaKey);
+        },
+        onOutputLabel(oldValue, newValue) {
+            this.$emit("onOutputLabel", oldValue, newValue);
         },
         onDatatype(newDatatype) {
             this.$emit("onDatatype", this.actionNames.ChangeDatatypeAction__newtype, this.outputName, newDatatype);

--- a/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
@@ -29,6 +29,10 @@ const props = withDefaults(
     }
 );
 
+const emit = defineEmits<{
+    (e: "onOutputLabel", oldValue: string | null, newValue: string | null): void;
+}>();
+
 const { stepStore } = useWorkflowStores();
 
 const error: Ref<string | undefined> = ref(undefined);
@@ -54,12 +58,14 @@ function onInput(newLabel: string | undefined | null) {
     }
 
     if (newLabel === "") {
+        const oldLabel = label.value || null;
         // user deleted existing label, we inactivate this as output
         const strippedWorkflowOutputs = (props.step.workflow_outputs || []).filter(
             (workflowOutput) => workflowOutput.output_name !== props.name
         );
         stepStore.updateStep({ ...props.step, workflow_outputs: strippedWorkflowOutputs });
         error.value = undefined;
+        emit("onOutputLabel", oldLabel, null);
         return;
     }
 
@@ -74,6 +80,8 @@ function onInput(newLabel: string | undefined | null) {
             output_name: props.name,
         });
         stepStore.updateStep({ ...props.step, workflow_outputs: newWorkflowOutputs });
+        const oldLabel = label.value || null;
+        emit("onOutputLabel", oldLabel, newLabel || null);
         error.value = undefined;
     } else if (existingWorkflowOutput.stepId !== props.step.id) {
         error.value = `Duplicate output label '${newLabel}' will be ignored.`;

--- a/client/src/components/Workflow/Editor/Forms/FormSection.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormSection.vue
@@ -23,6 +23,7 @@
             :datatypes="datatypes"
             :form-data="formData"
             @onInput="onInput"
+            @onOutputLabel="onOutputLabel"
             @onDatatype="onDatatype" />
     </div>
 </template>
@@ -147,6 +148,9 @@ export default {
             } else if (this.emailPayloadKey in pjas) {
                 delete pjas[this.emailPayloadKey];
             }
+        },
+        onOutputLabel(oldValue, newValue) {
+            this.$emit("onOutputLabel", oldValue, newValue);
         },
         onInput(value, pjaKey) {
             let changed = false;

--- a/client/src/components/Workflow/Editor/Forms/FormTool.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.vue
@@ -46,6 +46,7 @@
                     :step="step"
                     :datatypes="datatypes"
                     :post-job-actions="postJobActions"
+                    @onOutputLabel="onOutputLabel"
                     @onChange="onChangePostJobActions" />
             </div>
         </template>
@@ -88,7 +89,7 @@ export default {
             required: true,
         },
     },
-    emits: ["onSetData", "onUpdateStep", "onChangePostJobActions", "onAnnotation", "onLabel"],
+    emits: ["onSetData", "onUpdateStep", "onChangePostJobActions", "onAnnotation", "onLabel", "onOutputLabel"],
     setup(props, { emit }) {
         const { stepId, annotation, label, stepInputs, stepOutputs, configForm, postJobActions } = useStepProps(
             toRef(props, "step")
@@ -162,6 +163,9 @@ export default {
         },
         onLabel(newLabel) {
             this.$emit("onLabel", this.stepId, newLabel);
+        },
+        onOutputLabel(oldValue, newValue) {
+            this.$emit("onOutputLabel", oldValue, newValue);
         },
         /**
          * Change event is triggered on component creation and input changes.

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -169,6 +169,7 @@ import { Toast } from "composables/toast";
 import { storeToRefs } from "pinia";
 import Vue, { computed, onUnmounted, ref, unref } from "vue";
 
+import { replaceLabel } from "@/components/Markdown/parse";
 import { getUntypedWorkflowParameters } from "@/components/Workflow/Editor/modules/parameters";
 import { ConfirmDialog } from "@/composables/confirmDialog";
 import { useDatatypesMapper } from "@/composables/datatypesMapper";
@@ -642,7 +643,10 @@ export default {
         },
         onLabel(nodeId, newLabel) {
             const step = { ...this.steps[nodeId], label: newLabel };
+            const oldLabel = this.steps[nodeId].label;
             this.onUpdateStep(step);
+            const newMarkdown = replaceLabel(this.markdownText, "step", oldLabel, newLabel);
+            this.onReportUpdate(newMarkdown);
         },
         onScrollTo(stepId) {
             this.scrollToId = stepId;

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -338,6 +338,7 @@ export default {
             showSaveAsModal: false,
             transform: { x: 0, y: 0, k: 1 },
             graphOffset: { left: 0, top: 0, width: 0, height: 0 },
+            debounceTimer: null,
         };
     },
     computed: {
@@ -645,8 +646,18 @@ export default {
             const step = { ...this.steps[nodeId], label: newLabel };
             const oldLabel = this.steps[nodeId].label;
             this.onUpdateStep(step);
-            const newMarkdown = replaceLabel(this.markdownText, "step", oldLabel, newLabel);
+            const stepType = this.steps[nodeId].type;
+            const isInput = ["data_input", "data_collection_input", "parameter_input"].indexOf(stepType) >= 0;
+            const labelType = isInput ? "input" : "step";
+            const newMarkdown = replaceLabel(this.markdownText, labelType, oldLabel, newLabel);
+            if (newMarkdown !== this.markdownText) {
+                this.debouncedToast("Label updated in workflow report.", 1500);
+            }
             this.onReportUpdate(newMarkdown);
+        },
+        debouncedToast(message, delay) {
+            clearTimeout(this.debounceTimer);
+            this.debounceTimer = setTimeout(() => Toast.success(message), delay);
         },
         onScrollTo(stepId) {
             this.scrollToId = stepId;

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -95,6 +95,7 @@
                             @onChangePostJobActions="onChangePostJobActions"
                             @onAnnotation="onAnnotation"
                             @onLabel="onLabel"
+                            @onOutputLabel="onOutputLabel"
                             @onUpdateStep="onUpdateStep"
                             @onSetData="onSetData" />
                         <FormDefault
@@ -105,6 +106,7 @@
                             @onLabel="onLabel"
                             @onEditSubworkflow="onEditSubworkflow"
                             @onAttemptRefactor="onAttemptRefactor"
+                            @onOutputLabel="onOutputLabel"
                             @onUpdateStep="onUpdateStep"
                             @onSetData="onSetData" />
                         <WorkflowAttributes
@@ -642,6 +644,13 @@ export default {
                     this.onUpdateStep(step);
                 });
         },
+        onOutputLabel(oldValue, newValue) {
+            const newMarkdown = replaceLabel(this.markdownText, "output", oldValue, newValue);
+            if (newMarkdown !== this.markdownText) {
+                this.debouncedToast("Output label updated in workflow report.", 1500);
+            }
+            this.onReportUpdate(newMarkdown);
+        },
         onLabel(nodeId, newLabel) {
             const step = { ...this.steps[nodeId], label: newLabel };
             const oldLabel = this.steps[nodeId].label;
@@ -649,9 +658,10 @@ export default {
             const stepType = this.steps[nodeId].type;
             const isInput = ["data_input", "data_collection_input", "parameter_input"].indexOf(stepType) >= 0;
             const labelType = isInput ? "input" : "step";
+            const labelTypeTitle = isInput ? "Input" : "Step";
             const newMarkdown = replaceLabel(this.markdownText, labelType, oldLabel, newLabel);
             if (newMarkdown !== this.markdownText) {
-                this.debouncedToast("Label updated in workflow report.", 1500);
+                this.debouncedToast(`${labelTypeTitle} label updated in workflow report.`, 1500);
             }
             this.onReportUpdate(newMarkdown);
         },


### PR DESCRIPTION
Extends the work of @assuntad23 and myself in https://github.com/galaxyproject/galaxy/issues/16864 and https://github.com/galaxyproject/galaxy/pull/17264 to handle spaces and quotes in labels better and to include workflow output labels in addition to input and step labels.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Create a workflow with a label on one of the steps
  2. Go to edit the Report, and create an item in the report that references a label
  3. Navigate back to workflow steps, and change the label.
  4. Go back to the report and see that the label is changed. 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
