### PR TITLE
Add `email` notifications channel

### DIFF
--- a/client/src/api/notifications.preferences.ts
+++ b/client/src/api/notifications.preferences.ts
@@ -1,11 +1,18 @@
 import { type components, fetcher } from "@/api/schema";
 
-export type UserNotificationPreferences = components["schemas"]["UserNotificationPreferences"];
+type UserNotificationPreferences = components["schemas"]["UserNotificationPreferences"];
+
+export interface UserNotificationPreferencesExtended extends UserNotificationPreferences {
+    supportedChannels: string[];
+}
 
 const getNotificationsPreferences = fetcher.path("/api/notifications/preferences").method("get").create();
-export async function getNotificationsPreferencesFromServer() {
-    const { data } = await getNotificationsPreferences({});
-    return data;
+export async function getNotificationsPreferencesFromServer(): Promise<UserNotificationPreferencesExtended> {
+    const { data, headers } = await getNotificationsPreferences({});
+    return {
+        ...data,
+        supportedChannels: headers.get("supported-channels")?.split(",") ?? [],
+    };
 }
 
 type UpdateUserNotificationPreferencesRequest = components["schemas"]["UpdateUserNotificationPreferencesRequest"];

--- a/client/src/api/notifications.ts
+++ b/client/src/api/notifications.ts
@@ -25,7 +25,7 @@ export type NewSharedItemNotificationContentItemType =
 
 type UserNotificationUpdateRequest = components["schemas"]["UserNotificationUpdateRequest"];
 
-export type NotificationCreateRequest = components["schemas"]["NotificationCreateRequestBody"];
+export type NotificationCreateRequest = components["schemas"]["NotificationCreateRequest"];
 
 type NotificationResponse = components["schemas"]["NotificationResponse"];
 

--- a/client/src/api/notifications.ts
+++ b/client/src/api/notifications.ts
@@ -25,7 +25,7 @@ export type NewSharedItemNotificationContentItemType =
 
 type UserNotificationUpdateRequest = components["schemas"]["UserNotificationUpdateRequest"];
 
-type NotificationCreateRequest = components["schemas"]["NotificationCreateRequest"];
+export type NotificationCreateRequest = components["schemas"]["NotificationCreateRequestBody"];
 
 type NotificationResponse = components["schemas"]["NotificationResponse"];
 

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1255,6 +1255,9 @@ export interface paths {
         /**
          * Returns the current user's preferences for notifications.
          * @description Anonymous users cannot have notification preferences. They will receive only broadcasted notifications.
+         *
+         * - The settings will contain all possible channels, but the client should only show the ones that are really supported by the server.
+         *   The supported channels are returned in the `supported-channels` header.
          */
         get: operations["get_notification_preferences_api_notifications_preferences_get"];
         /**
@@ -20160,6 +20163,9 @@ export interface operations {
         /**
          * Returns the current user's preferences for notifications.
          * @description Anonymous users cannot have notification preferences. They will receive only broadcasted notifications.
+         *
+         * - The settings will contain all possible channels, but the client should only show the ones that are really supported by the server.
+         *   The supported channels are returned in the `supported-channels` header.
          */
         parameters?: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -9598,6 +9598,7 @@ export interface components {
              * Channels
              * @description The channels that the user wants to receive notifications from for this category.
              * @default {
+             *   "email": true,
              *   "push": true
              * }
              */
@@ -9614,6 +9615,12 @@ export interface components {
          * @description The settings for each channel of a notification category.
          */
         NotificationChannelSettings: {
+            /**
+             * Email
+             * @description Whether the user wants to receive email notifications for this category. This setting will be ignored unless the server supports asynchronous tasks.
+             * @default true
+             */
+            email?: boolean;
             /**
              * Push
              * @description Whether the user wants to receive push notifications in the browser for this category.

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -9638,14 +9638,18 @@ export interface components {
              */
             variant: components["schemas"]["NotificationVariant"];
         };
-        /** NotificationCreateRequestBody */
-        NotificationCreateRequestBody: {
+        /** NotificationCreateRequest */
+        NotificationCreateRequest: {
             /**
              * Notification
              * @description The notification to create. The structure depends on the category.
              */
             notification: components["schemas"]["NotificationCreateData"];
-            recipients: components["schemas"]["NotificationRecipientsPayload"];
+            /**
+             * Recipients
+             * @description The recipients of the notification. Can be a combination of users, groups and roles.
+             */
+            recipients: components["schemas"]["NotificationRecipientsRequest"];
         };
         /** NotificationCreatedResponse */
         NotificationCreatedResponse: {
@@ -9660,8 +9664,8 @@ export interface components {
              */
             total_notifications_sent: number;
         };
-        /** NotificationRecipientsPayload */
-        NotificationRecipientsPayload: {
+        /** NotificationRecipientsRequest */
+        NotificationRecipientsRequest: {
             /**
              * Group IDs
              * @description The list of encoded group IDs of the groups that should receive the notification.
@@ -19976,7 +19980,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["NotificationCreateRequestBody"];
+                "application/json": components["schemas"]["NotificationCreateRequest"];
             };
         };
         responses: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -5391,6 +5391,40 @@ export interface components {
             /** Tags */
             tags?: string[] | null;
         };
+        /** GenericNotificationCreateRequest[Annotated[int, BeforeValidator, BeforeValidator, PlainSerializer, WithJsonSchema, WithJsonSchema]] */
+        GenericNotificationCreateRequest_Annotated_int__BeforeValidator__BeforeValidator__PlainSerializer__WithJsonSchema__WithJsonSchema__: {
+            /**
+             * Notification
+             * @description The notification to create. The structure depends on the category.
+             */
+            notification: components["schemas"]["NotificationCreateData"];
+            /**
+             * Recipients
+             * @description The recipients of the notification. Can be a combination of users, groups and roles.
+             */
+            recipients: components["schemas"]["GenericNotificationRecipients_Annotated_int__BeforeValidator__BeforeValidator__PlainSerializer__WithJsonSchema__WithJsonSchema__"];
+        };
+        /** GenericNotificationRecipients[Annotated[int, BeforeValidator, BeforeValidator, PlainSerializer, WithJsonSchema, WithJsonSchema]] */
+        GenericNotificationRecipients_Annotated_int__BeforeValidator__BeforeValidator__PlainSerializer__WithJsonSchema__WithJsonSchema__: {
+            /**
+             * Group IDs
+             * @description The list of encoded group IDs of the groups that should receive the notification.
+             * @default []
+             */
+            group_ids?: string[];
+            /**
+             * Role IDs
+             * @description The list of encoded role IDs of the roles that should receive the notification.
+             * @default []
+             */
+            role_ids?: string[];
+            /**
+             * User IDs
+             * @description The list of encoded user IDs of the users that should receive the notification.
+             * @default []
+             */
+            user_ids?: string[];
+        };
         /**
          * GroupCreatePayload
          * @description Payload schema for creating a group.
@@ -9628,22 +9662,8 @@ export interface components {
              */
             variant: components["schemas"]["NotificationVariant"];
         };
-        /**
-         * NotificationCreateRequest
-         * @description Contains the recipients and the notification to create.
-         */
-        NotificationCreateRequest: {
-            /**
-             * Notification
-             * @description The notification to create. The structure depends on the category.
-             */
-            notification: components["schemas"]["NotificationCreateData"];
-            /**
-             * Recipients
-             * @description The recipients of the notification. Can be a combination of users, groups and roles.
-             */
-            recipients: components["schemas"]["NotificationRecipients"];
-        };
+        /** NotificationCreateRequestBody */
+        NotificationCreateRequestBody: components["schemas"]["GenericNotificationCreateRequest_Annotated_int__BeforeValidator__BeforeValidator__PlainSerializer__WithJsonSchema__WithJsonSchema__"];
         /** NotificationCreatedResponse */
         NotificationCreatedResponse: {
             /**
@@ -9656,30 +9676,6 @@ export interface components {
              * @description The total number of notifications that were sent to the recipients.
              */
             total_notifications_sent: number;
-        };
-        /**
-         * NotificationRecipients
-         * @description The recipients of a notification. Can be a combination of users, groups and roles.
-         */
-        NotificationRecipients: {
-            /**
-             * Group IDs
-             * @description The list of encoded group IDs of the groups that should receive the notification.
-             * @default []
-             */
-            group_ids?: string[];
-            /**
-             * Role IDs
-             * @description The list of encoded role IDs of the roles that should receive the notification.
-             * @default []
-             */
-            role_ids?: string[];
-            /**
-             * User IDs
-             * @description The list of encoded user IDs of the users that should receive the notification.
-             * @default []
-             */
-            user_ids?: string[];
         };
         /**
          * NotificationResponse
@@ -19976,14 +19972,16 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["NotificationCreateRequest"];
+                "application/json": components["schemas"]["NotificationCreateRequestBody"];
             };
         };
         responses: {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["NotificationCreatedResponse"];
+                    "application/json":
+                        | components["schemas"]["NotificationCreatedResponse"]
+                        | components["schemas"]["AsyncTaskResultSummary"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -5394,40 +5394,6 @@ export interface components {
             /** Tags */
             tags?: string[] | null;
         };
-        /** GenericNotificationCreateRequest[Annotated[int, BeforeValidator, BeforeValidator, PlainSerializer, WithJsonSchema, WithJsonSchema]] */
-        GenericNotificationCreateRequest_Annotated_int__BeforeValidator__BeforeValidator__PlainSerializer__WithJsonSchema__WithJsonSchema__: {
-            /**
-             * Notification
-             * @description The notification to create. The structure depends on the category.
-             */
-            notification: components["schemas"]["NotificationCreateData"];
-            /**
-             * Recipients
-             * @description The recipients of the notification. Can be a combination of users, groups and roles.
-             */
-            recipients: components["schemas"]["GenericNotificationRecipients_Annotated_int__BeforeValidator__BeforeValidator__PlainSerializer__WithJsonSchema__WithJsonSchema__"];
-        };
-        /** GenericNotificationRecipients[Annotated[int, BeforeValidator, BeforeValidator, PlainSerializer, WithJsonSchema, WithJsonSchema]] */
-        GenericNotificationRecipients_Annotated_int__BeforeValidator__BeforeValidator__PlainSerializer__WithJsonSchema__WithJsonSchema__: {
-            /**
-             * Group IDs
-             * @description The list of encoded group IDs of the groups that should receive the notification.
-             * @default []
-             */
-            group_ids?: string[];
-            /**
-             * Role IDs
-             * @description The list of encoded role IDs of the roles that should receive the notification.
-             * @default []
-             */
-            role_ids?: string[];
-            /**
-             * User IDs
-             * @description The list of encoded user IDs of the users that should receive the notification.
-             * @default []
-             */
-            user_ids?: string[];
-        };
         /**
          * GroupCreatePayload
          * @description Payload schema for creating a group.
@@ -9673,7 +9639,14 @@ export interface components {
             variant: components["schemas"]["NotificationVariant"];
         };
         /** NotificationCreateRequestBody */
-        NotificationCreateRequestBody: components["schemas"]["GenericNotificationCreateRequest_Annotated_int__BeforeValidator__BeforeValidator__PlainSerializer__WithJsonSchema__WithJsonSchema__"];
+        NotificationCreateRequestBody: {
+            /**
+             * Notification
+             * @description The notification to create. The structure depends on the category.
+             */
+            notification: components["schemas"]["NotificationCreateData"];
+            recipients: components["schemas"]["NotificationRecipientsPayload"];
+        };
         /** NotificationCreatedResponse */
         NotificationCreatedResponse: {
             /**
@@ -9686,6 +9659,27 @@ export interface components {
              * @description The total number of notifications that were sent to the recipients.
              */
             total_notifications_sent: number;
+        };
+        /** NotificationRecipientsPayload */
+        NotificationRecipientsPayload: {
+            /**
+             * Group IDs
+             * @description The list of encoded group IDs of the groups that should receive the notification.
+             * @default []
+             */
+            group_ids?: string[];
+            /**
+             * Role IDs
+             * @description The list of encoded role IDs of the roles that should receive the notification.
+             * @default []
+             */
+            role_ids?: string[];
+            /**
+             * User IDs
+             * @description The list of encoded user IDs of the users that should receive the notification.
+             * @default []
+             */
+            user_ids?: string[];
         };
         /**
          * NotificationResponse

--- a/client/src/components/Notifications/NotificationsList.vue
+++ b/client/src/components/Notifications/NotificationsList.vue
@@ -19,9 +19,17 @@ library.add(faCog, faHourglassHalf, faRetweet);
 const notificationsStore = useNotificationsStore();
 const { notifications, loadingNotifications } = storeToRefs(notificationsStore);
 
+interface Props {
+    shouldOpenPreferences?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    shouldOpenPreferences: false,
+});
+
 const showUnread = ref(false);
 const showShared = ref(false);
-const preferencesOpen = ref(false);
+const preferencesOpen = ref(props.shouldOpenPreferences);
 const selectedNotificationIds = ref<string[]>([]);
 
 const haveSelected = computed(() => selectedNotificationIds.value.length > 0);

--- a/client/src/components/admin/Notifications/NotificationForm.vue
+++ b/client/src/components/admin/Notifications/NotificationForm.vue
@@ -7,7 +7,7 @@ import { computed, type Ref, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { getAllGroups } from "@/api/groups";
-import { sendNotification } from "@/api/notifications";
+import { NotificationCreateRequest, sendNotification } from "@/api/notifications";
 import { getAllRoles } from "@/api/roles";
 import { type components } from "@/api/schema";
 import { getAllUsers } from "@/api/users";
@@ -25,7 +25,6 @@ library.add(faInfoCircle);
 
 type SelectOption = [string, string];
 type NotificationCreateData = components["schemas"]["NotificationCreateData"];
-type NotificationCreateRequest = components["schemas"]["NotificationCreateRequest"];
 
 interface MessageNotificationCreateData extends NotificationCreateData {
     category: "message";

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -450,6 +450,9 @@ export function getRouter(Galaxy) {
                         path: "user/notifications",
                         component: NotificationsList,
                         redirect: redirectIf(!Galaxy.config.enable_notification_system, "/") || redirectAnon(),
+                        props: (route) => ({
+                            shouldOpenPreferences: Boolean(route.query.preferences),
+                        }),
                     },
                     {
                         path: "user/notifications/preferences",

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5463,6 +5463,17 @@
 :Type: int
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``dispatch_notifications_interval``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    The interval in seconds between attempts to dispatch notifications
+    to users (every 10 minutes by default). Runs in a Celery task.
+:Default: ``600``
+:Type: int
+
+
 ~~~~~~~~~~~~~~~~~~~~~~
 ``help_forum_api_url``
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -238,7 +238,9 @@ def setup_periodic_tasks(config, celery_app):
     beat_schedule: Dict[str, Dict[str, Any]] = {}
     schedule_task("prune_history_audit_table", config.history_audit_table_prune_interval)
     schedule_task("cleanup_short_term_storage", config.short_term_storage_cleanup_interval)
+
     schedule_task("cleanup_expired_notifications", config.expired_notifications_cleanup_interval)
+    schedule_task("dispatch_pending_notifications", config.dispatch_notifications_interval)
 
     if config.object_store_cache_monitor_driver in ["auto", "celery"]:
         schedule_task("clean_object_store_caches", config.object_store_cache_monitor_interval)

--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -239,8 +239,9 @@ def setup_periodic_tasks(config, celery_app):
     schedule_task("prune_history_audit_table", config.history_audit_table_prune_interval)
     schedule_task("cleanup_short_term_storage", config.short_term_storage_cleanup_interval)
 
-    schedule_task("cleanup_expired_notifications", config.expired_notifications_cleanup_interval)
-    schedule_task("dispatch_pending_notifications", config.dispatch_notifications_interval)
+    if config.enable_notification_system:
+        schedule_task("cleanup_expired_notifications", config.expired_notifications_cleanup_interval)
+        schedule_task("dispatch_pending_notifications", config.dispatch_notifications_interval)
 
     if config.object_store_cache_monitor_driver in ["auto", "celery"]:
         schedule_task("clean_object_store_caches", config.object_store_cache_monitor_interval)

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -43,6 +43,7 @@ from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.objectstore import BaseObjectStore
 from galaxy.objectstore.caching import check_caches
 from galaxy.queue_worker import GalaxyQueueWorker
+from galaxy.schema.notifications import NotificationCreateRequest
 from galaxy.schema.tasks import (
     ComputeDatasetHashTaskRequest,
     GenerateHistoryContentDownload,
@@ -483,3 +484,13 @@ def cleanup_expired_notifications(notification_manager: NotificationManager):
 @galaxy_task(action="prune object store cache directories")
 def clean_object_store_caches(object_store: BaseObjectStore):
     check_caches(object_store.cache_targets())
+
+
+@galaxy_task(action="send notifications to all recipients")
+def send_notification_to_recipients_async(
+    request: NotificationCreateRequest, notification_manager: NotificationManager
+):
+    """Send a notification to a list of users."""
+    _, notifications_sent = notification_manager.send_notification_to_recipients(request=request)
+
+    log.info(f"Successfully sent {notifications_sent} notifications.")

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -494,3 +494,11 @@ def send_notification_to_recipients_async(
     _, notifications_sent = notification_manager.send_notification_to_recipients(request=request)
 
     log.info(f"Successfully sent {notifications_sent} notifications.")
+
+
+@galaxy_task(action="dispatch pending notifications")
+def dispatch_pending_notifications(notification_manager: NotificationManager):
+    """Dispatch pending notifications."""
+    count = notification_manager.dispatch_pending_notifications_via_channels()
+    if count:
+        log.info(f"Successfully dispatched {count} notifications.")

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2911,6 +2911,10 @@ galaxy:
   # a Celery task.
   #expired_notifications_cleanup_interval: 86400
 
+  # The interval in seconds between attempts to dispatch notifications
+  # to users (every 10 minutes by default). Runs in a Celery task.
+  #dispatch_notifications_interval: 600
+
   # The URL pointing to the Galaxy Help Forum API base URL. The API must
   # be compatible with Discourse API (https://docs.discourse.org/).
   #help_forum_api_url: https://help.galaxyproject.org/

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3990,6 +3990,13 @@ mapping:
         desc: |
           The interval in seconds between attempts to delete all expired notifications from the database (every 24 hours by default). Runs in a Celery task.
 
+      dispatch_notifications_interval:
+        type: int
+        required: false
+        default: 600
+        desc: |
+          The interval in seconds between attempts to dispatch notifications to users (every 10 minutes by default). Runs in a Celery task.
+
       help_forum_api_url:
         type: str
         required: false

--- a/lib/galaxy/config/templates/mail/notifications/message-email.html
+++ b/lib/galaxy/config/templates/mail/notifications/message-email.html
@@ -1,12 +1,12 @@
-Use this template to customize the HTML email your users will receive
+Use this template to customize the HTML-formatted email your users will receive
 when a new notification of category "message" is sent to them.
 Copy the file to {{ templates_dir }}/mail/notifications/message-email.html and modify as required.
 
-If you are adding URLs into this, remember that only absolute URLS (with
+If you are adding URLs, remember that only absolute URLs (with
 a domain name) make sense in email! They can be served from any stable
 location, including your Galaxy server or GitHub.
 
-The following variables are available for inserting into the html with Jinja2
+The following variables are available for inserting into the HTML with Jinja2
 syntax, like {{ variable_name }}. They will be rendered into the text before
 the email is sent:
 

--- a/lib/galaxy/config/templates/mail/notifications/message-email.html
+++ b/lib/galaxy/config/templates/mail/notifications/message-email.html
@@ -13,12 +13,13 @@ the email is sent:
 - name                      The user's name
 - user_email                The user's email
 - date                      Date and time of the notification
-- hostname                  Your galaxy's hostname
+- hostname                  Your galaxy's hostname (i.e. usegalaxy.* or the value in `server_name` from the galaxy config file)
 - contact_email             Your galaxy's contact email
 - notification_settings_url The URL to the user's notification settings to manage their subscriptions
 - content                   The message payload
   - subject                   The message subject
   - content                   The message content in HTML (converted from Markdown)
+- galaxy_url                The URL to the Galaxy instance (i.e. https://usegalaxy.*)
 
 Template begins here >>>>>>
 <!DOCTYPE html>
@@ -55,14 +56,20 @@ Template begins here >>>>>>
 
     <p style="font-size: 12pt;">
       Regards,<br>
-      Your Galaxy Team at {{ hostname }}
+      Your Galaxy Team at <a href="{{ galaxy_url }}">{{ hostname }}</a>
     </p>
 
     <p style="font-size: 10pt;">
-      This is an automated email. If you have any questions or concerns, please do not reply to this email, instead, contact us at <a href="mailto:{{ contact_email }}">{{ contact_email }}</a>.<br><br>
-
-      You received this email because you are subscribed to receive notifications of this type.
+      You received this email because you are subscribed to receive notifications from the Galaxy Team.
+      {% if notification_settings_url %}
       You can manage your notification settings <a href="{{ notification_settings_url }}">here</a>.
+      {% endif %}
+
+      <br>
+
+      {% if contact_email %}
+      This is an automated email. If you have any questions or concerns, please do not reply to this email, instead, contact us at <a href="mailto:{{ contact_email }}">{{ contact_email }}</a>.
+      {% endif %}
     </p>
 
     <img

--- a/lib/galaxy/config/templates/mail/notifications/message-email.html
+++ b/lib/galaxy/config/templates/mail/notifications/message-email.html
@@ -1,0 +1,77 @@
+Use this template to customize the HTML email your users will receive
+when a new notification of category "message" is sent to them.
+Copy the file to {{ templates_dir }}/mail/notifications/message-email.html and modify as required.
+
+If you are adding URLs into this, remember that only absolute URLS (with
+a domain name) make sense in email! They can be served from any stable
+location, including your Galaxy server or GitHub.
+
+The following variables are available for inserting into the html with Jinja2
+syntax, like {{ variable_name }}. They will be rendered into the text before
+the email is sent:
+
+- name                      The user's name
+- user_email                The user's email
+- date                      Date and time of the notification
+- hostname                  Your galaxy's hostname
+- contact_email             Your galaxy's contact email
+- notification_settings_url The URL to the user's notification settings to manage their subscriptions
+- content                   The message payload
+  - subject                   The message subject
+  - content                   The message content in HTML (converted from Markdown)
+
+Template begins here >>>>>>
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <title>[Galaxy] New message received: {{ content['subject'] }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+  </head>
+  <body style="font-family: 'Roboto', sans-serif;">
+
+    <p style="font-size: 12pt;">
+      Hello {{ name }},<br><br>
+
+      You have received a new message on <b>{{ date }}</b> from the Galaxy Team at <b>{{ hostname }}</b>, here are the details:
+      <br><br>
+    </p>
+
+    <p style="font-size: 12pt;">
+      <strong>Subject:</strong> 
+      <br>
+      {{ content['subject'] }}
+      <br><br>
+      <strong>Message:</strong>
+      <br>
+      {{ content['message'] }}
+      <br><br>
+    </p>
+    
+    <p style="font-size: 12pt;">
+      Thank you for using Galaxy!
+    </p>
+    
+
+    <p style="font-size: 12pt;">
+      Regards,<br>
+      Your Galaxy Team at {{ hostname }}
+    </p>
+
+    <p style="font-size: 10pt;">
+      This is an automated email. If you have any questions or concerns, please do not reply to this email, instead, contact us at <a href="mailto:{{ contact_email }}">{{ contact_email }}</a>.<br><br>
+
+      You received this email because you are subscribed to receive notifications of this type.
+      You can manage your notification settings <a href="{{ notification_settings_url }}">here</a>.
+    </p>
+
+    <img
+      style="width: 130px; height: auto; margin: 15px 0;"
+      src="https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.png"
+      alt="Galaxy project logo"
+    >
+
+    <br>
+
+  </body>
+</html>

--- a/lib/galaxy/config/templates/mail/notifications/message-email.txt
+++ b/lib/galaxy/config/templates/mail/notifications/message-email.txt
@@ -13,12 +13,13 @@ sent:
 - name                      The user's name
 - user_email                The user's email
 - date                      Date and time of the notification
-- hostname                  Your galaxy's hostname
+- hostname                  Your galaxy's hostname (i.e. usegalaxy.* or the value in `server_name` from the galaxy config file)
 - contact_email             Your galaxy's contact email
 - notification_settings_url The URL to the user's notification settings to manage their subscriptions
 - content                   The message payload
   - subject                 The message subject
   - content                 The message content in HTML (converted from Markdown)
+- galaxy_url                The URL to the Galaxy instance (i.e. https://usegalaxy.*)
 
 Template begins here>>>>>>
 Hello {{ name }},
@@ -31,11 +32,18 @@ Subject:
 Message:
 {{ content['message'] }}
 
-To manage your notification settings, please visit {{ notification_settings_url }}.
-
-If you have any questions, please contact us at {{ contact_email }}.
-
 Thank you for using Galaxy!
 
 Regards,
-Your Galaxy Team
+Your Galaxy Team at {{ hostname }}
+
+---
+
+You received this email because you are subscribed to receive notifications from the Galaxy Team.
+{% if notification_settings_url %}
+To manage your notification settings, please visit {{ notification_settings_url }}.
+{% endif %}
+
+{% if contact_email %}
+This is an automated email. If you have any questions or concerns, please do not reply to this email, instead, contact us at {{ contact_email }}.
+{% endif %}

--- a/lib/galaxy/config/templates/mail/notifications/message-email.txt
+++ b/lib/galaxy/config/templates/mail/notifications/message-email.txt
@@ -2,7 +2,7 @@ Use this template to customize the text email your users will receive
 when a new notification of category "message" is sent to them.
 Copy the file to {{ templates_dir }}/mail/notifications/message-email.txt and modify as required.
 
-If you are adding URLs into this, remember that only absolute URLS (with
+If you are adding URLs, remember that only absolute URLs (with
 a domain name) make sense in email! They can be served from any stable
 location, including your Galaxy server or GitHub.
 

--- a/lib/galaxy/config/templates/mail/notifications/message-email.txt
+++ b/lib/galaxy/config/templates/mail/notifications/message-email.txt
@@ -1,0 +1,41 @@
+Use this template to customize the text email your users will receive
+when a new notification of category "message" is sent to them.
+Copy the file to {{ templates_dir }}/mail/notifications/message-email.txt and modify as required.
+
+If you are adding URLs into this, remember that only absolute URLS (with
+a domain name) make sense in email! They can be served from any stable
+location, including your Galaxy server or GitHub.
+
+The following variables are available for inserting into the text like
+{{ variable_name }}. They will be rendered into the text before the email is
+sent:
+
+- name                      The user's name
+- user_email                The user's email
+- date                      Date and time of the notification
+- hostname                  Your galaxy's hostname
+- contact_email             Your galaxy's contact email
+- notification_settings_url The URL to the user's notification settings to manage their subscriptions
+- content                   The message payload
+  - subject                 The message subject
+  - content                 The message content in HTML (converted from Markdown)
+
+Template begins here>>>>>>
+Hello {{ name }},
+
+You have received a new message on {{ date }} from the Galaxy Team at {{ hostname }}, here are the details:
+
+Subject:
+{{ content['subject'] }}
+
+Message:
+{{ content['message'] }}
+
+To manage your notification settings, please visit {{ notification_settings_url }}.
+
+If you have any questions, please contact us at {{ contact_email }}.
+
+Thank you for using Galaxy!
+
+Regards,
+Your Galaxy Team

--- a/lib/galaxy/config/templates/mail/notifications/new_shared_item-email.html
+++ b/lib/galaxy/config/templates/mail/notifications/new_shared_item-email.html
@@ -1,0 +1,74 @@
+Use this template to customize the HTML email your users will receive
+when a new notification of category "new_shared_item" is sent to them.
+Copy the file to {{ templates_dir }}/mail/notifications/new_shared_item-email.html and modify as required.
+
+If you are adding URLs into this, remember that only absolute URLS (with
+a domain name) make sense in email! They can be served from any stable
+location, including your Galaxy server or GitHub.
+
+The following variables are available for inserting into the html with Jinja2
+syntax, like {{ variable_name }}. They will be rendered into the text before
+the email is sent:
+
+- name                      The user's name
+- user_email                The user's email
+- date                      Date and time of the notification
+- hostname                  Your galaxy's hostname
+- contact_email             Your galaxy's contact email
+- notification_settings_url The URL to the user's notification settings to manage their subscriptions
+- content                   The new_shared_item payload
+  - item_type               The type of the shared item
+  - item_name               The name of the shared item
+  - owner_name              The name of the owner of the shared item
+  - slug                    The slug of the shared item. Used for the link to the item.
+
+Template begins here >>>>>>
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <title>[Galaxy] New {{ content['item_type'] }} shared with you: </title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+  </head>
+  <body style="font-family: 'Roboto', sans-serif;">
+
+    <p style="font-size: 12pt;">
+      Hello {{ name }},<br><br>
+
+      A new <b>{{ content['item_type'] }}</b> named <i>{{ content['item_name'] }}</i> has been shared with you on <b>{{ date }}</b> by <b>{{ content['owner_name'] }}</b>.
+    </p>
+
+    <p style="font-size: 12pt;">
+      To access the shared {{ content['item_type'] }}, please visit the following link:
+      <br>
+      <a href="{{ content['slug'] }}">{{ content['item_name'] }}</a>
+      <br><br>
+    
+    <p style="font-size: 12pt;">
+      Thank you for using Galaxy!
+    </p>
+    
+
+    <p style="font-size: 12pt;">
+      Regards,<br>
+      Your Galaxy Team at {{ hostname }}
+    </p>
+
+    <p style="font-size: 10pt;">
+      This is an automated email. If you have any questions or concerns, please do not reply to this email, instead, contact us at <a href="mailto:{{ contact_email }}">{{ contact_email }}</a>.<br><br>
+
+      You received this email because you are subscribed to receive notifications when another user shares an item with you.
+      <br>
+      You can manage your notification settings <a href="{{ notification_settings_url }}">here</a>.
+    </p>
+
+    <img
+      style="width: 130px; height: auto; margin: 15px 0;"
+      src="https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.png"
+      alt="Galaxy project logo"
+    >
+
+    <br>
+
+  </body>
+</html>

--- a/lib/galaxy/config/templates/mail/notifications/new_shared_item-email.html
+++ b/lib/galaxy/config/templates/mail/notifications/new_shared_item-email.html
@@ -13,7 +13,7 @@ the email is sent:
 - name                      The user's name
 - user_email                The user's email
 - date                      Date and time of the notification
-- hostname                  Your galaxy's hostname
+- hostname                  Your galaxy's hostname (i.e. usegalaxy.* or the value in `server_name` from the galaxy config file)
 - contact_email             Your galaxy's contact email
 - notification_settings_url The URL to the user's notification settings to manage their subscriptions
 - content                   The new_shared_item payload
@@ -21,6 +21,7 @@ the email is sent:
   - item_name               The name of the shared item
   - owner_name              The name of the owner of the shared item
   - slug                    The slug of the shared item. Used for the link to the item.
+- galaxy_url                The URL to the Galaxy instance (i.e. https://usegalaxy.*)
 
 Template begins here >>>>>>
 <!DOCTYPE html>
@@ -41,7 +42,7 @@ Template begins here >>>>>>
     <p style="font-size: 12pt;">
       To access the shared {{ content['item_type'] }}, please visit the following link:
       <br>
-      <a href="{{ content['slug'] }}">{{ content['item_name'] }}</a>
+      <a href="{{galaxy_url}}/{{ content['slug'] }}">{{ content['item_name'] }}</a>
       <br><br>
     
     <p style="font-size: 12pt;">
@@ -51,15 +52,20 @@ Template begins here >>>>>>
 
     <p style="font-size: 12pt;">
       Regards,<br>
-      Your Galaxy Team at {{ hostname }}
+      Your Galaxy Team at <a href="{{ galaxy_url }}">{{ hostname }}</a>
     </p>
 
     <p style="font-size: 10pt;">
-      This is an automated email. If you have any questions or concerns, please do not reply to this email, instead, contact us at <a href="mailto:{{ contact_email }}">{{ contact_email }}</a>.<br><br>
-
       You received this email because you are subscribed to receive notifications when another user shares an item with you.
-      <br>
+      {% if notification_settings_url %}
       You can manage your notification settings <a href="{{ notification_settings_url }}">here</a>.
+      {% endif %}
+      
+      <br>
+
+      {% if contact_email %}
+      This is an automated email. If you have any questions or concerns, please do not reply to this email, instead, contact us at <a href="mailto:{{ contact_email }}">{{ contact_email }}</a>.
+      {% endif %}
     </p>
 
     <img

--- a/lib/galaxy/config/templates/mail/notifications/new_shared_item-email.html
+++ b/lib/galaxy/config/templates/mail/notifications/new_shared_item-email.html
@@ -2,11 +2,11 @@ Use this template to customize the HTML email your users will receive
 when a new notification of category "new_shared_item" is sent to them.
 Copy the file to {{ templates_dir }}/mail/notifications/new_shared_item-email.html and modify as required.
 
-If you are adding URLs into this, remember that only absolute URLS (with
+If you are adding URLs, remember that only absolute URLs (with
 a domain name) make sense in email! They can be served from any stable
 location, including your Galaxy server or GitHub.
 
-The following variables are available for inserting into the html with Jinja2
+The following variables are available for inserting into the HTML with Jinja2
 syntax, like {{ variable_name }}. They will be rendered into the text before
 the email is sent:
 

--- a/lib/galaxy/config/templates/mail/notifications/new_shared_item-email.txt
+++ b/lib/galaxy/config/templates/mail/notifications/new_shared_item-email.txt
@@ -2,7 +2,7 @@ Use this template to customize the text email your users will receive
 when a new notification of category "new_shared_item" is sent to them.
 Copy the file to {{ templates_dir }}/mail/notifications/new_shared_item-email.txt and modify as required.
 
-If you are adding URLs into this, remember that only absolute URLS (with
+If you are adding URLs, remember that only absolute URLs (with
 a domain name) make sense in email! They can be served from any stable
 location, including your Galaxy server or GitHub.
 

--- a/lib/galaxy/config/templates/mail/notifications/new_shared_item-email.txt
+++ b/lib/galaxy/config/templates/mail/notifications/new_shared_item-email.txt
@@ -13,7 +13,7 @@ sent:
 - name                      The user's name
 - user_email                The user's email
 - date                      Date and time of the notification
-- hostname                  Your galaxy's hostname
+- hostname                  Your galaxy's hostname (i.e. usegalaxy.* or the value in `server_name` from the galaxy config file)
 - contact_email             Your galaxy's contact email
 - notification_settings_url The URL to the user's notification settings to manage their subscriptions
 - content                   The new_shared_item payload
@@ -21,21 +21,30 @@ sent:
   - item_name               The name of the shared item
   - owner_name              The name of the owner of the shared item
   - slug                    The slug of the shared item. Used for the link to the item.
+- galaxy_url                The URL to the Galaxy instance (i.e. https://usegalaxy.*)
 
 Template begins here>>>>>>
 Hello {{ name }},
 
-A new {{ content['item_type'] }} has been shared with you by {{ content['owner_name'] }}.
+A new {{ content['item_type'] }} has been shared with you on {{ date }} by {{ content['owner_name'] }}.
 
 To access the shared {{ content['item_type'] }}, please visit the following link:
-{{ hostname }}/{{ content['slug'] }}
-
-You received this email because you are subscribed to receive notifications when another user shares an item with you.
-To manage your notification settings, please visit {{ notification_settings_url }}.
-
-If you have any questions, please contact us at {{ contact_email }}.
+{{ galaxy_url }}/{{ content['slug'] }}
 
 Thank you for using Galaxy!
 
 Regards,
-Your Galaxy Team
+Your Galaxy Team at {{ hostname }}
+
+---
+
+You received this email because you are subscribed to receive notifications when another user shares an item with you.
+{% if notification_settings_url %}
+To manage your notification settings, please visit {{ notification_settings_url }}.
+{% endif %}
+
+{% if contact_email %}
+This is an automated email. If you have any questions or concerns, please do not reply to this email, instead, contact us at {{ contact_email }}.
+{% endif %}
+
+

--- a/lib/galaxy/config/templates/mail/notifications/new_shared_item-email.txt
+++ b/lib/galaxy/config/templates/mail/notifications/new_shared_item-email.txt
@@ -1,0 +1,41 @@
+Use this template to customize the text email your users will receive
+when a new notification of category "new_shared_item" is sent to them.
+Copy the file to {{ templates_dir }}/mail/notifications/new_shared_item-email.txt and modify as required.
+
+If you are adding URLs into this, remember that only absolute URLS (with
+a domain name) make sense in email! They can be served from any stable
+location, including your Galaxy server or GitHub.
+
+The following variables are available for inserting into the text like
+{{ variable_name }}. They will be rendered into the text before the email is
+sent:
+
+- name                      The user's name
+- user_email                The user's email
+- date                      Date and time of the notification
+- hostname                  Your galaxy's hostname
+- contact_email             Your galaxy's contact email
+- notification_settings_url The URL to the user's notification settings to manage their subscriptions
+- content                   The new_shared_item payload
+  - item_type               The type of the shared item
+  - item_name               The name of the shared item
+  - owner_name              The name of the owner of the shared item
+  - slug                    The slug of the shared item. Used for the link to the item.
+
+Template begins here>>>>>>
+Hello {{ name }},
+
+A new {{ content['item_type'] }} has been shared with you by {{ content['owner_name'] }}.
+
+To access the shared {{ content['item_type'] }}, please visit the following link:
+{{ hostname }}/{{ content['slug'] }}
+
+You received this email because you are subscribed to receive notifications when another user shares an item with you.
+To manage your notification settings, please visit {{ notification_settings_url }}.
+
+If you have any questions, please contact us at {{ contact_email }}.
+
+Thank you for using Galaxy!
+
+Regards,
+Your Galaxy Team

--- a/lib/galaxy/managers/notification.py
+++ b/lib/galaxy/managers/notification.py
@@ -689,7 +689,9 @@ class EmailNotificationTemplateBuilder(Protocol):
             urlparse(self.notification.galaxy_url).hostname if self.notification.galaxy_url else self.config.server_name
         )
         notification_settings_url = (
-            f"{self.notification.galaxy_url}/user/notifications" if self.notification.galaxy_url else None
+            f"{self.notification.galaxy_url}/user/notifications?preferences=true"
+            if self.notification.galaxy_url
+            else None
         )
         contact_email = self.config.error_email_to or None
         return NotificationContext(

--- a/lib/galaxy/managers/notification.py
+++ b/lib/galaxy/managers/notification.py
@@ -1,8 +1,5 @@
 import logging
-from datetime import (
-    datetime,
-    UTC,
-)
+from datetime import datetime
 from enum import Enum
 from typing import (
     cast,
@@ -128,7 +125,7 @@ class NotificationManager:
 
     @property
     def _now(self):
-        return datetime.now(UTC)
+        return datetime.utcnow()
 
     @property
     def _notification_is_active(self):

--- a/lib/galaxy/managers/notification.py
+++ b/lib/galaxy/managers/notification.py
@@ -52,7 +52,7 @@ from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.schema.notifications import (
     AnyNotificationContent,
     BroadcastNotificationCreateRequest,
-    GenericNotificationCreateRequest,
+    GenericNotificationCreate,
     MandatoryNotificationCategory,
     MessageNotificationContent,
     NewSharedItemNotificationContent,
@@ -154,9 +154,7 @@ class NotificationManager:
     def can_send_notifications_async(self):
         return self.config.enable_celery_tasks
 
-    def send_notification_to_recipients(
-        self, request: GenericNotificationCreateRequest
-    ) -> Tuple[Optional[Notification], int]:
+    def send_notification_to_recipients(self, request: GenericNotificationCreate) -> Tuple[Optional[Notification], int]:
         """
         Creates a new notification and associates it with all the recipient users.
 

--- a/lib/galaxy/managers/notification.py
+++ b/lib/galaxy/managers/notification.py
@@ -726,7 +726,8 @@ class MessageEmailNotificationTemplateBuilder(EmailNotificationTemplateBuilder):
         return content
 
     def get_subject(self) -> str:
-        return "[Galaxy] New message received"
+        content = cast(MessageNotificationContent, self.get_content(TemplateFormats.TXT))
+        return f"[Galaxy] New message: {content.subject}"
 
 
 class NewSharedItemEmailNotificationTemplateBuilder(EmailNotificationTemplateBuilder):
@@ -737,7 +738,7 @@ class NewSharedItemEmailNotificationTemplateBuilder(EmailNotificationTemplateBui
 
     def get_subject(self) -> str:
         content = cast(NewSharedItemNotificationContent, self.get_content(TemplateFormats.TXT))
-        return f"[Galaxy] New {content.item_type} shared with you"
+        return f"[Galaxy] New {content.item_type} shared with you: {content.item_name}"
 
 
 class EmailNotificationChannelPlugin(NotificationChannelPlugin):

--- a/lib/galaxy/managers/notification.py
+++ b/lib/galaxy/managers/notification.py
@@ -648,7 +648,7 @@ class MessageEmailNotificationTemplateBuilder(EmailNotificationTemplateBuilder):
     }
 
     def get_content(self, template_format: TemplateFormats) -> AnyNotificationContent:
-        content = MessageNotificationContent.model_construct(**self.notification.content)
+        content = MessageNotificationContent.model_construct(**self.notification.content)  # type:ignore[arg-type]
         content.message = self.markdown_to[template_format](content.message)
         return content
 
@@ -659,7 +659,7 @@ class MessageEmailNotificationTemplateBuilder(EmailNotificationTemplateBuilder):
 class NewSharedItemEmailNotificationTemplateBuilder(EmailNotificationTemplateBuilder):
 
     def get_content(self, template_format: TemplateFormats) -> AnyNotificationContent:
-        content = NewSharedItemNotificationContent.model_construct(**self.notification.content)
+        content = NewSharedItemNotificationContent.model_construct(**self.notification.content)  # type:ignore[arg-type]
         return content
 
     def get_subject(self) -> str:
@@ -677,7 +677,8 @@ class EmailNotificationChannelPlugin(NotificationChannelPlugin):
 
     def send(self, notification: Notification, user: User):
         try:
-            email_template_builder = self.email_templates_by_category.get(notification.category)
+            category = cast(PersonalNotificationCategory, notification.category)
+            email_template_builder = self.email_templates_by_category.get(category)
             if email_template_builder is None:
                 log.warning(f"No email template found for notification category '{notification.category}'.")
                 return

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2946,7 +2946,7 @@ class Notification(Base, Dictifiable, RepresentById):
     variant: Mapped[str] = mapped_column(
         String(16), index=True, nullable=True
     )  # Defines the 'importance' of the notification ('info', 'warning', 'urgent', etc.). Used for filtering, highlight rendering, etc
-    dispatched: Mapped[Boolean] = mapped_column(
+    dispatched: Mapped[bool] = mapped_column(
         Boolean, index=True, default=False
     )  # Whether the notification has been dispatched to users via other channels
     galaxy_url: Mapped[Optional[str]] = mapped_column(

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2944,6 +2944,9 @@ class Notification(Base, Dictifiable, RepresentById):
     variant: Mapped[Optional[str]] = mapped_column(
         String(16), index=True
     )  # Defines the 'importance' of the notification ('info', 'warning', 'urgent', etc.). Used for filtering, highlight rendering, etc
+    dispatched: Mapped[Boolean] = mapped_column(
+        Boolean, index=True, nullable=False, default=False
+    )  # Whether the notification has been dispatched to users via other channels
     # A bug in early 23.1 led to values being stored as json string, so we use this special type to process the result value twice.
     # content should always be a dict
     content: Mapped[Optional[bytes]] = mapped_column(DoubleEncodedJsonType)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2947,7 +2947,7 @@ class Notification(Base, Dictifiable, RepresentById):
         String(16), index=True, nullable=True
     )  # Defines the 'importance' of the notification ('info', 'warning', 'urgent', etc.). Used for filtering, highlight rendering, etc
     dispatched: Mapped[Boolean] = mapped_column(
-        Boolean, index=True, nullable=False, default=False
+        Boolean, index=True, default=False
     )  # Whether the notification has been dispatched to users via other channels
     # A bug in early 23.1 led to values being stored as json string, so we use this special type to process the result value twice.
     # content should always be a dict

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2937,12 +2937,14 @@ class Notification(Base, Dictifiable, RepresentById):
     expiration_time: Mapped[Optional[datetime]] = mapped_column(
         default=now() + timedelta(days=30 * 6)
     )  # The expiration date, expired notifications will be permanently removed from DB regularly
-    source: Mapped[Optional[str]] = mapped_column(String(32), index=True)  # Who (or what) generated the notification
-    category: Mapped[Optional[str]] = mapped_column(
-        String(64), index=True
+    source: Mapped[str] = mapped_column(
+        String(32), index=True, nullable=True
+    )  # Who (or what) generated the notification
+    category: Mapped[str] = mapped_column(
+        String(64), index=True, nullable=True
     )  # Category of the notification, defines its contents. Used for filtering, un/subscribing, etc
-    variant: Mapped[Optional[str]] = mapped_column(
-        String(16), index=True
+    variant: Mapped[str] = mapped_column(
+        String(16), index=True, nullable=True
     )  # Defines the 'importance' of the notification ('info', 'warning', 'urgent', etc.). Used for filtering, highlight rendering, etc
     dispatched: Mapped[Boolean] = mapped_column(
         Boolean, index=True, nullable=False, default=False

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2949,6 +2949,9 @@ class Notification(Base, Dictifiable, RepresentById):
     dispatched: Mapped[Boolean] = mapped_column(
         Boolean, index=True, default=False
     )  # Whether the notification has been dispatched to users via other channels
+    galaxy_url: Mapped[Optional[str]] = mapped_column(
+        String(255)
+    )  # The URL to the Galaxy instance, used for generating links in the notification
     # A bug in early 23.1 led to values being stored as json string, so we use this special type to process the result value twice.
     # content should always be a dict
     content: Mapped[Optional[bytes]] = mapped_column(DoubleEncodedJsonType)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/303a5583a030_add_dispatched_column_to_notifications.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/303a5583a030_add_dispatched_column_to_notifications.py
@@ -1,0 +1,55 @@
+"""add dispatched column to notifications
+
+Revision ID: 303a5583a030
+Revises: 55f02fd8ab6c
+Create Date: 2024-04-04 11:45:54.018829
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import (
+    Boolean,
+    Column,
+)
+
+from galaxy.model.database_object_names import build_index_name
+from galaxy.model.migrations.util import (
+    add_column,
+    drop_column,
+    drop_index,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "303a5583a030"
+down_revision = "55f02fd8ab6c"
+branch_labels = None
+depends_on = None
+
+# database object names used in this revision
+table_name = "notification"
+column_name = "dispatched"
+publication_time_column_name = "publication_time"
+index_name = build_index_name(table_name, column_name)
+
+
+def upgrade():
+    with transaction():
+        add_column(
+            table_name,
+            Column(column_name, Boolean(), index=True, nullable=False, default=False, server_default=sa.false()),
+        )
+        # Set as already dispatched any notifications older than the current time to avoid sending them again
+        table = sa.sql.table(
+            table_name,
+            Column(column_name, Boolean()),
+            Column(publication_time_column_name, sa.DateTime()),
+        )
+        op.execute(table.update().where(table.c.publication_time <= sa.func.now()).values(dispatched=True))
+
+
+def downgrade():
+    with transaction():
+        drop_index(index_name, table_name)
+        drop_column(table_name, column_name)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/5924fbf10430_add_galaxy_url_column_to_notifications.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/5924fbf10430_add_galaxy_url_column_to_notifications.py
@@ -1,0 +1,36 @@
+"""add galaxy_url column to notifications
+
+Revision ID: 5924fbf10430
+Revises: 303a5583a030
+Create Date: 2024-04-11 09:56:26.200231
+
+"""
+
+from sqlalchemy import (
+    Column,
+    String,
+)
+
+from galaxy.model.migrations.util import (
+    add_column,
+    drop_column,
+)
+
+# revision identifiers, used by Alembic.
+revision = "5924fbf10430"
+down_revision = "303a5583a030"
+branch_labels = None
+depends_on = None
+
+
+# database object names used in this revision
+table_name = "notification"
+column_name = "galaxy_url"
+
+
+def upgrade():
+    add_column(table_name, Column(column_name, String(255)))
+
+
+def downgrade():
+    drop_column(table_name, column_name)

--- a/lib/galaxy/schema/generics.py
+++ b/lib/galaxy/schema/generics.py
@@ -1,0 +1,52 @@
+from typing import (
+    Any,
+    Tuple,
+    Type,
+    TypeVar,
+)
+
+from pydantic import BaseModel
+from pydantic.json_schema import GenerateJsonSchema
+
+from galaxy.schema.fields import (
+    DecodedDatabaseIdField,
+    EncodedDatabaseIdField,
+)
+
+DatabaseIdT = TypeVar("DatabaseIdT")
+
+ref_to_name = {}
+
+
+class GenericModel(BaseModel):
+    @classmethod
+    def model_parametrized_name(cls, params: Tuple[Type[Any], ...]) -> str:
+        suffix = cls.__determine_suffix__(params)
+        class_name = cls.__name__.split("Generic", 1)[-1]
+        return f"{class_name}{suffix}"
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, *args, **kwargs):
+        result = super().__get_pydantic_core_schema__(*args, **kwargs)
+        ref_to_name[result["ref"]] = cls.__name__
+        return result
+
+    @classmethod
+    def __determine_suffix__(cls, params: Tuple[Type[Any], ...]) -> str:
+        suffix = "Incoming"
+        if params[0] is EncodedDatabaseIdField:
+            suffix = "Response"
+        elif params[0] is DecodedDatabaseIdField:
+            suffix = "Request"
+        return suffix
+
+
+class CustomJsonSchema(GenerateJsonSchema):
+    def get_defs_ref(self, core_mode_ref):
+        full_def = super().get_defs_ref(core_mode_ref)
+        choices = self._prioritized_defsref_choices[full_def]
+        ref, mode = core_mode_ref
+        if ref in ref_to_name:
+            for i, choice in enumerate(choices):
+                choices[i] = choice.replace(choices[0], ref_to_name[ref])  # type: ignore[call-overload]
+        return full_def

--- a/lib/galaxy/schema/notifications.py
+++ b/lib/galaxy/schema/notifications.py
@@ -303,8 +303,12 @@ NotificationCreateRequest = GenericNotificationCreateRequest[int]
 NotificationRecipients = GenericNotificationRecipients[int]
 
 
-class NotificationCreateRequestBody(RootModel):
-    root: GenericNotificationCreateRequest[DecodedDatabaseIdField]
+class NotificationRecipientsPayload(GenericNotificationRecipients[DecodedDatabaseIdField]):
+    pass
+
+
+class NotificationCreateRequestBody(GenericNotificationCreateRequest[DecodedDatabaseIdField]):
+    recipients: NotificationRecipientsPayload
 
 
 class BroadcastNotificationCreateRequest(NotificationCreateData):

--- a/lib/galaxy/schema/notifications.py
+++ b/lib/galaxy/schema/notifications.py
@@ -299,7 +299,14 @@ class GenericNotificationCreate(GenericModel, Generic[DatabaseIdT]):
     )
 
 
-NotificationCreateRequest = GenericNotificationCreate[int]
+class NotificationCreateRequest(GenericNotificationCreate[int]):
+    galaxy_url: Optional[str] = Field(
+        None,
+        title="Galaxy URL",
+        description="The URL of the Galaxy instance. Used to generate links in the notification content.",
+    )
+
+
 NotificationRecipients = GenericNotificationRecipients[int]
 
 

--- a/lib/galaxy/schema/notifications.py
+++ b/lib/galaxy/schema/notifications.py
@@ -421,7 +421,10 @@ class NotificationChannelSettings(Model):
     email: bool = Field(
         default=True,
         title="Email",
-        description="Whether the user wants to receive email notifications for this category.",
+        description=(
+            "Whether the user wants to receive email notifications for this category. "
+            "This setting will be ignored unless the server supports asynchronous tasks."
+        ),
     )
     # TODO: Add more channels here and implement the corresponding plugin in lib/galaxy/managers/notification.py
     # matrix: bool # Possible future Matrix.org integration?

--- a/lib/galaxy/schema/notifications.py
+++ b/lib/galaxy/schema/notifications.py
@@ -299,9 +299,12 @@ class GenericNotificationCreateRequest(Model, Generic[DatabaseIdT]):
     )
 
 
-NotificationCreateRequestEncoded = GenericNotificationCreateRequest[DecodedDatabaseIdField]
 NotificationCreateRequest = GenericNotificationCreateRequest[int]
 NotificationRecipients = GenericNotificationRecipients[int]
+
+
+class NotificationCreateRequestBody(RootModel):
+    root: GenericNotificationCreateRequest[DecodedDatabaseIdField]
 
 
 class BroadcastNotificationCreateRequest(NotificationCreateData):

--- a/lib/galaxy/schema/notifications.py
+++ b/lib/galaxy/schema/notifications.py
@@ -3,8 +3,10 @@ from enum import Enum
 from typing import (
     Any,
     Dict,
+    Generic,
     List,
     Optional,
+    TypeVar,
     Union,
 )
 
@@ -259,30 +261,33 @@ class NotificationCreateData(Model):
     )
 
 
-class NotificationRecipients(Model):
+DatabaseIdT = TypeVar("DatabaseIdT")
+
+
+class GenericNotificationRecipients(Model, Generic[DatabaseIdT]):
     """The recipients of a notification. Can be a combination of users, groups and roles."""
 
-    user_ids: List[DecodedDatabaseIdField] = Field(
+    user_ids: List[DatabaseIdT] = Field(
         default=[],
         title="User IDs",
         description="The list of encoded user IDs of the users that should receive the notification.",
     )
-    group_ids: List[DecodedDatabaseIdField] = Field(
+    group_ids: List[DatabaseIdT] = Field(
         default=[],
         title="Group IDs",
         description="The list of encoded group IDs of the groups that should receive the notification.",
     )
-    role_ids: List[DecodedDatabaseIdField] = Field(
+    role_ids: List[DatabaseIdT] = Field(
         default=[],
         title="Role IDs",
         description="The list of encoded role IDs of the roles that should receive the notification.",
     )
 
 
-class NotificationCreateRequest(Model):
+class GenericNotificationCreateRequest(Model, Generic[DatabaseIdT]):
     """Contains the recipients and the notification to create."""
 
-    recipients: NotificationRecipients = Field(
+    recipients: GenericNotificationRecipients[DatabaseIdT] = Field(
         ...,
         title="Recipients",
         description="The recipients of the notification. Can be a combination of users, groups and roles.",
@@ -292,6 +297,11 @@ class NotificationCreateRequest(Model):
         title="Notification",
         description="The notification to create. The structure depends on the category.",
     )
+
+
+NotificationCreateRequestEncoded = GenericNotificationCreateRequest[DecodedDatabaseIdField]
+NotificationCreateRequest = GenericNotificationCreateRequest[int]
+NotificationRecipients = GenericNotificationRecipients[int]
 
 
 class BroadcastNotificationCreateRequest(NotificationCreateData):

--- a/lib/galaxy/schema/notifications.py
+++ b/lib/galaxy/schema/notifications.py
@@ -6,7 +6,6 @@ from typing import (
     Generic,
     List,
     Optional,
-    TypeVar,
     Union,
 )
 
@@ -23,6 +22,10 @@ from typing_extensions import (
 from galaxy.schema.fields import (
     DecodedDatabaseIdField,
     EncodedDatabaseIdField,
+)
+from galaxy.schema.generics import (
+    DatabaseIdT,
+    GenericModel,
 )
 from galaxy.schema.schema import Model
 from galaxy.schema.types import (
@@ -261,10 +264,7 @@ class NotificationCreateData(Model):
     )
 
 
-DatabaseIdT = TypeVar("DatabaseIdT")
-
-
-class GenericNotificationRecipients(Model, Generic[DatabaseIdT]):
+class GenericNotificationRecipients(GenericModel, Generic[DatabaseIdT]):
     """The recipients of a notification. Can be a combination of users, groups and roles."""
 
     user_ids: List[DatabaseIdT] = Field(
@@ -284,7 +284,7 @@ class GenericNotificationRecipients(Model, Generic[DatabaseIdT]):
     )
 
 
-class GenericNotificationCreateRequest(Model, Generic[DatabaseIdT]):
+class GenericNotificationCreate(GenericModel, Generic[DatabaseIdT]):
     """Contains the recipients and the notification to create."""
 
     recipients: GenericNotificationRecipients[DatabaseIdT] = Field(
@@ -299,16 +299,11 @@ class GenericNotificationCreateRequest(Model, Generic[DatabaseIdT]):
     )
 
 
-NotificationCreateRequest = GenericNotificationCreateRequest[int]
+NotificationCreateRequest = GenericNotificationCreate[int]
 NotificationRecipients = GenericNotificationRecipients[int]
 
 
-class NotificationRecipientsPayload(GenericNotificationRecipients[DecodedDatabaseIdField]):
-    pass
-
-
-class NotificationCreateRequestBody(GenericNotificationCreateRequest[DecodedDatabaseIdField]):
-    recipients: NotificationRecipientsPayload
+NotificationCreateRequestBody = GenericNotificationCreate[DecodedDatabaseIdField]
 
 
 class BroadcastNotificationCreateRequest(NotificationCreateData):

--- a/lib/galaxy/schema/notifications.py
+++ b/lib/galaxy/schema/notifications.py
@@ -418,8 +418,12 @@ class NotificationChannelSettings(Model):
         title="Push",
         description="Whether the user wants to receive push notifications in the browser for this category.",
     )
-    # TODO: Add more channels
-    # email: bool # Not supported for now
+    email: bool = Field(
+        default=True,
+        title="Email",
+        description="Whether the user wants to receive email notifications for this category.",
+    )
+    # TODO: Add more channels here and implement the corresponding plugin in lib/galaxy/managers/notification.py
     # matrix: bool # Possible future Matrix.org integration?
 
 

--- a/lib/galaxy/webapps/galaxy/api/notifications.py
+++ b/lib/galaxy/webapps/galaxy/api/notifications.py
@@ -3,7 +3,10 @@ API operations on Notification objects.
 """
 
 import logging
-from typing import Optional
+from typing import (
+    Optional,
+    Union,
+)
 
 from fastapi import (
     Body,
@@ -19,7 +22,7 @@ from galaxy.schema.notifications import (
     BroadcastNotificationResponse,
     NotificationBroadcastUpdateRequest,
     NotificationCreatedResponse,
-    NotificationCreateRequest,
+    NotificationCreateRequestBody,
     NotificationsBatchRequest,
     NotificationsBatchUpdateResponse,
     NotificationStatusSummary,
@@ -30,6 +33,7 @@ from galaxy.schema.notifications import (
     UserNotificationsBatchUpdateRequest,
     UserNotificationUpdateRequest,
 )
+from galaxy.schema.schema import AsyncTaskResultSummary
 from galaxy.schema.types import OffsetNaiveDatetime
 from galaxy.webapps.galaxy.api.common import NotificationIdPathParam
 from galaxy.webapps.galaxy.services.notifications import NotificationService
@@ -219,8 +223,8 @@ class FastAPINotifications:
     def send_notification(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        payload: NotificationCreateRequest = Body(),
-    ) -> NotificationCreatedResponse:
+        payload: NotificationCreateRequestBody = Body(),
+    ) -> Union[NotificationCreatedResponse, AsyncTaskResultSummary]:
         """Sends a notification to a list of recipients (users, groups or roles)."""
         return self.service.send_notification(sender_context=trans, payload=payload)
 

--- a/lib/galaxy/webapps/galaxy/api/notifications.py
+++ b/lib/galaxy/webapps/galaxy/api/notifications.py
@@ -70,10 +70,20 @@ class FastAPINotifications:
     )
     def get_notification_preferences(
         self,
+        response: Response,
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> UserNotificationPreferences:
-        """Anonymous users cannot have notification preferences. They will receive only broadcasted notifications."""
-        return self.service.get_user_notification_preferences(trans)
+        """Anonymous users cannot have notification preferences. They will receive only broadcasted notifications.
+
+        - The settings will contain all possible channels, but the client should only show the ones that are really supported by the server.
+          The supported channels are returned in the `supported-channels` header.
+        """
+        result = self.service.get_user_notification_preferences(trans)
+        # Inform the client which channels are really supported by the server since the settings will contain all possible channels.
+        response.headers["supported-channels"] = str.join(
+            ",", self.service.notification_manager.get_supported_channels()
+        )
+        return result
 
     @router.put(
         "/api/notifications/preferences",

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -12,7 +12,7 @@ from fastapi.openapi.constants import REF_TEMPLATE
 from starlette.middleware.cors import CORSMiddleware
 from starlette.responses import Response
 
-from galaxy.schema.invocation import CustomJsonSchema
+from galaxy.schema.generics import CustomJsonSchema
 from galaxy.version import VERSION
 from galaxy.webapps.base.api import (
     add_exception_handler,

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -40,7 +40,6 @@ from galaxy.managers.histories import (
     HistoryManager,
     HistorySerializer,
 )
-from galaxy.managers.notification import NotificationManager
 from galaxy.managers.users import UserManager
 from galaxy.model import HistoryDatasetAssociation
 from galaxy.model.base import transaction
@@ -89,6 +88,7 @@ from galaxy.webapps.galaxy.services.base import (
     ServesExportStores,
     ServiceBase,
 )
+from galaxy.webapps.galaxy.services.notifications import NotificationService
 from galaxy.webapps.galaxy.services.sharable import ShareableService
 
 log = logging.getLogger(__name__)
@@ -121,7 +121,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         history_export_manager: HistoryExportManager,
         filters: HistoryFilters,
         short_term_storage_allocator: ShortTermStorageAllocator,
-        notification_manager: NotificationManager,
+        notification_service: NotificationService,
     ):
         super().__init__(security)
         self.manager = manager
@@ -131,7 +131,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         self.citations_manager = citations_manager
         self.history_export_manager = history_export_manager
         self.filters = filters
-        self.shareable_service = ShareableHistoryService(self.manager, self.serializer, notification_manager)
+        self.shareable_service = ShareableHistoryService(self.manager, self.serializer, notification_service)
         self.short_term_storage_allocator = short_term_storage_allocator
 
     def index(

--- a/lib/galaxy/webapps/galaxy/services/notifications.py
+++ b/lib/galaxy/webapps/galaxy/services/notifications.py
@@ -57,8 +57,8 @@ class NotificationService(ServiceBase):
         self.notification_manager.ensure_notifications_enabled()
         self._ensure_user_can_send_notifications(sender_context)
         request = NotificationCreateRequest.model_construct(
-            notification=payload.root.notification,
-            recipients=payload.root.recipients,
+            notification=payload.notification,
+            recipients=payload.recipients,
         )
         return self.send_notification_internal(request)
 

--- a/lib/galaxy/webapps/galaxy/services/notifications.py
+++ b/lib/galaxy/webapps/galaxy/services/notifications.py
@@ -63,13 +63,16 @@ class NotificationService(ServiceBase):
         return self.send_notification_internal(request)
 
     def send_notification_internal(
-        self, request: NotificationCreateRequest
+        self, request: NotificationCreateRequest, force_sync: bool = False
     ) -> Union[NotificationCreatedResponse, AsyncTaskResultSummary]:
         """Sends a notification to a list of recipients (users, groups or roles).
 
+        If `force_sync` is set to `True`, the notification recipients will be processed synchronously instead of
+        in a background task.
+
         Note: This function is meant for internal use from other services that don't need to check sender permissions.
         """
-        if self.notification_manager.can_send_notifications_async:
+        if self.notification_manager.can_send_notifications_async and not force_sync:
             result = send_notification_to_recipients_async.delay(request)
             summary = async_task_summary(result)
             return summary

--- a/lib/galaxy/webapps/galaxy/services/notifications.py
+++ b/lib/galaxy/webapps/galaxy/services/notifications.py
@@ -22,10 +22,10 @@ from galaxy.schema.notifications import (
     BroadcastNotificationCreateRequest,
     BroadcastNotificationListResponse,
     BroadcastNotificationResponse,
-    GenericNotificationCreateRequest,
     NotificationBroadcastUpdateRequest,
     NotificationCreatedResponse,
     NotificationCreateRequest,
+    NotificationCreateRequestBody,
     NotificationResponse,
     NotificationsBatchUpdateResponse,
     NotificationStatusSummary,
@@ -48,7 +48,7 @@ class NotificationService(ServiceBase):
         self.notification_manager = notification_manager
 
     def send_notification(
-        self, sender_context: ProvidesUserContext, payload: NotificationCreateRequest
+        self, sender_context: ProvidesUserContext, payload: NotificationCreateRequestBody
     ) -> Union[NotificationCreatedResponse, AsyncTaskResultSummary]:
         """Sends a notification to a list of recipients (users, groups or roles).
 
@@ -56,10 +56,14 @@ class NotificationService(ServiceBase):
         """
         self.notification_manager.ensure_notifications_enabled()
         self._ensure_user_can_send_notifications(sender_context)
-        return self.send_notification_internal(payload)
+        request = NotificationCreateRequest.model_construct(
+            notification=payload.root.notification,
+            recipients=payload.root.recipients,
+        )
+        return self.send_notification_internal(request)
 
     def send_notification_internal(
-        self, request: GenericNotificationCreateRequest
+        self, request: NotificationCreateRequest
     ) -> Union[NotificationCreatedResponse, AsyncTaskResultSummary]:
         """Sends a notification to a list of recipients (users, groups or roles).
 

--- a/lib/galaxy/webapps/galaxy/services/notifications.py
+++ b/lib/galaxy/webapps/galaxy/services/notifications.py
@@ -56,9 +56,13 @@ class NotificationService(ServiceBase):
         """
         self.notification_manager.ensure_notifications_enabled()
         self._ensure_user_can_send_notifications(sender_context)
+        galaxy_url = (
+            str(sender_context.url_builder("/", qualified=True)).rstrip("/") if sender_context.url_builder else None
+        )
         request = NotificationCreateRequest.model_construct(
             notification=payload.notification,
             recipients=payload.recipients,
+            galaxy_url=galaxy_url,
         )
         return self.send_notification_internal(request)
 

--- a/lib/galaxy/webapps/galaxy/services/pages.py
+++ b/lib/galaxy/webapps/galaxy/services/pages.py
@@ -8,7 +8,6 @@ from galaxy.managers.markdown_util import (
     internal_galaxy_markdown_to_pdf,
     to_basic_markdown,
 )
-from galaxy.managers.notification import NotificationManager
 from galaxy.managers.pages import (
     PageManager,
     PageSerializer,
@@ -33,6 +32,7 @@ from galaxy.webapps.galaxy.services.base import (
     ensure_celery_tasks_enabled,
     ServiceBase,
 )
+from galaxy.webapps.galaxy.services.notifications import NotificationService
 from galaxy.webapps.galaxy.services.sharable import ShareableService
 
 log = logging.getLogger(__name__)
@@ -51,12 +51,12 @@ class PagesService(ServiceBase):
         manager: PageManager,
         serializer: PageSerializer,
         short_term_storage_allocator: ShortTermStorageAllocator,
-        notification_manager: NotificationManager,
+        notification_service: NotificationService,
     ):
         super().__init__(security)
         self.manager = manager
         self.serializer = serializer
-        self.shareable_service = ShareableService(self.manager, self.serializer, notification_manager)
+        self.shareable_service = ShareableService(self.manager, self.serializer, notification_service)
         self.short_term_storage_allocator = short_term_storage_allocator
 
     def index(

--- a/lib/galaxy/webapps/galaxy/services/sharable.py
+++ b/lib/galaxy/webapps/galaxy/services/sharable.py
@@ -180,7 +180,9 @@ class ShareableService:
             and users_to_notify
         ):
             request = SharedItemNotificationFactory.build_notification_request(item, users_to_notify, status)
-            self.notification_service.send_notification_internal(request)
+            # We can set force_sync=True here because we already have the set of users to notify
+            # and there is no need to resolve them asynchronously as no groups or roles are involved.
+            self.notification_service.send_notification_internal(request, force_sync=True)
 
 
 class SharedItemNotificationFactory:

--- a/lib/galaxy/webapps/galaxy/services/visualizations.py
+++ b/lib/galaxy/webapps/galaxy/services/visualizations.py
@@ -2,7 +2,6 @@ import logging
 from typing import Tuple
 
 from galaxy import exceptions
-from galaxy.managers.notification import NotificationManager
 from galaxy.managers.visualizations import (
     VisualizationManager,
     VisualizationSerializer,
@@ -13,6 +12,7 @@ from galaxy.schema.visualization import (
 )
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.webapps.galaxy.services.base import ServiceBase
+from galaxy.webapps.galaxy.services.notifications import NotificationService
 from galaxy.webapps.galaxy.services.sharable import ShareableService
 
 log = logging.getLogger(__name__)
@@ -30,12 +30,12 @@ class VisualizationsService(ServiceBase):
         security: IdEncodingHelper,
         manager: VisualizationManager,
         serializer: VisualizationSerializer,
-        notification_manager: NotificationManager,
+        notification_service: NotificationService,
     ):
         super().__init__(security)
         self.manager = manager
         self.serializer = serializer
-        self.shareable_service = ShareableService(self.manager, self.serializer, notification_manager)
+        self.shareable_service = ShareableService(self.manager, self.serializer, notification_service)
 
     # TODO: add the rest of the API actions here and call them directly from the API controller
 

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -13,7 +13,6 @@ from galaxy import (
     web,
 )
 from galaxy.managers.context import ProvidesUserContext
-from galaxy.managers.notification import NotificationManager
 from galaxy.managers.workflows import (
     RefactorResponse,
     WorkflowContentsManager,
@@ -33,6 +32,7 @@ from galaxy.schema.workflows import (
 )
 from galaxy.util.tool_shed.tool_shed_registry import Registry
 from galaxy.webapps.galaxy.services.base import ServiceBase
+from galaxy.webapps.galaxy.services.notifications import NotificationService
 from galaxy.webapps.galaxy.services.sharable import ShareableService
 from galaxy.workflow.run import queue_invoke
 from galaxy.workflow.run_request import build_workflow_run_configs
@@ -51,12 +51,12 @@ class WorkflowsService(ServiceBase):
         workflow_contents_manager: WorkflowContentsManager,
         serializer: WorkflowSerializer,
         tool_shed_registry: Registry,
-        notification_manager: NotificationManager,
+        notification_service: NotificationService,
     ):
         self._workflows_manager = workflows_manager
         self._workflow_contents_manager = workflow_contents_manager
         self._serializer = serializer
-        self.shareable_service = ShareableService(workflows_manager, serializer, notification_manager)
+        self.shareable_service = ShareableService(workflows_manager, serializer, notification_service)
         self._tool_shed_registry = tool_shed_registry
 
     def index(

--- a/test/integration/test_notifications.py
+++ b/test/integration/test_notifications.py
@@ -52,6 +52,7 @@ class TestNotificationsIntegration(IntegrationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
+        config["enable_celery_tasks"] = False
         config["enable_notification_system"] = True
 
     def setUp(self):

--- a/test/integration/test_notifications.py
+++ b/test/integration/test_notifications.py
@@ -44,7 +44,7 @@ def notification_broadcast_test_data(subject: Optional[str] = None, message: Opt
     }
 
 
-class TestNotificationsIntegration(IntegrationTestCase):
+class NotificationsIntegrationBase(IntegrationTestCase):
     dataset_populator: DatasetPopulator
     task_based = False
     framework_tool_and_types = False
@@ -67,12 +67,18 @@ class TestNotificationsIntegration(IntegrationTestCase):
         before_creating_notifications = datetime.utcnow()
 
         # Only user1 will receive this notification
-        created_response_1 = self._send_test_notification_to([user1["id"]], message="test_notification_status 1")
-        assert created_response_1["total_notifications_sent"] == 1
+        subject1 = f"notification_{uuid4()}"
+        created_response_1 = self._send_test_notification_to(
+            [user1["id"]], subject=subject1, message="test_notification_status 1"
+        )
+        self._assert_notifications_sent(created_response_1, expected_count=1)
 
         # Both user1 and user2 will receive this notification
-        created_response_2 = self._send_test_notification_to([user1["id"], user2["id"]], "test_notification_status 2")
-        assert created_response_2["total_notifications_sent"] == 2
+        subject2 = f"notification_{uuid4()}"
+        created_response_2 = self._send_test_notification_to(
+            [user1["id"], user2["id"]], subject=subject2, message="test_notification_status 2"
+        )
+        self._assert_notifications_sent(created_response_2, expected_count=2)
 
         # All users will receive this broadcasted notification
         created_response_3 = self._send_broadcast_notification("test_notification_status 3")
@@ -114,7 +120,8 @@ class TestNotificationsIntegration(IntegrationTestCase):
             assert len(status["broadcasts"]) == 0
 
             # Updating a notification association value should return that notification in the next request
-            notification_id = created_response_2["notification"]["id"]
+            notification_id = self._get_notification_id_by_subject(subject2)
+            assert notification_id is not None
             self._update_notification(notification_id, update_state={"seen": True})
             status = self._get_notifications_status_since(after_creating_notifications)
             assert status["total_unread_count"] == 0
@@ -132,16 +139,21 @@ class TestNotificationsIntegration(IntegrationTestCase):
         user1 = self._create_test_user()
         user2 = self._create_test_user()
 
+        subject = f"notification_{uuid4()}"
         created_response = self._send_test_notification_to(
-            [user1["id"]], message="test_user_cannot_access_other_users_notifications"
+            [user1["id"]], subject=subject, message="test_user_cannot_access_other_users_notifications"
         )
-        notification_id = created_response["notification"]["id"]
+        self._assert_notifications_sent(created_response, expected_count=1)
+        notification_id = None
 
         with self._different_user(user1["email"]):
+            notification_id = self._get_notification_id_by_subject(subject)
+            assert notification_id is not None
             response = self._get(f"notifications/{notification_id}")
             self._assert_status_code_is_ok(response)
 
         with self._different_user(user2["email"]):
+            assert notification_id is not None
             response = self._get(f"notifications/{notification_id}")
             self._assert_status_code_is(response, 404)
 
@@ -151,13 +163,15 @@ class TestNotificationsIntegration(IntegrationTestCase):
 
         before_creating_notifications = datetime.utcnow()
 
+        subject = f"notification_{uuid4()}"
         created_response = self._send_test_notification_to(
-            [user1["id"], user2["id"]], message="test_delete_notification_by_user"
+            [user1["id"], user2["id"]], subject=subject, message="test_delete_notification_by_user"
         )
-        assert created_response["total_notifications_sent"] == 2
-        notification_id = created_response["notification"]["id"]
+        self._assert_notifications_sent(created_response, expected_count=2)
 
         with self._different_user(user1["email"]):
+            notification_id = self._get_notification_id_by_subject(subject)
+            assert notification_id is not None
             response = self._get(f"notifications/{notification_id}")
             self._assert_status_code_is_ok(response)
             self._delete(f"notifications/{notification_id}")
@@ -170,6 +184,7 @@ class TestNotificationsIntegration(IntegrationTestCase):
             assert len(status["broadcasts"]) == 0
 
         with self._different_user(user2["email"]):
+            assert notification_id is not None
             response = self._get(f"notifications/{notification_id}")
             self._assert_status_code_is_ok(response)
 
@@ -196,11 +211,14 @@ class TestNotificationsIntegration(IntegrationTestCase):
 
     def test_update_notifications(self):
         recipient_user = self._create_test_user()
-        created_user_notification_response = self._send_test_notification_to(
-            [recipient_user["id"]], subject="User Notification to update"
-        )
-        assert created_user_notification_response["total_notifications_sent"] == 1
-        user_notification_id = created_user_notification_response["notification"]["id"]
+        subject = f"User Notification to update {uuid4()}"
+        created_user_notification_response = self._send_test_notification_to([recipient_user["id"]], subject=subject)
+        self._assert_notifications_sent(created_user_notification_response, expected_count=1)
+
+        with self._different_user(recipient_user["email"]):
+            user_notification_id = self._get_notification_id_by_subject(subject)
+
+        assert user_notification_id is not None
 
         created_broadcast_notification_response = self._send_broadcast_notification(
             subject="Broadcasted Notification to update"
@@ -403,3 +421,36 @@ class TestNotificationsIntegration(IntegrationTestCase):
     def _update_notification(self, notification_id: str, update_state: Dict[str, Any]):
         update_response = self._put(f"notifications/{notification_id}", data=update_state, json=True)
         self._assert_status_code_is(update_response, 204)
+
+    def _assert_notifications_sent(self, response, expected_count: int = 0):
+        if self.task_based:
+            task_id = response["id"]
+            assert task_id is not None
+            self.dataset_populator.wait_on_task_id(task_id)
+        else:
+            assert response["total_notifications_sent"] == expected_count
+
+    def _get_notification_id_by_subject(self, subject: str) -> Optional[str]:
+        notifications = self._get("notifications").json()
+        for notification in notifications:
+            if notification["content"]["subject"] == subject:
+                return notification["id"]
+        return None
+
+
+class TestNotificationsIntegration(NotificationsIntegrationBase):
+    task_based = False
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        config["enable_celery_tasks"] = False
+
+
+class TestNotificationsIntegrationTaskBased(NotificationsIntegrationBase):
+    task_based = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        config["enable_celery_tasks"] = True

--- a/test/unit/app/managers/test_NotificationManager.py
+++ b/test/unit/app/managers/test_NotificationManager.py
@@ -81,6 +81,7 @@ class NotificationManagerBaseTestCase(NotificationsBaseTestCase):
                 user_ids=[user.id for user in users],
             ),
             notification=notification_data,
+            galaxy_url="https://test.galaxy.url",
         )
         created_notification, notifications_sent = self.notification_manager.send_notification_to_recipients(request)
         return created_notification, notifications_sent

--- a/test/unit/app/test_celery.py
+++ b/test/unit/app/test_celery.py
@@ -26,10 +26,6 @@ def test_default_configuration():
         "task": "galaxy.cleanup_short_term_storage",
         "schedule": galaxy_conf.short_term_storage_cleanup_interval,
     }
-    assert conf.beat_schedule["cleanup-expired-notifications"] == {
-        "task": "galaxy.cleanup_expired_notifications",
-        "schedule": galaxy_conf.expired_notifications_cleanup_interval,
-    }
 
 
 def test_galaxycelery_trim_module_name():


### PR DESCRIPTION
Closes #17882

This PR adds a new `email` channel to the notifications system.

## Backend changes
- Includes 2 database migrations to add 2 new columns to the `notification` table.
  - `dispatched` column: will determine if this notification has been "dispatched" through the additional communication channels. Any existing notification will set this value to "True" so users won't get emails retroactively.
  - `galaxy_url` column: allows to build URLs from the notification channel plugins that don't have access to the web request context.
- Move the creation of notifications (database objects) to a celery task if enabled. This can offload resolving the recipient users when we include complex combinations of groups and/or roles as recipients. We can also control if we want to explicitly run this synchronously when we don't use groups or roles.
- Adds a new periodic celery task (every 10 minutes by default) that will process non `dispatched` notifications and send them via all available channels. In-app notifications don't depend on this task so they will pop up in Galaxy at their due time. Other external channels, like email, will probably carry some delay depending on the `dispatch_notifications_interval` configuration option.
- Adds personalizable email templates for the currently existing types of notifications.

## Frontend changes
- The notification preferences will display a new `Email` channel if the server "supports" it. The channels supported by the server are passed to the client via a new header named `supported-channels` when requesting `api/notifications/preferences`. 
- Navigating to `/user/notifications?preferences=true` will display the preferences panel open. This makes it easier to link to the preferences from the email templates.

## Sample Emails

### Shared Item
![Screenshot from 2024-04-11 13-46-29](https://github.com/galaxyproject/galaxy/assets/46503462/b907b1c2-99b1-4b17-afb2-4e6c49451e7d)


### Direct Message
![Screenshot from 2024-04-11 13-49-10](https://github.com/galaxyproject/galaxy/assets/46503462/4b36b2dd-6cad-4668-b680-4c1ec2e32828)

## See it in action
![NotificationEmails](https://github.com/galaxyproject/galaxy/assets/46503462/f982f132-5ce0-43b7-bc67-89a91c7bb7d1)


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Make sure `enable_celery_tasks` is set to true in your Galaxy config.
  - Set up the `smtp_server` in your config. I used https://github.com/rnwood/smtp4dev/
  - Play around with the email templates from `lib/galaxy/config/templates/mail/notifications/` by copying them and setting the `templates_dir` accordingly.
  - Play around disabling the email channel for certain notifications in your preferences.
  - Play around scheduling notifications as an admin.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
