### PR TITLE
[24.0] Update _thanks.rst in the User Release Notes to include new socials and remove inactive ones

### DIFF
--- a/doc/source/releases/_thanks.rst
+++ b/doc/source/releases/_thanks.rst
@@ -1,7 +1,5 @@
-To stay up to date with Galaxy's progress, watch our `screencasts <https://www.youtube.com/@GalaxyProject>`__,
-visit our community `Hub <https://galaxyproject.org/>`__, and follow
-`@galaxyproject@mstdn.science <https://mstdn.science/@galaxyproject>`__ on Mastodon or
-`@galaxyproject <https://twitter.com/galaxyproject>`__ on Twitter.
+To stay up to date with Galaxy's progress, watch our `screencasts <https://www.youtube.com/@GalaxyProject>`__;
+visit our community `Hub <https://galaxyproject.org/>`__; and follow us on `Bluesky <https://bsky.app/profile/galaxyproject.bsky.social>`__, `Mastodon <https://mstdn.science/@galaxyproject>`__, and `LinkedIn <https://linkedin.com/company/galaxy-project>`__.
 
 You can always chat with us on `Matrix <https://matrix.to/#/#galaxyproject_Lobby:gitter.im>`__.
 


### PR DESCRIPTION
Updating the _thanks.rst that is associated with the User Release Notes to reflect Galaxy's new social media presence.
Galaxy is no longer active on Twitter and has joined Bluesky and LinkedIn. The new 'thanks' message has been updated to reflect this with the appropriate links to the new socials.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
