### PR TITLE
Precreate populated dataset collections with fetch data tool

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4115,6 +4115,20 @@ class Dataset(Base, StorableObject, Serializable):
             object_store = self._assert_object_store_set()
             return not object_store.is_private(self)
 
+    def add_sources(self, sources: List[Dict[str, Any]]):
+        for source_dict in sources:
+            source = DatasetSource()
+            source.source_uri = source_dict["source_uri"]
+            source.transform = source_dict.get("transform")
+            self.sources.append(source)
+
+    def add_hashes(self, hashes: List[Dict[str, Any]]):
+        for hash_dict in hashes:
+            hash_object = galaxy.model.DatasetHash()
+            hash_object.hash_function = hash_dict["hash_function"]
+            hash_object.hash_value = hash_dict["hash_value"]
+            self.hashes.append(hash_object)
+
     def ensure_shareable(self):
         if not self.shareable:
             raise Exception(CANNOT_SHARE_PRIVATE_DATASET_MESSAGE)
@@ -6601,7 +6615,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
             if element.is_collection:
                 elements.extend(element.child_collection.dataset_elements_and_identifiers(_identifiers))
             else:
-                element._identifiers = _identifiers
+                element._identifiers = tuple(_identifiers)
                 elements.append(element)
         return elements
 

--- a/lib/galaxy/model/dataset_collections/builder.py
+++ b/lib/galaxy/model/dataset_collections/builder.py
@@ -1,10 +1,26 @@
+from typing import (
+    Dict,
+    Iterable,
+    Optional,
+)
+
+from typing_extensions import TypeAlias
+
 from galaxy import model
+from galaxy.model.dataset_collections.types import BaseDatasetCollectionType
 from galaxy.model.orm.util import add_object_to_object_session
 from galaxy.util.oset import OrderedSet
 from .type_description import COLLECTION_TYPE_DESCRIPTION_FACTORY
 
+Elements: TypeAlias = Dict[str, model.DatasetInstance]
 
-def build_collection(type, dataset_instances, collection=None, associated_identifiers=None):
+
+def build_collection(
+    type: BaseDatasetCollectionType,
+    dataset_instances: Elements,
+    collection: Optional[model.DatasetCollection] = None,
+    associated_identifiers: Optional[set[str]] = None,
+):
     """
     Build DatasetCollection with populated DatasetcollectionElement objects
     corresponding to the supplied dataset instances or throw exception if
@@ -16,8 +32,13 @@ def build_collection(type, dataset_instances, collection=None, associated_identi
     return dataset_collection
 
 
-def set_collection_elements(dataset_collection, type, dataset_instances, associated_identifiers):
-    new_element_keys = OrderedSet(dataset_instances.keys()) - associated_identifiers
+def set_collection_elements(
+    dataset_collection: model.DatasetCollection,
+    type: BaseDatasetCollectionType,
+    dataset_instances: Elements,
+    associated_identifiers: set[str],
+):
+    new_element_keys: Iterable[str] = OrderedSet(dataset_instances.keys()) - associated_identifiers
     new_dataset_instances = {k: dataset_instances[k] for k in new_element_keys}
     dataset_collection.element_count = dataset_collection.element_count or 0
     element_index = dataset_collection.element_count
@@ -113,7 +134,7 @@ class CollectionBuilder:
 class BoundCollectionBuilder(CollectionBuilder):
     """More stateful builder that is bound to a particular model object."""
 
-    def __init__(self, dataset_collection):
+    def __init__(self, dataset_collection: model.DatasetCollection):
         self.dataset_collection = dataset_collection
         if dataset_collection.populated:
             raise Exception("Cannot reset elements of an already populated dataset collection.")

--- a/lib/galaxy/model/dataset_collections/registry.py
+++ b/lib/galaxy/model/dataset_collections/registry.py
@@ -1,10 +1,19 @@
+from typing import (
+    List,
+    Type,
+)
+
 from galaxy import model
+from galaxy.model.dataset_collections.types import BaseDatasetCollectionType
 from .types import (
     list,
     paired,
 )
 
-PLUGIN_CLASSES = [list.ListDatasetCollectionType, paired.PairedDatasetCollectionType]
+PLUGIN_CLASSES: List[Type[BaseDatasetCollectionType]] = [
+    list.ListDatasetCollectionType,
+    paired.PairedDatasetCollectionType,
+]
 
 
 class DatasetCollectionTypesRegistry:

--- a/lib/galaxy/model/dataset_collections/type_description.py
+++ b/lib/galaxy/model/dataset_collections/type_description.py
@@ -47,7 +47,11 @@ class CollectionTypeDescription:
 
     collection_type: str
 
-    def __init__(self, collection_type: Union[str, "CollectionTypeDescription"], collection_type_description_factory):
+    def __init__(
+        self,
+        collection_type: Union[str, "CollectionTypeDescription"],
+        collection_type_description_factory: CollectionTypeDescriptionFactory,
+    ):
         if isinstance(collection_type, CollectionTypeDescription):
             self.collection_type = collection_type.collection_type
         else:

--- a/lib/galaxy/model/dataset_collections/types/__init__.py
+++ b/lib/galaxy/model/dataset_collections/types/__init__.py
@@ -3,15 +3,20 @@ from abc import (
     ABCMeta,
     abstractmethod,
 )
+from typing import TYPE_CHECKING
 
 from galaxy import exceptions
+
+if TYPE_CHECKING:
+    from galaxy.model import DatasetCollectionElement
+    from galaxy.model.dataset_collections.builder import Elements
 
 log = logging.getLogger(__name__)
 
 
 class DatasetCollectionType(metaclass=ABCMeta):
     @abstractmethod
-    def generate_elements(self, dataset_instances):
+    def generate_elements(self, dataset_instances: "Elements") -> list["DatasetCollectionElement"]:
         """Generate DatasetCollectionElements with corresponding
         to the supplied dataset instances or throw exception if
         this is not a valid collection of the specified type.
