### PR TITLE
[24.0] Raise ``RequestParameterInvalidException`` if collection element has unknown extension

### DIFF
--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -17,8 +17,12 @@ from typing import (
 from packaging.version import Version
 
 from galaxy import model
-from galaxy.exceptions import ItemAccessibilityException
+from galaxy.exceptions import (
+    ItemAccessibilityException,
+    RequestParameterInvalidException,
+)
 from galaxy.job_execution.actions.post import ActionBox
+from galaxy.managers.context import ProvidesHistoryContext
 from galaxy.model import (
     HistoryDatasetAssociation,
     Job,
@@ -98,7 +102,7 @@ class DefaultToolAction(ToolAction):
         self,
         tool,
         param_values,
-        trans,
+        trans: ProvidesHistoryContext,
         history,
         current_user_roles=None,
         dataset_collection_elements=None,
@@ -256,6 +260,10 @@ class DefaultToolAction(ToolAction):
                 for ext in extensions:
                     if ext:
                         datatype = trans.app.datatypes_registry.get_datatype_by_extension(ext)
+                        if not datatype:
+                            raise RequestParameterInvalidException(
+                                f"Extension '{ext}' unknown, cannot use dataset collection as input"
+                            )
                         if not datatype.matches_any(input.formats):
                             conversion_required = True
                             break


### PR DESCRIPTION
These might be typos or the result of bugs as in
https://github.com/galaxyproject/galaxy/issues/17938.

Fixes https://sentry.galaxyproject.org/share/issue/0761c11cefad49edae20bedbb4a662d7/:
```

Exception caught while attempting to execute tool with id 'toolshed.g2.bx.psu.edu/repos/iuc/mothur_make_contigs/mothur_make_contigs/1.39.5.1':

AttributeError: 'NoneType' object has no attribute 'matches_any'
  File "galaxy/tools/__init__.py", line 1968, in handle_single_execution
    rval = self.execute(
  File "galaxy/tools/__init__.py", line 2065, in execute
    return self.tool_action.execute(
  File "galaxy/tools/actions/__init__.py", line 418, in execute
    ) = self._collect_inputs(tool, trans, incoming, history, current_user_roles, collection_info)
  File "galaxy/tools/actions/__init__.py", line 352, in _collect_inputs
    inp_data, all_permissions = self._collect_input_datasets(
  File "galaxy/tools/actions/__init__.py", line 292, in _collect_input_datasets
    tool.visit_inputs(param_values, visitor)
  File "galaxy/tools/__init__.py", line 1792, in visit_inputs
    visit_input_values(self.inputs, values, callback)
  File "galaxy/tools/parameters/__init__.py", line 211, in visit_input_values
    visit_input_values(
  File "galaxy/tools/parameters/__init__.py", line 227, in visit_input_values
    callback_helper(
  File "galaxy/tools/parameters/__init__.py", line 162, in callback_helper
    new_value = callback(**args)
  File "galaxy/tools/actions/__init__.py", line 259, in visitor
    if not datatype.matches_any(input.formats):
```

into something more useful for users.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
