### PR TITLE
Ensures that the activity bar is not shown when use_panels is set to false

### DIFF
--- a/client/src/entry/analysis/modules/Analysis.vue
+++ b/client/src/entry/analysis/modules/Analysis.vue
@@ -37,7 +37,7 @@ onUnmounted(() => {
 
 <template>
     <div id="columns" class="d-flex">
-        <ActivityBar />
+        <ActivityBar v-if="showPanels" />
         <div id="center" class="overflow-auto p-3 w-100">
             <CenterFrame v-show="showCenter" id="galaxy_main" @load="onLoad" />
             <div v-show="!showCenter" class="h-100">


### PR DESCRIPTION
In certain context the history panel and the activity bar should be hidden e.g. when displaying a dataset in the window manager. This PR ensures that the `use_panels` url parameter is considered when showing the activity bar.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
