### PR TITLE
[23.2] Set from_tool_form: true when saving new workflow

### DIFF
--- a/client/src/components/Workflow/services.js
+++ b/client/src/components/Workflow/services.js
@@ -32,7 +32,7 @@ export class Services {
     async createWorkflow(workflow) {
         const url = withPrefix("/api/workflows");
         try {
-            const { data } = await axios.post(url, { workflow: toSimple(workflow.id, workflow) });
+            const { data } = await axios.post(url, { workflow: toSimple(workflow.id, workflow), from_tool_form: true });
             return data;
         } catch (e) {
             rethrowSimple(e);

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1510,7 +1510,7 @@ class NavigatesGalaxy(HasDriver):
             workflow_run.expand_form_link.wait_for_and_click()
             workflow_run.expanded_form.wait_for_visible()
 
-    def workflow_create_new(self, annotation=None, clear_placeholder=False):
+    def workflow_create_new(self, annotation=None, clear_placeholder=False, save_workflow=True):
         self.workflow_index_open()
         self.sleep_for(self.wait_types.UX_RENDER)
         self.click_button_new_workflow()
@@ -1522,11 +1522,12 @@ class NavigatesGalaxy(HasDriver):
         name_component.wait_for_and_send_keys(name)
         annotation = annotation or self._get_random_name()
         self.components.workflow_editor.edit_annotation.wait_for_and_send_keys(annotation)
-        save_button = self.components.workflow_editor.save_button
-        save_button.wait_for_visible()
-        assert not save_button.has_class("disabled")
-        save_button.wait_for_and_click()
-        self.sleep_for(self.wait_types.UX_RENDER)
+        if save_workflow:
+            save_button = self.components.workflow_editor.save_button
+            save_button.wait_for_visible()
+            assert not save_button.has_class("disabled")
+            save_button.wait_for_and_click()
+            self.sleep_for(self.wait_types.UX_RENDER)
         return name
 
     def invocation_index_table_elements(self):

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -224,7 +224,7 @@ steps:
     def test_integer_input(self):
         editor = self.components.workflow_editor
 
-        name = self.workflow_create_new()
+        name = self.workflow_create_new(save_workflow=False)
         self.workflow_editor_add_input(item_name="parameter_input")
         self.screenshot("workflow_editor_parameter_input_new")
         editor.label_input.wait_for_and_send_keys("input1")


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/17963 and https://github.com/galaxyproject/galaxy/issues/17970. Since https://github.com/galaxyproject/galaxy/pull/17406 we've been using POST to create the first version of the workflow, but we're of course sending values emitted by the tool form, so `from_tool_form: true` is necessary here.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
