### PR TITLE
Converts router push to Typescript

### DIFF
--- a/client/src/components/Grid/GridList.vue
+++ b/client/src/components/Grid/GridList.vue
@@ -170,8 +170,7 @@ async function onOperation(operation: Operation, rowData: RowData) {
  * Handle router push request emitted by grid module
  */
 function onRouterPush(route: string, options = {}) {
-    // @ts-ignore
-    router.push(route, options);
+    router.push({ path: route, params: { ...options } });
 }
 
 /**

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -255,11 +255,9 @@ function onDisplay() {
         // but we're using a __vkey__ bit as a workaround
         // Only conditionally force to keep urls clean most of the time.
         if (route.path === itemUrls.value.display) {
-            // @ts-ignore - monkeypatched router, drop with migration.
-            router.push(itemUrls.value.display, { title: props.name, force: true });
+            router.push({ path: itemUrls.value.display, params: { __title__: props.name, __force__: "true" } });
         } else if (itemUrls.value.display) {
-            // @ts-ignore - monkeypatched router, drop with migration.
-            router.push(itemUrls.value.display, { title: props.name });
+            router.push({ path: itemUrls.value.display, params: { __title__: props.name } });
         }
     }
 }

--- a/client/src/entry/analysis/router-push.ts
+++ b/client/src/entry/analysis/router-push.ts
@@ -1,5 +1,6 @@
-import { getGalaxyInstance } from "app";
-import { addSearchParams } from "utils/url";
+import { getGalaxyInstance } from "@/app";
+import { addSearchParams } from "@/utils/url";
+import { Route } from 'vue-router';
 
 /**
  * Is called before the regular router.push() and allows us to provide logs,
@@ -9,13 +10,15 @@ import { addSearchParams } from "utils/url";
  * @param {String} Location as parsed to original router.push()
  * @param {Object} Custom options, to provide a title and/or force reload
  */
-export function patchRouterPush(VueRouter) {
+export function patchRouterPush(VueRouter: any) {
     const originalPush = VueRouter.prototype.push;
-    VueRouter.prototype.push = function push(location, options = {}) {
+    VueRouter.prototype.push = function push(route: Route) {
+        let location: string = route.path;
+        const title = route.params?.__title__;
+        const force = route.params?.__force__;
         // add key to location to force component refresh
-        const { title, force } = options;
         if (force) {
-            location = addSearchParams(location, { __vkey__: Date.now() });
+            location = addSearchParams(location, { __vkey__: String(Date.now()) });
         }
         // verify if confirmation is required
         if (this.confirmation) {
@@ -34,7 +37,7 @@ export function patchRouterPush(VueRouter) {
         // always emit event, even when a duplicate route is pushed
         this.app.$emit("router-push");
         // avoid console warning when user clicks to revisit same route
-        return originalPush.call(this, location).catch((err) => {
+        return originalPush.call(this, location).catch((err: any) => {
             if (err.name !== "NavigationDuplicated") {
                 throw err;
             }


### PR DESCRIPTION
Requires #18016. Converts router push helper to typescript. Might not be necessary or can be done after the Vue3 transition has occurred to avoid merge conflicts.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
