### PR TITLE
[24.0] Fix workflow run form for workflows with null rename PJA

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2381,13 +2381,14 @@ class ToolModule(WorkflowModule):
             action_arguments = None
         return PostJobAction(value["action_type"], step, output_name, action_arguments)
 
-    def get_informal_replacement_parameters(self, step) -> List[str]:
+    def get_informal_replacement_parameters(self, step: WorkflowStep) -> List[str]:
         """Return a list of replacement parameters."""
         replacement_parameters = set()
         for pja in step.post_job_actions:
-            for argument in pja.action_arguments.values():
-                for match in re.findall(r"\$\{(.+?)\}", unicodify(argument)):
-                    replacement_parameters.add(match)
+            if action_arguments := pja.action_arguments:
+                for argument in action_arguments.values():
+                    for match in re.findall(r"\$\{(.+?)\}", unicodify(argument)):
+                        replacement_parameters.add(match)
 
         return list(replacement_parameters)
 


### PR DESCRIPTION
Fixes:
```
AttributeError: 'NoneType' object has no attribute 'values'
  File "galaxy/web/framework/decorators.py", line 346, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/api/workflows.py", line 357, in workflow_dict
    ret_dict = self.workflow_contents_manager.workflow_to_dict(
  File "galaxy/managers/workflows.py", line 907, in workflow_to_dict
    wf_dict = self._workflow_to_dict_run(trans, stored, workflow=workflow, history=history or trans.history)
  File "galaxy/managers/workflows.py", line 1025, in _workflow_to_dict_run
    step_model["replacement_parameters"] = step.module.get_informal_replacement_parameters(step)
  File "galaxy/workflow/modules.py", line 2388, in get_informal_replacement_parameters
    for argument in pja.action_arguments.values():
```
from https://sentry.galaxyproject.org/share/issue/954ebe7b658f401a8a8e40987d43a91d/

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
