### PR TITLE
[24.0] Fix search and version menu in docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -14,8 +14,6 @@ import datetime
 import os
 import sys
 
-import sphinx_rtd_theme
-
 # Set GALAXY_DOCS_SKIP_VIEW_CODE=1 to skip embedding highlighted source
 # code into docs.
 SKIP_VIEW_CODE = os.environ.get("GALAXY_DOCS_SKIP_VIEW_CODE", False) == "1"
@@ -161,11 +159,10 @@ html_theme_options = {
     "collapse_navigation": False,
     "display_version": True,
     "navigation_depth": 2,
-    "canonical_url": "https://docs.galaxyproject.org/en/master/",
 }
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
@@ -173,6 +170,8 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 # html_short_title = None
+
+html_baseurl = "https://docs.galaxyproject.org/en/master/"
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.


### PR DESCRIPTION
The `html_theme_path` option should not be used any more with sphinx-rtd-theme since it switches off the theme's ability to automatically enable the sphinxcontrib-jquery extension, i.e. jQuery is not loaded in the web pages when building the docs with Sphinx >=6.

xref: https://github.com/readthedocs/sphinx_rtd_theme/issues/1434#issuecomment-1472671651

Also replace the deprecated `canonical_url` theme option with Sphinx's `html_baseurl`.

xref: https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html#confval-canonical_url

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `cat doc/source/conf.versioning.py >> doc/source/conf.py`
  2. `TARGET_BRANCH=release_24.0 make docs-develop`
  3. `firefox doc/build/html/index.html`
  4. Check that the search and version menu work

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
