### PR TITLE
Fix AWS object store for us-east-2

### DIFF
--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -117,6 +117,8 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
         log.debug(f"Configuring `{provider}` Connection")
         if provider == "aws":
             config = {"aws_access_key": credentials["access_key"], "aws_secret_key": credentials["secret_key"]}
+            if "region" in credentials:
+                config["aws_region_name"] = credentials["region"]
             connection = CloudProviderFactory().create_provider(ProviderList.AWS, config)
         elif provider == "azure":
             config = {
@@ -184,8 +186,9 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
             if provider == "aws":
                 akey = auth_element.get("access_key")
                 skey = auth_element.get("secret_key")
-
                 config["auth"] = {"access_key": akey, "secret_key": skey}
+                if "region" in auth_element:
+                    config["auth"]["region"] = auth_element["region"]
             elif provider == "azure":
                 sid = auth_element.get("subscription_id")
                 if sid is None:

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -56,13 +56,6 @@ class CloudConfigMixin:
                 "name": self.bucket_name,
                 "use_reduced_redundancy": self.use_rr,
             },
-            "connection": {
-                "host": self.host,
-                "port": self.port,
-                "multipart": self.multipart,
-                "is_secure": self.is_secure,
-                "conn_path": self.conn_path,
-            },
             "cache": {
                 "size": self.cache_size,
                 "path": self.staging_path,
@@ -86,7 +79,6 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
         self.transfer_progress = 0
 
         bucket_dict = config_dict["bucket"]
-        connection_dict = config_dict.get("connection", {})
         cache_dict = config_dict.get("cache") or {}
         self.enable_cache_monitor, self.cache_monitor_interval = enable_cache_monitor(config, config_dict)
 
@@ -95,12 +87,6 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
         self.bucket_name = bucket_dict.get("name")
         self.use_rr = bucket_dict.get("use_reduced_redundancy", False)
         self.max_chunk_size = bucket_dict.get("max_chunk_size", 250)
-
-        self.host = connection_dict.get("host", None)
-        self.port = connection_dict.get("port", 6000)
-        self.multipart = connection_dict.get("multipart", True)
-        self.is_secure = connection_dict.get("is_secure", True)
-        self.conn_path = connection_dict.get("conn_path", "/")
 
         self.cache_size = cache_dict.get("size") or self.config.object_store_cache_size
         self.staging_path = cache_dict.get("path") or self.config.object_store_cache_path

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -539,7 +539,7 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
 
     def _empty(self, obj, **kwargs):
         if self._exists(obj, **kwargs):
-            return bool(self._size(obj, **kwargs) > 0)
+            return bool(self._size(obj, **kwargs) == 0)
         else:
             raise ObjectNotFound(f"objectstore.empty, object does not exist: {obj}, kwargs: {kwargs}")
 
@@ -678,7 +678,7 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
                 log.exception("Trouble generating URL for dataset '%s'", rel_path)
         return None
 
-    def _get_store_usage_percent(self):
+    def _get_store_usage_percent(self, obj):
         return 0.0
 
     def shutdown(self):

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -87,6 +87,7 @@ def parse_config_xml(config_xml):
         multipart = string_as_bool(cn_xml.get("multipart", "True"))
         is_secure = string_as_bool(cn_xml.get("is_secure", "True"))
         conn_path = cn_xml.get("conn_path", "/")
+        region = cn_xml.get("region", None)
 
         cache_dict = parse_caching_config_dict_from_xml(config_xml)
 
@@ -114,6 +115,7 @@ def parse_config_xml(config_xml):
                 "multipart": multipart,
                 "is_secure": is_secure,
                 "conn_path": conn_path,
+                "region": region,
             },
             "cache": cache_dict,
             "extra_dirs": extra_dirs,
@@ -142,6 +144,7 @@ class CloudConfigMixin:
                 "multipart": self.multipart,
                 "is_secure": self.is_secure,
                 "conn_path": self.conn_path,
