### PR TITLE
[24.0] Include traceback when logging email PJA exception

### DIFF
--- a/lib/galaxy/job_execution/actions/post.py
+++ b/lib/galaxy/job_execution/actions/post.py
@@ -9,10 +9,7 @@ from markupsafe import escape
 
 from galaxy.model import PostJobActionAssociation
 from galaxy.model.base import transaction
-from galaxy.util import (
-    send_mail,
-    unicodify,
-)
+from galaxy.util import send_mail
 from galaxy.util.custom_logging import get_logger
 
 log = get_logger(__name__)
@@ -70,8 +67,8 @@ class EmailAction(DefaultJobAction):
             if link_invocation:
                 body += f"\n\nWorkflow Invocation Report:\n{link_invocation}"
             send_mail(app.config.email_from, to, subject, body, app.config)
-        except Exception as e:
-            log.error("EmailAction PJA Failed, exception: %s", unicodify(e))
+        except Exception:
+            log.exception("EmailAction PJA Failed")
 
     @classmethod
     def get_short_str(cls, pja):


### PR DESCRIPTION
The exception that is logged currently is:
```
EmailAction PJA Failed, exception: 'NoneType' object has no attribute 'name'
```
The unepxected NoneType is probably job.history, but hard to know.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
