### PR TITLE
[24.0] Make sure step removal also resets mapOver state

### DIFF
--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -340,6 +340,7 @@ export const useWorkflowStepStore = defineScopedStore("workflowStepStore", (work
 
         del(steps.value, stepId.toString());
         del(stepExtraInputs.value, stepId);
+        del(stepMapOver.value, stepId.toString());
     }
 
     return {


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/17906

Before:
![before](https://github.com/galaxyproject/galaxy/assets/6804901/a59ceb38-954b-4998-aa07-ed1c5d958754)
After:
![after](https://github.com/galaxyproject/galaxy/assets/6804901/a104c4c2-ed31-489d-808e-73e27988686a)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
