### PR TITLE
Add pagination support to Files Source plugins

### DIFF
--- a/client/src/api/remoteFiles.ts
+++ b/client/src/api/remoteFiles.ts
@@ -51,10 +51,18 @@ export const remoteFilesFetcher = fetcher.path("/api/remote_files").method("get"
  * @param uri The file source URI to browse.
  * @param isRecursive Whether to recursively retrieve all files inside subdirectories.
  * @param writeable Whether to return only entries that can be written to.
+ * @param limit The maximum number of entries to return.
+ * @param offset The number of entries to skip before returning the rest.
  * @returns The list of files and directories from the server for the given URI.
  */
-export async function browseRemoteFiles(uri: string, isRecursive = false, writeable = false): Promise<RemoteEntry[]> {
-    const { data } = await remoteFilesFetcher({ target: uri, recursive: isRecursive, writeable });
+export async function browseRemoteFiles(
+    uri: string,
+    isRecursive = false,
+    writeable = false,
+    limit?: number,
+    offset?: number
+): Promise<RemoteEntry[]> {
+    const { data } = await remoteFilesFetcher({ target: uri, recursive: isRecursive, writeable, limit, offset });
     return data as RemoteEntry[];
 }
 

--- a/client/src/api/remoteFiles.ts
+++ b/client/src/api/remoteFiles.ts
@@ -46,6 +46,11 @@ export async function fetchFileSources(options: FilterFileSourcesOptions = {}): 
 
 export const remoteFilesFetcher = fetcher.path("/api/remote_files").method("get").create();
 
+export interface BrowseRemoteFilesResult {
+    entries: RemoteEntry[];
+    totalMatches: number;
+}
+
 /**
  * Get the list of files and directories from the server for the given file source URI.
  * @param uri The file source URI to browse.
@@ -65,8 +70,8 @@ export async function browseRemoteFiles(
     offset?: number,
     query?: string,
     sortBy?: string
-): Promise<RemoteEntry[]> {
-    const { data } = await remoteFilesFetcher({
+): Promise<BrowseRemoteFilesResult> {
+    const { data, headers } = await remoteFilesFetcher({
         target: uri,
         recursive: isRecursive,
         writeable,
@@ -75,7 +80,8 @@ export async function browseRemoteFiles(
         query,
         sort_by: sortBy,
     });
-    return data as RemoteEntry[];
+    const totalMatches = parseInt(headers.get("total_matches") ?? "0");
+    return { entries: data as RemoteEntry[], totalMatches };
 }
 
 const createEntry = fetcher.path("/api/remote_files").method("post").create();

--- a/client/src/api/remoteFiles.ts
+++ b/client/src/api/remoteFiles.ts
@@ -54,6 +54,7 @@ export const remoteFilesFetcher = fetcher.path("/api/remote_files").method("get"
  * @param limit The maximum number of entries to return.
  * @param offset The number of entries to skip before returning the rest.
  * @param query The query string to filter the entries.
+ * @param sortBy The field to sort the entries by.
  * @returns The list of files and directories from the server for the given URI.
  */
 export async function browseRemoteFiles(
@@ -62,9 +63,18 @@ export async function browseRemoteFiles(
     writeable = false,
     limit?: number,
     offset?: number,
-    query?: string
+    query?: string,
+    sortBy?: string
 ): Promise<RemoteEntry[]> {
-    const { data } = await remoteFilesFetcher({ target: uri, recursive: isRecursive, writeable, limit, offset, query });
+    const { data } = await remoteFilesFetcher({
+        target: uri,
+        recursive: isRecursive,
+        writeable,
+        limit,
+        offset,
+        query,
+        sort_by: sortBy,
+    });
     return data as RemoteEntry[];
 }
 

--- a/client/src/api/remoteFiles.ts
+++ b/client/src/api/remoteFiles.ts
@@ -53,6 +53,7 @@ export const remoteFilesFetcher = fetcher.path("/api/remote_files").method("get"
  * @param writeable Whether to return only entries that can be written to.
  * @param limit The maximum number of entries to return.
  * @param offset The number of entries to skip before returning the rest.
+ * @param query The query string to filter the entries.
  * @returns The list of files and directories from the server for the given URI.
  */
 export async function browseRemoteFiles(
@@ -60,9 +61,10 @@ export async function browseRemoteFiles(
     isRecursive = false,
     writeable = false,
     limit?: number,
-    offset?: number
+    offset?: number,
+    query?: string
 ): Promise<RemoteEntry[]> {
-    const { data } = await remoteFilesFetcher({ target: uri, recursive: isRecursive, writeable, limit, offset });
+    const { data } = await remoteFilesFetcher({ target: uri, recursive: isRecursive, writeable, limit, offset, query });
     return data as RemoteEntry[];
 }
 

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -2702,6 +2702,15 @@ export interface components {
              */
             requires_roles?: string | null;
             /**
+             * @description Features supported by this file source.
+             * @default {
+             *   "pagination": false,
+             *   "search": false,
+             *   "sorting": false
+             * }
+             */
+            supports?: components["schemas"]["FilesSourceSupports"];
+            /**
              * Type
              * @description The type of the plugin.
              */
@@ -5336,6 +5345,15 @@ export interface components {
              */
             requires_roles?: string | null;
             /**
+             * @description Features supported by this file source.
+             * @default {
+             *   "pagination": false,
+             *   "search": false,
+             *   "sorting": false
+             * }
+             */
+            supports?: components["schemas"]["FilesSourceSupports"];
+            /**
              * Type
              * @description The type of the plugin.
              */
@@ -5359,6 +5377,27 @@ export interface components {
             | components["schemas"]["BrowsableFilesSourcePlugin"]
             | components["schemas"]["FilesSourcePlugin"]
         )[];
+        /** FilesSourceSupports */
+        FilesSourceSupports: {
+            /**
+             * Pagination
+             * @description Whether this file source supports server-side pagination.
+             * @default false
+             */
+            pagination?: boolean;
+            /**
+             * Search
+             * @description Whether this file source supports server-side search.
+             * @default false
+             */
+            search?: boolean;
+            /**
+             * Sorting
+             * @description Whether this file source supports server-side sorting.
+             * @default false
+             */
+            sorting?: boolean;
+        };
         /** FillStepDefaultsAction */
         FillStepDefaultsAction: {
             /**

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -15567,6 +15567,7 @@ export interface operations {
             /** @description Maximum number of entries to return. */
             /** @description Number of entries to skip. */
             /** @description Search query to filter entries by. The syntax could be different depending on the target source. */
+            /** @description Sort the entries by the specified field. */
             query?: {
                 target?: string;
                 format?: components["schemas"]["RemoteFilesFormat"] | null;
@@ -21890,6 +21891,7 @@ export interface operations {
             /** @description Maximum number of entries to return. */
             /** @description Number of entries to skip. */
             /** @description Search query to filter entries by. The syntax could be different depending on the target source. */
+            /** @description Sort the entries by the specified field. */
             query?: {
                 target?: string;
                 format?: components["schemas"]["RemoteFilesFormat"] | null;

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -412,6 +412,8 @@ export interface paths {
          * Displays remote files available to the user. Please use /api/remote_files instead.
          * @deprecated
          * @description Lists all remote files available to the user from different sources.
+         *
+         * The total count of files and directories is returned in the 'total_matches' header.
          */
         get: operations["index_api_ftp_files_get"];
     };
@@ -1453,6 +1455,8 @@ export interface paths {
         /**
          * Displays remote files available to the user.
          * @description Lists all remote files available to the user from different sources.
+         *
+         * The total count of files and directories is returned in the 'total_matches' header.
          */
         get: operations["index_api_remote_files_get"];
         /**
@@ -15596,6 +15600,8 @@ export interface operations {
          * Displays remote files available to the user. Please use /api/remote_files instead.
          * @deprecated
          * @description Lists all remote files available to the user from different sources.
+         *
+         * The total count of files and directories is returned in the 'total_matches' header.
          */
         parameters?: {
             /** @description The source to load datasets from. Possible values: ftpdir, userdir, importdir */
@@ -21920,6 +21926,8 @@ export interface operations {
         /**
          * Displays remote files available to the user.
          * @description Lists all remote files available to the user from different sources.
+         *
+         * The total count of files and directories is returned in the 'total_matches' header.
          */
         parameters?: {
             /** @description The source to load datasets from. Possible values: ftpdir, userdir, importdir */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -15566,6 +15566,7 @@ export interface operations {
             /** @description Whether the query is made with the intention of writing to the source. If set to True, only entries that can be written to will be returned. */
             /** @description Maximum number of entries to return. */
             /** @description Number of entries to skip. */
+            /** @description Search query to filter entries by. The syntax could be different depending on the target source. */
             query?: {
                 target?: string;
                 format?: components["schemas"]["RemoteFilesFormat"] | null;
@@ -15574,6 +15575,7 @@ export interface operations {
                 writeable?: boolean | null;
                 limit?: number | null;
                 offset?: number | null;
+                query?: string | null;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -21886,6 +21888,7 @@ export interface operations {
             /** @description Whether the query is made with the intention of writing to the source. If set to True, only entries that can be written to will be returned. */
             /** @description Maximum number of entries to return. */
             /** @description Number of entries to skip. */
+            /** @description Search query to filter entries by. The syntax could be different depending on the target source. */
             query?: {
                 target?: string;
                 format?: components["schemas"]["RemoteFilesFormat"] | null;
@@ -21894,6 +21897,7 @@ export interface operations {
                 writeable?: boolean | null;
                 limit?: number | null;
                 offset?: number | null;
+                query?: string | null;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -15564,12 +15564,16 @@ export interface operations {
             /** @description Whether to recursively lists all sub-directories. This will be `True` by default depending on the `target`. */
             /** @description (This only applies when `format` is `jstree`) The value can be either `folders` or `files` and it will disable the corresponding nodes of the tree. */
             /** @description Whether the query is made with the intention of writing to the source. If set to True, only entries that can be written to will be returned. */
+            /** @description Maximum number of entries to return. */
+            /** @description Number of entries to skip. */
             query?: {
                 target?: string;
                 format?: components["schemas"]["RemoteFilesFormat"] | null;
                 recursive?: boolean | null;
                 disable?: components["schemas"]["RemoteFilesDisableMode"] | null;
                 writeable?: boolean | null;
+                limit?: number | null;
+                offset?: number | null;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -21880,12 +21884,16 @@ export interface operations {
             /** @description Whether to recursively lists all sub-directories. This will be `True` by default depending on the `target`. */
             /** @description (This only applies when `format` is `jstree`) The value can be either `folders` or `files` and it will disable the corresponding nodes of the tree. */
             /** @description Whether the query is made with the intention of writing to the source. If set to True, only entries that can be written to will be returned. */
+            /** @description Maximum number of entries to return. */
+            /** @description Number of entries to skip. */
             query?: {
                 target?: string;
                 format?: components["schemas"]["RemoteFilesFormat"] | null;
                 recursive?: boolean | null;
                 disable?: components["schemas"]["RemoteFilesDisableMode"] | null;
                 writeable?: boolean | null;
+                limit?: number | null;
+                offset?: number | null;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -15576,6 +15576,7 @@ export interface operations {
                 limit?: number | null;
                 offset?: number | null;
                 query?: string | null;
+                sort_by?: string | null;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -21898,6 +21899,7 @@ export interface operations {
                 limit?: number | null;
                 offset?: number | null;
                 query?: string | null;
+                sort_by?: string | null;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {

--- a/client/src/components/FilesDialog/FilesDialog.test.ts
+++ b/client/src/components/FilesDialog/FilesDialog.test.ts
@@ -88,7 +88,8 @@ function getMockedBrowseResponse(param: RemoteFilesParams) {
         throw Error(someErrorText);
     }
     const result = mockedOkApiRoutesMap.get(responseKey);
-    return { data: result };
+    const headers = new Map([["total_matches", result?.length.toString() ?? "0"]]);
+    return { data: result, headers };
 }
 
 const initComponent = async (props: { multiple: boolean; mode?: string }) => {

--- a/client/src/components/FilesDialog/FilesDialog.test.ts
+++ b/client/src/components/FilesDialog/FilesDialog.test.ts
@@ -1,3 +1,4 @@
+import { createTestingPinia } from "@pinia/testing";
 import { mount, Wrapper } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { getLocalVue } from "tests/jest/helpers";
@@ -98,9 +99,11 @@ const initComponent = async (props: { multiple: boolean; mode?: string }) => {
     mockFetcher.path("/api/remote_files/plugins").method("get").mock({ data: rootResponse });
     mockFetcher.path("/api/remote_files").method("get").mock(getMockedBrowseResponse);
 
+    const testingPinia = createTestingPinia({ stubActions: false });
     const wrapper = mount(FilesDialog, {
         localVue,
         propsData: { ...props, modalStatic: true },
+        pinia: testingPinia,
     });
 
     await flushPromises();

--- a/client/src/components/SelectionDialog/DataDialogSearch.vue
+++ b/client/src/components/SelectionDialog/DataDialogSearch.vue
@@ -34,7 +34,7 @@ const placeholder = computed(() => `search ${props.title.toLowerCase()}`);
 
 <template>
     <BInputGroup class="w-100">
-        <BFormInput v-model="filter" :placeholder="placeholder" />
+        <BFormInput v-model="filter" :placeholder="placeholder" debounce="500" />
         <BInputGroupAppend>
             <BButton :disabled="!filter" @click="filter = ''"><FontAwesomeIcon icon="times" /></BButton>
         </BInputGroupAppend>

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -26,6 +26,7 @@ interface Props {
     isBusy?: boolean;
     isEncoded?: boolean;
     items?: Array<SelectionItem>;
+    totalItems?: number;
     leafIcon?: string;
     modalShow?: boolean;
     modalStatic?: boolean;
@@ -45,6 +46,7 @@ const props = withDefaults(defineProps<Props>(), {
     isBusy: false,
     isEncoded: false,
     items: () => [],
+    totalItems: 0,
     leafIcon: "fa fa-file-o",
     modalShow: true,
     modalStatic: false,
@@ -67,7 +69,6 @@ const emit = defineEmits<{
 
 const filter = ref("");
 const currentPage = ref(1);
-const nItems = ref(0);
 const perPage = ref(100);
 
 const fieldDetails = computed(() => {
@@ -97,7 +98,6 @@ function selectionIcon(variant: string) {
 
 /** Resets pagination when a filter/search word is entered **/
 function filtered(items: Array<SelectionItem>) {
-    nItems.value = items.length;
     currentPage.value = 1;
 }
 
@@ -200,7 +200,7 @@ watch(
                     <BSpinner small type="grow" />
                     <BSpinner small type="grow" />
                 </div>
-                <div v-if="nItems === 0">
+                <div v-if="totalItems === 0">
                     <div v-if="filter">
                         No search results found for: <b>{{ filter }}</b
                         >.
@@ -223,12 +223,12 @@ watch(
                     <slot v-if="!errorMessage" name="buttons" />
                 </div>
                 <BPagination
-                    v-if="nItems > perPage"
+                    v-if="totalItems > perPage"
                     v-model="currentPage"
                     class="justify-content-md-center m-0"
                     size="sm"
                     :per-page="perPage"
-                    :total-rows="nItems" />
+                    :total-rows="totalItems" />
                 <div>
                     <BButton
                         data-description="selection dialog cancel"

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BButton, BLink, BModal, BPagination, BSpinner, BTable } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
 
-import { SELECTION_STATES } from "@/components/SelectionDialog/selectionTypes";
+import { ItemsProvider, SELECTION_STATES } from "@/components/SelectionDialog/selectionTypes";
 
 import { type FieldEntry, type SelectionItem } from "./selectionTypes";
 
@@ -22,10 +22,11 @@ interface Props {
     disableOk?: boolean;
     errorMessage?: string;
     fileMode?: boolean;
-    fields?: Array<FieldEntry>;
+    fields?: FieldEntry[];
     isBusy?: boolean;
     isEncoded?: boolean;
-    items?: Array<SelectionItem>;
+    items?: SelectionItem[];
+    itemsProvider?: ItemsProvider;
     totalItems?: number;
     leafIcon?: string;
     modalShow?: boolean;
@@ -46,6 +47,7 @@ const props = withDefaults(defineProps<Props>(), {
     isBusy: false,
     isEncoded: false,
     items: () => [],
+    itemsProvider: undefined,
     totalItems: 0,
     leafIcon: "fa fa-file-o",
     modalShow: true,
@@ -69,7 +71,7 @@ const emit = defineEmits<{
 
 const filter = ref("");
 const currentPage = ref(1);
-const perPage = ref(100);
+const perPage = ref(25);
 
 const fieldDetails = computed(() => {
     const fields = props.fields.slice().map((x) => {
@@ -98,7 +100,9 @@ function selectionIcon(variant: string) {
 
 /** Resets pagination when a filter/search word is entered **/
 function filtered(items: Array<SelectionItem>) {
-    currentPage.value = 1;
+    if (props.itemsProvider === undefined) {
+        currentPage.value = 1;
+    }
 }
 
 /** Format time stamp */
@@ -148,7 +152,7 @@ watch(
                     primary-key="id"
                     :busy="isBusy"
                     :current-page="currentPage"
-                    :items="items"
+                    :items="itemsProvider ?? items"
                     :fields="fieldDetails"
                     :filter="filter"
                     :per-page="perPage"

--- a/client/src/components/SelectionDialog/selectionTypes.ts
+++ b/client/src/components/SelectionDialog/selectionTypes.ts
@@ -17,3 +17,14 @@ export interface SelectionItem {
     isLeaf: boolean;
     url: string;
 }
+
+export interface ItemsProviderContext {
+    apiUrl?: string;
+    currentPage: number;
+    perPage: number;
+    filter?: string;
+    sortBy?: string;
+    sortDesc?: boolean;
+}
+
+export type ItemsProvider = (ctx: ItemsProviderContext) => Promise<SelectionItem[]>;

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -290,6 +290,8 @@ class SupportsBrowsing(metaclass=abc.ABCMeta):
         opts: Optional[FilesSourceOptions] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        query: Optional[str] = None,
+        sort_by: Optional[str] = None,
     ) -> List[AnyRemoteEntry]:
         """Return dictionary of 'Directory's and 'File's."""
 

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -103,6 +103,7 @@ class FilesSourceProperties(TypedDict):
     url: NotRequired[Optional[str]]
     supports_pagination: NotRequired[bool]
     supports_search: NotRequired[bool]
+    supports_sorting: NotRequired[bool]
 
 
 @dataclass
@@ -315,6 +316,7 @@ class BaseFilesSource(FilesSource):
     plugin_kind: ClassVar[PluginKind] = PluginKind.rfs  # Remote File Source by default, override in subclasses
     supports_pagination: ClassVar[bool] = False
     supports_search: ClassVar[bool] = False
+    supports_sorting: ClassVar[bool] = False
 
     def get_browsable(self) -> bool:
         return file_source_type_is_browsable(type(self))
@@ -395,6 +397,7 @@ class BaseFilesSource(FilesSource):
             "scheme": self.get_scheme(),
             "supports_pagination": self.supports_pagination,
             "supports_search": self.supports_search,
+            "supports_sorting": self.supports_sorting,
         }
         if self.get_browsable():
             rval["uri_root"] = self.get_uri_root()
@@ -427,12 +430,15 @@ class BaseFilesSource(FilesSource):
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         query: Optional[str] = None,
+        sort_by: Optional[str] = None,
     ) -> List[AnyRemoteEntry]:
         self._check_user_access(user_context)
         if not self.supports_pagination and (limit is not None or offset is not None):
             raise RequestParameterInvalidException("Pagination is not supported by this file source.")
         if not self.supports_search and query:
             raise RequestParameterInvalidException("Server-side search is not supported by this file source.")
+        if not self.supports_sorting and sort_by:
+            raise RequestParameterInvalidException("Server-side sorting is not supported by this file source.")
 
         return self._list(path, recursive, user_context, opts, limit, offset, query)
 
@@ -445,6 +451,7 @@ class BaseFilesSource(FilesSource):
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         query: Optional[str] = None,
+        sort_by: Optional[str] = None,
     ):
         pass
 

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -37,6 +37,7 @@ from galaxy.util.template import fill_template
 
 DEFAULT_SCHEME = "gxfiles"
 DEFAULT_WRITABLE = False
+DEFAULT_PAGE_LIMIT = 25
 
 if TYPE_CHECKING:
     from galaxy.files import (

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -13,6 +13,7 @@ from typing import (
     Optional,
     Set,
     Type,
+    Tuple,
     TYPE_CHECKING,
     Union,
 )
@@ -301,8 +302,8 @@ class SupportsBrowsing(metaclass=abc.ABCMeta):
         offset: Optional[int] = None,
         query: Optional[str] = None,
         sort_by: Optional[str] = None,
-    ) -> List[AnyRemoteEntry]:
-        """Return dictionary of 'Directory's and 'File's."""
+    ) -> Tuple[List[AnyRemoteEntry], int]:
+        """Return a list of 'Directory's and 'File's and the total count in a tuple."""
 
 
 class FilesSource(SingleFileSource, SupportsBrowsing):
@@ -444,7 +445,7 @@ class BaseFilesSource(FilesSource):
         offset: Optional[int] = None,
         query: Optional[str] = None,
         sort_by: Optional[str] = None,
-    ) -> List[AnyRemoteEntry]:
+    ) -> Tuple[List[AnyRemoteEntry], int]:
         self._check_user_access(user_context)
         if not self.supports_pagination and (limit is not None or offset is not None):
             raise RequestParameterInvalidException("Pagination is not supported by this file source.")
@@ -465,8 +466,8 @@ class BaseFilesSource(FilesSource):
         offset: Optional[int] = None,
         query: Optional[str] = None,
         sort_by: Optional[str] = None,
-    ):
-        pass
+    ) -> Tuple[List[AnyRemoteEntry], int]:
+        raise NotImplementedError()
 
     def create_entry(
         self,

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -80,6 +80,17 @@ class PluginKind(str, Enum):
     """
 
 
+class FileSourceSupports(TypedDict):
+    """Feature support flags for a file source plugin"""
+
+    # Indicates whether the file source supports pagination for listing files
+    pagination: NotRequired[bool]
+    # Indicates whether the file source supports server-side search for listing files
+    search: NotRequired[bool]
+    # Indicates whether the file source supports server-side sorting for listing files
+    sorting: NotRequired[bool]
+
+
 class FilesSourceProperties(TypedDict):
     """Initial set of properties used to initialize a filesource.
 
@@ -101,9 +112,7 @@ class FilesSourceProperties(TypedDict):
     type: NotRequired[str]
     browsable: NotRequired[bool]
     url: NotRequired[Optional[str]]
-    supports_pagination: NotRequired[bool]
-    supports_search: NotRequired[bool]
-    supports_sorting: NotRequired[bool]
+    supports: NotRequired[FileSourceSupports]
 
 
 @dataclass
@@ -397,9 +406,11 @@ class BaseFilesSource(FilesSource):
             "requires_groups": self.requires_groups,
             "disable_templating": self.disable_templating,
             "scheme": self.get_scheme(),
-            "supports_pagination": self.supports_pagination,
-            "supports_search": self.supports_search,
-            "supports_sorting": self.supports_sorting,
+            "supports": {
+                "pagination": self.supports_pagination,
+                "search": self.supports_search,
+                "sorting": self.supports_sorting,
+            },
         }
         if self.get_browsable():
             rval["uri_root"] = self.get_uri_root()

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -12,8 +12,8 @@ from typing import (
     List,
     Optional,
     Set,
-    Type,
     Tuple,
+    Type,
     TYPE_CHECKING,
     Union,
 )
@@ -453,6 +453,11 @@ class BaseFilesSource(FilesSource):
             raise RequestParameterInvalidException("Server-side search is not supported by this file source.")
         if not self.supports_sorting and sort_by:
             raise RequestParameterInvalidException("Server-side sorting is not supported by this file source.")
+        if self.supports_pagination:
+            if limit is not None and limit < 1:
+                raise RequestParameterInvalidException("Limit must be greater than 0.")
+            if offset is not None and offset < 0:
+                raise RequestParameterInvalidException("Offset must be greater than or equal to 0.")
 
         return self._list(path, recursive, user_context, opts, limit, offset, query)
 

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -283,6 +283,8 @@ class SupportsBrowsing(metaclass=abc.ABCMeta):
         recursive=False,
         user_context: "OptionalUserContext" = None,
         opts: Optional[FilesSourceOptions] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[AnyRemoteEntry]:
         """Return dictionary of 'Directory's and 'File's."""
 
@@ -414,9 +416,11 @@ class BaseFilesSource(FilesSource):
         recursive=False,
         user_context: "OptionalUserContext" = None,
         opts: Optional[FilesSourceOptions] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[AnyRemoteEntry]:
         self._check_user_access(user_context)
-        return self._list(path, recursive, user_context, opts)
+        return self._list(path, recursive, user_context, opts, limit, offset)
 
     def _list(
         self,
@@ -424,6 +428,8 @@ class BaseFilesSource(FilesSource):
         recursive=False,
         user_context: "OptionalUserContext" = None,
         opts: Optional[FilesSourceOptions] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ):
         pass
 

--- a/lib/galaxy/files/sources/_pyfilesystem2.py
+++ b/lib/galaxy/files/sources/_pyfilesystem2.py
@@ -56,6 +56,7 @@ class PyFilesystem2FilesSource(BaseFilesSource):
         opts: Optional[FilesSourceOptions] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        query: Optional[str] = None,
     ) -> List[AnyRemoteEntry]:
         """Return dictionary of 'Directory's and 'File's."""
         try:

--- a/lib/galaxy/files/sources/_pyfilesystem2.py
+++ b/lib/galaxy/files/sources/_pyfilesystem2.py
@@ -79,7 +79,9 @@ class PyFilesystem2FilesSource(BaseFilesSource):
         except fs.errors.FSError as e:
             raise MessageException(f"Problem listing file source path {path}. Reason: {e}") from e
 
-    def _to_page(self, limit: Optional[int] = None, offset: Optional[int] = None) -> Tuple[int, int]:
+    def _to_page(self, limit: Optional[int] = None, offset: Optional[int] = None) -> Optional[Tuple[int, int]]:
+        if limit is None and offset is None:
+            return None
         limit = limit or DEFAULT_PAGE_LIMIT
         start = offset or 0
         end = start + limit

--- a/lib/galaxy/files/sources/_pyfilesystem2.py
+++ b/lib/galaxy/files/sources/_pyfilesystem2.py
@@ -58,6 +58,7 @@ class PyFilesystem2FilesSource(BaseFilesSource):
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         query: Optional[str] = None,
+        sort_by: Optional[str] = None,
     ) -> List[AnyRemoteEntry]:
         """Return dictionary of 'Directory's and 'File's."""
         try:

--- a/lib/galaxy/files/sources/_pyfilesystem2.py
+++ b/lib/galaxy/files/sources/_pyfilesystem2.py
@@ -88,17 +88,17 @@ class PyFilesystem2FilesSource(BaseFilesSource):
         # For some reason, using "*" as glob does not return all files and directories, only files.
         # So we need to count files and directories "*/" separately.
         # Also, some filesystems do not properly support directories count (like Google Cloud Storage),
-        # so we need to catch exceptions and fallback to 0.
+        # so we need to catch TypeError exceptions and fallback to 0.
         files_glob_pattern = f"{path}/{filter[0] if filter else '*'}"
         try:
             files_count = fs.glob(files_glob_pattern).count().files
-        except:
+        except TypeError:
             files_count = 0
 
         directory_glob_pattern = f"{files_glob_pattern}/"
         try:
             directories_count = fs.glob(directory_glob_pattern).count().directories
-        except:
+        except TypeError:
             directories_count = 0
         return files_count + directories_count
 

--- a/lib/galaxy/files/sources/_pyfilesystem2.py
+++ b/lib/galaxy/files/sources/_pyfilesystem2.py
@@ -51,6 +51,8 @@ class PyFilesystem2FilesSource(BaseFilesSource):
         recursive=False,
         user_context: OptionalUserContext = None,
         opts: Optional[FilesSourceOptions] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[AnyRemoteEntry]:
         """Return dictionary of 'Directory's and 'File's."""
         try:

--- a/lib/galaxy/files/sources/_pyfilesystem2.py
+++ b/lib/galaxy/files/sources/_pyfilesystem2.py
@@ -87,11 +87,20 @@ class PyFilesystem2FilesSource(BaseFilesSource):
     def _get_total_matches_count(self, fs: FS, path: str, filter: Optional[List[str]] = None) -> int:
         # For some reason, using "*" as glob does not return all files and directories, only files.
         # So we need to count files and directories "*/" separately.
+        # Also, some filesystems do not properly support directories count (like Google Cloud Storage),
+        # so we need to catch exceptions and fallback to 0.
         files_glob_pattern = f"{path}/{filter[0] if filter else '*'}"
-        files_count = fs.glob(files_glob_pattern).count()
+        try:
+            files_count = fs.glob(files_glob_pattern).count().files
+        except:
+            files_count = 0
+
         directory_glob_pattern = f"{files_glob_pattern}/"
-        directories_count = fs.glob(directory_glob_pattern).count()
-        return files_count.files + directories_count.directories
+        try:
+            directories_count = fs.glob(directory_glob_pattern).count().directories
+        except:
+            directories_count = 0
+        return files_count + directories_count
 
     def _to_page(self, limit: Optional[int] = None, offset: Optional[int] = None) -> Optional[Tuple[int, int]]:
         if limit is None and offset is None:

--- a/lib/galaxy/files/sources/_pyfilesystem2.py
+++ b/lib/galaxy/files/sources/_pyfilesystem2.py
@@ -62,7 +62,7 @@ class PyFilesystem2FilesSource(BaseFilesSource):
             with self._open_fs(user_context=user_context, opts=opts) as h:
                 if recursive:
                     res: List[AnyRemoteEntry] = []
-                    for p, dirs, files in h.walk(path):
+                    for p, dirs, files in h.walk(path, namespaces=["details"]):
                         to_dict = functools.partial(self._resource_info_to_dict, p)
                         res.extend(map(to_dict, dirs))
                         res.extend(map(to_dict, files))

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -3,6 +3,7 @@ from typing import (
     List,
     NamedTuple,
     Optional,
+    Tuple,
 )
 
 from typing_extensions import Unpack
@@ -68,8 +69,8 @@ class RDMRepositoryInteractor:
         offset: Optional[int] = None,
         query: Optional[str] = None,
         sort_by: Optional[str] = None,
-    ) -> List[RemoteDirectory]:
-        """Returns the list of records in the repository.
+    ) -> Tuple[List[RemoteDirectory], int]:
+        """Returns the list of records in the repository and the total count of records.
 
         If writeable is True, only records that the user can write to will be returned.
         The user_context might be required to authenticate the user in the repository.

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -60,7 +60,13 @@ class RDMRepositoryInteractor:
         If a filename is provided, the URI will reference the specific file in the record."""
         raise NotImplementedError()
 
-    def get_records(self, writeable: bool, user_context: OptionalUserContext = None) -> List[RemoteDirectory]:
+    def get_records(
+        self,
+        writeable: bool,
+        user_context: OptionalUserContext = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> List[RemoteDirectory]:
         """Returns the list of records in the repository.
 
         If writeable is True, only records that the user can write to will be returned.

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -67,6 +67,7 @@ class RDMRepositoryInteractor:
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         query: Optional[str] = None,
+        sort_by: Optional[str] = None,
     ) -> List[RemoteDirectory]:
         """Returns the list of records in the repository.
 

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -66,6 +66,7 @@ class RDMRepositoryInteractor:
         user_context: OptionalUserContext = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        query: Optional[str] = None,
     ) -> List[RemoteDirectory]:
         """Returns the list of records in the repository.
 

--- a/lib/galaxy/files/sources/googlecloudstorage.py
+++ b/lib/galaxy/files/sources/googlecloudstorage.py
@@ -43,8 +43,6 @@ class GoogleCloudStorageFilesSource(PyFilesystem2FilesSource):
         elif props.get("token"):
             args["client"] = Client(project=project, credentials=Credentials(**props))
         handle = GCSFS(bucket_name, root_path=root_path, retry=0, **{**args, **extra_props})
-        # https://fs-gcsfs.readthedocs.io/en/stable/#limitations
-        handle.fix_storage()
         return handle
 
 

--- a/lib/galaxy/files/sources/googlecloudstorage.py
+++ b/lib/galaxy/files/sources/googlecloudstorage.py
@@ -43,6 +43,8 @@ class GoogleCloudStorageFilesSource(PyFilesystem2FilesSource):
         elif props.get("token"):
             args["client"] = Client(project=project, credentials=Credentials(**props))
         handle = GCSFS(bucket_name, root_path=root_path, retry=0, **{**args, **extra_props})
+        # https://fs-gcsfs.readthedocs.io/en/stable/#limitations
+        handle.fix_storage()
         return handle
 
 

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -121,6 +121,7 @@ class InvenioRDMFilesSource(RDMFilesSource):
 
     plugin_type = "inveniordm"
     supports_pagination = True
+    supports_search = True
 
     def __init__(self, **kwd: Unpack[RDMFilesSourceProperties]):
         super().__init__(**kwd)
@@ -158,7 +159,7 @@ class InvenioRDMFilesSource(RDMFilesSource):
         writeable = opts and opts.writeable or False
         is_root_path = path == "/"
         if is_root_path:
-            records = self.repository.get_records(writeable, user_context, limit=limit, offset=offset)
+            records = self.repository.get_records(writeable, user_context, limit=limit, offset=offset, query=query)
             return cast(List[AnyRemoteEntry], records)
         record_id = self.get_record_id_from_path(path)
         files = self.repository.get_files_in_record(record_id, writeable, user_context)
@@ -231,6 +232,9 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         size, page = self._to_size_page(limit, offset)
         params["size"] = size
         params["page"] = page
+        if query:
+            params["q"] = query
+            params["sort"] = "bestmatch"
         response_data = self._get_response(user_context, request_url, params=params)
         return self._get_records_from_response(response_data)
 

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -155,6 +155,7 @@ class InvenioRDMFilesSource(RDMFilesSource):
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         query: Optional[str] = None,
+        sort_by: Optional[str] = None,
     ) -> List[AnyRemoteEntry]:
         writeable = opts and opts.writeable or False
         is_root_path = path == "/"
@@ -222,6 +223,7 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         query: Optional[str] = None,
+        sort_by: Optional[str] = None,
     ) -> List[RemoteDirectory]:
         params: Dict[str, Any] = {}
         request_url = self.records_url

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -148,6 +148,8 @@ class InvenioRDMFilesSource(RDMFilesSource):
         recursive=True,
         user_context: OptionalUserContext = None,
         opts: Optional[FilesSourceOptions] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[AnyRemoteEntry]:
         writeable = opts and opts.writeable or False
         is_root_path = path == "/"

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -232,7 +232,9 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         response_data = self._get_response(user_context, request_url, params=params)
         return self._get_records_from_response(response_data)
 
-    def _to_size_page(self, limit: Optional[int], offset: Optional[int]) -> Tuple[int, int]:
+    def _to_size_page(self, limit: Optional[int], offset: Optional[int]) -> Tuple[Optional[int], Optional[int]]:
+        if limit is None and offset is None:
+            return None, None
         size = limit or DEFAULT_PAGE_LIMIT
         page = (offset or 0) // size + 1
         return size, page

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -153,6 +153,7 @@ class InvenioRDMFilesSource(RDMFilesSource):
         opts: Optional[FilesSourceOptions] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        query: Optional[str] = None,
     ) -> List[AnyRemoteEntry]:
         writeable = opts and opts.writeable or False
         is_root_path = path == "/"
@@ -219,6 +220,7 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         user_context: OptionalUserContext = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        query: Optional[str] = None,
     ) -> List[RemoteDirectory]:
         params: Dict[str, Any] = {}
         request_url = self.records_url

--- a/lib/galaxy/files/sources/posix.py
+++ b/lib/galaxy/files/sources/posix.py
@@ -4,6 +4,7 @@ import shutil
 from typing import (
     List,
     Optional,
+    Tuple,
 )
 
 from typing_extensions import Unpack
@@ -63,7 +64,7 @@ class PosixFilesSource(BaseFilesSource):
         offset: Optional[int] = None,
         query: Optional[str] = None,
         sort_by: Optional[str] = None,
-    ) -> List[AnyRemoteEntry]:
+    ) -> Tuple[List[AnyRemoteEntry], int]:
         if not self.root:
             raise exceptions.ItemAccessibilityException("Listing files at file:// URLs has been disabled.")
         dir_path = self._to_native_path(path, user_context=user_context)
@@ -77,11 +78,11 @@ class PosixFilesSource(BaseFilesSource):
                 to_dict = functools.partial(self._resource_info_to_dict, rel_dir, user_context=user_context)
                 res.extend(map(to_dict, dirs))
                 res.extend(map(to_dict, files))
-            return res
+            return res, len(res)
         else:
             res = os.listdir(dir_path)
             to_dict = functools.partial(self._resource_info_to_dict, path, user_context=user_context)
-            return list(map(to_dict, res))
+            return list(map(to_dict, res)), len(res)
 
     def _realize_to(
         self,

--- a/lib/galaxy/files/sources/posix.py
+++ b/lib/galaxy/files/sources/posix.py
@@ -59,6 +59,8 @@ class PosixFilesSource(BaseFilesSource):
         recursive=True,
         user_context: OptionalUserContext = None,
         opts: Optional[FilesSourceOptions] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[AnyRemoteEntry]:
         if not self.root:
             raise exceptions.ItemAccessibilityException("Listing files at file:// URLs has been disabled.")

--- a/lib/galaxy/files/sources/posix.py
+++ b/lib/galaxy/files/sources/posix.py
@@ -61,6 +61,7 @@ class PosixFilesSource(BaseFilesSource):
         opts: Optional[FilesSourceOptions] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        query: Optional[str] = None,
     ) -> List[AnyRemoteEntry]:
         if not self.root:
             raise exceptions.ItemAccessibilityException("Listing files at file:// URLs has been disabled.")

--- a/lib/galaxy/files/sources/posix.py
+++ b/lib/galaxy/files/sources/posix.py
@@ -62,6 +62,7 @@ class PosixFilesSource(BaseFilesSource):
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         query: Optional[str] = None,
+        sort_by: Optional[str] = None,
     ) -> List[AnyRemoteEntry]:
         if not self.root:
             raise exceptions.ItemAccessibilityException("Listing files at file:// URLs has been disabled.")

--- a/lib/galaxy/files/sources/s3fs.py
+++ b/lib/galaxy/files/sources/s3fs.py
@@ -63,6 +63,7 @@ class S3FsFilesSource(BaseFilesSource):
         opts: Optional[FilesSourceOptions] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        query: Optional[str] = None,
     ) -> List[AnyRemoteEntry]:
         _props = self._serialization_props(user_context)
         # we need to pop the 'bucket' here, because the argument is not recognised in a downstream function

--- a/lib/galaxy/files/sources/s3fs.py
+++ b/lib/galaxy/files/sources/s3fs.py
@@ -64,6 +64,7 @@ class S3FsFilesSource(BaseFilesSource):
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         query: Optional[str] = None,
+        sort_by: Optional[str] = None,
     ) -> List[AnyRemoteEntry]:
         _props = self._serialization_props(user_context)
         # we need to pop the 'bucket' here, because the argument is not recognised in a downstream function

--- a/lib/galaxy/files/sources/s3fs.py
+++ b/lib/galaxy/files/sources/s3fs.py
@@ -61,6 +61,8 @@ class S3FsFilesSource(BaseFilesSource):
         recursive=True,
         user_context: OptionalUserContext = None,
         opts: Optional[FilesSourceOptions] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[AnyRemoteEntry]:
         _props = self._serialization_props(user_context)
         # we need to pop the 'bucket' here, because the argument is not recognised in a downstream function

--- a/lib/galaxy/files/sources/s3fs.py
+++ b/lib/galaxy/files/sources/s3fs.py
@@ -5,6 +5,7 @@ from typing import (
     cast,
     List,
     Optional,
+    Tuple,
 )
 
 from typing_extensions import Unpack
@@ -65,7 +66,7 @@ class S3FsFilesSource(BaseFilesSource):
         offset: Optional[int] = None,
         query: Optional[str] = None,
         sort_by: Optional[str] = None,
-    ) -> List[AnyRemoteEntry]:
+    ) -> Tuple[List[AnyRemoteEntry], int]:
         _props = self._serialization_props(user_context)
         # we need to pop the 'bucket' here, because the argument is not recognised in a downstream function
         _bucket_name = _props.pop("bucket", "")
@@ -77,12 +78,12 @@ class S3FsFilesSource(BaseFilesSource):
                 to_dict = functools.partial(self._resource_info_to_dict, p)
                 res.extend(map(to_dict, dirs.values()))
                 res.extend(map(to_dict, files.values()))
-            return res
+            return res, len(res)
         else:
             bucket_path = self._bucket_path(_bucket_name, path)
             res = fs.ls(bucket_path, detail=True)
             to_dict = functools.partial(self._resource_info_to_dict, path)
-            return list(map(to_dict, res))
+            return list(map(to_dict, res)), len(res)
 
     def _realize_to(
         self,

--- a/lib/galaxy/files/sources/temp.py
+++ b/lib/galaxy/files/sources/temp.py
@@ -1,0 +1,32 @@
+from typing import Optional
+
+from fs.osfs import OSFS
+
+from . import FilesSourceOptions
+from ._pyfilesystem2 import PyFilesystem2FilesSource
+
+
+class TempFilesSource(PyFilesystem2FilesSource):
+    """A FilesSource plugin for temporary file systems.
+
+    Used for testing and other temporary file system needs.
+
+    Note: This plugin is not intended for production use.
+    """
+
+    plugin_type = "temp"
+    required_module = OSFS
+
+    def _open_fs(self, user_context=None, opts: Optional[FilesSourceOptions] = None):
+        props = self._serialization_props(user_context)
+        extra_props = opts.extra_props or {} if opts else {}
+        # We use OSFS here because using TempFS or MemoryFS would wipe out the files
+        # every time we instantiate a new handle, which happens on every request.
+        handle = OSFS(**{**props, **extra_props})
+        return handle
+
+    def get_scheme(self) -> str:
+        return "temp"
+
+
+__all__ = ("TempFilesSource",)

--- a/lib/galaxy/managers/remote_files.py
+++ b/lib/galaxy/managers/remote_files.py
@@ -53,6 +53,7 @@ class RemoteFilesManager:
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         query: Optional[str] = None,
+        sort_by: Optional[str] = None,
     ) -> AnyRemoteFilesListResponse:
         """Returns a list of remote files available to the user."""
 
@@ -99,6 +100,7 @@ class RemoteFilesManager:
                 limit=limit,
                 offset=offset,
                 query=query,
+                sort_by=sort_by,
             )
         except exceptions.MessageException:
             log.warning(self._get_error_message(file_source_path), exc_info=True)

--- a/lib/galaxy/managers/remote_files.py
+++ b/lib/galaxy/managers/remote_files.py
@@ -4,6 +4,7 @@ from operator import itemgetter
 from typing import (
     Optional,
     Set,
+    Tuple,
 )
 
 from galaxy import exceptions
@@ -54,8 +55,8 @@ class RemoteFilesManager:
         offset: Optional[int] = None,
         query: Optional[str] = None,
         sort_by: Optional[str] = None,
-    ) -> AnyRemoteFilesListResponse:
-        """Returns a list of remote files available to the user."""
+    ) -> Tuple[AnyRemoteFilesListResponse, int]:
+        """Returns a list of remote files and directories available to the user and the total count of them."""
 
         user_file_source_context = ProvidesFileSourcesUserContext(user_ctx)
         default_recursive = False
@@ -92,7 +93,7 @@ class RemoteFilesManager:
         opts = FilesSourceOptions()
         opts.writeable = writeable or False
         try:
-            index = file_source.list(
+            index, count = file_source.list(
                 file_source_path.path,
                 recursive=recursive,
                 user_context=user_file_source_context,
@@ -138,7 +139,7 @@ class RemoteFilesManager:
             userdir_jstree = jstree.JSTree(jstree_paths)
             index = userdir_jstree.jsonData()
 
-        return index
+        return index, count
 
     def _get_error_message(self, file_source_path: FileSourcePath) -> str:
         return f"Problem listing file source path {file_source_path.file_source.get_uri_root()}{file_source_path.path}"

--- a/lib/galaxy/managers/remote_files.py
+++ b/lib/galaxy/managers/remote_files.py
@@ -50,6 +50,8 @@ class RemoteFilesManager:
         recursive: Optional[bool],
         disable: Optional[RemoteFilesDisableMode],
         writeable: Optional[bool] = False,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> AnyRemoteFilesListResponse:
         """Returns a list of remote files available to the user."""
 
@@ -93,6 +95,8 @@ class RemoteFilesManager:
                 recursive=recursive,
                 user_context=user_file_source_context,
                 opts=opts,
+                limit=limit,
+                offset=offset,
             )
         except exceptions.MessageException:
             log.warning(self._get_error_message(file_source_path), exc_info=True)

--- a/lib/galaxy/managers/remote_files.py
+++ b/lib/galaxy/managers/remote_files.py
@@ -52,6 +52,7 @@ class RemoteFilesManager:
         writeable: Optional[bool] = False,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        query: Optional[str] = None,
     ) -> AnyRemoteFilesListResponse:
         """Returns a list of remote files available to the user."""
 
@@ -97,6 +98,7 @@ class RemoteFilesManager:
                 opts=opts,
                 limit=limit,
                 offset=offset,
+                query=query,
             )
         except exceptions.MessageException:
             log.warning(self._get_error_message(file_source_path), exc_info=True)

--- a/lib/galaxy/schema/remote_files.py
+++ b/lib/galaxy/schema/remote_files.py
@@ -35,6 +35,12 @@ class RemoteFilesDisableMode(str, Enum):
     files = "files"
 
 
+class FilesSourceSupports(Model):
+    pagination: Annotated[bool, Field(description="Whether this file source supports server-side pagination.")] = False
+    search: Annotated[bool, Field(description="Whether this file source supports server-side search.")] = False
+    sorting: Annotated[bool, Field(description="Whether this file source supports server-side sorting.")] = False
+
+
 class FilesSourcePlugin(Model):
     id: str = Field(
         ...,
@@ -86,6 +92,10 @@ class FilesSourcePlugin(Model):
         title="URL",
         description="Optional URL that might be provided by some plugins to link to the remote source.",
     )
+    supports: Annotated[
+        FilesSourceSupports,
+        Field(default=..., description="Features supported by this file source."),
+    ] = FilesSourceSupports()
 
 
 class BrowsableFilesSourcePlugin(FilesSourcePlugin):

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -125,9 +125,11 @@ class FastAPIRemoteFiles:
         recursive: Optional[bool] = RecursiveQueryParam,
         disable: Optional[RemoteFilesDisableMode] = DisableModeQueryParam,
         writeable: Optional[bool] = WriteableQueryParam,
+        limit: Optional[int] = Query(None, title="Limit", description="Maximum number of entries to return."),
+        offset: Optional[int] = Query(None, title="Offset", description="Number of entries to skip."),
     ) -> AnyRemoteFilesListResponse:
         """Lists all remote files available to the user from different sources."""
-        return self.manager.index(user_ctx, target, format, recursive, disable, writeable)
+        return self.manager.index(user_ctx, target, format, recursive, disable, writeable, limit, offset)
 
     @router.get(
         "/api/remote_files/plugins",

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -106,6 +106,12 @@ LimitQueryParam = Query(default=None, title="Limit", description="Maximum number
 
 OffsetQueryParam = Query(default=None, title="Offset", description="Number of entries to skip.")
 
+SearchQueryParam = Query(
+    default=None,
+    title="Query",
+    description="Search query to filter entries by. The syntax could be different depending on the target source.",
+)
+
 
 @router.cbv
 class FastAPIRemoteFiles:
@@ -131,9 +137,10 @@ class FastAPIRemoteFiles:
         writeable: Optional[bool] = WriteableQueryParam,
         limit: Optional[int] = LimitQueryParam,
         offset: Optional[int] = OffsetQueryParam,
+        query: Optional[str] = SearchQueryParam,
     ) -> AnyRemoteFilesListResponse:
         """Lists all remote files available to the user from different sources."""
-        return self.manager.index(user_ctx, target, format, recursive, disable, writeable, limit, offset)
+        return self.manager.index(user_ctx, target, format, recursive, disable, writeable, limit, offset, query)
 
     @router.get(
         "/api/remote_files/plugins",

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -112,6 +112,12 @@ SearchQueryParam = Query(
     description="Search query to filter entries by. The syntax could be different depending on the target source.",
 )
 
+SortByQueryParam = Query(
+    default=None,
+    title="Sort by",
+    description="Sort the entries by the specified field.",
+)
+
 
 @router.cbv
 class FastAPIRemoteFiles:
@@ -138,9 +144,12 @@ class FastAPIRemoteFiles:
         limit: Optional[int] = LimitQueryParam,
         offset: Optional[int] = OffsetQueryParam,
         query: Optional[str] = SearchQueryParam,
+        sort_by: Optional[str] = None,
     ) -> AnyRemoteFilesListResponse:
         """Lists all remote files available to the user from different sources."""
-        return self.manager.index(user_ctx, target, format, recursive, disable, writeable, limit, offset, query)
+        return self.manager.index(
+            user_ctx, target, format, recursive, disable, writeable, limit, offset, query, sort_by
+        )
 
     @router.get(
         "/api/remote_files/plugins",

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -102,6 +102,10 @@ ExcludeKindQueryParam = Query(
     ),
 )
 
+LimitQueryParam = Query(default=None, title="Limit", description="Maximum number of entries to return.")
+
+OffsetQueryParam = Query(default=None, title="Offset", description="Number of entries to skip.")
+
 
 @router.cbv
 class FastAPIRemoteFiles:
@@ -125,8 +129,8 @@ class FastAPIRemoteFiles:
         recursive: Optional[bool] = RecursiveQueryParam,
         disable: Optional[RemoteFilesDisableMode] = DisableModeQueryParam,
         writeable: Optional[bool] = WriteableQueryParam,
-        limit: Optional[int] = Query(None, title="Limit", description="Maximum number of entries to return."),
-        offset: Optional[int] = Query(None, title="Offset", description="Number of entries to skip."),
+        limit: Optional[int] = LimitQueryParam,
+        offset: Optional[int] = OffsetQueryParam,
     ) -> AnyRemoteFilesListResponse:
         """Lists all remote files available to the user from different sources."""
         return self.manager.index(user_ctx, target, format, recursive, disable, writeable, limit, offset)

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -35,13 +35,11 @@ log = logging.getLogger(__name__)
 router = Router(tags=["remote files"])
 
 TargetQueryParam: str = Query(
-    default=RemoteFilesTarget.ftpdir,
     title="Target source",
     description=("The source to load datasets from. Possible values: ftpdir, userdir, importdir"),
 )
 
 FormatQueryParam: Optional[RemoteFilesFormat] = Query(
-    default=RemoteFilesFormat.uri,
     title="Response format",
     description=(
         "The requested format of returned data. Either `flat` to simply list all the files"
@@ -51,7 +49,6 @@ FormatQueryParam: Optional[RemoteFilesFormat] = Query(
 )
 
 RecursiveQueryParam: Optional[bool] = Query(
-    default=None,
     title="Recursive",
     description=(
         "Whether to recursively lists all sub-directories. This will be `True` by default depending on the `target`."
@@ -59,7 +56,6 @@ RecursiveQueryParam: Optional[bool] = Query(
 )
 
 DisableModeQueryParam: Optional[RemoteFilesDisableMode] = Query(
-    default=None,
     title="Disable mode",
     description=(
         "(This only applies when `format` is `jstree`)"
@@ -69,7 +65,6 @@ DisableModeQueryParam: Optional[RemoteFilesDisableMode] = Query(
 )
 
 WriteableQueryParam: Optional[bool] = Query(
-    default=None,
     title="Writeable",
     description=(
         "Whether the query is made with the intention of writing to the source."
@@ -78,7 +73,6 @@ WriteableQueryParam: Optional[bool] = Query(
 )
 
 BrowsableQueryParam: Optional[bool] = Query(
-    default=True,
     title="Browsable filesources only",
     description=(
         "Whether to return browsable filesources only. The default is `True`, which will omit filesources"
@@ -102,18 +96,16 @@ ExcludeKindQueryParam = Query(
     ),
 )
 
-LimitQueryParam = Query(default=None, title="Limit", description="Maximum number of entries to return.")
+LimitQueryParam = Query(title="Limit", description="Maximum number of entries to return.")
 
-OffsetQueryParam = Query(default=None, title="Offset", description="Number of entries to skip.")
+OffsetQueryParam = Query(title="Offset", description="Number of entries to skip.")
 
 SearchQueryParam = Query(
-    default=None,
     title="Query",
     description="Search query to filter entries by. The syntax could be different depending on the target source.",
 )
 
 SortByQueryParam = Query(
-    default=None,
     title="Sort by",
     description="Sort the entries by the specified field.",
 )
@@ -136,15 +128,15 @@ class FastAPIRemoteFiles:
     async def index(
         self,
         user_ctx: ProvidesUserContext = DependsOnTrans,
-        target: str = TargetQueryParam,
-        format: Optional[RemoteFilesFormat] = FormatQueryParam,
-        recursive: Optional[bool] = RecursiveQueryParam,
-        disable: Optional[RemoteFilesDisableMode] = DisableModeQueryParam,
-        writeable: Optional[bool] = WriteableQueryParam,
-        limit: Optional[int] = LimitQueryParam,
-        offset: Optional[int] = OffsetQueryParam,
-        query: Optional[str] = SearchQueryParam,
-        sort_by: Optional[str] = None,
+        target: Annotated[str, TargetQueryParam] = RemoteFilesTarget.ftpdir,
+        format: Annotated[Optional[RemoteFilesFormat], FormatQueryParam] = RemoteFilesFormat.uri,
+        recursive: Annotated[Optional[bool], RecursiveQueryParam] = None,
+        disable: Annotated[Optional[RemoteFilesDisableMode], DisableModeQueryParam] = None,
+        writeable: Annotated[Optional[bool], WriteableQueryParam] = None,
+        limit: Annotated[Optional[int], LimitQueryParam] = None,
+        offset: Annotated[Optional[int], OffsetQueryParam] = None,
+        query: Annotated[Optional[str], SearchQueryParam] = None,
+        sort_by: Annotated[Optional[str], SortByQueryParam] = None,
     ) -> AnyRemoteFilesListResponse:
         """Lists all remote files available to the user from different sources."""
         return self.manager.index(
@@ -159,7 +151,7 @@ class FastAPIRemoteFiles:
     async def plugins(
         self,
         user_ctx: ProvidesUserContext = DependsOnTrans,
-        browsable_only: Optional[bool] = BrowsableQueryParam,
+        browsable_only: Annotated[Optional[bool], BrowsableQueryParam] = True,
         include_kind: Annotated[Optional[List[PluginKind]], IncludeKindQueryParam] = None,
         exclude_kind: Annotated[Optional[List[PluginKind]], ExcludeKindQueryParam] = None,
     ) -> FilesSourcePluginList:

--- a/test/unit/files/_util.py
+++ b/test/unit/files/_util.py
@@ -43,7 +43,7 @@ def list_root(
 ):
     file_source_pair = file_sources.get_file_source_path(uri)
     file_source = file_source_pair.file_source
-    res, count = file_source.list("/", recursive=recursive, user_context=user_context)
+    res, _ = file_source.list("/", recursive=recursive, user_context=user_context)
     return res
 
 
@@ -57,7 +57,7 @@ def list_dir(
     file_source = file_source_pair.file_source
     print(file_source_pair.path)
     print(uri)
-    res, count = file_source.list(file_source_pair.path, recursive=recursive, user_context=user_context)
+    res, _ = file_source.list(file_source_pair.path, recursive=recursive, user_context=user_context)
     return res
 
 
@@ -191,7 +191,7 @@ def assert_simple_file_realize(conf_file, recursive=False, filename="a", content
 
     assert file_source_pair.path == "/"
     file_source = file_source_pair.file_source
-    res, count = file_source.list("/", recursive=recursive, user_context=user_context)
+    res, _ = file_source.list("/", recursive=recursive, user_context=user_context)
     a_file = find(res, class_="File", name=filename)
     assert a_file
 

--- a/test/unit/files/_util.py
+++ b/test/unit/files/_util.py
@@ -43,7 +43,7 @@ def list_root(
 ):
     file_source_pair = file_sources.get_file_source_path(uri)
     file_source = file_source_pair.file_source
-    res = file_source.list("/", recursive=recursive, user_context=user_context)
+    res, count = file_source.list("/", recursive=recursive, user_context=user_context)
     return res
 
 
@@ -57,7 +57,7 @@ def list_dir(
     file_source = file_source_pair.file_source
     print(file_source_pair.path)
     print(uri)
-    res = file_source.list(file_source_pair.path, recursive=recursive, user_context=user_context)
+    res, count = file_source.list(file_source_pair.path, recursive=recursive, user_context=user_context)
     return res
 
 
@@ -191,7 +191,7 @@ def assert_simple_file_realize(conf_file, recursive=False, filename="a", content
 
     assert file_source_pair.path == "/"
     file_source = file_source_pair.file_source
-    res = file_source.list("/", recursive=recursive, user_context=user_context)
+    res, count = file_source.list("/", recursive=recursive, user_context=user_context)
     a_file = find(res, class_="File", name=filename)
     assert a_file
 

--- a/test/unit/files/temporary_file_sources_conf.yml
+++ b/test/unit/files/temporary_file_sources_conf.yml
@@ -1,5 +1,0 @@
-- type: temp
-  id: test1
-  doc: Test temporal file source
-  writable: true
-  root_path: /tmp/test1

--- a/test/unit/files/temporary_file_sources_conf.yml
+++ b/test/unit/files/temporary_file_sources_conf.yml
@@ -1,0 +1,5 @@
+- type: temp
+  id: test1
+  doc: Test temporal file source
+  writable: true
+  root_path: /tmp/test1

--- a/test/unit/files/test_basespace.py
+++ b/test/unit/files/test_basespace.py
@@ -30,7 +30,7 @@ def test_file_source():
     assert file_source_pair.path == "/"
     file_source = file_source_pair.file_source
     test_file = os.environ.get("GALAXY_TEST_BASESPACE_TEST_FILE_PATH", "")
-    res = file_source.list(os.path.dirname(test_file), recursive=False, user_context=user_context)
+    res, count = file_source.list(os.path.dirname(test_file), recursive=False, user_context=user_context)
     a_file = find(res, class_="File", name=os.path.basename(test_file))
     assert a_file
 

--- a/test/unit/files/test_basespace.py
+++ b/test/unit/files/test_basespace.py
@@ -30,7 +30,7 @@ def test_file_source():
     assert file_source_pair.path == "/"
     file_source = file_source_pair.file_source
     test_file = os.environ.get("GALAXY_TEST_BASESPACE_TEST_FILE_PATH", "")
-    res, count = file_source.list(os.path.dirname(test_file), recursive=False, user_context=user_context)
+    res, _ = file_source.list(os.path.dirname(test_file), recursive=False, user_context=user_context)
     a_file = find(res, class_="File", name=os.path.basename(test_file))
     assert a_file
 

--- a/test/unit/files/test_temp.py
+++ b/test/unit/files/test_temp.py
@@ -58,27 +58,32 @@ def test_list_recursive(temp_file_source: TempFilesSource):
 def test_pagination(temp_file_source: TempFilesSource):
     # Pagination is only supported for non-recursive listings.
     recursive = False
-    root_lvl_entries = temp_file_source.list("/", recursive=recursive)
+    root_lvl_entries, count = temp_file_source.list("/", recursive=recursive)
+    assert count == 4
     assert len(root_lvl_entries) == 4
 
     # Get first entry
-    result = temp_file_source.list("/", recursive=recursive, limit=1, offset=0)
+    result, count = temp_file_source.list("/", recursive=recursive, limit=1, offset=0)
+    assert count == 4
     assert len(result) == 1
     assert result[0] == root_lvl_entries[0]
 
     # Get second entry
-    result = temp_file_source.list("/", recursive=recursive, limit=1, offset=1)
+    result, count = temp_file_source.list("/", recursive=recursive, limit=1, offset=1)
+    assert count == 4
     assert len(result) == 1
     assert result[0] == root_lvl_entries[1]
 
     # Get second and third entry
-    result = temp_file_source.list("/", recursive=recursive, limit=2, offset=1)
+    result, count = temp_file_source.list("/", recursive=recursive, limit=2, offset=1)
+    assert count == 4
     assert len(result) == 2
     assert result[0] == root_lvl_entries[1]
     assert result[1] == root_lvl_entries[2]
 
     # Get last three entries
-    result = temp_file_source.list("/", recursive=recursive, limit=3, offset=1)
+    result, count = temp_file_source.list("/", recursive=recursive, limit=3, offset=1)
+    assert count == 4
     assert len(result) == 3
     assert result[0] == root_lvl_entries[1]
     assert result[1] == root_lvl_entries[2]
@@ -88,32 +93,39 @@ def test_pagination(temp_file_source: TempFilesSource):
 def test_search(temp_file_source: TempFilesSource):
     # Search is only supported for non-recursive listings.
     recursive = False
-    root_lvl_entries = temp_file_source.list("/", recursive=recursive)
+    root_lvl_entries, count = temp_file_source.list("/", recursive=recursive)
+    assert count == 4
     assert len(root_lvl_entries) == 4
 
-    result = temp_file_source.list("/", recursive=recursive, query="a")
+    result, count = temp_file_source.list("/", recursive=recursive, query="a")
+    assert count == 1
     assert len(result) == 1
     assert result[0]["name"] == "a"
 
-    result = temp_file_source.list("/", recursive=recursive, query="b")
+    result, count = temp_file_source.list("/", recursive=recursive, query="b")
+    assert count == 1
     assert len(result) == 1
     assert result[0]["name"] == "b"
 
-    result = temp_file_source.list("/", recursive=recursive, query="c")
+    result, count = temp_file_source.list("/", recursive=recursive, query="c")
+    assert count == 1
     assert len(result) == 1
     assert result[0]["name"] == "c"
 
     # Searching for 'd' at root level should return the directory 'dir1' but not the file 'd'
     # as it is not a direct child of the root.
-    result = temp_file_source.list("/", recursive=recursive, query="d")
+    result, count = temp_file_source.list("/", recursive=recursive, query="d")
+    assert count == 1
     assert len(result) == 1
     assert result[0]["name"] == "dir1"
 
     # Searching for 'e' at root level should not return anything.
-    result = temp_file_source.list("/", recursive=recursive, query="e")
+    result, count = temp_file_source.list("/", recursive=recursive, query="e")
+    assert count == 0
     assert len(result) == 0
 
-    result = temp_file_source.list("/dir1", recursive=recursive, query="e")
+    result, count = temp_file_source.list("/dir1", recursive=recursive, query="e")
+    assert count == 1
     assert len(result) == 1
     assert result[0]["name"] == "e"
 
@@ -138,7 +150,8 @@ def _upload_to(file_source: TempFilesSource, target_uri: str, content: str, user
 
 
 def assert_list_names(file_source: TempFilesSource, uri: str, recursive: bool, expected_names: List[str]):
-    result = file_source.list(uri, recursive=recursive)
+    result, count = file_source.list(uri, recursive=recursive)
+    assert count == len(expected_names)
     assert sorted([entry["name"] for entry in result]) == sorted(expected_names)
     return result
 

--- a/test/unit/files/test_temp.py
+++ b/test/unit/files/test_temp.py
@@ -85,6 +85,39 @@ def test_pagination(temp_file_source: TempFilesSource):
     assert result[2] == root_lvl_entries[3]
 
 
+def test_search(temp_file_source: TempFilesSource):
+    # Search is only supported for non-recursive listings.
+    recursive = False
+    root_lvl_entries = temp_file_source.list("/", recursive=recursive)
+    assert len(root_lvl_entries) == 4
+
+    result = temp_file_source.list("/", recursive=recursive, query="a")
+    assert len(result) == 1
+    assert result[0]["name"] == "a"
+
+    result = temp_file_source.list("/", recursive=recursive, query="b")
+    assert len(result) == 1
+    assert result[0]["name"] == "b"
+
+    result = temp_file_source.list("/", recursive=recursive, query="c")
+    assert len(result) == 1
+    assert result[0]["name"] == "c"
+
+    # Searching for 'd' at root level should return the directory 'dir1' but not the file 'd'
+    # as it is not a direct child of the root.
+    result = temp_file_source.list("/", recursive=recursive, query="d")
+    assert len(result) == 1
+    assert result[0]["name"] == "dir1"
+
+    # Searching for 'e' at root level should not return anything.
+    result = temp_file_source.list("/", recursive=recursive, query="e")
+    assert len(result) == 0
+
+    result = temp_file_source.list("/dir1", recursive=recursive, query="e")
+    assert len(result) == 1
+    assert result[0]["name"] == "e"
+
+
 def _populate_test_scenario(file_source: TempFilesSource):
     """Create a directory structure in the file source."""
     user_context = user_context_fixture()

--- a/test/unit/files/test_temp.py
+++ b/test/unit/files/test_temp.py
@@ -1,0 +1,112 @@
+import os
+import shutil
+import tempfile
+from typing import List
+
+import pytest
+
+from galaxy.files import ConfiguredFileSources
+from galaxy.files.sources import FilesSource
+from ._util import (
+    assert_realizes_contains,
+    configured_file_sources,
+    user_context_fixture,
+)
+
+SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
+FILE_SOURCES_CONF = os.path.join(SCRIPT_DIRECTORY, "temporary_file_sources_conf.yml")
+
+ROOT_URI = "temp://test1"
+ROOT_PATH = "/tmp/test1"
+
+
+@pytest.fixture(scope="session")
+def file_sources() -> ConfiguredFileSources:
+    file_sources = configured_file_sources(FILE_SOURCES_CONF)
+    return file_sources
+
+
+@pytest.fixture(scope="session")
+def temp_file_source(file_sources: ConfiguredFileSources) -> FilesSource:
+    file_source_pair = file_sources.get_file_source_path(ROOT_URI)
+    file_source = file_source_pair.file_source
+    _populate_test_scenario(file_source)
+    return file_source
+
+
+def test_file_source(file_sources: FilesSource):
+    assert_realizes_contains(file_sources, f"{ROOT_URI}/a", "a")
+    assert_realizes_contains(file_sources, f"{ROOT_URI}/b", "b")
+    assert_realizes_contains(file_sources, f"{ROOT_URI}/c", "c")
+    assert_realizes_contains(file_sources, f"{ROOT_URI}/dir1/d", "d")
+    assert_realizes_contains(file_sources, f"{ROOT_URI}/dir1/e", "e")
+    assert_realizes_contains(file_sources, f"{ROOT_URI}/dir1/sub1/f", "f")
+
+
+def test_list(temp_file_source: FilesSource):
+    assert_list_names(temp_file_source, "/", recursive=False, expected_names=["a", "b", "c", "dir1"])
+    assert_list_names(temp_file_source, "/dir1", recursive=False, expected_names=["d", "e", "sub1"])
+
+
+def test_list_recursive(temp_file_source: FilesSource):
+    expected_names = ["a", "b", "c", "dir1", "d", "e", "sub1", "f"]
+    assert_list_names(temp_file_source, "/", recursive=True, expected_names=expected_names)
+
+
+def test_pagination(temp_file_source: FilesSource):
+    # Pagination is only supported for non-recursive listings.
+    recursive = False
+    root_lvl_entries = temp_file_source.list("/", recursive=recursive)
+    assert len(root_lvl_entries) == 4
+
+    # Get first entry
+    result = temp_file_source.list("/", recursive=recursive, limit=1, offset=0)
+    assert len(result) == 1
+    assert result[0] == root_lvl_entries[0]
+
+    # Get second entry
+    result = temp_file_source.list("/", recursive=recursive, limit=1, offset=1)
+    assert len(result) == 1
+    assert result[0] == root_lvl_entries[1]
+
+    # Get second and third entry
+    result = temp_file_source.list("/", recursive=recursive, limit=2, offset=1)
+    assert len(result) == 2
+    assert result[0] == root_lvl_entries[1]
+    assert result[1] == root_lvl_entries[2]
+
+    # Get last three entries
+    result = temp_file_source.list("/", recursive=recursive, limit=3, offset=1)
+    assert len(result) == 3
+    assert result[0] == root_lvl_entries[1]
+    assert result[1] == root_lvl_entries[2]
+    assert result[2] == root_lvl_entries[3]
+
+
+def _populate_test_scenario(file_source: FilesSource):
+    """Create a directory structure in the file source."""
+    if os.path.exists(ROOT_PATH):
+        shutil.rmtree(ROOT_PATH)
+        os.mkdir(ROOT_PATH)
+
+    user_context = user_context_fixture()
+
+    _upload_to(file_source, "/a", content="a", user_context=user_context)
+    _upload_to(file_source, "/b", content="b", user_context=user_context)
+    _upload_to(file_source, "/c", content="c", user_context=user_context)
+    _upload_to(file_source, "/dir1/d", content="d", user_context=user_context)
+    _upload_to(file_source, "/dir1/e", content="e", user_context=user_context)
+    _upload_to(file_source, "/dir1/sub1/f", content="f", user_context=user_context)
+
+
+def _upload_to(file_source: FilesSource, target_uri: str, content: str, user_context=None):
+    with tempfile.NamedTemporaryFile(mode="w") as f:
+        f.write(content)
+        f.flush()
+        file_source.write_from(target_uri, f.name, user_context=user_context)
+
+
+def assert_list_names(file_source: FilesSource, uri: str, recursive: bool, expected_names: List[str]):
+    result = file_source.list(uri, recursive=recursive)
+    assert sorted([entry["name"] for entry in result]) == sorted(expected_names)
+    return result

--- a/test/unit/files/test_webdav.py
+++ b/test/unit/files/test_webdav.py
@@ -29,12 +29,12 @@ def test_file_source():
 
     assert file_source_pair.path == "/"
     file_source = file_source_pair.file_source
-    res = file_source.list("/", recursive=True)
+    res, count = file_source.list("/", recursive=True)
     a_file = find_file_a(res)
     assert a_file
     assert a_file["uri"] == "gxfiles://test1/a", a_file
 
-    res = file_source.list("/", recursive=False)
+    res, count = file_source.list("/", recursive=False)
     file_a = find_file_a(res)
     assert file_a
     assert file_a["uri"] == "gxfiles://test1/a"

--- a/test/unit/files/test_webdav.py
+++ b/test/unit/files/test_webdav.py
@@ -29,12 +29,12 @@ def test_file_source():
 
     assert file_source_pair.path == "/"
     file_source = file_source_pair.file_source
-    res, count = file_source.list("/", recursive=True)
+    res, _ = file_source.list("/", recursive=True)
     a_file = find_file_a(res)
     assert a_file
     assert a_file["uri"] == "gxfiles://test1/a", a_file
 
-    res, count = file_source.list("/", recursive=False)
+    res, _ = file_source.list("/", recursive=False)
     file_a = find_file_a(res)
     assert file_a
     assert file_a["uri"] == "gxfiles://test1/a"


### PR DESCRIPTION
Currently, when listing contents in a remote file source, we retrieve all possible files and directories inside, then perform client-side pagination and search. While this approach is enough for small sources with a limited number of files, larger repositories could potentially contain a vast number of files, making navigation within these sources very slow and difficult.

This addresses the issue by passing limit and offset parameters to paginate the contents. However, this approach comes with its own drawbacks. Specifically, we must carefully handle sorting, filtering, and searching server-side, which may prove challenging depending on the plugin implementation. Also, pagination is only applicable in a "non-recursive" view of the file source.

The pull request includes the following changes:
- A new serializable property for each plugin called `supports_pagination`. This property determines if the plugin can paginate the contents server-side so the client can delegate that.
- Implementation of pagination for every PyFilesystem2-based and Invenio-based plugin.
- A new plugin named `TempFileSource`, which simplifies testing of PyFilesystem2-based plugins. This plugin utilizes the built-in [OS Filesystem](https://docs.pyfilesystem.org/en/latest/reference/osfs.html). I wonder if we could even replace the `posix` plugin with this... unless there are specific functionalities unique to the `posix` plugin :thinking: 
- Fix an issue in PyFilesystem2 plugins when listing them recursively, which was detected during testing with the new `TempFileSource` plugin.
- A new serializable property for each plugin called `supports_search`. This property determines if the plugin can filter results by a search query. The syntax of the query is up to the plugin implementation, but a basic "search by name" should be supported as a minimum.
- A new serializable property for each plugin called `supports_sorting`. Most plugins (if any) won't support this, but it can signal the client to disable sorting in the UI when pagination is supported but server-side sorting is not, so the listings are always in sync.
- **Listing file source contents will now return the total number of matches for the request**. This is to be able to handle pagination correctly when using server-side pagination.

![FilesSourcesPagination](https://github.com/galaxyproject/galaxy/assets/46503462/d0c055f8-b7af-41a8-bd54-62bf4eb4ef6a)


# TODO
- [x] Support server-side pagination.
  - [x] Add `total_matches` as an additional return value when listing contents.
- [x] Support server-side filtering/search.
- [x] Support server-side sorting. 
- [x] Update UI to use server-side pagination 

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
