### PR TITLE
Ensure history `update_time` is set when exporting

### DIFF
--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -698,6 +698,7 @@ class HistoryExportManager:
     def _serialize_task_export(self, export: model.StoreExportAssociation, history: model.History):
         task_uuid = export.task_uuid
         export_date = export.create_time
+        assert history.update_time is not None, "History update time must be set"
         history_has_changed = history.update_time > export_date
         export_metadata = self.get_record_metadata(export)
         is_ready = export_metadata is not None and export_metadata.is_ready()

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -430,7 +430,7 @@ class HasName:
 
 
 class UsesCreateAndUpdateTime:
-    update_time: Mapped[datetime]
+    update_time: Mapped[Optional[datetime]]
 
     @property
     def seconds_since_updated(self):
@@ -454,7 +454,7 @@ class WorkerProcess(Base, UsesCreateAndUpdateTime):
     server_name: Mapped[Optional[str]] = mapped_column(String(255), index=True)
     hostname: Mapped[Optional[str]] = mapped_column(String(255))
     pid: Mapped[Optional[int]]
-    update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
+    update_time: Mapped[Optional[datetime]] = mapped_column(default=now, onupdate=now)
 
 
 def cached_id(galaxy_model_object):
@@ -5472,7 +5472,7 @@ class HistoryDatasetAssociationHistory(Base):
     history_dataset_association_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("history_dataset_association.id"), index=True
     )
-    update_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
+    update_time: Mapped[Optional[datetime]] = mapped_column(default=now)
     version: Mapped[Optional[int]]
     name: Mapped[Optional[str]] = mapped_column(TrimmedString(255))
     extension: Mapped[Optional[str]] = mapped_column(TrimmedString(64))
@@ -9638,8 +9638,8 @@ class FormDefinition(Base, Dictifiable, RepresentById):
     __tablename__ = "form_definition"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
-    update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
+    create_time: Mapped[Optional[datetime]] = mapped_column(default=now)
+    update_time: Mapped[Optional[datetime]] = mapped_column(default=now, onupdate=now)
     name: Mapped[str] = mapped_column(TrimmedString(255))
     desc: Mapped[Optional[str]] = mapped_column(TEXT)
     form_definition_current_id: Mapped[int] = mapped_column(

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -430,7 +430,7 @@ class HasName:
 
 
 class UsesCreateAndUpdateTime:
-    update_time: Mapped[Optional[datetime]]
+    update_time: Mapped[datetime]
 
     @property
     def seconds_since_updated(self):
@@ -454,7 +454,7 @@ class WorkerProcess(Base, UsesCreateAndUpdateTime):
     server_name: Mapped[Optional[str]] = mapped_column(String(255), index=True)
     hostname: Mapped[Optional[str]] = mapped_column(String(255))
     pid: Mapped[Optional[int]]
-    update_time: Mapped[Optional[datetime]] = mapped_column(default=now, onupdate=now)
+    update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
 
 
 def cached_id(galaxy_model_object):
@@ -5472,7 +5472,7 @@ class HistoryDatasetAssociationHistory(Base):
     history_dataset_association_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("history_dataset_association.id"), index=True
     )
-    update_time: Mapped[Optional[datetime]] = mapped_column(default=now)
+    update_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     version: Mapped[Optional[int]]
     name: Mapped[Optional[str]] = mapped_column(TrimmedString(255))
     extension: Mapped[Optional[str]] = mapped_column(TrimmedString(64))
@@ -9638,8 +9638,8 @@ class FormDefinition(Base, Dictifiable, RepresentById):
     __tablename__ = "form_definition"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    create_time: Mapped[Optional[datetime]] = mapped_column(default=now)
-    update_time: Mapped[Optional[datetime]] = mapped_column(default=now, onupdate=now)
+    create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
+    update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
     name: Mapped[str] = mapped_column(TrimmedString(255))
     desc: Mapped[Optional[str]] = mapped_column(TEXT)
     form_definition_current_id: Mapped[int] = mapped_column(


### PR DESCRIPTION
Addresses https://github.com/galaxyproject/galaxy/pull/18068#issuecomment-2090599978

<del>The default is `now` so we should always have a value in the Python model even if the column can be nullable.</del>
https://github.com/galaxyproject/galaxy/pull/18086/commits/561e6e900b3e71a5f280a45def78f66d22952d69 opened a can of worms... so falling back to a simple fix. At this point, we can be sure the history `update_time` will never be None.


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
