### PR TITLE
Hiding Edit Content Box on WF Invocation Report

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/page.py
+++ b/lib/galaxy/webapps/galaxy/controllers/page.py
@@ -53,7 +53,6 @@ class PageController(BaseUIController, SharableMixin, UsesStoredWorkflowMixin, U
             title = ""
             slug = ""
             content = ""
-            content_hide = True
             if "invocation_id" in kwd:
                 invocation_id = kwd.get("invocation_id")
                 form_title = f"{form_title} from Invocation Report"
@@ -63,7 +62,6 @@ class PageController(BaseUIController, SharableMixin, UsesStoredWorkflowMixin, U
                 )
                 title = invocation_report.get("title")
                 content = invocation_report.get("markdown")
-                content_hide = False
             return {
                 "title": form_title,
                 "inputs": [

--- a/lib/galaxy/webapps/galaxy/controllers/page.py
+++ b/lib/galaxy/webapps/galaxy/controllers/page.py
@@ -94,7 +94,7 @@ class PageController(BaseUIController, SharableMixin, UsesStoredWorkflowMixin, U
                         "label": "Content",
                         "area": True,
                         "value": content,
-                        "hidden": content_hide,
+                        "hidden": True,
                     },
                 ],
             }


### PR DESCRIPTION
Fix for #17524 

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Run a Workflow
  2. Go to Workflow Invocations (uner Data)
  3. View Report
  4. Then click Edit Report in the top right corner
  5. Note that the markdown text is no longer visible here to be edited

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
