### PR TITLE
Model typing and SA2.0 follow-up

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1554,7 +1554,7 @@ class MinimalJobWrapper(HasResourceParameters):
     def get_state(self) -> str:
         job = self.get_job()
         self.sa_session.refresh(job)
-        return job.state  # type:ignore[return-value]
+        return job.state
 
     def set_runner(self, runner_url, external_id):
         log.warning("set_runner() is deprecated, use set_job_destination()")

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -5,7 +5,10 @@ from datetime import (
     date,
     datetime,
 )
-from typing import List
+from typing import (
+    cast,
+    List,
+)
 
 import sqlalchemy
 from boltons.iterutils import remap
@@ -1065,6 +1068,7 @@ def summarize_job_outputs(job: model.Job, tool, params):
         ("hdca", "dataset_collection_id", job.output_dataset_collection_instances),
     )
     for src, attribute, output_associations in possible_outputs:
+        output_associations = cast(List, output_associations)  # during iteration, mypy sees it as object
         for output_association in output_associations:
             output_name = output_association.name
             if output_name not in output_labels and tool:

--- a/lib/galaxy/managers/notification.py
+++ b/lib/galaxy/managers/notification.py
@@ -275,8 +275,8 @@ class NotificationManager:
     def get_user_notification_preferences(self, user: User) -> UserNotificationPreferences:
         """Gets the user's current notification preferences or the default ones if no preferences are set."""
         current_notification_preferences = (
-            user.preferences[NOTIFICATION_PREFERENCES_SECTION_NAME]  # type:ignore[index]
-            if NOTIFICATION_PREFERENCES_SECTION_NAME in user.preferences  # type:ignore[operator]
+            user.preferences[NOTIFICATION_PREFERENCES_SECTION_NAME]
+            if NOTIFICATION_PREFERENCES_SECTION_NAME in user.preferences
             else None
         )
         try:
@@ -291,9 +291,7 @@ class NotificationManager:
         """Updates the user's notification preferences with the requested changes."""
         notification_preferences = self.get_user_notification_preferences(user)
         notification_preferences.update(request.preferences)
-        user.preferences[NOTIFICATION_PREFERENCES_SECTION_NAME] = (
-            notification_preferences.model_dump_json()
-        )  # type:ignore[index]
+        user.preferences[NOTIFICATION_PREFERENCES_SECTION_NAME] = notification_preferences.model_dump_json()
         with transaction(self.sa_session):
             self.sa_session.commit()
         return notification_preferences

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -179,7 +179,7 @@ class SharableModelManager(
         """
         # precondition: user has been validated
         # get or create
-        existing = self.get_share_assocs(item, user=user)  # type:ignore[dict-item]
+        existing = self.get_share_assocs(item, user=user)
         if existing:
             return existing.pop(0)
         return self._create_user_share_assoc(item, user, flush=flush)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8317,10 +8317,10 @@ class StoredWorkflowUserShareAssociation(Base, UserShareAssociation):
     __tablename__ = "stored_workflow_user_share_connection"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    stored_workflow_id: Mapped[Optional[int]] = mapped_column(ForeignKey("stored_workflow.id"), index=True)
-    user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
+    stored_workflow_id: Mapped[int] = mapped_column(ForeignKey("stored_workflow.id"), index=True, nullable=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("galaxy_user.id"), index=True, nullable=True)
     user: Mapped[User] = relationship()
-    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship(back_populates="users_shared_with")
+    stored_workflow: Mapped["StoredWorkflow"] = relationship(back_populates="users_shared_with")
 
 
 class StoredWorkflowMenuEntry(Base, RepresentById):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2386,13 +2386,13 @@ class JobToOutputDatasetCollectionAssociation(Base, RepresentById):
     __tablename__ = "job_to_output_dataset_collection"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
-    dataset_collection_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("history_dataset_collection_association.id"), index=True
+    job_id: Mapped[int] = mapped_column(ForeignKey("job.id"), index=True, nullable=True)
+    dataset_collection_id: Mapped[int] = mapped_column(
+        ForeignKey("history_dataset_collection_association.id"), index=True, nullable=True
     )
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
-    dataset_collection_instance: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(lazy="joined")
-    job: Mapped[Optional["Job"]] = relationship(back_populates="output_dataset_collection_instances")
+    dataset_collection_instance: Mapped["HistoryDatasetCollectionAssociation"] = relationship(lazy="joined")
+    job: Mapped["Job"] = relationship(back_populates="output_dataset_collection_instances")
 
     def __init__(self, name, dataset_collection_instance):
         self.name = name

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1400,12 +1400,14 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     library_folder: Mapped[Optional["LibraryFolder"]] = relationship()
     parameters = relationship("JobParameter")
     input_datasets = relationship("JobToInputDatasetAssociation", back_populates="job")
-    input_dataset_collections = relationship("JobToInputDatasetCollectionAssociation", back_populates="job")
-    input_dataset_collection_elements = relationship(
-        "JobToInputDatasetCollectionElementAssociation", back_populates="job"
+    input_dataset_collections: Mapped[List["JobToInputDatasetCollectionAssociation"]] = relationship(
+        back_populates="job"
+    )
+    input_dataset_collection_elements: Mapped[List["JobToInputDatasetCollectionElementAssociation"]] = relationship(
+        back_populates="job"
     )
     output_dataset_collection_instances: Mapped[List["JobToOutputDatasetCollectionAssociation"]] = relationship(
-        "JobToOutputDatasetCollectionAssociation", back_populates="job"
+        back_populates="job"
     )
     output_dataset_collections: Mapped[List["JobToImplicitOutputDatasetCollectionAssociation"]] = relationship(
         back_populates="job"
@@ -1413,12 +1415,8 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     post_job_actions: Mapped[List["PostJobActionAssociation"]] = relationship(
         back_populates="job", cascade_backrefs=False
     )
-    input_library_datasets: Mapped[List["JobToInputLibraryDatasetAssociation"]] = relationship(
-        "JobToInputLibraryDatasetAssociation", back_populates="job"
-    )
-    output_library_datasets: Mapped[List["JobToOutputLibraryDatasetAssociation"]] = relationship(
-        "JobToOutputLibraryDatasetAssociation", back_populates="job"
-    )
+    input_library_datasets: Mapped[List["JobToInputLibraryDatasetAssociation"]] = relationship(back_populates="job")
+    output_library_datasets: Mapped[List["JobToOutputLibraryDatasetAssociation"]] = relationship(back_populates="job")
     external_output_metadata: Mapped[List["JobExternalOutputMetadata"]] = relationship(back_populates="job")
     tasks: Mapped[List["Task"]] = relationship(back_populates="job")
     output_datasets = relationship("JobToOutputDatasetAssociation", back_populates="job")
@@ -1428,16 +1426,18 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     interactivetool_entry_points: Mapped[List["InteractiveToolEntryPoint"]] = relationship(
         back_populates="job", uselist=True
     )
-    implicit_collection_jobs_association = relationship(
-        "ImplicitCollectionJobsJobAssociation", back_populates="job", uselist=False, cascade_backrefs=False
+    implicit_collection_jobs_association: Mapped[List["ImplicitCollectionJobsJobAssociation"]] = relationship(
+        back_populates="job", uselist=False, cascade_backrefs=False
     )
-    container = relationship("JobContainerAssociation", back_populates="job", uselist=False)
-    data_manager_association = relationship(
-        "DataManagerJobAssociation", back_populates="job", uselist=False, cascade_backrefs=False
+    container: Mapped[Optional["JobContainerAssociation"]] = relationship(back_populates="job", uselist=False)
+    data_manager_association: Mapped[Optional["DataManagerJobAssociation"]] = relationship(
+        back_populates="job", uselist=False, cascade_backrefs=False
     )
-    history_dataset_collection_associations = relationship("HistoryDatasetCollectionAssociation", back_populates="job")
-    workflow_invocation_step = relationship(
-        "WorkflowInvocationStep", back_populates="job", uselist=False, cascade_backrefs=False
+    history_dataset_collection_associations: Mapped[List["HistoryDatasetCollectionAssociation"]] = relationship(
+        back_populates="job"
+    )
+    workflow_invocation_step: Mapped[Optional["WorkflowInvocationStep"]] = relationship(
+        back_populates="job", uselist=False, cascade_backrefs=False
     )
 
     any_output_dataset_collection_instances_deleted = None
@@ -3733,7 +3733,9 @@ class Quota(Base, Dictifiable, RepresentById):
     operation: Mapped[Optional[str]] = mapped_column(String(8))
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     quota_source_label: Mapped[Optional[str]] = mapped_column(String(32), default=None)
-    default = relationship("DefaultQuotaAssociation", back_populates="quota", cascade_backrefs=False)
+    default: Mapped[List["DefaultQuotaAssociation"]] = relationship(
+        "DefaultQuotaAssociation", back_populates="quota", cascade_backrefs=False
+    )
     groups: Mapped[List["GroupQuotaAssociation"]] = relationship(back_populates="quota")
     users: Mapped[List["UserQuotaAssociation"]] = relationship(back_populates="quota")
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3597,13 +3597,13 @@ class UserRoleAssociation(Base, RepresentById):
     __tablename__ = "user_role_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("galaxy_user.id"), index=True, nullable=True)
+    role_id: Mapped[int] = mapped_column(ForeignKey("role.id"), index=True, nullable=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
 
-    user: Mapped[Optional["User"]] = relationship(back_populates="roles")
-    role: Mapped[Optional["Role"]] = relationship(back_populates="users")
+    user: Mapped["User"] = relationship(back_populates="roles")
+    role: Mapped["Role"] = relationship(back_populates="users")
 
     def __init__(self, user, role):
         add_object_to_object_session(self, user)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -10053,7 +10053,7 @@ class CustosAuthnzToken(Base, RepresentById):
     )
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"))
+    user_id: Mapped[int] = mapped_column(ForeignKey("galaxy_user.id"), nullable=True)
     external_user_id: Mapped[Optional[str]] = mapped_column(String(255))
     provider: Mapped[Optional[str]] = mapped_column(String(255))
     access_token: Mapped[Optional[str]] = mapped_column(Text)
@@ -10061,7 +10061,7 @@ class CustosAuthnzToken(Base, RepresentById):
     refresh_token: Mapped[Optional[str]] = mapped_column(Text)
     expiration_time: Mapped[datetime] = mapped_column(nullable=True)
     refresh_expiration_time: Mapped[datetime] = mapped_column(nullable=True)
-    user = relationship("User", back_populates="custos_auth")
+    user: Mapped["User"] = relationship("User", back_populates="custos_auth")
 
 
 class CloudAuthz(Base):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3893,11 +3893,11 @@ class LibraryDatasetDatasetAssociationPermissions(Base, RepresentById):
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
     action: Mapped[Optional[str]] = mapped_column(TEXT)
-    library_dataset_dataset_association_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("library_dataset_dataset_association.id"), index=True
+    library_dataset_dataset_association_id: Mapped[int] = mapped_column(
+        ForeignKey("library_dataset_dataset_association.id"), index=True, nullable=True
     )
     role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
-    library_dataset_dataset_association: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
+    library_dataset_dataset_association: Mapped["LibraryDatasetDatasetAssociation"] = relationship(
         back_populates="actions"
     )
     role: Mapped[Optional["Role"]] = relationship()

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2310,14 +2310,12 @@ class JobToInputDatasetAssociation(Base, RepresentById):
     __tablename__ = "job_to_input_dataset"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
-    dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_association.id"), index=True)
+    job_id: Mapped[int] = mapped_column(ForeignKey("job.id"), index=True, nullable=True)
+    dataset_id: Mapped[int] = mapped_column(ForeignKey("history_dataset_association.id"), index=True, nullable=True)
     dataset_version: Mapped[Optional[int]]
     name: Mapped[Optional[str]] = mapped_column(String(255))
-    dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
-        lazy="joined", back_populates="dependent_jobs"
-    )
-    job: Mapped[Optional["Job"]] = relationship(back_populates="input_datasets")
+    dataset: Mapped["HistoryDatasetAssociation"] = relationship(lazy="joined", back_populates="dependent_jobs")
+    job: Mapped["Job"] = relationship(back_populates="input_datasets")
 
     def __init__(self, name, dataset):
         self.name = name

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2350,13 +2350,13 @@ class JobToInputDatasetCollectionAssociation(Base, RepresentById):
     __tablename__ = "job_to_input_dataset_collection"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
-    dataset_collection_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("history_dataset_collection_association.id"), index=True
+    job_id: Mapped[int] = mapped_column(ForeignKey("job.id"), index=True, nullable=True)
+    dataset_collection_id: Mapped[int] = mapped_column(
+        ForeignKey("history_dataset_collection_association.id"), index=True, nullable=True
     )
     name: Mapped[Optional[str]] = mapped_column(String(255))
-    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(lazy="joined")
-    job: Mapped[Optional["Job"]] = relationship(back_populates="input_dataset_collections")
+    dataset_collection: Mapped["HistoryDatasetCollectionAssociation"] = relationship(lazy="joined")
+    job: Mapped["Job"] = relationship(back_populates="input_dataset_collections")
 
     def __init__(self, name, dataset_collection):
         self.name = name

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1269,7 +1269,7 @@ class PasswordResetToken(Base):
     token: Mapped[str] = mapped_column(String(32), primary_key=True, unique=True, index=True)
     expiration_time: Mapped[Optional[datetime]]
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    user: Mapped["User"] = relationship("User")
+    user: Mapped[Optional["User"]] = relationship("User")
 
     def __init__(self, user, token=None):
         if token:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3782,8 +3782,8 @@ class DefaultQuotaAssociation(Base, Dictifiable, RepresentById):
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
     type: Mapped[Optional[str]] = mapped_column(String(32))
-    quota_id: Mapped[Optional[int]] = mapped_column(ForeignKey("quota.id"), index=True)
-    quota: Mapped[Optional["Quota"]] = relationship(back_populates="default")
+    quota_id: Mapped[int] = mapped_column(ForeignKey("quota.id"), index=True, nullable=True)
+    quota: Mapped["Quota"] = relationship(back_populates="default")
 
     dict_element_visible_keys = ["type"]
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -10894,8 +10894,8 @@ class CleanupEventDatasetAssociation(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
-    cleanup_event_id: Mapped[Optional[int]] = mapped_column(ForeignKey("cleanup_event.id"), index=True)
-    dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("dataset.id"), index=True)
+    cleanup_event_id: Mapped[int] = mapped_column(ForeignKey("cleanup_event.id"), index=True, nullable=True)
+    dataset_id: Mapped[int] = mapped_column(ForeignKey("dataset.id"), index=True, nullable=True)
 
 
 class CleanupEventMetadataFileAssociation(Base):
@@ -10903,8 +10903,8 @@ class CleanupEventMetadataFileAssociation(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
-    cleanup_event_id: Mapped[Optional[int]] = mapped_column(ForeignKey("cleanup_event.id"), index=True)
-    metadata_file_id: Mapped[Optional[int]] = mapped_column(ForeignKey("metadata_file.id"), index=True)
+    cleanup_event_id: Mapped[int] = mapped_column(ForeignKey("cleanup_event.id"), index=True, nullable=True)
+    metadata_file_id: Mapped[int] = mapped_column(ForeignKey("metadata_file.id"), index=True, nullable=True)
 
 
 class CleanupEventHistoryAssociation(Base):
@@ -10912,8 +10912,8 @@ class CleanupEventHistoryAssociation(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
-    cleanup_event_id: Mapped[Optional[int]] = mapped_column(ForeignKey("cleanup_event.id"), index=True)
-    history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
+    cleanup_event_id: Mapped[int] = mapped_column(ForeignKey("cleanup_event.id"), index=True, nullable=True)
+    history_id: Mapped[int] = mapped_column(ForeignKey("history.id"), index=True, nullable=True)
 
 
 class CleanupEventHistoryDatasetAssociationAssociation(Base):
@@ -10921,8 +10921,8 @@ class CleanupEventHistoryDatasetAssociationAssociation(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
-    cleanup_event_id: Mapped[Optional[int]] = mapped_column(ForeignKey("cleanup_event.id"), index=True)
-    hda_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_association.id"), index=True)
+    cleanup_event_id: Mapped[int] = mapped_column(ForeignKey("cleanup_event.id"), index=True, nullable=True)
+    hda_id: Mapped[int] = mapped_column(ForeignKey("history_dataset_association.id"), index=True, nullable=True)
 
 
 class CleanupEventLibraryAssociation(Base):
@@ -10930,8 +10930,8 @@ class CleanupEventLibraryAssociation(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
-    cleanup_event_id: Mapped[Optional[int]] = mapped_column(ForeignKey("cleanup_event.id"), index=True)
-    library_id: Mapped[Optional[int]] = mapped_column(ForeignKey("library.id"), index=True)
+    cleanup_event_id: Mapped[int] = mapped_column(ForeignKey("cleanup_event.id"), index=True, nullable=True)
+    library_id: Mapped[int] = mapped_column(ForeignKey("library.id"), index=True, nullable=True)
 
 
 class CleanupEventLibraryFolderAssociation(Base):
@@ -10939,8 +10939,8 @@ class CleanupEventLibraryFolderAssociation(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
-    cleanup_event_id: Mapped[Optional[int]] = mapped_column(ForeignKey("cleanup_event.id"), index=True)
-    library_folder_id: Mapped[Optional[int]] = mapped_column(ForeignKey("library_folder.id"), index=True)
+    cleanup_event_id: Mapped[int] = mapped_column(ForeignKey("cleanup_event.id"), index=True, nullable=True)
+    library_folder_id: Mapped[int] = mapped_column(ForeignKey("library_folder.id"), index=True, nullable=True)
 
 
 class CleanupEventLibraryDatasetAssociation(Base):
@@ -10948,8 +10948,8 @@ class CleanupEventLibraryDatasetAssociation(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
-    cleanup_event_id: Mapped[Optional[int]] = mapped_column(ForeignKey("cleanup_event.id"), index=True)
-    library_dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("library_dataset.id"), index=True)
+    cleanup_event_id: Mapped[int] = mapped_column(ForeignKey("cleanup_event.id"), index=True, nullable=True)
+    library_dataset_id: Mapped[int] = mapped_column(ForeignKey("library_dataset.id"), index=True, nullable=True)
 
 
 class CleanupEventLibraryDatasetDatasetAssociationAssociation(Base):
@@ -10957,8 +10957,10 @@ class CleanupEventLibraryDatasetDatasetAssociationAssociation(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
-    cleanup_event_id: Mapped[Optional[int]] = mapped_column(ForeignKey("cleanup_event.id"), index=True)
-    ldda_id: Mapped[Optional[int]] = mapped_column(ForeignKey("library_dataset_dataset_association.id"), index=True)
+    cleanup_event_id: Mapped[int] = mapped_column(ForeignKey("cleanup_event.id"), index=True, nullable=True)
+    ldda_id: Mapped[int] = mapped_column(
+        ForeignKey("library_dataset_dataset_association.id"), index=True, nullable=True
+    )
 
 
 class CleanupEventImplicitlyConvertedDatasetAssociationAssociation(Base):
@@ -10966,9 +10968,9 @@ class CleanupEventImplicitlyConvertedDatasetAssociationAssociation(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
-    cleanup_event_id: Mapped[Optional[int]] = mapped_column(ForeignKey("cleanup_event.id"), index=True)
-    icda_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("implicitly_converted_dataset_association.id"), index=True
+    cleanup_event_id: Mapped[int] = mapped_column(ForeignKey("cleanup_event.id"), index=True, nullable=True)
+    icda_id: Mapped[int] = mapped_column(
+        ForeignKey("implicitly_converted_dataset_association.id"), index=True, nullable=True
     )
 
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3615,12 +3615,12 @@ class GroupRoleAssociation(Base, RepresentById):
     __tablename__ = "group_role_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    group_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_group.id"), index=True)
-    role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
+    group_id: Mapped[int] = mapped_column(ForeignKey("galaxy_group.id"), index=True, nullable=True)
+    role_id: Mapped[int] = mapped_column(ForeignKey("role.id"), index=True, nullable=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
-    group: Mapped[Optional["Group"]] = relationship(back_populates="roles")
-    role: Mapped[Optional["Role"]] = relationship(back_populates="groups")
+    group: Mapped["Group"] = relationship(back_populates="roles")
+    role: Mapped["Role"] = relationship(back_populates="groups")
 
     def __init__(self, group, role):
         self.group = group

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1404,7 +1404,9 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     input_dataset_collection_elements = relationship(
         "JobToInputDatasetCollectionElementAssociation", back_populates="job"
     )
-    output_dataset_collection_instances = relationship("JobToOutputDatasetCollectionAssociation", back_populates="job")
+    output_dataset_collection_instances: Mapped[List["JobToOutputDatasetCollectionAssociation"]] = relationship(
+        "JobToOutputDatasetCollectionAssociation", back_populates="job"
+    )
     output_dataset_collections = relationship("JobToImplicitOutputDatasetCollectionAssociation", back_populates="job")
     post_job_actions: Mapped[List["PostJobActionAssociation"]] = relationship(
         back_populates="job", cascade_backrefs=False
@@ -2390,7 +2392,7 @@ class JobToOutputDatasetCollectionAssociation(Base, RepresentById):
     dataset_collection_id: Mapped[int] = mapped_column(
         ForeignKey("history_dataset_collection_association.id"), index=True, nullable=True
     )
-    name: Mapped[Optional[str]] = mapped_column(Unicode(255))
+    name: Mapped[str] = mapped_column(Unicode(255), nullable=True)
     dataset_collection_instance: Mapped["HistoryDatasetCollectionAssociation"] = relationship(lazy="joined")
     job: Mapped["Job"] = relationship(back_populates="output_dataset_collection_instances")
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2533,13 +2533,15 @@ class ImplicitCollectionJobsJobAssociation(Base, RepresentById):
     __tablename__ = "implicit_collection_jobs_job_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    implicit_collection_jobs_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("implicit_collection_jobs.id"), index=True
+    implicit_collection_jobs_id: Mapped[int] = mapped_column(
+        ForeignKey("implicit_collection_jobs.id"), index=True, nullable=True
     )
-    job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)  # Consider making this nullable...
+    job_id: Mapped[int] = mapped_column(
+        ForeignKey("job.id"), index=True, nullable=True
+    )  # Consider making this nullable...
     order_index: Mapped[int]
     implicit_collection_jobs = relationship("ImplicitCollectionJobs", back_populates="jobs")
-    job: Mapped[Optional["Job"]] = relationship(back_populates="implicit_collection_jobs_association")
+    job: Mapped["Job"] = relationship(back_populates="implicit_collection_jobs_association")
 
 
 class PostJobAction(Base, RepresentById):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2338,7 +2338,7 @@ class JobToOutputDatasetAssociation(Base, RepresentById):
     id: Mapped[int] = mapped_column(primary_key=True)
     job_id: Mapped[int] = mapped_column(ForeignKey("job.id"), index=True, nullable=True)
     dataset_id: Mapped[int] = mapped_column(ForeignKey("history_dataset_association.id"), index=True, nullable=True)
-    name: Mapped[Optional[str]] = mapped_column(String(255))
+    name: Mapped[str] = mapped_column(String(255), nullable=True)
     dataset: Mapped["HistoryDatasetAssociation"] = relationship(
         lazy="joined", back_populates="creating_job_associations"
     )

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -10683,10 +10683,10 @@ class HistoryRatingAssociation(ItemRatingAssociation, RepresentById):
     __tablename__ = "history_rating_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
+    history_id: Mapped[int] = mapped_column(ForeignKey("history.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    rating: Mapped[Optional[int]] = mapped_column(index=True)
-    history: Mapped[Optional["History"]] = relationship(back_populates="ratings")
+    rating: Mapped[int] = mapped_column(index=True, nullable=True)
+    history: Mapped["History"] = relationship(back_populates="ratings")
     user: Mapped[Optional["User"]] = relationship()
 
     def _set_item(self, history):
@@ -10698,12 +10698,12 @@ class HistoryDatasetAssociationRatingAssociation(ItemRatingAssociation, Represen
     __tablename__ = "history_dataset_association_rating_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    history_dataset_association_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("history_dataset_association.id"), index=True
+    history_dataset_association_id: Mapped[int] = mapped_column(
+        ForeignKey("history_dataset_association.id"), index=True, nullable=True
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    rating: Mapped[Optional[int]] = mapped_column(index=True)
-    history_dataset_association: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(back_populates="ratings")
+    rating: Mapped[int] = mapped_column(index=True, nullable=True)
+    history_dataset_association: Mapped["HistoryDatasetAssociation"] = relationship(back_populates="ratings")
     user: Mapped[Optional["User"]] = relationship()
 
     def _set_item(self, history_dataset_association):
@@ -10715,10 +10715,10 @@ class StoredWorkflowRatingAssociation(ItemRatingAssociation, RepresentById):
     __tablename__ = "stored_workflow_rating_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    stored_workflow_id: Mapped[Optional[int]] = mapped_column(ForeignKey("stored_workflow.id"), index=True)
+    stored_workflow_id: Mapped[int] = mapped_column(ForeignKey("stored_workflow.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    rating: Mapped[Optional[int]] = mapped_column(index=True)
-    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship(back_populates="ratings")
+    rating: Mapped[int] = mapped_column(index=True, nullable=True)
+    stored_workflow: Mapped["StoredWorkflow"] = relationship(back_populates="ratings")
     user: Mapped[Optional["User"]] = relationship()
 
     def _set_item(self, stored_workflow):
@@ -10730,10 +10730,10 @@ class PageRatingAssociation(ItemRatingAssociation, RepresentById):
     __tablename__ = "page_rating_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    page_id: Mapped[Optional[int]] = mapped_column(ForeignKey("page.id"), index=True)
+    page_id: Mapped[int] = mapped_column(ForeignKey("page.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    rating: Mapped[Optional[int]] = mapped_column(index=True)
-    page: Mapped[Optional["Page"]] = relationship(back_populates="ratings")
+    rating: Mapped[int] = mapped_column(index=True, nullable=True)
+    page: Mapped["Page"] = relationship(back_populates="ratings")
     user: Mapped[Optional["User"]] = relationship()
 
     def _set_item(self, page):
@@ -10745,10 +10745,10 @@ class VisualizationRatingAssociation(ItemRatingAssociation, RepresentById):
     __tablename__ = "visualization_rating_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    visualization_id: Mapped[Optional[int]] = mapped_column(ForeignKey("visualization.id"), index=True)
+    visualization_id: Mapped[int] = mapped_column(ForeignKey("visualization.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    rating: Mapped[Optional[int]] = mapped_column(index=True)
-    visualization: Mapped[Optional["Visualization"]] = relationship(back_populates="ratings")
+    rating: Mapped[int] = mapped_column(index=True, nullable=True)
+    visualization: Mapped["Visualization"] = relationship(back_populates="ratings")
     user: Mapped[Optional["User"]] = relationship()
 
     def _set_item(self, visualization):
@@ -10760,12 +10760,12 @@ class HistoryDatasetCollectionRatingAssociation(ItemRatingAssociation, Represent
     __tablename__ = "history_dataset_collection_rating_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    history_dataset_collection_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("history_dataset_collection_association.id"), index=True
+    history_dataset_collection_id: Mapped[int] = mapped_column(
+        ForeignKey("history_dataset_collection_association.id"), index=True, nullable=True
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    rating: Mapped[Optional[int]] = mapped_column(index=True)
-    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(back_populates="ratings")
+    rating: Mapped[int] = mapped_column(index=True, nullable=True)
+    dataset_collection: Mapped["HistoryDatasetCollectionAssociation"] = relationship(back_populates="ratings")
     user: Mapped[Optional["User"]] = relationship()
 
     def _set_item(self, dataset_collection):
@@ -10777,12 +10777,12 @@ class LibraryDatasetCollectionRatingAssociation(ItemRatingAssociation, Represent
     __tablename__ = "library_dataset_collection_rating_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    library_dataset_collection_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("library_dataset_collection_association.id"), index=True
+    library_dataset_collection_id: Mapped[int] = mapped_column(
+        ForeignKey("library_dataset_collection_association.id"), index=True, nullable=True
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    rating: Mapped[Optional[int]] = mapped_column(index=True)
-    dataset_collection: Mapped[Optional["LibraryDatasetCollectionAssociation"]] = relationship(back_populates="ratings")
+    rating: Mapped[int] = mapped_column(index=True, nullable=True)
+    dataset_collection: Mapped["LibraryDatasetCollectionAssociation"] = relationship(back_populates="ratings")
     user: Mapped[Optional["User"]] = relationship()
 
     def _set_item(self, dataset_collection):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2328,13 +2328,13 @@ class JobToOutputDatasetAssociation(Base, RepresentById):
     __tablename__ = "job_to_output_dataset"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
-    dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_association.id"), index=True)
+    job_id: Mapped[int] = mapped_column(ForeignKey("job.id"), index=True, nullable=True)
+    dataset_id: Mapped[int] = mapped_column(ForeignKey("history_dataset_association.id"), index=True, nullable=True)
     name: Mapped[Optional[str]] = mapped_column(String(255))
-    dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
+    dataset: Mapped["HistoryDatasetAssociation"] = relationship(
         lazy="joined", back_populates="creating_job_associations"
     )
-    job: Mapped[Optional["Job"]] = relationship(back_populates="output_datasets")
+    job: Mapped["Job"] = relationship(back_populates="output_datasets")
 
     def __init__(self, name, dataset):
         self.name = name

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2759,13 +2759,13 @@ class JobContainerAssociation(Base, RepresentById):
     __tablename__ = "job_container_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
+    job_id: Mapped[int] = mapped_column(ForeignKey("job.id"), index=True, nullable=True)
     container_type: Mapped[Optional[str]] = mapped_column(TEXT)
     container_name: Mapped[Optional[str]] = mapped_column(TEXT)
     container_info: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
     created_time: Mapped[Optional[datetime]] = mapped_column(default=now)
     modified_time: Mapped[Optional[datetime]] = mapped_column(default=now, onupdate=now)
-    job: Mapped[Optional["Job"]] = relationship(back_populates="container")
+    job: Mapped["Job"] = relationship(back_populates="container")
 
     def __init__(self, **kwd):
         if "job" in kwd:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3587,10 +3587,10 @@ class HistoryUserShareAssociation(Base, UserShareAssociation):
     __tablename__ = "history_user_share_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
-    user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    user: Mapped[User] = relationship()
-    history: Mapped[Optional["History"]] = relationship(back_populates="users_shared_with")
+    history_id: Mapped[int] = mapped_column(ForeignKey("history.id"), index=True, nullable=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("galaxy_user.id"), index=True, nullable=True)
+    user: Mapped["User"] = relationship()
+    history: Mapped["History"] = relationship(back_populates="users_shared_with")
 
 
 class UserRoleAssociation(Base, RepresentById):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2941,14 +2941,14 @@ class UserNotificationAssociation(Base, RepresentById):
     __tablename__ = "user_notification_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    notification_id: Mapped[Optional[int]] = mapped_column(ForeignKey("notification.id"), index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("galaxy_user.id"), index=True, nullable=True)
+    notification_id: Mapped[int] = mapped_column(ForeignKey("notification.id"), index=True, nullable=True)
     seen_time: Mapped[Optional[datetime]]
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     update_time: Mapped[Optional[datetime]] = mapped_column(default=now, onupdate=now)
 
-    user: Mapped[Optional["User"]] = relationship(back_populates="all_notifications")
-    notification: Mapped[Optional["Notification"]] = relationship(back_populates="user_notification_associations")
+    user: Mapped["User"] = relationship(back_populates="all_notifications")
+    notification: Mapped["Notification"] = relationship(back_populates="user_notification_associations")
 
     def __init__(self, user, notification):
         self.user = user

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -10357,10 +10357,10 @@ class VisualizationUserShareAssociation(Base, UserShareAssociation):
     __tablename__ = "visualization_user_share_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    visualization_id: Mapped[Optional[int]] = mapped_column(ForeignKey("visualization.id"), index=True)
-    user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
+    visualization_id: Mapped[int] = mapped_column(ForeignKey("visualization.id"), index=True, nullable=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("galaxy_user.id"), index=True, nullable=True)
     user: Mapped[User] = relationship()
-    visualization: Mapped[Optional["Visualization"]] = relationship(back_populates="users_shared_with")
+    visualization: Mapped["Visualization"] = relationship(back_populates="users_shared_with")
 
 
 class Tag(Base, RepresentById):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2443,11 +2443,13 @@ class JobToOutputLibraryDatasetAssociation(Base, RepresentById):
     __tablename__ = "job_to_output_library_dataset"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
-    ldda_id: Mapped[Optional[int]] = mapped_column(ForeignKey("library_dataset_dataset_association.id"), index=True)
+    job_id: Mapped[int] = mapped_column(ForeignKey("job.id"), index=True, nullable=True)
+    ldda_id: Mapped[int] = mapped_column(
+        ForeignKey("library_dataset_dataset_association.id"), index=True, nullable=True
+    )
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
-    job: Mapped[Optional["Job"]] = relationship(back_populates="output_library_datasets")
-    dataset: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
+    job: Mapped["Job"] = relationship(back_populates="output_library_datasets")
+    dataset: Mapped["LibraryDatasetDatasetAssociation"] = relationship(
         lazy="joined", back_populates="creating_job_associations"
     )
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2313,7 +2313,7 @@ class JobToInputDatasetAssociation(Base, RepresentById):
     job_id: Mapped[int] = mapped_column(ForeignKey("job.id"), index=True, nullable=True)
     dataset_id: Mapped[int] = mapped_column(ForeignKey("history_dataset_association.id"), index=True, nullable=True)
     dataset_version: Mapped[Optional[int]]
-    name: Mapped[Optional[str]] = mapped_column(String(255))
+    name: Mapped[str] = mapped_column(String(255), nullable=True)
     dataset: Mapped["HistoryDatasetAssociation"] = relationship(lazy="joined", back_populates="dependent_jobs")
     job: Mapped["Job"] = relationship(back_populates="input_datasets")
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2367,13 +2367,13 @@ class JobToInputDatasetCollectionElementAssociation(Base, RepresentById):
     __tablename__ = "job_to_input_dataset_collection_element"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
-    dataset_collection_element_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("dataset_collection_element.id"), index=True
+    job_id: Mapped[int] = mapped_column(ForeignKey("job.id"), index=True, nullable=True)
+    dataset_collection_element_id: Mapped[int] = mapped_column(
+        ForeignKey("dataset_collection_element.id"), index=True, nullable=True
     )
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
-    dataset_collection_element: Mapped[Optional["DatasetCollectionElement"]] = relationship(lazy="joined")
-    job: Mapped[Optional["Job"]] = relationship(back_populates="input_dataset_collection_elements")
+    dataset_collection_element: Mapped["DatasetCollectionElement"] = relationship(lazy="joined")
+    job: Mapped["Job"] = relationship(back_populates="input_dataset_collection_elements")
 
     def __init__(self, name, dataset_collection_element):
         self.name = name

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7455,12 +7455,6 @@ class GalaxySessionToHistoryAssociation(Base, RepresentById):
         self.history = history
 
 
-class UCI:
-    def __init__(self):
-        self.id = None
-        self.user = None
-
-
 class StoredWorkflow(Base, HasTags, Dictifiable, RepresentById):
     """
     StoredWorkflow represents the root node of a tree of objects that compose a workflow, including workflow revisions, steps, and subworkflows.

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3697,12 +3697,12 @@ class GroupQuotaAssociation(Base, Dictifiable, RepresentById):
     __tablename__ = "group_quota_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    group_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_group.id"), index=True)
