### PR TITLE
[24.0] Decrease log level for not loading IT when ITs are not enabled to warning

### DIFF
--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -898,6 +898,8 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
         except OSError as exc:
             exc_info = exc.errno != ENOENT
             log.error("Error reading tool configuration file from path '%s': %s", path, exc, exc_info=exc_info)
+        except AssertionError as exc:
+            log.warning("Error reading tool configuration file from path '%s': %s", path, exc)
         except Exception:
             log.exception("Error reading tool from path: %s", path)
 


### PR DESCRIPTION
I guess this could be debated ? What's your take on this @natefoo ? This is happening on the VGP instance in https://sentry.galaxyproject.org/share/issue/8860299efa3b49a2a620489692db039f/ ... maybe we should instead either enable ITs or remove the tools from the config ?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
