### PR TITLE
[24.0] History import - show user feedback on completion.

### DIFF
--- a/client/src/components/History/HistoryView.vue
+++ b/client/src/components/History/HistoryView.vue
@@ -8,7 +8,6 @@
             <b-button
                 v-if="userOwnsHistory"
                 size="sm"
-                variant="outline-info"
                 :title="setAsCurrentTitle"
                 :disabled="isSetAsCurrentDisabled"
                 data-description="switch to history button"
@@ -20,7 +19,6 @@
                 v-if="canImportHistory"
                 v-b-modal:copy-history-modal
                 size="sm"
-                variant="outline-info"
                 title="Import this history"
                 data-description="import history button">
                 Import this history

--- a/client/src/components/History/HistoryView.vue
+++ b/client/src/components/History/HistoryView.vue
@@ -25,6 +25,8 @@
             </b-button>
         </div>
 
+        <b-alert :show="copySuccess"> History imported and set to your active history. </b-alert>
+
         <CollectionPanel
             v-if="selectedCollections.length && selectedCollections[0].history_id == id"
             :history="history"
@@ -38,7 +40,7 @@
             filterable
             @view-collection="onViewCollection" />
 
-        <CopyModal id="copy-history-modal" :history="history" />
+        <CopyModal id="copy-history-modal" :history="history" @ok="copyOkay" />
     </div>
 </template>
 
@@ -67,6 +69,7 @@ export default {
     data() {
         return {
             selectedCollections: [],
+            copySuccess: false,
         };
     },
     computed: {
@@ -126,6 +129,9 @@ export default {
         ...mapActions(useHistoryStore, ["loadHistoryById", "setCurrentHistory"]),
         onViewCollection(collection) {
             this.selectedCollections = [...this.selectedCollections, collection];
+        },
+        copyOkay() {
+            this.copySuccess = true;
         },
     },
 };


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/17933

Just adds a simple info message on history import modal completion (but not cancel) saying that the history has been copied and set to the user's active history:

![image](https://github.com/galaxyproject/galaxy/assets/155398/ac1c784a-21ae-4e49-b9b6-0da2b24f2623)

Also swaps the button back to the standard non-primary-action variant to match more of the 'tertiary action' buttons across the application.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