@@ -19,5 +24,8 @@ class DatasetCollectionType(metaclass=ABCMeta):
 
 
 class BaseDatasetCollectionType(DatasetCollectionType):
+
+    collection_type: str
+
     def _validation_failed(self, message):
         raise exceptions.ObjectAttributeInvalidException(message)

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -26,7 +26,7 @@ class TestDatasetCollectionsApi(ApiTestCase):
                 history_id,
                 instance_type="history",
             )
-            create_response = self.dataset_populator.fetch(payload, wait=True)
+            create_response = self.dataset_populator.fetch(payload)
             dataset_collection = self._check_create_response(create_response)
             returned_datasets = dataset_collection["elements"]
             assert len(returned_datasets) == 2, dataset_collection
@@ -156,9 +156,7 @@ class TestDatasetCollectionsApi(ApiTestCase):
 
     def test_list_list_download(self):
         with self.dataset_populator.test_history(require_new=False) as history_id:
-            dataset_collection = self.dataset_collection_populator.create_list_of_list_in_history(
-                history_id, wait=True
-            ).json()
+            dataset_collection = self.dataset_collection_populator.create_list_of_list_in_history(history_id).json()
             returned_dce = dataset_collection["elements"]
             assert len(returned_dce) == 1, dataset_collection
             create_response = self._download_dataset_collection(history_id=history_id, hdca_id=dataset_collection["id"])
@@ -172,7 +170,6 @@ class TestDatasetCollectionsApi(ApiTestCase):
             dataset_collection = self.dataset_collection_populator.create_list_of_list_in_history(
                 history_id,
                 collection_type="list:list:list",
-                wait=True,
             ).json()
             returned_dce = dataset_collection["elements"]
             assert len(returned_dce) == 1, dataset_collection
@@ -185,7 +182,7 @@ class TestDatasetCollectionsApi(ApiTestCase):
     @requires_new_user
     def test_hda_security(self):
         with self.dataset_populator.test_history(require_new=False) as history_id:
-            element_identifiers = self.dataset_collection_populator.pair_identifiers(history_id, wait=True)
+            element_identifiers = self.dataset_collection_populator.pair_identifiers(history_id)
             self.dataset_populator.make_private(history_id, element_identifiers[0]["id"])
             with self._different_user():
                 history_id = self.dataset_populator.new_history()
@@ -203,7 +200,6 @@ class TestDatasetCollectionsApi(ApiTestCase):
             dataset_collection = self.dataset_collection_populator.create_list_of_list_in_history(
                 history_id,
                 collection_type="list:list:list",
-                wait=True,
             ).json()
             first_element = dataset_collection["elements"][0]
             assert first_element["model_class"] == "DatasetCollectionElement"
