### PR TITLE
[24.0] Fix tool form building if select filters from unavailable dataset metadata

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6854,14 +6854,23 @@ class HistoryDatasetCollectionAssociation(
             if self.collection:
                 flag_modified(self.collection, "collection_type")
 
-    def to_hda_representative(self, multiple=False):
+    @overload
+    def to_hda_representative(self, multiple: Literal[False] = False) -> Optional[HistoryDatasetAssociation]: ...
+
+    @overload
+    def to_hda_representative(self, multiple: Literal[True]) -> List[HistoryDatasetAssociation]: ...
+
+    def to_hda_representative(
+        self, multiple: bool = False
+    ) -> Union[List[HistoryDatasetAssociation], Optional[HistoryDatasetAssociation]]:
         rval = []
         for dataset in self.collection.dataset_elements:
             rval.append(dataset.dataset_instance)
             if multiple is False:
                 break
-        if len(rval) > 0:
-            return rval if multiple else rval[0]
+        if multiple:
+            return rval
+        return rval[0] if rval else None
 
     def _serialize(self, id_encoder, serialization_options):
         rval = dict_for(


### PR DESCRIPTION
Fixes:

```
Message
Uncaught exception in exposed API method:
Stack Trace(most recent call first)

TypeError: 'NoneType' object is not iterable
  File "galaxy/web/framework/decorators.py", line 346, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/api/tools.py", line 247, in build
    return tool.to_json(trans, kwd.get("inputs", kwd), history=history)
  File "galaxy/tools/__init__.py", line 2509, in to_json
    populate_state(request_context, self.inputs, params.__dict__, state_inputs, state_errors)
  File "galaxy/tools/parameters/__init__.py", line 412, in populate_state
    _populate_state_legacy(
  File "galaxy/tools/parameters/__init__.py", line 525, in _populate_state_legacy
    state[input.name] = input.get_initial_value(request_context, context)
  File "galaxy/tools/parameters/basic.py", line 1107, in get_initial_value
    options = list(self.get_options(trans, other_values))
  File "galaxy/tools/parameters/basic.py", line 960, in get_options
    return self.options.get_options(trans, other_values)
  File "galaxy/tools/parameters/dynamic_options.py", line 893, in get_options
    rval = filter.filter_options(rval, trans, other_values)
  File "galaxy/tools/parameters/dynamic_options.py", line 227, in filter_options
    for r in ref:
```
from

https://sentry.galaxyproject.org/share/issue/ac3a350198604034aca07eaca3cc9cb8/

This happens if you have the following input section:
```
        <param name="otu" type="data" format="mothur.list,mothur.shared" label="list or shared - OTU List of Shared"/>
        <param name="repfasta" type="data" format="fasta" optional="true" label="repfasta - rep.fasta" help="rep.fasta file generated by get.oturep"/>
        <param name="label" type="select" label="label - OTU Labels" optional="true" help="Select exactly one label. If none selected, first label in your list or shared file will be used">
            <options>
                <filter type="data_meta" ref="otu" key="labels"/>
            </options>
        </param>
```
but there's no mothur.list or mothur.shared dataset in your history.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
