### PR TITLE
[23.2] Fix message input type for notifications in admin panel

### DIFF
--- a/client/src/components/admin/Notifications/NotificationForm.vue
+++ b/client/src/components/admin/Notifications/NotificationForm.vue
@@ -153,7 +153,8 @@ async function sendNewNotification() {
                 :optional="false"
                 help="The message can be written in markdown."
                 placeholder="Enter message"
-                required />
+                required
+                area />
 
             <FormElement
                 id="notification-variant"


### PR DESCRIPTION
Otherwise, it is not possible to use line breaks in the `message` field, making it harder to take full advantage of the markdown support. It was present for Broadcast notifications but this one was missing.

| Before | After |
|--------|-------|
| ![Screenshot from 2024-04-11 15-39-51](https://github.com/galaxyproject/galaxy/assets/46503462/92a5cd42-bafc-416d-a6f7-09735a21d281)   | ![Screenshot from 2024-04-11 15-37-44](https://github.com/galaxyproject/galaxy/assets/46503462/a8de35a9-73b1-4e21-af8c-0488fc3ab05f)  |






## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
