### PR TITLE
Add admin activity to activity bar

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -11,12 +11,12 @@ import { type Activity, useActivityStore } from "@/stores/activityStore";
 import { useEventStore } from "@/stores/eventStore";
 import { useUserStore } from "@/stores/userStore";
 
-import AdminPanel from "@/components/admin/AdminPanel.vue";
 import VisualizationPanel from "../Panels/VisualizationPanel.vue";
 import ActivityItem from "./ActivityItem.vue";
 import InteractiveItem from "./Items/InteractiveItem.vue";
 import NotificationItem from "./Items/NotificationItem.vue";
 import UploadItem from "./Items/UploadItem.vue";
+import AdminPanel from "@/components/admin/AdminPanel.vue";
 import FlexPanel from "@/components/Panels/FlexPanel.vue";
 import MultiviewPanel from "@/components/Panels/MultiviewPanel.vue";
 import NotificationsPanel from "@/components/Panels/NotificationsPanel.vue";
@@ -48,7 +48,6 @@ const isDragging = ref(false);
 
 // sync built-in activities with cached activities
 activityStore.sync();
-
 
 const adminProperties = computed(() => {
     return {
@@ -214,6 +213,14 @@ watch(
                     :is-active="isActiveSideBar('notifications') || isActiveRoute('/user/notifications')"
                     title="Notifications"
                     @click="onToggleSidebar('notifications')" />
+                <ActivityItem
+                    id="activity-admin"
+                    icon="cog"
+                    :is-active="panelActivityIsActive('admin')"
+                    title="Admin"
+                    tooltip="Configure this Instance"
+                    to="/admin"
+                    @click="onToggleSidebar('admin', '/admin')" />
                 <ActivityItem
                     id="activity-settings"
                     icon="cog"

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -207,7 +207,7 @@ watch(
                     @click="onToggleSidebar('notifications')" />
                 <ActivityItem
                     id="activity-admin"
-                    icon="key"
+                    icon="user-cog"
                     :is-active="panelActivityIsActive('admin')"
                     title="Admin"
                     tooltip="Configure this Instance"

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -218,7 +218,7 @@ watch(
                     icon="user-cog"
                     :is-active="isActiveSideBar('admin')"
                     title="Admin"
-                    tooltip="Configure this Instance"
+                    tooltip="Administer this Galaxy"
                     variant="danger"
                     @click="onToggleSidebar('admin')" />
             </b-nav>

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -11,6 +11,7 @@ import { type Activity, useActivityStore } from "@/stores/activityStore";
 import { useEventStore } from "@/stores/eventStore";
 import { useUserStore } from "@/stores/userStore";
 
+import AdminPanel from "@/components/admin/AdminPanel.vue";
 import VisualizationPanel from "../Panels/VisualizationPanel.vue";
 import ActivityItem from "./ActivityItem.vue";
 import InteractiveItem from "./Items/InteractiveItem.vue";
@@ -173,7 +174,7 @@ watch(
                                 :to="activity.to"
                                 @click="onToggleSidebar()" />
                             <ActivityItem
-                                v-else-if="['tools', 'visualizations', 'multiview'].includes(activity.id)"
+                                v-else-if="['admin', 'tools', 'visualizations', 'multiview'].includes(activity.id)"
                                 :id="`activity-${activity.id}`"
                                 :key="activity.id"
                                 :icon="activity.icon"
@@ -219,6 +220,7 @@ watch(
             <MultiviewPanel v-else-if="isActiveSideBar('multiview')" />
             <NotificationsPanel v-else-if="isActiveSideBar('notifications')" />
             <SettingsPanel v-else-if="isActiveSideBar('settings')" />
+            <AdminPanel v-else-if="isActiveSideBar('admin')" />
         </FlexPanel>
     </div>
 </template>

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -32,7 +32,7 @@ const { hashedUserId } = useHashedUserId();
 
 const eventStore = useEventStore();
 const activityStore = useActivityStore();
-const { isAnonymous } = storeToRefs(userStore);
+const { isAdmin, isAnonymous } = storeToRefs(userStore);
 
 const emit = defineEmits(["dragstart"]);
 
@@ -213,6 +213,7 @@ watch(
                     tooltip="Edit preferences"
                     @click="onToggleSidebar('settings')" />
                 <ActivityItem
+                    v-if="isAdmin"
                     id="activity-admin"
                     icon="user-cog"
                     :is-active="isActiveSideBar('admin')"

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -49,14 +49,6 @@ const isDragging = ref(false);
 // sync built-in activities with cached activities
 activityStore.sync();
 
-const adminProperties = computed(() => {
-    return {
-        enableQuotas: config.value.enable_quotas,
-        isToolshedInstalled: config.value.tool_shed_urls && config.value.tool_shed_urls.length > 0,
-        versionMajor: config.value.version_major,
-    };
-});
-
 /**
  * Checks if the route of an activity is currently being visited and panels are collapsed
  */
@@ -215,18 +207,18 @@ watch(
                     @click="onToggleSidebar('notifications')" />
                 <ActivityItem
                     id="activity-admin"
-                    icon="cog"
+                    icon="key"
                     :is-active="panelActivityIsActive('admin')"
                     title="Admin"
                     tooltip="Configure this Instance"
-                    to="/admin"
-                    @click="onToggleSidebar('admin', '/admin')" />
+                    @click="onToggleSidebar('admin')" />
                 <ActivityItem
                     id="activity-settings"
                     icon="cog"
                     :is-active="isActiveSideBar('settings')"
                     title="Settings"
                     tooltip="Edit preferences"
+                    to="/admin"
                     @click="onToggleSidebar('settings')" />
             </b-nav>
         </div>
@@ -236,7 +228,7 @@ watch(
             <MultiviewPanel v-else-if="isActiveSideBar('multiview')" />
             <NotificationsPanel v-else-if="isActiveSideBar('notifications')" />
             <SettingsPanel v-else-if="isActiveSideBar('settings')" />
-            <AdminPanel v-else-if="isActiveSideBar('admin')" v-bind="adminProperties" />
+            <AdminPanel v-else-if="isActiveSideBar('admin')" />
         </FlexPanel>
     </div>
 </template>

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -206,20 +206,20 @@ watch(
                     title="Notifications"
                     @click="onToggleSidebar('notifications')" />
                 <ActivityItem
-                    id="activity-admin"
-                    icon="user-cog"
-                    :is-active="panelActivityIsActive('admin')"
-                    title="Admin"
-                    tooltip="Configure this Instance"
-                    @click="onToggleSidebar('admin')" />
-                <ActivityItem
                     id="activity-settings"
                     icon="cog"
                     :is-active="isActiveSideBar('settings')"
                     title="Settings"
                     tooltip="Edit preferences"
-                    to="/admin"
                     @click="onToggleSidebar('settings')" />
+                <ActivityItem
+                    id="activity-admin"
+                    icon="user-cog"
+                    :is-active="isActiveSideBar('admin')"
+                    title="Admin"
+                    tooltip="Configure this Instance"
+                    variant="danger"
+                    @click="onToggleSidebar('admin')" />
             </b-nav>
         </div>
         <FlexPanel v-if="isSideBarOpen" side="left" :collapsible="false">

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -49,6 +49,15 @@ const isDragging = ref(false);
 // sync built-in activities with cached activities
 activityStore.sync();
 
+
+const adminProperties = computed(() => {
+    return {
+        enableQuotas: config.value.enable_quotas,
+        isToolshedInstalled: config.value.tool_shed_urls && config.value.tool_shed_urls.length > 0,
+        versionMajor: config.value.version_major,
+    };
+});
+
 /**
  * Checks if the route of an activity is currently being visited and panels are collapsed
  */
@@ -220,7 +229,7 @@ watch(
             <MultiviewPanel v-else-if="isActiveSideBar('multiview')" />
             <NotificationsPanel v-else-if="isActiveSideBar('notifications')" />
             <SettingsPanel v-else-if="isActiveSideBar('settings')" />
-            <AdminPanel v-else-if="isActiveSideBar('admin')" />
+            <AdminPanel v-else-if="isActiveSideBar('admin')" v-bind="adminProperties" />
         </FlexPanel>
     </div>
 </template>

--- a/client/src/components/ActivityBar/ActivityItem.vue
+++ b/client/src/components/ActivityBar/ActivityItem.vue
@@ -24,6 +24,7 @@ export interface Props {
     progressStatus?: string;
     options?: Option[];
     to?: string;
+    variant?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -37,6 +38,7 @@ const props = withDefaults(defineProps<Props>(), {
     to: undefined,
     tooltip: undefined,
     tooltipPlacement: "right",
+    variant: "primary",
 });
 
 const emit = defineEmits<{
@@ -70,7 +72,7 @@ function onClick(evt: MouseEvent): void {
                                 width: `${Math.round(progressPercentage)}%`,
                             }" />
                     </span>
-                    <span class="position-relative">
+                    <span class="position-relative" :class="`text-${variant}`">
                         <div class="nav-icon">
                             <span v-if="indicator > 0" class="nav-indicator" data-description="activity indicator">
                                 {{ Math.min(indicator, 99) }}

--- a/client/src/components/admin/AdminPanel.test.js
+++ b/client/src/components/admin/AdminPanel.test.js
@@ -1,9 +1,18 @@
 import { mount } from "@vue/test-utils";
 import { getLocalVue } from "tests/jest/helpers";
 
+import { useConfig } from "@/composables/config";
+
 import MountTarget from "./AdminPanel.vue";
 
 const localVue = getLocalVue(true);
+
+jest.mock("@/composables/config", () => ({
+    useConfig: jest.fn(() => ({
+        config: { value: { enable_quotas: true, tool_shed_urls: ["tool_shed_url"], version_major: "1.0.1" } },
+        isConfigLoaded: true,
+    })),
+}));
 
 function createTarget(propsData = {}) {
     return mount(MountTarget, {
@@ -16,21 +25,29 @@ function createTarget(propsData = {}) {
 }
 
 describe("AdminPanel", () => {
-    it("ensure reactivity to prop changes", async () => {
-        const wrapper = createTarget();
-        const sections = {
-            isToolshedInstalled: "#admin-link-toolshed",
-            enableQuotas: "#admin-link-quotas",
-        };
-        for (const elementId of Object.values(sections)) {
-            expect(wrapper.find(elementId).exists()).toBe(false);
-        }
+    it("ensure section visibility with config changes", async () => {
+        const options = [
+            {
+                name: "tool_shed_urls",
+                elementId: "#admin-link-toolshed",
+                value: ["toolshed_url"],
+            },
+            {
+                name: "enable_quotas",
+                elementId: "#admin-link-quotas",
+                value: true,
+            },
+        ];
         for (const available of [true, false]) {
-            for (const [propId, elementId] of Object.entries(sections)) {
+            for (const option of options) {
                 const props = {};
-                props[propId] = available;
-                await wrapper.setProps(props);
-                expect(wrapper.find(elementId).exists()).toBe(available);
+                props[option.name] = available ? option.value : undefined;
+                useConfig.mockImplementation(() => ({
+                    config: { value: { ...props, version_major: "1.0.1" } },
+                    isConfigLoaded: true,
+                }));
+                const wrapper = createTarget();
+                expect(wrapper.find(option.elementId).exists()).toBe(available);
             }
         }
     });

--- a/client/src/components/admin/AdminPanel.vue
+++ b/client/src/components/admin/AdminPanel.vue
@@ -1,8 +1,131 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import { useConfig } from "@/composables/config";
+
+const { config, isConfigLoaded } = useConfig();
+
+const adminProperties = computed(() => {
+    return {
+        enableQuotas: config.value.enable_quotas,
+        isToolshedInstalled: config.value.tool_shed_urls && config.value.tool_shed_urls.length > 0,
+        versionMajor: config.value.version_major,
+    };
+});
+
+const sections = computed(() => {
+    return [
+        {
+            title: "Server",
+            items: [
+                {
+                    id: "admin-link-datatypes",
+                    title: "Data Types",
+                    route: "/admin/data_types",
+                },
+                {
+                    id: "admin-link-data-tables",
+                    title: "Data Tables",
+                    route: "/admin/data_tables",
+                },
+                {
+                    id: "admin-link-display-applications",
+                    title: "Display Applications",
+                    route: "/admin/display_applications",
+                },
+                {
+                    id: "admin-link-jobs",
+                    title: "Jobs",
+                    route: "/admin/jobs",
+                },
+                {
+                    id: "admin-link-invocations",
+                    title: "Workflow Invocations",
+                    route: "/admin/invocations",
+                },
+                {
+                    id: "admin-link-local-data",
+                    title: "Local Data",
+                    route: "/admin/data_manager",
+                },
+                {
+                    id: "admin-link-notifications",
+                    title: "Notifications and Broadcasts",
+                    route: "/admin/notifications",
+                },
+            ],
+        },
+        {
+            title: "User Management",
+            items: [
+                {
+                    id: "admin-link-users",
+                    title: "Users",
+                    route: "/admin/users",
+                },
+                {
+                    id: "admin-link-quotas",
+                    title: "Quotas",
+                    route: "/admin/quotas",
+                    disabled: !adminProperties.value.enableQuotas,
+                },
+                {
+                    id: "admin-link-groups",
+                    title: "Groups",
+                    route: "/admin/groups",
+                },
+                {
+                    id: "admin-link-roles",
+                    title: "Roles",
+                    route: "/admin/roles",
+                },
+                {
+                    id: "admin-link-forms",
+                    title: "Forms",
+                    route: "/admin/forms",
+                },
+            ],
+        },
+        {
+            title: "Tool Management",
+            items: [
+                {
+                    id: "admin-link-toolshed",
+                    title: "Install and Uninstall",
+                    route: "/admin/toolshed",
+                    disabled: !adminProperties.value.isToolshedInstalled,
+                },
+                {
+                    id: "admin-link-metadata",
+                    title: "Manage Metadata",
+                    route: "/admin/reset_metadata",
+                },
+                {
+                    id: "admin-link-allowlist",
+                    title: "Manage Allowlist",
+                    route: "/admin/sanitize_allow",
+                },
+                {
+                    id: "admin-link-manage-dependencies",
+                    title: "Manage Dependencies",
+                    route: "/admin/toolbox_dependencies",
+                },
+                {
+                    id: "admin-link-error-stack",
+                    title: "View Error Logs",
+                    route: "/admin/error_stack",
+                },
+            ],
+        },
+    ];
+});
+</script>
+
 <template>
-    <div class="unified-panel">
+    <div v-if="isConfigLoaded" class="unified-panel">
         <div class="unified-panel-header" unselectable="on">
             <div class="unified-panel-header-inner">
-                <div class="panel-header-text">Galaxy Version {{ versionMajor }}</div>
+                <div class="panel-header-text">Galaxy Version {{ config.version_major }}</div>
             </div>
         </div>
         <div class="unified-panel-body">
@@ -26,130 +149,3 @@
         </div>
     </div>
 </template>
-
-<script>
-export default {
-    props: {
-        enableQuotas: {
-            type: Boolean,
-            default: false,
-        },
-        isToolshedInstalled: {
-            type: Boolean,
-            default: false,
-        },
-        versionMajor: {
-            type: String,
-            default: "",
-        },
-    },
-    computed: {
-        sections() {
-            return [
-                {
-                    title: "Server",
-                    items: [
-                        {
-                            id: "admin-link-datatypes",
-                            title: "Data Types",
-                            route: "/admin/data_types",
-                        },
-                        {
-                            id: "admin-link-data-tables",
-                            title: "Data Tables",
-                            route: "/admin/data_tables",
-                        },
-                        {
-                            id: "admin-link-display-applications",
-                            title: "Display Applications",
-                            route: "/admin/display_applications",
-                        },
-                        {
-                            id: "admin-link-jobs",
-                            title: "Jobs",
-                            route: "/admin/jobs",
-                        },
-                        {
-                            id: "admin-link-invocations",
-                            title: "Workflow Invocations",
-                            route: "/admin/invocations",
-                        },
-                        {
-                            id: "admin-link-local-data",
-                            title: "Local Data",
-                            route: "/admin/data_manager",
-                        },
-                        {
-                            id: "admin-link-notifications",
-                            title: "Notifications and Broadcasts",
-                            route: "/admin/notifications",
-                        },
-                    ],
-                },
-                {
-                    title: "User Management",
-                    items: [
-                        {
-                            id: "admin-link-users",
-                            title: "Users",
-                            route: "/admin/users",
-                        },
-                        {
-                            id: "admin-link-quotas",
-                            title: "Quotas",
-                            route: "/admin/quotas",
-                            disabled: !this.enableQuotas,
-                        },
-                        {
-                            id: "admin-link-groups",
-                            title: "Groups",
-                            route: "/admin/groups",
-                        },
-                        {
-                            id: "admin-link-roles",
-                            title: "Roles",
-                            route: "/admin/roles",
-                        },
-                        {
-                            id: "admin-link-forms",
-                            title: "Forms",
-                            route: "/admin/forms",
-                        },
-                    ],
-                },
-                {
-                    title: "Tool Management",
-                    items: [
-                        {
-                            id: "admin-link-toolshed",
-                            title: "Install and Uninstall",
-                            route: "/admin/toolshed",
-                            disabled: !this.isToolshedInstalled,
-                        },
-                        {
-                            id: "admin-link-metadata",
-                            title: "Manage Metadata",
-                            route: "/admin/reset_metadata",
-                        },
-                        {
-                            id: "admin-link-allowlist",
-                            title: "Manage Allowlist",
-                            route: "/admin/sanitize_allow",
-                        },
-                        {
-                            id: "admin-link-manage-dependencies",
-                            title: "Manage Dependencies",
-                            route: "/admin/toolbox_dependencies",
-                        },
-                        {
-                            id: "admin-link-error-stack",
-                            title: "View Error Logs",
-                            route: "/admin/error_stack",
-                        },
-                    ],
-                },
-            ];
-        },
-    },
-};
-</script>

--- a/client/src/components/admin/AdminPanel.vue
+++ b/client/src/components/admin/AdminPanel.vue
@@ -129,19 +129,16 @@ const sections = computed(() => {
         <div class="unified-panel-body">
             <div class="toolMenuContainer">
                 <div class="toolSectionWrapper">
-            <div
-                v-for="(section, sectionIndex) in sections"
-                :key="sectionIndex"
-                class="toolSectionTitle pt-2">
-                <h2 class="font-weight-bold h-text mb-0">{{ section.title }}</h2>
-                <div class="toolSectionBody">
-                    <div v-for="(item, itemIndex) in section.items" :key="itemIndex" class="toolTitle">
-                        <router-link v-if="!item.disabled" :id="item.id" class="title-link" :to="item.route">
-                            <small class="name">{{ item.title }}</small>
-                        </router-link>
+                    <div v-for="(section, sectionIndex) in sections" :key="sectionIndex" class="toolSectionTitle pt-2">
+                        <h2 class="font-weight-bold h-text mb-0">{{ section.title }}</h2>
+                        <div class="toolSectionBody">
+                            <div v-for="(item, itemIndex) in section.items" :key="itemIndex" class="toolTitle">
+                                <router-link v-if="!item.disabled" :id="item.id" class="title-link" :to="item.route">
+                                    <small class="name">{{ item.title }}</small>
+                                </router-link>
+                            </div>
+                        </div>
                     </div>
-                </div>
-            </div>
                 </div>
             </div>
         </div>

--- a/client/src/components/admin/AdminPanel.vue
+++ b/client/src/components/admin/AdminPanel.vue
@@ -3,6 +3,8 @@ import { computed } from "vue";
 
 import { useConfig } from "@/composables/config";
 
+import ActivityPanel from "@/components/Panels/ActivityPanel.vue";
+
 const { config, isConfigLoaded } = useConfig();
 
 const adminProperties = computed(() => {
@@ -122,30 +124,26 @@ const sections = computed(() => {
 </script>
 
 <template>
-    <div v-if="isConfigLoaded" class="unified-panel">
-        <div class="unified-panel-header" unselectable="on">
-            <div class="unified-panel-header-inner">
-                <div class="panel-header-text">Galaxy Version {{ config.version_major }}</div>
-            </div>
-        </div>
+    <ActivityPanel v-if="isConfigLoaded" title="Administration" go-to-all-title="Admin Home" href="/admin">
+        <h3>Galaxy Version {{ adminProperties.versionMajor }}</h3>
         <div class="unified-panel-body">
             <div class="toolMenuContainer">
                 <div class="toolSectionWrapper">
-                    <div
-                        v-for="(section, sectionIndex) in sections"
-                        :key="sectionIndex"
-                        class="toolSectionTitle pt-1 px-3">
-                        <h2 class="font-weight-bold h-text mb-0">{{ section.title }}</h2>
-                        <div class="toolSectionBody">
-                            <div v-for="(item, itemIndex) in section.items" :key="itemIndex" class="toolTitle">
-                                <router-link v-if="!item.disabled" :id="item.id" class="title-link" :to="item.route">
-                                    <small class="name">{{ item.title }}</small>
-                                </router-link>
-                            </div>
-                        </div>
+            <div
+                v-for="(section, sectionIndex) in sections"
+                :key="sectionIndex"
+                class="toolSectionTitle pt-2">
+                <h2 class="font-weight-bold h-text mb-0">{{ section.title }}</h2>
+                <div class="toolSectionBody">
+                    <div v-for="(item, itemIndex) in section.items" :key="itemIndex" class="toolTitle">
+                        <router-link v-if="!item.disabled" :id="item.id" class="title-link" :to="item.route">
+                            <small class="name">{{ item.title }}</small>
+                        </router-link>
                     </div>
                 </div>
             </div>
+                </div>
+            </div>
         </div>
-    </div>
+    </ActivityPanel>
 </template>

--- a/client/src/components/admin/AdminPanel.vue
+++ b/client/src/components/admin/AdminPanel.vue
@@ -10,7 +10,7 @@ const { config, isConfigLoaded } = useConfig();
 const adminProperties = computed(() => {
     return {
         enableQuotas: config.value.enable_quotas,
-        isToolshedInstalled: config.value.tool_shed_urls && config.value.tool_shed_urls.length > 0,
+        isToolshedInstalled: config.value.tool_shed_urls?.length > 0 ?? false,
         versionMajor: config.value.version_major,
     };
 });

--- a/client/src/components/plugins/icons.js
+++ b/client/src/components/plugins/icons.js
@@ -48,6 +48,7 @@ import {
     faTrash,
     faTrashRestore,
     faUndo,
+    faUserCog,
     faUserLock,
     faWrench,
 } from "@fortawesome/free-solid-svg-icons";
@@ -102,6 +103,7 @@ library.add(
     faTrashRestore,
     faExclamationTriangle,
     faUndo,
+    faUserCog,
     faUserLock,
     faWrench
 );

--- a/client/src/entry/analysis/menu.js
+++ b/client/src/entry/analysis/menu.js
@@ -2,6 +2,8 @@ import { getGalaxyInstance } from "app";
 import _l from "utils/localization";
 import { userLogout } from "utils/logout";
 
+import { useUserStore } from "@/stores/userStore";
+
 export function fetchMenu(options = {}) {
     const Galaxy = getGalaxyInstance();
     const menu = [];
@@ -121,6 +123,10 @@ export function fetchMenu(options = {}) {
             url: "/admin",
             tooltip: _l("Administer this Galaxy"),
             cls: "admin-only",
+            onclick: () => {
+                const userStore = useUserStore();
+                userStore.toggleSideBar("admin");
+            },
         });
     }
 

--- a/client/src/entry/analysis/modules/Admin.vue
+++ b/client/src/entry/analysis/modules/Admin.vue
@@ -1,7 +1,3 @@
 <template>
-    <div id="columns" class="d-flex">
-        <div id="center" class="overflow-auto p-3 w-100">
-            <router-view :key="$route.fullPath" class="h-100" />
-        </div>
-    </div>
+    <router-view :key="$route.fullPath" />
 </template>

--- a/client/src/entry/analysis/modules/Admin.vue
+++ b/client/src/entry/analysis/modules/Admin.vue
@@ -1,27 +1,5 @@
-<script setup>
-import { computed } from "vue";
-
-import { useConfig } from "@/composables/config";
-
-import AdminPanel from "@/components/admin/AdminPanel.vue";
-import FlexPanel from "@/components/Panels/FlexPanel.vue";
-
-const { config, isConfigLoaded } = useConfig();
-
-const panelProperties = computed(() => {
-    return {
-        enableQuotas: config.value.enable_quotas,
-        isToolshedInstalled: config.value.tool_shed_urls && config.value.tool_shed_urls.length > 0,
-        versionMajor: config.value.version_major,
-    };
-});
-</script>
-
 <template>
-    <div v-if="isConfigLoaded" id="columns" class="d-flex">
-        <FlexPanel side="left">
-            <AdminPanel v-bind="panelProperties" />
-        </FlexPanel>
+    <div id="columns" class="d-flex">
         <div id="center" class="overflow-auto p-3 w-100">
             <router-view :key="$route.fullPath" class="h-100" />
         </div>

--- a/client/src/stores/activitySetup.ts
+++ b/client/src/stores/activitySetup.ts
@@ -113,6 +113,18 @@ export const Activities = [
         to: "/datasets/list",
         visible: false,
     },
+    {
+        anonymous: true,
+        description: "Adminstration.",
+        icon: "wrench",
+        id: "admin",
+        mutable: false,
+        optional: false,
+        title: "Admin",
+        to: null,
+        tooltip: "Search and run tools",
+        visible: true,
+    },
 ];
 
 export function convertDropData(data: EventData): Activity | null {

--- a/client/src/stores/activitySetup.ts
+++ b/client/src/stores/activitySetup.ts
@@ -113,18 +113,6 @@ export const Activities = [
         to: "/datasets/list",
         visible: false,
     },
-    {
-        anonymous: true,
-        description: "Adminstration.",
-        icon: "wrench",
-        id: "admin",
-        mutable: false,
-        optional: false,
-        title: "Admin",
-        to: "/admin",
-        tooltip: "Search and run tools",
-        visible: true,
-    },
 ];
 
 export function convertDropData(data: EventData): Activity | null {

--- a/client/src/stores/activitySetup.ts
+++ b/client/src/stores/activitySetup.ts
@@ -121,7 +121,7 @@ export const Activities = [
         mutable: false,
         optional: false,
         title: "Admin",
-        to: null,
+        to: "/admin",
         tooltip: "Search and run tools",
         visible: true,
     },

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -34,6 +34,10 @@ export const useUserStore = defineStore("userStore", () => {
         loadPromise = null;
     }
 
+    const isAdmin = computed(() => {
+        return currentUser.value?.is_admin ?? false;
+    });
+
     const isAnonymous = computed(() => {
         return !("email" in (currentUser.value || []));
     });
@@ -121,6 +125,7 @@ export const useUserStore = defineStore("userStore", () => {
     return {
         currentUser,
         currentPreferences,
+        isAdmin,
         isAnonymous,
         currentTheme,
         currentFavorites,

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -952,6 +952,7 @@ admin:
       allowlist: '#admin-link-allowlist'
 
   selectors:
+    activity: '#activity-admin'
     warning: '#center .alert-warning'
     # TODO: place betters IDS or something on this in these grids in the DOM
     jobs_title: '#jobs-title'

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1237,7 +1237,7 @@ class NavigatesGalaxy(HasDriver):
         self.components.masthead.pages.wait_for_and_click()
 
     def admin_open(self):
-        self.components.masthead.admin.wait_for_and_click()
+        self.components.admin.activity.wait_for_and_click()
 
     def create_quota(
         self,

--- a/lib/galaxy_test/selenium/test_admin_app.py
+++ b/lib/galaxy_test/selenium/test_admin_app.py
@@ -192,7 +192,6 @@ class TestAdminApp(SeleniumTestCase):
         admin_component.registration_form.wait_for_visible()
         self.screenshot("admin_user_registration")
 
-        self.admin_open()
         admin_component.index.groups.wait_for_and_click()
         admin_component.groups_grid.wait_for_visible()
         self.screenshot("admin_groups")
@@ -201,7 +200,6 @@ class TestAdminApp(SeleniumTestCase):
         admin_component.groups_create_view.wait_for_visible()
         self.screenshot("admin_groups_create")
 
-        self.admin_open()
         admin_component.index.roles.wait_for_and_click()
         admin_component.roles_grid.wait_for_visible()
         self.screenshot("admin_roles")


### PR DESCRIPTION
Adds an admin interface activity item to the activity bar.

<img width="1284" alt="image" src="https://github.com/galaxyproject/galaxy/assets/2105447/dd7ca687-d8b6-40bb-9aa9-5bca0c4858db">

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
