### PR TITLE
Add a button that filters out a tool section in the tool panel

### DIFF
--- a/client/src/components/History/HistoryScrollList.vue
+++ b/client/src/components/History/HistoryScrollList.vue
@@ -220,8 +220,8 @@ async function loadMore(noScroll = false) {
 <template>
     <div :class="isMultiviewPanel ? 'unified-panel' : 'flex-column-overflow'">
         <div class="unified-panel-controls">
-            <BBadge v-if="props.filter && !validFilter" class="alert-danger w-100 mb-2">
-                Search string too short!
+            <BBadge v-if="props.filter && !validFilter" class="alert-warning w-100 mb-2">
+                Search term is too short
             </BBadge>
             <BAlert v-else-if="!busy && hasNoResults" class="mb-2" variant="danger" show>No histories found.</BAlert>
         </div>

--- a/client/src/components/Panels/Common/ToolPanelLabel.vue
+++ b/client/src/components/Panels/Common/ToolPanelLabel.vue
@@ -1,28 +1,23 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import type { ToolSectionLabel } from "@/stores/toolStore";
+
+import ToolPanelLinks from "./ToolPanelLinks.vue";
+
+const props = defineProps<{
+    definition: ToolSectionLabel;
+}>();
+
+const description = computed(() => props.definition.description || undefined);
+</script>
+
 <template>
     <div v-b-tooltip.topright.hover.noninteractive class="tool-panel-label" tabindex="0" :title="description">
         {{ definition.text }}
-        <ToolPanelLinks :links="definition.links" />
+        <ToolPanelLinks :links="definition.links || undefined" />
     </div>
 </template>
-
-<script>
-import ToolPanelLinks from "./ToolPanelLinks";
-
-export default {
-    components: { ToolPanelLinks },
-    props: {
-        definition: {
-            type: Object,
-            required: true,
-        },
-    },
-    computed: {
-        description() {
-            return this.definition.description;
-        },
-    },
-};
-</script>
 
 <style scoped lang="scss">
 .tool-panel-label {

--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -154,7 +154,7 @@ watch(
 
 function checkQuery(q: string) {
     emit("onQuery", q);
-    if (q && q.length >= MIN_QUERY_LENGTH) {
+    if (q.trim() && q.trim().length >= MIN_QUERY_LENGTH) {
         if (FAVORITES.includes(q)) {
             post({ type: "favoriteTools" });
         } else {

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -171,8 +171,8 @@ function toggleMenu(nextState = !opened.value) {
                 </div>
                 <button
                     v-if="isSection && toolStore.currentPanelView === 'default'"
-                    v-b-tooltip.hover.noninteractive.right
-                    title="Filter by this section"
+                    v-b-tooltip.hover.noninteractive.bottom
+                    title="Show full section"
                     class="inline-icon-button"
                     @click.stop="emit('onFilter', `section:${toolSection.name}`)">
                     <FontAwesomeIcon :icon="faFilter" />
@@ -217,6 +217,10 @@ function toggleMenu(nextState = !opened.value) {
 <style lang="scss" scoped>
 @import "scss/theme/blue.scss";
 
+.inline-icon-button {
+    font-size: 75%;
+    padding: 0em 0.5em;
+}
 .tool-panel-label {
     background: darken($panel-bg-color, 5%);
     border-left: 0.25rem solid darken($panel-bg-color, 25%);

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -34,6 +34,7 @@ interface Props {
     sectionName?: string;
     expanded?: boolean;
     sortItems?: boolean;
+    hasFilterButton?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -46,6 +47,7 @@ const props = withDefaults(defineProps<Props>(), {
     sectionName: "default",
     expanded: false,
     sortItems: true,
+    hasFilterButton: false,
 });
 
 const { config, isConfigLoaded } = useConfig();
@@ -170,7 +172,7 @@ function toggleMenu(nextState = !opened.value) {
                     <ToolPanelLinks :links="links" />
                 </div>
                 <button
-                    v-if="isSection && toolStore.currentPanelView === 'default'"
+                    v-if="isSection && props.hasFilterButton"
                     v-b-tooltip.hover.noninteractive.bottom
                     title="Show full section"
                     class="inline-icon-button"

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -1,73 +1,63 @@
 <script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faFilter } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { useEventBus } from "@vueuse/core";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 
 import { useConfig } from "@/composables/config";
-import { type ToolSectionLabel, useToolStore } from "@/stores/toolStore";
+import { type Tool as ToolType, type ToolSection, type ToolSectionLabel, useToolStore } from "@/stores/toolStore";
 import ariaAlert from "@/utils/ariaAlert";
 
 import Tool from "./Tool.vue";
 import ToolPanelLabel from "./ToolPanelLabel.vue";
 import ToolPanelLinks from "./ToolPanelLinks.vue";
 
+library.add(faFilter);
+
 const emit = defineEmits<{
     (e: "onClick", tool: any, evt: Event): void;
+    (e: "onFilter", filter: string): void;
     (e: "onOperation", tool: any, evt: Event): void;
 }>();
 
 const eventBus = useEventBus<string>("open-tool-section");
 
-const props = defineProps({
-    category: {
-        type: Object,
-        required: true,
-    },
-    queryFilter: {
-        type: String,
-        default: "",
-    },
-    disableFilter: {
-        type: Boolean,
-    },
-    hideName: {
-        type: Boolean,
-    },
-    operationTitle: {
-        type: String,
-        default: "",
-    },
-    operationIcon: {
-        type: String,
-        default: "",
-    },
-    toolKey: {
-        type: String,
-        default: "",
-    },
-    sectionName: {
-        type: String,
-        default: "default",
-    },
-    expanded: {
-        type: Boolean,
-        default: false,
-    },
-    sortItems: {
-        type: Boolean,
-        default: true,
-    },
+interface Props {
+    category: ToolSection | ToolType | ToolSectionLabel;
+    queryFilter?: string;
+    disableFilter?: boolean;
+    hideName?: boolean;
+    operationTitle?: string;
+    operationIcon?: string;
+    toolKey?: string;
+    sectionName?: string;
+    expanded?: boolean;
+    sortItems?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    queryFilter: "",
+    disableFilter: false,
+    hideName: false,
+    operationTitle: "",
+    operationIcon: "",
+    toolKey: "",
+    sectionName: "default",
+    expanded: false,
+    sortItems: true,
 });
 
 const { config, isConfigLoaded } = useConfig();
 const toolStore = useToolStore();
 
 const elems = computed(() => {
-    if (props.category.elems !== undefined && props.category.elems.length > 0) {
-        return props.category.elems;
+    if (toolSection.value.elems !== undefined && toolSection.value.elems.length > 0) {
+        return toolSection.value.elems;
     }
-    if (props.category.tools !== undefined && props.category.tools.length > 0) {
-        return props.category.tools.map((toolId: string) => {
-            const tool = toolStore.getToolForId(toolId);
+    if (toolSection.value.tools !== undefined && toolSection.value.tools.length > 0) {
+        return toolSection.value.tools.map((toolId) => {
+            const tool = toolStore.getToolForId(toolId as string);
             if (!tool && typeof toolId !== "string") {
                 return toolId as ToolSectionLabel;
             } else {
@@ -78,11 +68,14 @@ const elems = computed(() => {
     return [];
 });
 
-const name = computed(() => props.category.title || props.category.name);
-const isSection = computed(() => props.category.tools !== undefined || props.category.elems !== undefined);
+const toolSection = computed(() => props.category as ToolSection);
+const toolSectionLabel = computed(() => props.category as ToolSectionLabel);
+
+const name = computed(() => toolSection.value.title || toolSection.value.name);
+const isSection = computed(() => toolSection.value.tools !== undefined || toolSection.value.elems !== undefined);
 const hasElements = computed(() => elems.value.length > 0);
-const title = computed(() => props.category.description);
-const links = computed(() => props.category.links || {});
+const title = computed(() => props.category.description || undefined);
+const links = computed(() => toolSection.value.links || {});
 
 const opened = ref(props.expanded || checkFilter());
 
@@ -96,12 +89,12 @@ const sortedElements = computed(() => {
         isConfigLoaded.value &&
         config.value.toolbox_auto_sort === true &&
         props.sortItems === true &&
-        !elems.value.some((el: ToolSectionLabel) => el.text !== undefined && el.text !== "")
+        !elems.value.some((el) => (el as ToolSectionLabel).text !== undefined && (el as ToolSectionLabel).text !== "")
     ) {
         const elements = [...elems.value];
         const sorted = elements.sort((a, b) => {
-            const aNameLower = a.name.toLowerCase();
-            const bNameLower = b.name.toLowerCase();
+            const aNameLower = (a as ToolSection).name.toLowerCase();
+            const bNameLower = (b as ToolSection).name.toLowerCase();
             if (aNameLower > bNameLower) {
                 return 1;
             } else if (aNameLower < bNameLower) {
@@ -166,18 +159,31 @@ function toggleMenu(nextState = !opened.value) {
             v-b-tooltip.topright.hover.noninteractive
             :class="['toolSectionTitle', `tool-menu-section-${sectionName}`]"
             :title="title">
-            <a class="title-link" href="javascript:void(0)" @click="toggleMenu()">
-                <span class="name">
-                    {{ name }}
-                </span>
-                <ToolPanelLinks :links="links" />
+            <a
+                class="title-link d-flex justify-content-between align-items-center"
+                href="javascript:void(0)"
+                @click="toggleMenu()">
+                <div>
+                    <span class="name">
+                        {{ name }}
+                    </span>
+                    <ToolPanelLinks :links="links" />
+                </div>
+                <button
+                    v-if="isSection && toolStore.currentPanelView === 'default'"
+                    v-b-tooltip.hover.noninteractive.right
+                    title="Filter by this section"
+                    class="inline-icon-button"
+                    @click.stop="emit('onFilter', `section:${toolSection.name}`)">
+                    <FontAwesomeIcon :icon="faFilter" />
+                </button>
             </a>
         </div>
         <transition name="slide">
             <div v-if="opened" data-description="opened tool panel section">
                 <template v-for="[key, el] in sortedElements">
                     <ToolPanelLabel
-                        v-if="category.text || el.model_class === 'ToolSectionLabel'"
+                        v-if="toolSectionLabel.text || el.model_class === 'ToolSectionLabel'"
                         :key="key"
                         :definition="el" />
                     <Tool
@@ -196,7 +202,7 @@ function toggleMenu(nextState = !opened.value) {
         </transition>
     </div>
     <div v-else>
-        <ToolPanelLabel v-if="category.text" :definition="category" />
+        <ToolPanelLabel v-if="toolSectionLabel.text" :definition="toolSectionLabel" />
         <Tool
             v-else
             :tool="category"

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -64,7 +64,7 @@ const propShowAdvanced = computed({
 });
 const query = computed({
     get: () => {
-        return props.panelQuery;
+        return props.panelQuery.trim();
     },
     set: (q: string) => {
         queryPending.value = true;

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -50,8 +50,6 @@ const queryPending = ref(false);
 const showSections = ref(props.workflow);
 const results: Ref<string[]> = ref([]);
 const resultPanel: Ref<Record<string, Tool | ToolSectionType> | null> = ref(null);
-const buttonText = ref("");
-const buttonIcon = ref("");
 const closestTerm: Ref<string | null> = ref(null);
 
 const toolStore = useToolStore();
@@ -172,6 +170,9 @@ const workflowSection = computed(() => {
     }
 });
 
+const buttonIcon = computed(() => (showSections.value ? faEyeSlash : faEye));
+const buttonText = computed(() => (showSections.value ? localize("Hide Sections") : localize("Show Sections")));
+
 function onInsertModule(module: Record<string, any>, event: Event) {
     event.preventDefault();
     emit("onInsertModule", module.name, module.title);
@@ -220,18 +221,22 @@ function onResults(
     }
     closestTerm.value = closestMatch;
     queryFilter.value = hasResults.value ? query.value : null;
-    setButtonText();
     queryPending.value = false;
+}
+
+function onSectionFilter(filter: string) {
+    if (query.value !== filter) {
+        query.value = filter;
+        if (!showSections.value) {
+            onToggle();
+        }
+    } else {
+        query.value = "";
+    }
 }
 
 function onToggle() {
     showSections.value = !showSections.value;
-    setButtonText();
-}
-
-function setButtonText() {
-    buttonText.value = showSections.value ? localize("Hide Sections") : localize("Show Sections");
-    buttonIcon.value = showSections.value ? "fa-eye-slash" : "fa-eye";
 }
 </script>
 
@@ -299,7 +304,8 @@ function setButtonText() {
                             v-if="panel"
                             :category="panel || {}"
                             :query-filter="queryFilter || undefined"
-                            @onClick="onToolClick" />
+                            @onClick="onToolClick"
+                            @onFilter="onSectionFilter" />
                     </div>
                 </div>
                 <ToolSection

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -262,10 +262,10 @@ function onToggle() {
                     </b-button>
                 </div>
                 <div v-else-if="queryTooShort" class="pb-2">
-                    <b-badge class="alert-danger w-100">Search string too short!</b-badge>
+                    <b-badge class="alert-info w-100">Search term is too short</b-badge>
                 </div>
                 <div v-else-if="queryFinished && !hasResults" class="pb-2">
-                    <b-badge class="alert-danger w-100">No results found!</b-badge>
+                    <b-badge class="alert-warning w-100">No results found</b-badge>
                 </div>
                 <div v-if="closestTerm" class="pb-2">
                     <b-badge class="alert-danger w-100">
@@ -304,7 +304,7 @@ function onToggle() {
                             v-if="panel"
                             :category="panel || {}"
                             :query-filter="queryFilter || undefined"
-                            :has-filter-button="!!query && currentPanelView === 'default'"
+                            :has-filter-button="!!query && !queryTooShort && currentPanelView === 'default'"
                             @onClick="onToolClick"
                             @onFilter="onSectionFilter" />
                     </div>

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -72,7 +72,7 @@ const query = computed({
     },
 });
 
-const { currentPanel } = storeToRefs(toolStore);
+const { currentPanel, currentPanelView } = storeToRefs(toolStore);
 const hasResults = computed(() => results.value.length > 0);
 const queryTooShort = computed(() => query.value && query.value.length < 3);
 const queryFinished = computed(() => query.value && queryPending.value != true);
@@ -304,6 +304,7 @@ function onToggle() {
                             v-if="panel"
                             :category="panel || {}"
                             :query-filter="queryFilter || undefined"
+                            :has-filter-button="!!query && currentPanelView === 'default'"
                             @onClick="onToolClick"
                             @onFilter="onSectionFilter" />
                     </div>

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -304,7 +304,7 @@ function onToggle() {
                             v-if="panel"
                             :category="panel || {}"
                             :query-filter="queryFilter || undefined"
-                            :has-filter-button="!!query && !queryTooShort && currentPanelView === 'default'"
+                            :has-filter-button="hasResults && currentPanelView === 'default'"
                             @onClick="onToolClick"
                             @onFilter="onSectionFilter" />
                     </div>

--- a/client/src/components/Panels/utilities.test.js
+++ b/client/src/components/Panels/utilities.test.js
@@ -147,6 +147,14 @@ describe("test helpers in tool searching utilities", () => {
                 tools: Object.values(tempToolsList.tools),
                 panel: tempToolPanel.default,
             },
+            {
+                // section is searchable if provided "section:"
+                q: "section:Lift-Over",
+                expectedResults: ["liftOver1"],
+                keys: { description: 1, name: 2 },
+                tools: toolsList,
+                panel: toolsListInPanel,
+            },
             // if at least couple words match, return results
             {
                 q: "filter datasets",

--- a/client/src/stores/toolStore.ts
+++ b/client/src/stores/toolStore.ts
@@ -37,6 +37,7 @@ export interface ToolSection {
     model_class: string;
     id: string;
     name: string;
+    title?: string;
     version?: string;
     description?: string;
     links?: Record<string, string>;


### PR DESCRIPTION
Adds a button that only shows the desired tool section in the panel (by emitting a `section:Section Name` filter:
![filter_tool_section_button](https://github.com/galaxyproject/galaxy/assets/78516064/3549063f-4f47-4561-80da-c3f60b68fe3c)

Users can filter on tool ids or sections if they specify `id:tool_id` or `section:Section name` in the search bar.

Fixes https://github.com/galaxyproject/galaxy/issues/17741

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
