### PR TITLE
[24.0] Backport `#16094` Missing outputs should be recorded as test errors

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1485,7 +1485,6 @@ def _handle_def_errors(testdef):
 
 
 def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, galaxy_interactor, quiet=False):
-    assert data_list or data_collection_list, "Tool produced no output data"
     assert len(jobs) == 1, "Test framework logic error, somehow tool test resulted in more than one job."
     job = jobs[0]
 
@@ -1498,6 +1497,10 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
                 if stream in job_stdio:
                     print(_format_stream(job_stdio[stream], stream=stream, format=True), file=sys.stderr)
         found_exceptions.append(e)
+
+    if not (data_list or data_collection_list):
+        error = AssertionError("Tool produced no output datasets or collections")
+        register_exception(error)
 
     if testdef.expect_failure:
         if testdef.outputs:

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1430,8 +1430,6 @@ def verify_tool(
             raise e
 
         if not expected_failure_occurred:
-            assert data_list or data_collection_list
-
             try:
                 job_stdio = _verify_outputs(
                     testdef, test_history, jobs, data_list, data_collection_list, galaxy_interactor, quiet=quiet
@@ -1487,6 +1485,7 @@ def _handle_def_errors(testdef):
 
 
 def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, galaxy_interactor, quiet=False):
+    assert data_list or data_collection_list, "Tool produced no output data"
     assert len(jobs) == 1, "Test framework logic error, somehow tool test resulted in more than one job."
     job = jobs[0]
 

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1498,10 +1498,6 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
                     print(_format_stream(job_stdio[stream], stream=stream, format=True), file=sys.stderr)
         found_exceptions.append(e)
 
-    if not (data_list or data_collection_list):
-        error = AssertionError("Tool produced no output datasets or collections")
-        register_exception(error)
-
     if testdef.expect_failure:
         if testdef.outputs:
             raise Exception("Cannot specify outputs in a test expecting failure.")
@@ -1518,6 +1514,10 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
             found_exceptions.append(e)
 
     job_stdio = galaxy_interactor.get_job_stdio(job["id"])
+
+    if not (data_list or data_collection_list):
+        error = AssertionError("Tool produced no output datasets or collections")
+        register_exception(error)
 
     if testdef.num_outputs is not None:
         expected = testdef.num_outputs

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1487,7 +1487,6 @@ def _handle_def_errors(testdef):
 def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, galaxy_interactor, quiet=False):
     assert len(jobs) == 1, "Test framework logic error, somehow tool test resulted in more than one job."
     job = jobs[0]
-
     found_exceptions: List[Exception] = []
 
     def register_exception(e: Exception):
@@ -1501,6 +1500,9 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
     if testdef.expect_failure:
         if testdef.outputs:
             raise Exception("Cannot specify outputs in a test expecting failure.")
+
+    if not data_list and not data_collection_list:
+        Exception("Job did not produce any outputs")
 
     maxseconds = testdef.maxseconds
     # Wait for the job to complete and register expections if the final

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1539,6 +1539,7 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
         outfile = output_dict["value"]
         attributes = output_dict["attributes"]
         output_testdef = Bunch(name=name, outfile=outfile, attributes=attributes)
+        output_data = None
         try:
             output_data = data_list[name]
         except (TypeError, KeyError):
@@ -1551,7 +1552,8 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
                 else:
                     output_data = data_list[len(data_list) - len(testdef.outputs) + output_index]
             except IndexError:
-                pass
+                error = AssertionError(f"Tool did not produce an output with name '{name}' (or at index {output_index})")
+                register_exception(error)
         if output_data:
             try:
                 galaxy_interactor.verify_output(
@@ -1565,9 +1567,6 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
                 )
             except Exception as e:
                 register_exception(e)
