### PR TITLE
Don't catch `ParameterValueError` after persisting values in database

### DIFF
--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -16,7 +16,6 @@ from galaxy.util.json import safe_loads
 from .basic import (
     DataCollectionToolParameter,
     DataToolParameter,
-    ParameterValueError,
     SelectToolParameter,
     ToolParameter,
 )
@@ -291,10 +290,8 @@ def params_from_strings(params: Dict[str, Union[Group, ToolParameter]], param_va
             # This would resolve a lot of back and forth in the various to/from methods.
             value = safe_loads(value)
         if param:
-            try:
-                value = param.value_from_basic(value, app, ignore_errors)
-            except ParameterValueError:
-                continue
+            # if ignore_error is true we return the value unmodified
+            value = param.value_from_basic(value, app, ignore_errors)
         rval[key] = value
     return rval
 


### PR DESCRIPTION
`params_from_strings` is called from within the compute environment, where we generate the command line, which is after we've persisted job parameters:

https://github.com/galaxyproject/galaxy/blob/5addd0093380118954d73ead601cc5ecc0e8b154/lib/galaxy/tools/evaluation.py#L137

 This is too late to decide to skip or null parameter values. Luckily it seems this isn't needed (anymore ?) as all tests are passing.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