-    quota_id: Mapped[Optional[int]] = mapped_column(ForeignKey("quota.id"), index=True)
+    group_id: Mapped[int] = mapped_column(ForeignKey("galaxy_group.id"), index=True, nullable=True)
+    quota_id: Mapped[int] = mapped_column(ForeignKey("quota.id"), index=True, nullable=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
-    group: Mapped[Optional["Group"]] = relationship(back_populates="quotas")
-    quota: Mapped[Optional["Quota"]] = relationship(back_populates="groups")
+    group: Mapped["Group"] = relationship(back_populates="quotas")
+    quota: Mapped["Quota"] = relationship(back_populates="groups")
 
     dict_element_visible_keys = ["group"]
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1413,7 +1413,9 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     post_job_actions: Mapped[List["PostJobActionAssociation"]] = relationship(
         back_populates="job", cascade_backrefs=False
     )
-    input_library_datasets = relationship("JobToInputLibraryDatasetAssociation", back_populates="job")
+    input_library_datasets: Mapped[List["JobToInputLibraryDatasetAssociation"]] = relationship(
+        "JobToInputLibraryDatasetAssociation", back_populates="job"
+    )
     output_library_datasets = relationship("JobToOutputLibraryDatasetAssociation", back_populates="job")
     external_output_metadata: Mapped[List["JobExternalOutputMetadata"]] = relationship(back_populates="job")
     tasks: Mapped[List["Task"]] = relationship(back_populates="job")
@@ -2433,7 +2435,7 @@ class JobToInputLibraryDatasetAssociation(Base, RepresentById):
     ldda_id: Mapped[int] = mapped_column(
         ForeignKey("library_dataset_dataset_association.id"), index=True, nullable=True
     )
-    name: Mapped[Optional[str]] = mapped_column(Unicode(255))
+    name: Mapped[str] = mapped_column(Unicode(255), nullable=True)
     job: Mapped["Job"] = relationship(back_populates="input_library_datasets")
     dataset: Mapped["LibraryDatasetDatasetAssociation"] = relationship(lazy="joined", back_populates="dependent_jobs")
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1416,7 +1416,9 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     input_library_datasets: Mapped[List["JobToInputLibraryDatasetAssociation"]] = relationship(
         "JobToInputLibraryDatasetAssociation", back_populates="job"
     )
-    output_library_datasets = relationship("JobToOutputLibraryDatasetAssociation", back_populates="job")
+    output_library_datasets: Mapped[List["JobToOutputLibraryDatasetAssociation"]] = relationship(
+        "JobToOutputLibraryDatasetAssociation", back_populates="job"
+    )
     external_output_metadata: Mapped[List["JobExternalOutputMetadata"]] = relationship(back_populates="job")
     tasks: Mapped[List["Task"]] = relationship(back_populates="job")
     output_datasets = relationship("JobToOutputDatasetAssociation", back_populates="job")
@@ -2453,7 +2455,7 @@ class JobToOutputLibraryDatasetAssociation(Base, RepresentById):
     ldda_id: Mapped[int] = mapped_column(
         ForeignKey("library_dataset_dataset_association.id"), index=True, nullable=True
     )
-    name: Mapped[Optional[str]] = mapped_column(Unicode(255))
+    name: Mapped[str] = mapped_column(Unicode(255), nullable=True)
     job: Mapped["Job"] = relationship(back_populates="output_library_datasets")
     dataset: Mapped["LibraryDatasetDatasetAssociation"] = relationship(
         lazy="joined", back_populates="creating_job_associations"

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -735,33 +735,27 @@ class User(Base, Dictifiable, RepresentById):
     activation_token: Mapped[Optional[str]] = mapped_column(TrimmedString(64), index=True)
 
     addresses: Mapped[List["UserAddress"]] = relationship(
-        "UserAddress", back_populates="user", order_by=lambda: desc(UserAddress.update_time), cascade_backrefs=False
+        back_populates="user", order_by=lambda: desc(UserAddress.update_time), cascade_backrefs=False
     )
-    cloudauthz: Mapped[List["CloudAuthz"]] = relationship("CloudAuthz", back_populates="user")
-    custos_auth: Mapped[List["CustosAuthnzToken"]] = relationship("CustosAuthnzToken", back_populates="user")
-    default_permissions: Mapped[List["DefaultUserPermissions"]] = relationship(
-        "DefaultUserPermissions", back_populates="user"
-    )
-    groups: Mapped[List["UserGroupAssociation"]] = relationship("UserGroupAssociation", back_populates="user")
+    cloudauthz: Mapped[List["CloudAuthz"]] = relationship(back_populates="user")
+    custos_auth: Mapped[List["CustosAuthnzToken"]] = relationship(back_populates="user")
+    default_permissions: Mapped[List["DefaultUserPermissions"]] = relationship(back_populates="user")
+    groups: Mapped[List["UserGroupAssociation"]] = relationship(back_populates="user")
     histories: Mapped[List["History"]] = relationship(
-        "History", back_populates="user", order_by=lambda: desc(History.update_time), cascade_backrefs=False  # type: ignore[has-type]
+        back_populates="user", order_by=lambda: desc(History.update_time), cascade_backrefs=False  # type: ignore[has-type]
     )
     active_histories: Mapped[List["History"]] = relationship(
-        "History",
         primaryjoin=(lambda: (History.user_id == User.id) & (not_(History.deleted)) & (not_(History.archived))),  # type: ignore[has-type]
         viewonly=True,
         order_by=lambda: desc(History.update_time),  # type: ignore[has-type]
     )
     galaxy_sessions: Mapped[List["GalaxySession"]] = relationship(
-        "GalaxySession", back_populates="user", order_by=lambda: desc(GalaxySession.update_time), cascade_backrefs=False  # type: ignore[has-type]
+        back_populates="user", order_by=lambda: desc(GalaxySession.update_time), cascade_backrefs=False  # type: ignore[has-type]
     )
-    quotas: Mapped[List["UserQuotaAssociation"]] = relationship("UserQuotaAssociation", back_populates="user")
-    quota_source_usages: Mapped[List["UserQuotaSourceUsage"]] = relationship(
-        "UserQuotaSourceUsage", back_populates="user"
-    )
-    social_auth: Mapped[List["UserAuthnzToken"]] = relationship("UserAuthnzToken", back_populates="user")
+    quotas: Mapped[List["UserQuotaAssociation"]] = relationship(back_populates="user")
+    quota_source_usages: Mapped[List["UserQuotaSourceUsage"]] = relationship(back_populates="user")
+    social_auth: Mapped[List["UserAuthnzToken"]] = relationship(back_populates="user")
     stored_workflow_menu_entries: Mapped[List["StoredWorkflowMenuEntry"]] = relationship(
-        "StoredWorkflowMenuEntry",
         primaryjoin=(
             lambda: (StoredWorkflowMenuEntry.user_id == User.id)
             & (StoredWorkflowMenuEntry.stored_workflow_id == StoredWorkflow.id)  # type: ignore[has-type]
@@ -771,15 +765,12 @@ class User(Base, Dictifiable, RepresentById):
         cascade="all, delete-orphan",
         collection_class=ordering_list("order_index"),
     )
-    _preferences: Mapped[Dict[str, "UserPreference"]] = relationship(
-        "UserPreference", collection_class=attribute_keyed_dict("name")
-    )
+    _preferences: Mapped[Dict[str, "UserPreference"]] = relationship(collection_class=attribute_keyed_dict("name"))
     values: Mapped[List["FormValues"]] = relationship(
-        "FormValues", primaryjoin=(lambda: User.form_values_id == FormValues.id)  # type: ignore[has-type]
+        primaryjoin=(lambda: User.form_values_id == FormValues.id)  # type: ignore[has-type]
     )
     # Add type hint (will this work w/SA?)
     api_keys: Mapped[List["APIKeys"]] = relationship(
-        "APIKeys",
         back_populates="user",
         order_by=lambda: desc(APIKeys.create_time),
         primaryjoin=(
@@ -789,21 +780,17 @@ class User(Base, Dictifiable, RepresentById):
             )
         ),
     )
-    data_manager_histories: Mapped[List["DataManagerHistoryAssociation"]] = relationship(
-        "DataManagerHistoryAssociation", back_populates="user"
-    )
-    roles: Mapped[List["UserRoleAssociation"]] = relationship("UserRoleAssociation", back_populates="user")
+    data_manager_histories: Mapped[List["DataManagerHistoryAssociation"]] = relationship(back_populates="user")
+    roles: Mapped[List["UserRoleAssociation"]] = relationship(back_populates="user")
     stored_workflows: Mapped[List["StoredWorkflow"]] = relationship(
-        "StoredWorkflow",
         back_populates="user",
         primaryjoin=(lambda: User.id == StoredWorkflow.user_id),  # type: ignore[has-type]
         cascade_backrefs=False,
     )
     all_notifications: Mapped[List["UserNotificationAssociation"]] = relationship(
-        "UserNotificationAssociation", back_populates="user", cascade_backrefs=False
+        back_populates="user", cascade_backrefs=False
     )
     non_private_roles: Mapped[List["UserRoleAssociation"]] = relationship(
-        "UserRoleAssociation",
         viewonly=True,
         primaryjoin=(
             lambda: (User.id == UserRoleAssociation.user_id)  # type: ignore[has-type]
@@ -1269,7 +1256,7 @@ class PasswordResetToken(Base):
     token: Mapped[str] = mapped_column(String(32), primary_key=True, unique=True, index=True)
     expiration_time: Mapped[Optional[datetime]]
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    user: Mapped[Optional["User"]] = relationship("User")
+    user: Mapped[Optional["User"]] = relationship()
 
     def __init__(self, user, token=None):
         if token:
@@ -1407,10 +1394,10 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     preferred_object_store_id: Mapped[Optional[str]] = mapped_column(String(255))
     object_store_id_overrides: Mapped[Optional[bytes]] = mapped_column(JSONType)
 
-    user: Mapped[Optional["User"]] = relationship("User")
-    galaxy_session: Mapped[Optional["GalaxySession"]] = relationship("GalaxySession")
-    history: Mapped[Optional["History"]] = relationship("History", back_populates="jobs")
-    library_folder: Mapped[Optional["LibraryFolder"]] = relationship("LibraryFolder")
+    user: Mapped[Optional["User"]] = relationship()
+    galaxy_session: Mapped[Optional["GalaxySession"]] = relationship()
+    history: Mapped[Optional["History"]] = relationship(back_populates="jobs")
+    library_folder: Mapped[Optional["LibraryFolder"]] = relationship()
     parameters = relationship("JobParameter")
     input_datasets = relationship("JobToInputDatasetAssociation", back_populates="job")
     input_dataset_collections = relationship("JobToInputDatasetCollectionAssociation", back_populates="job")
@@ -1420,20 +1407,18 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     output_dataset_collection_instances = relationship("JobToOutputDatasetCollectionAssociation", back_populates="job")
     output_dataset_collections = relationship("JobToImplicitOutputDatasetCollectionAssociation", back_populates="job")
     post_job_actions: Mapped[List["PostJobActionAssociation"]] = relationship(
-        "PostJobActionAssociation", back_populates="job", cascade_backrefs=False
+        back_populates="job", cascade_backrefs=False
     )
     input_library_datasets = relationship("JobToInputLibraryDatasetAssociation", back_populates="job")
     output_library_datasets = relationship("JobToOutputLibraryDatasetAssociation", back_populates="job")
-    external_output_metadata: Mapped[List["JobExternalOutputMetadata"]] = relationship(
-        "JobExternalOutputMetadata", back_populates="job"
-    )
-    tasks: Mapped[List["Task"]] = relationship("Task", back_populates="job")
+    external_output_metadata: Mapped[List["JobExternalOutputMetadata"]] = relationship(back_populates="job")
+    tasks: Mapped[List["Task"]] = relationship(back_populates="job")
     output_datasets = relationship("JobToOutputDatasetAssociation", back_populates="job")
-    state_history: Mapped[List["JobStateHistory"]] = relationship("JobStateHistory")
-    text_metrics: Mapped[List["JobMetricText"]] = relationship("JobMetricText")
-    numeric_metrics: Mapped[List["JobMetricNumeric"]] = relationship("JobMetricNumeric")
+    state_history: Mapped[List["JobStateHistory"]] = relationship()
+    text_metrics: Mapped[List["JobMetricText"]] = relationship()
+    numeric_metrics: Mapped[List["JobMetricNumeric"]] = relationship()
     interactivetool_entry_points: Mapped[List["InteractiveToolEntryPoint"]] = relationship(
-        "InteractiveToolEntryPoint", back_populates="job", uselist=True
+        back_populates="job", uselist=True
     )
     implicit_collection_jobs_association = relationship(
         "ImplicitCollectionJobsJobAssociation", back_populates="job", uselist=False, cascade_backrefs=False
@@ -2159,9 +2144,9 @@ class Task(Base, JobLike, RepresentById):
     task_runner_name: Mapped[Optional[str]] = mapped_column(String(255))
     task_runner_external_id: Mapped[Optional[str]] = mapped_column(String(255))
     prepare_input_files_cmd: Mapped[Optional[str]] = mapped_column(TEXT)
-    job: Mapped["Job"] = relationship("Job", back_populates="tasks")
-    text_metrics: Mapped[List["TaskMetricText"]] = relationship("TaskMetricText")
-    numeric_metrics: Mapped[List["TaskMetricNumeric"]] = relationship("TaskMetricNumeric")
+    job: Mapped["Job"] = relationship(back_populates="tasks")
+    text_metrics: Mapped[List["TaskMetricText"]] = relationship()
+    numeric_metrics: Mapped[List["TaskMetricNumeric"]] = relationship()
 
     _numeric_metric = TaskMetricNumeric
     _text_metric = TaskMetricText
@@ -2330,9 +2315,9 @@ class JobToInputDatasetAssociation(Base, RepresentById):
     dataset_version: Mapped[Optional[int]]
     name: Mapped[Optional[str]] = mapped_column(String(255))
     dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
-        "HistoryDatasetAssociation", lazy="joined", back_populates="dependent_jobs"
+        lazy="joined", back_populates="dependent_jobs"
     )
-    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="input_datasets")
+    job: Mapped[Optional["Job"]] = relationship(back_populates="input_datasets")
 
     def __init__(self, name, dataset):
         self.name = name
@@ -2349,9 +2334,9 @@ class JobToOutputDatasetAssociation(Base, RepresentById):
     dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_association.id"), index=True)
     name: Mapped[Optional[str]] = mapped_column(String(255))
     dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
-        "HistoryDatasetAssociation", lazy="joined", back_populates="creating_job_associations"
+        lazy="joined", back_populates="creating_job_associations"
     )
-    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="output_datasets")
+    job: Mapped[Optional["Job"]] = relationship(back_populates="output_datasets")
 
     def __init__(self, name, dataset):
         self.name = name
@@ -2372,10 +2357,8 @@ class JobToInputDatasetCollectionAssociation(Base, RepresentById):
         ForeignKey("history_dataset_collection_association.id"), index=True
     )
     name: Mapped[Optional[str]] = mapped_column(String(255))
-    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
-        "HistoryDatasetCollectionAssociation", lazy="joined"
-    )
-    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="input_dataset_collections")
+    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(lazy="joined")
+    job: Mapped[Optional["Job"]] = relationship(back_populates="input_dataset_collections")
 
     def __init__(self, name, dataset_collection):
         self.name = name
@@ -2391,10 +2374,8 @@ class JobToInputDatasetCollectionElementAssociation(Base, RepresentById):
         ForeignKey("dataset_collection_element.id"), index=True
     )
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
-    dataset_collection_element: Mapped[Optional["DatasetCollectionElement"]] = relationship(
-        "DatasetCollectionElement", lazy="joined"
-    )
-    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="input_dataset_collection_elements")
+    dataset_collection_element: Mapped[Optional["DatasetCollectionElement"]] = relationship(lazy="joined")
+    job: Mapped[Optional["Job"]] = relationship(back_populates="input_dataset_collection_elements")
 
     def __init__(self, name, dataset_collection_element):
         self.name = name
@@ -2412,10 +2393,8 @@ class JobToOutputDatasetCollectionAssociation(Base, RepresentById):
         ForeignKey("history_dataset_collection_association.id"), index=True
     )
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
-    dataset_collection_instance: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
-        "HistoryDatasetCollectionAssociation", lazy="joined"
-    )
-    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="output_dataset_collection_instances")
+    dataset_collection_instance: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(lazy="joined")
+    job: Mapped[Optional["Job"]] = relationship(back_populates="output_dataset_collection_instances")
 
     def __init__(self, name, dataset_collection_instance):
         self.name = name
@@ -2436,8 +2415,8 @@ class JobToImplicitOutputDatasetCollectionAssociation(Base, RepresentById):
     job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
     dataset_collection_id: Mapped[Optional[int]] = mapped_column(ForeignKey("dataset_collection.id"), index=True)
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
-    dataset_collection: Mapped[Optional["DatasetCollection"]] = relationship("DatasetCollection")
-    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="output_dataset_collections")
+    dataset_collection: Mapped[Optional["DatasetCollection"]] = relationship()
+    job: Mapped[Optional["Job"]] = relationship(back_populates="output_dataset_collections")
 
     def __init__(self, name, dataset_collection):
         self.name = name
@@ -2451,9 +2430,9 @@ class JobToInputLibraryDatasetAssociation(Base, RepresentById):
     job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
     ldda_id: Mapped[Optional[int]] = mapped_column(ForeignKey("library_dataset_dataset_association.id"), index=True)
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
-    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="input_library_datasets")
+    job: Mapped[Optional["Job"]] = relationship(back_populates="input_library_datasets")
     dataset: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
-        "LibraryDatasetDatasetAssociation", lazy="joined", back_populates="dependent_jobs"
+        lazy="joined", back_populates="dependent_jobs"
     )
 
     def __init__(self, name, dataset):
@@ -2469,9 +2448,9 @@ class JobToOutputLibraryDatasetAssociation(Base, RepresentById):
     job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
     ldda_id: Mapped[Optional[int]] = mapped_column(ForeignKey("library_dataset_dataset_association.id"), index=True)
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
-    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="output_library_datasets")
+    job: Mapped[Optional["Job"]] = relationship(back_populates="output_library_datasets")
     dataset: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
-        "LibraryDatasetDatasetAssociation", lazy="joined", back_populates="creating_job_associations"
+        lazy="joined", back_populates="creating_job_associations"
     )
 
     def __init__(self, name, dataset):
@@ -2508,7 +2487,6 @@ class ImplicitlyCreatedDatasetCollectionInput(Base, RepresentById):
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
 
     input_dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
-        "HistoryDatasetCollectionAssociation",
         primaryjoin=(
             lambda: HistoryDatasetCollectionAssociation.id  # type: ignore[has-type]
             == ImplicitlyCreatedDatasetCollectionInput.input_dataset_collection_id
@@ -2526,7 +2504,7 @@ class ImplicitCollectionJobs(Base, Serializable):
     id: Mapped[int] = mapped_column(primary_key=True)
     populated_state: Mapped[str] = mapped_column(TrimmedString(64), default="new")
     jobs: Mapped[List["ImplicitCollectionJobsJobAssociation"]] = relationship(
-        "ImplicitCollectionJobsJobAssociation", back_populates="implicit_collection_jobs", cascade_backrefs=False
+        back_populates="implicit_collection_jobs", cascade_backrefs=False
     )
 
     class populated_states(str, Enum):
@@ -2561,7 +2539,7 @@ class ImplicitCollectionJobsJobAssociation(Base, RepresentById):
     job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)  # Consider making this nullable...
     order_index: Mapped[int]
     implicit_collection_jobs = relationship("ImplicitCollectionJobs", back_populates="jobs")
-    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="implicit_collection_jobs_association")
+    job: Mapped[Optional["Job"]] = relationship(back_populates="implicit_collection_jobs_association")
 
 
 class PostJobAction(Base, RepresentById):
@@ -2573,7 +2551,6 @@ class PostJobAction(Base, RepresentById):
     output_name: Mapped[Optional[str]] = mapped_column(String(255))
     action_arguments: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
     workflow_step: Mapped[Optional["WorkflowStep"]] = relationship(
-        "WorkflowStep",
         back_populates="post_job_actions",
         primaryjoin=(lambda: WorkflowStep.id == PostJobAction.workflow_step_id),  # type: ignore[has-type]
     )
@@ -2592,8 +2569,8 @@ class PostJobActionAssociation(Base, RepresentById):
     id: Mapped[int] = mapped_column(primary_key=True)
     job_id: Mapped[int] = mapped_column(ForeignKey("job.id"), index=True)
     post_job_action_id: Mapped[int] = mapped_column(ForeignKey("post_job_action.id"), index=True)
-    post_job_action: Mapped["PostJobAction"] = relationship("PostJobAction")
-    job: Mapped["Job"] = relationship("Job", back_populates="post_job_actions")
+    post_job_action: Mapped["PostJobAction"] = relationship()
+    job: Mapped["Job"] = relationship(back_populates="post_job_actions")
 
     def __init__(self, pja, job=None, job_id=None):
         if job is not None:
@@ -2624,13 +2601,11 @@ class JobExternalOutputMetadata(Base, RepresentById):
     filename_kwds: Mapped[Optional[str]] = mapped_column(String(255))
     filename_override_metadata: Mapped[Optional[str]] = mapped_column(String(255))
     job_runner_external_pid: Mapped[Optional[str]] = mapped_column(String(255))
-    history_dataset_association: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
-        "HistoryDatasetAssociation", lazy="joined"
-    )
+    history_dataset_association: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(lazy="joined")
     library_dataset_dataset_association: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
-        "LibraryDatasetDatasetAssociation", lazy="joined"
+        lazy="joined"
     )
-    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="external_output_metadata")
+    job: Mapped[Optional["Job"]] = relationship(back_populates="external_output_metadata")
 
     def __init__(self, job=None, dataset=None):
         add_object_to_object_session(self, job)
@@ -2676,9 +2651,9 @@ class JobExportHistoryArchive(Base, RepresentById):
     dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("dataset.id"), index=True)
     compressed: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     history_attrs_filename: Mapped[Optional[str]] = mapped_column(TEXT)
-    job: Mapped[Optional["Job"]] = relationship("Job")
-    dataset: Mapped[Optional["Dataset"]] = relationship("Dataset")
-    history: Mapped[Optional["History"]] = relationship("History", back_populates="exports")
+    job: Mapped[Optional["Job"]] = relationship()
+    dataset: Mapped[Optional["Dataset"]] = relationship()
+    history: Mapped[Optional["History"]] = relationship(back_populates="exports")
 
     ATTRS_FILENAME_HISTORY = "history_attrs.txt"
 
@@ -2762,8 +2737,8 @@ class JobImportHistoryArchive(Base, RepresentById):
     job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
     history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
     archive_dir: Mapped[Optional[str]] = mapped_column(TEXT)
-    job: Mapped[Optional["Job"]] = relationship("Job")
-    history: Mapped[Optional["History"]] = relationship("History")
+    job: Mapped[Optional["Job"]] = relationship()
+    history: Mapped[Optional["History"]] = relationship()
 
 
 class StoreExportAssociation(Base, RepresentById):
@@ -2788,7 +2763,7 @@ class JobContainerAssociation(Base, RepresentById):
     container_info: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
     created_time: Mapped[Optional[datetime]] = mapped_column(default=now)
     modified_time: Mapped[Optional[datetime]] = mapped_column(default=now, onupdate=now)
-    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="container")
+    job: Mapped[Optional["Job"]] = relationship(back_populates="container")
 
     def __init__(self, **kwd):
         if "job" in kwd:
@@ -2818,7 +2793,7 @@ class InteractiveToolEntryPoint(Base, Dictifiable, RepresentById):
     created_time: Mapped[Optional[datetime]] = mapped_column(default=now)
     modified_time: Mapped[Optional[datetime]] = mapped_column(default=now, onupdate=now)
     label: Mapped[Optional[str]] = mapped_column(TEXT)
