### PR TITLE
Dynamic tool fixes

### DIFF
--- a/lib/galaxy/managers/tools.py
+++ b/lib/galaxy/managers/tools.py
@@ -110,8 +110,8 @@ class DynamicToolManager(ModelManager):
                 tool_path=tool_path,
                 tool_directory=tool_directory,
                 uuid=uuid,
-                active=tool_payload.get("active", True),
-                hidden=tool_payload.get("hidden", True),
+                active=tool_payload.get("active"),
+                hidden=tool_payload.get("hidden"),
                 value=representation,
             )
         self.app.toolbox.load_dynamic_tool(dynamic_tool)

--- a/lib/galaxy/managers/tools.py
+++ b/lib/galaxy/managers/tools.py
@@ -110,6 +110,8 @@ class DynamicToolManager(ModelManager):
                 tool_path=tool_path,
                 tool_directory=tool_directory,
                 uuid=uuid,
+                active=tool_payload.get("active", True),
+                hidden=tool_payload.get("hidden", True),
                 value=representation,
             )
         self.app.toolbox.load_dynamic_tool(dynamic_tool)

--- a/lib/galaxy/webapps/galaxy/api/dynamic_tools.py
+++ b/lib/galaxy/webapps/galaxy/api/dynamic_tools.py
@@ -40,7 +40,7 @@ class DynamicToolsController(BaseAPIController):
         """
         GET /api/dynamic_tools/{encoded_dynamic_tool_id|tool_uuid}
         """
-        self._get_dynamic_tool(trans, id).to_dict()
+        return self._get_dynamic_tool(trans, id).to_dict()
 
     @web.require_admin
     @expose_api


### PR DESCRIPTION
A missing return statement made the dynamic_tool API show endpoint always return null.
There is no way of passing hidden/active settings for dynamic tools through the API. Thay always resolve to the default settings which could only be changed directly on the DB.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ X] Instructions for manual testing are as follows:
  1. Test creation of a dynamic tool trhought the REST API with folloing curl:
 ```
curl --location 'http://localhost:8080/api/dynamic_tools?key={yourapikey}' \
--header 'Content-Type: application/json' \
--data '{
    "src" : "representation",
    "hidden" : false,
    "representation" : {
        "path": "dynamic_example",
        "version" : "0.1.0",
        "class" : "GalaxyTool",
        "raw_process_reference" : { 
            "cwlVersion" : "v1.2",
            "class" : "CommandLineTool",
            "baseCommand" : "echo",
            "inputs" : { "message" : { "type" : "string", "default" : "Hello world!", "inputBinding" : { "position" : 1}}
            },
            "outputs" : []
        }
    }
}'
```
 2. Test querying of dynamic tool with following curl:
` curl --location 'http://localhost:8080/api/dynamic_tools/{tool_id}'`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
