### PR TITLE
[24.0] tool linters: output filters should only consider child filter nodes

### DIFF
--- a/lib/galaxy/tool_util/linters/output.py
+++ b/lib/galaxy/tool_util/linters/output.py
@@ -86,7 +86,7 @@ class OutputsLabelDuplicatedFilter(Linter):
         for output in tool_xml.findall("./outputs/data") + tool_xml.findall("./outputs/collection"):
             name = output.attrib.get("name", "")
             label = output.attrib.get("label", "${tool.name} on ${on_string}")
-            if label in labels and output.find(".//filter") is not None:
+            if label in labels and output.find("./filter") is not None:
                 lint_ctx.warn(
                     f"Tool output [{name}] uses duplicated label '{label}', double check if filters imply disjoint cases",
                     linter=cls.name(),
@@ -105,7 +105,7 @@ class OutputsLabelDuplicatedNoFilter(Linter):
         for output in tool_xml.findall("./outputs/data[@name]") + tool_xml.findall("./outputs/collection[@name]"):
             name = output.attrib.get("name", "")
             label = output.attrib.get("label", "${tool.name} on ${on_string}")
-            if label in labels and output.find(".//filter") is None:
+            if label in labels and output.find("./filter") is None:
                 lint_ctx.warn(f"Tool output [{name}] uses duplicated label '{label}'", linter=cls.name(), node=output)
             labels.add(label)
 

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -144,11 +144,11 @@ class TestsExpectNumOutputs(Linter):
         for test_idx, test in enumerate(tests, start=1):
             # check if expect_num_outputs is set if there are outputs with filters
             # (except for tests with expect_failure .. which can't have test outputs)
-            filter = tool_xml.find("./outputs//filter")
+            has_no_filter = (
+                tool_xml.find("./outputs/data/filter") is None and tool_xml.find("./outputs/collection/filter") is None
+            )
             if not (
-                filter is None
-                or "expect_num_outputs" in test.attrib
-                or asbool(test.attrib.get("expect_failure", False))
+                has_no_filter or "expect_num_outputs" in test.attrib or asbool(test.attrib.get("expect_failure", False))
             ):
                 lint_ctx.warn(
                     f"Test {test_idx}: should specify 'expect_num_outputs' if outputs have filters",


### PR DESCRIPTION
otherwise these option filters (which we should document) produce false positives https://github.com/galaxyproject/tools-iuc/blob/57fa4dcee2aaa115df4a5b7173a3a8fb889bc5a3/tools/bwa/bwa_macros.xml#L83

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
