### PR TITLE
[24.0] Never fail dataset serialization if display_peek fails

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -337,10 +337,10 @@ class Data(metaclass=DataMeta):
 
     def display_peek(self, dataset: DatasetProtocol) -> str:
         """Create HTML table, used for displaying peek"""
+        if not dataset.peek:
+            return "Peek not available"
         out = ['<table cellspacing="0" cellpadding="3">']
         try:
-            if not dataset.peek:
-                dataset.set_peek()
             data = dataset.peek
             lines = data.splitlines()
             for line in lines:

--- a/lib/galaxy/datatypes/qiime2.py
+++ b/lib/galaxy/datatypes/qiime2.py
@@ -50,6 +50,10 @@ class _QIIME2ResultBase(CompressedZipArchive):
         dataset.peek = "\n".join(map(": ".join, self._peek(dataset)))
 
     def display_peek(self, dataset: DatasetProtocol) -> str:
+        if dataset.metadata.semantic_type is None:
+            # Proxy for metadata elements not (yet) set
+            return "Peek unavailable"
+
         def make_row(pair):
             return f"<tr><th>{pair[0]}</th><td>{html.escape(pair[1])}</td></tr>"
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4669,7 +4669,7 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
         try:
             return self.datatype.display_peek(self)
         except Exception:
-            log.exception("Error occurred while generating dataset pee")
+            log.exception("Error occurred while generating dataset peek")
             return None
 
     def display_name(self):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4666,7 +4666,11 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
         return self.datatype.as_display_type(self, type, **kwd)
 
     def display_peek(self):
-        return self.datatype.display_peek(self)
+        try:
+            return self.datatype.display_peek(self)
+        except Exception:
+            log.exception("Error occurred while generating dataset pee")
+            return None
 
     def display_name(self):
         return self.datatype.display_name(self)

--- a/test/unit/data/datatypes/test_qiime2.py
+++ b/test/unit/data/datatypes/test_qiime2.py
@@ -38,6 +38,9 @@ def test_qza_set_peek():
     with get_input_files("qiime2.qza") as input_files:
         dataset = MockDataset(1)
         dataset.set_file_name(input_files[0])
+        dataset.metadata.semantic_type = None
+        dataset.metadata.uuid = None
+        assert qza.display_peek(dataset) == "Peek unavailable"
 
         qza.set_meta(dataset)
         qza.set_peek(dataset)


### PR DESCRIPTION
Also fix qiime2 specifically and don't set_peek in display_peek method.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
