### PR TITLE
[24.0] Fix ``test_get_tags_histories_content`` test

### DIFF
--- a/lib/galaxy_test/api/test_item_tags.py
+++ b/lib/galaxy_test/api/test_item_tags.py
@@ -135,9 +135,9 @@ class TestItemTagsApi(ApiTestCase):
         return response
 
     def _create_history_contents(self, history_id):
-        history_content_id = self.dataset_collection_populator.create_list_in_history(
-            history_id, contents=["test_dataset"], direct_upload=True, wait=True
-        ).json()["outputs"][0]["id"]
+        history_content_id = self.dataset_populator.new_dataset(
+            history_id, contents="test_dataset", direct_upload=True, wait=True
+        )["id"]
         return history_content_id
 
     def _create_history(self):


### PR DESCRIPTION
The calling code expects that this creates a dataset, but instead this used to create dataset collection. It just so happened to pass tests because the id of the dataset collection created corresponded to the id of a history dataset association owned by the user ... and then it broke by creating more or less datasets or changing the order within which they were created.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
