### PR TITLE
[24.0] Fix `LengthValidator` if no value passed

### DIFF
--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -186,7 +186,9 @@ class LengthValidator(InRangeValidator):
         super().__init__(message, range_min=length_min, range_max=length_max, negate=negate)
 
     def validate(self, value, trans=None):
-        super().validate(len(value), trans)
+        if value is None:
+            raise ValueError("No value provided")
+        super().validate(len(value) if value else 0, trans)
 
 
 class DatasetOkValidator(Validator):

--- a/test/unit/app/tools/test_parameter_validation.py
+++ b/test/unit/app/tools/test_parameter_validation.py
@@ -186,6 +186,14 @@ class TestParameterValidation(BaseParameterTestCase):
             p.validate("bar")
         p.validate("f")
         p.validate("foobarbaz")
+        p = self._parameter_for(
+            xml="""
+<param name="blah" type="text" optional="false">
+    <validator type="length" min="2" max="8"/>
+</param>"""
+        )
+        with self.assertRaisesRegex(ValueError, "No value provided"):
+            p.validate(None)
 
     def test_InRangeValidator(self):
         p = self._parameter_for(


### PR DESCRIPTION
It is valid to pass `None` as a default value to the validator. It should just return ValueError, which it will do with this change.

Fixes https://github.com/galaxyproject/galaxy/issues/17961

Ideally we'd add type annotations, but with the current structure and instantiation order it seems impossible to do this in a meaningful way.

If we refactored the validators to be functions, and validators functions were registered per parameter type we could have narrow types on the validator signature.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
