### PR TITLE
[24.0] Fix activity bar touch events on iOS devices

### DIFF
--- a/client/src/components/Popper/usePopper.ts
+++ b/client/src/components/Popper/usePopper.ts
@@ -186,19 +186,14 @@ export function usePopperjs(
 
             case "hover": {
                 on(referenceRef.value!, "mouseover", doMouseover);
-                on(popperRef.value!, "mouseover", doMouseover);
                 on(referenceRef.value!, "mouseout", doMouseout);
-                on(popperRef.value!, "mouseout", doMouseout);
                 on(referenceRef.value!, "mousedown", doMouseout);
-                on(popperRef.value!, "mousedown", doMouseout);
                 break;
             }
 
             case "focus": {
                 on(referenceRef.value!, "focus", doOpen);
-                on(popperRef.value!, "focus", doOpen);
                 on(referenceRef.value!, "blur", doClose);
-                on(popperRef.value!, "blur", doClose);
                 break;
             }
 
@@ -218,16 +213,11 @@ export function usePopperjs(
         off(referenceRef.value!, "click", doToggle);
 
         off(referenceRef.value!, "mouseover", doMouseover);
-        off(popperRef.value!, "mouseover", doMouseover);
         off(referenceRef.value!, "mouseout", doMouseout);
-        off(popperRef.value!, "mouseout", doMouseout);
         off(referenceRef.value!, "mousedown", doMouseout);
-        off(popperRef.value!, "mousedown", doMouseout);
 
         off(referenceRef.value!, "focus", doOpen);
-        off(popperRef.value!, "focus", doOpen);
         off(referenceRef.value!, "blur", doClose);
-        off(popperRef.value!, "blur", doClose);
     };
     const doCloseForDocument = (e: Event) => {
         if (referenceRef.value?.contains(e.target as Element)) {


### PR DESCRIPTION
I'm not sure what the issue is here, the minimal fix is this:
```diff
diff --git a/client/src/components/Popper/usePopper.ts b/client/src/components/Popper/usePopper.ts
index ad18847d8d..183d2e49be 100644
--- a/client/src/components/Popper/usePopper.ts
+++ b/client/src/components/Popper/usePopper.ts
@@ -190,7 +190,7 @@ export function usePopperjs(
                 on(referenceRef.value!, "mouseout", doMouseout);
                 on(popperRef.value!, "mouseout", doMouseout);
                 on(referenceRef.value!, "mousedown", doMouseout);
-                on(popperRef.value!, "mousedown", doMouseout);
+                // on(popperRef.value!, "mousedown", doMouseout);
                 break;
             }

```
but I think we can probably just rely on events happening on referenceRef.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
