### PR TITLE
Drop unused workflow controller methods

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -1,5 +1,4 @@
 import logging
-from html.parser import HTMLParser
 
 from markupsafe import escape
 from sqlalchemy import desc
@@ -11,15 +10,9 @@ from galaxy import (
     web,
 )
 from galaxy.managers.sharable import SlugBuilder
-from galaxy.managers.workflows import (
-    MissingToolsException,
-    WorkflowUpdateOptions,
-)
-from galaxy.model.base import transaction
 from galaxy.model.item_attrs import UsesItemRatings
 from galaxy.tools.parameters.workflow_utils import workflow_building_modes
 from galaxy.util import FILENAME_VALID_CHARS
-from galaxy.util.sanitize_html import sanitize_html
 from galaxy.web import url_for
 from galaxy.webapps.base.controller import (
     BaseUIController,
@@ -33,25 +26,6 @@ from galaxy.workflow.extract import (
 from galaxy.workflow.modules import load_module_sections
 
 log = logging.getLogger(__name__)
-
-
-# Simple HTML parser to get all content in a single tag.
-class SingleTagContentsParser(HTMLParser):
-    def __init__(self, target_tag):
-        # Cannot use super() because HTMLParser is an old-style class in Python2
-        HTMLParser.__init__(self)
-        self.target_tag = target_tag
-        self.cur_tag = None
-        self.tag_content = ""
-
-    def handle_starttag(self, tag, attrs):
-        """Called for each start tag."""
-        self.cur_tag = tag
-
-    def handle_data(self, text):
-        """Called for each block of plain text."""
-        if self.cur_tag == self.target_tag:
-            self.tag_content += text
 
 
 class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixin, UsesItemRatings):
@@ -147,30 +121,6 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
 
     @web.expose
     @web.require_login("use Galaxy workflows")
-    def rename_async(self, trans, id, new_name=None, **kwargs):
-        stored = self.get_stored_workflow(trans, id)
-        if new_name:
-            san_new_name = sanitize_html(new_name)
-            stored.name = san_new_name
-            stored.latest_workflow.name = san_new_name
-            with transaction(trans.sa_session):
-                trans.sa_session.commit()
-            return stored.name
-
-    @web.expose
-    @web.require_login("use Galaxy workflows")
-    def annotate_async(self, trans, id, new_annotation=None, **kwargs):
-        stored = self.get_stored_workflow(trans, id)
-        if new_annotation:
-            # Sanitize annotation before adding it.
-            new_annotation = sanitize_html(new_annotation)
-            self.add_item_annotation(trans.sa_session, trans.get_user(), stored, new_annotation)
-            with transaction(trans.sa_session):
-                trans.sa_session.commit()
-            return new_annotation
-
-    @web.expose
-    @web.require_login("use Galaxy workflows")
     def gen_image(self, trans, id, embed="false", version="", **kwargs):
         embed = util.asbool(embed)
         if version:
@@ -187,109 +137,6 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
             log.exception("Failed to generate SVG image")
             error_message = str(e)
             return trans.show_error_message(error_message)
-
-    @web.legacy_expose_api
-    def create(self, trans, payload=None, **kwd):
-        if trans.request.method == "GET":
-            return {
-                "title": "Create Workflow",
-                "inputs": [
-                    {"name": "workflow_name", "label": "Name", "value": "Unnamed workflow"},
-                    {
-                        "name": "workflow_annotation",
-                        "label": "Annotation",
-                        "help": "A description of the workflow; annotation is shown alongside shared or published workflows.",
-                    },
-                ],
-            }
-        else:
-            user = trans.get_user()
-            workflow_name = payload.get("workflow_name")
-            workflow_annotation = payload.get("workflow_annotation")
-            workflow_tags = payload.get("workflow_tags", [])
-            if not workflow_name:
-                return self.message_exception(trans, "Please provide a workflow name.")
-            # Create the new stored workflow
-            stored_workflow = model.StoredWorkflow()
-            stored_workflow.name = workflow_name
-            stored_workflow.user = user
-            self.slug_builder.create_item_slug(trans.sa_session, stored_workflow)
-            # And the first (empty) workflow revision
-            workflow = model.Workflow()
-            workflow.name = workflow_name
-            workflow.stored_workflow = stored_workflow
-            stored_workflow.latest_workflow = workflow
-            # Add annotation.
-            workflow_annotation = sanitize_html(workflow_annotation)
-            self.add_item_annotation(trans.sa_session, trans.get_user(), stored_workflow, workflow_annotation)
-            # Add tags
-            trans.tag_handler.set_tags_from_list(
-                trans.user,
-                stored_workflow,
-                workflow_tags,
-            )
-            # Persist
-            session = trans.sa_session
-            session.add(stored_workflow)
-            with transaction(session):
-                session.commit()
-            return {
-                "id": trans.security.encode_id(stored_workflow.id),
-                "message": f"Workflow {workflow_name} has been created.",
-            }
-
-    @web.json
-    def save_workflow_as(
-        self, trans, workflow_name, workflow_data, workflow_annotation="", from_tool_form=False, **kwargs
-    ):
-        """
-        Creates a new workflow based on Save As command. It is a new workflow, but
-        is created with workflow_data already present.
-        """
-        user = trans.get_user()
-        if workflow_name is not None:
-            workflow_contents_manager = self.app.workflow_contents_manager
-            stored_workflow = model.StoredWorkflow()
-            stored_workflow.name = workflow_name
-            stored_workflow.user = user
-            self.slug_builder.create_item_slug(trans.sa_session, stored_workflow)
-            workflow = model.Workflow()
-            workflow.name = workflow_name
-            workflow.stored_workflow = stored_workflow
-            stored_workflow.latest_workflow = workflow
-            # Add annotation.
-            workflow_annotation = sanitize_html(workflow_annotation)
-            self.add_item_annotation(trans.sa_session, trans.get_user(), stored_workflow, workflow_annotation)
-
-            # Persist
-            session = trans.sa_session
-            session.add(stored_workflow)
-            with transaction(session):
-                session.commit()
-            workflow_update_options = WorkflowUpdateOptions(
-                update_stored_workflow_attributes=False,  # taken care of above
-                from_tool_form=from_tool_form,
-            )
-            try:
-                workflow, errors = workflow_contents_manager.update_workflow_from_raw_description(
-                    trans,
-                    stored_workflow,
-                    workflow_data,
-                    workflow_update_options,
-                )
-            except MissingToolsException as e:
-                return dict(
-                    name=e.workflow.name,
-                    message=(
-                        "This workflow includes missing or invalid tools. "
-                        "It cannot be saved until the following steps are removed or the missing tools are enabled."
-                    ),
-                    errors=e.errors,
-                )
-            return trans.security.encode_id(stored_workflow.id)
-        else:
-            # This is an error state, 'save as' must have a workflow_name
-            log.exception("Error in Save As workflow: no name.")
 
     @web.expose
     @web.json


### PR DESCRIPTION
Create and save_workflow_as usage was removed in https://github.com/galaxyproject/galaxy/pull/17406.
rename_async and annotate_async seem unused.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
