### PR TITLE
[24.0] Handle exceptions raised by the db api driver

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -18,7 +18,10 @@ from typing import (
     Union,
 )
 
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import (
+    DBAPIError,
+    OperationalError,
+)
 from sqlalchemy.sql.expression import (
     and_,
     func,
@@ -395,6 +398,10 @@ class JobHandlerQueue(BaseJobHandlerQueue):
             self.__handle_waiting_jobs()
         except StopSignalException:
             pass
+        except DBAPIError as e:
+            log.exception(f"Execution of a database operation failed due to the following exception: {e}")
+            self.sa_session.remove()
+
         log.trace(monitor_step_timer.to_str())
 
     def __handle_waiting_jobs(self):


### PR DESCRIPTION
The DBAPIError exception wraps exceptions raised by the dbapi driver, which will include the `InFailedTransaction` error rased by psycopg2. So, if such an error occurs, the session will be closed and removed, but galaxy won't crash. I'm not sure whether this approach is a reasonable approach or not (or is altogether wrong). 

We could try a more granular approach inside `__handle_waiting_jobs`, wrapping *each* database access in a helper that would wrap the call to the db in a try/except block, and then check if the error was due to a disconnect (by `if e.connection_invalidated`), and if so, we can let SQLAlchemy try to reconnect (it'll refresh the invalidated connections, as per [docs](https://docs.sqlalchemy.org/en/20/core/pooling.html#disconnect-handling-optimistic)), but only once. I don't think there's a way to recover anything or retry the failed statement if it's not a disconnect-related error (i.e., `InFailedTransaction` would mean we should kill the session, I think).

(ref. #17893)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
