### PR TITLE
[24.0] Raise ``MessageException`` when report references invalid workflow output

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8576,11 +8576,11 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
         # That probably isn't good.
         workflow_output = self.workflow.workflow_output_for(label)
         if workflow_output:
-            raise Exception(
+            raise galaxy.exceptions.MessageException(
                 f"Failed to find workflow output named [{label}], one was defined but none registered during execution."
             )
         else:
-            raise Exception(
+            raise galaxy.exceptions.MessageException(
                 f"Failed to find workflow output named [{label}], workflow doesn't define output by that name - valid names are {self.workflow.workflow_output_labels}."
             )
 


### PR DESCRIPTION
Marginally better than an uncaught exception IMO.
Fixes
https://sentry.galaxyproject.org/share/issue/45391593603042799ef5ac5b18d22440/:

```
Exception: Failed to find workflow output named [Fasta Statistics on input dataset(s): Fasta summary stats], workflow doesn't define output by that name - valid names are ['Flye assembly on input dataset(s) (consensus)', 'Flye assembly on input dataset(s) (assembly_graph)', 'Flye assembly on input dataset(s) (Graphical Fragment Assembly)', 'Flye assembly on input dataset(s) (assembly_info)', 'Flye assembly on input dataset(s) (log)', None, 'Bandage Image on input dataset(s): Assembly Graph Image', 'Quast on input dataset(s):  PDF report', 'Quast on input dataset(s):  HTML report', 'Quast on input dataset(s): tabular report', 'Quast on input dataset(s): Log', 'Bar chart showing contig sizes'].
  File "starlette/applications.py", line 123, in __call__
    await self.middleware_stack(scope, receive, send)
  File "starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "starlette_context/middleware/raw_middleware.py", line 92, in __call__
    await self.app(scope, receive, send_wrapper)
  File "starlette/middleware/base.py", line 189, in __call__
    with collapse_excgroups():
  File "contextlib.py", line 155, in __exit__
    self.gen.throw(typ, value, traceback)
  File "starlette/_utils.py", line 93, in collapse_excgroups
    raise exc
  File "starlette/middleware/base.py", line 191, in __call__
    response = await self.dispatch_func(request, call_next)
  File "galaxy/webapps/galaxy/fast_app.py", line 108, in add_x_frame_options
    response = await call_next(request)
  File "starlette/middleware/base.py", line 165, in call_next
    raise app_exc
  File "starlette/middleware/base.py", line 151, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "starlette/routing.py", line 758, in __call__
    await self.middleware_stack(scope, receive, send)
  File "starlette/routing.py", line 778, in app
    await route.handle(scope, receive, send)
  File "starlette/routing.py", line 299, in handle
    await self.app(scope, receive, send)
  File "starlette/routing.py", line 79, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "starlette/routing.py", line 74, in app
    response = await func(request)
  File "fastapi/routing.py", line 278, in app
    raw_response = await run_endpoint_function(
  File "fastapi/routing.py", line 193, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "starlette/concurrency.py", line 42, in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
  File "anyio/to_thread.py", line 56, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
  File "anyio/_backends/_asyncio.py", line 2144, in run_sync_in_worker_thread
    return await future
  File "anyio/_backends/_asyncio.py", line 851, in run
    result = context.run(func, *args)
  File "galaxy/webapps/galaxy/api/workflows.py", line 1485, in show_invocation_report
    return self.invocations_service.show_invocation_report(trans, invocation_id)
  File "galaxy/webapps/galaxy/services/invocations.py", line 143, in show_invocation_report
    wfi_report = self._workflows_manager.get_invocation_report(trans, invocation_id, format=format)
  File "galaxy/managers/workflows.py", line 428, in get_invocation_report
    return generate_report(
  File "galaxy/workflow/reports/__init__.py", line 14, in generate_report
    return plugin.generate_report_json(trans, invocation, runtime_report_config_json=runtime_report_config_json)
  File "galaxy/workflow/reports/generators/__init__.py", line 43, in generate_report_json
    internal_markdown = self._generate_internal_markdown(
  File "galaxy/workflow/reports/generators/__init__.py", line 73, in _generate_internal_markdown
    internal_markdown = resolve_invocation_markdown(trans, invocation, workflow_markdown)
  File "galaxy/managers/markdown_util.py", line 958, in resolve_invocation_markdown
    galaxy_markdown = _remap_galaxy_markdown_calls(_remap, workflow_markdown)
  File "galaxy/managers/markdown_util.py", line 1012, in _remap_galaxy_markdown_calls
    return _remap_galaxy_markdown_containers(_remap_container, markdown)
  File "galaxy/managers/markdown_util.py", line 971, in _remap_galaxy_markdown_containers
    (replacement, whole_block) = func(replace)
  File "galaxy/managers/markdown_util.py", line 1008, in _remap_container
    return func(match.group(1), f"{matching_line}\n")
  File "galaxy/managers/markdown_util.py", line 926, in _remap
    ref_object = invocation.get_output_object(name)
  File "galaxy/model/__init__.py", line 8593, in get_output_object
    raise Exception(
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
