### PR TITLE
[24.0] do not show copy button when editing

### DIFF
--- a/client/src/components/Sharing/EditableUrl.vue
+++ b/client/src/components/Sharing/EditableUrl.vue
@@ -84,9 +84,9 @@ function onCopyOut() {
         </BButton>
 
         <BButton
-            v-if="!editing"
             id="tooltip-clipboard"
             v-b-tooltip.hover
+            :disabled="editing"
             size="md"
             class="inline-icon-button"
             :title="clipboardTitle"
@@ -99,10 +99,16 @@ function onCopyOut() {
 </template>
 
 <style scoped lang="scss">
+@import "theme/blue.scss";
+
 .editable-url {
     height: 1.5rem;
     display: flex;
     align-items: center;
     gap: 0.25rem;
+}
+.inline-icon-button:disabled:hover {
+    background-color: $brand-secondary;
+    color: unset;
 }
 </style>

--- a/client/src/components/Sharing/EditableUrl.vue
+++ b/client/src/components/Sharing/EditableUrl.vue
@@ -84,6 +84,7 @@ function onCopyOut() {
         </BButton>
 
         <BButton
+            v-if="!editing"
             id="tooltip-clipboard"
             v-b-tooltip.hover
             size="md"


### PR DESCRIPTION
backport plus an addition to  https://github.com/galaxyproject/galaxy/pull/17888

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
