### PR TITLE
Add tags to data dialog display, restores update_time and extension columns

### DIFF
--- a/client/src/components/DataDialog/DataDialog.vue
+++ b/client/src/components/DataDialog/DataDialog.vue
@@ -61,6 +61,22 @@ const services = new Services();
 const model = new Model({ multiple: props.multiple, format: props.format });
 let urlTracker = new UrlTracker(getHistoryUrl());
 
+/** Specifies data columns to be shown in the dialog's table */
+const fields = [
+    {
+        key: "label",
+    },
+    {
+        key: "extension",
+    },
+    {
+        key: "tags",
+    },
+    {
+        key: "update_time",
+    },
+];
+
 /** Add highlighting for record variations, i.e. datasets vs. libraries/collections **/
 function formatRows() {
     for (const item of items.value) {
@@ -168,6 +184,7 @@ watch(
     <SelectionDialog
         :error-message="errorMessage"
         :disable-ok="!hasValue"
+        :fields="fields"
         :items="items"
         :modal-show="modalShow"
         :multiple="multiple"

--- a/client/src/components/SelectionDialog/BasicSelectionDialog.vue
+++ b/client/src/components/SelectionDialog/BasicSelectionDialog.vue
@@ -54,7 +54,7 @@ async function load() {
         const response = await props.getData();
         const incoming = response.data;
         items.value = incoming.map((item: any) => {
-            let timeStamp = item[props.timeKey];
+            const timeStamp = item[props.timeKey];
             showTime.value = !!timeStamp;
             return {
                 id: item.id,

--- a/client/src/components/SelectionDialog/BasicSelectionDialog.vue
+++ b/client/src/components/SelectionDialog/BasicSelectionDialog.vue
@@ -56,16 +56,6 @@ async function load() {
         items.value = incoming.map((item: any) => {
             let timeStamp = item[props.timeKey];
             showTime.value = !!timeStamp;
-            if (timeStamp) {
-                const date = new Date(timeStamp);
-                timeStamp = date.toLocaleString("default", {
-                    day: "numeric",
-                    month: "short",
-                    year: "numeric",
-                    minute: "numeric",
-                    hour: "numeric",
-                });
-            }
             return {
                 id: item.id,
                 label: item[props.labelKey] || null,

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -100,6 +100,22 @@ function filtered(items: Array<SelectionItem>) {
     currentPage.value = 1;
 }
 
+/** Format time stamp */
+function formatTime(value: string) {
+    if (value) {
+        const date = new Date(value);
+        return date.toLocaleString("default", {
+            day: "numeric",
+            month: "short",
+            year: "numeric",
+            minute: "numeric",
+            hour: "numeric",
+        });
+    } else {
+        return "-";
+    }
+}
+
 watch(
     () => props.items,
     () => {
@@ -169,6 +185,9 @@ watch(
                     </template>
                     <template v-slot:cell(time)="data">
                         {{ data.value ? data.value : "-" }}
+                    </template>
+                    <template v-slot:cell(update_time)="data">
+                        {{ formatTime(data.value) }}
                     </template>
                 </BTable>
                 <div v-if="isBusy" class="text-center">

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -189,7 +189,7 @@ watch(
                         <span v-else>-</span>
                     </template>
                     <template v-slot:cell(time)="data">
-                        {{ data.value ? data.value : "-" }}
+                        {{ formatTime(data.value) }}
                     </template>
                     <template v-slot:cell(update_time)="data">
                         {{ formatTime(data.value) }}

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -11,6 +11,7 @@ import { SELECTION_STATES } from "@/components/SelectionDialog/selectionTypes";
 import { type FieldEntry, type SelectionItem } from "./selectionTypes";
 
 import DataDialogSearch from "@/components/SelectionDialog/DataDialogSearch.vue";
+import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 
 library.add(faCaretLeft, faCheck, faCheckSquare, faFolder, faMinusSquare, faSpinner, faSquare, faTimes);
 
@@ -182,6 +183,10 @@ watch(
                     </template>
                     <template v-slot:cell(details)="data">
                         <span :title="`details-${data.item.url}`">{{ data.value ? data.value : "-" }}</span>
+                    </template>
+                    <template v-slot:cell(tags)="data">
+                        <StatelessTags v-if="data.value?.length > 0" :value="data.value" :disabled="true" />
+                        <span v-else>-</span>
                     </template>
                     <template v-slot:cell(time)="data">
                         {{ data.value ? data.value : "-" }}


### PR DESCRIPTION
Follow-up for #17802. Adds `tags` to data dialog display and restores update_time and extension column attributes. Fixes: #17527.

<img width="800" alt="image" src="https://github.com/galaxyproject/galaxy/assets/2105447/b0b6a4c7-3b3c-4bb3-956e-8ad1bdf65e2d">

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
