### PR TITLE
[24.0] Fix hasOwner function for histories in client

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -228,5 +228,5 @@ export function userOwnsHistory(user: User | AnonymousUser | null, history: AnyH
 }
 
 function hasOwner(history: AnyHistory): history is HistorySummaryExtended {
-    return "user_id" in history;
+    return "user_id" in history && history.user_id !== null;
 }


### PR DESCRIPTION
The `hasOwner` function in `api/index.ts` was checking:
```
return "user_id" in history;
```

whereas, it also needed to check:
```
return "user_id" in history && history.user_id !== null;
```

because we assume histories (summaries) initally fetched for the `historyStore` without `user_id` are owned by the current user, but the key is still present in the backend return.

This was causing a really troublesome bug in the `HistoryScrollList` found in the history selector modal, where we would constantly keep fetching `api/histories/count` since we didn't have the expected no. of histories loaded in the component; because `historiesProxy` (which only contains owned histories) would end up being empty.
Interestingly, this was only reproducible on Test and happening if the total number of histories was very small...

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
