### PR TITLE
[24.0] Drop session.begin context manager from __monitor_step

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -1087,7 +1087,7 @@ class JobHandlerStopQueue(BaseJobHandlerQueue):
             # Sleep
             self._monitor_sleep(1)
 
-    def __delete(self, job, error_msg, session):
+    def __delete(self, job: model.Job, error_msg, session):
         final_state = job.states.DELETED
         if error_msg is not None:
             final_state = job.states.ERROR
@@ -1096,7 +1096,7 @@ class JobHandlerStopQueue(BaseJobHandlerQueue):
         session.add(job)
         session.flush()
 
-    def __stop(self, job, session):
+    def __stop(self, job: model.Job, session):
         job.set_state(job.states.STOPPED)
         session.add(job)
         session.flush()
@@ -1107,7 +1107,7 @@ class JobHandlerStopQueue(BaseJobHandlerQueue):
         """
         # Pull all new jobs from the queue at once
         jobs_to_check = []
-        with self.sa_session() as session, session.begin():
+        with self.sa_session() as session:
             self._add_newly_deleted_jobs(session, jobs_to_check)
             try:
                 self._pull_from_queue(session, jobs_to_check)


### PR DESCRIPTION
Otherwise we can commit at most once inside the scope of the with statement, which would lead to
```
InvalidRequestError: Can't operate on closed transaction inside context manager.  Please complete the context manager before emitting further commands.
  File "galaxy/jobs/handler.py", line 1084, in __monitor
    self.__monitor_step()
  File "galaxy/jobs/handler.py", line 1116, in __monitor_step
    self._check_jobs(session, jobs_to_check)
  File "galaxy/jobs/handler.py", line 1182, in _check_jobs
    self.__stop(job, session)
  File "galaxy/jobs/handler.py", line 1100, in __stop
    job.set_state(job.states.STOPPED)
  File "galaxy/model/__init__.py", line 1703, in set_state
    self.state_history.append(JobStateHistory(self))
  File "sqlalchemy/orm/attributes.py", line 487, in __get__
    return self.impl.get(state, dict_)
  File "sqlalchemy/orm/attributes.py", line 959, in get
    value = self._fire_loader_callables(state, key, passive)
  File "sqlalchemy/orm/attributes.py", line 995, in _fire_loader_callables
    return self.callable_(state, passive)
  File "sqlalchemy/orm/strategies.py", line 912, in _load_for_state
    return self._emit_lazyload(
  File "sqlalchemy/orm/strategies.py", line 1022, in _emit_lazyload
    lazy_clause, params = self._generate_lazy_clause(state, passive)
  File "sqlalchemy/orm/strategies.py", line 807, in _generate_lazy_clause
    value = mapper._get_state_attr_by_column(
  File "sqlalchemy/orm/mapper.py", line 3018, in _get_state_attr_by_column
    return state.manager[prop.key].impl.get(state, dict_, passive=passive)
  File "sqlalchemy/orm/attributes.py", line 959, in get
    value = self._fire_loader_callables(state, key, passive)
  File "sqlalchemy/orm/attributes.py", line 990, in _fire_loader_callables
    return state._load_expired(state, passive)
  File "sqlalchemy/orm/state.py", line 712, in _load_expired
    self.manager.expired_attribute_loader(self, toload, passive)
  File "sqlalchemy/orm/loading.py", line 1451, in load_scalar_attributes
    result = load_on_ident(
  File "sqlalchemy/orm/loading.py", line 407, in load_on_ident
    return load_on_pk_identity(
  File "sqlalchemy/orm/loading.py", line 530, in load_on_pk_identity
    session.execute(
  File "sqlalchemy/orm/session.py", line 1716, in execute
    conn = self._connection_for_bind(bind)
  File "sqlalchemy/orm/session.py", line 1552, in _connection_for_bind
    TransactionalContext._trans_ctx_check(self)
  File "sqlalchemy/engine/util.py", line 199, in _trans_ctx_check
    raise exc.InvalidRequestError(
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