+                "region": self.region,
             },
             "cache": {
                 "size": self.cache_size,
@@ -185,6 +188,7 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
         self.multipart = connection_dict.get("multipart", True)
         self.is_secure = connection_dict.get("is_secure", True)
         self.conn_path = connection_dict.get("conn_path", "/")
+        self.region = connection_dict.get("region", None)
 
         self.cache_size = cache_dict.get("size") or self.config.object_store_cache_size
         self.staging_path = cache_dict.get("path") or self.config.object_store_cache_path
@@ -228,7 +232,23 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
         log.debug("Configuring S3 Connection")
         # If access_key is empty use default credential chain
         if self.access_key:
-            self.conn = S3Connection(self.access_key, self.secret_key)
+            if self.region:
+                # If specify a region we can infer a host and turn on SIGV4.
+                # https://stackoverflow.com/questions/26744712/s3-using-boto-and-sigv4-missing-host-parameter
+
+                # Turning on SIGV4 is needed for AWS regions created after 2014... from
+                # https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html:
+                #
+                # "Amazon S3 supports Signature Version 4, a protocol for authenticating inbound API requests to AWS services,
+                # in all AWS Regions. At this time, AWS Regions created before January 30, 2014 will continue to support the
+                # previous protocol, Signature Version 2. Any new Regions after January 30, 2014 will support only Signature
+                # Version 4 and therefore all requests to those Regions must be made with Signature Version 4."
+                os.environ["S3_USE_SIGV4"] = "True"
+                self.conn = S3Connection(self.access_key, self.secret_key, host=f"s3.{self.region}.amazonaws.com")
+            else:
+                # See notes above, this path through the code will not work for
+                # newer regions.
+                self.conn = S3Connection(self.access_key, self.secret_key)
         else:
             self.conn = S3Connection()
 
@@ -581,7 +601,7 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
 
     def _empty(self, obj, **kwargs):
         if self._exists(obj, **kwargs):
-            return bool(self._size(obj, **kwargs) > 0)
+            return bool(self._size(obj, **kwargs) == 0)
         else:
             raise ObjectNotFound(f"objectstore.empty, object does not exist: {obj}, kwargs: {kwargs}")
 

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -991,12 +991,6 @@ def test_config_parse_cloud():
             assert object_store.bucket_name == "unique_bucket_name_all_lowercase"
             assert object_store.use_rr is False
 
-            assert object_store.host is None
-            assert object_store.port == 6000
-            assert object_store.multipart is True
-            assert object_store.is_secure is True
-            assert object_store.conn_path == "/"
-
             cache_target = object_store.cache_target
             assert cache_target.size == 1000.0
             assert cache_target.path == "database/object_store_cache"
@@ -1004,13 +998,12 @@ def test_config_parse_cloud():
             assert object_store.extra_dirs["temp"] == "database/tmp_cloud"
 
             as_dict = object_store.to_dict()
-            _assert_has_keys(as_dict, ["provider", "auth", "bucket", "connection", "cache", "extra_dirs", "type"])
+            _assert_has_keys(as_dict, ["provider", "auth", "bucket", "cache", "extra_dirs", "type"])
 
             _assert_key_has_value(as_dict, "type", "cloud")
 
             auth_dict = as_dict["auth"]
             bucket_dict = as_dict["bucket"]
-            connection_dict = as_dict["connection"]
             cache_dict = as_dict["cache"]
 
             provider = as_dict["provider"]
@@ -1027,11 +1020,6 @@ def test_config_parse_cloud():
 
             _assert_key_has_value(bucket_dict, "name", "unique_bucket_name_all_lowercase")
             _assert_key_has_value(bucket_dict, "use_reduced_redundancy", False)
-
-            _assert_key_has_value(connection_dict, "host", None)
-            _assert_key_has_value(connection_dict, "port", 6000)
-            _assert_key_has_value(connection_dict, "multipart", True)
-            _assert_key_has_value(connection_dict, "is_secure", True)
 
             _assert_key_has_value(cache_dict, "size", 1000.0)
             _assert_key_has_value(cache_dict, "path", "database/object_store_cache")
@@ -1056,12 +1044,6 @@ def test_config_parse_cloud_noauth_for_aws():
             assert object_store.bucket_name == "unique_bucket_name_all_lowercase"
             assert object_store.use_rr is False
 
-            assert object_store.host is None
-            assert object_store.port == 6000
-            assert object_store.multipart is True
-            assert object_store.is_secure is True
-            assert object_store.conn_path == "/"
-
             cache_target = object_store.cache_target
             assert cache_target.size == 1000.0
             assert cache_target.path == "database/object_store_cache"
@@ -1069,13 +1051,12 @@ def test_config_parse_cloud_noauth_for_aws():
             assert object_store.extra_dirs["temp"] == "database/tmp_cloud"
 
             as_dict = object_store.to_dict()
-            _assert_has_keys(as_dict, ["provider", "auth", "bucket", "connection", "cache", "extra_dirs", "type"])
+            _assert_has_keys(as_dict, ["provider", "auth", "bucket", "cache", "extra_dirs", "type"])
 
             _assert_key_has_value(as_dict, "type", "cloud")
 
             auth_dict = as_dict["auth"]
             bucket_dict = as_dict["bucket"]
-            connection_dict = as_dict["connection"]
             cache_dict = as_dict["cache"]
 
             provider = as_dict["provider"]
@@ -1086,11 +1067,6 @@ def test_config_parse_cloud_noauth_for_aws():
 
             _assert_key_has_value(bucket_dict, "name", "unique_bucket_name_all_lowercase")
             _assert_key_has_value(bucket_dict, "use_reduced_redundancy", False)
-
-            _assert_key_has_value(connection_dict, "host", None)
-            _assert_key_has_value(connection_dict, "port", 6000)
-            _assert_key_has_value(connection_dict, "multipart", True)
-            _assert_key_has_value(connection_dict, "is_secure", True)
 
             _assert_key_has_value(cache_dict, "size", 1000.0)
             _assert_key_has_value(cache_dict, "path", "database/object_store_cache")

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -1518,6 +1518,9 @@ auth:
 bucket:
   name: ${bucket}
 
+connection:
+  region: ${region}
+
 extra_dirs:
 - type: job_work
   path: database/job_working_directory_azure
@@ -1529,11 +1532,13 @@ extra_dirs:
 @skip_unless_environ("GALAXY_TEST_AWS_ACCESS_KEY")
 @skip_unless_environ("GALAXY_TEST_AWS_SECRET_KEY")
 @skip_unless_environ("GALAXY_TEST_AWS_BUCKET")
+@skip_unless_environ("GALAXY_TEST_AWS_REGION")
 def test_real_aws_s3_store(tmp_path):
     template_vars = {
         "access_key": os.environ["GALAXY_TEST_AWS_ACCESS_KEY"],
         "secret_key": os.environ["GALAXY_TEST_AWS_SECRET_KEY"],
         "bucket": os.environ["GALAXY_TEST_AWS_BUCKET"],
+        "region": os.environ["GALAXY_TEST_AWS_REGION"],
     }
     with TestConfig(AMAZON_S3_SIMPLE_TEMPLATE_TEST_CONFIG_YAML, template_vars=template_vars) as (_, object_store):
         verify_caching_object_store_functionality(tmp_path, object_store)


### PR DESCRIPTION
Boto uses an older style signature for signing requests to AWS (v2). This is no allowed for regions created after 2014 - such as us-east-2. The newer style signatures can be turned on for newer regions but it requires also specifying a host. So the work around I worked through is allowing a region to be specified and if a region is specified just use the newer signatures and specify a host automatically. I put this all in the code as comments and I used it to run through a test case for AWS storage.

When we launch with #15875 I am guessing we probably want to allow a boto3 object store to be used. It has much easier multiprocess uploading and I think doesn't require this guess and check for the host and region and has been updated since 2018 unlike this older stuff.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
