### PR TITLE
Replace sample Celery result_backend in config

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5156,8 +5156,7 @@
     to set the `result_backend` option in the `celery_conf` option to
     a valid Celery result backend URL. By default, Galaxy uses an
     SQLite database at '<data_dir>/results.sqlite' for storing task
-    results. Please use a more robust backend (e.g. Redis) for
-    production setups. For details, see
+    results. For details, see
     https://docs.galaxyproject.org/en/master/admin/production.html#use-celery-for-asynchronous-tasks
 :Default: ``false``
 :Type: bool
@@ -5175,7 +5174,8 @@
     The `broker_url` option, if unset or null, defaults to the value
     of `amqp_internal_connection`. The `result_backend` option, if
     unset or null, defaults to an SQLite database at
-    '<data_dir>/results.sqlite' for storing task results.
+    '<data_dir>/results.sqlite' for storing task results. Please use a
+    more robust backend (e.g. Redis) for production setups.
     The galaxy.fetch_data task can be disabled by setting its route to
     "disabled": `galaxy.fetch_data: disabled`. (Other tasks cannot be
     disabled on a per-task basis at this time.)

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5154,7 +5154,9 @@
     only if you have setup a Celery worker for Galaxy and you have
     configured the `celery_conf` option below. Specifically, you need
     to set the `result_backend` option in the `celery_conf` option to
-    a valid Celery result backend URL. For details, see
+    a valid Celery result backend URL. By default a SQLite database is
+    used for storing task results, please use a more robust backend
+    for production setups like Redis. For details, see
     https://docs.galaxyproject.org/en/master/admin/production.html#use-celery-for-asynchronous-tasks
 :Default: ``false``
 :Type: bool
@@ -5177,7 +5179,7 @@
     disabled on a per-task basis at this time.)
     For details, see Celery documentation at
     https://docs.celeryq.dev/en/stable/userguide/configuration.html.
-:Default: ``{'result_backend': 'redis://127.0.0.1:6379/0', 'task_routes': {'galaxy.fetch_data': 'galaxy.external', 'galaxy.set_job_metadata': 'galaxy.external'}}``
+:Default: ``{'result_backend': 'db+sqlite:///./database/results.sqlite?isolation_level=IMMEDIATE', 'task_routes': {'galaxy.fetch_data': 'galaxy.external', 'galaxy.set_job_metadata': 'galaxy.external'}}``
 :Type: any
 
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5172,16 +5172,16 @@
     To refer to a task by name, use the template `galaxy.foo` where
     `foo` is the function name of the task defined in the
     galaxy.celery.tasks module.
-    The `broker_url` option, if unset, defaults to the value of
-    `amqp_internal_connection`. The `result_backend` option, if unset,
-    defaults to an SQLite database at '<data_dir>/results.sqlite' for
-    storing task results.
+    The `broker_url` option, if unset or null, defaults to the value
+    of `amqp_internal_connection`. The `result_backend` option, if
+    unset or null, defaults to an SQLite database at
+    '<data_dir>/results.sqlite' for storing task results.
     The galaxy.fetch_data task can be disabled by setting its route to
     "disabled": `galaxy.fetch_data: disabled`. (Other tasks cannot be
     disabled on a per-task basis at this time.)
     For details, see Celery documentation at
     https://docs.celeryq.dev/en/stable/userguide/configuration.html.
-:Default: ``{'task_routes': {'galaxy.fetch_data': 'galaxy.external', 'galaxy.set_job_metadata': 'galaxy.external'}}``
+:Default: ``{'broker_url': None, 'result_backend': None, 'task_routes': {'galaxy.fetch_data': 'galaxy.external', 'galaxy.set_job_metadata': 'galaxy.external'}}``
 :Type: any
 
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5173,14 +5173,15 @@
     `foo` is the function name of the task defined in the
     galaxy.celery.tasks module.
     The `broker_url` option, if unset, defaults to the value of
-    `amqp_internal_connection`. The `result_backend` option must be
-    set if the `enable_celery_tasks` option is set.
+    `amqp_internal_connection`. The `result_backend` option, if unset,
+    defaults to an SQLite database at '<data_dir>/results.sqlite' for
+    storing task results.
     The galaxy.fetch_data task can be disabled by setting its route to
     "disabled": `galaxy.fetch_data: disabled`. (Other tasks cannot be
     disabled on a per-task basis at this time.)
     For details, see Celery documentation at
     https://docs.celeryq.dev/en/stable/userguide/configuration.html.
