### PR TITLE
[24.0] Don't log exception if cancelled slurm job doesn't have stderr file

### DIFF
--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -222,6 +222,9 @@ class SlurmJobRunner(DRMAAJobRunner):
                         return OUT_OF_MEMORY_MSG
                     elif any(_ in stripped_line for _ in SLURM_MEMORY_LIMIT_EXCEEDED_PARTIAL_WARNINGS):
                         return PROBABLY_OUT_OF_MEMORY_MSG
+        except FileNotFoundError:
+            # Entirely expected, as __check_memory_limit is only called if the job state is CANCELLED
+            return False
         except Exception:
             log.exception("Error reading end of %s:", efile_path)
 


### PR DESCRIPTION
This seems entirely expected and not worth reporting at an ERROR level. Fixes https://sentry.galaxyproject.org/share/issue/c7332e0cf1554c33b2cf56283acfcd1d/:
```
FileNotFoundError
[Errno 2] No such file or directory: '/corral4/main/jobs/057/797/57797989/galaxy_57797989.e'
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
