### PR TITLE
Tweak export records UI

### DIFF
--- a/client/src/components/Common/ExportRecordDetails.vue
+++ b/client/src/components/Common/ExportRecordDetails.vue
@@ -8,12 +8,13 @@ import {
     faLink,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BButton, BCard, BCardTitle } from "bootstrap-vue";
+import { BAlert, BButton } from "bootstrap-vue";
 import { computed } from "vue";
 
 import type { ColorVariant } from ".";
 import { ExportRecord } from "./models/exportRecordModel";
 
+import Heading from "@/components/Common/Heading.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 library.add(faCheckCircle, faClock, faExclamationCircle, faExclamationTriangle, faLink);
@@ -61,9 +62,9 @@ function onMessageDismissed() {
 
 <template>
     <div class="export-record-details">
-        <BCardTitle>
+        <Heading size="sm">
             <b>{{ title }}</b> {{ props.record.elapsedTime }}
-        </BCardTitle>
+        </Heading>
 
         <p v-if="!props.record.isPreparing">
             Format: <b class="record-archive-format">{{ props.record.modelStoreFormat }}</b>

--- a/client/src/components/Common/ExportRecordDetails.vue
+++ b/client/src/components/Common/ExportRecordDetails.vue
@@ -60,7 +60,7 @@ function onMessageDismissed() {
 </script>
 
 <template>
-    <BCard class="export-record-details">
+    <div class="export-record-details">
         <BCardTitle>
             <b>{{ title }}</b> {{ props.record.elapsedTime }}
         </BCardTitle>
@@ -149,5 +149,5 @@ function onMessageDismissed() {
                 </div>
             </div>
         </div>
-    </BCard>
+    </div>
 </template>

--- a/client/src/components/History/Export/HistoryExport.vue
+++ b/client/src/components/History/Export/HistoryExport.vue
@@ -270,28 +270,28 @@ function updateExportParams(newParams: ExportParams) {
             {{ errorMessage }}
         </BAlert>
         <div v-else-if="latestExportRecord">
-            <h2 class="h-md mt-3">Latest Export Record</h2>
-            <ExportRecordDetails
-                :record="latestExportRecord"
-                object-type="history"
-                class="mt-3"
-                :action-message="actionMessage"
-                :action-message-variant="actionMessageVariant"
-                @onDownload="downloadFromRecord"
-                @onCopyDownloadLink="copyDownloadLinkFromRecord"
-                @onReimport="reimportFromRecord"
-                @onActionMessageDismissed="onActionMessageDismissedFromRecord" />
+            <h2 class="h-md mt-3">Export Records</h2>
+            <BCard>
+                <ExportRecordDetails
+                    :record="latestExportRecord"
+                    object-type="history"
+                    :action-message="actionMessage"
+                    :action-message-variant="actionMessageVariant"
+                    @onDownload="downloadFromRecord"
+                    @onCopyDownloadLink="copyDownloadLinkFromRecord"
+                    @onReimport="reimportFromRecord"
+                    @onActionMessageDismissed="onActionMessageDismissedFromRecord" />
+                <ExportRecordTable
+                    v-if="hasPreviousExports"
+                    id="previous-export-records"
+                    :records="previousExportRecords"
+                    class="mt-3"
+                    @onDownload="downloadFromRecord"
+                    @onReimport="reimportFromRecord" />
+            </BCard>
         </div>
         <BAlert v-else id="no-export-records-alert" variant="info" class="mt-3" show>
             {{ availableRecordsMessage }}
         </BAlert>
-
-        <ExportRecordTable
-            v-if="hasPreviousExports"
-            id="previous-export-records"
-            :records="previousExportRecords"
-            class="mt-3"
-            @onDownload="downloadFromRecord"
-            @onReimport="reimportFromRecord" />
     </span>
 </template>


### PR DESCRIPTION
Minimal UI tweak for exporting histories after feedback from @wm75 

- Rename `Latest Export Record` to `Export Records`
- Show old records inside the same Card/section instead of having them completely separated. It helps to keep the context.

| Before | After |
|--------|-------|
| ![Screenshot from 2024-04-22 18-02-54](https://github.com/galaxyproject/galaxy/assets/46503462/544aa58e-db95-43a8-880c-494ade7d367f) | ![Screenshot from 2024-04-22 18-02-02](https://github.com/galaxyproject/galaxy/assets/46503462/2b68c09c-109f-4e2f-87f6-9137b89db0cb) |

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
