### PR TITLE
[24.0] Always discard session after __handle_waiting_jobs is done

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -395,6 +395,8 @@ class JobHandlerQueue(BaseJobHandlerQueue):
             self.__handle_waiting_jobs()
         except StopSignalException:
             pass
+        finally:
+            self.sa_session.remove()
         log.trace(monitor_step_timer.to_str())
 
     def __handle_waiting_jobs(self):
@@ -582,9 +584,6 @@ class JobHandlerQueue(BaseJobHandlerQueue):
         # Commit updated state
         with transaction(self.sa_session):
             self.sa_session.commit()
-
-        # Done with the session
-        self.sa_session.remove()
 
     def __filter_jobs_with_invalid_input_states(self, jobs):
         """


### PR DESCRIPTION
This should guarantee recovery of the job monitor thread and fix https://github.com/galaxyproject/galaxy/issues/17893. Alternative to #17908, which is close but I think this avoids guessing which exceptions we gotta do this for, and since it's part of the normal control flow we have some test coverage here.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
