### PR TITLE
[24.0] Avoid exception when opening apply rules tool and no collection in history

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2646,8 +2646,7 @@ class RulesListToolParameter(BaseJsonToolParameter):
     def to_dict(self, trans, other_values=None):
         other_values = other_values or {}
         d = ToolParameter.to_dict(self, trans)
-        if (target_name := self.data_ref) in other_values:
-            target = other_values[target_name]
+        if target := other_values.get(self.data_ref):
             if not is_runtime_value(target):
                 d["target"] = {
                     "src": "hdca" if hasattr(target, "collection") else "hda",


### PR DESCRIPTION
Fixes https://sentry.galaxyproject.org/share/issue/97b5b9cfcef14ca0b59b851684170698/
```
AttributeError: 'NoneType' object has no attribute 'id'
  File "galaxy/tools/__init__.py", line 2601, in populate_model
    tool_dict = input.to_dict(request_context, other_values=other_values)
  File "galaxy/tools/parameters/basic.py", line 2648, in to_dict
    "id": trans.app.security.encode_id(target.id),
```

Which is in a try/except anyway, so fairly inconsequential, but results in cleaner logs / one less sentry error.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
