### PR TITLE
Drop "?" (Help) from DatasetActions list

### DIFF
--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -172,10 +172,6 @@ function onHighlight() {
                     @click.stop="onHighlight">
                     <FontAwesomeIcon :icon="faSitemap" />
                 </BButton>
-
-                <BButton v-if="showRerun" class="px-1" title="Help" size="sm" variant="link" @click.stop="onRerun">
-                    <FontAwesomeIcon :icon="faQuestion" />
-                </BButton>
             </div>
         </div>
     </div>

--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -1,14 +1,6 @@
 <script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
-import {
-    faBug,
-    faChartBar,
-    faInfoCircle,
-    faLink,
-    faQuestion,
-    faRedo,
-    faSitemap,
-} from "@fortawesome/free-solid-svg-icons";
+import { faBug, faChartBar, faInfoCircle, faLink, faRedo, faSitemap } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton } from "bootstrap-vue";
 import { computed } from "vue";
@@ -23,7 +15,7 @@ import { type ItemUrls } from ".";
 
 import DatasetDownload from "@/components/History/Content/Dataset/DatasetDownload.vue";
 
-library.add(faBug, faChartBar, faInfoCircle, faLink, faQuestion, faRedo, faSitemap);
+library.add(faBug, faChartBar, faInfoCircle, faLink, faRedo, faSitemap);
 
 interface Props {
     item: HDADetailed;

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -180,7 +180,6 @@ history_panel:
       # Action buttons...
       download_button: '${_} .download-btn'
       info_button: '${_} .params-btn'
-      tool_help_button: '${_} .fa.fa-question'
       rerun_button: '${_} .rerun-btn'
       alltags: '${_} .stateless-tags .tag'
 

--- a/client/src/utils/navigation/schema.ts
+++ b/client/src/utils/navigation/schema.ts
@@ -101,7 +101,6 @@ interface Roothistory_panelitem extends Component {
     delete_button: SelectorTemplate;
     download_button: SelectorTemplate;
     info_button: SelectorTemplate;
-    tool_help_button: SelectorTemplate;
     rerun_button: SelectorTemplate;
     alltags: SelectorTemplate;
 }


### PR DESCRIPTION
Was pointed out by @nekrut that it's confusing and redundant since it's identical to rerun.  

This feature when originally implemented used to pop up the tool help text in the history panel itself, but the display was always awkward and it never found much use.  Current implementation being 100% the same as rerun is less than helpful.

One option to attempt to 'fix' the feature would be to auto-scroll to help and make it more obvious what's going on, but in reality direct access to Tool Help from the output dataset simply isn't desired or useful, and it's actually more useful for users to understand the rerun path back to the tool form and accompanying information.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
