### PR TITLE
Use typed API client for reporting job errors.

### DIFF
--- a/client/src/api/jobs.ts
+++ b/client/src/api/jobs.ts
@@ -8,3 +8,5 @@ export const jobLockUpdate = fetcher.path("/api/job_lock").method("put").create(
 export const fetchJobDestinationParams = fetcher.path("/api/jobs/{job_id}/destination_params").method("get").create();
 
 export const jobsFetcher = fetcher.path("/api/jobs").method("get").create();
+
+export const jobsReportError = fetcher.path("/api/jobs/{job_id}/error").method("post").create();

--- a/client/src/components/DatasetInformation/services.js
+++ b/client/src/components/DatasetInformation/services.js
@@ -2,19 +2,18 @@ import axios from "axios";
 import { getAppRoot } from "onload/loadConfig";
 import { rethrowSimple } from "utils/simple-error";
 
+import { jobsReportError } from "@/api/jobs";
+
 export async function sendErrorReport(dataset, message, email) {
-    const payload = {
+    const jobId = dataset.creating_job;
+    const request = {
+        job_id: jobId,
         dataset_id: dataset.id,
         message,
         email,
     };
-    const url = `${getAppRoot()}api/jobs/${dataset.creating_job}/error`;
-    try {
-        const { data } = await axios.post(url, payload);
-        return data.messages;
-    } catch (e) {
-        rethrowSimple(e);
-    }
+    const { data } = await jobsReportError(request);
+    return data.messages;
 }
 
 export async function setAttributes(datasetId, settings, operation) {


### PR DESCRIPTION
## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Merge #17968, set ``email_error_to`` in ``galaxy.yml`` to anything and set ``smtp_server`` to point at a file like this ''mock_emails_to_path:///Users/jxc755/workspace/galaxy/email.json'. Find a dataset error in a history, click the bug icon and send one. Check email.json for the email that would be sent in production.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
