### PR TITLE
[24.0] Fix deprecated `deprecated` argument

### DIFF
--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -387,7 +387,7 @@ class UserDeletionPayload(Model):
         default=False,
         title="Purge user",
         description="Purge the user. Deprecated, please use the `purge` query parameter instead.",
-        deprecated=True,
+        json_schema_extra={"deprecated": True},
     )
 
 


### PR DESCRIPTION
I broke that while merging forward https://github.com/galaxyproject/galaxy/pull/18105


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