-:Default: ``{'result_backend': 'db+sqlite:///./database/results.sqlite?isolation_level=IMMEDIATE', 'task_routes': {'galaxy.fetch_data': 'galaxy.external', 'galaxy.set_job_metadata': 'galaxy.external'}}``
+:Default: ``{'task_routes': {'galaxy.fetch_data': 'galaxy.external', 'galaxy.set_job_metadata': 'galaxy.external'}}``
 :Type: any
 
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5154,9 +5154,10 @@
     only if you have setup a Celery worker for Galaxy and you have
     configured the `celery_conf` option below. Specifically, you need
     to set the `result_backend` option in the `celery_conf` option to
-    a valid Celery result backend URL. By default a SQLite database is
-    used for storing task results, please use a more robust backend
-    for production setups like Redis. For details, see
+    a valid Celery result backend URL. By default, Galaxy uses an
+    SQLite database at '<data_dir>/results.sqlite' for storing task
+    results. Please use a more robust backend for production setups
+    like Redis. For details, see
     https://docs.galaxyproject.org/en/master/admin/production.html#use-celery-for-asynchronous-tasks
 :Default: ``false``
 :Type: bool

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5156,8 +5156,8 @@
     to set the `result_backend` option in the `celery_conf` option to
     a valid Celery result backend URL. By default, Galaxy uses an
     SQLite database at '<data_dir>/results.sqlite' for storing task
-    results. Please use a more robust backend for production setups
-    like Redis. For details, see
+    results. Please use a more robust backend (e.g. Redis) for
+    production setups. For details, see
     https://docs.galaxyproject.org/en/master/admin/production.html#use-celery-for-asynchronous-tasks
 :Default: ``false``
 :Type: bool

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -1207,14 +1207,10 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             _load_theme(self.themes_config_file, self.themes)
 
     def _process_celery_config(self):
