### PR TITLE
Add Attributes section to Edit Collection view as well

### DIFF
--- a/client/src/components/DatasetInformation/DatasetAttributes.vue
+++ b/client/src/components/DatasetInformation/DatasetAttributes.vue
@@ -11,6 +11,7 @@ import { setAttributes } from "@/components/DatasetInformation/services";
 import { useHistoryStore } from "@/stores/historyStore";
 import localize from "@/utils/localization";
 
+import Heading from "../Common/Heading.vue";
 import FormDisplay from "@/components/Form/FormDisplay.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
@@ -89,7 +90,9 @@ onMounted(async () => {
 
 <template>
     <div aria-labelledby="dataset-attributes-heading">
-        <h1 id="dataset-attributes-heading" v-localize class="h-lg">Edit Dataset Attributes</h1>
+        <Heading id="dataset-attributes-heading" h1 separator inline size="xl">
+            {{ localize("Edit Dataset Attributes") }}
+        </Heading>
 
         <BAlert v-if="messageText" class="dataset-attributes-alert" :variant="messageVariant" show>
             {{ localize(messageText) }}

--- a/client/src/stores/collectionElementsStore.ts
+++ b/client/src/stores/collectionElementsStore.ts
@@ -159,13 +159,16 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
         }
     }
 
-    async function getCollection(collectionId: string) {
-        const collection = storedCollections.value[collectionId];
-        if (!collection) {
-            return await fetchCollection({ id: collectionId });
-        }
-        return collection;
-    }
+    /** Returns collection from storedCollections, will load collection if not in store */
+    const getCollectionById = computed(() => {
+        return (collectionId: string) => {
+            if (!storedCollections.value[collectionId]) {
+                // TODO: Try to remove this as it can cause computed side effects (use keyedCache in this store instead?)
+                fetchCollection({ id: collectionId });
+            }
+            return storedCollections.value[collectionId] ?? null;
+        };
+    });
 
     async function fetchCollection(params: { id: string }) {
         set(loadingCollectionElements.value, params.id, true);
@@ -200,7 +203,7 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
         storedCollectionElements,
         getCollectionElements,
         isLoadingCollectionElements,
-        getCollection,
+        getCollectionById,
         fetchCollection,
         invalidateCollectionElements,
         saveCollections,


### PR DESCRIPTION
This adds an `Attributes` section (**with only the edit `name` field**) to the `Edit Collection Attributes` view, similar to the one we have for datasets:

https://github.com/galaxyproject/galaxy/assets/78516064/be618dba-5b59-4162-bb19-98dbbbc477e3

Fixes #17257 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
