### PR TITLE
[24.0] Fix filtering workflow outputs by type in markdown directives

### DIFF
--- a/client/src/components/Markdown/MarkdownToolBox.vue
+++ b/client/src/components/Markdown/MarkdownToolBox.vue
@@ -259,17 +259,24 @@ export default {
                 });
             return steps;
         },
-        getOutputs() {
+        getOutputs(filterByType = undefined) {
             const outputLabels = [];
             this.steps &&
                 Object.values(this.steps).forEach((step) => {
                     step.workflow_outputs.forEach((workflowOutput) => {
                         if (workflowOutput.label) {
-                            outputLabels.push(workflowOutput.label);
+                            if (!filterByType || this.stepOutputMatchesType(step, workflowOutput, filterByType)) {
+                                outputLabels.push(workflowOutput.label);
+                            }
                         }
                     });
                 });
             return outputLabels;
+        },
+        stepOutputMatchesType(step, workflowOutput, type) {
+            return Boolean(
+                step.outputs.find((output) => output.name === workflowOutput.output_name && output.type === type)
+            );
         },
         getArgumentTitle(argumentName) {
             return (
@@ -331,13 +338,13 @@ export default {
         onHistoryDatasetId(argumentName) {
             this.selectedArgumentName = argumentName;
             this.selectedType = "history_dataset_id";
-            this.selectedLabels = this.getOutputs();
+            this.selectedLabels = this.getOutputs("data");
             this.selectedShow = true;
         },
         onHistoryCollectionId(argumentName) {
             this.selectedArgumentName = argumentName;
             this.selectedType = "history_dataset_collection_id";
-            this.selectedLabels = this.getOutputs();
+            this.selectedLabels = this.getOutputs("collection");
             this.selectedShow = true;
         },
         onWorkflowId(argumentName) {


### PR DESCRIPTION
Fixes #17945

I'm not sure this is the best way of doing it, but it works :thinking: 

![FixFilteringWFOMarkdown](https://github.com/galaxyproject/galaxy/assets/46503462/32d64c66-a56c-400b-b13d-f777f06f315c)



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
