### PR TITLE
Fix for unexpected OIDC XML validation error

### DIFF
--- a/lib/galaxy/authnz/xsd/oidc_backends_config.xsd
+++ b/lib/galaxy/authnz/xsd/oidc_backends_config.xsd
@@ -114,6 +114,13 @@
                                     </xs:documentation>
                                 </xs:annotation>
                             </xs:element>
+                            <xs:element name="tenant_id" minOccurs="0" type="xs:string">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Tenant ID for the IdP.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
                             <xs:element name="pkce_support" minOccurs="0" type="xs:boolean">
                                 <xs:annotation>
                                     <xs:documentation>

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -192,12 +192,13 @@ Please mind `http` and `https`.
         <client_id> ... </client_id>
         <client_secret> ... </client_secret>
         <redirect_uri>http://localhost:8080/authnz/azure/callback</redirect_uri>
-        <!-- Azure client_id, client_secret, and api_url can be obtained by folowing the instructions at
+        <!-- Azure client_id, client_secret, and tenant_id can be obtained by folowing the instructions at
         https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app
 
-        The api_url will typiclly be https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize
+        The required API URL will be automatically constructed from the provided tenant_id. In previous Galaxy versions
+         the entire "api_url" had to be provided including the tenant ID, this is no longer a valid configuration option.
          -->
-        <api_url> ... </api_url>
+        <tenant_id> ... </tenant_id>
     </provider>
 
     <!-- Documentation: https://docs.egi.eu/providers/check-in/sp -->


### PR DESCRIPTION
* Since Galaxy 23.1 using the api_url configuration parameter in the "oidc_backend_config.xml" file for authenticating with Azure will return an error when a user tries to log in. This bug has been documented before and can be seen here: https://github.com/galaxyproject/galaxy/issues/16373
* This problem can be solved by replacing the "api_url" parameter with the "tenant_id" parameter. However, this change of parameter name and expected value has not been documented in either the galaxy docs or in the oidc_backends_config.xml.sample example file since changes to the OIDC code have been made. This pull request attempts to solve that by updating the example file.
* In addition, since release_24.0, an XML validation is performed on the oidc_backends_config.xml file which causes the Galaxy process to return an error and exit on startup because it fails to acknowledge "tenant_id" as a legitimate parameter in the XML file. Even though this parameter is required since the OIDC changes in Galaxy 23.1. The changes to the oidc_backends_config.xsd file in this commit can fix that problem.
* Relevant error message:
```

galaxy.util ERROR 2024-05-08 09:52:56,530 [pN:main,p:108074,tN:MainThread] Validation of file /srv/galaxy/server/config/oidc_backends_config.xml failed
Traceback (most recent call last):
  File "/srv/galaxy/server/lib/galaxy/util/__init__.py", line 358, in parse_xml
    schema.assertValid(tree)
  File "src/lxml/etree.pyx", line 3650, in lxml.etree._Validator.assertValid
lxml.etree.DocumentInvalid: Element 'tenant_id': This element is not expected., line 8
Traceback (most recent call last):
  File "/srv/galaxy/server/lib/galaxy/webapps/galaxy/buildapp.py", line 60, in app_pair
    app = galaxy.app.UniverseApplication(global_conf=global_conf, is_webapp=True, **kwargs)
  File "/srv/galaxy/server/lib/galaxy/app.py", line 734, in __init__
    self.authnz_manager = managers.AuthnzManager(
  File "/srv/galaxy/server/lib/galaxy/authnz/managers.py", line 63, in __init__
    self._parse_oidc_backends_config(oidc_backends_config_file)
  File "/srv/galaxy/server/lib/galaxy/authnz/managers.py", line 111, in _parse_oidc_backends_config
    tree = parse_xml(config_file, schemafname=OIDC_BACKEND_SCHEMA)
  File "/srv/galaxy/server/lib/galaxy/util/__init__.py", line 358, in parse_xml
    schema.assertValid(tree)
  File "src/lxml/etree.pyx", line 3650, in lxml.etree._Validator.assertValid
lxml.etree.DocumentInvalid: Element 'tenant_id': This element is not expected., line 8

galaxy-handler@0.service: Main process exited, code=exited, status=1/FAILURE
galaxy-handler@0.service: Failed with result 'exit-code'.
galaxy-handler@0.service: Consumed 10.580s CPU time.
```

## How to test the changes?

Instructions for manual testing are as follows:
  1. Try to start a Galaxy instance using the release_24.0 branch (meaning without the fix in this pull request) while having a oidc_backends_config.xml configuration that contains the "tenant_id" configuration parameter.
  2. Notice that Galaxy  exists at startup with the following error message:   File "src/lxml/etree.pyx", line 3650, in lxml.etree._Validator.assertValid lxml.etree.DocumentInvalid: Element 'tenant_id': This element is not expected., line 8
  3. Try to start Galaxy again using the code added to the oidc_backends_config.xsd in this commit.
  4. Notice that Galaxy now starts correctly and doesn't return an error when detecting the "tenant_id" parameter in the oidc_backends_config.xml file.
## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
