### PR TITLE
[24.0] Fix tag regex pattern

### DIFF
--- a/client/src/components/Tags/model.js
+++ b/client/src/components/Tags/model.js
@@ -7,7 +7,7 @@ import { keyedColorScheme } from "utils/color";
 
 // Valid tag regex. The basic format here is a tag name with optional subtags
 // separated by a period, and then an optional value after a colon.
-export const VALID_TAG_RE = /^([^\s.:])+(.[^\s.:]+)*(:[^\s.:]+)?$/;
+export const VALID_TAG_RE = /^([^\s.:])+(\.[^\s.:]+)*(:\S+)?$/;
 
 export class TagModel {
     /**

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -296,7 +296,7 @@ class TagHandler:
 
     def _create_tags(self, tag_str: str):
         """
-        Create or retrieve one of more Tag objects from a tag string. If there are multiple
+        Create or retrieve one or more Tag objects from a tag string. If there are multiple
         hierarchical tags in the tag string, the string will be split along `self.hierarchy_separator` chars.
         A Tag instance will be created for each non-empty prefix. If a prefix corresponds to the
         name of an existing tag, that tag will be retrieved; otherwise, a new Tag object will be created.

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -300,7 +300,7 @@ class TagHandler:
         hierarchical tags in the tag string, the string will be split along `self.hierarchy_separator` chars.
         A Tag instance will be created for each non-empty prefix. If a prefix corresponds to the
         name of an existing tag, that tag will be retrieved; otherwise, a new Tag object will be created.
-        For example, for the tag string `a.b.c` 3 Tag isntances will be created: `a`, `a.b`, `a.b.c`.
+        For example, for the tag string `a.b.c` 3 Tag instances will be created: `a`, `a.b`, `a.b.c`.
         Return the last tag created (`a.b.c`).
         """
         tag_hierarchy = tag_str.split(self.hierarchy_separator)

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -351,7 +351,7 @@ class TagHandler:
         tag = self.get_tag_by_name(scrubbed_tag_str)
         # Create tag if necessary.
         if tag is None:
-            tag = self._create_tags(scrubbed_tag_str)
+            tag = self._create_tag(scrubbed_tag_str)
         return tag
 
     def _get_item_tag_assoc(self, user, item, tag_name):

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -294,7 +294,7 @@ class TagHandler:
             return self.sa_session.scalars(select(galaxy.model.Tag).filter_by(name=tag_name.lower()).limit(1)).first()
         return None
 
-    def _create_tags(self, tag_str: str):
+    def _create_tag(self, tag_str: str):
         """
         Create or retrieve one or more Tag objects from a tag string. If there are multiple
         hierarchical tags in the tag string, the string will be split along `self.hierarchy_separator` chars.

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -294,8 +294,15 @@ class TagHandler:
             return self.sa_session.scalars(select(galaxy.model.Tag).filter_by(name=tag_name.lower()).limit(1)).first()
         return None
 
-    def _create_tag(self, tag_str: str):
-        """Create a Tag object from a tag string."""
+    def _create_tags(self, tag_str: str):
+        """
+        Create or retrieve one of more Tag objects from a tag string. If there are multiple
+        hierarchical tags in the tag string, the string will be split along `self.hierarchy_separator` chars.
+        A Tag instance will be created for each non-empty prefix. If a prefix corresponds to the
+        name of an existing tag, that tag will be retrieved; otherwise, a new Tag object will be created.
+        For example, for the tag string `a.b.c` 3 Tag isntances will be created: `a`, `a.b`, `a.b.c`.
+        Return the last tag created (`a.b.c`).
+        """
         tag_hierarchy = tag_str.split(self.hierarchy_separator)
         tag_prefix = ""
         parent_tag = None
@@ -344,7 +351,7 @@ class TagHandler:
         tag = self.get_tag_by_name(scrubbed_tag_str)
         # Create tag if necessary.
         if tag is None:
-            tag = self._create_tag(scrubbed_tag_str)
+            tag = self._create_tags(scrubbed_tag_str)
         return tag
 
     def _get_item_tag_assoc(self, user, item, tag_name):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -66,7 +66,7 @@ IMPLICIT_COLLECTION_JOBS_MODEL_CLASS = Literal["ImplicitCollectionJobs"]
 
 OptionalNumberT = Annotated[Optional[Union[int, float]], Field(None)]
 
-TAG_ITEM_PATTERN = r"^([^\s.:])+(.[^\s.:]+)*(:[^\s.:]+)?$"
+TAG_ITEM_PATTERN = r"^([^\s.:])+(\.[^\s.:]+)*(:\S+)?$"
 
 
 class DatasetState(str, Enum):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -66,6 +66,8 @@ IMPLICIT_COLLECTION_JOBS_MODEL_CLASS = Literal["ImplicitCollectionJobs"]
 
 OptionalNumberT = Annotated[Optional[Union[int, float]], Field(None)]
 
+TAG_ITEM_PATTERN = r"^([^\s.:])+(.[^\s.:]+)*(:[^\s.:]+)?$"
+
 
 class DatasetState(str, Enum):
     NEW = "new"
@@ -527,7 +529,7 @@ class HistoryContentSource(str, Enum):
 DatasetCollectionInstanceType = Literal["history", "library"]
 
 
-TagItem = Annotated[str, Field(..., pattern=r"^([^\s.:])+(.[^\s.:]+)*(:[^\s.:]+)?$")]
+TagItem = Annotated[str, Field(..., pattern=TAG_ITEM_PATTERN)]
 
 
 class TagCollection(RootModel):

--- a/test/unit/app/managers/test_TagHandler.py
+++ b/test/unit/app/managers/test_TagHandler.py
@@ -114,12 +114,13 @@ class TestTagHandler(BaseTestCase):
         assert not self.tag_handler.item_has_tag(self.user, item=hda, tag="tag2")
 
     def test_get_name_value_pair(self):
-        """Test different combinations of tag and name/value delimiters via parse_tags()."""
+        """Verify that parsing a single tag string correctly splits it into name/value pairs."""
         assert self.tag_handler.parse_tags("a") == [("a", None)]
         assert self.tag_handler.parse_tags("a.b") == [("a.b", None)]
         assert self.tag_handler.parse_tags("a.b:c") == [("a.b", "c")]
         assert self.tag_handler.parse_tags("a.b:c.d") == [("a.b", "c.d")]
         assert self.tag_handler.parse_tags("a.b:c.d:e.f") == [("a.b", "c.d:e.f")]
         assert self.tag_handler.parse_tags("a.b:c.d:e.f.") == [("a.b", "c.d:e.f.")]
+        assert self.tag_handler.parse_tags("a.b:c.d:e.f..") == [("a.b", "c.d:e.f..")]
         assert self.tag_handler.parse_tags("a.b:c.d:e.f:") == [("a.b", "c.d:e.f:")]
-        assert self.tag_handler.parse_tags("a.b:c.d:e.f:::") == [("a.b", "c.d:e.f:::")]
+        assert self.tag_handler.parse_tags("a.b:c.d:e.f::") == [("a.b", "c.d:e.f::")]

--- a/test/unit/app/managers/test_TagHandler.py
+++ b/test/unit/app/managers/test_TagHandler.py
@@ -112,3 +112,14 @@ class TestTagHandler(BaseTestCase):
         # Tag
         assert self.tag_handler.item_has_tag(self.user, item=hda, tag=hda.tags[0].tag)
         assert not self.tag_handler.item_has_tag(self.user, item=hda, tag="tag2")
+
+    def test_get_name_value_pair(self):
+        """Test different combinations of tag and name/value delimiters via parse_tags()."""
+        assert self.tag_handler.parse_tags("a") == [("a", None)]
+        assert self.tag_handler.parse_tags("a.b") == [("a.b", None)]
+        assert self.tag_handler.parse_tags("a.b:c") == [("a.b", "c")]
+        assert self.tag_handler.parse_tags("a.b:c.d") == [("a.b", "c.d")]
+        assert self.tag_handler.parse_tags("a.b:c.d:e.f") == [("a.b", "c.d:e.f")]
+        assert self.tag_handler.parse_tags("a.b:c.d:e.f.") == [("a.b", "c.d:e.f.")]
+        assert self.tag_handler.parse_tags("a.b:c.d:e.f:") == [("a.b", "c.d:e.f:")]
+        assert self.tag_handler.parse_tags("a.b:c.d:e.f:::") == [("a.b", "c.d:e.f:::")]

--- a/test/unit/schema/test_schema.py
+++ b/test/unit/schema/test_schema.py
@@ -58,7 +58,7 @@ class TestTagPattern:
             "a::a",  # leading colon for tag value
             "a:.a",  # leading period for tag value
             "a:a:",  # trailing colon OK for tag value
-            "a:a.",  # training period OK for tag value
+            "a:a.",  # trailing period OK for tag value
         ]
         for t in tag_strings:
             assert re.match(TAG_ITEM_PATTERN, t)

--- a/test/unit/schema/test_schema.py
+++ b/test/unit/schema/test_schema.py
@@ -1,8 +1,12 @@
+import re
 from uuid import uuid4
 
 from pydantic import BaseModel
 
-from galaxy.schema.schema import DatasetStateField
+from galaxy.schema.schema import (
+    DatasetStateField,
+    TAG_ITEM_PATTERN,
+)
 from galaxy.schema.tasks import (
     GenerateInvocationDownload,
     RequestUser,
@@ -34,3 +38,43 @@ class StateModel(BaseModel):
 def test_dataset_state_coercion():
     assert StateModel(state="ok").state == "ok"
     assert StateModel(state="deleted").state == "discarded"
+
+
+class TestTagPattern:
+
+    def test_valid(self):
+        tag_strings = [
+            "a",
+            "aa",
+            "aa.aa",
+            "aa.aa.aa",
+            "~!@#$%^&*()_+`-=[]{};'\",./<>?",
+            "a.b:c",
+            "a.b:c.d:e.f",
+            "a.b:c.d:e..f",
+            "a.b:c.d:e.f:g",
+            "a.b:c.d:e.f::g",
+            "a.b:c.d:e.f::g:h",
+            "a::a",  # leading colon for tag value
+            "a:.a",  # leading period for tag value
+            "a:a:",  # training colon OK for tag value
+            "a:a.",  # training period OK for tag value
+        ]
+        for t in tag_strings:
+            assert re.match(TAG_ITEM_PATTERN, t)
+
+    def test_invalid(self):
+        tag_strings = [
+            " a",  # leading space for tag name
+            ":a",  # leading colon for tag name
+            ".a",  # leading period for tag name
+            "a ",  # trailing space for tag name
+            "a a",  # space inside tag name
+            "a: a",  # leading space for tag value
+            "a:a a",  # space inside tag value
+            "a:",  # trailing colon for tag name
+            "a.",  # trailing period for tag name
+            "a:b ",  # trailing space for tag value
+        ]
+        for t in tag_strings:
+            assert not re.match(TAG_ITEM_PATTERN, t)

--- a/test/unit/schema/test_schema.py
+++ b/test/unit/schema/test_schema.py
@@ -57,7 +57,7 @@ class TestTagPattern:
             "a.b:c.d:e.f::g:h",
             "a::a",  # leading colon for tag value
             "a:.a",  # leading period for tag value
-            "a:a:",  # training colon OK for tag value
+            "a:a:",  # trailing colon OK for tag value
             "a:a.",  # training period OK for tag value
         ]
         for t in tag_strings:


### PR DESCRIPTION
Fixes #17999. Trailing periods and colons allowed in tag value only. 

Also, fix pattern to disallow spaces in tag name and tag value. 

To do:
- [ ] Do not duplicate regex pattern across backend and client

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
