### PR TITLE
[23.0] Fix KeyError in ``XForwardedHostMiddleware``

### DIFF
--- a/lib/galaxy/web/framework/middleware/xforwardedhost.py
+++ b/lib/galaxy/web/framework/middleware/xforwardedhost.py
@@ -10,11 +10,11 @@ class XForwardedHostMiddleware:
     def __call__(self, environ, start_response):
         x_forwarded_host = environ.get("HTTP_X_FORWARDED_HOST", None)
         if x_forwarded_host:
-            environ["ORGINAL_HTTP_HOST"] = environ["HTTP_HOST"]
+            environ["ORIGINAL_HTTP_HOST"] = environ.get("HTTP_HOST")
             environ["HTTP_HOST"] = x_forwarded_host.split(", ", 1)[0]
         x_forwarded_for = environ.get("HTTP_X_FORWARDED_FOR", None)
         if x_forwarded_for:
-            environ["ORGINAL_REMOTE_ADDR"] = environ["REMOTE_ADDR"]
+            environ["ORIGINAL_REMOTE_ADDR"] = environ.get("REMOTE_ADDR")
             environ["REMOTE_ADDR"] = x_forwarded_for.split(",", 1)[0].strip()
         x_forwarded_proto = environ.get("HTTP_X_FORWARDED_PROTO", None)
         if x_forwarded_proto:


### PR DESCRIPTION
when `REMOTE_ADDR` is not defined.
Reported by @vazovn .

Also fix typos in environment variable names.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Start Galaxy with `./run.sh`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
