### PR TITLE
[24.0] Adds logging of messageExceptions in the fastapi exception handler.

### DIFF
--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -30,7 +30,7 @@ class MessageException(Exception):
     # Error code information embedded into API json responses.
     err_code: ErrorCode = error_codes_by_name["UNKNOWN"]
 
-    def __init__(self, err_msg: str = "", type="info", **extra_error_info):
+    def __init__(self, err_msg: Optional[str] = None, type="info", **extra_error_info):
         self.err_msg = err_msg or self.err_code.default_error_message
         self.type = type
         self.extra_error_info = extra_error_info
@@ -64,7 +64,7 @@ class AcceptedRetryLater(MessageException):
     err_code = error_codes_by_name["ACCEPTED_RETRY_LATER"]
     retry_after: int
 
-    def __init__(self, msg: str, retry_after=60):
+    def __init__(self, msg: Optional[str] = None, retry_after=60):
         super().__init__(msg)
         self.retry_after = retry_after
 
@@ -136,7 +136,7 @@ class ToolMissingException(MessageException):
     status_code = 400
     err_code = error_codes_by_name["USER_TOOL_MISSING_PROBLEM"]
 
-    def __init__(self, err_msg: str = "", type="info", tool_id=None, **extra_error_info):
+    def __init__(self, err_msg: Optional[str] = None, type="info", tool_id=None, **extra_error_info):
         super().__init__(err_msg, type, **extra_error_info)
         self.tool_id = tool_id
 
@@ -152,7 +152,7 @@ class ToolInputsNotReadyException(MessageException):
 
 
 class ToolInputsNotOKException(MessageException):
-    def __init__(self, err_msg: str = "", type="info", *, src: str, id: int, **extra_error_info):
+    def __init__(self, err_msg: Optional[str] = None, type="info", *, src: str, id: int, **extra_error_info):
         super().__init__(err_msg, type, **extra_error_info)
         self.src = src
         self.id = id

--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -30,7 +30,7 @@ class MessageException(Exception):
     # Error code information embedded into API json responses.
     err_code: ErrorCode = error_codes_by_name["UNKNOWN"]
 
-    def __init__(self, err_msg=None, type="info", **extra_error_info):
+    def __init__(self, err_msg: str = "", type="info", **extra_error_info):
         self.err_msg = err_msg or self.err_code.default_error_message
         self.type = type
         self.extra_error_info = extra_error_info
@@ -64,7 +64,7 @@ class AcceptedRetryLater(MessageException):
     err_code = error_codes_by_name["ACCEPTED_RETRY_LATER"]
     retry_after: int
 
-    def __init__(self, msg, retry_after=60):
+    def __init__(self, msg: str, retry_after=60):
         super().__init__(msg)
         self.retry_after = retry_after
 
@@ -136,7 +136,7 @@ class ToolMissingException(MessageException):
     status_code = 400
     err_code = error_codes_by_name["USER_TOOL_MISSING_PROBLEM"]
 
-    def __init__(self, err_msg=None, type="info", tool_id=None, **extra_error_info):
+    def __init__(self, err_msg: str = "", type="info", tool_id=None, **extra_error_info):
         super().__init__(err_msg, type, **extra_error_info)
         self.tool_id = tool_id
 
@@ -152,7 +152,7 @@ class ToolInputsNotReadyException(MessageException):
 
 
 class ToolInputsNotOKException(MessageException):
-    def __init__(self, err_msg=None, type="info", *, src: str, id: int, **extra_error_info):
+    def __init__(self, err_msg: str = "", type="info", *, src: str, id: int, **extra_error_info):
         super().__init__(err_msg, type, **extra_error_info)
         self.src = src
         self.id = id

--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -16,6 +16,8 @@ have nothing to do with the web - keep this in mind when defining exception name
 and messages.
 """
 
+from typing import Optional
+
 from .error_codes import (
     error_codes_by_name,
     ErrorCode,

--- a/lib/galaxy/webapps/base/api.py
+++ b/lib/galaxy/webapps/base/api.py
@@ -201,7 +201,7 @@ def add_exception_handler(app: FastAPI) -> None:
         # Intentionally not logging traceback here as the full context will be
         # dispatched to Sentry if configured.  This just makes logs less opaque
         # when one sees a 500.
-        log.error(f"MessageException: {exc}")
+        log.info(f"MessageException: {exc}")
         return get_error_response_for_request(request, exc)
 
 

--- a/lib/galaxy/webapps/base/api.py
+++ b/lib/galaxy/webapps/base/api.py
@@ -198,6 +198,10 @@ def add_exception_handler(app: FastAPI) -> None:
 
     @app.exception_handler(MessageException)
     async def message_exception_middleware(request: Request, exc: MessageException) -> Response:
+        # Intentionally not logging traceback here as the full context will be
+        # dispatched to Sentry if configured.  This just makes logs less opaque
+        # when one sees a 500.
+        log.error(f"MessageException: {exc}")
         return get_error_response_for_request(request, exc)
 
 

--- a/lib/galaxy/webapps/base/api.py
+++ b/lib/galaxy/webapps/base/api.py
@@ -201,7 +201,8 @@ def add_exception_handler(app: FastAPI) -> None:
         # Intentionally not logging traceback here as the full context will be
         # dispatched to Sentry if configured.  This just makes logs less opaque
         # when one sees a 500.
-        log.info(f"MessageException: {exc}")
+        if exc.status_code >= 500:
+            log.info(f"MessageException: {exc}")
         return get_error_response_for_request(request, exc)
 
 

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2557,11 +2557,13 @@ def populate_module_and_state(
         step_args = param_map.get(step.id, {})
         step_errors = module_injector.compute_runtime_state(step, step_args=step_args)
         if step_errors:
-            raise exceptions.MessageException(step_errors, err_data={step.order_index: step_errors})
+            raise exceptions.MessageException(
+                "Error computing workflow step runtime state", err_data={step.order_index: step_errors}
+            )
         if step.upgrade_messages:
             if allow_tool_state_corrections:
                 log.debug('Workflow step "%i" had upgrade messages: %s', step.id, step.upgrade_messages)
             else:
                 raise exceptions.MessageException(
-                    step.upgrade_messages, err_data={step.order_index: step.upgrade_messages}
+                    "Workflow step has upgrade messages", err_data={step.order_index: step.upgrade_messages}
                 )


### PR DESCRIPTION
We're intentionally not doing a full log.exception with the traceback here, though we could.  This exception will also be dispatched to Sentry if configured, this just makes logs less opaque when one sees a 500.

Ping @natefoo -- this will now show something like this, so you at least know what the error was from the logs.

```
galaxy.webapps.base.api ERROR 2024-04-22 17:36:23,219 [pN:main.1,p:10417,tN:MainThread] MessageException: PDF conversion service not available.
uvicorn.access INFO 2024-04-22 17:36:23,221 [pN:main.1,p:10417,tN:MainThread] 127.0.0.1:44056 - "GET /api/invocations/79966582feb6c081/report.pdf HTTP/1.1" 501
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
