### PR TITLE
[24.0] Fix workflow run form failing on certain histories

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -90,12 +90,14 @@ from galaxy.tools.parameters import (
     visit_input_values,
 )
 from galaxy.tools.parameters.basic import (
-    ConnectedValue,
     DataCollectionToolParameter,
     DataToolParameter,
-    RuntimeValue,
 )
-from galaxy.tools.parameters.workflow_building_modes import workflow_building_modes
+from galaxy.tools.parameters.workflow_utils import (
+    ConnectedValue,
+    RuntimeValue,
+    workflow_building_modes,
+)
 from galaxy.util.hash_util import md5_hash_str
 from galaxy.util.json import (
     safe_dumps,

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -142,7 +142,7 @@ from galaxy.tools.parameters.grouping import (
 )
 from galaxy.tools.parameters.input_translation import ToolInputTranslator
 from galaxy.tools.parameters.meta import expand_meta_parameters
-from galaxy.tools.parameters.workflow_building_modes import workflow_building_modes
+from galaxy.tools.parameters.workflow_utils import workflow_building_modes
 from galaxy.tools.parameters.wrapped_json import json_wrap
 from galaxy.tools.test import parse_tests
 from galaxy.util import (

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -33,9 +33,9 @@ from galaxy.tools.parameters import update_dataset_ids
 from galaxy.tools.parameters.basic import (
     DataCollectionToolParameter,
     DataToolParameter,
-    RuntimeValue,
     SelectToolParameter,
 )
+from galaxy.tools.parameters.workflow_utils import RuntimeValue
 from galaxy.tools.parameters.wrapped import (
     LegacyUnprefixedDict,
     WrappedParameters,

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -34,7 +34,7 @@ from galaxy.tools.actions import (
     on_text_for_names,
     ToolExecutionCache,
 )
-from galaxy.tools.parameters.basic import is_runtime_value
+from galaxy.tools.parameters.workflow_utils import is_runtime_value
 
 if typing.TYPE_CHECKING:
     from galaxy.tools import Tool

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -16,9 +16,7 @@ from galaxy.util.json import safe_loads
 from .basic import (
     DataCollectionToolParameter,
     DataToolParameter,
-    is_runtime_value,
     ParameterValueError,
-    runtime_to_json,
     SelectToolParameter,
     ToolParameter,
 )
@@ -28,6 +26,10 @@ from .grouping import (
     Repeat,
     Section,
     UploadDataset,
+)
+from .workflow_utils import (
+    is_runtime_value,
+    runtime_to_json,
 )
 from .wrapped import flat_to_nested_state
 

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -517,12 +517,9 @@ def _populate_state_legacy(
     request_context, inputs, incoming, state, errors, prefix="", context=None, check=True, simple_errors=True
 ):
     nested_state = flat_to_nested_state(incoming)
-    context = ExpressionContext(state, context)
+    context = ExpressionContext(state, nested_state)
     for input in inputs.values():
-        if input.name not in nested_state:
-            state[input.name] = input.get_initial_value(request_context, context)
-        else:
-            state[input.name] = nested_state[input.name]
+        state[input.name] = input.get_initial_value(request_context, context)
         key = prefix + input.name
         group_state = state[input.name]
         group_prefix = f"{key}|"

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -518,8 +518,9 @@ def populate_state(
 def _populate_state_legacy(
     request_context, inputs, incoming, state, errors, prefix="", context=None, check=True, simple_errors=True
 ):
-    nested_state = flat_to_nested_state(incoming)
-    context = ExpressionContext(state, nested_state)
+    if context is None:
+        context = flat_to_nested_state(incoming)
+    context = ExpressionContext(state, context)
     for input in inputs.values():
         state[input.name] = input.get_initial_value(request_context, context)
         key = prefix + input.name

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -42,7 +42,7 @@ from galaxy.model import (
 from galaxy.model.dataset_collections import builder
 from galaxy.schema.fetch_data import FilesPayload
 from galaxy.tool_util.parser import get_input_source as ensure_input_source
-from galaxy.tools.parameters.workflow_building_modes import workflow_building_modes
+from galaxy.tools.parameters.workflow_utils import workflow_building_modes
 from galaxy.util import (
     sanitize_param,
     string_as_bool,
@@ -61,6 +61,12 @@ from . import (
 )
 from .dataset_matcher import get_dataset_matcher_factory
 from .sanitize import ToolParameterSanitizer
+from .workflow_utils import (
+    is_runtime_value,
+    runtime_to_json,
+    runtime_to_object,
+    RuntimeValue,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -85,12 +91,6 @@ def contains_workflow_parameter(value, search=False):
     if not search and WORKFLOW_PARAMETER_REGULAR_EXPRESSION.match(value):
         return True
     return False
-
-
-def is_runtime_value(value):
-    return isinstance(value, RuntimeValue) or (
-        isinstance(value, MutableMapping) and value.get("__class__") in ["RuntimeValue", "ConnectedValue"]
-    )
 
 
 def is_runtime_context(trans, other_values):
@@ -2775,36 +2775,6 @@ parameter_types = dict(
     directory_uri=DirectoryUriToolParameter,
     drill_down=DrillDownSelectToolParameter,
 )
-
-
-def runtime_to_json(runtime_value):
-    if isinstance(runtime_value, ConnectedValue) or (
-        isinstance(runtime_value, MutableMapping) and runtime_value["__class__"] == "ConnectedValue"
-    ):
-        return {"__class__": "ConnectedValue"}
-    else:
-        return {"__class__": "RuntimeValue"}
-
-
-def runtime_to_object(runtime_value):
-    if isinstance(runtime_value, ConnectedValue) or (
-        isinstance(runtime_value, MutableMapping) and runtime_value["__class__"] == "ConnectedValue"
-    ):
-        return ConnectedValue()
-    else:
-        return RuntimeValue()
-
-
-class RuntimeValue:
-    """
-    Wrapper to note a value that is not yet set, but will be required at runtime.
-    """
-
-
-class ConnectedValue(RuntimeValue):
-    """
-    Wrapper to note a value that is not yet set, but will be inferred from a connection.
-    """
 
 
 def history_item_dict_to_python(value, app, name):

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -737,16 +737,20 @@ class DynamicOptions:
                 if not hasattr(dataset, "get_file_name"):
                     continue
                 # Ensure parsing dynamic options does not consume more than a megabyte worth memory.
-                path = dataset.get_file_name()
-                if os.path.getsize(path) < 1048576:
-                    with open(path) as fh:
-                        options += self.parse_file_fields(fh)
-                else:
-                    # Pass just the first megabyte to parse_file_fields.
-                    log.warning("Attempting to load options from large file, reading just first megabyte")
-                    with open(path) as fh:
-                        contents = fh.read(1048576)
-                    options += self.parse_file_fields(StringIO(contents))
+                try:
+                    path = dataset.get_file_name()
+                    if os.path.getsize(path) < 1048576:
+                        with open(path) as fh:
+                            options += self.parse_file_fields(fh)
+                    else:
+                        # Pass just the first megabyte to parse_file_fields.
+                        log.warning("Attempting to load options from large file, reading just first megabyte")
+                        with open(path) as fh:
+                            contents = fh.read(1048576)
+                        options += self.parse_file_fields(StringIO(contents))
+                except Exception as e:
+                    log.warning("Could not read contents from %s: %s", dataset, str(e))
+                    continue
         elif self.tool_data_table:
             options = self.tool_data_table.get_fields()
             if trans and trans.user and trans.workflow_building_mode != workflow_building_modes.ENABLED:

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -28,7 +28,10 @@ from galaxy.model import (
     User,
 )
 from galaxy.tools.expressions import do_eval
-from galaxy.tools.parameters.workflow_building_modes import workflow_building_modes
+from galaxy.tools.parameters.workflow_utils import (
+    is_runtime_value,
+    workflow_building_modes,
+)
 from galaxy.util import (
     Element,
     string_as_bool,
@@ -962,6 +965,8 @@ def _get_ref_data(other_values, ref_name):
             list,
         ),
     ):
+        if is_runtime_value(ref):
+            return []
         raise ValueError
     if isinstance(ref, DatasetCollectionElement) and ref.hda:
         ref = ref.hda

--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -618,8 +618,8 @@ class UploadDataset(Group):
         writable_files = d_type.writable_files
         writable_files_offset = 0
         groups_incoming = [None for _ in range(file_count)]
-        for group_incoming in context.get(self.name, []):
-            i = int(group_incoming["__index__"])
+        for i, group_incoming in enumerate(context.get(self.name, [])):
+            i = int(group_incoming.get("__index__", i))
             groups_incoming[i] = group_incoming
         if d_type.composite_type is not None or force_composite:
             # handle uploading of composite datatypes

--- a/lib/galaxy/tools/parameters/meta.py
+++ b/lib/galaxy/tools/parameters/meta.py
@@ -21,6 +21,7 @@ from galaxy.model.dataset_collections import (
 )
 from galaxy.util import permutations
 from . import visit_input_values
+from .wrapped import process_key
 
 log = logging.getLogger(__name__)
 
@@ -151,31 +152,6 @@ def expand_workflow_inputs(param_inputs, inputs=None):
         input_combinations.append(new_inputs)
 
     return WorkflowParameterExpansion(param_combinations, params_keys, input_combinations)
-
-
-def process_key(incoming_key, incoming_value, d):
-    key_parts = incoming_key.split("|")
-    if len(key_parts) == 1:
-        # Regular parameter
-        if incoming_key in d and not incoming_value:
-            # In case we get an empty repeat after we already filled in a repeat element
-            return
-        d[incoming_key] = incoming_value
-    elif key_parts[0].rsplit("_", 1)[-1].isdigit():
-        # Repeat
-        input_name, index = key_parts[0].rsplit("_", 1)
-        index = int(index)
-        d.setdefault(input_name, [])
-        newlist = [{} for _ in range(index + 1)]
-        d[input_name].extend(newlist[len(d[input_name]) :])
-        subdict = d[input_name][index]
-        process_key("|".join(key_parts[1:]), incoming_value=incoming_value, d=subdict)
-    else:
-        # Section / Conditional
-        input_name = key_parts[0]
-        subdict = {}
-        d[input_name] = subdict
-        process_key("|".join(key_parts[1:]), incoming_value=incoming_value, d=subdict)
 
 
 ExpandedT = Tuple[List[Dict[str, Any]], Optional[matching.MatchingCollections]]

--- a/lib/galaxy/tools/parameters/workflow_building_modes.py
+++ b/lib/galaxy/tools/parameters/workflow_building_modes.py
@@ -1,4 +1,0 @@
-class workflow_building_modes:
-    DISABLED = False
-    ENABLED = True
-    USE_HISTORY = 1

--- a/lib/galaxy/tools/parameters/workflow_utils.py
+++ b/lib/galaxy/tools/parameters/workflow_utils.py
@@ -1,0 +1,43 @@
+from collections.abc import MutableMapping
+
+
+class workflow_building_modes:
+    DISABLED = False
+    ENABLED = True
+    USE_HISTORY = 1
+
+
+def runtime_to_json(runtime_value):
+    if isinstance(runtime_value, ConnectedValue) or (
+        isinstance(runtime_value, MutableMapping) and runtime_value["__class__"] == "ConnectedValue"
+    ):
+        return {"__class__": "ConnectedValue"}
+    else:
+        return {"__class__": "RuntimeValue"}
+
+
+def runtime_to_object(runtime_value):
+    if isinstance(runtime_value, ConnectedValue) or (
+        isinstance(runtime_value, MutableMapping) and runtime_value["__class__"] == "ConnectedValue"
+    ):
+        return ConnectedValue()
+    else:
+        return RuntimeValue()
+
+
+class RuntimeValue:
+    """
+    Wrapper to note a value that is not yet set, but will be required at runtime.
+    """
+
+
+class ConnectedValue(RuntimeValue):
+    """
+    Wrapper to note a value that is not yet set, but will be inferred from a connection.
+    """
+
+
+def is_runtime_value(value):
+    return isinstance(value, RuntimeValue) or (
+        isinstance(value, MutableMapping) and value.get("__class__") in ["RuntimeValue", "ConnectedValue"]
+    )

--- a/lib/galaxy/tools/parameters/wrapped.py
+++ b/lib/galaxy/tools/parameters/wrapped.py
@@ -158,4 +158,36 @@ def make_list_copy(from_list):
     return new_list
 
 
-__all__ = ("LegacyUnprefixedDict", "WrappedParameters", "make_dict_copy")
+def process_key(incoming_key, incoming_value, d):
+    key_parts = incoming_key.split("|")
+    if len(key_parts) == 1:
+        # Regular parameter
+        if incoming_key in d and not incoming_value:
+            # In case we get an empty repeat after we already filled in a repeat element
+            return
+        d[incoming_key] = incoming_value
+    elif key_parts[0].rsplit("_", 1)[-1].isdigit():
+        # Repeat
+        input_name, index = key_parts[0].rsplit("_", 1)
+        index = int(index)
+        d.setdefault(input_name, [])
+        newlist = [{} for _ in range(index + 1)]
+        d[input_name].extend(newlist[len(d[input_name]) :])
+        subdict = d[input_name][index]
+        process_key("|".join(key_parts[1:]), incoming_value=incoming_value, d=subdict)
+    else:
+        # Section / Conditional
+        input_name = key_parts[0]
+        subdict = d.get(input_name, {})
+        d[input_name] = subdict
+        process_key("|".join(key_parts[1:]), incoming_value=incoming_value, d=subdict)
+
+
+def flat_to_nested_state(incoming):
+    nested_state = {}
+    for key, value in incoming.items():
+        process_key(key, value, nested_state)
+    return nested_state
+
+
+__all__ = ("LegacyUnprefixedDict", "WrappedParameters", "make_dict_copy", "process_key", "flat_to_nested_state")

--- a/lib/galaxy/tools/parameters/wrapped.py
+++ b/lib/galaxy/tools/parameters/wrapped.py
@@ -1,5 +1,9 @@
 from collections import UserDict
-from typing import Dict
+from typing import (
+    Any,
+    Dict,
+    List,
+)
 
 from galaxy.tools.parameters.basic import (
     DataCollectionToolParameter,
@@ -158,7 +162,7 @@ def make_list_copy(from_list):
     return new_list
 
 
-def process_key(incoming_key, incoming_value, d):
+def process_key(incoming_key: str, incoming_value: Any, d: Dict[str, Any]):
     key_parts = incoming_key.split("|")
     if len(key_parts) == 1:
         # Regular parameter
@@ -168,10 +172,10 @@ def process_key(incoming_key, incoming_value, d):
         d[incoming_key] = incoming_value
     elif key_parts[0].rsplit("_", 1)[-1].isdigit():
         # Repeat
-        input_name, index = key_parts[0].rsplit("_", 1)
-        index = int(index)
+        input_name, _index = key_parts[0].rsplit("_", 1)
+        index = int(_index)
         d.setdefault(input_name, [])
-        newlist = [{} for _ in range(index + 1)]
+        newlist: List[Dict[Any, Any]] = [{} for _ in range(index + 1)]
         d[input_name].extend(newlist[len(d[input_name]) :])
         subdict = d[input_name][index]
         process_key("|".join(key_parts[1:]), incoming_value=incoming_value, d=subdict)
@@ -183,8 +187,8 @@ def process_key(incoming_key, incoming_value, d):
         process_key("|".join(key_parts[1:]), incoming_value=incoming_value, d=subdict)
 
 
-def flat_to_nested_state(incoming):
-    nested_state = {}
+def flat_to_nested_state(incoming: Dict[str, Any]):
+    nested_state: Dict[str, Any] = {}
     for key, value in incoming.items():
         process_key(key, value, nested_state)
     return nested_state

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -10,7 +10,7 @@ import requests
 import yaml
 
 from galaxy.tools.parameters import populate_state
-from galaxy.tools.parameters.workflow_building_modes import workflow_building_modes
+from galaxy.tools.parameters.workflow_utils import workflow_building_modes
 from galaxy.util import DEFAULT_SOCKET_TIMEOUT
 from galaxy.workflow.modules import module_factory
 

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -86,7 +86,7 @@ from galaxy.structured_app import StructuredApp
 from galaxy.tool_shed.galaxy_install.install_manager import InstallRepositoryManager
 from galaxy.tools import recommendations
 from galaxy.tools.parameters import populate_state
-from galaxy.tools.parameters.workflow_building_modes import workflow_building_modes
+from galaxy.tools.parameters.workflow_utils import workflow_building_modes
 from galaxy.util.sanitize_html import sanitize_html
 from galaxy.version import VERSION
 from galaxy.web import (

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -17,7 +17,7 @@ from galaxy.managers.workflows import (
 )
 from galaxy.model.base import transaction
 from galaxy.model.item_attrs import UsesItemRatings
-from galaxy.tools.parameters.workflow_building_modes import workflow_building_modes
+from galaxy.tools.parameters.workflow_utils import workflow_building_modes
 from galaxy.util import FILENAME_VALID_CHARS
 from galaxy.util.sanitize_html import sanitize_html
 from galaxy.web import url_for

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1989,18 +1989,6 @@ class ToolModule(WorkflowModule):
                     and self.trans.workflow_building_mode is workflow_building_modes.USE_HISTORY
                 ):
                     if prefixed_name in input_connections_by_name:
-                        connection = input_connections_by_name[prefixed_name]
-                        output_step = next(
-                            output_step for output_step in steps if connection.output_step_id == output_step.id
-                        )
-                        if output_step.type.startswith("data"):
-                            output_inputs = output_step.module.get_runtime_inputs(output_step, connections=connections)
-                            output_value = output_inputs["input"].get_initial_value(self.trans, context)
-                            if input_type == "data" and isinstance(
-                                output_value, self.trans.app.model.HistoryDatasetCollectionAssociation
-                            ):
-                                return output_value.to_hda_representative()
-                            return output_value
                         return ConnectedValue()
                     else:
                         return input.get_initial_value(self.trans, context)

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -68,16 +68,13 @@ from galaxy.tools.parameters.basic import (
     BaseDataToolParameter,
     BooleanToolParameter,
     ColorToolParameter,
-    ConnectedValue,
     DataCollectionToolParameter,
     DataToolParameter,
     FloatToolParameter,
     HiddenToolParameter,
     IntegerToolParameter,
-    is_runtime_value,
     parameter_types,
     raw_to_galaxy,
-    runtime_to_json,
     SelectToolParameter,
     TextToolParameter,
 )
@@ -86,7 +83,12 @@ from galaxy.tools.parameters.grouping import (
     ConditionalWhen,
 )
 from galaxy.tools.parameters.history_query import HistoryQuery
-from galaxy.tools.parameters.workflow_building_modes import workflow_building_modes
+from galaxy.tools.parameters.workflow_utils import (
+    ConnectedValue,
+    is_runtime_value,
+    runtime_to_json,
+    workflow_building_modes,
+)
 from galaxy.tools.parameters.wrapped import make_dict_copy
 from galaxy.util import (
     listify,

--- a/lib/galaxy/workflow/refactor/execute.py
+++ b/lib/galaxy/workflow/refactor/execute.py
@@ -6,9 +6,9 @@ from typing import (
 
 from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.tools.parameters import visit_input_values
-from galaxy.tools.parameters.basic import (
+from galaxy.tools.parameters.basic import contains_workflow_parameter
+from galaxy.tools.parameters.workflow_utils import (
     ConnectedValue,
-    contains_workflow_parameter,
     runtime_to_json,
 )
 from .schema import (

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -57,6 +57,7 @@
   <tool file="filter_param_value_ref_attribute.xml" />
   <tool file="filter_static_regexp.xml" />
   <tool file="select_from_dataset.xml" />
+  <tool file="select_from_dataset_in_conditional.xml" />
   <tool file="select_from_csvdataset.xml" />
   <tool file="select_from_dataset_optional.xml" />
   <tool file="drill_down.xml" />

--- a/test/functional/tools/select_from_dataset_in_conditional.xml
+++ b/test/functional/tools/select_from_dataset_in_conditional.xml
@@ -1,0 +1,60 @@
+<tool id="select_from_dataset_in_conditional" name="select_from_dataset_in_conditional"
+    version="0.1.0">
+    <description>Create dynamic options from data sets</description>
+    <command><![CDATA[
+echo select_single '$cond.select_single' > '$output'
+    ]]></command>
+    <inputs>
+        <param name="single" type="data" format="tabular" label="single" />
+        <conditional name="cond">
+            <param name="cond" type="select">
+                <option value="single">single</option>
+            </param>
+            <when value="single">
+                <param name="select_single" type="select" label="select_single">
+                    <options from_dataset="single">
+                        <column name="name" index="1" />
+                        <column name="value" index="0" />
+                        <validator type="no_options" message="No data is available in single" />
+                    </options>
+                </param>
+                <conditional name="inner_cond">
+                    <param name="inner_cond" type="select">
+                        <option value="single">single</option>
+                    </param>
+                    <when value="single">
+                        <param name="select_single" type="select" label="select_single">
+                            <options from_dataset="single">
+                                <column name="name" index="1" />
+                                <column name="value" index="0" />
+                                <validator type="no_options"
+                                    message="No data is available in single" />
+                            </options>
+                        </param>
+                    </when>
+                </conditional>
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="single" value="1.tabular" />
+            <conditional name="cond">
+                <param name="select_single" value="chr10" />
+                <conditional name="inner_cond">
+                    <param name="select_single" value="chr10" />
+                </conditional>
+            </conditional>
+            <output name="output">
+                <assert_contents>
+                    <has_text text="select_single chr10" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/integration/test_workflow_refactoring.py
+++ b/test/integration/test_workflow_refactoring.py
@@ -21,7 +21,7 @@ from galaxy.model import (
     WorkflowStepConnection,
 )
 from galaxy.model.base import transaction
-from galaxy.tools.parameters.workflow_building_modes import workflow_building_modes
+from galaxy.tools.parameters.workflow_utils import workflow_building_modes
 from galaxy.workflow.refactor.schema import RefactorActionExecutionMessageTypeEnum
 from galaxy_test.base.populators import WorkflowPopulator
 from galaxy_test.base.uses_shed_api import UsesShedApi

--- a/test/unit/app/tools/test_parameter_parsing.py
+++ b/test/unit/app/tools/test_parameter_parsing.py
@@ -3,7 +3,7 @@ from typing import (
     Dict,
 )
 
-from galaxy.tools.parameters.meta import process_key
+from galaxy.tools.parameters.wrapped import process_key
 from .util import BaseParameterTestCase
 
 

--- a/test/unit/app/tools/test_select_parameters.py
+++ b/test/unit/app/tools/test_select_parameters.py
@@ -4,7 +4,7 @@ import pytest
 
 from galaxy import model
 from galaxy.model.base import transaction
-from galaxy.tools.parameters import basic
+from galaxy.tools.parameters.workflow_utils import RuntimeValue
 from .util import BaseParameterTestCase
 
 
@@ -36,7 +36,7 @@ class TestSelectToolParameter(BaseParameterTestCase):
         self.options_xml = """<options><filter type="data_meta" ref="input_bam" key="dbkey"/></options>"""
         self.trans.workflow_building_mode = True
         assert isinstance(
-            self.param.from_json(model.HistoryDatasetAssociation(), self.trans, {"input_bam": basic.RuntimeValue()}),
+            self.param.from_json(model.HistoryDatasetAssociation(), self.trans, {"input_bam": RuntimeValue()}),
             model.HistoryDatasetAssociation,
         )
 


### PR DESCRIPTION
If we don't replace connected values with concrete value in the run form we won't run into errors when trying to use datasets in the history as potential inputs to input parameters that are already connected. This doesn't seem necessary, and makes the run form behave more like workflow scheduling. Should fix various 500 errors that are possible if there are failed or otherwise unexpected datasets in a history.

Fixes https://sentry.galaxyproject.org/share/issue/b162b010af894eecafdaea3ae1fd8e19/:
```
FileNotFoundError: [Errno 2] No such file or directory: ''
  File "galaxy/web/framework/decorators.py", line 346, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/api/workflows.py", line 357, in workflow_dict
    ret_dict = self.workflow_contents_manager.workflow_to_dict(
  File "galaxy/managers/workflows.py", line 905, in workflow_to_dict
    wf_dict = self._workflow_to_dict_run(trans, stored, workflow=workflow, history=history or trans.history)
  File "galaxy/managers/workflows.py", line 1007, in _workflow_to_dict_run
    step_model = tool.to_json(
  File "galaxy/tools/__init__.py", line 2509, in to_json
    populate_state(request_context, self.inputs, params.__dict__, state_inputs, state_errors)
  File "galaxy/tools/parameters/__init__.py", line 409, in populate_state
    _populate_state_legacy(
  File "galaxy/tools/parameters/__init__.py", line 520, in _populate_state_legacy
    state[input.name] = input.get_initial_value(request_context, context)
  File "galaxy/tools/parameters/grouping.py", line 796, in get_initial_value
    rval[child_input.name] = child_input.get_initial_value(trans, child_context)
  File "galaxy/tools/parameters/basic.py", line 1107, in get_initial_value
    options = list(self.get_options(trans, other_values))
  File "galaxy/tools/parameters/basic.py", line 960, in get_options
    return self.options.get_options(trans, other_values)
  File "galaxy/tools/parameters/dynamic_options.py", line 874, in get_options
    options = self.get_fields(trans, other_values)
  File "galaxy/tools/parameters/dynamic_options.py", line 741, in get_fields
    if os.path.getsize(path) < 1048576:
  File "<frozen genericpath>", line 50, in getsize
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
