### PR TITLE
[24.0] Reduce notifications polling frequency

### DIFF
--- a/client/src/stores/notificationsStore.ts
+++ b/client/src/stores/notificationsStore.ts
@@ -12,8 +12,8 @@ import { mergeObjectListsById } from "@/utils/utils";
 
 import { useBroadcastsStore } from "./broadcastsStore";
 
-const ACTIVE_POLLING_INTERVAL = 5000;
-const INACTIVE_POLLING_INTERVAL = 30000;
+const ACTIVE_POLLING_INTERVAL = 60000; // 1 minute
+const INACTIVE_POLLING_INTERVAL = ACTIVE_POLLING_INTERVAL * 10; // 10 minutes
 
 export const useNotificationsStore = defineStore("notificationsStore", () => {
     const { startWatchingResource: startWatchingNotifications } = useResourceWatcher(getNotificationStatus, {

--- a/client/src/stores/notificationsStore.ts
+++ b/client/src/stores/notificationsStore.ts
@@ -12,8 +12,8 @@ import { mergeObjectListsById } from "@/utils/utils";
 
 import { useBroadcastsStore } from "./broadcastsStore";
 
-const ACTIVE_POLLING_INTERVAL = 60000; // 1 minute
-const INACTIVE_POLLING_INTERVAL = ACTIVE_POLLING_INTERVAL * 10; // 10 minutes
+const ACTIVE_POLLING_INTERVAL = 30000; // 30 seconds
+const INACTIVE_POLLING_INTERVAL = ACTIVE_POLLING_INTERVAL * 20; // 10 minutes
 
 export const useNotificationsStore = defineStore("notificationsStore", () => {
     const { startWatchingResource: startWatchingNotifications } = useResourceWatcher(getNotificationStatus, {


### PR DESCRIPTION
There is no need to check for notifications so frequently as they are not real-time critical.

New frequency:
- Active tab: 30 seconds
- Background tab: 10 minutes

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
