### PR TITLE
[24.0] Fix history update time after bulk operation

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2927,7 +2927,7 @@ class HistoryAudit(Base, RepresentById):
             session.execute(q)
 
 
-class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable):
+class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable, UsesCreateAndUpdateTime):
     __tablename__ = "history"
     __table_args__ = (Index("ix_history_slug", "slug", mysql_length=200),)
 
@@ -3093,6 +3093,9 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
     @property
     def count(self):
         return self.hid_counter - 1
+
+    def update(self):
+        self._update_time = now()
 
     def add_pending_items(self, set_output_hid=True):
         # These are assumed to be either copies of existing datasets or new, empty datasets,
@@ -7362,7 +7365,7 @@ class UCI:
         self.user = None
 
 
-class StoredWorkflow(Base, HasTags, Dictifiable, RepresentById):
+class StoredWorkflow(Base, HasTags, Dictifiable, RepresentById, UsesCreateAndUpdateTime):
     """
     StoredWorkflow represents the root node of a tree of objects that compose a workflow, including workflow revisions, steps, and subworkflows.
     It is responsible for the metadata associated with a workflow including owner, name, published, and create/update time.
@@ -7740,7 +7743,7 @@ class Workflow(Base, Dictifiable, RepresentById):
 InputConnDictType = Dict[str, Union[Dict[str, Any], List[Dict[str, Any]]]]
 
 
-class WorkflowStep(Base, RepresentById):
+class WorkflowStep(Base, RepresentById, UsesCreateAndUpdateTime):
     """
     WorkflowStep represents a tool or subworkflow, its inputs, annotations, and any outputs that are flagged as workflow outputs.
 
@@ -10061,7 +10064,7 @@ class CloudAuthz(Base):
         )
 
 
-class Page(Base, HasTags, Dictifiable, RepresentById):
+class Page(Base, HasTags, Dictifiable, RepresentById, UsesCreateAndUpdateTime):
     __tablename__ = "page"
     __table_args__ = (Index("ix_page_slug", "slug", mysql_length=200),)
 
@@ -10175,7 +10178,7 @@ class PageUserShareAssociation(Base, UserShareAssociation):
     page = relationship("Page", back_populates="users_shared_with")
 
 
-class Visualization(Base, HasTags, Dictifiable, RepresentById):
+class Visualization(Base, HasTags, Dictifiable, RepresentById, UsesCreateAndUpdateTime):
     __tablename__ = "visualization"
     __table_args__ = (
         Index("ix_visualization_dbkey", "dbkey", mysql_length=200),

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -95,7 +95,8 @@ class TagHandler:
         if flush:
             with transaction(self.sa_session):
                 self.sa_session.commit()
-        item.update()
+        if hasattr(item, "update"):
+            item.update()
         return item.tags
 
     def get_tag_assoc_class(self, item_class):

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -95,8 +95,7 @@ class TagHandler:
         if flush:
             with transaction(self.sa_session):
                 self.sa_session.commit()
-        if hasattr(item, "update"):
-            item.update()
+        item.update()
         return item.tags
 
     def get_tag_assoc_class(self, item_class):

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -95,6 +95,7 @@ class TagHandler:
         if flush:
             with transaction(self.sa_session):
                 self.sa_session.commit()
+        item.update()
         return item.tags
 
     def get_tag_assoc_class(self, item_class):

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1513,10 +1513,6 @@ class HistoryItemOperator:
 
     def _add_tags(self, trans: ProvidesUserContext, item: HistoryItemModel, params: TagOperationParams):
         trans.tag_handler.add_tags_from_list(trans.user, item, params.tags, flush=self.flush)
-        # Changing tags does not change the item, but we need to update the history to trigger the completion of the operation
-        item.update()
 
     def _remove_tags(self, trans: ProvidesUserContext, item: HistoryItemModel, params: TagOperationParams):
         trans.tag_handler.remove_tags_from_list(trans.user, item, params.tags, flush=self.flush)
-        # Changing tags does not change the item, but we need to update the history to trigger the completion of the operation
-        item.update()

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1445,6 +1445,9 @@ class HistoryItemOperator:
             raise exceptions.ItemDeletionException("This item has been permanently deleted and cannot be recovered.")
         manager = self._get_item_manager(item)
         manager.undelete(item, flush=self.flush)
+        # Again, we need to force an update in the edge case where all selected items are already undeleted
+        # or when the item was purged as undelete will not trigger an update
+        item.update()
 
     def _purge(self, item: HistoryItemModel, trans: ProvidesHistoryContext):
         if getattr(item, "purged", False):

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1510,6 +1510,10 @@ class HistoryItemOperator:
 
     def _add_tags(self, trans: ProvidesUserContext, item: HistoryItemModel, params: TagOperationParams):
         trans.tag_handler.add_tags_from_list(trans.user, item, params.tags, flush=self.flush)
+        # Changing tags does not change the item, but we need to update the history to trigger the completion of the operation
+        item.update()
 
     def _remove_tags(self, trans: ProvidesUserContext, item: HistoryItemModel, params: TagOperationParams):
         trans.tag_handler.remove_tags_from_list(trans.user, item, params.tags, flush=self.flush)
+        # Changing tags does not change the item, but we need to update the history to trigger the completion of the operation
+        item.update()


### PR DESCRIPTION
Fixes #18056

For some reason, when adding or removing tags from a dataset the items don't get their `update_time` changed. I forced that in `set_tags_from_list`. I'm not sure if adding or removing a tag can be considered `updating` a dataset, but, somehow, it used to work in the past...

There are some other cases where, after running a bulk operation on all of the items of a History, there is no actual change on the datasets (for example, undeleting a purged dataset) this means the associated history will not trigger a `update_time` change and the bulk operation in the UI will think it is still running even if it finished.

This includes additional checks in the API tests for bulk operations to ensure the history `update_time` gets updated on every operation.


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
