### PR TITLE
Use DeclarativeBase as base class for SA models

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -246,7 +246,7 @@ def get_uuid(uuid: Optional[Union[UUID, str]] = None) -> UUID:
     return UUID(str(uuid))
 
 
-class Base(_HasTable, DeclarativeBase):
+class Base(DeclarativeBase, _HasTable):
     __abstract__ = True
     metadata = MetaData(naming_convention=NAMING_CONVENTION)
     mapper_registry.metadata = metadata

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -106,6 +106,7 @@ from sqlalchemy.ext.orderinglist import ordering_list
 from sqlalchemy.orm import (
     aliased,
     column_property,
+    DeclarativeBase,
     deferred,
     joinedload,
     Mapped,
@@ -119,6 +120,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.orm.collections import attribute_keyed_dict
 from sqlalchemy.sql import exists
+from sqlalchemy.sql.expression import FromClause
 from typing_extensions import (
     Literal,
     Protocol,
@@ -224,23 +226,15 @@ CANNOT_SHARE_PRIVATE_DATASET_MESSAGE = "Attempting to share a non-shareable data
 
 
 if TYPE_CHECKING:
-    # Workaround for https://github.com/python/mypy/issues/14182
-    from sqlalchemy.orm import DeclarativeMeta as _DeclarativeMeta
-
-    class DeclarativeMeta(_DeclarativeMeta, type):
-        pass
-
     from galaxy.datatypes.data import Data
     from galaxy.tools import DefaultToolState
     from galaxy.workflow.modules import WorkflowModule
 
     class _HasTable:
-        table: Table
-        __table__: Table
+        table: FromClause
+        __table__: FromClause
 
 else:
-    from sqlalchemy.orm import DeclarativeMeta
-
     _HasTable = object
 
 
@@ -252,7 +246,7 @@ def get_uuid(uuid: Optional[Union[UUID, str]] = None) -> UUID:
     return UUID(str(uuid))
 
 
-class Base(_HasTable, metaclass=DeclarativeMeta):
+class Base(_HasTable, DeclarativeBase):
     __abstract__ = True
     metadata = MetaData(naming_convention=NAMING_CONVENTION)
     mapper_registry.metadata = metadata


### PR DESCRIPTION
Post-SA2.0 model fixes (cherry-picked from #17662):

1. Use proper DeclarativeBase as base class, as per sqlalchemy documentation. 
2. mypy bug workaround no longer needed as we are no longer specifying a metaclass.
3. Use FromClause as the correct type instead of Table
4. Fix `table/__table__/HasTable` for models. HasTable was a hack to accommodate declarative mapping without changing thousands of lines that referred to the `table` attribute of model instances.

    The one `type:ignore` added to managers.datasets can be removed after we map DatasetInstance models declaratively.





## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
