### PR TITLE
[24.0] Downgrade missing output file in working directory to warning for failed jobs

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1419,8 +1419,8 @@ class MinimalJobWrapper(HasResourceParameters):
                         try:
                             shutil.move(dataset_path.false_path, dataset_path.real_path)
                             log.debug("fail(): Moved %s to %s", dataset_path.false_path, dataset_path.real_path)
-                        except OSError as e:
-                            log.error("fail(): Missing output file in working directory: %s", unicodify(e))
+                        except FileNotFoundError as e:
+                            log.warning("fail(): Missing output file in working directory: %s", unicodify(e))
             except Exception as e:
                 log.exception(str(e))
             for dataset_assoc in job.output_datasets + job.output_library_datasets:


### PR DESCRIPTION
That seems perfectly normal, since jobs might die before they're actually even sent to the DRM, for instance when this happens:
```
parameter 'input1': the previously selected dataset has been deleted.
```

Might even set this to debug ...

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
