### PR TITLE
Add stronger type annotations in file sources + refactoring

### DIFF
--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -8,7 +8,7 @@ from typing import (
 from typing_extensions import Unpack
 
 from galaxy.exceptions import AuthenticationRequired
-from galaxy.files import ProvidesUserFileSourcesUserContext
+from galaxy.files import OptionalUserContext
 from galaxy.files.sources import (
     BaseFilesSource,
     FilesSourceProperties,
@@ -18,8 +18,6 @@ from galaxy.files.sources import (
 )
 
 log = logging.getLogger(__name__)
-
-OptionalUserContext = Optional[ProvidesUserFileSourcesUserContext]
 
 
 class RDMFilesSourceProperties(FilesSourceProperties):

--- a/lib/galaxy/files/sources/base64.py
+++ b/lib/galaxy/files/sources/base64.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from typing_extensions import Unpack
 
+from galaxy.files import OptionalUserContext
 from . import (
     BaseFilesSource,
     FilesSourceOptions,
@@ -30,14 +31,22 @@ class Base64FilesSource(BaseFilesSource):
         self._props = props
 
     def _realize_to(
-        self, source_path: str, native_path: str, user_context=None, opts: Optional[FilesSourceOptions] = None
+        self,
+        source_path: str,
+        native_path: str,
+        user_context: OptionalUserContext = None,
+        opts: Optional[FilesSourceOptions] = None,
     ):
         with open(native_path, "wb") as temp:
             temp.write(base64.b64decode(source_path[len("base64://") :]))
             temp.flush()
 
     def _write_from(
-        self, target_path: str, native_path: str, user_context=None, opts: Optional[FilesSourceOptions] = None
+        self,
+        target_path: str,
+        native_path: str,
+        user_context: OptionalUserContext = None,
+        opts: Optional[FilesSourceOptions] = None,
     ):
         raise NotImplementedError()
 
@@ -47,7 +56,7 @@ class Base64FilesSource(BaseFilesSource):
         else:
             return 0
 
-    def _serialization_props(self, user_context=None):
+    def _serialization_props(self, user_context: OptionalUserContext = None):
         effective_props = {}
         for key, val in self._props.items():
             effective_props[key] = self._evaluate_prop(val, user_context=user_context)

--- a/lib/galaxy/files/sources/drs.py
+++ b/lib/galaxy/files/sources/drs.py
@@ -8,6 +8,7 @@ from typing import (
 
 from typing_extensions import Unpack
 
+from galaxy.files import OptionalUserContext
 from . import (
     BaseFilesSource,
     FilesSourceOptions,
@@ -48,7 +49,13 @@ class DRSFilesSource(BaseFilesSource):
     def _allowlist(self):
         return self._file_sources_config.fetch_url_allowlist
 
-    def _realize_to(self, source_path, native_path, user_context=None, opts: Optional[FilesSourceOptions] = None):
+    def _realize_to(
+        self,
+        source_path: str,
+        native_path: str,
+        user_context: OptionalUserContext = None,
+        opts: Optional[FilesSourceOptions] = None,
+    ):
         props = self._serialization_props(user_context)
         headers = props.pop("http_headers", {}) or {}
         fetch_drs_to_file(
@@ -60,7 +67,13 @@ class DRSFilesSource(BaseFilesSource):
             force_http=self._force_http,
         )
 
-    def _write_from(self, target_path, native_path, user_context=None, opts: Optional[FilesSourceOptions] = None):
+    def _write_from(
+        self,
+        target_path: str,
+        native_path: str,
+        user_context: OptionalUserContext = None,
+        opts: Optional[FilesSourceOptions] = None,
+    ):
         raise NotImplementedError()
 
     def score_url_match(self, url: str):
@@ -69,7 +82,7 @@ class DRSFilesSource(BaseFilesSource):
         else:
             return 0
 
-    def _serialization_props(self, user_context=None) -> DRSFilesSourceProperties:
+    def _serialization_props(self, user_context: OptionalUserContext = None) -> DRSFilesSourceProperties:
         effective_props = {}
         for key, val in self._props.items():
             effective_props[key] = self._evaluate_prop(val, user_context=user_context)

--- a/lib/galaxy/files/sources/ftp.py
+++ b/lib/galaxy/files/sources/ftp.py
@@ -1,5 +1,7 @@
 import urllib.parse
 
+from galaxy.files import OptionalUserContext
+
 try:
     from fs.ftpfs import FTPFS
 except ImportError:
@@ -30,14 +32,18 @@ class FtpFilesSource(PyFilesystem2FilesSource):
     required_module = FTPFS
     required_package = "fs.ftpfs"
 
-    def _open_fs(self, user_context=None, opts: Optional[FilesSourceOptions] = None):
+    def _open_fs(self, user_context: OptionalUserContext = None, opts: Optional[FilesSourceOptions] = None):
         props = self._serialization_props(user_context)
         extra_props: FTPFilesSourceProperties = cast(FTPFilesSourceProperties, opts.extra_props or {} if opts else {})
         handle = FTPFS(**{**props, **extra_props})
         return handle
 
     def _realize_to(
-        self, source_path: str, native_path: str, user_context=None, opts: Optional[FilesSourceOptions] = None
+        self,
+        source_path: str,
+        native_path: str,
+        user_context: OptionalUserContext = None,
+        opts: Optional[FilesSourceOptions] = None,
     ):
         extra_props: FTPFilesSourceProperties
         if opts and opts.extra_props:
@@ -49,7 +55,11 @@ class FtpFilesSource(PyFilesystem2FilesSource):
         super()._realize_to(path, native_path, user_context=user_context, opts=opts)
 
     def _write_from(
-        self, target_path: str, native_path: str, user_context=None, opts: Optional[FilesSourceOptions] = None
+        self,
+        target_path: str,
+        native_path: str,
+        user_context: OptionalUserContext = None,
+        opts: Optional[FilesSourceOptions] = None,
     ):
         extra_props: FTPFilesSourceProperties
         if opts and opts.extra_props:

--- a/lib/galaxy/files/sources/http.py
+++ b/lib/galaxy/files/sources/http.py
@@ -10,6 +10,7 @@ from typing import (
 
 from typing_extensions import Unpack
 
+from galaxy.files import OptionalUserContext
 from galaxy.files.uris import validate_non_local
 from galaxy.util import (
     DEFAULT_SOCKET_TIMEOUT,
@@ -56,7 +57,11 @@ class HTTPFilesSource(BaseFilesSource):
         return self._file_sources_config.fetch_url_allowlist
 
     def _realize_to(
-        self, source_path: str, native_path: str, user_context=None, opts: Optional[FilesSourceOptions] = None
+        self,
+        source_path: str,
+        native_path: str,
+        user_context: OptionalUserContext = None,
+        opts: Optional[FilesSourceOptions] = None,
     ):
         props = self._serialization_props(user_context)
         extra_props: HTTPFilesSourceProperties = cast(HTTPFilesSourceProperties, opts.extra_props or {} if opts else {})
@@ -73,11 +78,15 @@ class HTTPFilesSource(BaseFilesSource):
             )
 
     def _write_from(
-        self, target_path: str, native_path: str, user_context=None, opts: Optional[FilesSourceOptions] = None
+        self,
+        target_path: str,
+        native_path: str,
+        user_context: OptionalUserContext = None,
+        opts: Optional[FilesSourceOptions] = None,
     ):
         raise NotImplementedError()
 
-    def _serialization_props(self, user_context=None) -> HTTPFilesSourceProperties:
+    def _serialization_props(self, user_context: OptionalUserContext = None) -> HTTPFilesSourceProperties:
         effective_props = {}
         for key, val in self._props.items():
             effective_props[key] = self._evaluate_prop(val, user_context=user_context)

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -4,6 +4,7 @@ import re
 import urllib.request
 from typing import (
     Any,
+    cast,
     Dict,
     List,
     Optional,
@@ -17,7 +18,9 @@ from typing_extensions import (
     Unpack,
 )
 
+from galaxy.files import OptionalUserContext
 from galaxy.files.sources import (
+    AnyRemoteEntry,
     DEFAULT_SCHEME,
     Entry,
     EntryData,
@@ -26,7 +29,6 @@ from galaxy.files.sources import (
     RemoteFile,
 )
 from galaxy.files.sources._rdm import (
-    OptionalUserContext,
     RDMFilesSource,
     RDMFilesSourceProperties,
     RDMRepositoryInteractor,
@@ -145,13 +147,15 @@ class InvenioRDMFilesSource(RDMFilesSource):
         recursive=True,
         user_context: OptionalUserContext = None,
         opts: Optional[FilesSourceOptions] = None,
-    ):
+    ) -> List[AnyRemoteEntry]:
         writeable = opts and opts.writeable or False
         is_root_path = path == "/"
         if is_root_path:
-            return self.repository.get_records(writeable, user_context)
+            records = self.repository.get_records(writeable, user_context)
+            return cast(List[AnyRemoteEntry], records)
         record_id = self.get_record_id_from_path(path)
-        return self.repository.get_files_in_record(record_id, writeable, user_context)
+        files = self.repository.get_files_in_record(record_id, writeable, user_context)
+        return cast(List[AnyRemoteEntry], files)
 
     def _create_entry(
         self,

--- a/lib/galaxy/files/sources/posix.py
+++ b/lib/galaxy/files/sources/posix.py
@@ -2,8 +2,6 @@ import functools
 import os
 import shutil
 from typing import (
-    Any,
-    Dict,
     List,
     Optional,
 )
@@ -11,12 +9,14 @@ from typing import (
 from typing_extensions import Unpack
 
 from galaxy import exceptions
+from galaxy.files import OptionalUserContext
 from galaxy.util.path import (
     safe_contains,
     safe_path,
     safe_walk,
 )
 from . import (
+    AnyRemoteEntry,
     BaseFilesSource,
     FilesSourceOptions,
     FilesSourceProperties,
@@ -53,14 +53,20 @@ class PosixFilesSource(BaseFilesSource):
         self.delete_on_realize = props.get("delete_on_realize", DEFAULT_DELETE_ON_REALIZE)
         self.allow_subdir_creation = props.get("allow_subdir_creation", DEFAULT_ALLOW_SUBDIR_CREATION)
 
-    def _list(self, path="/", recursive=True, user_context=None, opts: Optional[FilesSourceOptions] = None):
+    def _list(
+        self,
+        path="/",
+        recursive=True,
+        user_context: OptionalUserContext = None,
+        opts: Optional[FilesSourceOptions] = None,
+    ) -> List[AnyRemoteEntry]:
         if not self.root:
             raise exceptions.ItemAccessibilityException("Listing files at file:// URLs has been disabled.")
         dir_path = self._to_native_path(path, user_context=user_context)
         if not self._safe_directory(dir_path):
             raise exceptions.ObjectNotFound(f"The specified directory does not exist [{dir_path}].")
         if recursive:
-            res: List[Dict[str, Any]] = []
+            res: List[AnyRemoteEntry] = []
             effective_root = self._effective_root(user_context)
             for p, dirs, files in safe_walk(dir_path, allowlist=self._allowlist):
                 rel_dir = os.path.relpath(p, effective_root)
@@ -74,7 +80,11 @@ class PosixFilesSource(BaseFilesSource):
             return list(map(to_dict, res))
 
     def _realize_to(
-        self, source_path: str, native_path: str, user_context=None, opts: Optional[FilesSourceOptions] = None
+        self,
+        source_path: str,
+        native_path: str,
+        user_context: OptionalUserContext = None,
+        opts: Optional[FilesSourceOptions] = None,
     ):
         if not self.root and (not user_context or not user_context.is_admin):
             raise exceptions.ItemAccessibilityException("Writing to file:// URLs has been disabled.")
@@ -94,7 +104,11 @@ class PosixFilesSource(BaseFilesSource):
             shutil.move(source_native_path, native_path)
 
     def _write_from(
-        self, target_path: str, native_path: str, user_context=None, opts: Optional[FilesSourceOptions] = None
+        self,
+        target_path: str,
+        native_path: str,
+        user_context: OptionalUserContext = None,
+        opts: Optional[FilesSourceOptions] = None,
     ):
         effective_root = self._effective_root(user_context)
         target_native_path = self._to_native_path(target_path, user_context=user_context)
@@ -118,16 +132,16 @@ class PosixFilesSource(BaseFilesSource):
         shutil.copyfile(native_path, target_native_path_part)
         os.rename(target_native_path_part, target_native_path)
 
-    def _to_native_path(self, source_path: str, user_context=None):
+    def _to_native_path(self, source_path: str, user_context: OptionalUserContext = None):
         source_path = os.path.normpath(source_path)
         if source_path.startswith("/"):
             source_path = source_path[1:]
         return os.path.join(self._effective_root(user_context), source_path)
 
-    def _effective_root(self, user_context=None):
+    def _effective_root(self, user_context: OptionalUserContext = None):
         return self._evaluate_prop(self.root or "/", user_context=user_context)
 
-    def _resource_info_to_dict(self, dir: str, name: str, user_context=None):
+    def _resource_info_to_dict(self, dir: str, name: str, user_context: OptionalUserContext = None) -> AnyRemoteEntry:
         rel_path = os.path.normpath(os.path.join(dir, name))
         full_path = self._to_native_path(rel_path, user_context=user_context)
         uri = self.uri_from_path(rel_path)
@@ -155,7 +169,7 @@ class PosixFilesSource(BaseFilesSource):
             return False
         return True
 
-    def _serialization_props(self, user_context=None) -> PosixFilesSourceProperties:
+    def _serialization_props(self, user_context: OptionalUserContext = None) -> PosixFilesSourceProperties:
         return {
             # abspath needed because will be used by external Python from
             # a job working directory

--- a/lib/galaxy/files/sources/s3fs.py
+++ b/lib/galaxy/files/sources/s3fs.py
@@ -2,16 +2,16 @@ import functools
 import logging
 import os
 from typing import (
-    Any,
     cast,
-    Dict,
     List,
     Optional,
 )
 
 from typing_extensions import Unpack
 
+from galaxy.files import OptionalUserContext
 from . import (
+    AnyRemoteEntry,
     FilesSourceOptions,
     FilesSourceProperties,
 )
@@ -55,13 +55,19 @@ class S3FsFilesSource(BaseFilesSource):
         if self._endpoint_url:
             self._props.update({"client_kwargs": {"endpoint_url": self._endpoint_url}})
 
-    def _list(self, path="/", recursive=True, user_context=None, opts: Optional[FilesSourceOptions] = None):
+    def _list(
+        self,
+        path="/",
+        recursive=True,
+        user_context: OptionalUserContext = None,
+        opts: Optional[FilesSourceOptions] = None,
+    ) -> List[AnyRemoteEntry]:
         _props = self._serialization_props(user_context)
         # we need to pop the 'bucket' here, because the argument is not recognised in a downstream function
         _bucket_name = _props.pop("bucket", "")
         fs = self._open_fs(props=_props, opts=opts)
         if recursive:
-            res: List[Dict[str, Any]] = []
+            res: List[AnyRemoteEntry] = []
             bucket_path = self._bucket_path(_bucket_name, path)
             for p, dirs, files in fs.walk(bucket_path, detail=True):
                 to_dict = functools.partial(self._resource_info_to_dict, p)
@@ -74,14 +80,26 @@ class S3FsFilesSource(BaseFilesSource):
             to_dict = functools.partial(self._resource_info_to_dict, path)
             return list(map(to_dict, res))
 
-    def _realize_to(self, source_path, native_path, user_context=None, opts: Optional[FilesSourceOptions] = None):
+    def _realize_to(
+        self,
+        source_path: str,
+        native_path: str,
+        user_context: OptionalUserContext = None,
+        opts: Optional[FilesSourceOptions] = None,
+    ):
         _props = self._serialization_props(user_context)
         _bucket_name = _props.pop("bucket", "")
         fs = self._open_fs(props=_props, opts=opts)
         bucket_path = self._bucket_path(_bucket_name, source_path)
         fs.download(bucket_path, native_path)
 
-    def _write_from(self, target_path, native_path, user_context=None, opts: Optional[FilesSourceOptions] = None):
+    def _write_from(
+        self,
+        target_path,
+        native_path,
+        user_context: OptionalUserContext = None,
+        opts: Optional[FilesSourceOptions] = None,
+    ):
         _props = self._serialization_props(user_context)
         _bucket_name = _props.pop("bucket", "")
         fs = self._open_fs(props=_props, opts=opts)
@@ -100,7 +118,7 @@ class S3FsFilesSource(BaseFilesSource):
         fs = s3fs.S3FileSystem(**{**props, **extra_props})
         return fs
 
-    def _resource_info_to_dict(self, dir_path: str, resource_info):
+    def _resource_info_to_dict(self, dir_path: str, resource_info) -> AnyRemoteEntry:
         name = os.path.basename(resource_info["name"])
         path = os.path.join(dir_path, name)
         uri = self.uri_from_path(path)
@@ -117,7 +135,7 @@ class S3FsFilesSource(BaseFilesSource):
                 "path": path,
             }
 
-    def _serialization_props(self, user_context=None) -> S3FsFilesSourceProperties:
+    def _serialization_props(self, user_context: OptionalUserContext = None) -> S3FsFilesSourceProperties:
         effective_props = {}
         for key, val in self._props.items():
             effective_props[key] = self._evaluate_prop(val, user_context=user_context)

--- a/lib/galaxy/files/sources/util.py
+++ b/lib/galaxy/files/sources/util.py
@@ -12,7 +12,7 @@ import requests
 from galaxy import exceptions
 from galaxy.files import (
     ConfiguredFileSources,
-    FileSourceDictifiable,
+    FileSourcesUserContext,
 )
 from galaxy.files.sources import FilesSourceOptions
 from galaxy.files.sources.http import HTTPFilesSourceProperties
@@ -79,7 +79,7 @@ def _get_access_info(obj_url: str, access_method: dict, headers=None) -> Tuple[s
 def fetch_drs_to_file(
     drs_uri: str,
     target_path: TargetPathT,
-    user_context: FileSourceDictifiable,
+    user_context: Optional[FileSourcesUserContext],
     force_http=False,
     retry_options: Optional[RetryOptions] = None,
     headers: Optional[dict] = None,

--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -17,7 +17,7 @@ from typing import (
 from galaxy.files import (
     ConfiguredFileSources,
     DictFileSourcesUserContext,
-    ProvidesUserFileSourcesUserContext,
+    FileSourcesUserContext,
 )
 from galaxy.job_execution.datasets import (
     DatasetPath,
@@ -109,13 +109,13 @@ class JobIO(Dictifiable):
         check_job_script_integrity_count: int,
         check_job_script_integrity_sleep: float,
         file_sources_dict: Dict[str, Any],
-        user_context: Union[ProvidesUserFileSourcesUserContext, Dict["str", Any]],
+        user_context: Union[FileSourcesUserContext, Dict[str, Any]],
         tool_source: Optional[str] = None,
         tool_source_class: Optional["str"] = "XmlToolSource",
         tool_dir: Optional[str] = None,
         is_task: bool = False,
     ):
-        user_context_instance: Union[ProvidesUserFileSourcesUserContext, DictFileSourcesUserContext]
+        user_context_instance: FileSourcesUserContext
         self.file_sources_dict = file_sources_dict
         if isinstance(user_context, dict):
             user_context_instance = DictFileSourcesUserContext(**user_context, file_sources=self.file_sources)

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -38,7 +38,7 @@ from galaxy.exceptions import (
     ObjectInvalid,
     ObjectNotFound,
 )
-from galaxy.files import ProvidesUserFileSourcesUserContext
+from galaxy.files import ProvidesFileSourcesUserContext
 from galaxy.job_execution.actions.post import ActionBox
 from galaxy.job_execution.compute_environment import SharedComputeEnvironment
 from galaxy.job_execution.output_collect import (
@@ -1060,7 +1060,7 @@ class MinimalJobWrapper(HasResourceParameters):
         if self._job_io is None:
             job = self.get_job()
             work_request = WorkRequestContext(self.app, user=job.user, galaxy_session=job.galaxy_session)
-            user_context = ProvidesUserFileSourcesUserContext(work_request)
+            user_context = ProvidesFileSourcesUserContext(work_request)
             tool_source = self.tool and self.tool.tool_source.to_string()
             self._job_io = JobIO(
                 sa_session=self.sa_session,

--- a/lib/galaxy/managers/remote_files.py
+++ b/lib/galaxy/managers/remote_files.py
@@ -10,7 +10,7 @@ from galaxy import exceptions
 from galaxy.files import (
     ConfiguredFileSources,
     FileSourcePath,
-    ProvidesUserFileSourcesUserContext,
+    ProvidesFileSourcesUserContext,
 )
 from galaxy.files.sources import (
     FilesSourceOptions,
@@ -53,7 +53,7 @@ class RemoteFilesManager:
     ) -> AnyRemoteFilesListResponse:
         """Returns a list of remote files available to the user."""
 
-        user_file_source_context = ProvidesUserFileSourcesUserContext(user_ctx)
+        user_file_source_context = ProvidesFileSourcesUserContext(user_ctx)
         default_recursive = False
         default_format = RemoteFilesFormat.uri
 
@@ -143,7 +143,7 @@ class RemoteFilesManager:
         exclude_kind: Optional[Set[PluginKind]] = None,
     ):
         """Display plugin information for each of the gxfiles:// URI targets available."""
-        user_file_source_context = ProvidesUserFileSourcesUserContext(user_context)
+        user_file_source_context = ProvidesFileSourcesUserContext(user_context)
         browsable_only = True if browsable_only is None else browsable_only
         plugins_dict = self._file_sources.plugins_to_dict(
             user_context=user_file_source_context,
@@ -160,7 +160,7 @@ class RemoteFilesManager:
     def create_entry(self, user_ctx: ProvidesUserContext, entry_data: CreateEntryPayload) -> CreatedEntryResponse:
         """Create an entry (directory or record) in a remote files location."""
         target = entry_data.target
-        user_file_source_context = ProvidesUserFileSourcesUserContext(user_ctx)
+        user_file_source_context = ProvidesFileSourcesUserContext(user_ctx)
         self._file_sources.validate_uri_root(target, user_context=user_file_source_context)
         file_source_path = self._file_sources.get_file_source_path(target)
         file_source = file_source_path.file_source

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -57,7 +57,7 @@ from galaxy.exceptions import (
 )
 from galaxy.files import (
     ConfiguredFileSources,
-    ProvidesUserFileSourcesUserContext,
+    ProvidesFileSourcesUserContext,
 )
 from galaxy.files.uris import stream_url_to_file
 from galaxy.model.base import (
@@ -1902,7 +1902,7 @@ class DirectoryModelExportStore(ModelExportStore):
             sessionless = True
             security = IdEncodingHelper(id_secret="randomdoesntmatter")
 
-        self.user_context = ProvidesUserFileSourcesUserContext(user_context)
+        self.user_context = ProvidesFileSourcesUserContext(user_context)
         self.file_sources = file_sources
         self.serialize_jobs = serialize_jobs
         self.sessionless = sessionless
@@ -3033,7 +3033,7 @@ def source_to_import_store(
         if source_uri.startswith("file://"):
             source_uri = source_uri[len("file://") :]
         if "://" in source_uri:
-            user_context = ProvidesUserFileSourcesUserContext(user_context)
+            user_context = ProvidesFileSourcesUserContext(user_context)
             source_uri = stream_url_to_file(
                 source_uri, app.file_sources, prefix="gx_import_model_store", user_context=user_context
             )

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -25,7 +25,7 @@ from packaging.version import Version
 from webob.compat import cgi_FieldStorage
 
 from galaxy import util
-from galaxy.files import ProvidesUserFileSourcesUserContext
+from galaxy.files import ProvidesFileSourcesUserContext
 from galaxy.managers.dbkeys import read_dbnames
 from galaxy.model import (
     cached_id,
@@ -2633,7 +2633,7 @@ class DirectoryUriToolParameter(SimpleTextToolParameter):
         file_source = file_source_path.file_source
         if file_source is None:
             raise ParameterValueError(f"'{value}' is not a valid file source uri.", self.name)
-        user_context = ProvidesUserFileSourcesUserContext(trans)
+        user_context = ProvidesFileSourcesUserContext(trans)
         user_has_access = file_source.user_has_access(user_context)
         if not user_has_access:
             raise ParameterValueError(f"The user cannot access {value}.", self.name)

--- a/test/unit/files/_util.py
+++ b/test/unit/files/_util.py
@@ -6,6 +6,7 @@ import tempfile
 from galaxy.files import (
     ConfiguredFileSources,
     DictFileSourcesUserContext,
+    OptionalUserContext,
 )
 from galaxy.files.plugins import FileSourcePluginsConfig
 
@@ -13,7 +14,7 @@ TEST_USERNAME = "alice"
 TEST_EMAIL = "alice@galaxyproject.org"
 
 
-def serialize_and_recover(file_sources_o, user_context=None):
+def serialize_and_recover(file_sources_o: ConfiguredFileSources, user_context: OptionalUserContext = None):
     as_dict = file_sources_o.to_dict(for_serialization=True, user_context=user_context)
     file_sources = ConfiguredFileSources.from_dict(as_dict)
     return file_sources
@@ -33,14 +34,24 @@ def find(dir_list, class_=None, name=None):
     return None
 
 
-def list_root(file_sources, uri, recursive, user_context=None):
+def list_root(
+    file_sources: ConfiguredFileSources,
+    uri: str,
+    recursive: bool,
+    user_context: OptionalUserContext = None,
+):
     file_source_pair = file_sources.get_file_source_path(uri)
     file_source = file_source_pair.file_source
     res = file_source.list("/", recursive=recursive, user_context=user_context)
     return res
 
 
-def list_dir(file_sources, uri, recursive, user_context=None):
+def list_dir(
+    file_sources: ConfiguredFileSources,
+    uri: str,
+    recursive: bool,
+    user_context: OptionalUserContext = None,
+):
     file_source_pair = file_sources.get_file_source_path(uri)
     file_source = file_source_pair.file_source
     print(file_source_pair.path)
@@ -82,7 +93,9 @@ def user_context_fixture(user_ftp_dir=None, role_names=None, group_names=None, i
     return user_context
 
 
-def realize_to_temp_file(file_sources, uri, user_context=None):
+def realize_to_temp_file(
+    file_sources: ConfiguredFileSources, uri: str, user_context: OptionalUserContext = None
+) -> str:
     file_source_path = file_sources.get_file_source_path(uri)
     with tempfile.NamedTemporaryFile(mode="r") as temp:
         file_source_path.file_source.realize_to(file_source_path.path, temp.name, user_context=user_context)
@@ -91,7 +104,12 @@ def realize_to_temp_file(file_sources, uri, user_context=None):
             return realized_contents
 
 
-def assert_realizes_as(file_sources, uri, expected, user_context=None):
+def assert_realizes_as(
+    file_sources: ConfiguredFileSources,
+    uri: str,
+    expected: str,
+    user_context: OptionalUserContext = None,
+):
     realized_contents = realize_to_temp_file(file_sources, uri, user_context=user_context)
     if realized_contents != expected:
         raise AssertionError(
@@ -99,7 +117,12 @@ def assert_realizes_as(file_sources, uri, expected, user_context=None):
         )
 
 
-def assert_realizes_contains(file_sources, uri, expected, user_context=None):
+def assert_realizes_contains(
+    file_sources: ConfiguredFileSources,
+    uri: str,
+    expected: str,
+    user_context: OptionalUserContext = None,
+):
     realized_contents = realize_to_temp_file(file_sources, uri, user_context=user_context)
     if expected not in realized_contents:
         raise AssertionError(
@@ -107,7 +130,9 @@ def assert_realizes_contains(file_sources, uri, expected, user_context=None):
         )
 
 
-def assert_realizes_throws_exception(file_sources, uri, user_context=None) -> Exception:
+def assert_realizes_throws_exception(
+    file_sources: ConfiguredFileSources, uri: str, user_context: OptionalUserContext = None
+) -> Exception:
     exception = None
     try:
         realize_to_temp_file(file_sources, uri, user_context=user_context)
@@ -117,7 +142,12 @@ def assert_realizes_throws_exception(file_sources, uri, user_context=None) -> Ex
     return exception
 
 
-def write_from(file_sources, uri, content, user_context=None):
+def write_from(
+    file_sources: ConfiguredFileSources,
+    uri: str,
+    content: str,
+    user_context: OptionalUserContext = None,
+):
     file_source_path = file_sources.get_file_source_path(uri)
     with tempfile.NamedTemporaryFile(mode="w") as f:
         f.write(content)


### PR DESCRIPTION
Maybe it is a bit too much, but with this, all functions are consistently annotated around file sources.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
