### PR TITLE
Remove duplicate tool panel insertion, rely on activity bar

### DIFF
--- a/client/src/components/Common/PublishedItem.vue
+++ b/client/src/components/Common/PublishedItem.vue
@@ -1,12 +1,9 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-import { usePanels } from "@/composables/usePanels";
-
 import ActivityBar from "@/components/ActivityBar/ActivityBar.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import FlexPanel from "@/components/Panels/FlexPanel.vue";
-import ToolPanel from "@/components/Panels/ToolPanel.vue";
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 
 interface Item {
@@ -45,17 +42,11 @@ const owner = computed(() => props.item?.owner ?? props.item?.username ?? "Unava
 const pluralPath = computed(() => plural.value.toLowerCase());
 const publishedByUser = computed(() => `/${pluralPath.value}/list_published?f-username=${owner.value}`);
 const urlAll = computed(() => `/${pluralPath.value}/list_published`);
-
-const { showToolbox } = usePanels();
 </script>
 
 <template>
     <div id="columns" class="d-flex">
         <ActivityBar />
-
-        <FlexPanel v-if="showToolbox" side="left">
-            <ToolPanel />
-        </FlexPanel>
 
         <div id="center" class="m-3 w-100 overflow-auto d-flex flex-column">
             <slot />

--- a/client/src/components/Workflow/Published/WorkflowPublished.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublished.vue
@@ -7,7 +7,6 @@ import { computed, ref, watch } from "vue";
 
 import { fromSimple } from "@/components/Workflow/Editor/modules/model";
 import { useDatatypesMapper } from "@/composables/datatypesMapper";
-import { usePanels } from "@/composables/usePanels";
 import { provideScopedWorkflowStores } from "@/composables/workflowStores";
 import { useUserStore } from "@/stores/userStore";
 import type { Workflow } from "@/stores/workflowStore";
@@ -17,8 +16,6 @@ import { withPrefix } from "@/utils/redirect";
 import WorkflowInformation from "./WorkflowInformation.vue";
 import ActivityBar from "@/components/ActivityBar/ActivityBar.vue";
 import Heading from "@/components/Common/Heading.vue";
-import FlexPanel from "@/components/Panels/FlexPanel.vue";
-import ToolPanel from "@/components/Panels/ToolPanel.vue";
 import WorkflowGraph from "@/components/Workflow/Editor/WorkflowGraph.vue";
 
 library.add(faSpinner, faUser, faBuilding, faPlay, faEdit, faDownload);
@@ -130,8 +127,6 @@ watch(
     }
 );
 
-const { showToolbox } = usePanels();
-
 const downloadUrl = computed(() => withPrefix(`/api/workflows/${props.id}/download?format=json-download`));
 const importUrl = computed(() => withPrefix(`/workflow/imp?id=${props.id}`));
 const runUrl = computed(() => withPrefix(`/workflows/run?id=${props.id}`));
@@ -157,9 +152,6 @@ const viewUrl = computed(() => withPrefix(`/published/workflow?id=${props.id}`))
 <template>
     <div id="columns" class="d-flex">
         <ActivityBar v-if="!props.embed" />
-        <FlexPanel v-if="!props.embed && showToolbox" side="left">
-            <ToolPanel />
-        </FlexPanel>
 
         <div id="center" class="container-root m-3 w-100 overflow-auto d-flex flex-column">
             <div v-if="loading">

--- a/client/src/composables/usePanels.ts
+++ b/client/src/composables/usePanels.ts
@@ -12,10 +12,7 @@ export function usePanels() {
         return true;
     });
 
-    const showToolbox = computed(() => showPanels.value);
-
     return {
         showPanels,
-        showToolbox,
     };
 }


### PR DESCRIPTION
When displaying published items such as Workflows and Pages, a second, duplicate tool panel appears. One is displayed in the context of the activity bar, and the second one is inserted manually. This PR resolves this by removing the duplicate tool panel insertion.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
