### PR TITLE
[24.0] Change wrong quota_source value from KeyError to ValueError

### DIFF
--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -592,7 +592,7 @@ class HistoryContentsFilters(
                     if val == "__null__":
                         val = None
                     if val not in ids:
-                        raise KeyError(f"Could not find key {val} in object store keys {list(ids.keys())}")
+                        raise ValueError(f"Could not find key {val} in object store keys {list(ids.keys())}")
                     object_store_ids = ids[val]
                     return sql.column("object_store_id").in_(object_store_ids)
 

--- a/test/integration/test_quota.py
+++ b/test/integration/test_quota.py
@@ -196,6 +196,13 @@ class TestQuotaIntegration(integration_util.IntegrationTestCase):
         labels = [q["quota_source_label"] for q in quotas]
         assert "mylabel" in labels
 
+        with self.dataset_populator.test_history() as history_id:
+            response = self.dataset_populator._get_contents_request(
+                history_id, data={"q": "quota_source_label-eq", "qv": "invalid", "v": "dev"}
+            )
+        assert response.status_code == 400
+        assert "unparsable value for filter" in response.json()["err_msg"]
+
     def _create_quota_with_name(self, quota_name: str, is_default: bool = False):
         payload = self._build_quota_payload_with_name(quota_name, is_default)
         create_response = self._post("quotas", data=payload, json=True)


### PR DESCRIPTION
Which is caught in https://github.com/galaxyproject/galaxy/blob/44782a44c14885df2d9d1bcb91698245bfb3aed8/lib/galaxy/managers/base.py#L1121-L1124

Fixes https://sentry.galaxyproject.org/share/issue/16a3342631224d8292ef792298175dea/:
```
KeyError: "Could not find key nul in object store keys [None, 'scratch']"
  File "starlette/applications.py", line 123, in __call__
    await self.middleware_stack(scope, receive, send)
  File "starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "starlette_context/middleware/raw_middleware.py", line 92, in __call__
    await self.app(scope, receive, send_wrapper)
  File "starlette/middleware/base.py", line 189, in __call__
    with collapse_excgroups():
  File "contextlib.py", line 155, in __exit__
    self.gen.throw(typ, value, traceback)
  File "starlette/_utils.py", line 93, in collapse_excgroups
    raise exc
  File "starlette/middleware/base.py", line 191, in __call__
    response = await self.dispatch_func(request, call_next)
  File "galaxy/webapps/galaxy/fast_app.py", line 108, in add_x_frame_options
    response = await call_next(request)
  File "starlette/middleware/base.py", line 165, in call_next
    raise app_exc
  File "starlette/middleware/base.py", line 151, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "starlette/routing.py", line 758, in __call__
    await self.middleware_stack(scope, receive, send)
  File "starlette/routing.py", line 778, in app
    await route.handle(scope, receive, send)
  File "starlette/routing.py", line 299, in handle
    await self.app(scope, receive, send)
  File "starlette/routing.py", line 79, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "starlette/routing.py", line 74, in app
    response = await func(request)
  File "fastapi/routing.py", line 278, in app
    raw_response = await run_endpoint_function(
  File "fastapi/routing.py", line 193, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "starlette/concurrency.py", line 42, in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
  File "anyio/to_thread.py", line 56, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
  File "anyio/_backends/_asyncio.py", line 2144, in run_sync_in_worker_thread
    return await future
  File "anyio/_backends/_asyncio.py", line 851, in run
    result = context.run(func, *args)
  File "galaxy/webapps/galaxy/api/history_contents.py", line 465, in index
    items = self.service.index(
  File "galaxy/webapps/galaxy/services/history_contents.py", line 312, in index
    return self.__index_v2(trans, history_id, params, serialization_params, filter_query_params, accept)
  File "galaxy/webapps/galaxy/services/history_contents.py", line 972, in __index_v2
    filters = self.history_contents_filters.parse_query_filters_with_relations(filter_query_params, history_id)
  File "galaxy/managers/history_contents.py", line 525, in parse_query_filters_with_relations
    return super().parse_query_filters(query_filters)
  File "galaxy/managers/base.py", line 1087, in parse_query_filters
    return self.parse_filters(filter_params)
  File "galaxy/managers/base.py", line 1096, in parse_filters
    filter_ = self.parse_filter(attr, op, val)
  File "galaxy/managers/base.py", line 1116, in parse_filter
    orm_filter = self._parse_orm_filter(attr, op, val)
  File "galaxy/managers/history_contents.py", line 601, in _parse_orm_filter
    if (column_filter := get_filter(attr, op, val)) is not None:
  File "galaxy/managers/history_contents.py", line 595, in get_filter
    raise KeyError(f"Could not find key {val} in object store keys {list(ids.keys())}")
```

Instead of no feedback and empty results users will see this:

![Screenshot 2024-04-22 at 19 28 55](https://github.com/galaxyproject/galaxy/assets/6804901/60514601-27fd-4e37-839a-4d839d061851)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
