### PR TITLE
[24.0] Make `wait_for_history_jobs` look at jobs, not datasets

### DIFF
--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -5477,7 +5477,7 @@ steps:
     tool_id: output_filter
     state:
       produce_out_1: False
-      filter_text_1: '1'
+      filter_text_1: 'foo'
       produce_collection: False
 """,
                 test_data={},

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -630,7 +630,8 @@ class BaseDatasetPopulator(BasePopulator):
             raise TimeoutAssertionError(message)
 
         if assert_ok:
-            self.wait_for_history(history_id, assert_ok=True, timeout=timeout)
+            for job in self.history_jobs(history_id=history_id):
+                assert job["state"] in ("ok", "skipped"), f"Job {job} not in expected state"
 
     def wait_for_jobs(
         self,

--- a/test/functional/tools/output_filter.xml
+++ b/test/functional/tools/output_filter.xml
@@ -59,15 +59,9 @@ echo 'p2.reverse' > p2.reverse
                 </assert_contents>
             </output>
         </test>
-        <!-- tool runs with no outputs should fail -->
-        <test expect_num_outputs="0" expect_test_failure="true">
+        <test expect_num_outputs="0">
             <param name="produce_out_1" value="false" />
             <param name="filter_text_1" value="not_foo_or_bar" />
-            <output name="out_3">
-                <assert_contents>
-                    <has_line line="test" />
-                </assert_contents>
-            </output>
             <assert_stdout>
                 <has_n_lines n="0"/>
             </assert_stdout>


### PR DESCRIPTION
That fixes test_optional_workflow_output, which started failing after https://github.com/galaxyproject/galaxy/pull/17874, which removed the last static output of `output_filter`, and so there would never be any active datasets to wait on.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