-        if self.celery_conf:
-            result_backend = self.celery_conf.get("result_backend")
-            if result_backend:
-                # If the result_backend is the default SQLite database, we need to
-                # ensure that the correct data directory is used.
-                if "results.sqlite" in result_backend:
-                    result_backend = f"db+sqlite:///{self._in_data_dir('results.sqlite')}?isolation_level=IMMEDIATE"
-                self.celery_conf["result_backend"] = result_backend
+        if self.celery_conf and self.celery_conf.get("result_backend") is None:
+            # If the result_backend is not set, use a SQLite database in the data directory
+            result_backend = f"db+sqlite:///{self._in_data_dir('results.sqlite')}?isolation_level=IMMEDIATE"
+            self.celery_conf["result_backend"] = result_backend
 
     def _check_database_connection_strings(self):
         """

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2773,15 +2773,15 @@ galaxy:
   # `foo` is the function name of the task defined in the
   # galaxy.celery.tasks module.
   # The `broker_url` option, if unset, defaults to the value of
-  # `amqp_internal_connection`. The `result_backend` option must be set
-  # if the `enable_celery_tasks` option is set.
+  # `amqp_internal_connection`. The `result_backend` option, if unset,
+  # defaults to an SQLite database at '<data_dir>/results.sqlite' for
+  # storing task results.
   # The galaxy.fetch_data task can be disabled by setting its route to
   # "disabled": `galaxy.fetch_data: disabled`. (Other tasks cannot be
   # disabled on a per-task basis at this time.)
   # For details, see Celery documentation at
   # https://docs.celeryq.dev/en/stable/userguide/configuration.html.
   #celery_conf:
-  #  result_backend: db+sqlite:///./database/results.sqlite?isolation_level=IMMEDIATE
   #  task_routes:
   #    galaxy.fetch_data: galaxy.external
   #    galaxy.set_job_metadata: galaxy.external

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2763,7 +2763,6 @@ galaxy:
   # set the `result_backend` option in the `celery_conf` option to a
   # valid Celery result backend URL. By default, Galaxy uses an SQLite
   # database at '<data_dir>/results.sqlite' for storing task results.
-  # Please use a more robust backend (e.g. Redis) for production setups.
   # For details, see
   # https://docs.galaxyproject.org/en/master/admin/production.html#use-celery-for-asynchronous-tasks
   #enable_celery_tasks: false
@@ -2775,7 +2774,8 @@ galaxy:
   # The `broker_url` option, if unset or null, defaults to the value of
   # `amqp_internal_connection`. The `result_backend` option, if unset or
   # null, defaults to an SQLite database at '<data_dir>/results.sqlite'
-  # for storing task results.
+  # for storing task results. Please use a more robust backend (e.g.
+  # Redis) for production setups.
   # The galaxy.fetch_data task can be disabled by setting its route to
   # "disabled": `galaxy.fetch_data: disabled`. (Other tasks cannot be
   # disabled on a per-task basis at this time.)

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2772,16 +2772,18 @@ galaxy:
   # To refer to a task by name, use the template `galaxy.foo` where
   # `foo` is the function name of the task defined in the
   # galaxy.celery.tasks module.
-  # The `broker_url` option, if unset, defaults to the value of
-  # `amqp_internal_connection`. The `result_backend` option, if unset,
-  # defaults to an SQLite database at '<data_dir>/results.sqlite' for
-  # storing task results.
+  # The `broker_url` option, if unset or null, defaults to the value of
+  # `amqp_internal_connection`. The `result_backend` option, if unset or
+  # null, defaults to an SQLite database at '<data_dir>/results.sqlite'
+  # for storing task results.
   # The galaxy.fetch_data task can be disabled by setting its route to
   # "disabled": `galaxy.fetch_data: disabled`. (Other tasks cannot be
   # disabled on a per-task basis at this time.)
   # For details, see Celery documentation at
   # https://docs.celeryq.dev/en/stable/userguide/configuration.html.
   #celery_conf:
+  #  broker_url: null
+  #  result_backend: null
   #  task_routes:
   #    galaxy.fetch_data: galaxy.external
   #    galaxy.set_job_metadata: galaxy.external

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2763,7 +2763,7 @@ galaxy:
   # set the `result_backend` option in the `celery_conf` option to a
   # valid Celery result backend URL. By default, Galaxy uses an SQLite
   # database at '<data_dir>/results.sqlite' for storing task results.
-  # Please use a more robust backend for production setups like Redis.
+  # Please use a more robust backend (e.g. Redis) for production setups.
   # For details, see
   # https://docs.galaxyproject.org/en/master/admin/production.html#use-celery-for-asynchronous-tasks
   #enable_celery_tasks: false

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2761,7 +2761,9 @@ galaxy:
   # only if you have setup a Celery worker for Galaxy and you have
   # configured the `celery_conf` option below. Specifically, you need to
   # set the `result_backend` option in the `celery_conf` option to a
-  # valid Celery result backend URL. For details, see
+  # valid Celery result backend URL. By default a SQLite database is
+  # used for storing task results, please use a more robust backend for
+  # production setups like Redis. For details, see
   # https://docs.galaxyproject.org/en/master/admin/production.html#use-celery-for-asynchronous-tasks
   #enable_celery_tasks: false
 
@@ -2778,7 +2780,7 @@ galaxy:
   # For details, see Celery documentation at
   # https://docs.celeryq.dev/en/stable/userguide/configuration.html.
   #celery_conf:
-  #  result_backend: redis://127.0.0.1:6379/0
+  #  result_backend: db+sqlite:///./database/results.sqlite?isolation_level=IMMEDIATE
   #  task_routes:
   #    galaxy.fetch_data: galaxy.external
   #    galaxy.set_job_metadata: galaxy.external

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2761,9 +2761,10 @@ galaxy:
   # only if you have setup a Celery worker for Galaxy and you have
   # configured the `celery_conf` option below. Specifically, you need to
   # set the `result_backend` option in the `celery_conf` option to a
-  # valid Celery result backend URL. By default a SQLite database is
-  # used for storing task results, please use a more robust backend for
-  # production setups like Redis. For details, see
+  # valid Celery result backend URL. By default, Galaxy uses an SQLite
+  # database at '<data_dir>/results.sqlite' for storing task results.
+  # Please use a more robust backend for production setups like Redis.
+  # For details, see
   # https://docs.galaxyproject.org/en/master/admin/production.html#use-celery-for-asynchronous-tasks
   #enable_celery_tasks: false
 

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3772,7 +3772,6 @@ mapping:
         type: any
         required: false
         default:
-          result_backend: db+sqlite:///./database/results.sqlite?isolation_level=IMMEDIATE
           task_routes:
             'galaxy.fetch_data': 'galaxy.external'
             'galaxy.set_job_metadata': 'galaxy.external'
@@ -3783,7 +3782,8 @@ mapping:
           of the task defined in the galaxy.celery.tasks module.
 
           The `broker_url` option, if unset, defaults to the value of `amqp_internal_connection`.
-          The `result_backend` option must be set if the `enable_celery_tasks` option is set.
+          The `result_backend` option, if unset, defaults to an SQLite database at '<data_dir>/results.sqlite'
+          for storing task results.
 
           The galaxy.fetch_data task can be disabled by setting its route to "disabled": `galaxy.fetch_data: disabled`.
           (Other tasks cannot be disabled on a per-task basis at this time.)

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3772,6 +3772,8 @@ mapping:
         type: any
         required: false
         default:
+          broker_url: null
+          result_backend: null
           task_routes:
             'galaxy.fetch_data': 'galaxy.external'
             'galaxy.set_job_metadata': 'galaxy.external'
@@ -3781,8 +3783,8 @@ mapping:
           To refer to a task by name, use the template `galaxy.foo` where `foo` is the function name
           of the task defined in the galaxy.celery.tasks module.
 
-          The `broker_url` option, if unset, defaults to the value of `amqp_internal_connection`.
-          The `result_backend` option, if unset, defaults to an SQLite database at '<data_dir>/results.sqlite'
+          The `broker_url` option, if unset or null, defaults to the value of `amqp_internal_connection`.
+          The `result_backend` option, if unset or null, defaults to an SQLite database at '<data_dir>/results.sqlite'
           for storing task results.
 
           The galaxy.fetch_data task can be disabled by setting its route to "disabled": `galaxy.fetch_data: disabled`.

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3765,7 +3765,6 @@ mapping:
           configured the `celery_conf` option below. Specifically, you need to set the
           `result_backend` option in the `celery_conf` option to a valid Celery result
           backend URL. By default, Galaxy uses an SQLite database at '<data_dir>/results.sqlite' for storing task results.
-          Please use a more robust backend (e.g. Redis) for production setups.
           For details, see https://docs.galaxyproject.org/en/master/admin/production.html#use-celery-for-asynchronous-tasks
           
       celery_conf:
@@ -3785,7 +3784,7 @@ mapping:
 
           The `broker_url` option, if unset or null, defaults to the value of `amqp_internal_connection`.
           The `result_backend` option, if unset or null, defaults to an SQLite database at '<data_dir>/results.sqlite'
-          for storing task results.
+          for storing task results. Please use a more robust backend (e.g. Redis) for production setups.
 
           The galaxy.fetch_data task can be disabled by setting its route to "disabled": `galaxy.fetch_data: disabled`.
           (Other tasks cannot be disabled on a per-task basis at this time.)

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3765,7 +3765,7 @@ mapping:
           configured the `celery_conf` option below. Specifically, you need to set the
           `result_backend` option in the `celery_conf` option to a valid Celery result
           backend URL. By default, Galaxy uses an SQLite database at '<data_dir>/results.sqlite' for storing task results.
-          Please use a more robust backend for production setups like Redis.
+          Please use a more robust backend for production setups (e.g. Redis).
           For details, see https://docs.galaxyproject.org/en/master/admin/production.html#use-celery-for-asynchronous-tasks
           
       celery_conf:

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3765,7 +3765,7 @@ mapping:
           configured the `celery_conf` option below. Specifically, you need to set the
           `result_backend` option in the `celery_conf` option to a valid Celery result
           backend URL. By default, Galaxy uses an SQLite database at '<data_dir>/results.sqlite' for storing task results.
-          Please use a more robust backend for production setups (e.g. Redis).
+          Please use a more robust backend (e.g. Redis) for production setups.
           For details, see https://docs.galaxyproject.org/en/master/admin/production.html#use-celery-for-asynchronous-tasks
           
       celery_conf:

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3764,8 +3764,8 @@ mapping:
           Activate this only if you have setup a Celery worker for Galaxy and you have
           configured the `celery_conf` option below. Specifically, you need to set the
           `result_backend` option in the `celery_conf` option to a valid Celery result
-          backend URL. By default a SQLite database is used for storing task results, please
-          use a more robust backend for production setups like Redis.
+          backend URL. By default, Galaxy uses an SQLite database at '<data_dir>/results.sqlite' for storing task results.
+          Please use a more robust backend for production setups like Redis.
           For details, see https://docs.galaxyproject.org/en/master/admin/production.html#use-celery-for-asynchronous-tasks
           
       celery_conf:

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3764,14 +3764,15 @@ mapping:
           Activate this only if you have setup a Celery worker for Galaxy and you have
           configured the `celery_conf` option below. Specifically, you need to set the
           `result_backend` option in the `celery_conf` option to a valid Celery result
-          backend URL.
+          backend URL. By default a SQLite database is used for storing task results, please
+          use a more robust backend for production setups like Redis.
           For details, see https://docs.galaxyproject.org/en/master/admin/production.html#use-celery-for-asynchronous-tasks
           
       celery_conf:
         type: any
         required: false
         default:
-          result_backend: redis://127.0.0.1:6379/0
+          result_backend: db+sqlite:///./database/results.sqlite?isolation_level=IMMEDIATE
           task_routes:
             'galaxy.fetch_data': 'galaxy.external'
             'galaxy.set_job_metadata': 'galaxy.external'


### PR DESCRIPTION
Closes #17881
Fixes #17878

It just replaces the default Celery `result_backend` from `redis` to an SQLite database so it should "work out of the box" with a development instance. Production instances should change to something more robust as hinted in the documentation.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
