### PR TITLE
[24.0] Raise appropriate exception if user forces a collection that is not populated with elements as input

### DIFF
--- a/lib/galaxy/tools/parameters/dataset_matcher.py
+++ b/lib/galaxy/tools/parameters/dataset_matcher.py
@@ -262,7 +262,7 @@ class DatasetCollectionMatcher:
     def dataset_collection_match(self, dataset_collection):
         # If dataset collection not yet populated, cannot determine if it
         # would be a valid match for this parameter.
-        if not dataset_collection.populated:
+        if not dataset_collection.populated_optimized:
             return False
 
         valid = True

--- a/lib/galaxy/tools/parameters/meta.py
+++ b/lib/galaxy/tools/parameters/meta.py
@@ -242,6 +242,8 @@ def __expand_collection_parameter(trans, input_key, incoming_val, collections_to
             subcollection_type = None
     hdc_id = trans.app.security.decode_id(encoded_hdc_id)
     hdc = trans.sa_session.get(HistoryDatasetCollectionAssociation, hdc_id)
+    if not hdc.collection.populated_optimized:
+        raise exceptions.ToolInputsNotReadyException("An input collection is not populated.")
     collections_to_match.add(input_key, hdc, subcollection_type=subcollection_type, linked=linked)
     if subcollection_type is not None:
         subcollection_elements = subcollections.split_dataset_collection_instance(hdc, subcollection_type)

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -1659,9 +1659,8 @@ class TestToolsApi(ApiTestCase, TestsTools):
 
     @skip_without_tool("cat1")
     def test_map_over_empty_collection(self, history_id):
-        hdca_id = self.dataset_collection_populator.create_list_in_history(history_id, contents=[]).json()["outputs"][
-            0
-        ]["id"]
+        response = self.dataset_collection_populator.create_list_in_history(history_id, contents=[], wait=True).json()
+        hdca_id = response["output_collections"][0]["id"]
         inputs = {
             "input1": {"batch": True, "values": [{"src": "hdca", "id": hdca_id}]},
         }


### PR DESCRIPTION
These aren't valid inputs and I think the only way to get here is by dragging such a collection into an input field, which bypasses all the validations happening in the dataset collection matcher.

Minor performance fix included for nested collections in said dataset collection matcher.
Fixes #18012 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
