### PR TITLE
[24.0] CitationsList - fix prop spec and config access.

### DIFF
--- a/client/src/components/Citation/CitationsList.vue
+++ b/client/src/components/Citation/CitationsList.vue
@@ -18,7 +18,7 @@ const outputFormats = Object.freeze({
 interface Props {
     id: string;
     source: string;
-    simple: boolean;
+    simple?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/client/src/components/Citation/CitationsList.vue
+++ b/client/src/components/Citation/CitationsList.vue
@@ -29,7 +29,7 @@ const { config } = useConfig(true);
 
 const emit = defineEmits(["rendered", "show", "shown", "hide", "hidden"]);
 
-const outputFormat = ref(outputFormats.CITATION);
+const outputFormat = ref<string>(outputFormats.CITATION);
 const citations = ref<Citation[]>([]);
 
 onUpdated(() => {

--- a/client/src/components/Citation/CitationsList.vue
+++ b/client/src/components/Citation/CitationsList.vue
@@ -65,7 +65,7 @@ onMounted(async () => {
             </template>
 
             <div v-if="source === 'histories'" class="infomessage">
-                <div v-html="config.citations_export_message_html"></div>
+                <div v-html="config?.citations_export_message_html"></div>
             </div>
 
             <div class="citations-formatted">


### PR DESCRIPTION
Fixes prop spec for CitationsList -- this was optional and has a default defined, but the optional bit in the interface/prop spec was missed in recent refactoring.

![image](https://github.com/galaxyproject/galaxy/assets/155398/8ed584a5-71aa-4105-9fdb-8edb2980283a)

Also fixes accessing citation message when configuration isn't yet loaded:

![image](https://github.com/galaxyproject/galaxy/assets/155398/2d1daafe-1867-47e3-9bc2-7e048d878a18)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
