### PR TITLE
fix for https://sentry.galaxyproject.org/organizations/galaxy/issues/…

### DIFF
--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -441,7 +441,6 @@ def active_folders(trans, folder):
         select(LibraryFolder)
         .filter_by(parent=folder, deleted=False)
         .options(joinedload(LibraryFolder.actions))
-        .unique()
         .order_by(LibraryFolder.name)
     )
     return trans.sa_session.scalars(stmt).all()


### PR DESCRIPTION
This hopefully fixes: https://sentry.galaxyproject.org/organizations/galaxy/issues/148718/?project=7

Looks like there was no unique before the change: https://github.com/galaxyproject/galaxy/blame/19a1f90a96cbf245949b1bbd6b9019482ffceade/lib/galaxy/tools/actions/upload_common.py

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
