### PR TITLE
Add Zenodo integration

### DIFF
--- a/client/src/api/remoteFiles.ts
+++ b/client/src/api/remoteFiles.ts
@@ -7,6 +7,7 @@ import { fetcher } from "@/api/schema/fetcher";
  * - `source` - allows to select a source plugin root and doesn't list its contents
  */
 export type FileSourceBrowsingMode = "file" | "directory" | "source";
+export type FilesSourcePlugin = components["schemas"]["FilesSourcePlugin"];
 export type BrowsableFilesSourcePlugin = components["schemas"]["BrowsableFilesSourcePlugin"];
 export type RemoteFile = components["schemas"]["RemoteFile"];
 export type RemoteDirectory = components["schemas"]["RemoteDirectory"];

--- a/client/src/components/Common/ExportRDMForm.test.ts
+++ b/client/src/components/Common/ExportRDMForm.test.ts
@@ -100,8 +100,9 @@ describe("ExportRDMForm", () => {
         });
     });
 
-    async function selectExportChoice(choice: string) {
-        const exportChoice = wrapper.find(`#radio-${choice}`);
+    async function selectExportChoice(choice: string, fileSourceId?: string) {
+        const suffix = fileSourceId ? `${fileSourceId}` : "any";
+        const exportChoice = wrapper.find(`#radio-${choice}-${suffix}`);
         await exportChoice.setChecked(true);
     }
 

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -3,7 +3,6 @@ import { BAlert } from "bootstrap-vue";
 import Vue, { computed, onMounted, ref } from "vue";
 
 import {
-    BrowsableFilesSourcePlugin,
     browseRemoteFiles,
     FileSourceBrowsingMode,
     FilterFileSourcesOptions,
@@ -11,7 +10,7 @@ import {
     RemoteEntry,
 } from "@/api/remoteFiles";
 import { UrlTracker } from "@/components/DataDialog/utilities";
-import { isSubPath } from "@/components/FilesDialog/utilities";
+import { fileSourcePluginToItem, isSubPath } from "@/components/FilesDialog/utilities";
 import { SELECTION_STATES, type SelectionItem } from "@/components/SelectionDialog/selectionTypes";
 import { useConfig } from "@/composables/config";
 import { errorMessageAsString } from "@/utils/simple-error";
@@ -236,7 +235,7 @@ function load(record?: SelectionItem) {
             .then((results) => {
                 const convertedItems = results
                     .filter((item) => !props.requireWritable || item.writable)
-                    .map(fileSourcePluginToRecord);
+                    .map(fileSourcePluginToItem);
                 items.value = convertedItems;
                 formatRows();
                 optionsShow.value = true;
@@ -289,17 +288,6 @@ function entryToRecord(entry: RemoteEntry): SelectionItem {
         isLeaf: entry.class === "File",
         url: entry.uri,
         size: entry.class === "File" ? entry.size : 0,
-    };
-    return result;
-}
-
-function fileSourcePluginToRecord(plugin: BrowsableFilesSourcePlugin): SelectionItem {
-    const result = {
-        id: plugin.id,
-        label: plugin.label,
-        details: plugin.doc,
-        isLeaf: false,
-        url: plugin.uri_root,
     };
     return result;
 }

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -33,6 +33,8 @@ interface FilesDialogProps {
     multiple?: boolean;
     /** Whether to show only writable sources */
     requireWritable?: boolean;
+    /** Optional selected item to start browsing from */
+    selectedItem?: SelectionItem;
 }
 
 const props = withDefaults(defineProps<FilesDialogProps>(), {
@@ -42,6 +44,7 @@ const props = withDefaults(defineProps<FilesDialogProps>(), {
     mode: "file",
     multiple: false,
     requireWritable: false,
+    selectedItem: undefined,
 });
 
 const { config, isConfigLoaded } = useConfig();
@@ -343,7 +346,7 @@ function onOk() {
 }
 
 onMounted(() => {
-    load();
+    load(props.selectedItem);
 });
 </script>
 

--- a/client/src/components/FilesDialog/FilesInput.vue
+++ b/client/src/components/FilesDialog/FilesInput.vue
@@ -5,11 +5,14 @@ import { computed } from "vue";
 import { FileSourceBrowsingMode, FilterFileSourcesOptions } from "@/api/remoteFiles";
 import { filesDialog } from "@/utils/data";
 
+import { SelectionItem } from "../SelectionDialog/selectionTypes";
+
 interface Props {
     value: string;
     mode?: FileSourceBrowsingMode;
     requireWritable?: boolean;
     filterOptions?: FilterFileSourcesOptions;
+    selectedItem?: SelectionItem;
 }
 
 interface SelectableFile {
@@ -20,6 +23,7 @@ const props = withDefaults(defineProps<Props>(), {
     mode: "file",
     requireWritable: false,
     filterOptions: undefined,
+    selectedItem: undefined,
 });
 
 const emit = defineEmits<{
@@ -40,6 +44,7 @@ const selectFile = () => {
         mode: props.mode,
         requireWritable: props.requireWritable,
         filterOptions: props.filterOptions,
+        selectedItem: props.selectedItem,
     };
     filesDialog((selected: SelectableFile) => {
         currentValue.value = selected?.url;

--- a/client/src/components/FilesDialog/utilities.ts
+++ b/client/src/components/FilesDialog/utilities.ts
@@ -1,3 +1,7 @@
+import type { BrowsableFilesSourcePlugin } from "@/api/remoteFiles";
+
+import type { SelectionItem } from "../SelectionDialog/selectionTypes";
+
 export const isSubPath = (originPath: string, destinationPath: string) => {
     return subPathCondition(ensureTrailingSlash(originPath), ensureTrailingSlash(destinationPath));
 };
@@ -8,4 +12,15 @@ function ensureTrailingSlash(path: string) {
 }
 function subPathCondition(originPath: string, destinationPath: string) {
     return originPath !== destinationPath && destinationPath.startsWith(originPath);
+}
+
+export function fileSourcePluginToItem(plugin: BrowsableFilesSourcePlugin): SelectionItem {
+    const result = {
+        id: plugin.id,
+        label: plugin.label,
+        details: plugin.doc,
+        isLeaf: false,
+        url: plugin.uri_root,
+    };
+    return result;
 }

--- a/client/src/components/History/Export/HistoryExport.vue
+++ b/client/src/components/History/Export/HistoryExport.vue
@@ -4,7 +4,6 @@ import { faFileExport } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BButton, BCard, BTab, BTabs } from "bootstrap-vue";
 import { computed, onMounted, ref, watch } from "vue";
-import { RouterLink } from "vue-router";
 
 import {
     exportHistoryToFileSource,
@@ -23,10 +22,12 @@ import { absPath } from "@/utils/redirect";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import ExportOptions from "./ExportOptions.vue";
+import RDMCredentialsInfo from "./RDMCredentialsInfo.vue";
 import ExportToFileSourceForm from "@/components/Common/ExportForm.vue";
 import ExportToRDMRepositoryForm from "@/components/Common/ExportRDMForm.vue";
 import ExportRecordDetails from "@/components/Common/ExportRecordDetails.vue";
 import ExportRecordTable from "@/components/Common/ExportRecordTable.vue";
+import ExternalLink from "@/components/ExternalLink.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 const {
@@ -63,6 +64,7 @@ const isLoadingRecords = ref(true);
 const exportRecords = ref<ExportRecord[]>([]);
 
 const historyName = computed(() => history.value?.name ?? props.historyId);
+const defaultFileName = computed(() => `(Galaxy History) ${historyName.value}`);
 const latestExportRecord = computed(() => (exportRecords.value?.length ? exportRecords.value.at(0) : null));
 const isLatestExportRecordReadyToDownload = computed(
     () =>
@@ -203,11 +205,13 @@ function updateExportParams(newParams: ExportParams) {
                         Here you can generate a temporal download for your history. When your download link expires or
                         your history changes you can re-generate it again.
                     </p>
+
                     <BAlert show variant="warning">
                         History archive downloads can expire and are removed at regular intervals. For permanent
                         storage, export to a <b>remote file</b> or download and then import the archive on another
                         Galaxy server.
                     </BAlert>
+
                     <BButton
                         class="gen-direct-download-btn"
                         :disabled="!canGenerateDownload"
@@ -215,6 +219,7 @@ function updateExportParams(newParams: ExportParams) {
                         @click="prepareDownload">
                         Generate direct download
                     </BButton>
+
                     <span v-if="isPreparingDownload">
                         <LoadingSpan message="Galaxy is preparing your download, this will likely take a while" />
                     </span>
@@ -233,6 +238,7 @@ function updateExportParams(newParams: ExportParams) {
                         one of the available remote file sources here. You will be able to re-import it later as long as
                         it remains available on the remote server.
                     </p>
+
                     <ExportToFileSourceForm
                         what="history"
                         :clear-input-after-export="true"
@@ -244,21 +250,12 @@ function updateExportParams(newParams: ExportParams) {
                     title="to RDM repository"
                     title-link-class="tab-export-to-rdm-repo">
                     <p>You can <b>upload your history</b> to one of the available RDM repositories here.</p>
-                    <p>
-                        Your history export archive needs to be uploaded to an existing <i>draft</i> record. You will
-                        need to create a <b>new record</b> on the repository or select an existing
-                        <b>draft record</b> and then export your history to it.
-                    </p>
-                    <BAlert show variant="info">
-                        You may need to setup your credentials for the selected repository in your
-                        <RouterLink to="/user/information" target="_blank">settings page</RouterLink> to be able to
-                        export. You can also define some default options for the export in those settings, like the
-                        public name you want to associate with your records or whether you want to publish them
-                        immediately or keep them as drafts after export.
-                    </BAlert>
+
+                    <RDMCredentialsInfo what="history export archive" />
+
                     <ExportToRDMRepositoryForm
                         what="history"
-                        :default-filename="historyName + ' (Galaxy History)'"
+                        :default-filename="defaultFileName"
                         :default-record-name="historyName"
                         :clear-input-after-export="true"
                         @export="doExportToFileSource" />

--- a/client/src/components/History/Export/HistoryExport.vue
+++ b/client/src/components/History/Export/HistoryExport.vue
@@ -38,7 +38,7 @@ const {
 } = useTaskMonitor();
 
 const { hasWritable: hasWritableFileSources } = useFileSources({ exclude: ["rdm"] });
-const { hasWritable: hasWritableRDMFileSources } = useFileSources({ include: ["rdm"] });
+const { hasWritable: hasWritableRDMFileSources, getFileSourceById } = useFileSources({ include: ["rdm"] });
 
 const {
     isPreparing: isPreparingDownload,
@@ -92,6 +92,7 @@ const history = computed(() => {
 const errorMessage = ref<string | undefined>(undefined);
 const actionMessage = ref<string | undefined>(undefined);
 const actionMessageVariant = ref<ColorVariant | undefined>(undefined);
+const zenodoSource = computed(() => getFileSourceById("zenodo"));
 
 onMounted(async () => {
     updateExports();
@@ -260,6 +261,37 @@ function updateExportParams(newParams: ExportParams) {
                         :clear-input-after-export="true"
                         @export="doExportToFileSource" />
                 </BTab>
+                <BTab
+                    v-if="zenodoSource"
+                    id="zenodo-file-source-tab"
+                    title="to ZENODO"
+                    title-link-class="tab-export-to-zenodo-repo">
+                    <div class="zenodo-info">
+                        <img
+                            src="https://raw.githubusercontent.com/zenodo/zenodo/master/zenodo/modules/theme/static/img/logos/zenodo-gradient-square.svg"
+                            alt="ZENODO Logo" />
+                        <p>
+                            <ExternalLink href="https://zenodo.org"><b>Zenodo</b></ExternalLink> is a general-purpose
+                            open repository developed under the
+                            <ExternalLink href="https://www.openaire.eu">European OpenAIRE</ExternalLink> program and
+                            operated by <ExternalLink href="https://home.cern">CERN</ExternalLink>. It allows
+                            researchers to deposit research papers, data sets, research software, reports, and any other
+                            research related digital artefacts. For each submission, a persistent
+                            <b>digital object identifier (DOI)</b> is minted, which makes the stored items easily
+                            citeable.
+                        </p>
+                    </div>
+
+                    <RDMCredentialsInfo what="history export archive" selected-repository="ZENODO" />
+                    <ExportToRDMRepositoryForm
+                        what="history"
+                        :default-filename="defaultFileName"
+                        :default-record-name="historyName"
+                        :clear-input-after-export="true"
+                        :file-source="zenodoSource"
+                        @export="doExportToFileSource">
+                    </ExportToRDMRepositoryForm>
+                </BTab>
             </BTabs>
         </BCard>
 
@@ -292,3 +324,11 @@ function updateExportParams(newParams: ExportParams) {
             @onReimport="reimportFromRecord" />
     </span>
 </template>
+
+<style scoped>
+.zenodo-info {
+    display: flex;
+    align-items: start;
+    gap: 0.5rem;
+}
+</style>

--- a/client/src/components/History/Export/RDMCredentialsInfo.vue
+++ b/client/src/components/History/Export/RDMCredentialsInfo.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { BAlert } from "bootstrap-vue";
+import { RouterLink } from "vue-router";
+
+interface Props {
+    selectedRepository?: string;
+    what?: string;
+}
+
+withDefaults(defineProps<Props>(), {
+    selectedRepository: "the selected repository",
+    what: "file",
+});
+</script>
+
+<template>
+    <BAlert show variant="info">
+        You may need to setup your credentials for {{ selectedRepository }} in your
+        <RouterLink to="/user/information" target="_blank">preferences page</RouterLink> to be able to export. You can
+        also define some default options for the export in those settings, like the public name you want to associate
+        with your records or whether you want to publish them immediately or keep them as drafts after export.
+    </BAlert>
+</template>

--- a/client/src/components/History/Export/RDMCredentialsInfo.vue
+++ b/client/src/components/History/Export/RDMCredentialsInfo.vue
@@ -18,6 +18,6 @@ withDefaults(defineProps<Props>(), {
         You may need to setup your credentials for {{ selectedRepository }} in your
         <RouterLink to="/user/information" target="_blank">preferences page</RouterLink> to be able to export. You can
         also define some default options for the export in those settings, like the public name you want to associate
-        with your records or whether you want to publish them immediately or keep them as drafts after export.
+        with your records.
     </BAlert>
 </template>

--- a/client/src/composables/fileSources.ts
+++ b/client/src/composables/fileSources.ts
@@ -18,6 +18,10 @@ export function useFileSources(options: FilterFileSourcesOptions = {}) {
         isLoading.value = false;
     });
 
+    function getFileSourceById(id: string) {
+        return fileSources.value.find((fs) => fs.id === id);
+    }
+
     return {
         /**
          * The list of available file sources from the server.
@@ -31,5 +35,12 @@ export function useFileSources(options: FilterFileSourcesOptions = {}) {
          * Whether the user can write files to any of the available file sources.
          */
         hasWritable: readonly(hasWritable),
+        /**
+         * Get the file source with the given ID.
+         *
+         * @param id - The ID of the file source to get.
+         * @returns The file source with the given ID, if found.
+         */
+        getFileSourceById,
     };
 }

--- a/client/src/utils/upload-payload.js
+++ b/client/src/utils/upload-payload.js
@@ -9,6 +9,7 @@ export const URI_PREFIXES = [
     "gxuserimport://",
     "gxftp://",
     "drs://",
+    "invenio://",
 ];
 
 export function isUrl(content) {

--- a/client/src/utils/upload-payload.js
+++ b/client/src/utils/upload-payload.js
@@ -10,6 +10,7 @@ export const URI_PREFIXES = [
     "gxftp://",
     "drs://",
     "invenio://",
+    "zenodo://",
 ];
 
 export function isUrl(content) {

--- a/lib/galaxy/config/sample/file_sources_conf.yml.sample
+++ b/lib/galaxy/config/sample/file_sources_conf.yml.sample
@@ -211,6 +211,24 @@
   public_name: ${user.preferences['invenio_sandbox|public_name']}
   writable: true
 
+- type: zenodo
+  id: zenodo
+  doc: Zenodo is a general-purpose open-access repository developed under the European OpenAIRE program and operated by CERN. It allows researchers to deposit data sets, research software, reports, and any other research-related digital artifacts. For each submission, a persistent digital object identifier (DOI) is minted, which makes the stored items easily citeable.
+  label: Zenodo
+  url: https://zenodo.org
+  token: ${user.user_vault.read_secret('preferences/zenodo/token')}
+  public_name: ${user.preferences['zenodo|public_name']}
+  writable: true
+
+- type: zenodo
+  id: zenodo_sandbox
+  doc: This is the Sandbox instance of Zenodo. It is used for testing purposes only, content is NOT preserved. DOIs created in this instance are not real and will not resolve.
+  label: Zenodo Sandbox (TESTING ONLY)
+  url: https://sandbox.zenodo.org
+  token: ${user.user_vault.read_secret('preferences/zenodo_sandbox/token')}
+  public_name: ${user.preferences['zenodo_sandbox|public_name']}
+  writable: true
+
 - type: onedata
   id: onedata1
   label: Onedata

--- a/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
+++ b/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
@@ -110,6 +110,32 @@ preferences:
               type: text
               required: False
 
+    zenodo:
+        description: Your Zenodo Integration Settings
+        inputs:
+            - name: token
+              label: Personal Access Token used to create draft records and to upload files. You can manage your tokens at https://zenodo.org/account/settings/applications/
+              type: secret
+              store: vault # Requires setting up vault_config_file in your galaxy.yml
+              required: False
+            - name: public_name
+              label: Creator name to associate with new records (formatted as "Last name, First name"). If left blank "Anonymous Galaxy User" will be used. You can always change this by editing your record directly.
+              type: text
+              required: False
+
+    zenodo_sandbox:
+        description: Your Zenodo Sandbox Integration Settings (TESTING ONLY)
+        inputs:
+            - name: token
+              label: Personal Access Token used to create draft records and to upload files. You can manage your tokens at https://sandbox.zenodo.org/account/settings/applications/
+              type: secret
+              store: vault # Requires setting up vault_config_file in your galaxy.yml
+              required: False
+            - name: public_name
+              label: Creator name to associate with new records (formatted as "Last name, First name"). If left blank "Anonymous Galaxy User" will be used. You can always change this by editing your record directly.
+              type: text
+              required: False
+
     # Used in file_sources_conf.yml
     onedata:
         description: Your Onedata account

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -138,7 +138,7 @@ class RDMFilesSource(BaseFilesSource):
 
     plugin_kind = PluginKind.rdm
 
-    def __init__(self, **kwd: Unpack[FilesSourceProperties]):
+    def __init__(self, **kwd: Unpack[RDMFilesSourceProperties]):
         props = self._parse_common_config_opts(kwd)
         base_url = props.get("url")
         if not base_url:

--- a/lib/galaxy/files/sources/zenodo.py
+++ b/lib/galaxy/files/sources/zenodo.py
@@ -1,0 +1,21 @@
+from galaxy.files.sources.invenio import InvenioRDMFilesSource
+
+
+class ZenodoRDMFilesSource(InvenioRDMFilesSource):
+    """A files source for Zenodo repositories.
+
+    Zenodo is an open science platform developed by CERN. It allows researchers
+    to deposit data, software, and other research outputs for long-term
+    preservation and sharing.
+
+    Zenodo repositories are based on InvenioRDM, so this class is a subclass of
+    InvenioRDMFilesSource with the appropriate plugin type.
+    """
+
+    plugin_type = "zenodo"
+
+    def get_scheme(self) -> str:
+        return "zenodo"
+
+
+__all__ = ("ZenodoRDMFilesSource",)

--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -38,7 +38,19 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 URI_PREFIXES = [
-    f"{x}://" for x in ["http", "https", "ftp", "file", "gxfiles", "gximport", "gxuserimport", "gxftp", "drs"]
+    f"{x}://"
+    for x in [
+        "http",
+        "https",
+        "ftp",
+        "file",
+        "gxfiles",
+        "gximport",
+        "gxuserimport",
+        "gxftp",
+        "drs",
+        "invenio",
+    ]
 ]
 
 

--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -50,6 +50,7 @@ URI_PREFIXES = [
         "gxftp",
         "drs",
         "invenio",
+        "zenodo",
     ]
 ]
 


### PR DESCRIPTION
Requires #18028

This PR adds a new Zenodo file source plugin based on Invenio to make the integration a bit more obvious.

This also uses new schemes for Invenio (`invenio://`) and Zenodo (`zenodo://`) file sources as they should have been from the beginning... The previous `gxfiles://` scheme in the case of existing exports will still work as expected.

![image](https://github.com/galaxyproject/galaxy/assets/46503462/2ada3994-f170-4eea-b6c2-544d22136f2e)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Set `enable_celery_tasks` to `true` in your galaxy.yml config file.
  - Add to your `file_sources_conf.yml`
    ```yml
      - type: zenodo
        id: zenodo
        doc: Zenodo is a general-purpose open-access repository developed under the European OpenAIRE program and operated by CERN. It allows researchers to deposit data sets, research software, reports, and any other research-related digital artifacts. For each submission, a persistent digital object identifier (DOI) is minted, which makes the stored items easily citeable.
        label: Zenodo
        url: https://sandbox.zenodo.org # To use the real Zenodo instance replace with https://zenodo.org
        token: ${user.user_vault.read_secret('preferences/zenodo/token')}
        # token: ${user.preferences['zenodo|token']} # Alternatively use this for retrieving the token from user preferences instead of the Vault
        public_name: ${user.preferences['zenodo|public_name']}
        writable: true
    ```
  - Add to your `user_preferences_extra_conf.yml`
    ```yml
        zenodo:
                description: Your Zenodo Integration Settings
                inputs:
                    - name: token
                      label: Personal Access Token used to create draft records and to upload files. You can manage your tokens at https://zenodo.org/account/settings/applications/
                      type: secret
                      store: vault # Requires setting up vault_config_file in your galaxy.yml
                      required: False
                    - name: public_name
                      label: Creator name to associate with new records (formatted as "Last name, First name"). If left blank "Anonymous Galaxy User" will be used. You can always change this by editing your record directly.
                      type: text
                      required: False
    ```
  - Try to export a history

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
