### PR TITLE
[24.0] Add a link to histories list in history import message for situations…

### DIFF
--- a/client/src/components/History/HistoryView.vue
+++ b/client/src/components/History/HistoryView.vue
@@ -25,7 +25,9 @@
             </b-button>
         </div>
 
-        <b-alert :show="copySuccess"> History imported and set to your active history. </b-alert>
+        <b-alert :show="copySuccess">
+            History imported and is now your active history. <b-link to="/histories/list">View here</b-link>.
+        </b-alert>
 
         <CollectionPanel
             v-if="selectedCollections.length && selectedCollections[0].history_id == id"


### PR DESCRIPTION
Minor tweak to import message to fix https://github.com/galaxyproject/galaxy/issues/17989

If you import from a context that has a history visible, it's obvious (and synchronous) that your history has changed.  In some contexts, like a published history your current history isn't visible so you may not know it has changed or how to take the next step to get moving with the freshly imported history.

This link works for anonymous users, too, who will simply get redirected back to the root analysis view (in which they see their history).

![image](https://github.com/galaxyproject/galaxy/assets/155398/3a005b7e-3bb2-4ff6-b6d8-2ada4fcaade1)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