@@ -408,6 +404,7 @@ class TestDatasetCollectionsApi(ApiTestCase):
         return dataset_collection
 
     def _download_dataset_collection(self, history_id: str, hdca_id: str):
+        self.dataset_populator.wait_for_history(history_id, assert_ok=False)
         return self._get(f"histories/{history_id}/contents/dataset_collections/{hdca_id}/download")
 
     @requires_new_user
@@ -455,7 +452,7 @@ class TestDatasetCollectionsApi(ApiTestCase):
         # Get contents_url from history contents, use it to show the first level
         # of collection contents in the created HDCA, then use it again to drill
         # down into the nested collection contents
-        hdca = self.dataset_collection_populator.create_list_of_list_in_history(history_id, wait=True).json()
+        hdca = self.dataset_collection_populator.create_list_of_list_in_history(history_id).json()
         root_contents_url = self._get_contents_url_for_hdca(history_id, hdca)
 
         # check root contents for this collection
@@ -489,7 +486,8 @@ class TestDatasetCollectionsApi(ApiTestCase):
 
     def test_collection_contents_empty_root(self, history_id):
         create_response = self.dataset_collection_populator.create_list_in_history(
-            history_id, contents=[], wait=True
+            history_id,
+            contents=[],
         ).json()
         hdca = create_response["output_collections"][0]
         assert hdca["elements"] == []
@@ -518,7 +516,6 @@ class TestDatasetCollectionsApi(ApiTestCase):
                     ],
                 },
             ],
-            wait=True,
         )
         self._assert_status_code_is(response, 200)
         hdca_list_id = response.json()["outputs"][0]["id"]
@@ -562,7 +559,6 @@ class TestDatasetCollectionsApi(ApiTestCase):
                     ],
                 },
             ],
-            wait=True,
         )
         self._assert_status_code_is(response, 200)
         hdca_list_id = response.json()["outputs"][0]["id"]
@@ -593,7 +589,6 @@ class TestDatasetCollectionsApi(ApiTestCase):
                     ],
                 },
             ],
-            wait=True,
         )
         self._assert_status_code_is(response, 200)
         hdca_list_id = response.json()["outputs"][0]["id"]
@@ -619,7 +614,7 @@ class TestDatasetCollectionsApi(ApiTestCase):
             "targets": targets,
             "__files": {"files_0|file_data": open(self.test_data_resolver.get_filename("4.bed"))},
         }
-        hdca_id = self.dataset_populator.fetch(payload).json()["output_collections"][0]["id"]
+        hdca_id = self.dataset_populator.fetch(payload, wait=True).json()["output_collections"][0]["id"]
         inputs = {
             "input": {"batch": False, "src": "hdca", "id": hdca_id},
         }
@@ -629,9 +624,10 @@ class TestDatasetCollectionsApi(ApiTestCase):
             history_id=history_id,
             input_format="legacy",
         )
-        response = self._post("tools", payload).json()
+        response = self._post("tools", payload)
+        self._assert_status_code_is(response, 200)
         self.dataset_populator.wait_for_history(history_id, assert_ok=False)
-        output_collection = response["output_collections"][0]
+        output_collection = response.json()["output_collections"][0]
         # collection should not inherit tags from input collection elements, only parent collection
         assert output_collection["tags"] == ["name:collection_tag"]
         element = output_collection["elements"][0]
@@ -648,7 +644,7 @@ class TestDatasetCollectionsApi(ApiTestCase):
     def _create_collection_contents_pair(self, history_id: str):
         # Create a simple collection, return hdca and contents_url
         payload = self.dataset_collection_populator.create_pair_payload(history_id, instance_type="history")
-        create_response = self.dataset_populator.fetch(payload=payload, wait=True)
+        create_response = self.dataset_populator.fetch(payload=payload)
         hdca = self._check_create_response(create_response)
         root_contents_url = self._get_contents_url_for_hdca(history_id, hdca)
         return hdca, root_contents_url


### PR DESCRIPTION
(if possible ... this isn't going to work for uploads from archives)

Small enhancement that lets us consume collection uploads immediately. We're not using this way of uploading on the frontend yet, but I think it would be a neat enhancement to the collection tab that would save us an additional click.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
