### PR TITLE
[24.0] Fix `null` values in tool expression

### DIFF
--- a/lib/galaxy/tools/parameters/wrapped_json.py
+++ b/lib/galaxy/tools/parameters/wrapped_json.py
@@ -136,7 +136,7 @@ def _json_wrap_input(input, value_wrapper, profile, handle_files="skip"):
                 if isinstance(value_wrapper, list):
                     value_wrapper = value_wrapper[0]
                 json_value = _hda_to_object(value_wrapper)
-                if input.load_contents:
+                if json_value is not None and input.load_contents:
                     with open(str(value_wrapper), mode="rb") as fh:
                         json_value["contents"] = fh.read(input.load_contents).decode("utf-8", errors="replace")
                 return json_value

--- a/tools/expression_tools/parse_values_from_file.xml
+++ b/tools/expression_tools/parse_values_from_file.xml
@@ -1,12 +1,15 @@
-<tool name="Parse parameter value" id="param_value_from_file" version="0.1.0" tool_type="expression">
+<tool name="Parse parameter value" id="param_value_from_file" version="0.1.1" tool_type="expression">
     <description>from dataset</description>
     <macros>
         <import>expression_macros.xml</import>
     </macros>
-    <expression type="ecma5.1">{
+    <expression type="ecma5.1"><![CDATA[{
 var output;
 if ($job.remove_newlines || $job.param_type != 'text') {
-   $job.input1.contents = $job.input1.contents.trim();
+    if($job.input1 && $job.input1.contents)
+    {
+        $job.input1.contents = $job.input1.contents.trim();
+    }
 }
 if ($job.param_type == 'integer') {
     output = parseInt($job.input1.contents);
@@ -25,12 +28,12 @@ if ($job.param_type == 'integer') {
         return 'NOT A BOOLEAN VALUE';
     }
 } else {
-    output = $job.input1.contents;
+    output = $job.input1?.contents;
 }
 return {'output': output};
-    }</expression>
+    }]]></expression>
     <inputs>
-        <param type="data" label="Input file containing parameter to parse out of" load_contents="64000" name="input1" />
+        <param type="data" label="Input file containing parameter to parse out of" load_contents="64000" name="input1"/>
         <param name="param_type" type="select" label="Select type of parameter to parse">
             <option value="text">Text</option>
             <option value="integer">Integer</option>
@@ -39,7 +42,7 @@ return {'output': output};
         </param>
         <param name="remove_newlines" checked="true" type="boolean" label="Remove newlines ?" help="Uncheck this only if newlines should be preserved in parameter"/>
     </inputs>
-    <expand macro="typed_outputs" />
+    <expand macro="typed_outputs"/>
     <tests>
         <test expect_num_outputs="1">
             <param name="input1" value="simple_line.txt"/>
@@ -92,5 +95,5 @@ return {'output': output};
             </output>
         </test>
     </tests>
-    <help></help>
+    <help/>
 </tool>


### PR DESCRIPTION
Fixes #17960

WIP

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Create a paste upload with `null` and set the datatype to `expression.json`
  - Create a Workflow and add a step with `Expression Tools -> Parse parameter value`
  - Run the workflow passing the `expression.json` dataset as input
  - Observe the result

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
