### PR TITLE
[24.0] Fix lost reports when switching workflow versions

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -145,7 +145,7 @@
     <MarkdownEditor
         v-else
         :markdown-text="markdownText"
-        :markdown-config="markdownConfig"
+        :markdown-config="report"
         mode="report"
         :title="'Workflow Report: ' + name"
         :steps="steps"
@@ -310,7 +310,6 @@ export default {
     data() {
         return {
             isCanvas: true,
-            markdownConfig: null,
             markdownText: null,
             versions: [],
             parameters: null,
@@ -762,8 +761,8 @@ export default {
 
             const report = data.report || {};
             const markdown = report.markdown || reportDefault;
+            this.report = report;
             this.markdownText = markdown;
-            this.markdownConfig = report;
             this.hideModal();
             this.stateMessages = getStateUpgradeMessages(data);
             const has_changes = this.stateMessages.length > 0;


### PR DESCRIPTION
We serialize workflow.reports, but we were only setting it on the workflow instance if the markdown editor emits it.

Fixes a part of https://github.com/galaxyproject/galaxy/issues/17903

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