-        else:
-            error = AssertionError(f"Tool did not produce an output with name '{name}' (or at index {output_index})")
-            register_exception(error)
 
     other_checks = {
         "command_line": "Command produced by the job",

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1501,9 +1501,6 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
         if testdef.outputs:
             raise Exception("Cannot specify outputs in a test expecting failure.")
 
-    if not data_list and not data_collection_list:
-        Exception("Job did not produce any outputs")
-
     maxseconds = testdef.maxseconds
     # Wait for the job to complete and register expections if the final
     # status was not what test was expecting.
@@ -1517,9 +1514,7 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
 
     job_stdio = galaxy_interactor.get_job_stdio(job["id"])
 
-    if not (data_list or data_collection_list):
-        error = AssertionError("Tool produced no output datasets or collections")
-        register_exception(error)
+    assert data_list or data_collection_list, "Tool produced no output datasets or collections"
 
     if testdef.num_outputs is not None:
         expected = testdef.num_outputs

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1552,7 +1552,9 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
                 else:
                     output_data = data_list[len(data_list) - len(testdef.outputs) + output_index]
             except IndexError:
-                error = AssertionError(f"Tool did not produce an output with name '{name}' (or at index {output_index})")
+                error = AssertionError(
+                    f"Tool did not produce an output with name '{name}' (or at index {output_index})"
+                )
                 register_exception(error)
         if output_data:
             try:

--- a/test/functional/tools/output_filter.xml
+++ b/test/functional/tools/output_filter.xml
@@ -78,6 +78,9 @@ echo 'p2.reverse' > p2.reverse
                     <has_line line="test" />
                 </assert_contents>
             </output>
+            <assert_stdout>
+                <has_n_lines n="0"/>
+            </assert_stdout>
         </test>
         <test expect_num_outputs="4">
             <param name="produce_out_1" value="true" />

--- a/test/functional/tools/output_filter.xml
+++ b/test/functional/tools/output_filter.xml
@@ -1,15 +1,15 @@
 <tool id="output_filter" name="output_filter" version="1.0.0">
     <description>test for output filtering and expect_num_outputs</description>
     <command><![CDATA[
-echo 'test' > 1 &&
-echo 'test' > 2 &&
-echo 'test' > 3 &&
-echo 'test' > 4 &&
-echo 'test' > 5 &&
-echo 'test' > p1.forward &&
-echo 'test' > p1.reverse &&
-echo 'test' > p2.forward &&
-echo 'test' > p2.reverse 
+echo '1' > 1 &&
+echo '2' > 2 &&
+echo '3' > 3 &&
+echo '4' > 4 &&
+echo '5' > 5 &&
+echo 'p1.forward' > p1.forward &&
+echo 'p1.reverse' > p1.reverse &&
+echo 'p2.forward' > p2.forward &&
+echo 'p2.reverse' > p2.reverse 
     ]]></command>
     <inputs>
         <param name="produce_out_1" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Do Filter 1" />
@@ -42,12 +42,12 @@ echo 'test' > p2.reverse
             <param name="filter_text_1" value="foo" />
             <output name="out_1">
                 <assert_contents>
-                    <has_line line="test" />
+                    <has_line line="1" />
                 </assert_contents>
             </output>
             <output name="out_2">
                 <assert_contents>
-                    <has_line line="test" />
+                    <has_line line="2" />
                 </assert_contents>
             </output>
             <output name="out_3">
@@ -61,7 +61,7 @@ echo 'test' > p2.reverse
             <param name="filter_text_1" value="bar" /> <!-- fails second filter in out2 -->
             <output name="out_1">
                 <assert_contents>
-                    <has_line line="test" />
+                    <has_line line="1" />
                 </assert_contents>
             </output>
             <output name="out_3">
@@ -85,12 +85,12 @@ echo 'test' > p2.reverse
             <param name="produce_collection" value="true" />
             <output name="out_1">
                 <assert_contents>
-                    <has_line line="test" />
+                    <has_line line="1" />
                 </assert_contents>
             </output>
             <output name="out_2">
                 <assert_contents>
-                    <has_line line="test" />
+                    <has_line line="2" />
                 </assert_contents>
             </output>
             <output name="out_3">
@@ -101,12 +101,12 @@ echo 'test' > p2.reverse
             <output_collection name="list_output" type="list" count="2">
                 <element name="4">
                     <assert_contents>
-                        <has_line line="test" />
+                        <has_line line="4" />
                     </assert_contents>
                 </element>
                 <element name="5">
                     <assert_contents>
-                        <has_line line="test" />
+                        <has_line line="5" />
                     </assert_contents>
                 </element>
             </output_collection>
@@ -118,12 +118,12 @@ echo 'test' > p2.reverse
             <param name="produce_paired_collection" value="true" />
             <output name="out_1">
                 <assert_contents>
-                    <has_line line="test" />
+                    <has_line line="1" />
                 </assert_contents>
             </output>
             <output name="out_2">
                 <assert_contents>
-                    <has_line line="test" />
+                    <has_line line="2" />
                 </assert_contents>
             </output>
             <output name="out_3">
@@ -134,12 +134,12 @@ echo 'test' > p2.reverse
             <output_collection name="list_output" type="list" count="2">
                 <element name="4">
                     <assert_contents>
-                        <has_line line="test" />
+                        <has_line line="4" />
                     </assert_contents>
                 </element>
                 <element name="5">
                     <assert_contents>
-                        <has_line line="test" />
+                        <has_line line="5" />
                     </assert_contents>
                 </element>
             </output_collection>
@@ -147,24 +147,24 @@ echo 'test' > p2.reverse
                 <element name="p1">
                     <element name="forward">
                         <assert_contents>
-                            <has_line line="test" />
+                            <has_line line="p1.forward" />
                         </assert_contents>
                     </element>
                     <element name="reverse">
                         <assert_contents>
-                            <has_line line="test" />
+                            <has_line line="p1.reverse" />
                         </assert_contents>
                     </element>
                 </element>
                 <element name="p2">
                     <element name="forward">
                         <assert_contents>
-                            <has_line line="test" />
+                            <has_line line="p2.forward" />
                         </assert_contents>
                     </element>
                     <element name="reverse">
                         <assert_contents>
-                            <has_line line="test" />
+                            <has_line line="p2.reverse" />
                         </assert_contents>
                     </element>
                 </element>


### PR DESCRIPTION
Ref: #16094

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
