### PR TITLE
[24.0] Fix remote files sources error handling

### DIFF
--- a/lib/galaxy/files/sources/_pyfilesystem2.py
+++ b/lib/galaxy/files/sources/_pyfilesystem2.py
@@ -16,7 +16,10 @@ import fs.errors
 from fs.base import FS
 from typing_extensions import Unpack
 
-from galaxy.exceptions import MessageException
+from galaxy.exceptions import (
+    AuthenticationRequired,
+    MessageException,
+)
 from . import (
     BaseFilesSource,
     FilesSourceOptions,
@@ -58,7 +61,7 @@ class PyFilesystem2FilesSource(BaseFilesSource):
                     to_dict = functools.partial(self._resource_info_to_dict, path)
                     return list(map(to_dict, res))
         except fs.errors.PermissionDenied as e:
-            raise MessageException(
+            raise AuthenticationRequired(
                 f"Permission Denied. Reason: {e}. Please check your credentials in your preferences for {self.label}."
             )
         except fs.errors.FSError as e:

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -7,7 +7,7 @@ from typing import (
 
 from typing_extensions import Unpack
 
-from galaxy.exceptions import AuthenticationRequired
+from galaxy.exceptions import MessageException
 from galaxy.files import ProvidesUserFileSourcesUserContext
 from galaxy.files.sources import (
     BaseFilesSource,
@@ -199,7 +199,7 @@ class RDMFilesSource(BaseFilesSource):
             effective_props = self._serialization_props(user_context)
             token = effective_props.get("token")
         if not token:
-            raise AuthenticationRequired(
+            raise MessageException(
                 f"Please provide a personal access token in your user's preferences for '{self.label}'"
             )
         return token

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -7,7 +7,7 @@ from typing import (
 
 from typing_extensions import Unpack
 
-from galaxy.exceptions import MessageException
+from galaxy.exceptions import AuthenticationRequired
 from galaxy.files import ProvidesUserFileSourcesUserContext
 from galaxy.files.sources import (
     BaseFilesSource,
@@ -199,7 +199,7 @@ class RDMFilesSource(BaseFilesSource):
             effective_props = self._serialization_props(user_context)
             token = effective_props.get("token")
         if not token:
-            raise MessageException(
+            raise AuthenticationRequired(
                 f"Please provide a personal access token in your user's preferences for '{self.label}'"
             )
         return token

--- a/lib/galaxy/files/sources/dropbox.py
+++ b/lib/galaxy/files/sources/dropbox.py
@@ -8,6 +8,7 @@ from typing import (
     Union,
 )
 
+from galaxy.exceptions import MessageException
 from . import (
     FilesSourceOptions,
     FilesSourceProperties,
@@ -27,8 +28,17 @@ class DropboxFilesSource(PyFilesystem2FilesSource):
         if "accessToken" in props:
             props["access_token"] = props.pop("accessToken")
 
-        handle = DropboxFS(**{**props, **extra_props})
-        return handle
+        try:
+            handle = DropboxFS(**{**props, **extra_props})
+            return handle
+        except Exception as e:
+            # This plugin might raise dropbox.dropbox_client.BadInputException
+            # which is not a subclass of fs.errors.FSError
+            if "OAuth2" in str(e):
+                raise MessageException(
+                    f"Permission Denied. Reason: {e}. Please check your credentials in your preferences for {self.label}."
+                )
+            raise MessageException(f"Error connecting to Dropbox. Reason: {e}")
 
 
 __all__ = ("DropboxFilesSource",)

--- a/lib/galaxy/files/sources/dropbox.py
+++ b/lib/galaxy/files/sources/dropbox.py
@@ -8,7 +8,10 @@ from typing import (
     Union,
 )
 
-from galaxy.exceptions import MessageException
+from galaxy.exceptions import (
+    AuthenticationRequired,
+    MessageException,
+)
 from . import (
     FilesSourceOptions,
     FilesSourceProperties,
@@ -35,7 +38,7 @@ class DropboxFilesSource(PyFilesystem2FilesSource):
             # This plugin might raise dropbox.dropbox_client.BadInputException
             # which is not a subclass of fs.errors.FSError
             if "OAuth2" in str(e):
-                raise MessageException(
+                raise AuthenticationRequired(
                     f"Permission Denied. Reason: {e}. Please check your credentials in your preferences for {self.label}."
                 )
             raise MessageException(f"Error connecting to Dropbox. Reason: {e}")

--- a/lib/galaxy/managers/remote_files.py
+++ b/lib/galaxy/managers/remote_files.py
@@ -162,6 +162,9 @@ class RemoteFilesManager:
         file_source = file_source_path.file_source
         try:
             result = file_source.create_entry(entry_data.dict(), user_context=user_file_source_context)
+        except exceptions.MessageException:
+            log.warning(f"Problem creating entry {entry_data.name} in file source {entry_data.target}", exc_info=True)
+            raise
         except Exception:
             message = f"Problem creating entry {entry_data.name} in file source {entry_data.target}"
             log.warning(message, exc_info=True)

--- a/lib/galaxy/managers/remote_files.py
+++ b/lib/galaxy/managers/remote_files.py
@@ -9,6 +9,7 @@ from typing import (
 from galaxy import exceptions
 from galaxy.files import (
     ConfiguredFileSources,
+    FileSourcePath,
     ProvidesUserFileSourcesUserContext,
 )
 from galaxy.files.sources import (
@@ -94,10 +95,10 @@ class RemoteFilesManager:
                 opts=opts,
             )
         except exceptions.MessageException:
-            log.warning(f"Problem listing file source path {file_source_path}", exc_info=True)
+            log.warning(self._get_error_message(file_source_path), exc_info=True)
             raise
         except Exception:
-            message = f"Problem listing file source path {file_source_path}"
+            message = self._get_error_message(file_source_path)
             log.warning(message, exc_info=True)
             raise exceptions.InternalServerError(message)
         if format == RemoteFilesFormat.flat:
@@ -130,6 +131,9 @@ class RemoteFilesManager:
             index = userdir_jstree.jsonData()
 
         return index
+
+    def _get_error_message(self, file_source_path: FileSourcePath) -> str:
+        return f"Problem listing file source path {file_source_path.file_source.get_uri_root()}{file_source_path.path}"
 
     def get_files_source_plugins(
         self,


### PR DESCRIPTION
Fixes #17993

With this PR, known remote file source errors are less prone to turn into internal server errors. In addition, it handles the authentication required error in a more user-friendly way.

| Before | After |
|--------|-------|
| ![image](https://github.com/galaxyproject/galaxy/assets/46503462/f0bd2c4b-f8b9-4550-95cb-d655a61f2e6a)   | ![image](https://github.com/galaxyproject/galaxy/assets/46503462/d45a2f68-2ce6-49d5-9c99-025eca893b92)  |

| Before | After |
|--------|-------|
| ![image](https://github.com/galaxyproject/galaxy/assets/46503462/9d1418a7-27a2-4a0a-95e3-2128bbf5301b)   | ![image](https://github.com/galaxyproject/galaxy/assets/46503462/622190c3-2ec7-483d-b3d8-1481b8c2ee74)  |

| Before | After |
|--------|-------|
| ![image](https://github.com/galaxyproject/galaxy/assets/46503462/18ce0509-413a-4caf-b66c-2d555f73e3e1)  | ![image](https://github.com/galaxyproject/galaxy/assets/46503462/60e61da9-0326-4c84-8536-abcbce39f01e)  |


I targeted 24.0 but it can be backported to older versions if needed.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
