### PR TITLE
[24.0] Fix saving user preferences crashes tab

### DIFF
--- a/client/src/components/User/UserActivityBarSettings.vue
+++ b/client/src/components/User/UserActivityBarSettings.vue
@@ -11,13 +11,13 @@ const enableActivityBar: WritableComputedRef<Boolean> = computed({
     get: () => {
         return userStore.showActivityBar;
     },
-    set: () => {
+    set: (toggle) => {
         // always toggle tool side panel when enabling activity bar
         if (userStore.toggledSideBar !== "tools") {
             userStore.toggleSideBar("tools");
         }
         // toggle activity bar
-        userStore.toggleActivityBar();
+        userStore.showActivityBar = toggle;
     },
 });
 </script>


### PR DESCRIPTION
fixes #17862

The cause was a computed setter triggering an infinite loop.

The computeds getter was getting a bool value, while it's setter was toggling the value (not setting it)

In combination with a library component which was triggering the setter on getter changes, this caused an infinite loop when the bool value was set to true via code after component mount.

Due to this value being linked to UI components conditional rendering and the local storage, this rapid self-toggling quickly crashed the tab.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
