### PR TITLE
[24.0] Raise exception if collection elements missing during download

### DIFF
--- a/client/src/components/History/CurrentCollection/CollectionOperations.vue
+++ b/client/src/components/History/CurrentCollection/CollectionOperations.vue
@@ -18,6 +18,8 @@ const rerunUrl = computed(() =>
 const showCollectionDetailsUrl = computed(() =>
     props.dsc.job_source_type == "Job" ? `/jobs/${props.dsc.job_source_id}/view` : null
 );
+const disableDownload = props.dsc.populated_state !== "ok";
+
 function onDownload() {
     window.location.href = downloadUrl.value;
 }
@@ -28,6 +30,7 @@ function onDownload() {
             <b-button-group>
                 <b-button
                     title="Download Collection"
+                    :disabled="disableDownload"
                     class="rounded-0 text-decoration-none"
                     size="sm"
                     variant="link"

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -42,6 +42,9 @@ def stream_dataset_collection(dataset_collection_instance, upstream_mod_zip=Fals
 def write_dataset_collection(dataset_collection_instance, archive):
     names, hdas = get_hda_and_element_identifiers(dataset_collection_instance)
     for name, hda in zip(names, hdas):
+        if not hda:
+            # TODO should we raise galaxy.exceptions.InternalServerError or create a new exception type?
+            raise Exception("Attempt to write dataset collection with missing elements")
         if hda.state != hda.states.OK:
             continue
         for file_path, relpath in hda.datatype.to_archive(dataset=hda, name=name):

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -9,6 +9,7 @@ import logging
 from typing import Dict
 
 from galaxy import model
+from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.managers import (
     annotatable,
     base,
@@ -40,11 +41,10 @@ def stream_dataset_collection(dataset_collection_instance, upstream_mod_zip=Fals
 
 
 def write_dataset_collection(dataset_collection_instance, archive):
+    if not dataset_collection_instance.populated_optimized():
+        raise RequestParameterInvalidException("Attempt to write dataset collection that has not been populated yet")
     names, hdas = get_hda_and_element_identifiers(dataset_collection_instance)
     for name, hda in zip(names, hdas):
-        if not hda:
-            # TODO should we raise galaxy.exceptions.InternalServerError or create a new exception type?
-            raise Exception("Attempt to write dataset collection with missing elements")
         if hda.state != hda.states.OK:
             continue
         for file_path, relpath in hda.datatype.to_archive(dataset=hda, name=name):

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -41,7 +41,7 @@ def stream_dataset_collection(dataset_collection_instance, upstream_mod_zip=Fals
 
 
 def write_dataset_collection(dataset_collection_instance, archive):
-    if not dataset_collection_instance.populated_optimized():
+    if not dataset_collection_instance.collection.populated_optimized():
         raise RequestParameterInvalidException("Attempt to write dataset collection that has not been populated yet")
     names, hdas = get_hda_and_element_identifiers(dataset_collection_instance)
     for name, hda in zip(names, hdas):

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -41,7 +41,7 @@ def stream_dataset_collection(dataset_collection_instance, upstream_mod_zip=Fals
 
 
 def write_dataset_collection(dataset_collection_instance, archive):
-    if not dataset_collection_instance.collection.populated_optimized():
+    if not dataset_collection_instance.collection.populated_optimized:
         raise RequestParameterInvalidException("Attempt to write dataset collection that has not been populated yet")
     names, hdas = get_hda_and_element_identifiers(dataset_collection_instance)
     for name, hda in zip(names, hdas):

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -626,8 +626,7 @@ class FastAPIHistoryContents:
         """Download the content of a history dataset collection as a `zip` archive
         while maintaining approximate collection structure.
         """
-        archive = self.service.get_dataset_collection_archive_for_download(trans, id)
-        return StreamingResponse(archive.response(), headers=archive.get_headers())
+        return self._download_collection(trans, id)
 
     @router.get(
         "/api/dataset_collections/{id}/download",
@@ -644,8 +643,7 @@ class FastAPIHistoryContents:
         """Download the content of a history dataset collection as a `zip` archive
         while maintaining approximate collection structure.
         """
-        archive = self.service.get_dataset_collection_archive_for_download(trans, id)
-        return StreamingResponse(archive.response(), headers=archive.get_headers())
+        return self._download_collection(trans, id)
 
     @router.post(
         "/api/histories/{history_id}/contents/dataset_collections/{id}/prepare_download",
@@ -1033,3 +1031,7 @@ class FastAPIHistoryContents:
         )
         rval = self.service.materialize(trans, materialize_request)
         return rval
+
+    def _download_collection(self, trans, id):
+        archive = self.service.get_dataset_collection_archive_for_download(trans, id)
+        return StreamingResponse(archive.response(), headers=archive.get_headers())


### PR DESCRIPTION
Fixes #18075

To do:
- [x] Decide what type of exception to raise instead of generic Exception
- [x] Client fix: grey out the download button if the collection isn't populated yet


Is this a good location for raising the exception? I assume if that method is called, the collection *must* be populated? Or should we let it break and catch the AttributeError instead in the api module?



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
