### PR TITLE
Add section divider to activity bar, fix click handler

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -23,6 +23,9 @@ import NotificationsPanel from "@/components/Panels/NotificationsPanel.vue";
 import SettingsPanel from "@/components/Panels/SettingsPanel.vue";
 import ToolPanel from "@/components/Panels/ToolPanel.vue";
 
+// require user to long click before dragging
+const DRAG_DELAY = 50;
+
 const { config, isConfigLoaded } = useConfig();
 
 const route = useRoute();
@@ -150,6 +153,7 @@ watch(
                     :class="{ 'activity-popper-disabled': isDragging }"
                     :force-fallback="true"
                     chosen-class="activity-chosen-class"
+                    :delay="DRAG_DELAY"
                     drag-class="activity-drag-class"
                     ghost-class="activity-chosen-class"
                     @start="isDragging = true"

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -197,7 +197,7 @@ watch(
                     </div>
                 </draggable>
             </b-nav>
-            <b-nav v-if="!isAnonymous" vertical class="flex-nowrap p-1">
+            <b-nav v-if="!isAnonymous" vertical class="activity-footer flex-nowrap p-1">
                 <NotificationItem
                     v-if="isConfigLoaded && config.enable_notification_system"
                     id="activity-notifications"
@@ -253,6 +253,11 @@ watch(
 
 .activity-drag-class {
     display: none;
+}
+
+.activity-footer {
+    border-top: $border-default;
+    border-top-style: dotted;
 }
 
 .activity-popper-disabled {


### PR DESCRIPTION
This PR adds a dotted line between the activity bars main and footer section. The main section is scrollable and as of right now still draggable while the items in the footer are fixed. Additionally this PR adds a drag-delay to resolve the convolution of click and drag handler triggers. Fixes: #16633.
Moving forward our goal is to move dragging of activities to the settings panel to improve accessibility.

<img width="83" alt="image" src="https://github.com/galaxyproject/galaxy/assets/2105447/ae435517-02b2-406d-a209-87a50b90c5b5">


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
