### PR TITLE
[23.0] Fix output datatype when uncompressing a dataset with incorrect datatype

### DIFF
--- a/lib/galaxy/datatypes/converters/gz_to_uncompressed.xml
+++ b/lib/galaxy/datatypes/converters/gz_to_uncompressed.xml
@@ -6,7 +6,7 @@ gzip -dcf '$input1' > '$output1'
     <configfiles>
         <configfile name="ext_config">{"output1": {
   "name": "${input1.name[0:-len('.gz')] if $input1.name.endswith('.gz') else $input1.name} uncompressed",
-  "ext": "${input1.ext[0:-len('.gz')] if $input1.ext != 'vcf_bgzip' else 'vcf'}"
+  "ext": "${'vcf' if $input1.ext == 'vcf_bgzip' else $input1.ext[0:-len('.gz')] if $input1.ext.endswith('.gz') else $input1.ext}"
 }}</configfile>
     </configfiles>
     <inputs>
@@ -20,6 +20,15 @@ gzip -dcf '$input1' > '$output1'
         <test>
             <param name="input1" value="test.vcf.gz" ftype="vcf_bgzip"/>
             <output name="output1" file="test.vcf" ftype="vcf"/>
+        </test>
+        <test>
+            <param name="input1" value="1.fasta.gz" ftype="fasta.gz"/>
+            <output name="output1" file="1.fasta" ftype="fasta"/>
+        </test>
+        <!-- Test input with wrong format -->
+        <test>
+            <param name="input1" value="1.fasta.gz" ftype="fasta"/>
+            <output name="output1" file="1.fasta" ftype="fasta"/>
         </test>
     </tests>
     <help>


### PR DESCRIPTION
with the ``CONVERTER_gz_to_uncompressed`` tool.

Previously, if a user forced an incorrect datatype to a compressed input dataset (e.g. `fastqsanger` instead of `fastqsanger.gz`), then the output datatype assigned by this tool would be an invalid one (`fastqsan`).

Fix #17938.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
