### PR TITLE
[24.0] Preserve surrounding whitespace when localizing complex nodes

### DIFF
--- a/client/src/components/plugins/localization.js
+++ b/client/src/components/plugins/localization.js
@@ -12,11 +12,14 @@ function localizeDirective(l) {
         // TODO consider using a different hook if we need dynamic updates in content translation
         bind(el, binding, vnode) {
             el.childNodes.forEach((node) => {
+                // trim for lookup, but put back whitespace after
+                const leadingSpace = node.textContent.match(/^\s*/)[0];
+                const trailingSpace = node.textContent.match(/\s*$/)[0];
                 const standardizedContent = node.textContent
                     .replace(newlineMatch, " ")
                     .replace(doublespaces, " ")
                     .trim();
-                node.textContent = l(standardizedContent);
+                node.textContent = leadingSpace + l(standardizedContent) + trailingSpace;
             });
         },
     };


### PR DESCRIPTION
Fixes whitespace issues by preserving context in localization which is useful when dealing with multiple child nodes.

Fixes issues like:

![image](https://github.com/galaxyproject/galaxy/assets/155398/df5fc6ef-d118-4fb6-a7f1-ef70a717936f)

After:

![image](https://github.com/galaxyproject/galaxy/assets/155398/6aef3b63-9c36-4fc8-bd45-b7d8ed2b607c)




## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
