### PR TITLE
[23.2] Don't attempt to commit in dry_run mode

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -707,7 +707,8 @@ class WorkflowContentsManager(UsesAnnotations):
             trans.tag_handler.set_tags_from_list(
                 trans.user,
                 stored_workflow,
-                data.get("tags", []),
+                data["tags"],
+                flush=False,
             )
 
         if workflow_update_options.update_stored_workflow_attributes:


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/17959:
```
NotNullViolation: null value in column "workflow_step_id" of relation "workflow_output" violates not-null constraint
DETAIL:  Failing row contains (3843428, null, multiqc_fastqc_html, multiqc_fastqc_html, 1d8a0c348b6f446eb4d84770365f570f).

  File "sqlalchemy/engine/base.py", line 1890, in _execute_context
    self.dialect.do_executemany(
  File "sqlalchemy/dialects/postgresql/psycopg2.py", line 982, in do_executemany
    context._psycopg2_fetched_rows = xtras.execute_values(
  File "psycopg2/extras.py", line 1299, in execute_values
    cur.execute(b''.join(parts))
IntegrityError: (psycopg2.errors.NotNullViolation) null value in column "workflow_step_id" of relation "workflow_output" violates not-null constraint
DETAIL:  Failing row contains (3843428, null, multiqc_fastqc_html, multiqc_fastqc_html, 1d8a0c348b6f446eb4d84770365f570f).

[SQL: INSERT INTO workflow_output (workflow_step_id, output_name, label, uuid) VALUES (%(workflow_step_id)s, %(output_name)s, %(label)s, %(uuid)s) RETURNING workflow_output.id]
[parameters: ({'workflow_step_id': None, 'output_name': 'multiqc_fastqc_html', 'label': 'multiqc_fastqc_html', 'uuid': '1d8a0c348b6f446eb4d84770365f570f'}, {'workflow_step_id': None, 'output_name': 'multiqc_cutadapt_html', 'label': 'multiqc_cutadapt_html', 'uuid': '11fef12f5cf24904b31dac7a277f5fda'}, {'workflow_step_id': None, 'output_name': 'multiqc_star_html', 'label': 'multiqc_star_html', 'uuid': '383da02d5a4b4af7ac2933b9cfad316f'}, {'workflow_step_id': None, 'output_name': 'STAR_BAM', 'label': 'STAR_BAM', 'uuid': '6aed76c8a4a5491bacd2f995f16df86b'}, {'workflow_step_id': None,...
  File "starlette/applications.py", line 123, in __call__
    await self.middleware_stack(scope, receive, send)
  File "starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "starlette_context/middleware/raw_middleware.py", line 92, in __call__
    await self.app(scope, receive, send_wrapper)
  File "starlette/middleware/base.py", line 189, in __call__
    with collapse_excgroups():
  File "contextlib.py", line 155, in __exit__
    self.gen.throw(typ, value, traceback)
  File "starlette/_utils.py", line 93, in collapse_excgroups
    raise exc
  File "starlette/middleware/base.py", line 191, in __call__
    response = await self.dispatch_func(request, call_next)
  File "galaxy/webapps/galaxy/fast_app.py", line 108, in add_x_frame_options
    response = await call_next(request)
  File "starlette/middleware/base.py", line 165, in call_next
    raise app_exc
  File "starlette/middleware/base.py", line 151, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "starlette/routing.py", line 758, in __call__
    await self.middleware_stack(scope, receive, send)
  File "starlette/routing.py", line 778, in app
    await route.handle(scope, receive, send)
  File "starlette/routing.py", line 299, in handle
    await self.app(scope, receive, send)
  File "starlette/routing.py", line 79, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "starlette/routing.py", line 74, in app
    response = await func(request)
  File "fastapi/routing.py", line 278, in app
    raw_response = await run_endpoint_function(
  File "fastapi/routing.py", line 193, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "starlette/concurrency.py", line 42, in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
  File "anyio/to_thread.py", line 56, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
  File "anyio/_backends/_asyncio.py", line 2144, in run_sync_in_worker_thread
    return await future
  File "anyio/_backends/_asyncio.py", line 851, in run
    result = context.run(func, *args)
  File "galaxy/webapps/galaxy/api/workflows.py", line 987, in refactor
    return self.service.refactor(trans, workflow_id, payload, instance or False)
  File "galaxy/webapps/galaxy/services/workflows.py", line 218, in refactor
    return self._workflow_contents_manager.refactor(trans, stored_workflow, payload)
  File "galaxy/managers/workflows.py", line 1963, in refactor
    refactored_workflow, action_executions = self.do_refactor(trans, stored_workflow, refactor_request)
  File "galaxy/managers/workflows.py", line 1948, in do_refactor
    refactored_workflow, errors = self.update_workflow_from_raw_description(
  File "galaxy/managers/workflows.py", line 728, in update_workflow_from_raw_description
    trans.tag_handler.set_tags_from_list(
  File "galaxy/model/tags.py", line 94, in set_tags_from_list
    self.apply_item_tags(user, item, unicodify(new_tags_str, "utf-8"), flush=flush)
  File "galaxy/model/tags.py", line 265, in apply_item_tags
    self.apply_item_tag(user, item, name, value, flush=flush)
  File "galaxy/model/tags.py", line 249, in apply_item_tag
    self.sa_session.commit()
  File "<string>", line 2, in commit
  File "sqlalchemy/orm/session.py", line 1454, in commit
    self._transaction.commit(_to_root=self.future)
  File "sqlalchemy/orm/session.py", line 832, in commit
    self._prepare_impl()
  File "sqlalchemy/orm/session.py", line 811, in _prepare_impl
    self.session.flush()
  File "sqlalchemy/orm/session.py", line 3449, in flush
    self._flush(objects)
  File "sqlalchemy/orm/session.py", line 3588, in _flush
    with util.safe_reraise():
  File "sqlalchemy/util/langhelpers.py", line 70, in __exit__
    compat.raise_(
  File "sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "sqlalchemy/orm/session.py", line 3549, in _flush
    flush_context.execute()
  File "sqlalchemy/orm/unitofwork.py", line 456, in execute
    rec.execute(self)
  File "sqlalchemy/orm/unitofwork.py", line 630, in execute
    util.preloaded.orm_persistence.save_obj(
  File "sqlalchemy/orm/persistence.py", line 245, in save_obj
    _emit_insert_statements(
  File "sqlalchemy/orm/persistence.py", line 1156, in _emit_insert_statements
    c = connection._execute_20(
  File "sqlalchemy/engine/base.py", line 1710, in _execute_20
    return meth(self, args_10style, kwargs_10style, execution_options)
  File "sqlalchemy/sql/elements.py", line 334, in _execute_on_connection
    return connection._execute_clauseelement(
  File "sqlalchemy/engine/base.py", line 1577, in _execute_clauseelement
    ret = self._execute_context(
  File "sqlalchemy/engine/base.py", line 1953, in _execute_context
    self._handle_dbapi_exception(
  File "sqlalchemy/engine/base.py", line 2134, in _handle_dbapi_exception
    util.raise_(
  File "sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "sqlalchemy/engine/base.py", line 1890, in _execute_context
    self.dialect.do_executemany(
  File "sqlalchemy/dialects/postgresql/psycopg2.py", line 982, in do_executemany
    context._psycopg2_fetched_rows = xtras.execute_values(
  File "psycopg2/extras.py", line 1299, in execute_values
    cur.execute(b''.join(parts))
```

broken in commit b00a94c1f7972dcd1060069fe83fece7b8943165 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
