### PR TITLE
[24.0] Show dataset image in workflow_outputs display listing.

### DIFF
--- a/client/src/components/Datatypes/model.ts
+++ b/client/src/components/Datatypes/model.ts
@@ -14,6 +14,13 @@ export class DatatypesMapperModel {
         this.datatypesMapping = typesAndMapping.datatypes_mapping;
     }
 
+    /**
+     * Checks if a given child datatype is a subtype of a parent datatype.
+     * @param child - The child datatype extension as registered in the datatypes registry.
+     * @param parent - The parent datatype, which can be an extension or explicit class name
+     *                 Can also be used with extensionless abstract datatypes (e.g. "galaxy.datatypes.images.Image")
+     * @returns A boolean indicating whether the child is a subtype of the parent.
+     */
     isSubType(child: string, parent: string): boolean {
         const mapping = this.datatypesMapping;
         const childClassName = mapping.ext_to_class_name[child];

--- a/client/src/components/Datatypes/model.ts
+++ b/client/src/components/Datatypes/model.ts
@@ -17,7 +17,8 @@ export class DatatypesMapperModel {
     isSubType(child: string, parent: string): boolean {
         const mapping = this.datatypesMapping;
         const childClassName = mapping.ext_to_class_name[child];
-        const parentClassName = mapping.ext_to_class_name[parent];
+        const parentClassName = mapping.ext_to_class_name[parent] || parent;
+
         if (!childClassName || !parentClassName) {
             return false;
         }

--- a/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
@@ -61,16 +61,13 @@
                     <div v-else-if="error">{{ error }}</div>
                     <div v-else :class="contentClass">
                         <b-embed
-                            v-if="
-                                isSubTypeOfAny(
-                                    datasetType,
-                                    ['pdf', 'html', 'galaxy.datatypes.images.Image'],
-                                    datatypesModel
-                                )
-                            "
+                            v-if="isSubTypeOfAny(datasetType, ['pdf', 'html'], datatypesModel)"
                             type="iframe"
                             aspect="16by9"
                             :src="displayUrl" />
+                        <HistoryDatasetAsImage
+                            v-else-if="isSubTypeOfAny(datasetType, ['galaxy.datatypes.images.Image'], datatypesModel)"
+                            :args="args" />
                         <div v-else-if="itemContent.item_data">
                             <div v-if="isSubTypeOfAny(datasetType, ['tabular'], datatypesModel)">
                                 <UrlDataProvider
@@ -87,8 +84,8 @@
                                 </UrlDataProvider>
                             </div>
                             <pre v-else>
-                                    <code class="word-wrap-normal">{{ itemContent.item_data }}</code>
-                                </pre>
+                                <code class="word-wrap-normal">{{ itemContent.item_data }}</code>
+                            </pre>
                         </div>
                         <div v-else>No content found.</div>
                         <b-link v-if="itemContent.truncated" :href="itemContent.item_url"> Show More... </b-link>
@@ -105,10 +102,13 @@ import LoadingSpan from "components/LoadingSpan";
 import { UrlDataProvider } from "components/providers/UrlDataProvider";
 import { getAppRoot } from "onload/loadConfig";
 
+import HistoryDatasetAsImage from "./HistoryDatasetAsImage.vue";
+
 export default {
     components: {
         LoadingSpan,
         UrlDataProvider,
+        HistoryDatasetAsImage,
     },
     props: {
         args: {

--- a/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
@@ -61,7 +61,13 @@
                     <div v-else-if="error">{{ error }}</div>
                     <div v-else :class="contentClass">
                         <b-embed
-                            v-if="isSubTypeOfAny(datasetType, ['pdf', 'html'], datatypesModel)"
+                            v-if="
+                                isSubTypeOfAny(
+                                    datasetType,
+                                    ['pdf', 'html', 'galaxy.datatypes.images.Image'],
+                                    datatypesModel
+                                )
+                            "
                             type="iframe"
                             aspect="16by9"
                             :src="displayUrl" />


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/16558

Another approach might be to overhaul the workflow outputs directive logic to divert between the two directives (history_dataset_as_image, history_dataset_display), but it seems nicer to me to just do the right thing for image datatypes in history_dataset_display.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
