### PR TITLE
Revises handling of warnings in the workflow run form

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -213,9 +213,10 @@ export interface User extends QuotaUsageResponse {
 }
 
 export interface AnonymousUser {
+    id: undefined;
     isAnonymous: true;
-    username?: string;
     is_admin?: false;
+    username?: string;
 }
 
 export type GenericUser = User | AnonymousUser;

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -213,7 +213,7 @@ export interface User extends QuotaUsageResponse {
 }
 
 export interface AnonymousUser {
-    id: undefined;
+    id?: string;
     isAnonymous: true;
     is_admin?: false;
     username?: string;

--- a/client/src/components/LoadingSpan.vue
+++ b/client/src/components/LoadingSpan.vue
@@ -1,7 +1,9 @@
 <template>
     <span>
         <span :class="spinnerClasses" title="loading"></span>
-        <span v-if="!spinnerOnly" class="loading-message">{{ message }}.<span class="blinking">..</span></span>
+        <span v-if="!spinnerOnly" class="loading-message" data-description="loading message">
+            {{ message }}.<span class="blinking">..</span>
+        </span>
     </span>
 </template>
 <script>

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { BAlert } from "bootstrap-vue";
+import { storeToRefs } from "pinia";
 import { computed, onMounted, ref, watch } from "vue";
 import { RouterLink } from "vue-router";
 
 import { useHistoryItemsStore } from "@/stores/historyItemsStore";
 import { useHistoryStore } from "@/stores/historyStore";
+import { useUserStore } from "@/stores/userStore";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import { WorkflowRunModel } from "./model";
@@ -17,6 +19,7 @@ import WorkflowRunSuccess from "@/components/Workflow/Run/WorkflowRunSuccess.vue
 
 const historyStore = useHistoryStore();
 const historyItemsStore = useHistoryItemsStore();
+const { currentUser } = storeToRefs(useUserStore());
 
 interface Props {
     workflowId: string;
@@ -44,6 +47,7 @@ const workflowModel: any = ref(null);
 const currentHistoryId = computed(() => historyStore.currentHistoryId);
 const editorLink = computed(() => `/workflows/edit?id=${props.workflowId}`);
 const historyStatusKey = computed(() => `${currentHistoryId.value}_${lastUpdateTime.value}`);
+const isOwner = computed(() => currentUser.value?.id === workflowModel.value.runData.id);
 const lastUpdateTime = computed(() => historyItemsStore.lastUpdateTime);
 
 function handleInvocations(incomingInvocations: any) {

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -162,7 +162,7 @@ defineExpose({
                     data-description="workflow run warning">
                     <span>
                         The <b>`{{ workflowName }}`</b> workflow may contain tools which have changed since it was last
-                        saved or some error have been detected. Please
+                        saved or some other problems have been detected. Please
                     </span>
                     <RouterLink v-if="isOwner" :to="editorLink">click here to edit and review the issues</RouterLink>
                     <BLink v-else @click="onImport">click here to import the workflow and review the issues</BLink>

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -37,13 +37,13 @@ const props = withDefaults(defineProps<Props>(), {
     simpleFormUseJobCache: false,
 });
 
-const formError = ref("");
 const loading = ref(true);
 const hasUpgradeMessages = ref(false);
 const hasStepVersionChanges = ref(false);
 const invocations = ref([]);
 const simpleForm = ref(false);
 const submissionError = ref("");
+const workflowError = ref("");
 const workflowName = ref("");
 const workflowModel: any = ref(null);
 
@@ -103,7 +103,7 @@ function loadRun() {
             loading.value = false;
         })
         .catch((response) => {
-            formError.value = errorMessageAsString(response);
+            workflowError.value = errorMessageAsString(response);
         });
 }
 
@@ -128,13 +128,22 @@ watch(
         }
     }
 );
+
+defineExpose({
+    loading,
+    simpleForm,
+    submissionError,
+    handleSubmissionError,
+    workflowError,
+    workflowModel,
+});
 </script>
 
 <template>
     <span>
-        <BAlert v-if="formError" variant="danger" show>
+        <BAlert v-if="workflowError" variant="danger" show>
             <h2 class="h-text">Workflow cannot be executed. Please resolve the following issue:</h2>
-            {{ formError }}
+            {{ workflowError }}
         </BAlert>
         <span v-else>
             <BAlert v-if="loading" variant="info" show>
@@ -145,7 +154,12 @@ watch(
                 :invocations="invocations"
                 :workflow-name="workflowName" />
             <div v-else class="ui-form-composite">
-                <BAlert v-if="hasUpgradeMessages || hasStepVersionChanges" class="mb-4" variant="warning" show>
+                <BAlert
+                    v-if="hasUpgradeMessages || hasStepVersionChanges"
+                    class="mb-4"
+                    variant="warning"
+                    show
+                    data-description="workflow run warning">
                     <span>
                         The <b>`{{ workflowName }}`</b> workflow may contain tools which have changed since it was last
                         saved or some error have been detected. Please

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -10,35 +10,30 @@
             </b-alert>
             <WorkflowRunSuccess v-else-if="!!invocations" :invocations="invocations" :workflow-name="workflowName" />
             <div v-else class="ui-form-composite">
-                <div class="ui-form-composite-messages mb-4">
-                    <b-alert v-if="hasUpgradeMessages" variant="warning" show>
-                        Some tools in this workflow may have changed since it was last saved or some errors were found.
-                        The workflow may still run, but any new options will have default values. Please review the
-                        messages below to make a decision about whether the changes will affect your analysis.
-                    </b-alert>
-                    <b-alert v-if="hasStepVersionChanges" variant="warning" show>
-                        Some tools are being executed with different versions compared to those available when this
-                        workflow was last saved because the other versions are not or no longer available on this Galaxy
-                        instance. To upgrade your workflow and dismiss this message simply edit the workflow and re-save
-                        it.
-                    </b-alert>
-                    <b-alert v-if="submissionError" variant="danger" show>
+                <b-alert v-if="hasUpgradeMessages || hasStepVersionChanges" class="mb-4" variant="warning" show>
+                    The <b>`{{ model.name }}`</b> workflow may contain tools which have changed since it was last saved
+                    or some error have been detected. Please
+                    <a :to="editorLink" :href="editorLink">click here to edit and review the issues</a> before running
+                    this workflow.
+                </b-alert>
+                <div v-else>
+                    <b-alert v-if="submissionError" class="mb-4" variant="danger" show>
                         Workflow submission failed: {{ submissionError }}
                     </b-alert>
+                    <WorkflowRunFormSimple
+                        v-else-if="simpleForm"
+                        :model="model"
+                        :target-history="simpleFormTargetHistory"
+                        :use-job-cache="simpleFormUseJobCache"
+                        @submissionSuccess="handleInvocations"
+                        @submissionError="handleSubmissionError"
+                        @showAdvanced="showAdvanced" />
+                    <WorkflowRunForm
+                        v-else
+                        :model="model"
+                        @submissionSuccess="handleInvocations"
+                        @submissionError="handleSubmissionError" />
                 </div>
-                <WorkflowRunFormSimple
-                    v-if="simpleForm"
-                    :model="model"
-                    :target-history="simpleFormTargetHistory"
-                    :use-job-cache="simpleFormUseJobCache"
-                    @submissionSuccess="handleInvocations"
-                    @submissionError="handleSubmissionError"
-                    @showAdvanced="showAdvanced" />
-                <WorkflowRunForm
-                    v-else
-                    :model="model"
-                    @submissionSuccess="handleInvocations"
-                    @submissionError="handleSubmissionError" />
             </div>
         </span>
     </span>
@@ -99,6 +94,9 @@ export default {
     computed: {
         ...mapState(useHistoryStore, ["currentHistoryId", "getHistoryById"]),
         ...mapState(useHistoryItemsStore, ["lastUpdateTime"]),
+        editorLink() {
+            return `/workflows/edit?id=${this.model.workflowId}`;
+        },
         historyStatusKey() {
             return `${this.currentHistoryId}_${this.lastUpdateTime}`;
         },

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { BAlert } from "bootstrap-vue";
+import { BAlert, BLink } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, onMounted, ref, watch } from "vue";
 import { RouterLink } from "vue-router";

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -145,7 +145,7 @@ watch(
                 :invocations="invocations"
                 :workflow-name="workflowName" />
             <div v-else class="ui-form-composite">
-                <BAlert v-if="!hasUpgradeMessages || hasStepVersionChanges" class="mb-4" variant="warning" show>
+                <BAlert v-if="hasUpgradeMessages || hasStepVersionChanges" class="mb-4" variant="warning" show>
                     <span>
                         The <b>`{{ workflowName }}`</b> workflow may contain tools which have changed since it was last
                         saved or some error have been detected. Please

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { BAlert } from "bootstrap-vue";
 import { computed, onMounted, ref, watch } from "vue";
+import { RouterLink } from "vue-router";
 
 import { useHistoryItemsStore } from "@/stores/historyItemsStore";
 import { useHistoryStore } from "@/stores/historyStore";
@@ -132,10 +133,10 @@ watch(
                 :invocations="invocations"
                 :workflow-name="workflowName" />
             <div v-else class="ui-form-composite">
-                <BAlert v-if="hasUpgradeMessages || hasStepVersionChanges" class="mb-4" variant="warning" show>
+                <BAlert v-if="!hasUpgradeMessages || hasStepVersionChanges" class="mb-4" variant="warning" show>
                     The <b>`{{ workflowName }}`</b> workflow may contain tools which have changed since it was last
                     saved or some error have been detected. Please
-                    <a :to="editorLink" :href="editorLink">click here to edit and review the issues</a> before running
+                    <RouterLink :to="editorLink">click here to edit and review the issues</RouterLink> before running
                     this workflow.
                 </BAlert>
                 <div v-else>

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { BAlert } from "bootstrap-vue";
 import { computed, onMounted, ref, watch } from "vue";
 
 import { useHistoryItemsStore } from "@/stores/historyItemsStore";
@@ -118,29 +119,29 @@ watch(
 
 <template>
     <span>
-        <b-alert v-if="formError" variant="danger" show>
+        <BAlert v-if="formError" variant="danger" show>
             <h2 class="h-text">Workflow cannot be executed. Please resolve the following issue:</h2>
             {{ formError }}
-        </b-alert>
+        </BAlert>
         <span v-else>
-            <b-alert v-if="loading" variant="info" show>
+            <BAlert v-if="loading" variant="info" show>
                 <LoadingSpan message="Loading workflow run data" />
-            </b-alert>
+            </BAlert>
             <WorkflowRunSuccess
                 v-else-if="invocations.length > 0"
                 :invocations="invocations"
                 :workflow-name="workflowName" />
             <div v-else class="ui-form-composite">
-                <b-alert v-if="hasUpgradeMessages || hasStepVersionChanges" class="mb-4" variant="warning" show>
+                <BAlert v-if="hasUpgradeMessages || hasStepVersionChanges" class="mb-4" variant="warning" show>
                     The <b>`{{ workflowName }}`</b> workflow may contain tools which have changed since it was last
                     saved or some error have been detected. Please
                     <a :to="editorLink" :href="editorLink">click here to edit and review the issues</a> before running
                     this workflow.
-                </b-alert>
+                </BAlert>
                 <div v-else>
-                    <b-alert v-if="submissionError" class="mb-4" variant="danger" show>
+                    <BAlert v-if="submissionError" class="mb-4" variant="danger" show>
                         Workflow submission failed: {{ submissionError }}
-                    </b-alert>
+                    </BAlert>
                     <WorkflowRunFormSimple
                         v-else-if="simpleForm"
                         :model="workflowModel"

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -3,7 +3,9 @@ import { BAlert } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, onMounted, ref, watch } from "vue";
 import { RouterLink } from "vue-router";
+import { useRouter } from "vue-router/composables";
 
+import { copyWorkflow } from "@/components/Workflow/workflows.services";
 import { useHistoryItemsStore } from "@/stores/historyItemsStore";
 import { useHistoryStore } from "@/stores/historyStore";
 import { useUserStore } from "@/stores/userStore";
@@ -20,6 +22,7 @@ import WorkflowRunSuccess from "@/components/Workflow/Run/WorkflowRunSuccess.vue
 const historyStore = useHistoryStore();
 const historyItemsStore = useHistoryItemsStore();
 const { currentUser } = storeToRefs(useUserStore());
+const router = useRouter();
 
 interface Props {
     workflowId: string;
@@ -104,7 +107,10 @@ function loadRun() {
         });
 }
 
-function onImport() {}
+async function onImport() {
+    const response = await copyWorkflow(props.workflowId, workflowModel.value.runData.owner);
+    router.push(`/workflows/edit?id=${response.id}`);
+}
 
 function showAdvanced() {
     simpleForm.value = false;

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -104,6 +104,8 @@ function loadRun() {
         });
 }
 
+function onImport() {}
+
 function showAdvanced() {
     simpleForm.value = false;
 }
@@ -138,10 +140,13 @@ watch(
                 :workflow-name="workflowName" />
             <div v-else class="ui-form-composite">
                 <BAlert v-if="!hasUpgradeMessages || hasStepVersionChanges" class="mb-4" variant="warning" show>
-                    The <b>`{{ workflowName }}`</b> workflow may contain tools which have changed since it was last
-                    saved or some error have been detected. Please
-                    <RouterLink :to="editorLink">click here to edit and review the issues</RouterLink> before running
-                    this workflow.
+                    <span>
+                        The <b>`{{ workflowName }}`</b> workflow may contain tools which have changed since it was last
+                        saved or some error have been detected. Please
+                    </span>
+                    <RouterLink v-if="isOwner" :to="editorLink">click here to edit and review the issues</RouterLink>
+                    <BLink v-else @click="onImport">click here to import the workflow and review the issues</BLink>
+                    <span>before running this workflow.</span>
                 </BAlert>
                 <div v-else>
                     <BAlert v-if="submissionError" class="mb-4" variant="danger" show>

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -47,7 +47,7 @@ const workflowModel: any = ref(null);
 const currentHistoryId = computed(() => historyStore.currentHistoryId);
 const editorLink = computed(() => `/workflows/edit?id=${props.workflowId}`);
 const historyStatusKey = computed(() => `${currentHistoryId.value}_${lastUpdateTime.value}`);
-const isOwner = computed(() => currentUser.value?.id === workflowModel.value.runData.id);
+const isOwner = computed(() => currentUser.value?.username === workflowModel.value.runData.owner);
 const lastUpdateTime = computed(() => historyItemsStore.lastUpdateTime);
 
 function handleInvocations(incomingInvocations: any) {

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -663,7 +663,7 @@ trs_import:
 
 workflow_run:
   selectors:
-    warning: ".ui-form-composite-messages .alert-warning"
+    warning: '[data-description="workflow run warning"]'
     input_div: "[step-label='${label}']"
     input_data_div: "[step-label='${label}'] .multiselect"
     # TODO: put step labels in the DOM ideally

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1046,9 +1046,9 @@ class WorkflowContentsManager(UsesAnnotations):
             "id": trans.app.security.encode_id(stored.id),
             "history_id": trans.app.security.encode_id(history.id) if history else None,
             "name": stored.name,
+            "owner": stored.user.username,
             "steps": step_models,
             "step_version_changes": step_version_changes,
-            "user_id": trans.app.security.encode_id(stored.user_id),
             "has_upgrade_messages": has_upgrade_messages,
             "workflow_resource_parameters": self._workflow_resource_parameters(trans, stored, workflow),
         }

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1048,6 +1048,7 @@ class WorkflowContentsManager(UsesAnnotations):
             "name": stored.name,
             "steps": step_models,
             "step_version_changes": step_version_changes,
+            "user_id": trans.app.security.encode_id(stored.user_id),
             "has_upgrade_messages": has_upgrade_messages,
             "workflow_resource_parameters": self._workflow_resource_parameters(trans, stored, workflow),
         }

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -177,7 +177,7 @@ steps:
         self.workflow_run_with_name(name)
         self.sleep_for(self.wait_types.UX_TRANSITION)
         # Check that this tool form contains a warning about different versions.
-        self.assert_message(self.components.workflow_run.warning, contains="different versions")
+        self.assert_message(self.components.workflow_run.warning, contains="tools which have changed")
         self.screenshot("workflow_run_tool_upgrade")
 
     @selenium_test
@@ -189,7 +189,7 @@ steps:
         name = self.workflow_upload_yaml_with_random_name(workflow_with_rules_json, exact_tools=True)
         self.workflow_run_with_name(name)
         self.sleep_for(self.wait_types.UX_TRANSITION)
-        self.assert_message(self.components.workflow_run.warning, contains="different versions")
+        self.assert_message(self.components.workflow_run.warning, contains="tools which have changed")
         # 1.0.0 is a version that exists in WORKFLOW_SAFE_TOOL_VERSION_UPDATES
         workflow_with_rules["steps"]["apply"]["tool_version"] = "1.0.0"
         workflow_with_rules_json = json.dumps(workflow_with_rules)


### PR DESCRIPTION
Fixes #18077.

This PR replaces the workflow run form warning messages, and redirects the user to the workflow editor instead. It also contains refactoring towards typescript and composition api.

If the user attempts to run a public workflow which contains changes and requires review, the following message is shown, and the workflow is imported before loading the workflow editor:
<img width="671" alt="image" src="https://github.com/galaxyproject/galaxy/assets/2105447/4dd4efc0-58b4-451c-be66-992b64952101">

If the user already owns the workflow, the workflow editor is loaded directly upon clicking the link shown in the message:
<img width="672" alt="image" src="https://github.com/galaxyproject/galaxy/assets/2105447/39c28daa-70ef-443d-9196-eb2411a74787">

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
