### PR TITLE
[24.0] Do not save workflow on Run without user confirmation

### DIFF
--- a/client/src/components/Workflow/Editor/SaveChangesModal.vue
+++ b/client/src/components/Workflow/Editor/SaveChangesModal.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faSave, faTimes, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BButton, BModal } from "bootstrap-vue";
+import { ref } from "vue";
+
+import localize from "@/utils/localization";
+
+library.add(faSave, faTimes, faTrash);
+
+interface Props {
+    /** Show the save changes modal */
+    showModal: boolean;
+    /** The URL to navigate to before saving/ignoring changes */
+    navUrl: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    showModal: false,
+});
+
+const busy = ref(false);
+
+const emit = defineEmits<{
+    /** Proceed with or without saving the changes */
+    (e: "on-proceed", url: string, forceSave: boolean, ignoreChanges: boolean): void;
+    /** Update the nav URL prop */
+    (e: "update:nav-url", url: string): void;
+    /** Update the show modal boolean prop */
+    (e: "update:show-modal", showModal: boolean): void;
+}>();
+
+const title = localize("You have unsaved changes. Do you want to save them before proceeding?");
+const body = localize(
+    "Click 'Save' to save your changes and proceed, 'Don't Save' to discard them and proceed, or 'Cancel' to return to the editor."
+);
+
+const buttonTitles = {
+    cancel: localize("Do not run proceed and return to editor"),
+    dontSave: localize("Discard changes and proceed"),
+    save: localize("Save changes and proceed"),
+};
+
+function closeModal() {
+    emit("update:show-modal", false);
+    emit("update:nav-url", "");
+}
+
+function dontSave() {
+    busy.value = true;
+    emit("on-proceed", props.navUrl, false, true);
+}
+
+function saveChanges() {
+    busy.value = true;
+    closeModal();
+    emit("on-proceed", props.navUrl, true, false);
+}
+</script>
+
+<template>
+    <BModal :title="title" :visible="props.showModal" @close="closeModal" @hide="closeModal">
+        <div>
+            {{ body }}
+        </div>
+        <template v-slot:modal-footer>
+            <BButton
+                v-b-tooltip.noninteractive.hover
+                :title="buttonTitles['cancel']"
+                variant="secondary"
+                :disabled="busy"
+                @click="closeModal">
+                <FontAwesomeIcon :icon="faTimes" />
+                {{ localize("Cancel") }}
+            </BButton>
+            <BButton
+                v-b-tooltip.noninteractive.hover
+                :title="buttonTitles['dontSave']"
+                variant="danger"
+                :disabled="busy"
+                @click="dontSave">
+                <FontAwesomeIcon :icon="faTrash" />
+                {{ localize("Don't Save") }}
+            </BButton>
+            <BButton
+                v-b-tooltip.noninteractive.hover
+                :title="buttonTitles['save']"
+                variant="primary"
+                :disabled="busy"
+                @click="saveChanges">
+                <FontAwesomeIcon :icon="faSave" />
+                {{ localize("Save") }}
+            </BButton>
+        </template>
+    </BModal>
+</template>


### PR DESCRIPTION
This adds a modal when the user runs a workflow with changes, that asks for user confirmation on whether to proceed without saving changes or to save changes and then proceed. Currently, we _always_ save the workflow when it is run (even if there are no changes at all).

Fixes https://github.com/galaxyproject/galaxy/issues/17903

| Before ✖️   |
| ------ |
| <video src="https://github.com/galaxyproject/galaxy/assets/78516064/2da58f04-d7be-41cb-a8b2-d67c59c625d1" /> |
| We save the workflow every time it is run, also note that a new version is created for each run as well |

| Now ✅  |
| ------ |
| <video src="https://github.com/galaxyproject/galaxy/assets/78516064/5cf84f70-bba5-43a7-9fa2-384105646615" /> |
| <li>If the user makes no changes, we simply route to the run without saving at all (a new version is not created) </li> <li>If the user makes changes, but does not wish to save them before running, they have the option using the modal </li> <li>If the user makes changes, and wishes to save before running, they can do so using the modal </li> <li>If the user makes changes and they wish to return to the editor and review them, they can do so by exiting the modal and not proceeding at all </li> |



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