-    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="interactivetool_entry_points", uselist=False)
+    job: Mapped[Optional["Job"]] = relationship(back_populates="interactivetool_entry_points", uselist=False)
 
     dict_collection_visible_keys = [
         "id",
@@ -2884,9 +2859,9 @@ class GenomeIndexToolData(Base, RepresentById):  # TODO: params arg is lost
     modified_time: Mapped[Optional[datetime]] = mapped_column(default=now, onupdate=now)
     indexer: Mapped[Optional[str]] = mapped_column(String(64))
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    job: Mapped[Optional["Job"]] = relationship("Job")
-    dataset: Mapped[Optional["Dataset"]] = relationship("Dataset")
-    user: Mapped[Optional["User"]] = relationship("User")
+    job: Mapped[Optional["Job"]] = relationship()
+    dataset: Mapped[Optional["Dataset"]] = relationship()
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class Group(Base, Dictifiable, RepresentById):
@@ -2897,10 +2872,8 @@ class Group(Base, Dictifiable, RepresentById):
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
     name: Mapped[Optional[str]] = mapped_column(String(255), index=True, unique=True)
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
-    quotas: Mapped[List["GroupQuotaAssociation"]] = relationship("GroupQuotaAssociation", back_populates="group")
-    roles: Mapped[List["GroupRoleAssociation"]] = relationship(
-        "GroupRoleAssociation", back_populates="group", cascade_backrefs=False
-    )
+    quotas: Mapped[List["GroupQuotaAssociation"]] = relationship(back_populates="group")
+    roles: Mapped[List["GroupRoleAssociation"]] = relationship(back_populates="group", cascade_backrefs=False)
     users = relationship("UserGroupAssociation", back_populates="group")
 
     dict_collection_visible_keys = ["id", "name"]
@@ -2919,8 +2892,8 @@ class UserGroupAssociation(Base, RepresentById):
     group_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_group.id"), index=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
-    user: Mapped[Optional["User"]] = relationship("User", back_populates="groups")
-    group: Mapped[Optional["Group"]] = relationship("Group", back_populates="users")
+    user: Mapped[Optional["User"]] = relationship(back_populates="groups")
+    group: Mapped[Optional["Group"]] = relationship(back_populates="users")
 
     def __init__(self, user, group):
         add_object_to_object_session(self, user)
@@ -2952,7 +2925,7 @@ class Notification(Base, Dictifiable, RepresentById):
     content: Mapped[Optional[bytes]] = mapped_column(DoubleEncodedJsonType)
 
     user_notification_associations: Mapped[List["UserNotificationAssociation"]] = relationship(
-        "UserNotificationAssociation", back_populates="notification"
+        back_populates="notification"
     )
 
     def __init__(self, source: str, category: str, variant: str, content):
@@ -2972,10 +2945,8 @@ class UserNotificationAssociation(Base, RepresentById):
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     update_time: Mapped[Optional[datetime]] = mapped_column(default=now, onupdate=now)
 
-    user: Mapped[Optional["User"]] = relationship("User", back_populates="all_notifications")
-    notification: Mapped[Optional["Notification"]] = relationship(
-        "Notification", back_populates="user_notification_associations"
-    )
+    user: Mapped[Optional["User"]] = relationship(back_populates="all_notifications")
+    notification: Mapped[Optional["Notification"]] = relationship(back_populates="user_notification_associations")
 
     def __init__(self, user, notification):
         self.user = user
@@ -3054,16 +3025,14 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
     archive_export_id: Mapped[Optional[int]] = mapped_column(ForeignKey("store_export_association.id"), default=None)
 
     datasets: Mapped[List["HistoryDatasetAssociation"]] = relationship(
-        "HistoryDatasetAssociation", back_populates="history", cascade_backrefs=False, order_by=lambda: asc(HistoryDatasetAssociation.hid)  # type: ignore[has-type]
+        back_populates="history", cascade_backrefs=False, order_by=lambda: asc(HistoryDatasetAssociation.hid)  # type: ignore[has-type]
     )
     exports: Mapped[List["JobExportHistoryArchive"]] = relationship(
-        "JobExportHistoryArchive",
         back_populates="history",
         primaryjoin=lambda: JobExportHistoryArchive.history_id == History.id,
         order_by=lambda: desc(JobExportHistoryArchive.id),
     )
     active_datasets: Mapped[List["HistoryDatasetAssociation"]] = relationship(
-        "HistoryDatasetAssociation",
         primaryjoin=(
             lambda: and_(
                 HistoryDatasetAssociation.history_id == History.id,  # type: ignore[arg-type]
@@ -3073,11 +3042,8 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
         order_by=lambda: asc(HistoryDatasetAssociation.hid),  # type: ignore[has-type]
         viewonly=True,
     )
-    dataset_collections: Mapped[List["HistoryDatasetCollectionAssociation"]] = relationship(
-        "HistoryDatasetCollectionAssociation", back_populates="history"
-    )
+    dataset_collections: Mapped[List["HistoryDatasetCollectionAssociation"]] = relationship(back_populates="history")
     active_dataset_collections: Mapped[List["HistoryDatasetCollectionAssociation"]] = relationship(
-        "HistoryDatasetCollectionAssociation",
         primaryjoin=(
             lambda: (
                 and_(
@@ -3090,7 +3056,6 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
         viewonly=True,
     )
     visible_datasets: Mapped[List["HistoryDatasetAssociation"]] = relationship(
-        "HistoryDatasetAssociation",
         primaryjoin=(
             lambda: and_(
                 HistoryDatasetAssociation.history_id == History.id,  # type: ignore[arg-type]
@@ -3102,7 +3067,6 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
         viewonly=True,
     )
     visible_dataset_collections: Mapped[List["HistoryDatasetCollectionAssociation"]] = relationship(
-        "HistoryDatasetCollectionAssociation",
         primaryjoin=(
             lambda: and_(
                 HistoryDatasetCollectionAssociation.history_id == History.id,  # type: ignore[has-type]
@@ -3114,28 +3078,23 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
         viewonly=True,
     )
     tags: Mapped[List["HistoryTagAssociation"]] = relationship(
-        "HistoryTagAssociation", order_by=lambda: HistoryTagAssociation.id, back_populates="history"
+        order_by=lambda: HistoryTagAssociation.id, back_populates="history"
     )
     annotations: Mapped[List["HistoryAnnotationAssociation"]] = relationship(
-        "HistoryAnnotationAssociation", order_by=lambda: HistoryAnnotationAssociation.id, back_populates="history"
+        order_by=lambda: HistoryAnnotationAssociation.id, back_populates="history"
     )
     ratings: Mapped[List["HistoryRatingAssociation"]] = relationship(
-        "HistoryRatingAssociation",
         order_by=lambda: HistoryRatingAssociation.id,  # type: ignore[has-type]
         back_populates="history",
     )
-    default_permissions: Mapped[List["DefaultHistoryPermissions"]] = relationship(
-        "DefaultHistoryPermissions", back_populates="history"
-    )
-    users_shared_with: Mapped[List["HistoryUserShareAssociation"]] = relationship(
-        "HistoryUserShareAssociation", back_populates="history"
-    )
+    default_permissions: Mapped[List["DefaultHistoryPermissions"]] = relationship(back_populates="history")
+    users_shared_with: Mapped[List["HistoryUserShareAssociation"]] = relationship(back_populates="history")
     galaxy_sessions = relationship("GalaxySessionToHistoryAssociation", back_populates="history")
     workflow_invocations: Mapped[List["WorkflowInvocation"]] = relationship(
-        "WorkflowInvocation", back_populates="history", cascade_backrefs=False
+        back_populates="history", cascade_backrefs=False
     )
-    user: Mapped[Optional["User"]] = relationship("User", back_populates="histories")
-    jobs: Mapped[List["Job"]] = relationship("Job", back_populates="history", cascade_backrefs=False)
+    user: Mapped[Optional["User"]] = relationship(back_populates="histories")
+    jobs: Mapped[List["Job"]] = relationship(back_populates="history", cascade_backrefs=False)
 
     update_time = column_property(
         select(func.max(HistoryAudit.update_time)).where(HistoryAudit.history_id == id).scalar_subquery(),
@@ -3628,8 +3587,8 @@ class HistoryUserShareAssociation(Base, UserShareAssociation):
     id: Mapped[int] = mapped_column(primary_key=True)
     history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    user: Mapped[User] = relationship("User")
-    history: Mapped[Optional["History"]] = relationship("History", back_populates="users_shared_with")
+    user: Mapped[User] = relationship()
+    history: Mapped[Optional["History"]] = relationship(back_populates="users_shared_with")
 
 
 class UserRoleAssociation(Base, RepresentById):
@@ -3641,8 +3600,8 @@ class UserRoleAssociation(Base, RepresentById):
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
 
-    user: Mapped[Optional["User"]] = relationship("User", back_populates="roles")
-    role: Mapped[Optional["Role"]] = relationship("Role", back_populates="users")
+    user: Mapped[Optional["User"]] = relationship(back_populates="roles")
+    role: Mapped[Optional["Role"]] = relationship(back_populates="users")
 
     def __init__(self, user, role):
         add_object_to_object_session(self, user)
@@ -3658,8 +3617,8 @@ class GroupRoleAssociation(Base, RepresentById):
     role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
-    group: Mapped[Optional["Group"]] = relationship("Group", back_populates="roles")
-    role: Mapped[Optional["Role"]] = relationship("Role", back_populates="groups")
+    group: Mapped[Optional["Group"]] = relationship(back_populates="roles")
+    role: Mapped[Optional["Role"]] = relationship(back_populates="groups")
 
     def __init__(self, group, role):
         self.group = group
@@ -3677,9 +3636,9 @@ class Role(Base, Dictifiable, RepresentById):
     description: Mapped[Optional[str]] = mapped_column(TEXT)
     type: Mapped[Optional[str]] = mapped_column(String(40), index=True)
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
-    dataset_actions: Mapped[List["DatasetPermissions"]] = relationship("DatasetPermissions", back_populates="role")
-    groups: Mapped[List["GroupRoleAssociation"]] = relationship("GroupRoleAssociation", back_populates="role")
-    users: Mapped[List["UserRoleAssociation"]] = relationship("UserRoleAssociation", back_populates="role")
+    dataset_actions: Mapped[List["DatasetPermissions"]] = relationship(back_populates="role")
+    groups: Mapped[List["GroupRoleAssociation"]] = relationship(back_populates="role")
+    users: Mapped[List["UserRoleAssociation"]] = relationship(back_populates="role")
 
     dict_collection_visible_keys = ["id", "name"]
     dict_element_visible_keys = ["id", "name", "description", "type"]
@@ -3710,7 +3669,7 @@ class UserQuotaSourceUsage(Base, Dictifiable, RepresentById):
     quota_source_label: Mapped[Optional[str]] = mapped_column(String(32), index=True)
     # user had an index on disk_usage - does that make any sense? -John
     disk_usage: Mapped[Decimal] = mapped_column(Numeric(15, 0), default=0)
-    user: Mapped[Optional["User"]] = relationship("User", back_populates="quota_source_usages")
+    user: Mapped[Optional["User"]] = relationship(back_populates="quota_source_usages")
 
 
 class UserQuotaAssociation(Base, Dictifiable, RepresentById):
@@ -3721,8 +3680,8 @@ class UserQuotaAssociation(Base, Dictifiable, RepresentById):
     quota_id: Mapped[Optional[int]] = mapped_column(ForeignKey("quota.id"), index=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
-    user: Mapped[Optional["User"]] = relationship("User", back_populates="quotas")
-    quota: Mapped[Optional["Quota"]] = relationship("Quota", back_populates="users")
+    user: Mapped[Optional["User"]] = relationship(back_populates="quotas")
+    quota: Mapped[Optional["Quota"]] = relationship(back_populates="users")
 
     dict_element_visible_keys = ["user"]
 
@@ -3740,8 +3699,8 @@ class GroupQuotaAssociation(Base, Dictifiable, RepresentById):
     quota_id: Mapped[Optional[int]] = mapped_column(ForeignKey("quota.id"), index=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
-    group: Mapped[Optional["Group"]] = relationship("Group", back_populates="quotas")
-    quota: Mapped[Optional["Quota"]] = relationship("Quota", back_populates="groups")
+    group: Mapped[Optional["Group"]] = relationship(back_populates="quotas")
+    quota: Mapped[Optional["Quota"]] = relationship(back_populates="groups")
 
     dict_element_visible_keys = ["group"]
 
@@ -3765,8 +3724,8 @@ class Quota(Base, Dictifiable, RepresentById):
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     quota_source_label: Mapped[Optional[str]] = mapped_column(String(32), default=None)
     default = relationship("DefaultQuotaAssociation", back_populates="quota", cascade_backrefs=False)
-    groups: Mapped[List["GroupQuotaAssociation"]] = relationship("GroupQuotaAssociation", back_populates="quota")
-    users: Mapped[List["UserQuotaAssociation"]] = relationship("UserQuotaAssociation", back_populates="quota")
+    groups: Mapped[List["GroupQuotaAssociation"]] = relationship(back_populates="quota")
+    users: Mapped[List["UserQuotaAssociation"]] = relationship(back_populates="quota")
 
     dict_collection_visible_keys = ["id", "name", "quota_source_label"]
     dict_element_visible_keys = [
@@ -3822,7 +3781,7 @@ class DefaultQuotaAssociation(Base, Dictifiable, RepresentById):
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
     type: Mapped[Optional[str]] = mapped_column(String(32))
     quota_id: Mapped[Optional[int]] = mapped_column(ForeignKey("quota.id"), index=True)
-    quota: Mapped[Optional["Quota"]] = relationship("Quota", back_populates="default")
+    quota: Mapped[Optional["Quota"]] = relationship(back_populates="default")
 
     dict_element_visible_keys = ["type"]
 
@@ -3846,8 +3805,8 @@ class DatasetPermissions(Base, RepresentById):
     action: Mapped[Optional[str]] = mapped_column(TEXT)
     dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("dataset.id"), index=True)
     role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
-    dataset: Mapped[Optional["Dataset"]] = relationship("Dataset", back_populates="actions")
-    role: Mapped[Optional["Role"]] = relationship("Role", back_populates="dataset_actions")
+    dataset: Mapped[Optional["Dataset"]] = relationship(back_populates="actions")
+    role: Mapped[Optional["Role"]] = relationship(back_populates="dataset_actions")
 
     def __init__(self, action, dataset, role=None, role_id=None):
         self.action = action
@@ -3868,8 +3827,8 @@ class LibraryPermissions(Base, RepresentById):
     action: Mapped[Optional[str]] = mapped_column(TEXT)
     library_id: Mapped[Optional[int]] = mapped_column(ForeignKey("library.id"), index=True)
     role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
-    library: Mapped[Optional["Library"]] = relationship("Library", back_populates="actions")
-    role: Mapped[Optional["Role"]] = relationship("Role")
+    library: Mapped[Optional["Library"]] = relationship(back_populates="actions")
+    role: Mapped[Optional["Role"]] = relationship()
 
     def __init__(self, action, library_item, role):
         self.action = action
@@ -3890,8 +3849,8 @@ class LibraryFolderPermissions(Base, RepresentById):
     action: Mapped[Optional[str]] = mapped_column(TEXT)
     library_folder_id: Mapped[Optional[int]] = mapped_column(ForeignKey("library_folder.id"), index=True)
     role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
-    folder: Mapped[Optional["LibraryFolder"]] = relationship("LibraryFolder", back_populates="actions")
-    role: Mapped[Optional["Role"]] = relationship("Role")
+    folder: Mapped[Optional["LibraryFolder"]] = relationship(back_populates="actions")
+    role: Mapped[Optional["Role"]] = relationship()
 
     def __init__(self, action, library_item, role):
         self.action = action
@@ -3912,8 +3871,8 @@ class LibraryDatasetPermissions(Base, RepresentById):
     action: Mapped[Optional[str]] = mapped_column(TEXT)
     library_dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("library_dataset.id"), index=True)
     role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
-    library_dataset: Mapped[Optional["LibraryDataset"]] = relationship("LibraryDataset", back_populates="actions")
-    role: Mapped[Optional["Role"]] = relationship("Role")
+    library_dataset: Mapped[Optional["LibraryDataset"]] = relationship(back_populates="actions")
+    role: Mapped[Optional["Role"]] = relationship()
 
     def __init__(self, action, library_item, role):
         self.action = action
@@ -3937,9 +3896,9 @@ class LibraryDatasetDatasetAssociationPermissions(Base, RepresentById):
     )
     role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
     library_dataset_dataset_association: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
-        "LibraryDatasetDatasetAssociation", back_populates="actions"
+        back_populates="actions"
     )
-    role: Mapped[Optional["Role"]] = relationship("Role")
+    role: Mapped[Optional["Role"]] = relationship()
 
     def __init__(self, action, library_item, role):
         self.action = action
@@ -3958,8 +3917,8 @@ class DefaultUserPermissions(Base, RepresentById):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     action: Mapped[Optional[str]] = mapped_column(TEXT)
     role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
-    user: Mapped[Optional["User"]] = relationship("User", back_populates="default_permissions")
-    role: Mapped[Optional["Role"]] = relationship("Role")
+    user: Mapped[Optional["User"]] = relationship(back_populates="default_permissions")
+    role: Mapped[Optional["Role"]] = relationship()
 
     def __init__(self, user, action, role):
         add_object_to_object_session(self, user)
@@ -3975,8 +3934,8 @@ class DefaultHistoryPermissions(Base, RepresentById):
     history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
     action: Mapped[Optional[str]] = mapped_column(TEXT)
     role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
-    history: Mapped[Optional["History"]] = relationship("History", back_populates="default_permissions")
-    role: Mapped[Optional["Role"]] = relationship("Role")
+    history: Mapped[Optional["History"]] = relationship(back_populates="default_permissions")
+    role: Mapped[Optional["Role"]] = relationship()
 
     def __init__(self, history, action, role):
         add_object_to_object_session(self, history)
@@ -4011,10 +3970,9 @@ class Dataset(Base, StorableObject, Serializable):
     total_size: Mapped[Optional[Decimal]] = mapped_column(Numeric(15, 0))
     uuid: Mapped[Optional[Union[UUID, str]]] = mapped_column(UUIDType())
 
-    actions: Mapped[List["DatasetPermissions"]] = relationship("DatasetPermissions", back_populates="dataset")
-    job: Mapped[Optional["Job"]] = relationship(Job, primaryjoin=(lambda: Dataset.job_id == Job.id))
+    actions: Mapped[List["DatasetPermissions"]] = relationship(back_populates="dataset")
+    job: Mapped[Optional["Job"]] = relationship(primaryjoin=(lambda: Dataset.job_id == Job.id))
     active_history_associations: Mapped[List["HistoryDatasetAssociation"]] = relationship(
-        "HistoryDatasetAssociation",
         primaryjoin=(
             lambda: and_(
                 Dataset.id == HistoryDatasetAssociation.dataset_id,  # type: ignore[attr-defined]
@@ -4025,7 +3983,6 @@ class Dataset(Base, StorableObject, Serializable):
         viewonly=True,
     )
     purged_history_associations: Mapped[List["HistoryDatasetAssociation"]] = relationship(
-        "HistoryDatasetAssociation",
         primaryjoin=(
             lambda: and_(
                 Dataset.id == HistoryDatasetAssociation.dataset_id,  # type: ignore[attr-defined]
@@ -4035,7 +3992,6 @@ class Dataset(Base, StorableObject, Serializable):
         viewonly=True,
     )
     active_library_associations: Mapped[List["LibraryDatasetDatasetAssociation"]] = relationship(
-        "LibraryDatasetDatasetAssociation",
         primaryjoin=(
             lambda: and_(
                 Dataset.id == LibraryDatasetDatasetAssociation.dataset_id,  # type: ignore[attr-defined]
@@ -4044,13 +4000,12 @@ class Dataset(Base, StorableObject, Serializable):
         ),
         viewonly=True,
     )
-    hashes: Mapped[List["DatasetHash"]] = relationship("DatasetHash", back_populates="dataset", cascade_backrefs=False)
-    sources: Mapped[List["DatasetSource"]] = relationship("DatasetSource", back_populates="dataset")
+    hashes: Mapped[List["DatasetHash"]] = relationship(back_populates="dataset", cascade_backrefs=False)
+    sources: Mapped[List["DatasetSource"]] = relationship(back_populates="dataset")
     history_associations: Mapped[List["HistoryDatasetAssociation"]] = relationship(
-        "HistoryDatasetAssociation", back_populates="dataset", cascade_backrefs=False
+        back_populates="dataset", cascade_backrefs=False
     )
     library_associations: Mapped[List["LibraryDatasetDatasetAssociation"]] = relationship(
-        "LibraryDatasetDatasetAssociation",
         primaryjoin=(lambda: LibraryDatasetDatasetAssociation.table.c.dataset_id == Dataset.id),
         back_populates="dataset",
         cascade_backrefs=False,
@@ -4382,8 +4337,8 @@ class DatasetSource(Base, Dictifiable, Serializable):
     source_uri: Mapped[Optional[str]] = mapped_column(TEXT)
     extra_files_path: Mapped[Optional[str]] = mapped_column(TEXT)
     transform: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
-    dataset: Mapped[Optional["Dataset"]] = relationship("Dataset", back_populates="sources")
-    hashes: Mapped[List["DatasetSourceHash"]] = relationship("DatasetSourceHash", back_populates="source")
+    dataset: Mapped[Optional["Dataset"]] = relationship(back_populates="sources")
+    hashes: Mapped[List["DatasetSourceHash"]] = relationship(back_populates="source")
     dict_collection_visible_keys = ["id", "source_uri", "extra_files_path", "transform"]
     dict_element_visible_keys = [
         "id",
@@ -4419,7 +4374,7 @@ class DatasetSourceHash(Base, Serializable):
     dataset_source_id: Mapped[Optional[int]] = mapped_column(ForeignKey("dataset_source.id"), index=True)
     hash_function: Mapped[Optional[str]] = mapped_column(TEXT)
     hash_value: Mapped[Optional[str]] = mapped_column(TEXT)
-    source: Mapped[Optional["DatasetSource"]] = relationship("DatasetSource", back_populates="hashes")
+    source: Mapped[Optional["DatasetSource"]] = relationship(back_populates="hashes")
 
     def _serialize(self, id_encoder, serialization_options):
         rval = dict_for(
@@ -4445,7 +4400,7 @@ class DatasetHash(Base, Dictifiable, Serializable):
     hash_function: Mapped[Optional[str]] = mapped_column(TEXT)
     hash_value: Mapped[Optional[str]] = mapped_column(TEXT)
     extra_files_path: Mapped[Optional[str]] = mapped_column(TEXT)
-    dataset: Mapped[Optional["Dataset"]] = relationship("Dataset", back_populates="hashes")
+    dataset: Mapped[Optional["Dataset"]] = relationship(back_populates="hashes")
     dict_collection_visible_keys = ["id", "hash_function", "hash_value", "extra_files_path"]
     dict_element_visible_keys = ["id", "hash_function", "hash_value", "extra_files_path"]
 
@@ -5526,10 +5481,8 @@ class HistoryDatasetAssociationDisplayAtAuthorization(Base, RepresentById):
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     site: Mapped[Optional[str]] = mapped_column(TrimmedString(255))
-    history_dataset_association: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
-        "HistoryDatasetAssociation"
-    )
-    user: Mapped[Optional["User"]] = relationship("User")
+    history_dataset_association: Mapped[Optional["HistoryDatasetAssociation"]] = relationship()
+    user: Mapped[Optional["User"]] = relationship()
 
     def __init__(self, hda=None, user=None, site=None):
         self.history_dataset_association = hda
@@ -5550,13 +5503,11 @@ class HistoryDatasetAssociationSubset(Base, RepresentById):
     location: Mapped[Optional[str]] = mapped_column(Unicode(255), index=True)
 
     hda: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
-        "HistoryDatasetAssociation",
         primaryjoin=(
             lambda: HistoryDatasetAssociationSubset.history_dataset_association_id == HistoryDatasetAssociation.id
         ),
     )
     subset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
-        "HistoryDatasetAssociation",
         primaryjoin=(
             lambda: HistoryDatasetAssociationSubset.history_dataset_association_subset_id
             == HistoryDatasetAssociation.id
@@ -5582,9 +5533,7 @@ class Library(Base, Dictifiable, HasName, Serializable):
     description: Mapped[Optional[str]] = mapped_column(TEXT)
     synopsis: Mapped[Optional[str]] = mapped_column(TEXT)
     root_folder = relationship("LibraryFolder", back_populates="library_root")
-    actions: Mapped[List["LibraryPermissions"]] = relationship(
-        "LibraryPermissions", back_populates="library", cascade_backrefs=False
-    )
+    actions: Mapped[List["LibraryPermissions"]] = relationship(back_populates="library", cascade_backrefs=False)
 
     permitted_actions = get_permitted_actions(filter="LIBRARY")
     dict_collection_visible_keys = ["id", "name"]
@@ -5665,17 +5614,13 @@ class LibraryFolder(Base, Dictifiable, HasName, Serializable):
     genome_build: Mapped[Optional[str]] = mapped_column(TrimmedString(40))
 
     folders: Mapped[List["LibraryFolder"]] = relationship(
-        "LibraryFolder",
         primaryjoin=(lambda: LibraryFolder.id == LibraryFolder.parent_id),
         order_by=asc(name),
         back_populates="parent",
     )
-    parent: Mapped[Optional["LibraryFolder"]] = relationship(
-        "LibraryFolder", back_populates="folders", remote_side=[id]
-    )
+    parent: Mapped[Optional["LibraryFolder"]] = relationship(back_populates="folders", remote_side=[id])
 
     active_folders: Mapped[List["LibraryFolder"]] = relationship(
-        "LibraryFolder",
         primaryjoin=("and_(LibraryFolder.parent_id == LibraryFolder.id, not_(LibraryFolder.deleted))"),
         order_by=asc(name),
         # """sqlalchemy.exc.ArgumentError: Error creating eager relationship 'active_folders'
@@ -5686,7 +5631,6 @@ class LibraryFolder(Base, Dictifiable, HasName, Serializable):
     )
 
     datasets: Mapped[List["LibraryDataset"]] = relationship(
-        "LibraryDataset",
         primaryjoin=(
             lambda: LibraryDataset.folder_id == LibraryFolder.id
             and LibraryDataset.library_dataset_dataset_association_id.isnot(None)
@@ -5696,7 +5640,6 @@ class LibraryFolder(Base, Dictifiable, HasName, Serializable):
     )
 
     active_datasets: Mapped[List["LibraryDataset"]] = relationship(
-        "LibraryDataset",
         primaryjoin=(
             "and_(LibraryDataset.folder_id == LibraryFolder.id, not_(LibraryDataset.deleted), LibraryDataset.library_dataset_dataset_association_id.isnot(None))"
         ),
@@ -5705,9 +5648,7 @@ class LibraryFolder(Base, Dictifiable, HasName, Serializable):
     )
 
     library_root = relationship("Library", back_populates="root_folder")
-    actions: Mapped[List["LibraryFolderPermissions"]] = relationship(
-        "LibraryFolderPermissions", back_populates="folder", cascade_backrefs=False
-    )
+    actions: Mapped[List["LibraryFolderPermissions"]] = relationship(back_populates="folder", cascade_backrefs=False)
 
     dict_element_visible_keys = [
         "id",
@@ -5816,12 +5757,11 @@ class LibraryDataset(Base, Serializable):
     _info: Mapped[Optional[str]] = mapped_column("info", TrimmedString(255))
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     purged: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
-    folder: Mapped[Optional["LibraryFolder"]] = relationship("LibraryFolder")
+    folder: Mapped[Optional["LibraryFolder"]] = relationship()
     library_dataset_dataset_association = relationship(
         "LibraryDatasetDatasetAssociation", foreign_keys=library_dataset_dataset_association_id, post_update=True
     )
     expired_datasets: Mapped[List["LibraryDatasetDatasetAssociation"]] = relationship(
-        "LibraryDatasetDatasetAssociation",
         foreign_keys=[id, library_dataset_dataset_association_id],
         primaryjoin=(
             "and_(LibraryDataset.id == LibraryDatasetDatasetAssociation.library_dataset_id, \
@@ -5831,7 +5771,7 @@ class LibraryDataset(Base, Serializable):
         uselist=True,
     )
     actions: Mapped[List["LibraryDatasetPermissions"]] = relationship(
-        "LibraryDatasetPermissions", back_populates="library_dataset", cascade_backrefs=False
+        back_populates="library_dataset", cascade_backrefs=False
     )
 
     # This class acts as a proxy to the currently selected LDDA
@@ -6100,9 +6040,7 @@ class ExtendedMetadata(Base, RepresentById):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     data: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
-    children: Mapped[List["ExtendedMetadataIndex"]] = relationship(
-        "ExtendedMetadataIndex", back_populates="extended_metadata"
-    )
+    children: Mapped[List["ExtendedMetadataIndex"]] = relationship(back_populates="extended_metadata")
 
     def __init__(self, data):
         self.data = data
@@ -6117,9 +6055,7 @@ class ExtendedMetadataIndex(Base, RepresentById):
     )
     path: Mapped[Optional[str]] = mapped_column(String(255))
     value: Mapped[Optional[str]] = mapped_column(TEXT)
-    extended_metadata: Mapped[Optional["ExtendedMetadata"]] = relationship(
-        "ExtendedMetadata", back_populates="children"
-    )
+    extended_metadata: Mapped[Optional["ExtendedMetadata"]] = relationship(back_populates="children")
 
     def __init__(self, extended_metadata, path, value):
         self.extended_metadata = extended_metadata
@@ -6138,7 +6074,6 @@ class LibraryInfoAssociation(Base, RepresentById):
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
 
     library: Mapped[Optional["Library"]] = relationship(
-        "Library",
         primaryjoin=(
             lambda: and_(
                 LibraryInfoAssociation.library_id == Library.id,
@@ -6147,10 +6082,10 @@ class LibraryInfoAssociation(Base, RepresentById):
         ),
     )
     template: Mapped[Optional["FormDefinition"]] = relationship(
-        "FormDefinition", primaryjoin=lambda: LibraryInfoAssociation.form_definition_id == FormDefinition.id
+        primaryjoin=lambda: LibraryInfoAssociation.form_definition_id == FormDefinition.id
     )
     info: Mapped[Optional["FormValues"]] = relationship(
-        "FormValues", primaryjoin=lambda: LibraryInfoAssociation.form_values_id == FormValues.id  # type: ignore[has-type]
+        primaryjoin=lambda: LibraryInfoAssociation.form_values_id == FormValues.id  # type: ignore[has-type]
     )
 
     def __init__(self, library, form_definition, info, inheritable=False):
@@ -6171,17 +6106,16 @@ class LibraryFolderInfoAssociation(Base, RepresentById):
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
 
     folder: Mapped[Optional["LibraryFolder"]] = relationship(
-        "LibraryFolder",
         primaryjoin=(
             lambda: (LibraryFolderInfoAssociation.library_folder_id == LibraryFolder.id)
             & (not_(LibraryFolderInfoAssociation.deleted))
         ),
     )
     template: Mapped[Optional["FormDefinition"]] = relationship(
-        "FormDefinition", primaryjoin=(lambda: LibraryFolderInfoAssociation.form_definition_id == FormDefinition.id)
+        primaryjoin=(lambda: LibraryFolderInfoAssociation.form_definition_id == FormDefinition.id)
     )
     info: Mapped[Optional["FormValues"]] = relationship(
-        "FormValues", primaryjoin=(lambda: LibraryFolderInfoAssociation.form_values_id == FormValues.id)  # type: ignore[has-type]
+        primaryjoin=(lambda: LibraryFolderInfoAssociation.form_values_id == FormValues.id)  # type: ignore[has-type]
     )
 
     def __init__(self, folder, form_definition, info, inheritable=False):
@@ -6203,7 +6137,6 @@ class LibraryDatasetDatasetInfoAssociation(Base, RepresentById):
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
 
     library_dataset_dataset_association: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
-        "LibraryDatasetDatasetAssociation",
         primaryjoin=(
             lambda: (
                 LibraryDatasetDatasetInfoAssociation.library_dataset_dataset_association_id
@@ -6213,11 +6146,10 @@ class LibraryDatasetDatasetInfoAssociation(Base, RepresentById):
         ),
     )
     template: Mapped[Optional["FormDefinition"]] = relationship(
-        "FormDefinition",
         primaryjoin=(lambda: LibraryDatasetDatasetInfoAssociation.form_definition_id == FormDefinition.id),
     )
     info: Mapped[Optional["FormValues"]] = relationship(
-        "FormValues", primaryjoin=(lambda: LibraryDatasetDatasetInfoAssociation.form_values_id == FormValues.id)  # type: ignore[has-type]
+        primaryjoin=(lambda: LibraryDatasetDatasetInfoAssociation.form_values_id == FormValues.id)  # type: ignore[has-type]
     )
 
     def __init__(self, library_dataset_dataset_association, form_definition, info):
@@ -6248,22 +6180,18 @@ class ImplicitlyConvertedDatasetAssociation(Base, Serializable):
     type: Mapped[Optional[str]] = mapped_column(TrimmedString(255))
 
     parent_hda: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
-        "HistoryDatasetAssociation",
         primaryjoin=(lambda: ImplicitlyConvertedDatasetAssociation.hda_parent_id == HistoryDatasetAssociation.id),
         back_populates="implicitly_converted_datasets",
     )
     dataset_ldda: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
-        "LibraryDatasetDatasetAssociation",
         primaryjoin=(lambda: ImplicitlyConvertedDatasetAssociation.ldda_id == LibraryDatasetDatasetAssociation.id),
         back_populates="implicitly_converted_parent_datasets",
     )
     dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
-        "HistoryDatasetAssociation",
         primaryjoin=(lambda: ImplicitlyConvertedDatasetAssociation.hda_id == HistoryDatasetAssociation.id),
         back_populates="implicitly_converted_parent_datasets",
     )
     parent_ldda: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
-        "LibraryDatasetDatasetAssociation",
         primaryjoin=(
             lambda: ImplicitlyConvertedDatasetAssociation.ldda_parent_id == LibraryDatasetDatasetAssociation.table.c.id
         ),
@@ -6355,7 +6283,6 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
 
     elements: Mapped[List["DatasetCollectionElement"]] = relationship(
-        "DatasetCollectionElement",
         primaryjoin=(lambda: DatasetCollection.id == DatasetCollectionElement.dataset_collection_id),  # type: ignore[has-type]
         back_populates="collection",
         order_by=lambda: DatasetCollectionElement.element_index,  # type: ignore[has-type]
@@ -6823,7 +6750,7 @@ class HistoryDatasetCollectionAssociation(
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, index=True, nullable=True)
 
     collection = relationship("DatasetCollection")
-    history: Mapped[Optional["History"]] = relationship("History", back_populates="dataset_collections")
+    history: Mapped[Optional["History"]] = relationship(back_populates="dataset_collections")
 
     copied_from_history_dataset_collection_association = relationship(
         "HistoryDatasetCollectionAssociation",
@@ -6837,7 +6764,6 @@ class HistoryDatasetCollectionAssociation(
         back_populates="copied_from_history_dataset_collection_association",
     )
     implicit_input_collections: Mapped[List["ImplicitlyCreatedDatasetCollectionInput"]] = relationship(
-        "ImplicitlyCreatedDatasetCollectionInput",
         primaryjoin=(
             lambda: HistoryDatasetCollectionAssociation.id
             == ImplicitlyCreatedDatasetCollectionInput.dataset_collection_id
@@ -6845,28 +6771,22 @@ class HistoryDatasetCollectionAssociation(
     )
     implicit_collection_jobs = relationship("ImplicitCollectionJobs", uselist=False)
     job: Mapped[Optional["Job"]] = relationship(
-        "Job",
         back_populates="history_dataset_collection_associations",
         uselist=False,
     )
     tags: Mapped[List["HistoryDatasetCollectionTagAssociation"]] = relationship(
-        "HistoryDatasetCollectionTagAssociation",
         order_by=lambda: HistoryDatasetCollectionTagAssociation.id,
         back_populates="dataset_collection",
     )
     annotations: Mapped[List["HistoryDatasetCollectionAssociationAnnotationAssociation"]] = relationship(
-        "HistoryDatasetCollectionAssociationAnnotationAssociation",
         order_by=lambda: HistoryDatasetCollectionAssociationAnnotationAssociation.id,
         back_populates="history_dataset_collection",
     )
     ratings: Mapped[List["HistoryDatasetCollectionRatingAssociation"]] = relationship(
-        "HistoryDatasetCollectionRatingAssociation",
         order_by=lambda: HistoryDatasetCollectionRatingAssociation.id,  # type: ignore[has-type]
         back_populates="dataset_collection",
     )
-    creating_job_associations: Mapped[List["JobToOutputDatasetCollectionAssociation"]] = relationship(
-        "JobToOutputDatasetCollectionAssociation", viewonly=True
-    )
+    creating_job_associations: Mapped[List["JobToOutputDatasetCollectionAssociation"]] = relationship(viewonly=True)
 
     dict_dbkeysandextensions_visible_keys = ["dbkeys", "extensions"]
     editable_keys = ("name", "deleted", "visible")
@@ -7210,17 +7130,14 @@ class LibraryDatasetCollectionAssociation(Base, DatasetCollectionInstance, Repre
     folder = relationship("LibraryFolder")
 
     tags: Mapped[List["LibraryDatasetCollectionTagAssociation"]] = relationship(
-        "LibraryDatasetCollectionTagAssociation",
         order_by=lambda: LibraryDatasetCollectionTagAssociation.id,
         back_populates="dataset_collection",
     )
     annotations: Mapped[List["LibraryDatasetCollectionAnnotationAssociation"]] = relationship(
-        "LibraryDatasetCollectionAnnotationAssociation",
         order_by=lambda: LibraryDatasetCollectionAnnotationAssociation.id,
         back_populates="dataset_collection",
     )
     ratings: Mapped[List["LibraryDatasetCollectionRatingAssociation"]] = relationship(
-        "LibraryDatasetCollectionRatingAssociation",
         order_by=lambda: LibraryDatasetCollectionRatingAssociation.id,  # type: ignore[has-type]
         back_populates="dataset_collection",
     )
@@ -7443,9 +7360,9 @@ class Event(Base, RepresentById):
     session_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_session.id"), index=True)
     tool_id: Mapped[Optional[str]] = mapped_column(String(255))
 
-    history: Mapped[Optional["History"]] = relationship("History")
-    user: Mapped[Optional["User"]] = relationship("User")
-    galaxy_session: Mapped[Optional["GalaxySession"]] = relationship("GalaxySession")
+    history: Mapped[Optional["History"]] = relationship()
+    user: Mapped[Optional["User"]] = relationship()
+    galaxy_session: Mapped[Optional["GalaxySession"]] = relationship()
 
 
 class GalaxySession(Base, RepresentById):
@@ -7466,11 +7383,11 @@ class GalaxySession(Base, RepresentById):
     prev_session_id: Mapped[Optional[int]]
     disk_usage: Mapped[Optional[Decimal]] = mapped_column(Numeric(15, 0), index=True)
     last_action: Mapped[Optional[datetime]]
-    current_history: Mapped[Optional["History"]] = relationship("History")
+    current_history: Mapped[Optional["History"]] = relationship()
     histories: Mapped[List["GalaxySessionToHistoryAssociation"]] = relationship(
-        "GalaxySessionToHistoryAssociation", back_populates="galaxy_session", cascade_backrefs=False
+        back_populates="galaxy_session", cascade_backrefs=False
     )
-    user: Mapped[Optional["User"]] = relationship("User", back_populates="galaxy_sessions")
+    user: Mapped[Optional["User"]] = relationship(back_populates="galaxy_sessions")
 
     def __init__(self, is_valid=False, **kwd):
         super().__init__(**kwd)
@@ -7501,8 +7418,8 @@ class GalaxySessionToHistoryAssociation(Base, RepresentById):
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     session_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_session.id"), index=True)
     history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
-    galaxy_session: Mapped[Optional["GalaxySession"]] = relationship("GalaxySession", back_populates="histories")
-    history: Mapped[Optional["History"]] = relationship("History", back_populates="galaxy_sessions")
+    galaxy_session: Mapped[Optional["GalaxySession"]] = relationship(back_populates="histories")
+    history: Mapped[Optional["History"]] = relationship(back_populates="galaxy_sessions")
 
     def __init__(self, galaxy_session, history):
         self.galaxy_session = galaxy_session
@@ -7539,10 +7456,9 @@ class StoredWorkflow(Base, HasTags, Dictifiable, RepresentById):
     published: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
 
     user: Mapped["User"] = relationship(
-        "User", primaryjoin=(lambda: User.id == StoredWorkflow.user_id), back_populates="stored_workflows"
+        primaryjoin=(lambda: User.id == StoredWorkflow.user_id), back_populates="stored_workflows"
     )
     workflows: Mapped[List["Workflow"]] = relationship(
-        "Workflow",
         back_populates="stored_workflow",
         cascade="all, delete-orphan",
         primaryjoin=(lambda: StoredWorkflow.id == Workflow.stored_workflow_id),  # type: ignore[has-type]
@@ -7556,12 +7472,10 @@ class StoredWorkflow(Base, HasTags, Dictifiable, RepresentById):
         lazy=False,
     )
     tags: Mapped[List["StoredWorkflowTagAssociation"]] = relationship(
-        "StoredWorkflowTagAssociation",
         order_by=lambda: StoredWorkflowTagAssociation.id,
         back_populates="stored_workflow",
     )
     owner_tags: Mapped[List["StoredWorkflowTagAssociation"]] = relationship(
-        "StoredWorkflowTagAssociation",
         primaryjoin=(
             lambda: and_(
                 StoredWorkflow.id == StoredWorkflowTagAssociation.stored_workflow_id,
@@ -7572,17 +7486,15 @@ class StoredWorkflow(Base, HasTags, Dictifiable, RepresentById):
         order_by=lambda: StoredWorkflowTagAssociation.id,
     )
     annotations: Mapped[List["StoredWorkflowAnnotationAssociation"]] = relationship(
-        "StoredWorkflowAnnotationAssociation",
         order_by=lambda: StoredWorkflowAnnotationAssociation.id,
         back_populates="stored_workflow",
     )
     ratings: Mapped[List["StoredWorkflowRatingAssociation"]] = relationship(
-        "StoredWorkflowRatingAssociation",
         order_by=lambda: StoredWorkflowRatingAssociation.id,  # type: ignore[has-type]
         back_populates="stored_workflow",
     )
     users_shared_with: Mapped[List["StoredWorkflowUserShareAssociation"]] = relationship(
-        "StoredWorkflowUserShareAssociation", back_populates="stored_workflow"
+        back_populates="stored_workflow"
     )
 
     average_rating = None
@@ -7723,7 +7635,6 @@ class Workflow(Base, Dictifiable, RepresentById):
         lazy=False,
     )
     comments: Mapped[List["WorkflowComment"]] = relationship(
-        "WorkflowComment",
         back_populates="workflow",
         primaryjoin=(lambda: Workflow.id == WorkflowComment.workflow_id),  # type: ignore[has-type]
         cascade="all, delete-orphan",
@@ -7903,37 +7814,33 @@ class WorkflowStep(Base, RepresentById):
     parent_comment_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_comment.id"), index=True)
 
     parent_comment: Mapped[Optional["WorkflowComment"]] = relationship(
-        "WorkflowComment",
         primaryjoin=(lambda: WorkflowComment.id == WorkflowStep.parent_comment_id),
         back_populates="child_steps",
     )
 
     subworkflow: Mapped[Optional["Workflow"]] = relationship(
-        "Workflow",
         primaryjoin=(lambda: Workflow.id == WorkflowStep.subworkflow_id),
         back_populates="parent_workflow_steps",
     )
     dynamic_tool: Mapped[Optional["DynamicTool"]] = relationship(
-        "DynamicTool", primaryjoin=(lambda: DynamicTool.id == WorkflowStep.dynamic_tool_id)
+        primaryjoin=(lambda: DynamicTool.id == WorkflowStep.dynamic_tool_id)
     )
     tags: Mapped[List["WorkflowStepTagAssociation"]] = relationship(
-        "WorkflowStepTagAssociation", order_by=lambda: WorkflowStepTagAssociation.id, back_populates="workflow_step"
+        order_by=lambda: WorkflowStepTagAssociation.id, back_populates="workflow_step"
     )
     annotations: Mapped[List["WorkflowStepAnnotationAssociation"]] = relationship(
-        "WorkflowStepAnnotationAssociation",
         order_by=lambda: WorkflowStepAnnotationAssociation.id,
         back_populates="workflow_step",
     )
     post_job_actions = relationship("PostJobAction", back_populates="workflow_step", cascade_backrefs=False)
     inputs = relationship("WorkflowStepInput", back_populates="workflow_step")
     workflow_outputs: Mapped[List["WorkflowOutput"]] = relationship(
-        "WorkflowOutput", back_populates="workflow_step", cascade_backrefs=False
+        back_populates="workflow_step", cascade_backrefs=False
     )
     output_connections: Mapped[List["WorkflowStepConnection"]] = relationship(
-        "WorkflowStepConnection", primaryjoin=(lambda: WorkflowStepConnection.output_step_id == WorkflowStep.id)
+        primaryjoin=(lambda: WorkflowStepConnection.output_step_id == WorkflowStep.id)
     )
     workflow: Mapped["Workflow"] = relationship(
-        "Workflow",
         primaryjoin=(lambda: Workflow.id == WorkflowStep.workflow_id),
         back_populates="steps",
         cascade_backrefs=False,
@@ -8213,13 +8120,11 @@ class WorkflowStepInput(Base, RepresentById):
     runtime_value: Mapped[Optional[bool]] = mapped_column(default=False)
 
     workflow_step: Mapped[Optional["WorkflowStep"]] = relationship(
-        "WorkflowStep",
         back_populates="inputs",
         cascade="all",
         primaryjoin=(lambda: WorkflowStepInput.workflow_step_id == WorkflowStep.id),
     )
     connections: Mapped[List["WorkflowStepConnection"]] = relationship(
-        "WorkflowStepConnection",
         back_populates="input_step_input",
         primaryjoin=(lambda: WorkflowStepConnection.input_step_input_id == WorkflowStepInput.id),
         cascade_backrefs=False,
@@ -8307,7 +8212,6 @@ class WorkflowOutput(Base, Serializable):
     label: Mapped[Optional[str]] = mapped_column(Unicode(255))
     uuid: Mapped[Optional[Union[UUID, str]]] = mapped_column(UUIDType)
     workflow_step: Mapped["WorkflowStep"] = relationship(
-        "WorkflowStep",
         back_populates="workflow_outputs",
         primaryjoin=(lambda: WorkflowStep.id == WorkflowOutput.workflow_step_id),
     )
@@ -8353,7 +8257,6 @@ class WorkflowComment(Base, RepresentById):
     parent_comment_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_comment.id"), index=True)
 
     workflow: Mapped["Workflow"] = relationship(
-        "Workflow",
         primaryjoin=(lambda: Workflow.id == WorkflowComment.workflow_id),
         back_populates="comments",
     )
@@ -8365,14 +8268,12 @@ class WorkflowComment(Base, RepresentById):
     )
 
     parent_comment: Mapped[Optional["WorkflowComment"]] = relationship(
-        "WorkflowComment",
         primaryjoin=(lambda: WorkflowComment.id == WorkflowComment.parent_comment_id),
         back_populates="child_comments",
         remote_side=[id],
     )
 
     child_comments: Mapped[List["WorkflowComment"]] = relationship(
-        "WorkflowComment",
         primaryjoin=(lambda: WorkflowComment.parent_comment_id == WorkflowComment.id),
         back_populates="parent_comment",
     )
@@ -8416,10 +8317,8 @@ class StoredWorkflowUserShareAssociation(Base, UserShareAssociation):
     id: Mapped[int] = mapped_column(primary_key=True)
     stored_workflow_id: Mapped[Optional[int]] = mapped_column(ForeignKey("stored_workflow.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    user: Mapped[User] = relationship("User")
-    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship(
-        "StoredWorkflow", back_populates="users_shared_with"
-    )
+    user: Mapped[User] = relationship()
+    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship(back_populates="users_shared_with")
 
 
 class StoredWorkflowMenuEntry(Base, RepresentById):
@@ -8430,9 +8329,8 @@ class StoredWorkflowMenuEntry(Base, RepresentById):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     order_index: Mapped[Optional[int]]
 
-    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship("StoredWorkflow")
+    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship()
     user: Mapped[Optional["User"]] = relationship(
-        "User",
         back_populates="stored_workflow_menu_entries",
         primaryjoin=(
             lambda: (StoredWorkflowMenuEntry.user_id == User.id)
@@ -9032,14 +8930,10 @@ class WorkflowInvocationMessage(Base, Dictifiable, Serializable):
     hda_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_association.id"))
     hdca_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_collection_association.id"))
 
-    workflow_invocation: Mapped["WorkflowInvocation"] = relationship(
-        "WorkflowInvocation", back_populates="messages", lazy=True
-    )
-    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship(
-        "WorkflowStep", foreign_keys=workflow_step_id, lazy=True
-    )
+    workflow_invocation: Mapped["WorkflowInvocation"] = relationship(back_populates="messages", lazy=True)
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship(foreign_keys=workflow_step_id, lazy=True)
     dependent_workflow_step: Mapped[Optional["WorkflowStep"]] = relationship(
-        "WorkflowStep", foreign_keys=dependent_workflow_step_id, lazy=True
+        foreign_keys=dependent_workflow_step_id, lazy=True
     )
 
     @property
@@ -9113,7 +9007,7 @@ class WorkflowInvocationStep(Base, Dictifiable, Serializable):
     action: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
 
     workflow_step = relationship("WorkflowStep")
-    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="workflow_invocation_step", uselist=False)
+    job: Mapped[Optional["Job"]] = relationship(back_populates="workflow_invocation_step", uselist=False)
     implicit_collection_jobs = relationship("ImplicitCollectionJobs", uselist=False)
     output_dataset_collections = relationship(
         "WorkflowInvocationStepOutputDatasetCollectionAssociation",
@@ -9125,7 +9019,7 @@ class WorkflowInvocationStep(Base, Dictifiable, Serializable):
         back_populates="workflow_invocation_step",
         cascade_backrefs=False,
     )
-    workflow_invocation: Mapped["WorkflowInvocation"] = relationship("WorkflowInvocation", back_populates="steps")
+    workflow_invocation: Mapped["WorkflowInvocation"] = relationship(back_populates="steps")
     output_value = relationship(
         "WorkflowInvocationOutputValue",
         foreign_keys="[WorkflowInvocationStep.workflow_invocation_id, WorkflowInvocationStep.workflow_step_id]",
@@ -9317,9 +9211,7 @@ class WorkflowRequestInputParameter(Base, Dictifiable, Serializable):
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
     value: Mapped[Optional[str]] = mapped_column(TEXT)
     type: Mapped[Optional[str]] = mapped_column(Unicode(255))
-    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(
-        "WorkflowInvocation", back_populates="input_parameters"
-    )
+    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(back_populates="input_parameters")
 
     dict_collection_visible_keys = ["id", "name", "value", "type"]
 
@@ -9348,10 +9240,8 @@ class WorkflowRequestStepState(Base, Dictifiable, Serializable):
     )
     workflow_step_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_step.id"))
     value: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
-    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep")
-    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(
-        "WorkflowInvocation", back_populates="step_states"
-    )
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship()
+    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(back_populates="step_states")
 
     dict_collection_visible_keys = ["id", "name", "value", "workflow_step_id"]
 
@@ -9373,11 +9263,9 @@ class WorkflowRequestToInputDatasetAssociation(Base, Dictifiable, Serializable):
     workflow_step_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_step.id"))
     dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_association.id"), index=True)
 
-    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep")
-    dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship("HistoryDatasetAssociation")
-    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(
-        "WorkflowInvocation", back_populates="input_datasets"
-    )
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship()
+    dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship()
+    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(back_populates="input_datasets")
 
     history_content_type = "dataset"
     dict_collection_visible_keys = ["id", "workflow_invocation_id", "workflow_step_id", "dataset_id", "name"]
@@ -9404,12 +9292,10 @@ class WorkflowRequestToInputDatasetCollectionAssociation(Base, Dictifiable, Seri
     dataset_collection_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("history_dataset_collection_association.id"), index=True
     )
-    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep")
-    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
-        "HistoryDatasetCollectionAssociation"
-    )
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship()
+    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship()
     workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(
-        "WorkflowInvocation", back_populates="input_dataset_collections"
+        back_populates="input_dataset_collections"
     )
 
     history_content_type = "dataset_collection"
@@ -9435,10 +9321,8 @@ class WorkflowRequestInputStepParameter(Base, Dictifiable, Serializable):
     workflow_step_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_step.id"))
     parameter_value: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
 
-    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep")
-    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(
-        "WorkflowInvocation", back_populates="input_step_parameters"
-    )
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship()
+    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(back_populates="input_step_parameters")
 
     dict_collection_visible_keys = ["id", "workflow_invocation_id", "workflow_step_id", "parameter_value"]
 
@@ -9460,12 +9344,10 @@ class WorkflowInvocationOutputDatasetAssociation(Base, Dictifiable, Serializable
     dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_association.id"), index=True)
     workflow_output_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_output.id"), index=True)
 
-    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(
-        "WorkflowInvocation", back_populates="output_datasets"
-    )
-    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep")
-    dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship("HistoryDatasetAssociation")
-    workflow_output: Mapped[Optional["WorkflowOutput"]] = relationship("WorkflowOutput")
+    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(back_populates="output_datasets")
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship()
+    dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship()
+    workflow_output: Mapped[Optional["WorkflowOutput"]] = relationship()
 
     history_content_type = "dataset"
     dict_collection_visible_keys = ["id", "workflow_invocation_id", "workflow_step_id", "dataset_id", "name"]
@@ -9498,13 +9380,11 @@ class WorkflowInvocationOutputDatasetCollectionAssociation(Base, Dictifiable, Se
     )
 
     workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(
-        "WorkflowInvocation", back_populates="output_dataset_collections"
+        back_populates="output_dataset_collections"
     )
-    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep")
-    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
-        "HistoryDatasetCollectionAssociation"
-    )
-    workflow_output: Mapped[Optional["WorkflowOutput"]] = relationship("WorkflowOutput")
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship()
+    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship()
+    workflow_output: Mapped[Optional["WorkflowOutput"]] = relationship()
 
     history_content_type = "dataset_collection"
     dict_collection_visible_keys = ["id", "workflow_invocation_id", "workflow_step_id", "dataset_collection_id", "name"]
@@ -9530,12 +9410,9 @@ class WorkflowInvocationOutputValue(Base, Dictifiable, Serializable):
     workflow_output_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_output.id"), index=True)
     value: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
 
-    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(
-        "WorkflowInvocation", back_populates="output_values"
-    )
+    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(back_populates="output_values")
 
     workflow_invocation_step: Mapped[Optional["WorkflowInvocationStep"]] = relationship(
-        "WorkflowInvocationStep",
         foreign_keys="[WorkflowInvocationStep.workflow_invocation_id, WorkflowInvocationStep.workflow_step_id]",
         primaryjoin=(
             lambda: and_(
@@ -9547,8 +9424,8 @@ class WorkflowInvocationOutputValue(Base, Dictifiable, Serializable):
         viewonly=True,
     )
 
-    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep")
-    workflow_output: Mapped[Optional["WorkflowOutput"]] = relationship("WorkflowOutput")
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship()
+    workflow_output: Mapped[Optional["WorkflowOutput"]] = relationship()
 
     dict_collection_visible_keys = ["id", "workflow_invocation_id", "workflow_step_id", "value"]
 
@@ -9572,9 +9449,9 @@ class WorkflowInvocationStepOutputDatasetAssociation(Base, Dictifiable, Represen
     dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_association.id"), index=True)
     output_name: Mapped[Optional[str]] = mapped_column(String(255))
     workflow_invocation_step: Mapped[Optional["WorkflowInvocationStep"]] = relationship(
-        "WorkflowInvocationStep", back_populates="output_datasets"
+        back_populates="output_datasets"
     )
-    dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship("HistoryDatasetAssociation")
+    dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship()
 
     dict_collection_visible_keys = ["id", "workflow_invocation_step_id", "dataset_id", "output_name"]
 
@@ -9597,11 +9474,9 @@ class WorkflowInvocationStepOutputDatasetCollectionAssociation(Base, Dictifiable
     output_name: Mapped[Optional[str]] = mapped_column(String(255))
 
     workflow_invocation_step: Mapped[Optional["WorkflowInvocationStep"]] = relationship(
-        "WorkflowInvocationStep", back_populates="output_dataset_collections"
+        back_populates="output_dataset_collections"
     )
-    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
-        "HistoryDatasetCollectionAssociation"
-    )
+    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship()
 
     dict_collection_visible_keys = ["id", "workflow_invocation_step_id", "dataset_collection_id", "output_name"]
 
@@ -9620,7 +9495,7 @@ class MetadataFile(Base, StorableObject, Serializable):
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     purged: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
 
-    history_dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship("HistoryDatasetAssociation")
+    history_dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship()
     library_dataset = relationship("LibraryDatasetDatasetAssociation")
 
     def __init__(self, dataset=None, name=None, uuid=None):
@@ -9703,7 +9578,6 @@ class FormDefinition(Base, Dictifiable, RepresentById):
     type: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     layout: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
     form_definition_current: Mapped["FormDefinitionCurrent"] = relationship(
-        "FormDefinitionCurrent",
         back_populates="forms",
         primaryjoin=(lambda: FormDefinitionCurrent.id == FormDefinition.form_definition_current_id),  # type: ignore[has-type]
     )
@@ -9769,13 +9643,11 @@ class FormDefinitionCurrent(Base, RepresentById):
     latest_form_id: Mapped[Optional[int]] = mapped_column(ForeignKey("form_definition.id"), index=True)
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     forms: Mapped[List["FormDefinition"]] = relationship(
-        "FormDefinition",
         back_populates="form_definition_current",
         cascade="all, delete-orphan",
         primaryjoin=(lambda: FormDefinitionCurrent.id == FormDefinition.form_definition_current_id),
     )
     latest_form: Mapped[Optional["FormDefinition"]] = relationship(
-        "FormDefinition",
         post_update=True,
         primaryjoin=(lambda: FormDefinitionCurrent.latest_form_id == FormDefinition.id),
     )
@@ -9793,7 +9665,7 @@ class FormValues(Base, RepresentById):
     form_definition_id: Mapped[Optional[int]] = mapped_column(ForeignKey("form_definition.id"), index=True)
     content: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
     form_definition: Mapped[Optional["FormDefinition"]] = relationship(
-        "FormDefinition", primaryjoin=(lambda: FormValues.form_definition_id == FormDefinition.id)
+        primaryjoin=(lambda: FormValues.form_definition_id == FormDefinition.id)
     )
 
     def __init__(self, form_def=None, content=None):
@@ -9821,9 +9693,7 @@ class UserAddress(Base, RepresentById):
     purged: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     # `desc` needs to be fully qualified because it is shadowed by `desc` Column defined above
     # TODO: db migration to rename column, then use `desc`
-    user: Mapped[Optional["User"]] = relationship(
-        "User", back_populates="addresses", order_by=sqlalchemy.desc("update_time")
-    )
+    user: Mapped[Optional["User"]] = relationship(back_populates="addresses", order_by=sqlalchemy.desc("update_time"))
 
     def to_dict(self, trans):
         return {
@@ -10024,7 +9894,7 @@ class UserAuthnzToken(Base, UserMixin, RepresentById):
     extra_data: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
     lifetime: Mapped[Optional[int]]
     assoc_type: Mapped[Optional[str]] = mapped_column(VARCHAR(64))
-    user: Mapped[Optional["User"]] = relationship("User", back_populates="social_auth")
+    user: Mapped[Optional["User"]] = relationship(back_populates="social_auth")
 
     # This static property is set at: galaxy.authnz.psa_authnz.PSAAuthnz
     sa_session = None
@@ -10205,8 +10075,8 @@ class CloudAuthz(Base):
     last_activity: Mapped[Optional[datetime]]
     description: Mapped[Optional[str]] = mapped_column(TEXT)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
-    user: Mapped[Optional["User"]] = relationship("User", back_populates="cloudauthz")
-    authn: Mapped[Optional["UserAuthnzToken"]] = relationship("UserAuthnzToken")
+    user: Mapped[Optional["User"]] = relationship(back_populates="cloudauthz")
+    authn: Mapped[Optional["UserAuthnzToken"]] = relationship()
 
     def __init__(self, user_id, provider, config, authn_id, description=None):
         self.user_id = user_id
@@ -10244,33 +10114,28 @@ class Page(Base, HasTags, Dictifiable, RepresentById):
     importable: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     slug: Mapped[Optional[str]] = mapped_column(TEXT)
     published: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
-    user: Mapped["User"] = relationship("User")
+    user: Mapped["User"] = relationship()
     revisions: Mapped[List["PageRevision"]] = relationship(
-        "PageRevision",
         cascade="all, delete-orphan",
         primaryjoin=(lambda: Page.id == PageRevision.page_id),  # type: ignore[has-type]
         back_populates="page",
     )
     latest_revision: Mapped[Optional["PageRevision"]] = relationship(
-        "PageRevision",
         post_update=True,
         primaryjoin=(lambda: Page.latest_revision_id == PageRevision.id),  # type: ignore[has-type]
         lazy=False,
     )
     tags: Mapped[List["PageTagAssociation"]] = relationship(
-        "PageTagAssociation", order_by=lambda: PageTagAssociation.id, back_populates="page"
+        order_by=lambda: PageTagAssociation.id, back_populates="page"
     )
     annotations: Mapped[List["PageAnnotationAssociation"]] = relationship(
-        "PageAnnotationAssociation", order_by=lambda: PageAnnotationAssociation.id, back_populates="page"
+        order_by=lambda: PageAnnotationAssociation.id, back_populates="page"
     )
     ratings: Mapped[List["PageRatingAssociation"]] = relationship(
-        "PageRatingAssociation",
         order_by=lambda: PageRatingAssociation.id,  # type: ignore[has-type]
         back_populates="page",
     )
-    users_shared_with: Mapped[List["PageUserShareAssociation"]] = relationship(
-        "PageUserShareAssociation", back_populates="page"
-    )
+    users_shared_with: Mapped[List["PageUserShareAssociation"]] = relationship(back_populates="page")
 
     average_rating = None
 
@@ -10322,7 +10187,7 @@ class PageRevision(Base, Dictifiable, RepresentById):
     title: Mapped[Optional[str]] = mapped_column(TEXT)
     content: Mapped[Optional[str]] = mapped_column(TEXT)
     content_format: Mapped[Optional[str]] = mapped_column(TrimmedString(32))
-    page: Mapped["Page"] = relationship("Page", primaryjoin=(lambda: Page.id == PageRevision.page_id))
+    page: Mapped["Page"] = relationship(primaryjoin=(lambda: Page.id == PageRevision.page_id))
     DEFAULT_CONTENT_FORMAT = "html"
     dict_element_visible_keys = ["id", "page_id", "title", "content", "content_format"]
 
@@ -10342,8 +10207,8 @@ class PageUserShareAssociation(Base, UserShareAssociation):
     id: Mapped[int] = mapped_column(primary_key=True)
     page_id: Mapped[Optional[int]] = mapped_column(ForeignKey("page.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    user: Mapped[User] = relationship("User")
-    page: Mapped[Optional["Page"]] = relationship("Page", back_populates="users_shared_with")
+    user: Mapped[User] = relationship()
+    page: Mapped[Optional["Page"]] = relationship(back_populates="users_shared_with")
 
 
 class Visualization(Base, HasTags, Dictifiable, RepresentById):
@@ -10369,36 +10234,30 @@ class Visualization(Base, HasTags, Dictifiable, RepresentById):
     slug: Mapped[Optional[str]] = mapped_column(TEXT)
     published: Mapped[Optional[bool]] = mapped_column(default=False, index=True)
 
-    user: Mapped["User"] = relationship("User")
+    user: Mapped["User"] = relationship()
     revisions: Mapped[List["VisualizationRevision"]] = relationship(
-        "VisualizationRevision",
         back_populates="visualization",
         cascade="all, delete-orphan",
         primaryjoin=(lambda: Visualization.id == VisualizationRevision.visualization_id),
         cascade_backrefs=False,
     )
     latest_revision: Mapped[Optional["VisualizationRevision"]] = relationship(
-        "VisualizationRevision",
         post_update=True,
         primaryjoin=(lambda: Visualization.latest_revision_id == VisualizationRevision.id),
         lazy=False,
     )
     tags: Mapped[List["VisualizationTagAssociation"]] = relationship(
-        "VisualizationTagAssociation", order_by=lambda: VisualizationTagAssociation.id, back_populates="visualization"
+        order_by=lambda: VisualizationTagAssociation.id, back_populates="visualization"
     )
     annotations: Mapped[List["VisualizationAnnotationAssociation"]] = relationship(
-        "VisualizationAnnotationAssociation",
         order_by=lambda: VisualizationAnnotationAssociation.id,
         back_populates="visualization",
     )
     ratings: Mapped[List["VisualizationRatingAssociation"]] = relationship(
-        "VisualizationRatingAssociation",
         order_by=lambda: VisualizationRatingAssociation.id,  # type: ignore[has-type]
         back_populates="visualization",
     )
-    users_shared_with: Mapped[List["VisualizationUserShareAssociation"]] = relationship(
-        "VisualizationUserShareAssociation", back_populates="visualization"
-    )
+    users_shared_with: Mapped[List["VisualizationUserShareAssociation"]] = relationship(back_populates="visualization")
 
     average_rating = None
 
@@ -10476,7 +10335,6 @@ class VisualizationRevision(Base, RepresentById):
     dbkey: Mapped[Optional[str]] = mapped_column(TEXT)
     config: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
     visualization: Mapped["Visualization"] = relationship(
-        "Visualization",
         back_populates="revisions",
         primaryjoin=(lambda: Visualization.id == VisualizationRevision.visualization_id),
     )
@@ -10499,8 +10357,8 @@ class VisualizationUserShareAssociation(Base, UserShareAssociation):
     id: Mapped[int] = mapped_column(primary_key=True)
     visualization_id: Mapped[Optional[int]] = mapped_column(ForeignKey("visualization.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    user: Mapped[User] = relationship("User")
-    visualization: Mapped[Optional["Visualization"]] = relationship("Visualization", back_populates="users_shared_with")
+    user: Mapped[User] = relationship()
+    visualization: Mapped[Optional["Visualization"]] = relationship(back_populates="users_shared_with")
 
 
 class Tag(Base, RepresentById):
@@ -10511,8 +10369,8 @@ class Tag(Base, RepresentById):
     type: Mapped[Optional[int]]
     parent_id: Mapped[Optional[int]] = mapped_column(ForeignKey("tag.id"))
     name: Mapped[Optional[str]] = mapped_column(TrimmedString(255))
-    children: Mapped[List["Tag"]] = relationship("Tag", back_populates="parent")
-    parent: Mapped[Optional["Tag"]] = relationship("Tag", back_populates="children", remote_side=[id])
+    children: Mapped[List["Tag"]] = relationship(back_populates="parent")
+    parent: Mapped[Optional["Tag"]] = relationship(back_populates="children", remote_side=[id])
 
     def __str__(self):
         return "Tag(id=%s, type=%i, parent_id=%s, name=%s)" % (self.id, self.type or -1, self.parent_id, self.name)
@@ -10548,9 +10406,9 @@ class HistoryTagAssociation(Base, ItemTagAssociation, RepresentById):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    history: Mapped[Optional["History"]] = relationship("History", back_populates="tags")
-    tag: Mapped[Optional["Tag"]] = relationship("Tag")
-    user: Mapped[Optional["User"]] = relationship("User")
+    history: Mapped[Optional["History"]] = relationship(back_populates="tags")
+    tag: Mapped[Optional["Tag"]] = relationship()
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class HistoryDatasetAssociationTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10564,11 +10422,9 @@ class HistoryDatasetAssociationTagAssociation(Base, ItemTagAssociation, Represen
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    history_dataset_association: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
-        "HistoryDatasetAssociation", back_populates="tags"
-    )
-    tag: Mapped[Optional["Tag"]] = relationship("Tag")
-    user: Mapped[Optional["User"]] = relationship("User")
+    history_dataset_association: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(back_populates="tags")
+    tag: Mapped[Optional["Tag"]] = relationship()
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class LibraryDatasetDatasetAssociationTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10583,10 +10439,10 @@ class LibraryDatasetDatasetAssociationTagAssociation(Base, ItemTagAssociation, R
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     library_dataset_dataset_association: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
-        "LibraryDatasetDatasetAssociation", back_populates="tags"
+        back_populates="tags"
     )
-    tag: Mapped[Optional["Tag"]] = relationship("Tag")
-    user: Mapped[Optional["User"]] = relationship("User")
+    tag: Mapped[Optional["Tag"]] = relationship()
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class PageTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10598,9 +10454,9 @@ class PageTagAssociation(Base, ItemTagAssociation, RepresentById):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    page: Mapped[Optional["Page"]] = relationship("Page", back_populates="tags")
-    tag: Mapped[Optional["Tag"]] = relationship("Tag")
-    user: Mapped[Optional["User"]] = relationship("User")
+    page: Mapped[Optional["Page"]] = relationship(back_populates="tags")
+    tag: Mapped[Optional["Tag"]] = relationship()
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class WorkflowStepTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10612,9 +10468,9 @@ class WorkflowStepTagAssociation(Base, ItemTagAssociation, RepresentById):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep", back_populates="tags")
-    tag: Mapped[Optional["Tag"]] = relationship("Tag")
-    user: Mapped[Optional["User"]] = relationship("User")
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship(back_populates="tags")
+    tag: Mapped[Optional["Tag"]] = relationship()
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class StoredWorkflowTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10626,9 +10482,9 @@ class StoredWorkflowTagAssociation(Base, ItemTagAssociation, RepresentById):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship("StoredWorkflow", back_populates="tags")
-    tag: Mapped[Optional["Tag"]] = relationship("Tag")
-    user: Mapped[Optional["User"]] = relationship("User")
+    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship(back_populates="tags")
+    tag: Mapped[Optional["Tag"]] = relationship()
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class VisualizationTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10640,9 +10496,9 @@ class VisualizationTagAssociation(Base, ItemTagAssociation, RepresentById):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    visualization: Mapped[Optional["Visualization"]] = relationship("Visualization", back_populates="tags")
-    tag: Mapped[Optional["Tag"]] = relationship("Tag")
-    user: Mapped[Optional["User"]] = relationship("User")
+    visualization: Mapped[Optional["Visualization"]] = relationship(back_populates="tags")
+    tag: Mapped[Optional["Tag"]] = relationship()
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class HistoryDatasetCollectionTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10656,11 +10512,9 @@ class HistoryDatasetCollectionTagAssociation(Base, ItemTagAssociation, Represent
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
-        "HistoryDatasetCollectionAssociation", back_populates="tags"
-    )
-    tag: Mapped[Optional["Tag"]] = relationship("Tag")
-    user: Mapped[Optional["User"]] = relationship("User")
+    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(back_populates="tags")
+    tag: Mapped[Optional["Tag"]] = relationship()
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class LibraryDatasetCollectionTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10674,11 +10528,9 @@ class LibraryDatasetCollectionTagAssociation(Base, ItemTagAssociation, Represent
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    dataset_collection: Mapped[Optional["LibraryDatasetCollectionAssociation"]] = relationship(
-        "LibraryDatasetCollectionAssociation", back_populates="tags"
-    )
-    tag: Mapped[Optional["Tag"]] = relationship("Tag")
-    user: Mapped[Optional["User"]] = relationship("User")
+    dataset_collection: Mapped[Optional["LibraryDatasetCollectionAssociation"]] = relationship(back_populates="tags")
+    tag: Mapped[Optional["Tag"]] = relationship()
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class ToolTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10690,8 +10542,8 @@ class ToolTagAssociation(Base, ItemTagAssociation, RepresentById):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    tag: Mapped[Optional["Tag"]] = relationship("Tag")
-    user: Mapped[Optional["User"]] = relationship("User")
+    tag: Mapped[Optional["Tag"]] = relationship()
+    user: Mapped[Optional["User"]] = relationship()
 
 
 # Item annotation classes.
@@ -10703,8 +10555,8 @@ class HistoryAnnotationAssociation(Base, RepresentById):
     history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    history: Mapped[Optional["History"]] = relationship("History", back_populates="annotations")
-    user: Mapped[Optional["User"]] = relationship("User")
+    history: Mapped[Optional["History"]] = relationship(back_populates="annotations")
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class HistoryDatasetAssociationAnnotationAssociation(Base, RepresentById):
@@ -10717,10 +10569,8 @@ class HistoryDatasetAssociationAnnotationAssociation(Base, RepresentById):
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    hda: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
-        "HistoryDatasetAssociation", back_populates="annotations"
-    )
-    user: Mapped[Optional["User"]] = relationship("User")
+    hda: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(back_populates="annotations")
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class StoredWorkflowAnnotationAssociation(Base, RepresentById):
@@ -10731,8 +10581,8 @@ class StoredWorkflowAnnotationAssociation(Base, RepresentById):
     stored_workflow_id: Mapped[Optional[int]] = mapped_column(ForeignKey("stored_workflow.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship("StoredWorkflow", back_populates="annotations")
-    user: Mapped[Optional["User"]] = relationship("User")
+    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship(back_populates="annotations")
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class WorkflowStepAnnotationAssociation(Base, RepresentById):
@@ -10743,8 +10593,8 @@ class WorkflowStepAnnotationAssociation(Base, RepresentById):
     workflow_step_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_step.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep", back_populates="annotations")
-    user: Mapped[Optional["User"]] = relationship("User")
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship(back_populates="annotations")
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class PageAnnotationAssociation(Base, RepresentById):
@@ -10755,8 +10605,8 @@ class PageAnnotationAssociation(Base, RepresentById):
     page_id: Mapped[Optional[int]] = mapped_column(ForeignKey("page.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    page: Mapped[Optional["Page"]] = relationship("Page", back_populates="annotations")
-    user: Mapped[Optional["User"]] = relationship("User")
+    page: Mapped[Optional["Page"]] = relationship(back_populates="annotations")
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class VisualizationAnnotationAssociation(Base, RepresentById):
@@ -10767,8 +10617,8 @@ class VisualizationAnnotationAssociation(Base, RepresentById):
     visualization_id: Mapped[Optional[int]] = mapped_column(ForeignKey("visualization.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    visualization: Mapped[Optional["Visualization"]] = relationship("Visualization", back_populates="annotations")
-    user: Mapped[Optional["User"]] = relationship("User")
+    visualization: Mapped[Optional["Visualization"]] = relationship(back_populates="annotations")
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class HistoryDatasetCollectionAssociationAnnotationAssociation(Base, RepresentById):
@@ -10781,9 +10631,9 @@ class HistoryDatasetCollectionAssociationAnnotationAssociation(Base, RepresentBy
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     annotation: Mapped[Optional[str]] = mapped_column(TEXT)
     history_dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
-        "HistoryDatasetCollectionAssociation", back_populates="annotations"
+        back_populates="annotations"
     )
-    user: Mapped[Optional["User"]] = relationship("User")
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class LibraryDatasetCollectionAnnotationAssociation(Base, RepresentById):
@@ -10796,9 +10646,9 @@ class LibraryDatasetCollectionAnnotationAssociation(Base, RepresentById):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     annotation: Mapped[Optional[str]] = mapped_column(TEXT)
     dataset_collection: Mapped[Optional["LibraryDatasetCollectionAssociation"]] = relationship(
-        "LibraryDatasetCollectionAssociation", back_populates="annotations"
+        back_populates="annotations"
     )
-    user: Mapped[Optional["User"]] = relationship("User")
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class Vault(Base):
@@ -10806,8 +10656,8 @@ class Vault(Base):
 
     key: Mapped[str] = mapped_column(Text, primary_key=True)
     parent_key: Mapped[Optional[str]] = mapped_column(Text, ForeignKey(key), index=True)
-    children: Mapped[List["Vault"]] = relationship("Vault", back_populates="parent")
-    parent: Mapped[Optional["Vault"]] = relationship("Vault", back_populates="children", remote_side=[key])
+    children: Mapped[List["Vault"]] = relationship(back_populates="parent")
+    parent: Mapped[Optional["Vault"]] = relationship(back_populates="children", remote_side=[key])
     value: Mapped[Optional[str]] = mapped_column(Text)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
@@ -10834,8 +10684,8 @@ class HistoryRatingAssociation(ItemRatingAssociation, RepresentById):
     history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     rating: Mapped[Optional[int]] = mapped_column(index=True)
-    history: Mapped[Optional["History"]] = relationship("History", back_populates="ratings")
-    user: Mapped[Optional["User"]] = relationship("User")
+    history: Mapped[Optional["History"]] = relationship(back_populates="ratings")
+    user: Mapped[Optional["User"]] = relationship()
 
     def _set_item(self, history):
         add_object_to_object_session(self, history)
@@ -10851,10 +10701,8 @@ class HistoryDatasetAssociationRatingAssociation(ItemRatingAssociation, Represen
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     rating: Mapped[Optional[int]] = mapped_column(index=True)
-    history_dataset_association: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
-        "HistoryDatasetAssociation", back_populates="ratings"
-    )
-    user: Mapped[Optional["User"]] = relationship("User")
+    history_dataset_association: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(back_populates="ratings")
+    user: Mapped[Optional["User"]] = relationship()
 
     def _set_item(self, history_dataset_association):
         add_object_to_object_session(self, history_dataset_association)
@@ -10868,8 +10716,8 @@ class StoredWorkflowRatingAssociation(ItemRatingAssociation, RepresentById):
     stored_workflow_id: Mapped[Optional[int]] = mapped_column(ForeignKey("stored_workflow.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     rating: Mapped[Optional[int]] = mapped_column(index=True)
-    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship("StoredWorkflow", back_populates="ratings")
-    user: Mapped[Optional["User"]] = relationship("User")
+    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship(back_populates="ratings")
+    user: Mapped[Optional["User"]] = relationship()
 
     def _set_item(self, stored_workflow):
         add_object_to_object_session(self, stored_workflow)
@@ -10883,8 +10731,8 @@ class PageRatingAssociation(ItemRatingAssociation, RepresentById):
     page_id: Mapped[Optional[int]] = mapped_column(ForeignKey("page.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     rating: Mapped[Optional[int]] = mapped_column(index=True)
-    page: Mapped[Optional["Page"]] = relationship("Page", back_populates="ratings")
-    user: Mapped[Optional["User"]] = relationship("User")
+    page: Mapped[Optional["Page"]] = relationship(back_populates="ratings")
+    user: Mapped[Optional["User"]] = relationship()
 
     def _set_item(self, page):
         add_object_to_object_session(self, page)
@@ -10898,8 +10746,8 @@ class VisualizationRatingAssociation(ItemRatingAssociation, RepresentById):
     visualization_id: Mapped[Optional[int]] = mapped_column(ForeignKey("visualization.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     rating: Mapped[Optional[int]] = mapped_column(index=True)
-    visualization: Mapped[Optional["Visualization"]] = relationship("Visualization", back_populates="ratings")
-    user: Mapped[Optional["User"]] = relationship("User")
+    visualization: Mapped[Optional["Visualization"]] = relationship(back_populates="ratings")
+    user: Mapped[Optional["User"]] = relationship()
 
     def _set_item(self, visualization):
         add_object_to_object_session(self, visualization)
@@ -10915,10 +10763,8 @@ class HistoryDatasetCollectionRatingAssociation(ItemRatingAssociation, Represent
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     rating: Mapped[Optional[int]] = mapped_column(index=True)
-    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
-        "HistoryDatasetCollectionAssociation", back_populates="ratings"
-    )
-    user: Mapped[Optional["User"]] = relationship("User")
+    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(back_populates="ratings")
+    user: Mapped[Optional["User"]] = relationship()
 
     def _set_item(self, dataset_collection):
         add_object_to_object_session(self, dataset_collection)
@@ -10934,10 +10780,8 @@ class LibraryDatasetCollectionRatingAssociation(ItemRatingAssociation, Represent
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     rating: Mapped[Optional[int]] = mapped_column(index=True)
-    dataset_collection: Mapped[Optional["LibraryDatasetCollectionAssociation"]] = relationship(
-        "LibraryDatasetCollectionAssociation", back_populates="ratings"
-    )
-    user: Mapped[Optional["User"]] = relationship("User")
+    dataset_collection: Mapped[Optional["LibraryDatasetCollectionAssociation"]] = relationship(back_populates="ratings")
+    user: Mapped[Optional["User"]] = relationship()
 
     def _set_item(self, dataset_collection):
         add_object_to_object_session(self, dataset_collection)
@@ -10953,8 +10797,8 @@ class DataManagerHistoryAssociation(Base, RepresentById):
     update_time: Mapped[datetime] = mapped_column(index=True, default=now, onupdate=now, nullable=True)
     history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    history: Mapped[Optional["History"]] = relationship("History")
-    user: Mapped[Optional["User"]] = relationship("User", back_populates="data_manager_histories")
+    history: Mapped[Optional["History"]] = relationship()
+    user: Mapped[Optional["User"]] = relationship(back_populates="data_manager_histories")
 
 
 class DataManagerJobAssociation(Base, RepresentById):
@@ -10966,7 +10810,7 @@ class DataManagerJobAssociation(Base, RepresentById):
     update_time: Mapped[datetime] = mapped_column(index=True, default=now, onupdate=now, nullable=True)
     job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
     data_manager_id: Mapped[Optional[str]] = mapped_column(TEXT)
-    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="data_manager_association", uselist=False)
+    job: Mapped[Optional["Job"]] = relationship(back_populates="data_manager_association", uselist=False)
 
 
 class UserPreference(Base, RepresentById):
@@ -10994,7 +10838,7 @@ class UserAction(Base, RepresentById):
     action: Mapped[Optional[str]] = mapped_column(Unicode(255))
     context: Mapped[Optional[str]] = mapped_column(Unicode(512))
     params: Mapped[Optional[str]] = mapped_column(Unicode(1024))
-    user: Mapped[Optional["User"]] = relationship("User")
+    user: Mapped[Optional["User"]] = relationship()
 
 
 class APIKeys(Base, RepresentById):
@@ -11004,7 +10848,7 @@ class APIKeys(Base, RepresentById):
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     key: Mapped[Optional[str]] = mapped_column(TrimmedString(32), index=True, unique=True)
-    user: Mapped[Optional["User"]] = relationship("User", back_populates="api_keys")
+    user: Mapped[Optional["User"]] = relationship(back_populates="api_keys")
     deleted: Mapped[bool] = mapped_column(index=True, server_default=false())
 
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1367,7 +1367,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     tool_version: Mapped[Optional[str]] = mapped_column(TEXT, default="1.0.0")
     galaxy_version: Mapped[Optional[str]] = mapped_column(String(64), default=None)
     dynamic_tool_id: Mapped[Optional[int]] = mapped_column(ForeignKey("dynamic_tool.id"), index=True)
-    state: Mapped[Optional[str]] = mapped_column(String(64), index=True)
+    state: Mapped[str] = mapped_column(String(64), index=True, nullable=True)
     info: Mapped[Optional[str]] = mapped_column(TrimmedString(255))
     copied_from_job_id: Mapped[Optional[int]]
     command_line: Mapped[Optional[str]] = mapped_column(TEXT)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2425,13 +2425,13 @@ class JobToInputLibraryDatasetAssociation(Base, RepresentById):
     __tablename__ = "job_to_input_library_dataset"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
-    ldda_id: Mapped[Optional[int]] = mapped_column(ForeignKey("library_dataset_dataset_association.id"), index=True)
-    name: Mapped[Optional[str]] = mapped_column(Unicode(255))
-    job: Mapped[Optional["Job"]] = relationship(back_populates="input_library_datasets")
-    dataset: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
-        lazy="joined", back_populates="dependent_jobs"
+    job_id: Mapped[int] = mapped_column(ForeignKey("job.id"), index=True, nullable=True)
+    ldda_id: Mapped[int] = mapped_column(
+        ForeignKey("library_dataset_dataset_association.id"), index=True, nullable=True
     )
+    name: Mapped[Optional[str]] = mapped_column(Unicode(255))
+    job: Mapped["Job"] = relationship(back_populates="input_library_datasets")
+    dataset: Mapped["LibraryDatasetDatasetAssociation"] = relationship(lazy="joined", back_populates="dependent_jobs")
 
     def __init__(self, name, dataset):
         self.name = name

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1407,10 +1407,10 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     preferred_object_store_id: Mapped[Optional[str]] = mapped_column(String(255))
     object_store_id_overrides: Mapped[Optional[bytes]] = mapped_column(JSONType)
 
-    user = relationship("User")
-    galaxy_session = relationship("GalaxySession")
-    history = relationship("History", back_populates="jobs")
-    library_folder = relationship("LibraryFolder")
+    user: Mapped[Optional["User"]] = relationship("User")
+    galaxy_session: Mapped[Optional["GalaxySession"]] = relationship("GalaxySession")
+    history: Mapped[Optional["History"]] = relationship("History", back_populates="jobs")
+    library_folder: Mapped[Optional["LibraryFolder"]] = relationship("LibraryFolder")
     parameters = relationship("JobParameter")
     input_datasets = relationship("JobToInputDatasetAssociation", back_populates="job")
     input_dataset_collections = relationship("JobToInputDatasetCollectionAssociation", back_populates="job")
@@ -2153,7 +2153,7 @@ class Task(Base, JobLike, RepresentById):
     task_runner_name: Mapped[Optional[str]] = mapped_column(String(255))
     task_runner_external_id: Mapped[Optional[str]] = mapped_column(String(255))
     prepare_input_files_cmd: Mapped[Optional[str]] = mapped_column(TEXT)
-    job = relationship("Job", back_populates="tasks")
+    job: Mapped["Job"] = relationship("Job", back_populates="tasks")
     text_metrics = relationship("TaskMetricText")
     numeric_metrics = relationship("TaskMetricNumeric")
 
@@ -2323,8 +2323,10 @@ class JobToInputDatasetAssociation(Base, RepresentById):
     dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_association.id"), index=True)
     dataset_version: Mapped[Optional[int]]
     name: Mapped[Optional[str]] = mapped_column(String(255))
-    dataset = relationship("HistoryDatasetAssociation", lazy="joined", back_populates="dependent_jobs")
-    job = relationship("Job", back_populates="input_datasets")
+    dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
+        "HistoryDatasetAssociation", lazy="joined", back_populates="dependent_jobs"
+    )
+    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="input_datasets")
 
     def __init__(self, name, dataset):
         self.name = name
@@ -2340,8 +2342,10 @@ class JobToOutputDatasetAssociation(Base, RepresentById):
     job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
     dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_association.id"), index=True)
     name: Mapped[Optional[str]] = mapped_column(String(255))
-    dataset = relationship("HistoryDatasetAssociation", lazy="joined", back_populates="creating_job_associations")
-    job = relationship("Job", back_populates="output_datasets")
+    dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
+        "HistoryDatasetAssociation", lazy="joined", back_populates="creating_job_associations"
+    )
+    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="output_datasets")
 
     def __init__(self, name, dataset):
         self.name = name
@@ -2362,8 +2366,10 @@ class JobToInputDatasetCollectionAssociation(Base, RepresentById):
         ForeignKey("history_dataset_collection_association.id"), index=True
     )
     name: Mapped[Optional[str]] = mapped_column(String(255))
-    dataset_collection = relationship("HistoryDatasetCollectionAssociation", lazy="joined")
-    job = relationship("Job", back_populates="input_dataset_collections")
+    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
+        "HistoryDatasetCollectionAssociation", lazy="joined"
+    )
+    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="input_dataset_collections")
 
     def __init__(self, name, dataset_collection):
         self.name = name
@@ -2379,8 +2385,10 @@ class JobToInputDatasetCollectionElementAssociation(Base, RepresentById):
         ForeignKey("dataset_collection_element.id"), index=True
     )
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
-    dataset_collection_element = relationship("DatasetCollectionElement", lazy="joined")
-    job = relationship("Job", back_populates="input_dataset_collection_elements")
+    dataset_collection_element: Mapped[Optional["DatasetCollectionElement"]] = relationship(
+        "DatasetCollectionElement", lazy="joined"
+    )
+    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="input_dataset_collection_elements")
 
     def __init__(self, name, dataset_collection_element):
         self.name = name
@@ -2398,8 +2406,10 @@ class JobToOutputDatasetCollectionAssociation(Base, RepresentById):
         ForeignKey("history_dataset_collection_association.id"), index=True
     )
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
-    dataset_collection_instance = relationship("HistoryDatasetCollectionAssociation", lazy="joined")
-    job = relationship("Job", back_populates="output_dataset_collection_instances")
+    dataset_collection_instance: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
+        "HistoryDatasetCollectionAssociation", lazy="joined"
+    )
+    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="output_dataset_collection_instances")
 
     def __init__(self, name, dataset_collection_instance):
         self.name = name
@@ -2420,8 +2430,8 @@ class JobToImplicitOutputDatasetCollectionAssociation(Base, RepresentById):
     job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
     dataset_collection_id: Mapped[Optional[int]] = mapped_column(ForeignKey("dataset_collection.id"), index=True)
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
-    dataset_collection = relationship("DatasetCollection")
-    job = relationship("Job", back_populates="output_dataset_collections")
+    dataset_collection: Mapped[Optional["DatasetCollection"]] = relationship("DatasetCollection")
+    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="output_dataset_collections")
 
     def __init__(self, name, dataset_collection):
         self.name = name
@@ -2435,8 +2445,10 @@ class JobToInputLibraryDatasetAssociation(Base, RepresentById):
     job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
     ldda_id: Mapped[Optional[int]] = mapped_column(ForeignKey("library_dataset_dataset_association.id"), index=True)
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
-    job = relationship("Job", back_populates="input_library_datasets")
-    dataset = relationship("LibraryDatasetDatasetAssociation", lazy="joined", back_populates="dependent_jobs")
+    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="input_library_datasets")
+    dataset: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
+        "LibraryDatasetDatasetAssociation", lazy="joined", back_populates="dependent_jobs"
+    )
 
     def __init__(self, name, dataset):
         self.name = name
@@ -2451,8 +2463,8 @@ class JobToOutputLibraryDatasetAssociation(Base, RepresentById):
     job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
     ldda_id: Mapped[Optional[int]] = mapped_column(ForeignKey("library_dataset_dataset_association.id"), index=True)
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
-    job = relationship("Job", back_populates="output_library_datasets")
-    dataset = relationship(
+    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="output_library_datasets")
+    dataset: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
         "LibraryDatasetDatasetAssociation", lazy="joined", back_populates="creating_job_associations"
     )
 
@@ -2489,7 +2501,7 @@ class ImplicitlyCreatedDatasetCollectionInput(Base, RepresentById):
     )
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
 
-    input_dataset_collection = relationship(
+    input_dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
         "HistoryDatasetCollectionAssociation",
         primaryjoin=(
             lambda: HistoryDatasetCollectionAssociation.id  # type: ignore[has-type]
@@ -2543,7 +2555,7 @@ class ImplicitCollectionJobsJobAssociation(Base, RepresentById):
     job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)  # Consider making this nullable...
     order_index: Mapped[int]
     implicit_collection_jobs = relationship("ImplicitCollectionJobs", back_populates="jobs")
-    job = relationship("Job", back_populates="implicit_collection_jobs_association")
+    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="implicit_collection_jobs_association")
 
 
 class PostJobAction(Base, RepresentById):
@@ -2554,7 +2566,7 @@ class PostJobAction(Base, RepresentById):
     action_type: Mapped[str] = mapped_column(String(255))
     output_name: Mapped[Optional[str]] = mapped_column(String(255))
     action_arguments: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
-    workflow_step = relationship(
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship(
         "WorkflowStep",
         back_populates="post_job_actions",
         primaryjoin=(lambda: WorkflowStep.id == PostJobAction.workflow_step_id),  # type: ignore[has-type]
@@ -2574,8 +2586,8 @@ class PostJobActionAssociation(Base, RepresentById):
     id: Mapped[int] = mapped_column(primary_key=True)
     job_id: Mapped[int] = mapped_column(ForeignKey("job.id"), index=True)
     post_job_action_id: Mapped[int] = mapped_column(ForeignKey("post_job_action.id"), index=True)
-    post_job_action = relationship("PostJobAction")
-    job = relationship("Job", back_populates="post_job_actions")
+    post_job_action: Mapped["PostJobAction"] = relationship("PostJobAction")
+    job: Mapped["Job"] = relationship("Job", back_populates="post_job_actions")
 
     def __init__(self, pja, job=None, job_id=None):
         if job is not None:
@@ -2606,9 +2618,13 @@ class JobExternalOutputMetadata(Base, RepresentById):
     filename_kwds: Mapped[Optional[str]] = mapped_column(String(255))
     filename_override_metadata: Mapped[Optional[str]] = mapped_column(String(255))
     job_runner_external_pid: Mapped[Optional[str]] = mapped_column(String(255))
-    history_dataset_association = relationship("HistoryDatasetAssociation", lazy="joined")
-    library_dataset_dataset_association = relationship("LibraryDatasetDatasetAssociation", lazy="joined")
-    job = relationship("Job", back_populates="external_output_metadata")
+    history_dataset_association: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
+        "HistoryDatasetAssociation", lazy="joined"
+    )
+    library_dataset_dataset_association: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
+        "LibraryDatasetDatasetAssociation", lazy="joined"
+    )
+    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="external_output_metadata")
 
     def __init__(self, job=None, dataset=None):
         add_object_to_object_session(self, job)
@@ -2654,9 +2670,9 @@ class JobExportHistoryArchive(Base, RepresentById):
     dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("dataset.id"), index=True)
     compressed: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     history_attrs_filename: Mapped[Optional[str]] = mapped_column(TEXT)
-    job = relationship("Job")
-    dataset = relationship("Dataset")
-    history = relationship("History", back_populates="exports")
+    job: Mapped[Optional["Job"]] = relationship("Job")
+    dataset: Mapped[Optional["Dataset"]] = relationship("Dataset")
+    history: Mapped[Optional["History"]] = relationship("History", back_populates="exports")
 
     ATTRS_FILENAME_HISTORY = "history_attrs.txt"
 
@@ -2740,8 +2756,8 @@ class JobImportHistoryArchive(Base, RepresentById):
     job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
     history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
     archive_dir: Mapped[Optional[str]] = mapped_column(TEXT)
-    job = relationship("Job")
-    history = relationship("History")
+    job: Mapped[Optional["Job"]] = relationship("Job")
+    history: Mapped[Optional["History"]] = relationship("History")
 
 
 class StoreExportAssociation(Base, RepresentById):
@@ -2766,7 +2782,7 @@ class JobContainerAssociation(Base, RepresentById):
     container_info: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
     created_time: Mapped[Optional[datetime]] = mapped_column(default=now)
     modified_time: Mapped[Optional[datetime]] = mapped_column(default=now, onupdate=now)
-    job = relationship("Job", back_populates="container")
+    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="container")
 
     def __init__(self, **kwd):
         if "job" in kwd:
@@ -2796,7 +2812,7 @@ class InteractiveToolEntryPoint(Base, Dictifiable, RepresentById):
     created_time: Mapped[Optional[datetime]] = mapped_column(default=now)
     modified_time: Mapped[Optional[datetime]] = mapped_column(default=now, onupdate=now)
     label: Mapped[Optional[str]] = mapped_column(TEXT)
-    job = relationship("Job", back_populates="interactivetool_entry_points", uselist=False)
+    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="interactivetool_entry_points", uselist=False)
 
     dict_collection_visible_keys = [
         "id",
@@ -2862,9 +2878,9 @@ class GenomeIndexToolData(Base, RepresentById):  # TODO: params arg is lost
     modified_time: Mapped[Optional[datetime]] = mapped_column(default=now, onupdate=now)
     indexer: Mapped[Optional[str]] = mapped_column(String(64))
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    job = relationship("Job")
-    dataset = relationship("Dataset")
-    user = relationship("User")
+    job: Mapped[Optional["Job"]] = relationship("Job")
+    dataset: Mapped[Optional["Dataset"]] = relationship("Dataset")
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class Group(Base, Dictifiable, RepresentById):
@@ -2895,8 +2911,8 @@ class UserGroupAssociation(Base, RepresentById):
     group_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_group.id"), index=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
-    user = relationship("User", back_populates="groups")
-    group = relationship("Group", back_populates="users")
+    user: Mapped[Optional["User"]] = relationship("User", back_populates="groups")
+    group: Mapped[Optional["Group"]] = relationship("Group", back_populates="users")
 
     def __init__(self, user, group):
         add_object_to_object_session(self, user)
@@ -2946,8 +2962,10 @@ class UserNotificationAssociation(Base, RepresentById):
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     update_time: Mapped[Optional[datetime]] = mapped_column(default=now, onupdate=now)
 
-    user = relationship("User", back_populates="all_notifications")
-    notification = relationship("Notification", back_populates="user_notification_associations")
+    user: Mapped[Optional["User"]] = relationship("User", back_populates="all_notifications")
+    notification: Mapped[Optional["Notification"]] = relationship(
+        "Notification", back_populates="user_notification_associations"
+    )
 
     def __init__(self, user, notification):
         self.user = user
@@ -3098,7 +3116,7 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
     users_shared_with = relationship("HistoryUserShareAssociation", back_populates="history")
     galaxy_sessions = relationship("GalaxySessionToHistoryAssociation", back_populates="history")
     workflow_invocations = relationship("WorkflowInvocation", back_populates="history", cascade_backrefs=False)
-    user = relationship("User", back_populates="histories")
+    user: Mapped[Optional["User"]] = relationship("User", back_populates="histories")
     jobs = relationship("Job", back_populates="history", cascade_backrefs=False)
 
     update_time = column_property(
@@ -3593,7 +3611,7 @@ class HistoryUserShareAssociation(Base, UserShareAssociation):
     history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user: Mapped[User] = relationship("User")
-    history = relationship("History", back_populates="users_shared_with")
+    history: Mapped[Optional["History"]] = relationship("History", back_populates="users_shared_with")
 
 
 class UserRoleAssociation(Base, RepresentById):
@@ -3605,8 +3623,8 @@ class UserRoleAssociation(Base, RepresentById):
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
 
-    user = relationship("User", back_populates="roles")
-    role = relationship("Role", back_populates="users")
+    user: Mapped[Optional["User"]] = relationship("User", back_populates="roles")
+    role: Mapped[Optional["Role"]] = relationship("Role", back_populates="users")
 
     def __init__(self, user, role):
         add_object_to_object_session(self, user)
@@ -3622,8 +3640,8 @@ class GroupRoleAssociation(Base, RepresentById):
     role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
-    group = relationship("Group", back_populates="roles")
-    role = relationship("Role", back_populates="groups")
+    group: Mapped[Optional["Group"]] = relationship("Group", back_populates="roles")
+    role: Mapped[Optional["Role"]] = relationship("Role", back_populates="groups")
 
     def __init__(self, group, role):
         self.group = group
@@ -3674,7 +3692,7 @@ class UserQuotaSourceUsage(Base, Dictifiable, RepresentById):
     quota_source_label: Mapped[Optional[str]] = mapped_column(String(32), index=True)
     # user had an index on disk_usage - does that make any sense? -John
     disk_usage: Mapped[Decimal] = mapped_column(Numeric(15, 0), default=0)
-    user = relationship("User", back_populates="quota_source_usages")
+    user: Mapped[Optional["User"]] = relationship("User", back_populates="quota_source_usages")
 
 
 class UserQuotaAssociation(Base, Dictifiable, RepresentById):
@@ -3685,8 +3703,8 @@ class UserQuotaAssociation(Base, Dictifiable, RepresentById):
     quota_id: Mapped[Optional[int]] = mapped_column(ForeignKey("quota.id"), index=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
-    user = relationship("User", back_populates="quotas")
-    quota = relationship("Quota", back_populates="users")
+    user: Mapped[Optional["User"]] = relationship("User", back_populates="quotas")
+    quota: Mapped[Optional["Quota"]] = relationship("Quota", back_populates="users")
 
     dict_element_visible_keys = ["user"]
 
@@ -3704,8 +3722,8 @@ class GroupQuotaAssociation(Base, Dictifiable, RepresentById):
     quota_id: Mapped[Optional[int]] = mapped_column(ForeignKey("quota.id"), index=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
-    group = relationship("Group", back_populates="quotas")
-    quota = relationship("Quota", back_populates="groups")
+    group: Mapped[Optional["Group"]] = relationship("Group", back_populates="quotas")
+    quota: Mapped[Optional["Quota"]] = relationship("Quota", back_populates="groups")
 
     dict_element_visible_keys = ["group"]
 
@@ -3786,7 +3804,7 @@ class DefaultQuotaAssociation(Base, Dictifiable, RepresentById):
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
     type: Mapped[Optional[str]] = mapped_column(String(32))
     quota_id: Mapped[Optional[int]] = mapped_column(ForeignKey("quota.id"), index=True)
-    quota = relationship("Quota", back_populates="default")
+    quota: Mapped[Optional["Quota"]] = relationship("Quota", back_populates="default")
 
     dict_element_visible_keys = ["type"]
 
@@ -3810,8 +3828,8 @@ class DatasetPermissions(Base, RepresentById):
     action: Mapped[Optional[str]] = mapped_column(TEXT)
     dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("dataset.id"), index=True)
     role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
-    dataset = relationship("Dataset", back_populates="actions")
-    role = relationship("Role", back_populates="dataset_actions")
+    dataset: Mapped[Optional["Dataset"]] = relationship("Dataset", back_populates="actions")
+    role: Mapped[Optional["Role"]] = relationship("Role", back_populates="dataset_actions")
 
     def __init__(self, action, dataset, role=None, role_id=None):
         self.action = action
@@ -3832,8 +3850,8 @@ class LibraryPermissions(Base, RepresentById):
     action: Mapped[Optional[str]] = mapped_column(TEXT)
     library_id: Mapped[Optional[int]] = mapped_column(ForeignKey("library.id"), index=True)
     role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
-    library = relationship("Library", back_populates="actions")
-    role = relationship("Role")
+    library: Mapped[Optional["Library"]] = relationship("Library", back_populates="actions")
+    role: Mapped[Optional["Role"]] = relationship("Role")
 
     def __init__(self, action, library_item, role):
         self.action = action
@@ -3854,8 +3872,8 @@ class LibraryFolderPermissions(Base, RepresentById):
     action: Mapped[Optional[str]] = mapped_column(TEXT)
     library_folder_id: Mapped[Optional[int]] = mapped_column(ForeignKey("library_folder.id"), index=True)
     role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
-    folder = relationship("LibraryFolder", back_populates="actions")
-    role = relationship("Role")
+    folder: Mapped[Optional["LibraryFolder"]] = relationship("LibraryFolder", back_populates="actions")
+    role: Mapped[Optional["Role"]] = relationship("Role")
 
     def __init__(self, action, library_item, role):
         self.action = action
@@ -3876,8 +3894,8 @@ class LibraryDatasetPermissions(Base, RepresentById):
     action: Mapped[Optional[str]] = mapped_column(TEXT)
     library_dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("library_dataset.id"), index=True)
     role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
-    library_dataset = relationship("LibraryDataset", back_populates="actions")
-    role = relationship("Role")
+    library_dataset: Mapped[Optional["LibraryDataset"]] = relationship("LibraryDataset", back_populates="actions")
+    role: Mapped[Optional["Role"]] = relationship("Role")
 
     def __init__(self, action, library_item, role):
         self.action = action
@@ -3900,8 +3918,10 @@ class LibraryDatasetDatasetAssociationPermissions(Base, RepresentById):
         ForeignKey("library_dataset_dataset_association.id"), index=True
     )
     role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
-    library_dataset_dataset_association = relationship("LibraryDatasetDatasetAssociation", back_populates="actions")
-    role = relationship("Role")
+    library_dataset_dataset_association: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
+        "LibraryDatasetDatasetAssociation", back_populates="actions"
+    )
+    role: Mapped[Optional["Role"]] = relationship("Role")
 
     def __init__(self, action, library_item, role):
         self.action = action
@@ -3920,8 +3940,8 @@ class DefaultUserPermissions(Base, RepresentById):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     action: Mapped[Optional[str]] = mapped_column(TEXT)
     role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
-    user = relationship("User", back_populates="default_permissions")
-    role = relationship("Role")
+    user: Mapped[Optional["User"]] = relationship("User", back_populates="default_permissions")
+    role: Mapped[Optional["Role"]] = relationship("Role")
 
     def __init__(self, user, action, role):
         add_object_to_object_session(self, user)
@@ -3937,8 +3957,8 @@ class DefaultHistoryPermissions(Base, RepresentById):
     history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
     action: Mapped[Optional[str]] = mapped_column(TEXT)
     role_id: Mapped[Optional[int]] = mapped_column(ForeignKey("role.id"), index=True)
-    history = relationship("History", back_populates="default_permissions")
-    role = relationship("Role")
+    history: Mapped[Optional["History"]] = relationship("History", back_populates="default_permissions")
+    role: Mapped[Optional["Role"]] = relationship("Role")
 
     def __init__(self, history, action, role):
         add_object_to_object_session(self, history)
@@ -3974,7 +3994,7 @@ class Dataset(Base, StorableObject, Serializable):
     uuid: Mapped[Optional[Union[UUID, str]]] = mapped_column(UUIDType())
 
     actions = relationship("DatasetPermissions", back_populates="dataset")
-    job = relationship(Job, primaryjoin=(lambda: Dataset.job_id == Job.id))
+    job: Mapped[Optional["Job"]] = relationship(Job, primaryjoin=(lambda: Dataset.job_id == Job.id))
     active_history_associations = relationship(
         "HistoryDatasetAssociation",
         primaryjoin=(
@@ -4342,7 +4362,7 @@ class DatasetSource(Base, Dictifiable, Serializable):
     source_uri: Mapped[Optional[str]] = mapped_column(TEXT)
     extra_files_path: Mapped[Optional[str]] = mapped_column(TEXT)
     transform: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
-    dataset = relationship("Dataset", back_populates="sources")
+    dataset: Mapped[Optional["Dataset"]] = relationship("Dataset", back_populates="sources")
     hashes = relationship("DatasetSourceHash", back_populates="source")
     dict_collection_visible_keys = ["id", "source_uri", "extra_files_path", "transform"]
     dict_element_visible_keys = [
@@ -4379,7 +4399,7 @@ class DatasetSourceHash(Base, Serializable):
     dataset_source_id: Mapped[Optional[int]] = mapped_column(ForeignKey("dataset_source.id"), index=True)
     hash_function: Mapped[Optional[str]] = mapped_column(TEXT)
     hash_value: Mapped[Optional[str]] = mapped_column(TEXT)
-    source = relationship("DatasetSource", back_populates="hashes")
+    source: Mapped[Optional["DatasetSource"]] = relationship("DatasetSource", back_populates="hashes")
 
     def _serialize(self, id_encoder, serialization_options):
         rval = dict_for(
@@ -4405,7 +4425,7 @@ class DatasetHash(Base, Dictifiable, Serializable):
     hash_function: Mapped[Optional[str]] = mapped_column(TEXT)
     hash_value: Mapped[Optional[str]] = mapped_column(TEXT)
     extra_files_path: Mapped[Optional[str]] = mapped_column(TEXT)
-    dataset = relationship("Dataset", back_populates="hashes")
+    dataset: Mapped[Optional["Dataset"]] = relationship("Dataset", back_populates="hashes")
     dict_collection_visible_keys = ["id", "hash_function", "hash_value", "extra_files_path"]
     dict_element_visible_keys = ["id", "hash_function", "hash_value", "extra_files_path"]
 
@@ -5486,8 +5506,10 @@ class HistoryDatasetAssociationDisplayAtAuthorization(Base, RepresentById):
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     site: Mapped[Optional[str]] = mapped_column(TrimmedString(255))
-    history_dataset_association = relationship("HistoryDatasetAssociation")
-    user = relationship("User")
+    history_dataset_association: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
+        "HistoryDatasetAssociation"
+    )
+    user: Mapped[Optional["User"]] = relationship("User")
 
     def __init__(self, hda=None, user=None, site=None):
         self.history_dataset_association = hda
@@ -5507,13 +5529,13 @@ class HistoryDatasetAssociationSubset(Base, RepresentById):
     )
     location: Mapped[Optional[str]] = mapped_column(Unicode(255), index=True)
 
-    hda = relationship(
+    hda: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
         "HistoryDatasetAssociation",
         primaryjoin=(
             lambda: HistoryDatasetAssociationSubset.history_dataset_association_id == HistoryDatasetAssociation.id
         ),
     )
-    subset = relationship(
+    subset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
         "HistoryDatasetAssociation",
         primaryjoin=(
             lambda: HistoryDatasetAssociationSubset.history_dataset_association_subset_id
@@ -5626,7 +5648,9 @@ class LibraryFolder(Base, Dictifiable, HasName, Serializable):
         order_by=asc(name),
         back_populates="parent",
     )
-    parent = relationship("LibraryFolder", back_populates="folders", remote_side=[id])
+    parent: Mapped[Optional["LibraryFolder"]] = relationship(
+        "LibraryFolder", back_populates="folders", remote_side=[id]
+    )
 
     active_folders = relationship(
         "LibraryFolder",
@@ -5768,7 +5792,7 @@ class LibraryDataset(Base, Serializable):
     _info: Mapped[Optional[str]] = mapped_column("info", TrimmedString(255))
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     purged: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
-    folder = relationship("LibraryFolder")
+    folder: Mapped[Optional["LibraryFolder"]] = relationship("LibraryFolder")
     library_dataset_dataset_association = relationship(
         "LibraryDatasetDatasetAssociation", foreign_keys=library_dataset_dataset_association_id, post_update=True
     )
@@ -6065,7 +6089,9 @@ class ExtendedMetadataIndex(Base, RepresentById):
     )
     path: Mapped[Optional[str]] = mapped_column(String(255))
     value: Mapped[Optional[str]] = mapped_column(TEXT)
-    extended_metadata = relationship("ExtendedMetadata", back_populates="children")
+    extended_metadata: Mapped[Optional["ExtendedMetadata"]] = relationship(
+        "ExtendedMetadata", back_populates="children"
+    )
 
     def __init__(self, extended_metadata, path, value):
         self.extended_metadata = extended_metadata
@@ -6083,7 +6109,7 @@ class LibraryInfoAssociation(Base, RepresentById):
     inheritable: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
 
-    library = relationship(
+    library: Mapped[Optional["Library"]] = relationship(
         "Library",
         primaryjoin=(
             lambda: and_(
@@ -6092,10 +6118,10 @@ class LibraryInfoAssociation(Base, RepresentById):
             )
         ),
     )
-    template = relationship(
+    template: Mapped[Optional["FormDefinition"]] = relationship(
         "FormDefinition", primaryjoin=lambda: LibraryInfoAssociation.form_definition_id == FormDefinition.id
     )
-    info = relationship(
+    info: Mapped[Optional["FormValues"]] = relationship(
         "FormValues", primaryjoin=lambda: LibraryInfoAssociation.form_values_id == FormValues.id  # type: ignore[has-type]
     )
 
@@ -6116,17 +6142,17 @@ class LibraryFolderInfoAssociation(Base, RepresentById):
     inheritable: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
 
-    folder = relationship(
+    folder: Mapped[Optional["LibraryFolder"]] = relationship(
         "LibraryFolder",
         primaryjoin=(
             lambda: (LibraryFolderInfoAssociation.library_folder_id == LibraryFolder.id)
             & (not_(LibraryFolderInfoAssociation.deleted))
         ),
     )
-    template = relationship(
+    template: Mapped[Optional["FormDefinition"]] = relationship(
         "FormDefinition", primaryjoin=(lambda: LibraryFolderInfoAssociation.form_definition_id == FormDefinition.id)
     )
-    info = relationship(
+    info: Mapped[Optional["FormValues"]] = relationship(
         "FormValues", primaryjoin=(lambda: LibraryFolderInfoAssociation.form_values_id == FormValues.id)  # type: ignore[has-type]
     )
 
@@ -6148,7 +6174,7 @@ class LibraryDatasetDatasetInfoAssociation(Base, RepresentById):
     form_values_id: Mapped[Optional[int]] = mapped_column(ForeignKey("form_values.id"), index=True)
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
 
-    library_dataset_dataset_association = relationship(
+    library_dataset_dataset_association: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
         "LibraryDatasetDatasetAssociation",
         primaryjoin=(
             lambda: (
@@ -6158,11 +6184,11 @@ class LibraryDatasetDatasetInfoAssociation(Base, RepresentById):
             & (not_(LibraryDatasetDatasetInfoAssociation.deleted))
         ),
     )
-    template = relationship(
+    template: Mapped[Optional["FormDefinition"]] = relationship(
         "FormDefinition",
         primaryjoin=(lambda: LibraryDatasetDatasetInfoAssociation.form_definition_id == FormDefinition.id),
     )
-    info = relationship(
+    info: Mapped[Optional["FormValues"]] = relationship(
         "FormValues", primaryjoin=(lambda: LibraryDatasetDatasetInfoAssociation.form_values_id == FormValues.id)  # type: ignore[has-type]
     )
 
@@ -6193,22 +6219,22 @@ class ImplicitlyConvertedDatasetAssociation(Base, Serializable):
     metadata_safe: Mapped[Optional[bool]] = mapped_column(index=True, default=True)
     type: Mapped[Optional[str]] = mapped_column(TrimmedString(255))
 
-    parent_hda = relationship(
+    parent_hda: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
         "HistoryDatasetAssociation",
         primaryjoin=(lambda: ImplicitlyConvertedDatasetAssociation.hda_parent_id == HistoryDatasetAssociation.id),
         back_populates="implicitly_converted_datasets",
     )
-    dataset_ldda = relationship(
+    dataset_ldda: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
         "LibraryDatasetDatasetAssociation",
         primaryjoin=(lambda: ImplicitlyConvertedDatasetAssociation.ldda_id == LibraryDatasetDatasetAssociation.id),
         back_populates="implicitly_converted_parent_datasets",
     )
-    dataset = relationship(
+    dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
         "HistoryDatasetAssociation",
         primaryjoin=(lambda: ImplicitlyConvertedDatasetAssociation.hda_id == HistoryDatasetAssociation.id),
         back_populates="implicitly_converted_parent_datasets",
     )
-    parent_ldda = relationship(
+    parent_ldda: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
         "LibraryDatasetDatasetAssociation",
         primaryjoin=(
             lambda: ImplicitlyConvertedDatasetAssociation.ldda_parent_id == LibraryDatasetDatasetAssociation.table.c.id
@@ -6769,7 +6795,7 @@ class HistoryDatasetCollectionAssociation(
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, index=True, nullable=True)
 
     collection = relationship("DatasetCollection")
-    history = relationship("History", back_populates="dataset_collections")
+    history: Mapped[Optional["History"]] = relationship("History", back_populates="dataset_collections")
 
     copied_from_history_dataset_collection_association = relationship(
         "HistoryDatasetCollectionAssociation",
@@ -6790,7 +6816,7 @@ class HistoryDatasetCollectionAssociation(
         ),
     )
     implicit_collection_jobs = relationship("ImplicitCollectionJobs", uselist=False)
-    job = relationship(
+    job: Mapped[Optional["Job"]] = relationship(
         "Job",
         back_populates="history_dataset_collection_associations",
         uselist=False,
@@ -7387,9 +7413,9 @@ class Event(Base, RepresentById):
     session_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_session.id"), index=True)
     tool_id: Mapped[Optional[str]] = mapped_column(String(255))
 
-    history = relationship("History")
-    user = relationship("User")
-    galaxy_session = relationship("GalaxySession")
+    history: Mapped[Optional["History"]] = relationship("History")
+    user: Mapped[Optional["User"]] = relationship("User")
+    galaxy_session: Mapped[Optional["GalaxySession"]] = relationship("GalaxySession")
 
 
 class GalaxySession(Base, RepresentById):
@@ -7410,11 +7436,11 @@ class GalaxySession(Base, RepresentById):
     prev_session_id: Mapped[Optional[int]]
     disk_usage: Mapped[Optional[Decimal]] = mapped_column(Numeric(15, 0), index=True)
     last_action: Mapped[Optional[datetime]]
-    current_history = relationship("History")
+    current_history: Mapped[Optional["History"]] = relationship("History")
     histories = relationship(
         "GalaxySessionToHistoryAssociation", back_populates="galaxy_session", cascade_backrefs=False
     )
-    user = relationship("User", back_populates="galaxy_sessions")
+    user: Mapped[Optional["User"]] = relationship("User", back_populates="galaxy_sessions")
 
     def __init__(self, is_valid=False, **kwd):
         super().__init__(**kwd)
@@ -7445,8 +7471,8 @@ class GalaxySessionToHistoryAssociation(Base, RepresentById):
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     session_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_session.id"), index=True)
     history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
-    galaxy_session = relationship("GalaxySession", back_populates="histories")
-    history = relationship("History", back_populates="galaxy_sessions")
+    galaxy_session: Mapped[Optional["GalaxySession"]] = relationship("GalaxySession", back_populates="histories")
+    history: Mapped[Optional["History"]] = relationship("History", back_populates="galaxy_sessions")
 
     def __init__(self, galaxy_session, history):
         self.galaxy_session = galaxy_session
@@ -7482,7 +7508,7 @@ class StoredWorkflow(Base, HasTags, Dictifiable, RepresentById):
     from_path: Mapped[Optional[str]] = mapped_column(TEXT)
     published: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
 
-    user = relationship(
+    user: Mapped["User"] = relationship(
         "User", primaryjoin=(lambda: User.id == StoredWorkflow.user_id), back_populates="stored_workflows"
     )
     workflows = relationship(
@@ -7844,18 +7870,20 @@ class WorkflowStep(Base, RepresentById):
     temp_input_connections = None
     parent_comment_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_comment.id"), index=True)
 
-    parent_comment = relationship(
+    parent_comment: Mapped[Optional["WorkflowComment"]] = relationship(
         "WorkflowComment",
         primaryjoin=(lambda: WorkflowComment.id == WorkflowStep.parent_comment_id),
         back_populates="child_steps",
     )
 
-    subworkflow = relationship(
+    subworkflow: Mapped[Optional["Workflow"]] = relationship(
         "Workflow",
         primaryjoin=(lambda: Workflow.id == WorkflowStep.subworkflow_id),
         back_populates="parent_workflow_steps",
     )
-    dynamic_tool = relationship("DynamicTool", primaryjoin=(lambda: DynamicTool.id == WorkflowStep.dynamic_tool_id))
+    dynamic_tool: Mapped[Optional["DynamicTool"]] = relationship(
+        "DynamicTool", primaryjoin=(lambda: DynamicTool.id == WorkflowStep.dynamic_tool_id)
+    )
     tags: Mapped[List["WorkflowStepTagAssociation"]] = relationship(
         "WorkflowStepTagAssociation", order_by=lambda: WorkflowStepTagAssociation.id, back_populates="workflow_step"
     )
@@ -7870,7 +7898,7 @@ class WorkflowStep(Base, RepresentById):
     output_connections = relationship(
         "WorkflowStepConnection", primaryjoin=(lambda: WorkflowStepConnection.output_step_id == WorkflowStep.id)
     )
-    workflow = relationship(
+    workflow: Mapped["Workflow"] = relationship(
         "Workflow",
         primaryjoin=(lambda: Workflow.id == WorkflowStep.workflow_id),
         back_populates="steps",
@@ -8150,7 +8178,7 @@ class WorkflowStepInput(Base, RepresentById):
     default_value_set: Mapped[Optional[bool]] = mapped_column(default=False)
     runtime_value: Mapped[Optional[bool]] = mapped_column(default=False)
 
-    workflow_step = relationship(
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship(
         "WorkflowStep",
         back_populates="inputs",
         cascade="all",
@@ -8244,7 +8272,7 @@ class WorkflowOutput(Base, Serializable):
     output_name: Mapped[Optional[str]] = mapped_column(String(255))
     label: Mapped[Optional[str]] = mapped_column(Unicode(255))
     uuid: Mapped[Optional[Union[UUID, str]]] = mapped_column(UUIDType)
-    workflow_step = relationship(
+    workflow_step: Mapped["WorkflowStep"] = relationship(
         "WorkflowStep",
         back_populates="workflow_outputs",
         primaryjoin=(lambda: WorkflowStep.id == WorkflowOutput.workflow_step_id),
@@ -8290,7 +8318,7 @@ class WorkflowComment(Base, RepresentById):
     data: Mapped[Optional[bytes]] = mapped_column(JSONType)
     parent_comment_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_comment.id"), index=True)
 
-    workflow = relationship(
+    workflow: Mapped["Workflow"] = relationship(
         "Workflow",
         primaryjoin=(lambda: Workflow.id == WorkflowComment.workflow_id),
         back_populates="comments",
@@ -8302,7 +8330,7 @@ class WorkflowComment(Base, RepresentById):
         back_populates="parent_comment",
     )
 
-    parent_comment = relationship(
+    parent_comment: Mapped[Optional["WorkflowComment"]] = relationship(
         "WorkflowComment",
         primaryjoin=(lambda: WorkflowComment.id == WorkflowComment.parent_comment_id),
         back_populates="child_comments",
@@ -8355,7 +8383,9 @@ class StoredWorkflowUserShareAssociation(Base, UserShareAssociation):
     stored_workflow_id: Mapped[Optional[int]] = mapped_column(ForeignKey("stored_workflow.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user: Mapped[User] = relationship("User")
-    stored_workflow = relationship("StoredWorkflow", back_populates="users_shared_with")
+    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship(
+        "StoredWorkflow", back_populates="users_shared_with"
+    )
 
 
 class StoredWorkflowMenuEntry(Base, RepresentById):
@@ -8366,8 +8396,8 @@ class StoredWorkflowMenuEntry(Base, RepresentById):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     order_index: Mapped[Optional[int]]
 
-    stored_workflow = relationship("StoredWorkflow")
-    user = relationship(
+    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship("StoredWorkflow")
+    user: Mapped[Optional["User"]] = relationship(
         "User",
         back_populates="stored_workflow_menu_entries",
         primaryjoin=(
@@ -8968,9 +8998,15 @@ class WorkflowInvocationMessage(Base, Dictifiable, Serializable):
     hda_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_association.id"))
     hdca_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_collection_association.id"))
 
-    workflow_invocation = relationship("WorkflowInvocation", back_populates="messages", lazy=True)
-    workflow_step = relationship("WorkflowStep", foreign_keys=workflow_step_id, lazy=True)
-    dependent_workflow_step = relationship("WorkflowStep", foreign_keys=dependent_workflow_step_id, lazy=True)
+    workflow_invocation: Mapped["WorkflowInvocation"] = relationship(
+        "WorkflowInvocation", back_populates="messages", lazy=True
+    )
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship(
+        "WorkflowStep", foreign_keys=workflow_step_id, lazy=True
+    )
+    dependent_workflow_step: Mapped[Optional["WorkflowStep"]] = relationship(
+        "WorkflowStep", foreign_keys=dependent_workflow_step_id, lazy=True
+    )
 
     @property
     def workflow_step_index(self):
@@ -9043,7 +9079,7 @@ class WorkflowInvocationStep(Base, Dictifiable, Serializable):
     action: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
 
     workflow_step = relationship("WorkflowStep")
-    job = relationship("Job", back_populates="workflow_invocation_step", uselist=False)
+    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="workflow_invocation_step", uselist=False)
     implicit_collection_jobs = relationship("ImplicitCollectionJobs", uselist=False)
     output_dataset_collections = relationship(
         "WorkflowInvocationStepOutputDatasetCollectionAssociation",
@@ -9055,7 +9091,7 @@ class WorkflowInvocationStep(Base, Dictifiable, Serializable):
         back_populates="workflow_invocation_step",
         cascade_backrefs=False,
     )
-    workflow_invocation = relationship("WorkflowInvocation", back_populates="steps")
+    workflow_invocation: Mapped["WorkflowInvocation"] = relationship("WorkflowInvocation", back_populates="steps")
     output_value = relationship(
         "WorkflowInvocationOutputValue",
         foreign_keys="[WorkflowInvocationStep.workflow_invocation_id, WorkflowInvocationStep.workflow_step_id]",
@@ -9247,7 +9283,9 @@ class WorkflowRequestInputParameter(Base, Dictifiable, Serializable):
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
     value: Mapped[Optional[str]] = mapped_column(TEXT)
     type: Mapped[Optional[str]] = mapped_column(Unicode(255))
-    workflow_invocation = relationship("WorkflowInvocation", back_populates="input_parameters")
+    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(
+        "WorkflowInvocation", back_populates="input_parameters"
+    )
 
     dict_collection_visible_keys = ["id", "name", "value", "type"]
 
@@ -9276,8 +9314,10 @@ class WorkflowRequestStepState(Base, Dictifiable, Serializable):
     )
     workflow_step_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_step.id"))
     value: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
-    workflow_step = relationship("WorkflowStep")
-    workflow_invocation = relationship("WorkflowInvocation", back_populates="step_states")
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep")
+    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(
+        "WorkflowInvocation", back_populates="step_states"
+    )
 
     dict_collection_visible_keys = ["id", "name", "value", "workflow_step_id"]
 
@@ -9299,9 +9339,11 @@ class WorkflowRequestToInputDatasetAssociation(Base, Dictifiable, Serializable):
     workflow_step_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_step.id"))
     dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_association.id"), index=True)
 
-    workflow_step = relationship("WorkflowStep")
-    dataset = relationship("HistoryDatasetAssociation")
-    workflow_invocation = relationship("WorkflowInvocation", back_populates="input_datasets")
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep")
+    dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship("HistoryDatasetAssociation")
+    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(
+        "WorkflowInvocation", back_populates="input_datasets"
+    )
 
     history_content_type = "dataset"
     dict_collection_visible_keys = ["id", "workflow_invocation_id", "workflow_step_id", "dataset_id", "name"]
@@ -9328,9 +9370,13 @@ class WorkflowRequestToInputDatasetCollectionAssociation(Base, Dictifiable, Seri
     dataset_collection_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("history_dataset_collection_association.id"), index=True
     )
-    workflow_step = relationship("WorkflowStep")
-    dataset_collection = relationship("HistoryDatasetCollectionAssociation")
-    workflow_invocation = relationship("WorkflowInvocation", back_populates="input_dataset_collections")
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep")
+    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
+        "HistoryDatasetCollectionAssociation"
+    )
+    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(
+        "WorkflowInvocation", back_populates="input_dataset_collections"
+    )
 
     history_content_type = "dataset_collection"
     dict_collection_visible_keys = ["id", "workflow_invocation_id", "workflow_step_id", "dataset_collection_id", "name"]
@@ -9355,8 +9401,10 @@ class WorkflowRequestInputStepParameter(Base, Dictifiable, Serializable):
     workflow_step_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_step.id"))
     parameter_value: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
 
-    workflow_step = relationship("WorkflowStep")
-    workflow_invocation = relationship("WorkflowInvocation", back_populates="input_step_parameters")
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep")
+    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(
+        "WorkflowInvocation", back_populates="input_step_parameters"
+    )
 
     dict_collection_visible_keys = ["id", "workflow_invocation_id", "workflow_step_id", "parameter_value"]
 
@@ -9378,10 +9426,12 @@ class WorkflowInvocationOutputDatasetAssociation(Base, Dictifiable, Serializable
     dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_association.id"), index=True)
     workflow_output_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_output.id"), index=True)
 
-    workflow_invocation = relationship("WorkflowInvocation", back_populates="output_datasets")
-    workflow_step = relationship("WorkflowStep")
-    dataset = relationship("HistoryDatasetAssociation")
-    workflow_output = relationship("WorkflowOutput")
+    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(
+        "WorkflowInvocation", back_populates="output_datasets"
+    )
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep")
+    dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship("HistoryDatasetAssociation")
+    workflow_output: Mapped[Optional["WorkflowOutput"]] = relationship("WorkflowOutput")
 
     history_content_type = "dataset"
     dict_collection_visible_keys = ["id", "workflow_invocation_id", "workflow_step_id", "dataset_id", "name"]
@@ -9413,10 +9463,14 @@ class WorkflowInvocationOutputDatasetCollectionAssociation(Base, Dictifiable, Se
         ForeignKey("workflow_output.id", name="fk_wiodca_woi"), index=True
     )
 
-    workflow_invocation = relationship("WorkflowInvocation", back_populates="output_dataset_collections")
-    workflow_step = relationship("WorkflowStep")
-    dataset_collection = relationship("HistoryDatasetCollectionAssociation")
-    workflow_output = relationship("WorkflowOutput")
+    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(
+        "WorkflowInvocation", back_populates="output_dataset_collections"
+    )
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep")
+    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
+        "HistoryDatasetCollectionAssociation"
+    )
+    workflow_output: Mapped[Optional["WorkflowOutput"]] = relationship("WorkflowOutput")
 
     history_content_type = "dataset_collection"
     dict_collection_visible_keys = ["id", "workflow_invocation_id", "workflow_step_id", "dataset_collection_id", "name"]
@@ -9442,9 +9496,11 @@ class WorkflowInvocationOutputValue(Base, Dictifiable, Serializable):
     workflow_output_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_output.id"), index=True)
     value: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
 
-    workflow_invocation = relationship("WorkflowInvocation", back_populates="output_values")
+    workflow_invocation: Mapped[Optional["WorkflowInvocation"]] = relationship(
+        "WorkflowInvocation", back_populates="output_values"
+    )
 
-    workflow_invocation_step = relationship(
+    workflow_invocation_step: Mapped[Optional["WorkflowInvocationStep"]] = relationship(
         "WorkflowInvocationStep",
         foreign_keys="[WorkflowInvocationStep.workflow_invocation_id, WorkflowInvocationStep.workflow_step_id]",
         primaryjoin=(
@@ -9457,8 +9513,8 @@ class WorkflowInvocationOutputValue(Base, Dictifiable, Serializable):
         viewonly=True,
     )
 
-    workflow_step = relationship("WorkflowStep")
-    workflow_output = relationship("WorkflowOutput")
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep")
+    workflow_output: Mapped[Optional["WorkflowOutput"]] = relationship("WorkflowOutput")
 
     dict_collection_visible_keys = ["id", "workflow_invocation_id", "workflow_step_id", "value"]
 
@@ -9481,8 +9537,10 @@ class WorkflowInvocationStepOutputDatasetAssociation(Base, Dictifiable, Represen
     )
     dataset_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_association.id"), index=True)
     output_name: Mapped[Optional[str]] = mapped_column(String(255))
-    workflow_invocation_step = relationship("WorkflowInvocationStep", back_populates="output_datasets")
-    dataset = relationship("HistoryDatasetAssociation")
+    workflow_invocation_step: Mapped[Optional["WorkflowInvocationStep"]] = relationship(
+        "WorkflowInvocationStep", back_populates="output_datasets"
+    )
+    dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship("HistoryDatasetAssociation")
 
     dict_collection_visible_keys = ["id", "workflow_invocation_step_id", "dataset_id", "output_name"]
 
@@ -9504,8 +9562,12 @@ class WorkflowInvocationStepOutputDatasetCollectionAssociation(Base, Dictifiable
     )
     output_name: Mapped[Optional[str]] = mapped_column(String(255))
 
-    workflow_invocation_step = relationship("WorkflowInvocationStep", back_populates="output_dataset_collections")
-    dataset_collection = relationship("HistoryDatasetCollectionAssociation")
+    workflow_invocation_step: Mapped[Optional["WorkflowInvocationStep"]] = relationship(
+        "WorkflowInvocationStep", back_populates="output_dataset_collections"
+    )
+    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
+        "HistoryDatasetCollectionAssociation"
+    )
 
     dict_collection_visible_keys = ["id", "workflow_invocation_step_id", "dataset_collection_id", "output_name"]
 
@@ -9524,7 +9586,7 @@ class MetadataFile(Base, StorableObject, Serializable):
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     purged: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
 
-    history_dataset = relationship("HistoryDatasetAssociation")
+    history_dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship("HistoryDatasetAssociation")
     library_dataset = relationship("LibraryDatasetDatasetAssociation")
 
     def __init__(self, dataset=None, name=None, uuid=None):
@@ -9606,7 +9668,7 @@ class FormDefinition(Base, Dictifiable, RepresentById):
     fields: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
     type: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     layout: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
-    form_definition_current = relationship(
+    form_definition_current: Mapped["FormDefinitionCurrent"] = relationship(
         "FormDefinitionCurrent",
         back_populates="forms",
         primaryjoin=(lambda: FormDefinitionCurrent.id == FormDefinition.form_definition_current_id),  # type: ignore[has-type]
@@ -9678,7 +9740,7 @@ class FormDefinitionCurrent(Base, RepresentById):
         cascade="all, delete-orphan",
         primaryjoin=(lambda: FormDefinitionCurrent.id == FormDefinition.form_definition_current_id),
     )
-    latest_form = relationship(
+    latest_form: Mapped[Optional["FormDefinition"]] = relationship(
         "FormDefinition",
         post_update=True,
         primaryjoin=(lambda: FormDefinitionCurrent.latest_form_id == FormDefinition.id),
@@ -9696,7 +9758,7 @@ class FormValues(Base, RepresentById):
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
     form_definition_id: Mapped[Optional[int]] = mapped_column(ForeignKey("form_definition.id"), index=True)
     content: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
-    form_definition = relationship(
+    form_definition: Mapped[Optional["FormDefinition"]] = relationship(
         "FormDefinition", primaryjoin=(lambda: FormValues.form_definition_id == FormDefinition.id)
     )
 
@@ -9725,7 +9787,9 @@ class UserAddress(Base, RepresentById):
     purged: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     # `desc` needs to be fully qualified because it is shadowed by `desc` Column defined above
     # TODO: db migration to rename column, then use `desc`
-    user = relationship("User", back_populates="addresses", order_by=sqlalchemy.desc("update_time"))
+    user: Mapped[Optional["User"]] = relationship(
+        "User", back_populates="addresses", order_by=sqlalchemy.desc("update_time")
+    )
 
     def to_dict(self, trans):
         return {
@@ -9926,7 +9990,7 @@ class UserAuthnzToken(Base, UserMixin, RepresentById):
     extra_data: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
     lifetime: Mapped[Optional[int]]
     assoc_type: Mapped[Optional[str]] = mapped_column(VARCHAR(64))
-    user = relationship("User", back_populates="social_auth")
+    user: Mapped[Optional["User"]] = relationship("User", back_populates="social_auth")
 
     # This static property is set at: galaxy.authnz.psa_authnz.PSAAuthnz
     sa_session = None
@@ -10107,8 +10171,8 @@ class CloudAuthz(Base):
     last_activity: Mapped[Optional[datetime]]
     description: Mapped[Optional[str]] = mapped_column(TEXT)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
-    user = relationship("User", back_populates="cloudauthz")
-    authn = relationship("UserAuthnzToken")
+    user: Mapped[Optional["User"]] = relationship("User", back_populates="cloudauthz")
+    authn: Mapped[Optional["UserAuthnzToken"]] = relationship("UserAuthnzToken")
 
     def __init__(self, user_id, provider, config, authn_id, description=None):
         self.user_id = user_id
@@ -10146,14 +10210,14 @@ class Page(Base, HasTags, Dictifiable, RepresentById):
     importable: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     slug: Mapped[Optional[str]] = mapped_column(TEXT)
     published: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
-    user = relationship("User")
+    user: Mapped["User"] = relationship("User")
     revisions = relationship(
         "PageRevision",
         cascade="all, delete-orphan",
         primaryjoin=(lambda: Page.id == PageRevision.page_id),  # type: ignore[has-type]
         back_populates="page",
     )
-    latest_revision = relationship(
+    latest_revision: Mapped[Optional["PageRevision"]] = relationship(
         "PageRevision",
         post_update=True,
         primaryjoin=(lambda: Page.latest_revision_id == PageRevision.id),  # type: ignore[has-type]
@@ -10222,7 +10286,7 @@ class PageRevision(Base, Dictifiable, RepresentById):
     title: Mapped[Optional[str]] = mapped_column(TEXT)
     content: Mapped[Optional[str]] = mapped_column(TEXT)
     content_format: Mapped[Optional[str]] = mapped_column(TrimmedString(32))
-    page = relationship("Page", primaryjoin=(lambda: Page.id == PageRevision.page_id))
+    page: Mapped["Page"] = relationship("Page", primaryjoin=(lambda: Page.id == PageRevision.page_id))
     DEFAULT_CONTENT_FORMAT = "html"
     dict_element_visible_keys = ["id", "page_id", "title", "content", "content_format"]
 
@@ -10243,7 +10307,7 @@ class PageUserShareAssociation(Base, UserShareAssociation):
     page_id: Mapped[Optional[int]] = mapped_column(ForeignKey("page.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user: Mapped[User] = relationship("User")
-    page = relationship("Page", back_populates="users_shared_with")
+    page: Mapped[Optional["Page"]] = relationship("Page", back_populates="users_shared_with")
 
 
 class Visualization(Base, HasTags, Dictifiable, RepresentById):
@@ -10269,7 +10333,7 @@ class Visualization(Base, HasTags, Dictifiable, RepresentById):
     slug: Mapped[Optional[str]] = mapped_column(TEXT)
     published: Mapped[Optional[bool]] = mapped_column(default=False, index=True)
 
-    user = relationship("User")
+    user: Mapped["User"] = relationship("User")
     revisions = relationship(
         "VisualizationRevision",
         back_populates="visualization",
@@ -10277,7 +10341,7 @@ class Visualization(Base, HasTags, Dictifiable, RepresentById):
         primaryjoin=(lambda: Visualization.id == VisualizationRevision.visualization_id),
         cascade_backrefs=False,
     )
-    latest_revision = relationship(
+    latest_revision: Mapped[Optional["VisualizationRevision"]] = relationship(
         "VisualizationRevision",
         post_update=True,
         primaryjoin=(lambda: Visualization.latest_revision_id == VisualizationRevision.id),
@@ -10373,7 +10437,7 @@ class VisualizationRevision(Base, RepresentById):
     title: Mapped[Optional[str]] = mapped_column(TEXT)
     dbkey: Mapped[Optional[str]] = mapped_column(TEXT)
     config: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
-    visualization = relationship(
+    visualization: Mapped["Visualization"] = relationship(
         "Visualization",
         back_populates="revisions",
         primaryjoin=(lambda: Visualization.id == VisualizationRevision.visualization_id),
@@ -10398,7 +10462,7 @@ class VisualizationUserShareAssociation(Base, UserShareAssociation):
     visualization_id: Mapped[Optional[int]] = mapped_column(ForeignKey("visualization.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user: Mapped[User] = relationship("User")
-    visualization = relationship("Visualization", back_populates="users_shared_with")
+    visualization: Mapped[Optional["Visualization"]] = relationship("Visualization", back_populates="users_shared_with")
 
 
 class Tag(Base, RepresentById):
@@ -10410,7 +10474,7 @@ class Tag(Base, RepresentById):
     parent_id: Mapped[Optional[int]] = mapped_column(ForeignKey("tag.id"))
     name: Mapped[Optional[str]] = mapped_column(TrimmedString(255))
     children = relationship("Tag", back_populates="parent")
-    parent = relationship("Tag", back_populates="children", remote_side=[id])
+    parent: Mapped[Optional["Tag"]] = relationship("Tag", back_populates="children", remote_side=[id])
 
     def __str__(self):
         return "Tag(id=%s, type=%i, parent_id=%s, name=%s)" % (self.id, self.type or -1, self.parent_id, self.name)
@@ -10446,9 +10510,9 @@ class HistoryTagAssociation(Base, ItemTagAssociation, RepresentById):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    history = relationship("History", back_populates="tags")
-    tag = relationship("Tag")
-    user = relationship("User")
+    history: Mapped[Optional["History"]] = relationship("History", back_populates="tags")
+    tag: Mapped[Optional["Tag"]] = relationship("Tag")
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class HistoryDatasetAssociationTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10462,9 +10526,11 @@ class HistoryDatasetAssociationTagAssociation(Base, ItemTagAssociation, Represen
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    history_dataset_association = relationship("HistoryDatasetAssociation", back_populates="tags")
-    tag = relationship("Tag")
-    user = relationship("User")
+    history_dataset_association: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
+        "HistoryDatasetAssociation", back_populates="tags"
+    )
+    tag: Mapped[Optional["Tag"]] = relationship("Tag")
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class LibraryDatasetDatasetAssociationTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10478,9 +10544,11 @@ class LibraryDatasetDatasetAssociationTagAssociation(Base, ItemTagAssociation, R
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    library_dataset_dataset_association = relationship("LibraryDatasetDatasetAssociation", back_populates="tags")
-    tag = relationship("Tag")
-    user = relationship("User")
+    library_dataset_dataset_association: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
+        "LibraryDatasetDatasetAssociation", back_populates="tags"
+    )
+    tag: Mapped[Optional["Tag"]] = relationship("Tag")
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class PageTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10492,9 +10560,9 @@ class PageTagAssociation(Base, ItemTagAssociation, RepresentById):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    page = relationship("Page", back_populates="tags")
-    tag = relationship("Tag")
-    user = relationship("User")
+    page: Mapped[Optional["Page"]] = relationship("Page", back_populates="tags")
+    tag: Mapped[Optional["Tag"]] = relationship("Tag")
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class WorkflowStepTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10506,9 +10574,9 @@ class WorkflowStepTagAssociation(Base, ItemTagAssociation, RepresentById):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    workflow_step = relationship("WorkflowStep", back_populates="tags")
-    tag = relationship("Tag")
-    user = relationship("User")
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep", back_populates="tags")
+    tag: Mapped[Optional["Tag"]] = relationship("Tag")
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class StoredWorkflowTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10520,9 +10588,9 @@ class StoredWorkflowTagAssociation(Base, ItemTagAssociation, RepresentById):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    stored_workflow = relationship("StoredWorkflow", back_populates="tags")
-    tag = relationship("Tag")
-    user = relationship("User")
+    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship("StoredWorkflow", back_populates="tags")
+    tag: Mapped[Optional["Tag"]] = relationship("Tag")
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class VisualizationTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10534,9 +10602,9 @@ class VisualizationTagAssociation(Base, ItemTagAssociation, RepresentById):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    visualization = relationship("Visualization", back_populates="tags")
-    tag = relationship("Tag")
-    user = relationship("User")
+    visualization: Mapped[Optional["Visualization"]] = relationship("Visualization", back_populates="tags")
+    tag: Mapped[Optional["Tag"]] = relationship("Tag")
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class HistoryDatasetCollectionTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10550,9 +10618,11 @@ class HistoryDatasetCollectionTagAssociation(Base, ItemTagAssociation, Represent
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    dataset_collection = relationship("HistoryDatasetCollectionAssociation", back_populates="tags")
-    tag = relationship("Tag")
-    user = relationship("User")
+    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
+        "HistoryDatasetCollectionAssociation", back_populates="tags"
+    )
+    tag: Mapped[Optional["Tag"]] = relationship("Tag")
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class LibraryDatasetCollectionTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10566,9 +10636,11 @@ class LibraryDatasetCollectionTagAssociation(Base, ItemTagAssociation, Represent
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    dataset_collection = relationship("LibraryDatasetCollectionAssociation", back_populates="tags")
-    tag = relationship("Tag")
-    user = relationship("User")
+    dataset_collection: Mapped[Optional["LibraryDatasetCollectionAssociation"]] = relationship(
+        "LibraryDatasetCollectionAssociation", back_populates="tags"
+    )
+    tag: Mapped[Optional["Tag"]] = relationship("Tag")
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class ToolTagAssociation(Base, ItemTagAssociation, RepresentById):
@@ -10580,8 +10652,8 @@ class ToolTagAssociation(Base, ItemTagAssociation, RepresentById):
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    tag = relationship("Tag")
-    user = relationship("User")
+    tag: Mapped[Optional["Tag"]] = relationship("Tag")
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 # Item annotation classes.
@@ -10593,8 +10665,8 @@ class HistoryAnnotationAssociation(Base, RepresentById):
     history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    history = relationship("History", back_populates="annotations")
-    user = relationship("User")
+    history: Mapped[Optional["History"]] = relationship("History", back_populates="annotations")
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class HistoryDatasetAssociationAnnotationAssociation(Base, RepresentById):
@@ -10607,8 +10679,10 @@ class HistoryDatasetAssociationAnnotationAssociation(Base, RepresentById):
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    hda = relationship("HistoryDatasetAssociation", back_populates="annotations")
-    user = relationship("User")
+    hda: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
+        "HistoryDatasetAssociation", back_populates="annotations"
+    )
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class StoredWorkflowAnnotationAssociation(Base, RepresentById):
@@ -10619,8 +10693,8 @@ class StoredWorkflowAnnotationAssociation(Base, RepresentById):
     stored_workflow_id: Mapped[Optional[int]] = mapped_column(ForeignKey("stored_workflow.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    stored_workflow = relationship("StoredWorkflow", back_populates="annotations")
-    user = relationship("User")
+    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship("StoredWorkflow", back_populates="annotations")
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class WorkflowStepAnnotationAssociation(Base, RepresentById):
@@ -10631,8 +10705,8 @@ class WorkflowStepAnnotationAssociation(Base, RepresentById):
     workflow_step_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_step.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    workflow_step = relationship("WorkflowStep", back_populates="annotations")
-    user = relationship("User")
+    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship("WorkflowStep", back_populates="annotations")
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class PageAnnotationAssociation(Base, RepresentById):
@@ -10643,8 +10717,8 @@ class PageAnnotationAssociation(Base, RepresentById):
     page_id: Mapped[Optional[int]] = mapped_column(ForeignKey("page.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    page = relationship("Page", back_populates="annotations")
-    user = relationship("User")
+    page: Mapped[Optional["Page"]] = relationship("Page", back_populates="annotations")
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class VisualizationAnnotationAssociation(Base, RepresentById):
@@ -10655,8 +10729,8 @@ class VisualizationAnnotationAssociation(Base, RepresentById):
     visualization_id: Mapped[Optional[int]] = mapped_column(ForeignKey("visualization.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    visualization = relationship("Visualization", back_populates="annotations")
-    user = relationship("User")
+    visualization: Mapped[Optional["Visualization"]] = relationship("Visualization", back_populates="annotations")
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class HistoryDatasetCollectionAssociationAnnotationAssociation(Base, RepresentById):
@@ -10668,8 +10742,10 @@ class HistoryDatasetCollectionAssociationAnnotationAssociation(Base, RepresentBy
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    history_dataset_collection = relationship("HistoryDatasetCollectionAssociation", back_populates="annotations")
-    user = relationship("User")
+    history_dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
+        "HistoryDatasetCollectionAssociation", back_populates="annotations"
+    )
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class LibraryDatasetCollectionAnnotationAssociation(Base, RepresentById):
@@ -10681,8 +10757,10 @@ class LibraryDatasetCollectionAnnotationAssociation(Base, RepresentById):
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    dataset_collection = relationship("LibraryDatasetCollectionAssociation", back_populates="annotations")
-    user = relationship("User")
+    dataset_collection: Mapped[Optional["LibraryDatasetCollectionAssociation"]] = relationship(
+        "LibraryDatasetCollectionAssociation", back_populates="annotations"
+    )
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class Vault(Base):
@@ -10691,7 +10769,7 @@ class Vault(Base):
     key: Mapped[str] = mapped_column(Text, primary_key=True)
     parent_key: Mapped[Optional[str]] = mapped_column(Text, ForeignKey(key), index=True)
     children = relationship("Vault", back_populates="parent")
-    parent = relationship("Vault", back_populates="children", remote_side=[key])
+    parent: Mapped[Optional["Vault"]] = relationship("Vault", back_populates="children", remote_side=[key])
     value: Mapped[Optional[str]] = mapped_column(Text)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
@@ -10718,8 +10796,8 @@ class HistoryRatingAssociation(ItemRatingAssociation, RepresentById):
     history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     rating: Mapped[Optional[int]] = mapped_column(index=True)
-    history = relationship("History", back_populates="ratings")
-    user = relationship("User")
+    history: Mapped[Optional["History"]] = relationship("History", back_populates="ratings")
+    user: Mapped[Optional["User"]] = relationship("User")
 
     def _set_item(self, history):
         add_object_to_object_session(self, history)
@@ -10735,8 +10813,10 @@ class HistoryDatasetAssociationRatingAssociation(ItemRatingAssociation, Represen
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     rating: Mapped[Optional[int]] = mapped_column(index=True)
-    history_dataset_association = relationship("HistoryDatasetAssociation", back_populates="ratings")
-    user = relationship("User")
+    history_dataset_association: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
+        "HistoryDatasetAssociation", back_populates="ratings"
+    )
+    user: Mapped[Optional["User"]] = relationship("User")
 
     def _set_item(self, history_dataset_association):
         add_object_to_object_session(self, history_dataset_association)
@@ -10750,8 +10830,8 @@ class StoredWorkflowRatingAssociation(ItemRatingAssociation, RepresentById):
     stored_workflow_id: Mapped[Optional[int]] = mapped_column(ForeignKey("stored_workflow.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     rating: Mapped[Optional[int]] = mapped_column(index=True)
-    stored_workflow = relationship("StoredWorkflow", back_populates="ratings")
-    user = relationship("User")
+    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship("StoredWorkflow", back_populates="ratings")
+    user: Mapped[Optional["User"]] = relationship("User")
 
     def _set_item(self, stored_workflow):
         add_object_to_object_session(self, stored_workflow)
@@ -10765,8 +10845,8 @@ class PageRatingAssociation(ItemRatingAssociation, RepresentById):
     page_id: Mapped[Optional[int]] = mapped_column(ForeignKey("page.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     rating: Mapped[Optional[int]] = mapped_column(index=True)
-    page = relationship("Page", back_populates="ratings")
-    user = relationship("User")
+    page: Mapped[Optional["Page"]] = relationship("Page", back_populates="ratings")
+    user: Mapped[Optional["User"]] = relationship("User")
 
     def _set_item(self, page):
         add_object_to_object_session(self, page)
@@ -10780,8 +10860,8 @@ class VisualizationRatingAssociation(ItemRatingAssociation, RepresentById):
     visualization_id: Mapped[Optional[int]] = mapped_column(ForeignKey("visualization.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     rating: Mapped[Optional[int]] = mapped_column(index=True)
-    visualization = relationship("Visualization", back_populates="ratings")
-    user = relationship("User")
+    visualization: Mapped[Optional["Visualization"]] = relationship("Visualization", back_populates="ratings")
+    user: Mapped[Optional["User"]] = relationship("User")
 
     def _set_item(self, visualization):
         add_object_to_object_session(self, visualization)
@@ -10797,8 +10877,10 @@ class HistoryDatasetCollectionRatingAssociation(ItemRatingAssociation, Represent
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     rating: Mapped[Optional[int]] = mapped_column(index=True)
-    dataset_collection = relationship("HistoryDatasetCollectionAssociation", back_populates="ratings")
-    user = relationship("User")
+    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
+        "HistoryDatasetCollectionAssociation", back_populates="ratings"
+    )
+    user: Mapped[Optional["User"]] = relationship("User")
 
     def _set_item(self, dataset_collection):
         add_object_to_object_session(self, dataset_collection)
@@ -10814,8 +10896,10 @@ class LibraryDatasetCollectionRatingAssociation(ItemRatingAssociation, Represent
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     rating: Mapped[Optional[int]] = mapped_column(index=True)
-    dataset_collection = relationship("LibraryDatasetCollectionAssociation", back_populates="ratings")
-    user = relationship("User")
+    dataset_collection: Mapped[Optional["LibraryDatasetCollectionAssociation"]] = relationship(
+        "LibraryDatasetCollectionAssociation", back_populates="ratings"
+    )
+    user: Mapped[Optional["User"]] = relationship("User")
 
     def _set_item(self, dataset_collection):
         add_object_to_object_session(self, dataset_collection)
@@ -10831,8 +10915,8 @@ class DataManagerHistoryAssociation(Base, RepresentById):
     update_time: Mapped[datetime] = mapped_column(index=True, default=now, onupdate=now, nullable=True)
     history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    history = relationship("History")
-    user = relationship("User", back_populates="data_manager_histories")
+    history: Mapped[Optional["History"]] = relationship("History")
+    user: Mapped[Optional["User"]] = relationship("User", back_populates="data_manager_histories")
 
 
 class DataManagerJobAssociation(Base, RepresentById):
@@ -10844,7 +10928,7 @@ class DataManagerJobAssociation(Base, RepresentById):
     update_time: Mapped[datetime] = mapped_column(index=True, default=now, onupdate=now, nullable=True)
     job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
     data_manager_id: Mapped[Optional[str]] = mapped_column(TEXT)
-    job = relationship("Job", back_populates="data_manager_association", uselist=False)
+    job: Mapped[Optional["Job"]] = relationship("Job", back_populates="data_manager_association", uselist=False)
 
 
 class UserPreference(Base, RepresentById):
@@ -10872,7 +10956,7 @@ class UserAction(Base, RepresentById):
     action: Mapped[Optional[str]] = mapped_column(Unicode(255))
     context: Mapped[Optional[str]] = mapped_column(Unicode(512))
     params: Mapped[Optional[str]] = mapped_column(Unicode(1024))
-    user = relationship("User")
+    user: Mapped[Optional["User"]] = relationship("User")
 
 
 class APIKeys(Base, RepresentById):
@@ -10882,7 +10966,7 @@ class APIKeys(Base, RepresentById):
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     key: Mapped[Optional[str]] = mapped_column(TrimmedString(32), index=True, unique=True)
-    user = relationship("User", back_populates="api_keys")
+    user: Mapped[Optional["User"]] = relationship("User", back_populates="api_keys")
     deleted: Mapped[bool] = mapped_column(index=True, server_default=false())
 
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2362,7 +2362,7 @@ class JobToInputDatasetCollectionAssociation(Base, RepresentById):
     dataset_collection_id: Mapped[int] = mapped_column(
         ForeignKey("history_dataset_collection_association.id"), index=True, nullable=True
     )
-    name: Mapped[Optional[str]] = mapped_column(String(255))
+    name: Mapped[str] = mapped_column(String(255), nullable=True)
     dataset_collection: Mapped["HistoryDatasetCollectionAssociation"] = relationship(lazy="joined")
     job: Mapped["Job"] = relationship(back_populates="input_dataset_collections")
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -771,7 +771,7 @@ class User(Base, Dictifiable, RepresentById):
         cascade="all, delete-orphan",
         collection_class=ordering_list("order_index"),
     )
-    _preferences: Mapped[List["UserPreference"]] = relationship(
+    _preferences: Mapped[Dict[str, "UserPreference"]] = relationship(
         "UserPreference", collection_class=attribute_keyed_dict("name")
     )
     values: Mapped[List["FormValues"]] = relationship(

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3678,12 +3678,12 @@ class UserQuotaAssociation(Base, Dictifiable, RepresentById):
     __tablename__ = "user_quota_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    quota_id: Mapped[Optional[int]] = mapped_column(ForeignKey("quota.id"), index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("galaxy_user.id"), index=True, nullable=True)
+    quota_id: Mapped[int] = mapped_column(ForeignKey("quota.id"), index=True, nullable=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
-    user: Mapped[Optional["User"]] = relationship(back_populates="quotas")
-    quota: Mapped[Optional["Quota"]] = relationship(back_populates="users")
+    user: Mapped["User"] = relationship(back_populates="quotas")
+    quota: Mapped["Quota"] = relationship(back_populates="users")
 
     dict_element_visible_keys = ["user"]
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2379,7 +2379,7 @@ class JobToInputDatasetCollectionElementAssociation(Base, RepresentById):
     dataset_collection_element_id: Mapped[int] = mapped_column(
         ForeignKey("dataset_collection_element.id"), index=True, nullable=True
     )
-    name: Mapped[Optional[str]] = mapped_column(Unicode(255))
+    name: Mapped[str] = mapped_column(Unicode(255), nullable=True)
     dataset_collection_element: Mapped["DatasetCollectionElement"] = relationship(lazy="joined")
     job: Mapped["Job"] = relationship(back_populates="input_dataset_collection_elements")
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1419,7 +1419,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     output_library_datasets: Mapped[List["JobToOutputLibraryDatasetAssociation"]] = relationship(back_populates="job")
     external_output_metadata: Mapped[List["JobExternalOutputMetadata"]] = relationship(back_populates="job")
     tasks: Mapped[List["Task"]] = relationship(back_populates="job")
-    output_datasets = relationship("JobToOutputDatasetAssociation", back_populates="job")
+    output_datasets: Mapped[List["JobToOutputDatasetAssociation"]] = relationship(back_populates="job")
     state_history: Mapped[List["JobStateHistory"]] = relationship()
     text_metrics: Mapped[List["JobMetricText"]] = relationship()
     numeric_metrics: Mapped[List["JobMetricNumeric"]] = relationship()

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -737,8 +737,8 @@ class User(Base, Dictifiable, RepresentById):
     addresses: Mapped[List["UserAddress"]] = relationship(
         "UserAddress", back_populates="user", order_by=lambda: desc(UserAddress.update_time), cascade_backrefs=False
     )
-    cloudauthz = relationship("CloudAuthz", back_populates="user")
-    custos_auth = relationship("CustosAuthnzToken", back_populates="user")
+    cloudauthz: Mapped[List["CloudAuthz"]] = relationship("CloudAuthz", back_populates="user")
+    custos_auth: Mapped[List["CustosAuthnzToken"]] = relationship("CustosAuthnzToken", back_populates="user")
     default_permissions: Mapped[List["DefaultUserPermissions"]] = relationship(
         "DefaultUserPermissions", back_populates="user"
     )
@@ -759,7 +759,7 @@ class User(Base, Dictifiable, RepresentById):
     quota_source_usages: Mapped[List["UserQuotaSourceUsage"]] = relationship(
         "UserQuotaSourceUsage", back_populates="user"
     )
-    social_auth = relationship("UserAuthnzToken", back_populates="user")
+    social_auth: Mapped[List["UserAuthnzToken"]] = relationship("UserAuthnzToken", back_populates="user")
     stored_workflow_menu_entries: Mapped[List["StoredWorkflowMenuEntry"]] = relationship(
         "StoredWorkflowMenuEntry",
         primaryjoin=(
@@ -1419,16 +1419,22 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     )
     output_dataset_collection_instances = relationship("JobToOutputDatasetCollectionAssociation", back_populates="job")
     output_dataset_collections = relationship("JobToImplicitOutputDatasetCollectionAssociation", back_populates="job")
-    post_job_actions = relationship("PostJobActionAssociation", back_populates="job", cascade_backrefs=False)
+    post_job_actions: Mapped[List["PostJobActionAssociation"]] = relationship(
+        "PostJobActionAssociation", back_populates="job", cascade_backrefs=False
+    )
     input_library_datasets = relationship("JobToInputLibraryDatasetAssociation", back_populates="job")
     output_library_datasets = relationship("JobToOutputLibraryDatasetAssociation", back_populates="job")
-    external_output_metadata = relationship("JobExternalOutputMetadata", back_populates="job")
-    tasks = relationship("Task", back_populates="job")
+    external_output_metadata: Mapped[List["JobExternalOutputMetadata"]] = relationship(
+        "JobExternalOutputMetadata", back_populates="job"
+    )
+    tasks: Mapped[List["Task"]] = relationship("Task", back_populates="job")
     output_datasets = relationship("JobToOutputDatasetAssociation", back_populates="job")
-    state_history = relationship("JobStateHistory")
-    text_metrics = relationship("JobMetricText")
-    numeric_metrics = relationship("JobMetricNumeric")
-    interactivetool_entry_points = relationship("InteractiveToolEntryPoint", back_populates="job", uselist=True)
+    state_history: Mapped[List["JobStateHistory"]] = relationship("JobStateHistory")
+    text_metrics: Mapped[List["JobMetricText"]] = relationship("JobMetricText")
+    numeric_metrics: Mapped[List["JobMetricNumeric"]] = relationship("JobMetricNumeric")
+    interactivetool_entry_points: Mapped[List["InteractiveToolEntryPoint"]] = relationship(
+        "InteractiveToolEntryPoint", back_populates="job", uselist=True
+    )
     implicit_collection_jobs_association = relationship(
         "ImplicitCollectionJobsJobAssociation", back_populates="job", uselist=False, cascade_backrefs=False
     )
@@ -2154,8 +2160,8 @@ class Task(Base, JobLike, RepresentById):
     task_runner_external_id: Mapped[Optional[str]] = mapped_column(String(255))
     prepare_input_files_cmd: Mapped[Optional[str]] = mapped_column(TEXT)
     job: Mapped["Job"] = relationship("Job", back_populates="tasks")
-    text_metrics = relationship("TaskMetricText")
-    numeric_metrics = relationship("TaskMetricNumeric")
+    text_metrics: Mapped[List["TaskMetricText"]] = relationship("TaskMetricText")
+    numeric_metrics: Mapped[List["TaskMetricNumeric"]] = relationship("TaskMetricNumeric")
 
     _numeric_metric = TaskMetricNumeric
     _text_metric = TaskMetricText
@@ -2519,7 +2525,7 @@ class ImplicitCollectionJobs(Base, Serializable):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     populated_state: Mapped[str] = mapped_column(TrimmedString(64), default="new")
-    jobs = relationship(
+    jobs: Mapped[List["ImplicitCollectionJobsJobAssociation"]] = relationship(
         "ImplicitCollectionJobsJobAssociation", back_populates="implicit_collection_jobs", cascade_backrefs=False
     )
 
@@ -2891,8 +2897,10 @@ class Group(Base, Dictifiable, RepresentById):
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
     name: Mapped[Optional[str]] = mapped_column(String(255), index=True, unique=True)
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
-    quotas = relationship("GroupQuotaAssociation", back_populates="group")
-    roles = relationship("GroupRoleAssociation", back_populates="group", cascade_backrefs=False)
+    quotas: Mapped[List["GroupQuotaAssociation"]] = relationship("GroupQuotaAssociation", back_populates="group")
+    roles: Mapped[List["GroupRoleAssociation"]] = relationship(
+        "GroupRoleAssociation", back_populates="group", cascade_backrefs=False
+    )
     users = relationship("UserGroupAssociation", back_populates="group")
 
     dict_collection_visible_keys = ["id", "name"]
@@ -2943,7 +2951,9 @@ class Notification(Base, Dictifiable, RepresentById):
     # content should always be a dict
     content: Mapped[Optional[bytes]] = mapped_column(DoubleEncodedJsonType)
 
-    user_notification_associations = relationship("UserNotificationAssociation", back_populates="notification")
+    user_notification_associations: Mapped[List["UserNotificationAssociation"]] = relationship(
+        "UserNotificationAssociation", back_populates="notification"
+    )
 
     def __init__(self, source: str, category: str, variant: str, content):
         self.source = source
@@ -3043,16 +3053,16 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
     archived: Mapped[Optional[bool]] = mapped_column(index=True, default=False, server_default=false())
     archive_export_id: Mapped[Optional[int]] = mapped_column(ForeignKey("store_export_association.id"), default=None)
 
-    datasets = relationship(
+    datasets: Mapped[List["HistoryDatasetAssociation"]] = relationship(
         "HistoryDatasetAssociation", back_populates="history", cascade_backrefs=False, order_by=lambda: asc(HistoryDatasetAssociation.hid)  # type: ignore[has-type]
     )
-    exports = relationship(
+    exports: Mapped[List["JobExportHistoryArchive"]] = relationship(
         "JobExportHistoryArchive",
         back_populates="history",
         primaryjoin=lambda: JobExportHistoryArchive.history_id == History.id,
         order_by=lambda: desc(JobExportHistoryArchive.id),
     )
-    active_datasets = relationship(
+    active_datasets: Mapped[List["HistoryDatasetAssociation"]] = relationship(
         "HistoryDatasetAssociation",
         primaryjoin=(
             lambda: and_(
@@ -3063,8 +3073,10 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
         order_by=lambda: asc(HistoryDatasetAssociation.hid),  # type: ignore[has-type]
         viewonly=True,
     )
-    dataset_collections = relationship("HistoryDatasetCollectionAssociation", back_populates="history")
-    active_dataset_collections = relationship(
+    dataset_collections: Mapped[List["HistoryDatasetCollectionAssociation"]] = relationship(
+        "HistoryDatasetCollectionAssociation", back_populates="history"
+    )
+    active_dataset_collections: Mapped[List["HistoryDatasetCollectionAssociation"]] = relationship(
         "HistoryDatasetCollectionAssociation",
         primaryjoin=(
             lambda: (
@@ -3077,7 +3089,7 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
         order_by=lambda: asc(HistoryDatasetCollectionAssociation.hid),  # type: ignore[has-type]
         viewonly=True,
     )
-    visible_datasets = relationship(
+    visible_datasets: Mapped[List["HistoryDatasetAssociation"]] = relationship(
         "HistoryDatasetAssociation",
         primaryjoin=(
             lambda: and_(
@@ -3089,7 +3101,7 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
         order_by=lambda: asc(HistoryDatasetAssociation.hid),  # type: ignore[has-type]
         viewonly=True,
     )
-    visible_dataset_collections = relationship(
+    visible_dataset_collections: Mapped[List["HistoryDatasetCollectionAssociation"]] = relationship(
         "HistoryDatasetCollectionAssociation",
         primaryjoin=(
             lambda: and_(
@@ -3104,20 +3116,26 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
     tags: Mapped[List["HistoryTagAssociation"]] = relationship(
         "HistoryTagAssociation", order_by=lambda: HistoryTagAssociation.id, back_populates="history"
     )
-    annotations = relationship(
+    annotations: Mapped[List["HistoryAnnotationAssociation"]] = relationship(
         "HistoryAnnotationAssociation", order_by=lambda: HistoryAnnotationAssociation.id, back_populates="history"
     )
-    ratings = relationship(
+    ratings: Mapped[List["HistoryRatingAssociation"]] = relationship(
         "HistoryRatingAssociation",
         order_by=lambda: HistoryRatingAssociation.id,  # type: ignore[has-type]
         back_populates="history",
     )
-    default_permissions = relationship("DefaultHistoryPermissions", back_populates="history")
-    users_shared_with = relationship("HistoryUserShareAssociation", back_populates="history")
+    default_permissions: Mapped[List["DefaultHistoryPermissions"]] = relationship(
+        "DefaultHistoryPermissions", back_populates="history"
+    )
+    users_shared_with: Mapped[List["HistoryUserShareAssociation"]] = relationship(
+        "HistoryUserShareAssociation", back_populates="history"
+    )
     galaxy_sessions = relationship("GalaxySessionToHistoryAssociation", back_populates="history")
-    workflow_invocations = relationship("WorkflowInvocation", back_populates="history", cascade_backrefs=False)
+    workflow_invocations: Mapped[List["WorkflowInvocation"]] = relationship(
+        "WorkflowInvocation", back_populates="history", cascade_backrefs=False
+    )
     user: Mapped[Optional["User"]] = relationship("User", back_populates="histories")
-    jobs = relationship("Job", back_populates="history", cascade_backrefs=False)
+    jobs: Mapped[List["Job"]] = relationship("Job", back_populates="history", cascade_backrefs=False)
 
     update_time = column_property(
         select(func.max(HistoryAudit.update_time)).where(HistoryAudit.history_id == id).scalar_subquery(),
@@ -3659,9 +3677,9 @@ class Role(Base, Dictifiable, RepresentById):
     description: Mapped[Optional[str]] = mapped_column(TEXT)
     type: Mapped[Optional[str]] = mapped_column(String(40), index=True)
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
-    dataset_actions = relationship("DatasetPermissions", back_populates="role")
-    groups = relationship("GroupRoleAssociation", back_populates="role")
-    users = relationship("UserRoleAssociation", back_populates="role")
+    dataset_actions: Mapped[List["DatasetPermissions"]] = relationship("DatasetPermissions", back_populates="role")
+    groups: Mapped[List["GroupRoleAssociation"]] = relationship("GroupRoleAssociation", back_populates="role")
+    users: Mapped[List["UserRoleAssociation"]] = relationship("UserRoleAssociation", back_populates="role")
 
     dict_collection_visible_keys = ["id", "name"]
     dict_element_visible_keys = ["id", "name", "description", "type"]
@@ -3747,8 +3765,8 @@ class Quota(Base, Dictifiable, RepresentById):
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     quota_source_label: Mapped[Optional[str]] = mapped_column(String(32), default=None)
     default = relationship("DefaultQuotaAssociation", back_populates="quota", cascade_backrefs=False)
-    groups = relationship("GroupQuotaAssociation", back_populates="quota")
-    users = relationship("UserQuotaAssociation", back_populates="quota")
+    groups: Mapped[List["GroupQuotaAssociation"]] = relationship("GroupQuotaAssociation", back_populates="quota")
+    users: Mapped[List["UserQuotaAssociation"]] = relationship("UserQuotaAssociation", back_populates="quota")
 
     dict_collection_visible_keys = ["id", "name", "quota_source_label"]
     dict_element_visible_keys = [
@@ -3993,9 +4011,9 @@ class Dataset(Base, StorableObject, Serializable):
     total_size: Mapped[Optional[Decimal]] = mapped_column(Numeric(15, 0))
     uuid: Mapped[Optional[Union[UUID, str]]] = mapped_column(UUIDType())
 
-    actions = relationship("DatasetPermissions", back_populates="dataset")
+    actions: Mapped[List["DatasetPermissions"]] = relationship("DatasetPermissions", back_populates="dataset")
     job: Mapped[Optional["Job"]] = relationship(Job, primaryjoin=(lambda: Dataset.job_id == Job.id))
-    active_history_associations = relationship(
+    active_history_associations: Mapped[List["HistoryDatasetAssociation"]] = relationship(
         "HistoryDatasetAssociation",
         primaryjoin=(
             lambda: and_(
@@ -4006,7 +4024,7 @@ class Dataset(Base, StorableObject, Serializable):
         ),
         viewonly=True,
     )
-    purged_history_associations = relationship(
+    purged_history_associations: Mapped[List["HistoryDatasetAssociation"]] = relationship(
         "HistoryDatasetAssociation",
         primaryjoin=(
             lambda: and_(
@@ -4016,7 +4034,7 @@ class Dataset(Base, StorableObject, Serializable):
         ),
         viewonly=True,
     )
-    active_library_associations = relationship(
+    active_library_associations: Mapped[List["LibraryDatasetDatasetAssociation"]] = relationship(
         "LibraryDatasetDatasetAssociation",
         primaryjoin=(
             lambda: and_(
@@ -4026,10 +4044,12 @@ class Dataset(Base, StorableObject, Serializable):
         ),
         viewonly=True,
     )
-    hashes = relationship("DatasetHash", back_populates="dataset", cascade_backrefs=False)
-    sources = relationship("DatasetSource", back_populates="dataset")
-    history_associations = relationship("HistoryDatasetAssociation", back_populates="dataset", cascade_backrefs=False)
-    library_associations = relationship(
+    hashes: Mapped[List["DatasetHash"]] = relationship("DatasetHash", back_populates="dataset", cascade_backrefs=False)
+    sources: Mapped[List["DatasetSource"]] = relationship("DatasetSource", back_populates="dataset")
+    history_associations: Mapped[List["HistoryDatasetAssociation"]] = relationship(
+        "HistoryDatasetAssociation", back_populates="dataset", cascade_backrefs=False
+    )
+    library_associations: Mapped[List["LibraryDatasetDatasetAssociation"]] = relationship(
         "LibraryDatasetDatasetAssociation",
         primaryjoin=(lambda: LibraryDatasetDatasetAssociation.table.c.dataset_id == Dataset.id),
         back_populates="dataset",
@@ -4363,7 +4383,7 @@ class DatasetSource(Base, Dictifiable, Serializable):
     extra_files_path: Mapped[Optional[str]] = mapped_column(TEXT)
     transform: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
     dataset: Mapped[Optional["Dataset"]] = relationship("Dataset", back_populates="sources")
-    hashes = relationship("DatasetSourceHash", back_populates="source")
+    hashes: Mapped[List["DatasetSourceHash"]] = relationship("DatasetSourceHash", back_populates="source")
     dict_collection_visible_keys = ["id", "source_uri", "extra_files_path", "transform"]
     dict_element_visible_keys = [
         "id",
@@ -5562,7 +5582,9 @@ class Library(Base, Dictifiable, HasName, Serializable):
     description: Mapped[Optional[str]] = mapped_column(TEXT)
     synopsis: Mapped[Optional[str]] = mapped_column(TEXT)
     root_folder = relationship("LibraryFolder", back_populates="library_root")
-    actions = relationship("LibraryPermissions", back_populates="library", cascade_backrefs=False)
+    actions: Mapped[List["LibraryPermissions"]] = relationship(
+        "LibraryPermissions", back_populates="library", cascade_backrefs=False
+    )
 
     permitted_actions = get_permitted_actions(filter="LIBRARY")
     dict_collection_visible_keys = ["id", "name"]
@@ -5642,7 +5664,7 @@ class LibraryFolder(Base, Dictifiable, HasName, Serializable):
     purged: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     genome_build: Mapped[Optional[str]] = mapped_column(TrimmedString(40))
 
-    folders = relationship(
+    folders: Mapped[List["LibraryFolder"]] = relationship(
         "LibraryFolder",
         primaryjoin=(lambda: LibraryFolder.id == LibraryFolder.parent_id),
         order_by=asc(name),
@@ -5652,7 +5674,7 @@ class LibraryFolder(Base, Dictifiable, HasName, Serializable):
         "LibraryFolder", back_populates="folders", remote_side=[id]
     )
 
-    active_folders = relationship(
+    active_folders: Mapped[List["LibraryFolder"]] = relationship(
         "LibraryFolder",
         primaryjoin=("and_(LibraryFolder.parent_id == LibraryFolder.id, not_(LibraryFolder.deleted))"),
         order_by=asc(name),
@@ -5663,7 +5685,7 @@ class LibraryFolder(Base, Dictifiable, HasName, Serializable):
         viewonly=True,
     )
 
-    datasets = relationship(
+    datasets: Mapped[List["LibraryDataset"]] = relationship(
         "LibraryDataset",
         primaryjoin=(
             lambda: LibraryDataset.folder_id == LibraryFolder.id
@@ -5673,7 +5695,7 @@ class LibraryFolder(Base, Dictifiable, HasName, Serializable):
         viewonly=True,
     )
 
-    active_datasets = relationship(
+    active_datasets: Mapped[List["LibraryDataset"]] = relationship(
         "LibraryDataset",
         primaryjoin=(
             "and_(LibraryDataset.folder_id == LibraryFolder.id, not_(LibraryDataset.deleted), LibraryDataset.library_dataset_dataset_association_id.isnot(None))"
@@ -5683,7 +5705,9 @@ class LibraryFolder(Base, Dictifiable, HasName, Serializable):
     )
 
     library_root = relationship("Library", back_populates="root_folder")
-    actions = relationship("LibraryFolderPermissions", back_populates="folder", cascade_backrefs=False)
+    actions: Mapped[List["LibraryFolderPermissions"]] = relationship(
+        "LibraryFolderPermissions", back_populates="folder", cascade_backrefs=False
+    )
 
     dict_element_visible_keys = [
         "id",
@@ -5796,7 +5820,7 @@ class LibraryDataset(Base, Serializable):
     library_dataset_dataset_association = relationship(
         "LibraryDatasetDatasetAssociation", foreign_keys=library_dataset_dataset_association_id, post_update=True
     )
-    expired_datasets = relationship(
+    expired_datasets: Mapped[List["LibraryDatasetDatasetAssociation"]] = relationship(
         "LibraryDatasetDatasetAssociation",
         foreign_keys=[id, library_dataset_dataset_association_id],
         primaryjoin=(
@@ -5806,7 +5830,9 @@ class LibraryDataset(Base, Serializable):
         viewonly=True,
         uselist=True,
     )
-    actions = relationship("LibraryDatasetPermissions", back_populates="library_dataset", cascade_backrefs=False)
+    actions: Mapped[List["LibraryDatasetPermissions"]] = relationship(
+        "LibraryDatasetPermissions", back_populates="library_dataset", cascade_backrefs=False
+    )
 
     # This class acts as a proxy to the currently selected LDDA
     upload_options = [
@@ -6074,7 +6100,9 @@ class ExtendedMetadata(Base, RepresentById):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     data: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
-    children = relationship("ExtendedMetadataIndex", back_populates="extended_metadata")
+    children: Mapped[List["ExtendedMetadataIndex"]] = relationship(
+        "ExtendedMetadataIndex", back_populates="extended_metadata"
+    )
 
     def __init__(self, data):
         self.data = data
@@ -6326,7 +6354,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
 
-    elements = relationship(
+    elements: Mapped[List["DatasetCollectionElement"]] = relationship(
         "DatasetCollectionElement",
         primaryjoin=(lambda: DatasetCollection.id == DatasetCollectionElement.dataset_collection_id),  # type: ignore[has-type]
         back_populates="collection",
@@ -6808,7 +6836,7 @@ class HistoryDatasetCollectionAssociation(
         "HistoryDatasetCollectionAssociation",
         back_populates="copied_from_history_dataset_collection_association",
     )
-    implicit_input_collections = relationship(
+    implicit_input_collections: Mapped[List["ImplicitlyCreatedDatasetCollectionInput"]] = relationship(
         "ImplicitlyCreatedDatasetCollectionInput",
         primaryjoin=(
             lambda: HistoryDatasetCollectionAssociation.id
@@ -6826,17 +6854,19 @@ class HistoryDatasetCollectionAssociation(
         order_by=lambda: HistoryDatasetCollectionTagAssociation.id,
         back_populates="dataset_collection",
     )
-    annotations = relationship(
+    annotations: Mapped[List["HistoryDatasetCollectionAssociationAnnotationAssociation"]] = relationship(
         "HistoryDatasetCollectionAssociationAnnotationAssociation",
         order_by=lambda: HistoryDatasetCollectionAssociationAnnotationAssociation.id,
         back_populates="history_dataset_collection",
     )
-    ratings = relationship(
+    ratings: Mapped[List["HistoryDatasetCollectionRatingAssociation"]] = relationship(
         "HistoryDatasetCollectionRatingAssociation",
         order_by=lambda: HistoryDatasetCollectionRatingAssociation.id,  # type: ignore[has-type]
         back_populates="dataset_collection",
     )
-    creating_job_associations = relationship("JobToOutputDatasetCollectionAssociation", viewonly=True)
+    creating_job_associations: Mapped[List["JobToOutputDatasetCollectionAssociation"]] = relationship(
+        "JobToOutputDatasetCollectionAssociation", viewonly=True
+    )
 
     dict_dbkeysandextensions_visible_keys = ["dbkeys", "extensions"]
     editable_keys = ("name", "deleted", "visible")
@@ -7184,12 +7214,12 @@ class LibraryDatasetCollectionAssociation(Base, DatasetCollectionInstance, Repre
         order_by=lambda: LibraryDatasetCollectionTagAssociation.id,
         back_populates="dataset_collection",
     )
-    annotations = relationship(
+    annotations: Mapped[List["LibraryDatasetCollectionAnnotationAssociation"]] = relationship(
         "LibraryDatasetCollectionAnnotationAssociation",
         order_by=lambda: LibraryDatasetCollectionAnnotationAssociation.id,
         back_populates="dataset_collection",
     )
-    ratings = relationship(
+    ratings: Mapped[List["LibraryDatasetCollectionRatingAssociation"]] = relationship(
         "LibraryDatasetCollectionRatingAssociation",
         order_by=lambda: LibraryDatasetCollectionRatingAssociation.id,  # type: ignore[has-type]
         back_populates="dataset_collection",
@@ -7437,7 +7467,7 @@ class GalaxySession(Base, RepresentById):
     disk_usage: Mapped[Optional[Decimal]] = mapped_column(Numeric(15, 0), index=True)
     last_action: Mapped[Optional[datetime]]
     current_history: Mapped[Optional["History"]] = relationship("History")
-    histories = relationship(
+    histories: Mapped[List["GalaxySessionToHistoryAssociation"]] = relationship(
         "GalaxySessionToHistoryAssociation", back_populates="galaxy_session", cascade_backrefs=False
     )
     user: Mapped[Optional["User"]] = relationship("User", back_populates="galaxy_sessions")
@@ -7511,7 +7541,7 @@ class StoredWorkflow(Base, HasTags, Dictifiable, RepresentById):
     user: Mapped["User"] = relationship(
         "User", primaryjoin=(lambda: User.id == StoredWorkflow.user_id), back_populates="stored_workflows"
     )
-    workflows = relationship(
+    workflows: Mapped[List["Workflow"]] = relationship(
         "Workflow",
         back_populates="stored_workflow",
         cascade="all, delete-orphan",
@@ -7541,17 +7571,19 @@ class StoredWorkflow(Base, HasTags, Dictifiable, RepresentById):
         viewonly=True,
         order_by=lambda: StoredWorkflowTagAssociation.id,
     )
-    annotations = relationship(
+    annotations: Mapped[List["StoredWorkflowAnnotationAssociation"]] = relationship(
         "StoredWorkflowAnnotationAssociation",
         order_by=lambda: StoredWorkflowAnnotationAssociation.id,
         back_populates="stored_workflow",
     )
-    ratings = relationship(
+    ratings: Mapped[List["StoredWorkflowRatingAssociation"]] = relationship(
         "StoredWorkflowRatingAssociation",
         order_by=lambda: StoredWorkflowRatingAssociation.id,  # type: ignore[has-type]
         back_populates="stored_workflow",
     )
-    users_shared_with = relationship("StoredWorkflowUserShareAssociation", back_populates="stored_workflow")
+    users_shared_with: Mapped[List["StoredWorkflowUserShareAssociation"]] = relationship(
+        "StoredWorkflowUserShareAssociation", back_populates="stored_workflow"
+    )
 
     average_rating = None
 
@@ -7690,7 +7722,7 @@ class Workflow(Base, Dictifiable, RepresentById):
         cascade="all, delete-orphan",
         lazy=False,
     )
-    comments = relationship(
+    comments: Mapped[List["WorkflowComment"]] = relationship(
         "WorkflowComment",
         back_populates="workflow",
         primaryjoin=(lambda: Workflow.id == WorkflowComment.workflow_id),  # type: ignore[has-type]
@@ -7887,15 +7919,17 @@ class WorkflowStep(Base, RepresentById):
     tags: Mapped[List["WorkflowStepTagAssociation"]] = relationship(
         "WorkflowStepTagAssociation", order_by=lambda: WorkflowStepTagAssociation.id, back_populates="workflow_step"
     )
-    annotations = relationship(
+    annotations: Mapped[List["WorkflowStepAnnotationAssociation"]] = relationship(
         "WorkflowStepAnnotationAssociation",
         order_by=lambda: WorkflowStepAnnotationAssociation.id,
         back_populates="workflow_step",
     )
     post_job_actions = relationship("PostJobAction", back_populates="workflow_step", cascade_backrefs=False)
     inputs = relationship("WorkflowStepInput", back_populates="workflow_step")
-    workflow_outputs = relationship("WorkflowOutput", back_populates="workflow_step", cascade_backrefs=False)
-    output_connections = relationship(
+    workflow_outputs: Mapped[List["WorkflowOutput"]] = relationship(
+        "WorkflowOutput", back_populates="workflow_step", cascade_backrefs=False
+    )
+    output_connections: Mapped[List["WorkflowStepConnection"]] = relationship(
         "WorkflowStepConnection", primaryjoin=(lambda: WorkflowStepConnection.output_step_id == WorkflowStep.id)
     )
     workflow: Mapped["Workflow"] = relationship(
@@ -8184,7 +8218,7 @@ class WorkflowStepInput(Base, RepresentById):
         cascade="all",
         primaryjoin=(lambda: WorkflowStepInput.workflow_step_id == WorkflowStep.id),
     )
-    connections = relationship(
+    connections: Mapped[List["WorkflowStepConnection"]] = relationship(
         "WorkflowStepConnection",
         back_populates="input_step_input",
         primaryjoin=(lambda: WorkflowStepConnection.input_step_input_id == WorkflowStepInput.id),
@@ -8337,7 +8371,7 @@ class WorkflowComment(Base, RepresentById):
         remote_side=[id],
     )
 
-    child_comments = relationship(
+    child_comments: Mapped[List["WorkflowComment"]] = relationship(
         "WorkflowComment",
         primaryjoin=(lambda: WorkflowComment.parent_comment_id == WorkflowComment.id),
         back_populates="parent_comment",
@@ -9734,7 +9768,7 @@ class FormDefinitionCurrent(Base, RepresentById):
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
     latest_form_id: Mapped[Optional[int]] = mapped_column(ForeignKey("form_definition.id"), index=True)
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
-    forms = relationship(
+    forms: Mapped[List["FormDefinition"]] = relationship(
         "FormDefinition",
         back_populates="form_definition_current",
         cascade="all, delete-orphan",
@@ -10211,7 +10245,7 @@ class Page(Base, HasTags, Dictifiable, RepresentById):
     slug: Mapped[Optional[str]] = mapped_column(TEXT)
     published: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     user: Mapped["User"] = relationship("User")
-    revisions = relationship(
+    revisions: Mapped[List["PageRevision"]] = relationship(
         "PageRevision",
         cascade="all, delete-orphan",
         primaryjoin=(lambda: Page.id == PageRevision.page_id),  # type: ignore[has-type]
@@ -10226,15 +10260,17 @@ class Page(Base, HasTags, Dictifiable, RepresentById):
     tags: Mapped[List["PageTagAssociation"]] = relationship(
         "PageTagAssociation", order_by=lambda: PageTagAssociation.id, back_populates="page"
     )
-    annotations = relationship(
+    annotations: Mapped[List["PageAnnotationAssociation"]] = relationship(
         "PageAnnotationAssociation", order_by=lambda: PageAnnotationAssociation.id, back_populates="page"
     )
-    ratings = relationship(
+    ratings: Mapped[List["PageRatingAssociation"]] = relationship(
         "PageRatingAssociation",
         order_by=lambda: PageRatingAssociation.id,  # type: ignore[has-type]
         back_populates="page",
     )
-    users_shared_with = relationship("PageUserShareAssociation", back_populates="page")
+    users_shared_with: Mapped[List["PageUserShareAssociation"]] = relationship(
+        "PageUserShareAssociation", back_populates="page"
+    )
 
     average_rating = None
 
@@ -10334,7 +10370,7 @@ class Visualization(Base, HasTags, Dictifiable, RepresentById):
     published: Mapped[Optional[bool]] = mapped_column(default=False, index=True)
 
     user: Mapped["User"] = relationship("User")
-    revisions = relationship(
+    revisions: Mapped[List["VisualizationRevision"]] = relationship(
         "VisualizationRevision",
         back_populates="visualization",
         cascade="all, delete-orphan",
@@ -10350,17 +10386,19 @@ class Visualization(Base, HasTags, Dictifiable, RepresentById):
     tags: Mapped[List["VisualizationTagAssociation"]] = relationship(
         "VisualizationTagAssociation", order_by=lambda: VisualizationTagAssociation.id, back_populates="visualization"
     )
-    annotations = relationship(
+    annotations: Mapped[List["VisualizationAnnotationAssociation"]] = relationship(
         "VisualizationAnnotationAssociation",
         order_by=lambda: VisualizationAnnotationAssociation.id,
         back_populates="visualization",
     )
-    ratings = relationship(
+    ratings: Mapped[List["VisualizationRatingAssociation"]] = relationship(
         "VisualizationRatingAssociation",
         order_by=lambda: VisualizationRatingAssociation.id,  # type: ignore[has-type]
         back_populates="visualization",
     )
-    users_shared_with = relationship("VisualizationUserShareAssociation", back_populates="visualization")
+    users_shared_with: Mapped[List["VisualizationUserShareAssociation"]] = relationship(
+        "VisualizationUserShareAssociation", back_populates="visualization"
+    )
 
     average_rating = None
 
@@ -10473,7 +10511,7 @@ class Tag(Base, RepresentById):
     type: Mapped[Optional[int]]
     parent_id: Mapped[Optional[int]] = mapped_column(ForeignKey("tag.id"))
     name: Mapped[Optional[str]] = mapped_column(TrimmedString(255))
-    children = relationship("Tag", back_populates="parent")
+    children: Mapped[List["Tag"]] = relationship("Tag", back_populates="parent")
     parent: Mapped[Optional["Tag"]] = relationship("Tag", back_populates="children", remote_side=[id])
 
     def __str__(self):
@@ -10768,7 +10806,7 @@ class Vault(Base):
 
     key: Mapped[str] = mapped_column(Text, primary_key=True)
     parent_key: Mapped[Optional[str]] = mapped_column(Text, ForeignKey(key), index=True)
-    children = relationship("Vault", back_populates="parent")
+    children: Mapped[List["Vault"]] = relationship("Vault", back_populates="parent")
     parent: Mapped[Optional["Vault"]] = relationship("Vault", back_populates="children", remote_side=[key])
     value: Mapped[Optional[str]] = mapped_column(Text)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1399,7 +1399,9 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     history: Mapped[Optional["History"]] = relationship(back_populates="jobs")
     library_folder: Mapped[Optional["LibraryFolder"]] = relationship()
     parameters = relationship("JobParameter")
-    input_datasets = relationship("JobToInputDatasetAssociation", back_populates="job")
+    input_datasets: Mapped[List["JobToInputDatasetAssociation"]] = relationship(
+        "JobToInputDatasetAssociation", back_populates="job"
+    )
     input_dataset_collections: Mapped[List["JobToInputDatasetCollectionAssociation"]] = relationship(
         back_populates="job"
     )

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -10554,11 +10554,11 @@ class HistoryAnnotationAssociation(Base, RepresentById):
     __table_args__ = (Index("ix_history_anno_assoc_annotation", "annotation", mysql_length=200),)
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
+    history_id: Mapped[int] = mapped_column(ForeignKey("history.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    history: Mapped[Optional["History"]] = relationship(back_populates="annotations")
-    user: Mapped[Optional["User"]] = relationship()
+    annotation: Mapped[str] = mapped_column(TEXT, nullable=True)
+    history: Mapped["History"] = relationship(back_populates="annotations")
+    user: Mapped["User"] = relationship()
 
 
 class HistoryDatasetAssociationAnnotationAssociation(Base, RepresentById):
@@ -10566,12 +10566,12 @@ class HistoryDatasetAssociationAnnotationAssociation(Base, RepresentById):
     __table_args__ = (Index("ix_history_dataset_anno_assoc_annotation", "annotation", mysql_length=200),)
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    history_dataset_association_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("history_dataset_association.id"), index=True
+    history_dataset_association_id: Mapped[int] = mapped_column(
+        ForeignKey("history_dataset_association.id"), index=True, nullable=True
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    hda: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(back_populates="annotations")
+    annotation: Mapped[str] = mapped_column(TEXT, nullable=True)
+    hda: Mapped["HistoryDatasetAssociation"] = relationship(back_populates="annotations")
     user: Mapped[Optional["User"]] = relationship()
 
 
@@ -10580,10 +10580,10 @@ class StoredWorkflowAnnotationAssociation(Base, RepresentById):
     __table_args__ = (Index("ix_stored_workflow_ann_assoc_annotation", "annotation", mysql_length=200),)
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    stored_workflow_id: Mapped[Optional[int]] = mapped_column(ForeignKey("stored_workflow.id"), index=True)
+    stored_workflow_id: Mapped[int] = mapped_column(ForeignKey("stored_workflow.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship(back_populates="annotations")
+    annotation: Mapped[str] = mapped_column(TEXT, nullable=True)
+    stored_workflow: Mapped["StoredWorkflow"] = relationship(back_populates="annotations")
     user: Mapped[Optional["User"]] = relationship()
 
 
@@ -10592,10 +10592,10 @@ class WorkflowStepAnnotationAssociation(Base, RepresentById):
     __table_args__ = (Index("ix_workflow_step_ann_assoc_annotation", "annotation", mysql_length=200),)
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    workflow_step_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_step.id"), index=True)
+    workflow_step_id: Mapped[int] = mapped_column(ForeignKey("workflow_step.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship(back_populates="annotations")
+    annotation: Mapped[str] = mapped_column(TEXT, nullable=True)
+    workflow_step: Mapped["WorkflowStep"] = relationship(back_populates="annotations")
     user: Mapped[Optional["User"]] = relationship()
 
 
@@ -10604,10 +10604,10 @@ class PageAnnotationAssociation(Base, RepresentById):
     __table_args__ = (Index("ix_page_annotation_association_annotation", "annotation", mysql_length=200),)
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    page_id: Mapped[Optional[int]] = mapped_column(ForeignKey("page.id"), index=True)
+    page_id: Mapped[int] = mapped_column(ForeignKey("page.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    page: Mapped[Optional["Page"]] = relationship(back_populates="annotations")
+    annotation: Mapped[str] = mapped_column(TEXT, nullable=True)
+    page: Mapped["Page"] = relationship(back_populates="annotations")
     user: Mapped[Optional["User"]] = relationship()
 
 
@@ -10616,10 +10616,10 @@ class VisualizationAnnotationAssociation(Base, RepresentById):
     __table_args__ = (Index("ix_visualization_annotation_association_annotation", "annotation", mysql_length=200),)
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    visualization_id: Mapped[Optional[int]] = mapped_column(ForeignKey("visualization.id"), index=True)
+    visualization_id: Mapped[int] = mapped_column(ForeignKey("visualization.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    visualization: Mapped[Optional["Visualization"]] = relationship(back_populates="annotations")
+    annotation: Mapped[str] = mapped_column(TEXT, nullable=True)
+    visualization: Mapped["Visualization"] = relationship(back_populates="annotations")
     user: Mapped[Optional["User"]] = relationship()
 
 
@@ -10627,12 +10627,12 @@ class HistoryDatasetCollectionAssociationAnnotationAssociation(Base, RepresentBy
     __tablename__ = "history_dataset_collection_annotation_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    history_dataset_collection_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("history_dataset_collection_association.id"), index=True
+    history_dataset_collection_id: Mapped[int] = mapped_column(
+        ForeignKey("history_dataset_collection_association.id"), index=True, nullable=True
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    history_dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(
+    annotation: Mapped[str] = mapped_column(TEXT, nullable=True)
+    history_dataset_collection: Mapped["HistoryDatasetCollectionAssociation"] = relationship(
         back_populates="annotations"
     )
     user: Mapped[Optional["User"]] = relationship()
@@ -10642,14 +10642,12 @@ class LibraryDatasetCollectionAnnotationAssociation(Base, RepresentById):
     __tablename__ = "library_dataset_collection_annotation_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    library_dataset_collection_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("library_dataset_collection_association.id"), index=True
+    library_dataset_collection_id: Mapped[int] = mapped_column(
+        ForeignKey("library_dataset_collection_association.id"), index=True, nullable=True
     )
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    annotation: Mapped[Optional[str]] = mapped_column(TEXT)
-    dataset_collection: Mapped[Optional["LibraryDatasetCollectionAssociation"]] = relationship(
-        back_populates="annotations"
-    )
+    annotation: Mapped[str] = mapped_column(TEXT, nullable=True)
+    dataset_collection: Mapped["LibraryDatasetCollectionAssociation"] = relationship(back_populates="annotations")
     user: Mapped[Optional["User"]] = relationship()
 
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -10403,13 +10403,13 @@ class HistoryTagAssociation(Base, ItemTagAssociation, RepresentById):
     __tablename__ = "history_tag_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
-    tag_id: Mapped[Optional[int]] = mapped_column(ForeignKey("tag.id"), index=True)
+    history_id: Mapped[int] = mapped_column(ForeignKey("history.id"), index=True, nullable=True)
+    tag_id: Mapped[int] = mapped_column(ForeignKey("tag.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    history: Mapped[Optional["History"]] = relationship(back_populates="tags")
-    tag: Mapped[Optional["Tag"]] = relationship()
+    history: Mapped["History"] = relationship(back_populates="tags")
+    tag: Mapped["Tag"] = relationship()
     user: Mapped[Optional["User"]] = relationship()
 
 
@@ -10417,15 +10417,15 @@ class HistoryDatasetAssociationTagAssociation(Base, ItemTagAssociation, Represen
     __tablename__ = "history_dataset_association_tag_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    history_dataset_association_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("history_dataset_association.id"), index=True
+    history_dataset_association_id: Mapped[int] = mapped_column(
+        ForeignKey("history_dataset_association.id"), index=True, nullable=True
     )
-    tag_id: Mapped[Optional[int]] = mapped_column(ForeignKey("tag.id"), index=True)
+    tag_id: Mapped[int] = mapped_column(ForeignKey("tag.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    history_dataset_association: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(back_populates="tags")
-    tag: Mapped[Optional["Tag"]] = relationship()
+    history_dataset_association: Mapped["HistoryDatasetAssociation"] = relationship(back_populates="tags")
+    tag: Mapped["Tag"] = relationship()
     user: Mapped[Optional["User"]] = relationship()
 
 
@@ -10433,17 +10433,17 @@ class LibraryDatasetDatasetAssociationTagAssociation(Base, ItemTagAssociation, R
     __tablename__ = "library_dataset_dataset_association_tag_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    library_dataset_dataset_association_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("library_dataset_dataset_association.id"), index=True
+    library_dataset_dataset_association_id: Mapped[int] = mapped_column(
+        ForeignKey("library_dataset_dataset_association.id"), index=True, nullable=True
     )
-    tag_id: Mapped[Optional[int]] = mapped_column(ForeignKey("tag.id"), index=True)
+    tag_id: Mapped[int] = mapped_column(ForeignKey("tag.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    library_dataset_dataset_association: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship(
+    library_dataset_dataset_association: Mapped["LibraryDatasetDatasetAssociation"] = relationship(
         back_populates="tags"
     )
-    tag: Mapped[Optional["Tag"]] = relationship()
+    tag: Mapped["Tag"] = relationship()
     user: Mapped[Optional["User"]] = relationship()
 
 
@@ -10451,13 +10451,13 @@ class PageTagAssociation(Base, ItemTagAssociation, RepresentById):
     __tablename__ = "page_tag_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    page_id: Mapped[Optional[int]] = mapped_column(ForeignKey("page.id"), index=True)
-    tag_id: Mapped[Optional[int]] = mapped_column(ForeignKey("tag.id"), index=True)
+    page_id: Mapped[int] = mapped_column(ForeignKey("page.id"), index=True, nullable=True)
+    tag_id: Mapped[int] = mapped_column(ForeignKey("tag.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    page: Mapped[Optional["Page"]] = relationship(back_populates="tags")
-    tag: Mapped[Optional["Tag"]] = relationship()
+    page: Mapped["Page"] = relationship(back_populates="tags")
+    tag: Mapped["Tag"] = relationship()
     user: Mapped[Optional["User"]] = relationship()
 
 
@@ -10465,13 +10465,13 @@ class WorkflowStepTagAssociation(Base, ItemTagAssociation, RepresentById):
     __tablename__ = "workflow_step_tag_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    workflow_step_id: Mapped[Optional[int]] = mapped_column(ForeignKey("workflow_step.id"), index=True)
-    tag_id: Mapped[Optional[int]] = mapped_column(ForeignKey("tag.id"), index=True)
+    workflow_step_id: Mapped[int] = mapped_column(ForeignKey("workflow_step.id"), index=True, nullable=True)
+    tag_id: Mapped[int] = mapped_column(ForeignKey("tag.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    workflow_step: Mapped[Optional["WorkflowStep"]] = relationship(back_populates="tags")
-    tag: Mapped[Optional["Tag"]] = relationship()
+    workflow_step: Mapped["WorkflowStep"] = relationship(back_populates="tags")
+    tag: Mapped["Tag"] = relationship()
     user: Mapped[Optional["User"]] = relationship()
 
 
@@ -10479,13 +10479,13 @@ class StoredWorkflowTagAssociation(Base, ItemTagAssociation, RepresentById):
     __tablename__ = "stored_workflow_tag_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    stored_workflow_id: Mapped[Optional[int]] = mapped_column(ForeignKey("stored_workflow.id"), index=True)
-    tag_id: Mapped[Optional[int]] = mapped_column(ForeignKey("tag.id"), index=True)
+    stored_workflow_id: Mapped[int] = mapped_column(ForeignKey("stored_workflow.id"), index=True, nullable=True)
+    tag_id: Mapped[int] = mapped_column(ForeignKey("tag.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship(back_populates="tags")
-    tag: Mapped[Optional["Tag"]] = relationship()
+    stored_workflow: Mapped["StoredWorkflow"] = relationship(back_populates="tags")
+    tag: Mapped["Tag"] = relationship()
     user: Mapped[Optional["User"]] = relationship()
 
 
@@ -10493,13 +10493,13 @@ class VisualizationTagAssociation(Base, ItemTagAssociation, RepresentById):
     __tablename__ = "visualization_tag_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    visualization_id: Mapped[Optional[int]] = mapped_column(ForeignKey("visualization.id"), index=True)
-    tag_id: Mapped[Optional[int]] = mapped_column(ForeignKey("tag.id"), index=True)
+    visualization_id: Mapped[int] = mapped_column(ForeignKey("visualization.id"), index=True, nullable=True)
+    tag_id: Mapped[int] = mapped_column(ForeignKey("tag.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    visualization: Mapped[Optional["Visualization"]] = relationship(back_populates="tags")
-    tag: Mapped[Optional["Tag"]] = relationship()
+    visualization: Mapped["Visualization"] = relationship(back_populates="tags")
+    tag: Mapped["Tag"] = relationship()
     user: Mapped[Optional["User"]] = relationship()
 
 
@@ -10507,15 +10507,15 @@ class HistoryDatasetCollectionTagAssociation(Base, ItemTagAssociation, Represent
     __tablename__ = "history_dataset_collection_tag_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    history_dataset_collection_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("history_dataset_collection_association.id"), index=True
+    history_dataset_collection_id: Mapped[int] = mapped_column(
+        ForeignKey("history_dataset_collection_association.id"), index=True, nullable=True
     )
-    tag_id: Mapped[Optional[int]] = mapped_column(ForeignKey("tag.id"), index=True)
+    tag_id: Mapped[int] = mapped_column(ForeignKey("tag.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    dataset_collection: Mapped[Optional["HistoryDatasetCollectionAssociation"]] = relationship(back_populates="tags")
-    tag: Mapped[Optional["Tag"]] = relationship()
+    dataset_collection: Mapped["HistoryDatasetCollectionAssociation"] = relationship(back_populates="tags")
+    tag: Mapped["Tag"] = relationship()
     user: Mapped[Optional["User"]] = relationship()
 
 
@@ -10523,15 +10523,15 @@ class LibraryDatasetCollectionTagAssociation(Base, ItemTagAssociation, Represent
     __tablename__ = "library_dataset_collection_tag_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    library_dataset_collection_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("library_dataset_collection_association.id"), index=True
+    library_dataset_collection_id: Mapped[int] = mapped_column(
+        ForeignKey("library_dataset_collection_association.id"), index=True, nullable=True
     )
-    tag_id: Mapped[Optional[int]] = mapped_column(ForeignKey("tag.id"), index=True)
+    tag_id: Mapped[int] = mapped_column(ForeignKey("tag.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    dataset_collection: Mapped[Optional["LibraryDatasetCollectionAssociation"]] = relationship(back_populates="tags")
-    tag: Mapped[Optional["Tag"]] = relationship()
+    dataset_collection: Mapped["LibraryDatasetCollectionAssociation"] = relationship(back_populates="tags")
+    tag: Mapped["Tag"] = relationship()
     user: Mapped[Optional["User"]] = relationship()
 
 
@@ -10539,12 +10539,12 @@ class ToolTagAssociation(Base, ItemTagAssociation, RepresentById):
     __tablename__ = "tool_tag_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    tool_id: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    tag_id: Mapped[Optional[int]] = mapped_column(ForeignKey("tag.id"), index=True)
+    tool_id: Mapped[str] = mapped_column(TrimmedString(255), index=True, nullable=True)
+    tag_id: Mapped[int] = mapped_column(ForeignKey("tag.id"), index=True, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     user_tname: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
     value: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True)
-    tag: Mapped[Optional["Tag"]] = relationship()
+    tag: Mapped["Tag"] = relationship()
     user: Mapped[Optional["User"]] = relationship()
 
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9498,7 +9498,7 @@ class MetadataFile(Base, StorableObject, Serializable):
     purged: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
 
     history_dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship()
-    library_dataset = relationship("LibraryDatasetDatasetAssociation")
+    library_dataset: Mapped[Optional["LibraryDatasetDatasetAssociation"]] = relationship()
 
     def __init__(self, dataset=None, name=None, uuid=None):
         self.uuid = get_uuid(uuid)
@@ -9509,7 +9509,7 @@ class MetadataFile(Base, StorableObject, Serializable):
         self.name = name
 
     @property
-    def dataset(self) -> Optional[Dataset]:
+    def dataset(self) -> Optional["DatasetInstance"]:
         da = self.history_dataset or self.library_dataset
         return da and da.dataset
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1407,7 +1407,9 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     output_dataset_collection_instances: Mapped[List["JobToOutputDatasetCollectionAssociation"]] = relationship(
         "JobToOutputDatasetCollectionAssociation", back_populates="job"
     )
-    output_dataset_collections = relationship("JobToImplicitOutputDatasetCollectionAssociation", back_populates="job")
+    output_dataset_collections: Mapped[List["JobToImplicitOutputDatasetCollectionAssociation"]] = relationship(
+        back_populates="job"
+    )
     post_job_actions: Mapped[List["PostJobActionAssociation"]] = relationship(
         back_populates="job", cascade_backrefs=False
     )
@@ -2414,7 +2416,7 @@ class JobToImplicitOutputDatasetCollectionAssociation(Base, RepresentById):
     id: Mapped[int] = mapped_column(primary_key=True)
     job_id: Mapped[int] = mapped_column(ForeignKey("job.id"), index=True, nullable=True)
     dataset_collection_id: Mapped[int] = mapped_column(ForeignKey("dataset_collection.id"), index=True, nullable=True)
-    name: Mapped[Optional[str]] = mapped_column(Unicode(255))
+    name: Mapped[str] = mapped_column(Unicode(255), nullable=True)
     dataset_collection: Mapped["DatasetCollection"] = relationship()
     job: Mapped["Job"] = relationship(back_populates="output_dataset_collections")
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2874,7 +2874,7 @@ class Group(Base, Dictifiable, RepresentById):
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
     quotas: Mapped[List["GroupQuotaAssociation"]] = relationship(back_populates="group")
     roles: Mapped[List["GroupRoleAssociation"]] = relationship(back_populates="group", cascade_backrefs=False)
-    users = relationship("UserGroupAssociation", back_populates="group")
+    users: Mapped[List["UserGroupAssociation"]] = relationship("UserGroupAssociation", back_populates="group")
 
     dict_collection_visible_keys = ["id", "name"]
     dict_element_visible_keys = ["id", "name"]
@@ -2888,12 +2888,12 @@ class UserGroupAssociation(Base, RepresentById):
     __tablename__ = "user_group_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    group_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_group.id"), index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("galaxy_user.id"), index=True, nullable=True)
+    group_id: Mapped[int] = mapped_column(ForeignKey("galaxy_group.id"), index=True, nullable=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
-    user: Mapped[Optional["User"]] = relationship(back_populates="groups")
-    group: Mapped[Optional["Group"]] = relationship(back_populates="users")
+    user: Mapped["User"] = relationship(back_populates="groups")
+    group: Mapped["Group"] = relationship(back_populates="users")
 
     def __init__(self, user, group):
         add_object_to_object_session(self, user)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -10207,10 +10207,10 @@ class PageUserShareAssociation(Base, UserShareAssociation):
     __tablename__ = "page_user_share_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    page_id: Mapped[Optional[int]] = mapped_column(ForeignKey("page.id"), index=True)
-    user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
+    page_id: Mapped[int] = mapped_column(ForeignKey("page.id"), index=True, nullable=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("galaxy_user.id"), index=True, nullable=True)
     user: Mapped[User] = relationship()
-    page: Mapped[Optional["Page"]] = relationship(back_populates="users_shared_with")
+    page: Mapped["Page"] = relationship(back_populates="users_shared_with")
 
 
 class Visualization(Base, HasTags, Dictifiable, RepresentById):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2410,11 +2410,11 @@ class JobToImplicitOutputDatasetCollectionAssociation(Base, RepresentById):
     __tablename__ = "job_to_implicit_output_dataset_collection"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
-    dataset_collection_id: Mapped[Optional[int]] = mapped_column(ForeignKey("dataset_collection.id"), index=True)
+    job_id: Mapped[int] = mapped_column(ForeignKey("job.id"), index=True, nullable=True)
+    dataset_collection_id: Mapped[int] = mapped_column(ForeignKey("dataset_collection.id"), index=True, nullable=True)
     name: Mapped[Optional[str]] = mapped_column(Unicode(255))
-    dataset_collection: Mapped[Optional["DatasetCollection"]] = relationship()
-    job: Mapped[Optional["Job"]] = relationship(back_populates="output_dataset_collections")
+    dataset_collection: Mapped["DatasetCollection"] = relationship()
+    job: Mapped["Job"] = relationship(back_populates="output_dataset_collections")
 
     def __init__(self, name, dataset_collection):
         self.name = name

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -2065,84 +2065,84 @@ class DirectoryModelExportStore(ModelExportStore):
                 output_dataset_collection_mapping: Dict[str, List[Union[str, int]]] = {}
                 implicit_output_dataset_collection_mapping: Dict[str, List[Union[str, int]]] = {}
 
-                for assoc in job.input_datasets:
+                for id_assoc in job.input_datasets:
                     # Optional data inputs will not have a dataset.
-                    if assoc.dataset:
-                        name = assoc.name
+                    if id_assoc.dataset:
+                        name = id_assoc.name
                         if name not in input_dataset_mapping:
                             input_dataset_mapping[name] = []
 
-                        input_dataset_mapping[name].append(self.exported_key(assoc.dataset))
+                        input_dataset_mapping[name].append(self.exported_key(id_assoc.dataset))
                         if include_job_data:
-                            self.add_dataset(assoc.dataset)
+                            self.add_dataset(id_assoc.dataset)
 
-                for assoc2 in job.output_datasets:
+                for od_assoc in job.output_datasets:
                     # Optional data inputs will not have a dataset.
-                    if assoc2.dataset:
-                        name = assoc2.name
+                    if od_assoc.dataset:
+                        name = od_assoc.name
                         if name not in output_dataset_mapping:
                             output_dataset_mapping[name] = []
 
-                        output_dataset_mapping[name].append(self.exported_key(assoc2.dataset))
+                        output_dataset_mapping[name].append(self.exported_key(od_assoc.dataset))
                         if include_job_data:
-                            self.add_dataset(assoc2.dataset)
+                            self.add_dataset(od_assoc.dataset)
 
-                for assoc3 in job.input_dataset_collections:
+                for idc_assoc in job.input_dataset_collections:
                     # Optional data inputs will not have a dataset.
-                    if assoc3.dataset_collection:
-                        name = assoc3.name
+                    if idc_assoc.dataset_collection:
+                        name = idc_assoc.name
                         if name not in input_dataset_collection_mapping:
                             input_dataset_collection_mapping[name] = []
 
-                        input_dataset_collection_mapping[name].append(self.exported_key(assoc3.dataset_collection))
+                        input_dataset_collection_mapping[name].append(self.exported_key(idc_assoc.dataset_collection))
                         if include_job_data:
-                            self.export_collection(assoc3.dataset_collection)
+                            self.export_collection(idc_assoc.dataset_collection)
 
-                for assoc4 in job.input_dataset_collection_elements:
-                    if assoc4.dataset_collection_element:
-                        name = assoc4.name
+                for idce_assoc in job.input_dataset_collection_elements:
+                    if idce_assoc.dataset_collection_element:
+                        name = idce_assoc.name
                         if name not in input_dataset_collection_element_mapping:
                             input_dataset_collection_element_mapping[name] = []
 
                         input_dataset_collection_element_mapping[name].append(
-                            self.exported_key(assoc4.dataset_collection_element)
+                            self.exported_key(idce_assoc.dataset_collection_element)
                         )
                         if include_job_data:
-                            if assoc4.dataset_collection_element.is_collection:
+                            if idce_assoc.dataset_collection_element.is_collection:
                                 assert isinstance(
-                                    assoc4.dataset_collection_element.element_object, model.DatasetCollection
+                                    idce_assoc.dataset_collection_element.element_object, model.DatasetCollection
                                 )
-                                self.export_collection(assoc4.dataset_collection_element.element_object)
+                                self.export_collection(idce_assoc.dataset_collection_element.element_object)
                             else:
                                 assert isinstance(
-                                    assoc4.dataset_collection_element.element_object, model.DatasetInstance
+                                    idce_assoc.dataset_collection_element.element_object, model.DatasetInstance
                                 )
-                                self.add_dataset(assoc4.dataset_collection_element.element_object)
+                                self.add_dataset(idce_assoc.dataset_collection_element.element_object)
 
-                for assoc5 in job.output_dataset_collection_instances:
+                for odci_assoc in job.output_dataset_collection_instances:
                     # Optional data outputs will not have a dataset.
                     # These are implicit outputs, we don't need to export them
-                    if assoc5.dataset_collection_instance:
-                        name = assoc5.name
+                    if odci_assoc.dataset_collection_instance:
+                        name = odci_assoc.name
                         if name not in output_dataset_collection_mapping:
                             output_dataset_collection_mapping[name] = []
 
                         output_dataset_collection_mapping[name].append(
-                            self.exported_key(assoc5.dataset_collection_instance)
+                            self.exported_key(odci_assoc.dataset_collection_instance)
                         )
 
-                for assoc6 in job.output_dataset_collections:
-                    if assoc6.dataset_collection:
-                        name = assoc6.name
+                for odc_assoc in job.output_dataset_collections:
+                    if odc_assoc.dataset_collection:
+                        name = odc_assoc.name
 
                         if name not in implicit_output_dataset_collection_mapping:
                             implicit_output_dataset_collection_mapping[name] = []
 
                         implicit_output_dataset_collection_mapping[name].append(
-                            self.exported_key(assoc6.dataset_collection)
+                            self.exported_key(odc_assoc.dataset_collection)
                         )
                         if include_job_data:
-                            self.export_collection(assoc6.dataset_collection)
+                            self.export_collection(odc_assoc.dataset_collection)
 
                 job_attrs["input_dataset_mapping"] = input_dataset_mapping
                 job_attrs["input_dataset_collection_mapping"] = input_dataset_collection_mapping

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -2076,67 +2076,73 @@ class DirectoryModelExportStore(ModelExportStore):
                         if include_job_data:
                             self.add_dataset(assoc.dataset)
 
-                for assoc in job.output_datasets:
+                for assoc2 in job.output_datasets:
                     # Optional data inputs will not have a dataset.
-                    if assoc.dataset:
-                        name = assoc.name
+                    if assoc2.dataset:
+                        name = assoc2.name
                         if name not in output_dataset_mapping:
                             output_dataset_mapping[name] = []
 
-                        output_dataset_mapping[name].append(self.exported_key(assoc.dataset))
+                        output_dataset_mapping[name].append(self.exported_key(assoc2.dataset))
                         if include_job_data:
-                            self.add_dataset(assoc.dataset)
+                            self.add_dataset(assoc2.dataset)
 
-                for assoc in job.input_dataset_collections:
+                for assoc3 in job.input_dataset_collections:
                     # Optional data inputs will not have a dataset.
-                    if assoc.dataset_collection:
-                        name = assoc.name
+                    if assoc3.dataset_collection:
+                        name = assoc3.name
                         if name not in input_dataset_collection_mapping:
                             input_dataset_collection_mapping[name] = []
 
-                        input_dataset_collection_mapping[name].append(self.exported_key(assoc.dataset_collection))
+                        input_dataset_collection_mapping[name].append(self.exported_key(assoc3.dataset_collection))
                         if include_job_data:
-                            self.export_collection(assoc.dataset_collection)
+                            self.export_collection(assoc3.dataset_collection)
 
-                for assoc in job.input_dataset_collection_elements:
-                    if assoc.dataset_collection_element:
-                        name = assoc.name
+                for assoc4 in job.input_dataset_collection_elements:
+                    if assoc4.dataset_collection_element:
+                        name = assoc4.name
                         if name not in input_dataset_collection_element_mapping:
                             input_dataset_collection_element_mapping[name] = []
 
                         input_dataset_collection_element_mapping[name].append(
-                            self.exported_key(assoc.dataset_collection_element)
+                            self.exported_key(assoc4.dataset_collection_element)
                         )
                         if include_job_data:
-                            if assoc.dataset_collection_element.is_collection:
-                                self.export_collection(assoc.dataset_collection_element.element_object)
+                            if assoc4.dataset_collection_element.is_collection:
+                                assert isinstance(
+                                    assoc4.dataset_collection_element.element_object, model.DatasetCollection
+                                )
+                                self.export_collection(assoc4.dataset_collection_element.element_object)
                             else:
-                                self.add_dataset(assoc.dataset_collection_element.element_object)
+                                assert isinstance(
+                                    assoc4.dataset_collection_element.element_object, model.DatasetInstance
+                                )
+                                self.add_dataset(assoc4.dataset_collection_element.element_object)
 
-                for assoc in job.output_dataset_collection_instances:
+                for assoc5 in job.output_dataset_collection_instances:
                     # Optional data outputs will not have a dataset.
                     # These are implicit outputs, we don't need to export them
-                    if assoc.dataset_collection_instance:
-                        name = assoc.name
+                    if assoc5.dataset_collection_instance:
+                        name = assoc5.name
                         if name not in output_dataset_collection_mapping:
                             output_dataset_collection_mapping[name] = []
 
                         output_dataset_collection_mapping[name].append(
-                            self.exported_key(assoc.dataset_collection_instance)
+                            self.exported_key(assoc5.dataset_collection_instance)
                         )
 
-                for assoc in job.output_dataset_collections:
-                    if assoc.dataset_collection:
-                        name = assoc.name
+                for assoc6 in job.output_dataset_collections:
+                    if assoc6.dataset_collection:
+                        name = assoc6.name
 
                         if name not in implicit_output_dataset_collection_mapping:
                             implicit_output_dataset_collection_mapping[name] = []
 
                         implicit_output_dataset_collection_mapping[name].append(
-                            self.exported_key(assoc.dataset_collection)
+                            self.exported_key(assoc6.dataset_collection)
                         )
                         if include_job_data:
-                            self.export_collection(assoc.dataset_collection)
+                            self.export_collection(assoc6.dataset_collection)
 
                 job_attrs["input_dataset_mapping"] = input_dataset_mapping
                 job_attrs["input_dataset_collection_mapping"] = input_dataset_collection_mapping

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -264,7 +264,7 @@ class FastAPIJobs:
         for job_input_assoc in job.input_datasets:
             input_dataset_instance = job_input_assoc.dataset
             if input_dataset_instance is None:
-                continue
+                continue  # type:ignore[unreachable]  # TODO if job_input_assoc.dataset is indeed never None, remove the above check
             if input_dataset_instance.get_total_size() == 0:
                 has_empty_inputs = True
             input_instance_id = input_dataset_instance.id

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2516,13 +2516,13 @@ class WorkflowModuleInjector:
         If step_args is provided from a web form this is applied to generate
         'state' else it is just obtained from the database.
         """
-        step.upgrade_messages = {}  # type: ignore[assignment]
+        step.upgrade_messages = {}
 
         # Make connection information available on each step by input name.
         step.setup_input_connections_by_name()
 
         # Populate module.
-        module = step.module = module_factory.from_workflow_step(self.trans, step, **kwargs)  # type: ignore[assignment]
+        module = step.module = module_factory.from_workflow_step(self.trans, step, **kwargs)
 
         # Any connected input needs to have value DummyDataset (these
         # are not persisted so we need to do it every time)


### PR DESCRIPTION
This is another batch of model improvements:
1. Add type hints to most relationship-mapped attributes (there are 48 left, all or most of these require additional fixes in other parts of the code base before they can be applied)
1. Remove redundant class names from relationship calls (inferred from type hints)
1. Fix incorrect types in model. Just because a column is nullable in the database doesn't mean the attribute has to be optional.  The fix is to apply a non-optional type hint and add `nullable=True` to `mapped_column()`. I've applied this only to obvious cases, like association models, and cases that caused an error when types were applied to other fields.
1. Start removing `type:ignore` statements added in the SQLAlchemy 2.0 PR #17778 (most of those still are contingent on moving dataset instance models to declarative)

To do in follow-up PRs:
- Add remaining type hints to relationship-mapped attributes
- Remove `type:ignore` statements added during move to SA2.0
- Review model attributes for correct use of `Optional` type. If an attribute should be not optional, remove `Optional` from type and add `nullable=True` to the mapped_column call.
- Improve types of JSON fields ([ref](https://github.com/galaxyproject/galaxy/pull/17922#discussion_r1561291093), also #17902)

I have verified the model definition programmatically (https://github.com/galaxyproject/galaxy/pull/17922#issuecomment-2050762745)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
