### PR TITLE
Syntax for conditionally loading toolbox items.

### DIFF
--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -408,6 +408,12 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                 panel_dict = self._tool_panel
             if integrated_panel_dict is None:
                 integrated_panel_dict = self._integrated_tool_panel
+            load_if = item.get("if")
+            if load_if == "interactivetools_enable":
+                if not self.app.config.interactivetools_enable:
+                    raise ValueError("Trying to load an InteractiveTool, but InteractiveTools are not enabled.")
+            elif load_if:
+                raise ValueError(f"Unknown conditional tool load condition '{load_if}'")
             if item_type == "tool":
                 self._load_tool_tag_set(
                     item,

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -237,8 +237,8 @@
   <tool file="multiple_versions_changes_v01.xml" />
   <tool file="multiple_versions_changes_v02.xml" />
 
-  <tool file="interactivetool_simple.xml" />
-  <tool file="interactivetool_two_entry_points.xml" />
+  <tool file="interactivetool_simple.xml" if="interactivetools_enable" />
+  <tool file="interactivetool_two_entry_points.xml" if="interactivetools_enable" />
   <tool file="converter_target_datatype.xml" />
 
   <!-- Tools interesting only for building up test workflows. -->


### PR DESCRIPTION
Alternative to https://github.com/galaxyproject/galaxy/pull/17998. I've always been annoyed by this message in my local dev logs - seems to be a better fix? The syntax only allows one thing right now but can be parameterized in the future in obvious ways if we decide we need more conditions.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Disable interactive tools, load the sample tool conf GALAXY_RUN_WITH_TEST_TOOLS=1 sh run.sh and verify the error message disappears.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
