### PR TITLE
[24.0] Fix and unify axios error handling

### DIFF
--- a/client/src/components/Login/ChangePassword.vue
+++ b/client/src/components/Login/ChangePassword.vue
@@ -17,6 +17,7 @@
 import axios from "axios";
 import BootstrapVue from "bootstrap-vue";
 import { withPrefix } from "utils/redirect";
+import { errorMessageAsString } from "utils/simple-error";
 import Vue from "vue";
 
 Vue.use(BootstrapVue);
@@ -64,8 +65,7 @@ export default {
                 })
                 .catch((error) => {
                     this.variant = "danger";
-                    const message = error.response && error.response.data && error.response.data.err_msg;
-                    this.message = message || "Password change failed for an unknown reason.";
+                    this.message = errorMessageAsString(error, "Password change failed for an unknown reason.");
                 });
         },
     },

--- a/client/src/components/Login/LoginForm.vue
+++ b/client/src/components/Login/LoginForm.vue
@@ -106,12 +106,12 @@ import BootstrapVue from "bootstrap-vue";
 import ExternalLogin from "components/User/ExternalIdentities/ExternalLogin";
 import _l from "utils/localization";
 import { withPrefix } from "utils/redirect";
+import { errorMessageAsString } from "utils/simple-error";
 import Vue from "vue";
 
 import NewUserConfirmation from "./NewUserConfirmation";
 
 Vue.use(BootstrapVue);
-
 export default {
     components: {
         ExternalLogin,
@@ -212,12 +212,12 @@ export default {
                 })
                 .catch((error) => {
                     this.messageVariant = "danger";
-                    const message = error.response && error.response.data && error.response.data.err_msg;
+                    const message = errorMessageAsString(error, "Login failed for an unknown reason.");
                     if (this.connectExternalProvider && message && message.toLowerCase().includes("invalid")) {
                         this.messageText =
                             message + " Try logging in to the existing account through an external provider below.";
                     } else {
-                        this.messageText = message || "Login failed for an unknown reason.";
+                        this.messageText = message;
                     }
                 });
         },
@@ -233,8 +233,7 @@ export default {
                 })
                 .catch((error) => {
                     this.messageVariant = "danger";
-                    const message = error.response.data && error.response.data.err_msg;
-                    this.messageText = message || "Password reset failed for an unknown reason.";
+                    this.messageText = errorMessageAsString(error, "Password reset failed for an unknown reason.");
                 });
         },
         returnToLogin() {

--- a/client/src/components/Login/NewUserConfirmation.vue
+++ b/client/src/components/Login/NewUserConfirmation.vue
@@ -60,6 +60,7 @@
 import axios from "axios";
 import BootstrapVue from "bootstrap-vue";
 import { withPrefix } from "utils/redirect";
+import { errorMessageAsString } from "utils/simple-error";
 import Vue from "vue";
 
 Vue.use(BootstrapVue);
@@ -112,8 +113,7 @@ export default {
                     })
                     .catch((error) => {
                         this.messageVariant = "danger";
-                        const message = error.response.data && error.response.data.err_msg;
-                        this.messageText = message || "Login failed for an unknown reason.";
+                        this.messageText = errorMessageAsString(error, "Login failed for an unknown reason.");
                     });
             }
         },

--- a/client/src/components/Login/RegisterForm.vue
+++ b/client/src/components/Login/RegisterForm.vue
@@ -106,6 +106,7 @@ import BootstrapVue from "bootstrap-vue";
 import ExternalLogin from "components/User/ExternalIdentities/ExternalLogin";
 import _l from "utils/localization";
 import { withPrefix } from "utils/redirect";
+import { errorMessageAsString } from "utils/simple-error";
 import Vue from "vue";
 
 Vue.use(BootstrapVue);
@@ -198,8 +199,7 @@ export default {
                 .catch((error) => {
                     this.disableCreate = false;
                     this.messageVariant = "danger";
-                    const message = error.response.data && error.response.data.err_msg;
-                    this.messageText = message || "Registration failed for an unknown reason.";
+                    this.messageText = errorMessageAsString(error, "Registration failed for an unknown reason.");
                 });
         },
     },

--- a/client/src/components/User/ExternalIdentities/ExternalLogin.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalLogin.vue
@@ -101,6 +101,7 @@ import axios from "axios";
 import BootstrapVue from "bootstrap-vue";
 import LoadingSpan from "components/LoadingSpan";
 import { getAppRoot } from "onload";
+import { errorMessageAsString } from "utils/simple-error";
 import Vue from "vue";
 import Multiselect from "vue-multiselect";
 
@@ -186,8 +187,7 @@ export default {
                 })
                 .catch((error) => {
                     this.messageVariant = "danger";
-                    const message = error.response.data && error.response.data.err_msg;
-                    this.messageText = message || "Login failed for an unknown reason.";
+                    this.messageText = errorMessageAsString(error, "Login failed for an unknown reason.");
                     this.loading = false;
                 });
         },
@@ -208,9 +208,7 @@ export default {
                 })
                 .catch((error) => {
                     this.messageVariant = "danger";
-                    const message = error.response.data && error.response.data.err_msg;
-
-                    this.messageText = message || "Login failed for an unknown reason.";
+                    this.messageText = errorMessageAsString(error, "Login failed for an unknown reason.");
                     this.loading = false;
                 });
         },


### PR DESCRIPTION
Fixes https://sentry.galaxyproject.org/organizations/galaxy/issues/151896/?project=3&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=8:

```
TypeError: undefined is not an object (evaluating 'e.response.data')
  at <anonymous>(webpack://@galaxyproject/galaxy-client/src/components/Login/RegisterForm.vue:201:43)
```


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
