### PR TITLE
Improve type hints in manager classes

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -4019,14 +4019,10 @@ export interface components {
             /**
              * Source
              * @description The source of this dataset, either `hda` or `ldda` depending of its origin.
+             * @enum {string}
              */
-            src: components["schemas"]["DatasetSourceType"];
+            src: "hda" | "ldda";
         };
-        /**
-         * DatasetSourceType
-         * @enum {string}
-         */
-        DatasetSourceType: "hda" | "ldda";
         /**
          * DatasetState
          * @enum {string}
@@ -4645,8 +4641,9 @@ export interface components {
             /**
              * Source
              * @description The source of this dataset, either `hda` or `ldda` depending of its origin.
+             * @enum {string}
              */
-            src: components["schemas"]["DatasetSourceType"];
+            src: "hda" | "ldda";
         };
         /** EncodedHdcaSourceId */
         EncodedHdcaSourceId: {
@@ -5605,7 +5602,7 @@ export interface components {
              * HDA or LDDA
              * @description Whether this dataset belongs to a history (HDA) or a library (LDDA).
              */
-            hda_ldda?: components["schemas"]["DatasetSourceType"] | null;
+            hda_ldda?: components["schemas"]["DataItemSourceType"] | null;
             /**
              * HID
              * @description The index position of this item in the History.
@@ -5851,7 +5848,7 @@ export interface components {
              * @description Whether this dataset belongs to a history (HDA) or a library (LDDA).
              * @default hda
              */
-            hda_ldda?: components["schemas"]["DatasetSourceType"];
+            hda_ldda?: components["schemas"]["DataItemSourceType"];
             /**
              * HID
              * @description The index position of this item in the History.
@@ -6000,7 +5997,7 @@ export interface components {
              * @description Whether this dataset belongs to a history (HDA) or a library (LDDA).
              * @default hda
              */
-            hda_ldda?: components["schemas"]["DatasetSourceType"];
+            hda_ldda?: components["schemas"]["DataItemSourceType"];
             /**
              * History ID
              * @example 0123456789ABCDEF
@@ -9370,8 +9367,9 @@ export interface components {
             /**
              * Source
              * @description The source of the content. Can be other history element to be copied or library elements.
+             * @enum {string}
              */
-            source: components["schemas"]["DatasetSourceType"];
+            source: "hda" | "ldda";
         };
         /** MessageNotificationContent */
         MessageNotificationContent: {
@@ -13847,7 +13845,7 @@ export interface operations {
             /** @description View to be passed to the serializer */
             /** @description Comma-separated list of keys to be passed to the serializer */
             query?: {
-                hda_ldda?: components["schemas"]["DatasetSourceType"];
+                hda_ldda?: "hda" | "ldda";
                 data_type?: components["schemas"]["RequestDataType"] | null;
                 view?: string | null;
                 keys?: string | null;
@@ -14148,7 +14146,7 @@ export interface operations {
         parameters: {
             /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
             query?: {
-                hda_ldda?: components["schemas"]["DatasetSourceType"];
+                hda_ldda?: "hda" | "ldda";
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -14184,7 +14182,7 @@ export interface operations {
         parameters: {
             /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
             query?: {
-                hda_ldda?: components["schemas"]["DatasetSourceType"];
+                hda_ldda?: "hda" | "ldda";
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -14218,7 +14216,7 @@ export interface operations {
         parameters: {
             /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
             query?: {
-                hda_ldda?: components["schemas"]["DatasetSourceType"];
+                hda_ldda?: "hda" | "ldda";
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -14287,7 +14285,7 @@ export interface operations {
         parameters: {
             /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
             query?: {
-                hda_ldda?: components["schemas"]["DatasetSourceType"];
+                hda_ldda?: "hda" | "ldda";
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -14353,7 +14351,7 @@ export interface operations {
         parameters: {
             /** @description Whether this dataset belongs to a history (HDA) or a library (LDDA). */
             query?: {
-                hda_ldda?: components["schemas"]["DatasetSourceType"];
+                hda_ldda?: "hda" | "ldda";
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -19697,7 +19695,7 @@ export interface operations {
              * @description Whether this dataset belongs to a history (HDA) or a library (LDDA).
              */
             query?: {
-                hda_ldda?: components["schemas"]["DatasetSourceType"] | null;
+                hda_ldda?: ("hda" | "ldda") | null;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -19798,7 +19796,7 @@ export interface operations {
              * @description Whether this dataset belongs to a history (HDA) or a library (LDDA).
              */
             query?: {
-                hda_ldda?: components["schemas"]["DatasetSourceType"] | null;
+                hda_ldda?: ("hda" | "ldda") | null;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -722,7 +722,7 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
         self.test_data_resolver = self._register_singleton(
             TestDataResolver, TestDataResolver(file_dirs=self.config.tool_test_data_directories)
         )
-        self.api_keys_manager = self._register_singleton(ApiKeyManager)
+        self.api_keys_manager = self._register_singleton(ApiKeyManager[galaxy.model.APIKeys, galaxy.model.User])
 
         # Tool Data Tables
         self._configure_tool_data_tables(from_shed_config=False)

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -47,7 +47,7 @@ from galaxy.files.plugins import (
 from galaxy.files.templates import ConfiguredFileSourceTemplates
 from galaxy.job_metrics import JobMetrics
 from galaxy.jobs.manager import JobManager
-from galaxy.managers.api_keys import ApiKeyManager
+from galaxy.managers.api_keys import GalaxyApiKeyManager
 from galaxy.managers.citations import CitationsManager
 from galaxy.managers.collections import DatasetCollectionManager
 from galaxy.managers.dbkeys import GenomeBuilds
@@ -722,7 +722,7 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
         self.test_data_resolver = self._register_singleton(
             TestDataResolver, TestDataResolver(file_dirs=self.config.tool_test_data_directories)
         )
-        self.api_keys_manager = self._register_singleton(ApiKeyManager[galaxy.model.APIKeys, galaxy.model.User])
+        self.api_keys_manager = self._register_singleton(GalaxyApiKeyManager)
 
         # Tool Data Tables
         self._configure_tool_data_tables(from_shed_config=False)

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -196,7 +196,7 @@ def set_metadata(
     try:
         if overwrite:
             hda_manager.overwrite_metadata(dataset_instance)
-        dataset_instance.datatype.set_meta(dataset_instance)  # type:ignore [arg-type]
+        dataset_instance.datatype.set_meta(dataset_instance)
         dataset_instance.set_peek()
         # Reset SETTING_METADATA state so the dataset instance getter picks the dataset state
         dataset_instance.set_metadata_success_state()

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -69,7 +69,6 @@ from galaxy.datatypes.metadata import (
     MetadataParameter,
 )
 from galaxy.datatypes.protocols import (
-    DatasetHasHidProtocol,
     DatasetProtocol,
     HasExtraFilesAndMetadata,
     HasFileName,
@@ -692,7 +691,7 @@ class BamNative(CompressedArchive, _BamOrSam):
     def display_data(
         self,
         trans,
-        dataset: DatasetHasHidProtocol,
+        dataset: DatasetProtocol,
         preview: bool = False,
         filename: Optional[str] = None,
         to_ext: Optional[str] = None,
@@ -2094,7 +2093,7 @@ class H5MLM(H5):
     def display_data(
         self,
         trans,
-        dataset: DatasetHasHidProtocol,
+        dataset: DatasetProtocol,
         preview: bool = False,
         filename: Optional[str] = None,
         to_ext: Optional[str] = None,

--- a/lib/galaxy/datatypes/blast.py
+++ b/lib/galaxy/datatypes/blast.py
@@ -40,10 +40,7 @@ from typing import (
     Optional,
 )
 
-from galaxy.datatypes.protocols import (
-    DatasetHasHidProtocol,
-    DatasetProtocol,
-)
+from galaxy.datatypes.protocols import DatasetProtocol
 from galaxy.datatypes.sniff import (
     build_sniff_from_prefix,
     FilePrefix,
@@ -210,7 +207,7 @@ class _BlastDb(Data):
     def display_data(
         self,
         trans,
-        dataset: DatasetHasHidProtocol,
+        dataset: DatasetProtocol,
         preview: bool = False,
         filename: Optional[str] = None,
         to_ext: Optional[str] = None,

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -422,7 +422,7 @@ class Data(metaclass=DataMeta):
                 yield fpath, rpath
 
     def _serve_raw(
-        self, dataset: DatasetHasHidProtocol, to_ext: Optional[str], headers: Headers, **kwd
+        self, dataset: DatasetProtocol, to_ext: Optional[str], headers: Headers, **kwd
     ) -> Tuple[IO, Headers]:
         headers["Content-Length"] = str(os.stat(dataset.get_file_name()).st_size)
         headers["content-type"] = (
@@ -516,7 +516,7 @@ class Data(metaclass=DataMeta):
     def display_data(
         self,
         trans,
-        dataset: DatasetHasHidProtocol,
+        dataset: DatasetProtocol,
         preview: bool = False,
         filename: Optional[str] = None,
         to_ext: Optional[str] = None,
@@ -648,7 +648,7 @@ class Data(metaclass=DataMeta):
 
     def _download_filename(
         self,
-        dataset: DatasetHasHidProtocol,
+        dataset: Union[DatasetProtocol, DatasetHasHidProtocol],
         to_ext: Optional[str] = None,
         hdca: Optional[DatasetHasHidProtocol] = None,
         element_identifier: Optional[str] = None,
@@ -665,7 +665,7 @@ class Data(metaclass=DataMeta):
         template_values = {
             "name": escape(dataset.name),
             "ext": to_ext,
-            "hid": dataset.hid,
+            "hid": getattr(dataset, "hid", "-library"),
         }
 
         if not filename_pattern:

--- a/lib/galaxy/datatypes/isa.py
+++ b/lib/galaxy/datatypes/isa.py
@@ -28,7 +28,6 @@ from markupsafe import escape
 from galaxy import util
 from galaxy.datatypes.data import Data
 from galaxy.datatypes.protocols import (
-    DatasetHasHidProtocol,
     DatasetProtocol,
     HasExtraFilesAndMetadata,
     HasExtraFilesPath,
@@ -266,7 +265,7 @@ class _Isa(Data):
     def display_data(
         self,
         trans,
-        dataset: DatasetHasHidProtocol,
+        dataset: DatasetProtocol,
         preview: bool = False,
         filename: Optional[str] = None,
         to_ext: Optional[str] = None,

--- a/lib/galaxy/datatypes/protocols.py
+++ b/lib/galaxy/datatypes/protocols.py
@@ -2,9 +2,15 @@
 Location of protocols used in datatypes
 """
 
-from typing import Any
+from typing import (
+    Any,
+    TYPE_CHECKING,
+)
 
 from typing_extensions import Protocol
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm.base import Mapped
 
 
 class HasClearAssociatedFiles(Protocol):
@@ -35,7 +41,7 @@ class HasHid(Protocol):
 
 
 class HasId(Protocol):
-    id: int
+    id: "Mapped[int]"
 
 
 class HasInfo(Protocol):

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -31,7 +31,6 @@ from galaxy.datatypes.metadata import (
     MetadataElement,
 )
 from galaxy.datatypes.protocols import (
-    DatasetHasHidProtocol,
     DatasetProtocol,
     HasMetadata,
 )
@@ -766,7 +765,7 @@ class BaseFastq(Sequence):
     def display_data(
         self,
         trans,
-        dataset: DatasetHasHidProtocol,
+        dataset: DatasetProtocol,
         preview: bool = False,
         filename: Optional[str] = None,
         to_ext: Optional[str] = None,

--- a/lib/galaxy/datatypes/spaln.py
+++ b/lib/galaxy/datatypes/spaln.py
@@ -14,7 +14,6 @@ from typing import (
 from galaxy.datatypes.data import Data
 from galaxy.datatypes.metadata import MetadataElement
 from galaxy.datatypes.protocols import (
-    DatasetHasHidProtocol,
     DatasetProtocol,
     HasExtraFilesAndMetadata,
 )
@@ -117,7 +116,7 @@ class _SpalnDb(Data):
     def display_data(
         self,
         trans,
-        dataset: DatasetHasHidProtocol,
+        dataset: DatasetProtocol,
         preview: bool = False,
         filename: Optional[str] = None,
         to_ext: Optional[str] = None,

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -53,7 +53,6 @@ from galaxy.datatypes.metadata import (
     MetadataParameter,
 )
 from galaxy.datatypes.protocols import (
-    DatasetHasHidProtocol,
     DatasetProtocol,
     HasFileName,
     HasMetadata,
@@ -168,7 +167,7 @@ class TabularData(Text):
     def display_data(
         self,
         trans,
-        dataset: DatasetHasHidProtocol,
+        dataset: DatasetProtocol,
         preview: bool = False,
         filename: Optional[str] = None,
         to_ext: Optional[str] = None,

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -27,7 +27,6 @@ from galaxy.datatypes.metadata import (
     MetadataParameter,
 )
 from galaxy.datatypes.protocols import (
-    DatasetHasHidProtocol,
     DatasetProtocol,
     HasCreatingJob,
     HasExtraFilesAndMetadata,
@@ -208,7 +207,7 @@ class Ipynb(Json):
     def display_data(
         self,
         trans,
-        dataset: DatasetHasHidProtocol,
+        dataset: DatasetProtocol,
         preview: bool = False,
         filename: Optional[str] = None,
         to_ext: Optional[str] = None,
@@ -224,7 +223,7 @@ class Ipynb(Json):
     def _display_data_trusted(
         self,
         trans,
-        dataset: DatasetHasHidProtocol,
+        dataset: DatasetProtocol,
         preview: bool = False,
         filename: Optional[str] = None,
         to_ext: Optional[str] = None,

--- a/lib/galaxy/managers/api_keys.py
+++ b/lib/galaxy/managers/api_keys.py
@@ -1,29 +1,45 @@
+from typing import (
+    Generic,
+    Optional,
+    TYPE_CHECKING,
+    TypeVar,
+    Union,
+)
+
 from sqlalchemy import (
     false,
     select,
     update,
 )
-from typing_extensions import Protocol
 
 from galaxy.model.base import transaction
 from galaxy.structured_app import BasicSharedApp
 
+if TYPE_CHECKING:
+    from galaxy.model import (
+        APIKeys as GalaxyAPIKeys,
+        User as GalaxyUser,
+    )
+    from tool_shed.webapp.model import (
+        APIKeys as ToolShedAPIKeys,
+        User as ToolShedUser,
+    )
 
-class IsUserModel(Protocol):
-    id: int
+A = TypeVar("A", bound=Union["GalaxyAPIKeys", "ToolShedAPIKeys"])
+U = TypeVar("U", bound=Union["GalaxyUser", "ToolShedUser"])
 
 
-class ApiKeyManager:
+class ApiKeyManager(Generic[A, U]):
     def __init__(self, app: BasicSharedApp):
         self.app = app
         self.session = self.app.model.context
 
-    def get_api_key(self, user: IsUserModel):
+    def get_api_key(self, user: U) -> Optional[A]:
         APIKeys = self.app.model.APIKeys
         stmt = select(APIKeys).filter_by(user_id=user.id, deleted=False).order_by(APIKeys.create_time.desc()).limit(1)
         return self.session.scalars(stmt).first()
 
-    def create_api_key(self, user: IsUserModel):
+    def create_api_key(self, user: U) -> A:
         guid = self.app.security.get_new_guid()
         new_key = self.app.model.APIKeys()
         new_key.user_id = user.id
@@ -33,15 +49,16 @@ class ApiKeyManager:
             self.session.commit()
         return new_key
 
-    def get_or_create_api_key(self, user: IsUserModel) -> str:
+    def get_or_create_api_key(self, user: U) -> str:
         # Logic Galaxy has always used - but it would appear to have a race
         # condition. Worth fixing? Would kind of need a message queue to fix
         # in multiple process mode.
         api_key = self.get_api_key(user)
         key = api_key.key if api_key else self.create_api_key(user).key
+        assert key
         return key
 
-    def delete_api_key(self, user: IsUserModel) -> None:
+    def delete_api_key(self, user: U) -> None:
         """Marks the current user API key as deleted."""
         # Before it was possible to create multiple API keys for the same user although they were not considered valid
         # So all non-deleted keys are marked as deleted for backward compatibility

--- a/lib/galaxy/managers/api_keys.py
+++ b/lib/galaxy/managers/api_keys.py
@@ -76,3 +76,7 @@ class ApiKeyManager(Generic[A, U]):
             .execution_options(synchronize_session="evaluate")
         )
         return self.session.execute(stmt)
+
+
+class GalaxyApiKeyManager(ApiKeyManager["GalaxyAPIKeys", "GalaxyUser"]):
+    pass

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -196,8 +196,12 @@ def get_object(trans, id, class_name, check_ownership=False, check_accessible=Fa
 U = TypeVar("U", bound=model._HasTable)
 
 
+class HasModelClass(Generic[U]):
+    model_class: Type[U]
+
+
 # -----------------------------------------------------------------------------
-class ModelManager(Generic[U]):
+class ModelManager(Generic[U], HasModelClass[U]):
     """
     Base class for all model/resource managers.
 
@@ -205,7 +209,6 @@ class ModelManager(Generic[U]):
     over the ORM.
     """
 
-    model_class: Type[U]
     foreign_key_name: str
     app: BasicSharedApp
 
@@ -215,7 +218,7 @@ class ModelManager(Generic[U]):
     def session(self) -> scoped_session:
         return self.app.model.context
 
-    def _session_setattr(self, item: model.Base, attr: str, val: Any, flush: bool = True):
+    def _session_setattr(self, item: U, attr: str, val: Any, flush: bool = True):
         setattr(item, attr, val)
 
         self.session().add(item)

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -200,6 +200,13 @@ class HasModelClass(Generic[U]):
     model_class: Type[U]
 
 
+HasIdT = TypeVar("HasIdT", covariant=True)
+
+
+class HasById(Protocol[HasIdT]):
+    def by_id(self, id: int) -> HasIdT: ...
+
+
 # -----------------------------------------------------------------------------
 class ModelManager(Generic[U], HasModelClass[U]):
     """

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -243,7 +243,7 @@ class ModelManager(Generic[U], HasModelClass[U]):
         order_by=None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-    ) -> Query:
+    ) -> Query[U]:
         """
         Return a basic query from model_class, filters, order_by, and limit and offset.
 
@@ -256,8 +256,8 @@ class ModelManager(Generic[U], HasModelClass[U]):
         return self._filter_and_order_query(query, filters=filters, order_by=order_by, limit=limit, offset=offset)
 
     def _filter_and_order_query(
-        self, query: Query, filters=None, order_by=None, limit: Optional[int] = None, offset: Optional[int] = None
-    ) -> Query:
+        self, query: Query[U], filters=None, order_by=None, limit: Optional[int] = None, offset: Optional[int] = None
+    ) -> Query[U]:
         # TODO: not a lot of functional cohesion here
         query = self._apply_orm_filters(query, filters)
         query = self._apply_order_by(query, order_by)
@@ -265,7 +265,7 @@ class ModelManager(Generic[U], HasModelClass[U]):
         return query
 
     # .... filters
-    def _apply_orm_filters(self, query: Query, filters) -> Query:
+    def _apply_orm_filters(self, query: Query[U], filters) -> Query[U]:
         """
         Add any filters to the given query.
         """
@@ -280,7 +280,7 @@ class ModelManager(Generic[U], HasModelClass[U]):
         return query
 
     # .... order, limit, and offset
-    def _apply_order_by(self, query: Query, order_by) -> Query:
+    def _apply_order_by(self, query: Query[U], order_by) -> Query[U]:
         """
         Return the query after adding the order_by clauses.
 
@@ -299,7 +299,7 @@ class ModelManager(Generic[U], HasModelClass[U]):
         """
         return (self.model_class.__table__.c.create_time,)
 
-    def _apply_orm_limit_offset(self, query: Query, limit: Optional[int], offset: Optional[int]) -> Query:
+    def _apply_orm_limit_offset(self, query: Query[U], limit: Optional[int], offset: Optional[int]) -> Query[U]:
         """
         Return the query after applying the given limit and offset (if not None).
         """

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -46,7 +46,11 @@ log = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-class DatasetManager(base.ModelManager[model.Dataset], secured.AccessibleManagerMixin, deletable.PurgableManagerMixin):
+class DatasetManager(
+    base.ModelManager[model.Dataset],
+    secured.AccessibleManagerMixin[model.Dataset],
+    deletable.PurgableManagerMixin[model.Dataset],
+):
     """
     Manipulate datasets: the components contained in DatasetAssociations/DatasetInstances/HDAs/LDDAs
     """
@@ -344,7 +348,7 @@ DI = TypeVar("DI", bound=model.DatasetInstance)
 class DatasetAssociationManager(
     Generic[DI],
     base.ModelManager[DI],
-    secured.AccessibleManagerMixin,
+    secured.AccessibleManagerMixin[DI],
     secured.OwnableManagerMixin[DI],
     deletable.PurgableManagerMixin[DI],
 ):

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -8,6 +8,7 @@ import os
 from typing import (
     Any,
     Dict,
+    Generic,
     List,
     Optional,
     Type,
@@ -336,12 +337,16 @@ class DatasetSerializer(base.ModelSerializer[DatasetManager], deletable.Purgable
         return permissions
 
 
+DI = TypeVar("DI", bound=model.DatasetInstance)
+
+
 # ============================================================================= AKA DatasetInstanceManager
 class DatasetAssociationManager(
-    base.ModelManager[model.DatasetInstance],
+    Generic[DI],
+    base.ModelManager[DI],
     secured.AccessibleManagerMixin,
-    secured.OwnableManagerMixin,
-    deletable.PurgableManagerMixin,
+    secured.OwnableManagerMixin[DI],
+    deletable.PurgableManagerMixin[DI],
 ):
     """
     DatasetAssociation/DatasetInstances are intended to be working
@@ -359,14 +364,14 @@ class DatasetAssociationManager(
         super().__init__(app)
         self.dataset_manager = DatasetManager(app)
 
-    def is_accessible(self, item, user: Optional[model.User], **kwargs: Any) -> bool:
+    def is_accessible(self, item: DI, user: Optional[model.User], **kwargs: Any) -> bool:
         """
         Is this DA accessible to `user`?
         """
         # defer to the dataset
         return self.dataset_manager.is_accessible(item.dataset, user, **kwargs)
 
-    def delete(self, item, flush: bool = True, stop_job: bool = False, **kwargs):
+    def delete(self, item: DI, flush: bool = True, stop_job: bool = False, **kwargs):
         """
         Marks this dataset association as deleted.
         If `stop_job` is True, will stop the creating job if all other outputs are deleted.
@@ -376,7 +381,7 @@ class DatasetAssociationManager(
             self.stop_creating_job(item, flush=flush)
         return item
 
-    def purge(self, dataset_assoc, flush=True):
+    def purge(self, item: DI, flush=True, **kwargs) -> DI:
         """
         Purge this DatasetInstance and the dataset underlying it.
         """
@@ -388,15 +393,15 @@ class DatasetAssociationManager(
         # so that job cleanup associated with stop_creating_job will see
         # the dataset as purged.
         flush_required = not self.app.config.track_jobs_in_database
-        super().purge(dataset_assoc, flush=flush or flush_required)
+        super().purge(item, flush=flush or flush_required)
 
         # stop any jobs outputing the dataset_assoc
-        self.stop_creating_job(dataset_assoc, flush=True)
+        self.stop_creating_job(item, flush=True)
 
         # more importantly, purge underlying dataset as well
-        if dataset_assoc.dataset.user_can_purge:
-            self.dataset_manager.purge(dataset_assoc.dataset)
-        return dataset_assoc
+        if item.dataset.user_can_purge:
+            self.dataset_manager.purge(item.dataset)
+        return item
 
     def by_user(self, user):
         raise exceptions.NotImplemented("Abstract Method")

--- a/lib/galaxy/managers/deletable.py
+++ b/lib/galaxy/managers/deletable.py
@@ -12,19 +12,20 @@ attribute 'purged'.
 from typing import (
     Any,
     Dict,
+    Generic,
     Set,
 )
 
-from galaxy.model import Base
 from .base import (
     Deserializer,
     ModelValidator,
     OrmFilterParsersType,
     parse_bool,
+    U,
 )
 
 
-class DeletableManagerMixin:
+class DeletableManagerMixin(Generic[U]):
     """
     A mixin/interface for a model that is deletable (i.e. has a 'deleted' attr).
 
@@ -33,15 +34,15 @@ class DeletableManagerMixin:
     removed by an admin/script.
     """
 
-    def _session_setattr(self, item: Base, attr: str, val: Any, flush: bool = True): ...
+    def _session_setattr(self, item: U, attr: str, val: Any, flush: bool = True): ...
 
-    def delete(self, item, flush=True, **kwargs):
+    def delete(self, item: U, flush=True, **kwargs):
         """
         Mark as deleted and return.
         """
         return self._session_setattr(item, "deleted", True, flush=flush)
 
-    def undelete(self, item, flush=True, **kwargs):
+    def undelete(self, item: U, flush=True, **kwargs):
         """
         Mark as not deleted and return.
         """
@@ -84,16 +85,16 @@ class DeletableFiltersMixin:
         self.orm_filter_parsers.update({"deleted": {"op": ("eq"), "val": parse_bool}})
 
 
-class PurgableManagerMixin(DeletableManagerMixin):
+class PurgableManagerMixin(Generic[U], DeletableManagerMixin[U]):
     """
     A manager interface/mixin for a resource that allows deleting and purging where
     purging is often removal of some additional, non-db resource (e.g. a dataset's
     file).
     """
 
-    def _session_setattr(self, item: Base, attr: str, val: Any, flush: bool = True): ...
+    def _session_setattr(self, item: U, attr: str, val: Any, flush: bool = True): ...
 
-    def purge(self, item, flush=True, **kwargs):
+    def purge(self, item: U, flush=True, **kwargs):
         """
         Mark as purged and return.
 

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -14,6 +14,7 @@ from typing import (
     List,
     Optional,
     Set,
+    Union,
 )
 
 from sqlalchemy import (
@@ -51,7 +52,6 @@ from galaxy.model import (
 )
 from galaxy.model.base import transaction
 from galaxy.model.deferred import materializer_factory
-from galaxy.schema.schema import DatasetSourceType
 from galaxy.schema.storage_cleaner import (
     CleanableItemsSummary,
     StorageItemCleanupError,
@@ -184,8 +184,10 @@ class HDAManager(
             sa_session=self.app.model.session(),
         )
         user = self.user_manager.by_id(request_user.user_id)
-        if request.source == DatasetSourceType.hda:
-            dataset_instance = self.get_accessible(request.content, user)
+        if request.source == "hda":
+            dataset_instance: Union[model.HistoryDatasetAssociation, model.LibraryDatasetDatasetAssociation] = (
+                self.get_accessible(request.content, user)
+            )
         else:
             dataset_instance = self.ldda_manager.get_accessible(request.content, user)
         history = self.app.history_manager.by_id(request.history_id)

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -196,7 +196,12 @@ class HDAManager(
             session.commit()
 
     def copy(
-        self, item: Any, history=None, hide_copy: bool = False, flush: bool = True, **kwargs: Any
+        self,
+        item: model.HistoryDatasetAssociation,
+        history=None,
+        hide_copy: bool = False,
+        flush: bool = True,
+        **kwargs: Any,
     ) -> model.HistoryDatasetAssociation:
         """
         Copy hda, including annotation and tags, add to history and return the given HDA.

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -78,8 +78,8 @@ class HistoryDatasetAssociationNoHistoryException(Exception):
 
 
 class HDAManager(
-    datasets.DatasetAssociationManager,
-    secured.OwnableManagerMixin,
+    datasets.DatasetAssociationManager[model.HistoryDatasetAssociation],
+    secured.OwnableManagerMixin[model.HistoryDatasetAssociation],
     annotatable.AnnotatableManagerMixin,
 ):
     """
@@ -126,7 +126,9 @@ class HDAManager(
         #     return True
         return super().is_accessible(item, user, **kwargs)
 
-    def is_owner(self, item, user: Optional[model.User], current_history=None, **kwargs: Any) -> bool:
+    def is_owner(
+        self, item: model.HistoryDatasetAssociation, user: Optional[model.User], current_history=None, **kwargs: Any
+    ) -> bool:
         """
         Use history to see if current user owns HDA.
         """

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -96,7 +96,7 @@ INDEX_SEARCH_FILTERS = {
 }
 
 
-class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMixin, SortableManager):
+class HistoryManager(sharable.SharableModelManager[History], deletable.PurgableManagerMixin[History], SortableManager):
     model_class = model.History
     foreign_key_name = "history"
     user_share_model = model.HistoryUserShareAssociation
@@ -259,7 +259,7 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
 
     def is_owner(
         self,
-        item: model.Base,
+        item: model.History,
         user: Optional[model.User],
         current_history: Optional[model.History] = None,
         **kwargs: Any,

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -529,7 +529,7 @@ class JobSearch:
             model.HistoryDatasetAssociation.id == e.history_dataset_association_id
         )
         # b is the HDA used for the job
-        stmt = stmt.join(b, a.dataset_id == b.id).join(c, c.dataset_id == b.dataset_id)  # type:ignore[attr-defined]
+        stmt = stmt.join(b, a.dataset_id == b.id).join(c, c.dataset_id == b.dataset_id)
         name_condition = []
         if identifier:
             stmt = stmt.join(d)
@@ -627,7 +627,7 @@ class JobSearch:
                 ),
             )
             .outerjoin(d, d.id == c.hda_id)
-            .outerjoin(e, e.dataset_id == d.dataset_id)  # type:ignore[attr-defined]
+            .outerjoin(e, e.dataset_id == d.dataset_id)
         )
         data_conditions.append(
             and_(
@@ -637,7 +637,7 @@ class JobSearch:
                     and_(
                         c.hda_id == b.hda_id,
                         d.id == c.hda_id,
-                        e.dataset_id == d.dataset_id,  # type:ignore[attr-defined]
+                        e.dataset_id == d.dataset_id,
                     ),
                 ),
                 c.id == v,

--- a/lib/galaxy/managers/lddas.py
+++ b/lib/galaxy/managers/lddas.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from galaxy import model
 from galaxy.managers import base as manager_base
@@ -8,7 +9,7 @@ from galaxy.structured_app import MinimalManagerApp
 log = logging.getLogger(__name__)
 
 
-class LDDAManager(DatasetAssociationManager):
+class LDDAManager(DatasetAssociationManager[model.LibraryDatasetDatasetAssociation]):
     """
     A fairly sparse manager for LDDAs.
     """
@@ -20,6 +21,16 @@ class LDDAManager(DatasetAssociationManager):
         Set up and initialize other managers needed by lddas.
         """
         super().__init__(app)
+
+    def is_owner(
+        self, item: model.LibraryDatasetDatasetAssociation, user: Optional[model.User], trans=None, **kwargs
+    ) -> bool:
+        return manager_base.get_object(
+            trans,
+            id,
+            "LibraryDatasetDatasetAssociation",
+            check_ownership=True,
+        )
 
     def get(self, trans, id: int, check_accessible=True) -> model.LibraryDatasetDatasetAssociation:
         return manager_base.get_object(

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -27,7 +27,7 @@ from galaxy.util import validation
 log = logging.getLogger(__name__)
 
 
-class LibraryDatasetsManager(datasets.DatasetAssociationManager):
+class LibraryDatasetsManager(datasets.DatasetAssociationManager[model.LibraryDatasetDatasetAssociation]):
     """Interface/service object for interacting with library datasets."""
 
     model_class = model.LibraryDatasetDatasetAssociation

--- a/lib/galaxy/managers/pages.py
+++ b/lib/galaxy/managers/pages.py
@@ -122,7 +122,7 @@ INDEX_SEARCH_FILTERS = {
 }
 
 
-class PageManager(sharable.SharableModelManager, UsesAnnotations):
+class PageManager(sharable.SharableModelManager[Page], UsesAnnotations):
     """Provides operations for managing a Page."""
 
     model_class = model.Page

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -30,10 +30,7 @@ from sqlalchemy import (
     true,
 )
 
-from galaxy import (
-    exceptions,
-    model,
-)
+from galaxy import exceptions
 from galaxy.managers import (
     annotatable,
     base,
@@ -107,7 +104,7 @@ class SharableModelManager(
         # ... effectively a good fit to have this here, but not semantically
         if self.user_manager.is_admin(user, trans=kwargs.get("trans", None)):
             return True
-        return item.user == user  # type:ignore[attr-defined]
+        return item.user == user
 
     def is_accessible(self, item: U, user: Optional[User], **kwargs: Any) -> bool:
         """

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -295,7 +295,7 @@ class BaseUserManager(Generic[U], base.ModelManager[U], deletable.PurgableManage
             raise exceptions.AuthenticationFailed(msg, **kwargs)
         return user
 
-    def get_user_by_identity(self, identity) -> Optional[U]:
+    def get_user_by_identity(self, identity: str) -> Optional[U]:
         """Get user by username or email."""
         if VALID_EMAIL_RE.match(identity):
             # VALID_PUBLICNAME and VALID_EMAIL do not overlap, so 'identity' here is an email address
@@ -499,7 +499,7 @@ class BaseUserManager(Generic[U], base.ModelManager[U], deletable.PurgableManage
         with transaction(session):
             session.commit()
 
-    def _get_user_by_email_case_insensitive(self, session, email):
+    def _get_user_by_email_case_insensitive(self, session, email: str):
         stmt = select(self.app.model.User).where(func.lower(self.app.model.User.email) == email.lower()).limit(1)
         return session.scalars(stmt).first()
 

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -572,15 +572,18 @@ class UserManager(BaseUserManager[User]):
         if self.app.config.redact_user_address_during_deletion:
             stmt = select(UserAddress).where(UserAddress.user_id == item.id)
             for addr in self.session().scalars(stmt):
-                addr.desc = new_secure_hash_v2(addr.desc + pseudorandom_value)
+                if addr.desc:
+                    addr.desc = new_secure_hash_v2(addr.desc + pseudorandom_value)
                 addr.name = new_secure_hash_v2(addr.name + pseudorandom_value)
-                addr.institution = new_secure_hash_v2(addr.institution + pseudorandom_value)
+                if addr.institution:
+                    addr.institution = new_secure_hash_v2(addr.institution + pseudorandom_value)
                 addr.address = new_secure_hash_v2(addr.address + pseudorandom_value)
                 addr.city = new_secure_hash_v2(addr.city + pseudorandom_value)
                 addr.state = new_secure_hash_v2(addr.state + pseudorandom_value)
                 addr.postal_code = new_secure_hash_v2(addr.postal_code + pseudorandom_value)
                 addr.country = new_secure_hash_v2(addr.country + pseudorandom_value)
-                addr.phone = new_secure_hash_v2(addr.phone + pseudorandom_value)
+                if addr.phone:
+                    addr.phone = new_secure_hash_v2(addr.phone + pseudorandom_value)
                 self.session().add(addr)
         # Purge the user
         super().purge(item, flush=flush)

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -196,7 +196,7 @@ class BaseUserManager(Generic[U], base.ModelManager[U], deletable.PurgableManage
             raise exceptions.Conflict("Email must be unique", email=email)
 
     def by_id(self, user_id: int) -> U:
-        return self.app.model.session.get(self.model_class, user_id)
+        return self.one(id=user_id)
 
     # ---- filters
     def by_email(self, email: str, filters=None, **kwargs) -> Optional[U]:

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -195,9 +195,6 @@ class BaseUserManager(Generic[U], base.ModelManager[U], deletable.PurgableManage
         if self.by_email(email) is not None:
             raise exceptions.Conflict("Email must be unique", email=email)
 
-    def by_id(self, user_id: int) -> U:
-        return self.one(id=user_id)
-
     # ---- filters
     def by_email(self, email: str, filters=None, **kwargs) -> Optional[U]:
         """

--- a/lib/galaxy/managers/visualizations.py
+++ b/lib/galaxy/managers/visualizations.py
@@ -59,7 +59,7 @@ INDEX_SEARCH_FILTERS = {
 }
 
 
-class VisualizationManager(sharable.SharableModelManager):
+class VisualizationManager(sharable.SharableModelManager[model.Visualization]):
     """
     Handle operations outside and between visualizations and other models.
     """

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -145,7 +145,7 @@ INDEX_SEARCH_FILTERS = {
 }
 
 
-class WorkflowsManager(sharable.SharableModelManager, deletable.DeletableManagerMixin):
+class WorkflowsManager(sharable.SharableModelManager[StoredWorkflow], deletable.DeletableManagerMixin[StoredWorkflow]):
     """Handle CRUD type operations related to workflows. More interesting
     stuff regarding workflow execution, step sorting, etc... can be found in
     the galaxy.workflow module.

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -782,7 +782,7 @@ class User(Base, Dictifiable, RepresentById):
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
     email: Mapped[str] = mapped_column(TrimmedString(255), index=True)
-    username: Mapped[str] = mapped_column(TrimmedString(255), index=True, unique=True)
+    username: Mapped[str] = mapped_column(TrimmedString(255), index=True, unique=True, nullable=True)
     password: Mapped[str] = mapped_column(TrimmedString(255))
     last_password_change: Mapped[Optional[datetime]] = mapped_column(default=now)
     external: Mapped[Optional[bool]] = mapped_column(default=False)
@@ -6847,7 +6847,7 @@ class HistoryDatasetCollectionAssociation(
     collection_id: Mapped[int] = mapped_column(ForeignKey("dataset_collection.id"), index=True)
     history_id: Mapped[int] = mapped_column(ForeignKey("history.id"), index=True)
     name: Mapped[Optional[str]] = mapped_column(TrimmedString(255))
-    hid: Mapped[int]
+    hid: Mapped[int] = mapped_column(nullabled=True)
     visible: Mapped[Optional[bool]]
     deleted: Mapped[Optional[bool]] = mapped_column(default=False)
     copied_from_history_dataset_collection_association_id: Mapped[Optional[int]] = mapped_column(
@@ -11152,7 +11152,7 @@ class APIKeys(Base, RepresentById):
     id: Mapped[int] = mapped_column(primary_key=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    key: Mapped[str] = mapped_column(TrimmedString(32), index=True, unique=True)
+    key: Mapped[str] = mapped_column(TrimmedString(32), index=True, unique=True, nullable=True)
     user: Mapped[Optional["User"]] = relationship(back_populates="api_keys")
     deleted: Mapped[bool] = mapped_column(index=True, server_default=false())
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4074,7 +4074,7 @@ class Dataset(Base, StorableObject, Serializable):
     active_history_associations: Mapped[List["HistoryDatasetAssociation"]] = relationship(
         primaryjoin=(
             lambda: and_(
-                Dataset.id == HistoryDatasetAssociation.dataset_id,  # type: ignore[attr-defined]
+                Dataset.id == HistoryDatasetAssociation.dataset_id,
                 HistoryDatasetAssociation.deleted == false(),  # type: ignore[has-type]
                 HistoryDatasetAssociation.purged == false(),  # type: ignore[arg-type]
             )
@@ -4084,7 +4084,7 @@ class Dataset(Base, StorableObject, Serializable):
     purged_history_associations: Mapped[List["HistoryDatasetAssociation"]] = relationship(
         primaryjoin=(
             lambda: and_(
-                Dataset.id == HistoryDatasetAssociation.dataset_id,  # type: ignore[attr-defined]
+                Dataset.id == HistoryDatasetAssociation.dataset_id,
                 HistoryDatasetAssociation.purged == true(),  # type: ignore[arg-type]
             )
         ),

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -777,7 +777,7 @@ class User(Base, Dictifiable, RepresentById):
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
     email: Mapped[str] = mapped_column(TrimmedString(255), index=True)
-    username: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True, unique=True)
+    username: Mapped[str] = mapped_column(TrimmedString(255), index=True, unique=True)
     password: Mapped[str] = mapped_column(TrimmedString(255))
     last_password_change: Mapped[Optional[datetime]] = mapped_column(default=now)
     external: Mapped[Optional[bool]] = mapped_column(default=False)
@@ -6834,10 +6834,10 @@ class HistoryDatasetCollectionAssociation(
     __tablename__ = "history_dataset_collection_association"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    collection_id: Mapped[Optional[int]] = mapped_column(ForeignKey("dataset_collection.id"), index=True)
-    history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
+    collection_id: Mapped[int] = mapped_column(ForeignKey("dataset_collection.id"), index=True)
+    history_id: Mapped[int] = mapped_column(ForeignKey("history.id"), index=True)
     name: Mapped[Optional[str]] = mapped_column(TrimmedString(255))
-    hid: Mapped[Optional[int]]
+    hid: Mapped[int]
     visible: Mapped[Optional[bool]]
     deleted: Mapped[Optional[bool]] = mapped_column(default=False)
     copied_from_history_dataset_collection_association_id: Mapped[Optional[int]] = mapped_column(
@@ -6852,7 +6852,7 @@ class HistoryDatasetCollectionAssociation(
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, index=True, nullable=True)
 
     collection = relationship("DatasetCollection")
-    history: Mapped[Optional["History"]] = relationship(back_populates="dataset_collections")
+    history: Mapped["History"] = relationship(back_populates="dataset_collections")
 
     copied_from_history_dataset_collection_association = relationship(
         "HistoryDatasetCollectionAssociation",

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6847,7 +6847,7 @@ class HistoryDatasetCollectionAssociation(
     collection_id: Mapped[int] = mapped_column(ForeignKey("dataset_collection.id"), index=True)
     history_id: Mapped[int] = mapped_column(ForeignKey("history.id"), index=True)
     name: Mapped[Optional[str]] = mapped_column(TrimmedString(255))
-    hid: Mapped[int] = mapped_column(nullabled=True)
+    hid: Mapped[int] = mapped_column(nullable=True)
     visible: Mapped[Optional[bool]]
     deleted: Mapped[Optional[bool]] = mapped_column(default=False)
     copied_from_history_dataset_collection_association_id: Mapped[Optional[int]] = mapped_column(

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -11142,7 +11142,7 @@ class APIKeys(Base, RepresentById):
     id: Mapped[int] = mapped_column(primary_key=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    key: Mapped[Optional[str]] = mapped_column(TrimmedString(32), index=True, unique=True)
+    key: Mapped[str] = mapped_column(TrimmedString(32), index=True, unique=True)
     user: Mapped[Optional["User"]] = relationship(back_populates="api_keys")
     deleted: Mapped[bool] = mapped_column(index=True, server_default=false())
 

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -716,7 +716,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                                 # Try to set metadata directly. @mvdbeek thinks we should only record the datasets
                                 try:
                                     if dataset_instance.has_metadata_files:
-                                        dataset_instance.datatype.set_meta(dataset_instance)  # type:ignore[arg-type]
+                                        dataset_instance.datatype.set_meta(dataset_instance)
                                 except Exception:
                                     log.debug(f"Metadata setting failed on {dataset_instance}", exc_info=True)
                                     dataset_instance.state = dataset_instance.dataset.states.FAILED_METADATA

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -699,11 +699,14 @@ class HDAInaccessible(HDACommon):
     state: DatasetStateField
 
 
-HdaLddaField = Field(
-    DatasetSourceType.hda,
-    title="HDA or LDDA",
-    description="Whether this dataset belongs to a history (HDA) or a library (LDDA).",
-)
+HdaLddaField = Annotated[
+    DataItemSourceType,
+    Field(
+        "hda",
+        title="HDA or LDDA",
+        description="Whether this dataset belongs to a history (HDA) or a library (LDDA).",
+    ),
+]
 
 
 class DatasetValidatedState(str, Enum):
@@ -760,7 +763,7 @@ class HDADetailed(HDASummary, WithModelClass):
     """History Dataset Association detailed information."""
 
     model_class: Annotated[HDA_MODEL_CLASS, ModelClassField(HDA_MODEL_CLASS)]
-    hda_ldda: DatasetSourceType = HdaLddaField
+    hda_ldda: HdaLddaField
     accessible: bool = AccessibleField
     misc_info: Optional[str] = Field(
         default=None,
@@ -942,7 +945,7 @@ class HDAObject(Model, WithModelClass):
     id: HistoryDatasetAssociationId
     model_class: HDA_MODEL_CLASS = ModelClassField(HDA_MODEL_CLASS)
     state: DatasetStateField
-    hda_ldda: DatasetSourceType = HdaLddaField
+    hda_ldda: HdaLddaField
     history_id: HistoryID
     tags: List[str]
     copied_from_ldda_id: Optional[EncodedDatabaseIdField] = None

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -503,9 +503,7 @@ class DCEType(str, Enum):  # TODO: suspiciously similar to HistoryContentType
     dataset_collection = "dataset_collection"
 
 
-class DatasetSourceType(str, Enum):
-    hda = "hda"
-    ldda = "ldda"
+DatasetSourceType = Annotated[Literal["hda", "ldda"], Field(description="Type of dataset association")]
 
 
 class DataItemSourceType(str, Enum):

--- a/lib/galaxy/structured_app.py
+++ b/lib/galaxy/structured_app.py
@@ -43,6 +43,7 @@ from galaxy.workflow.trs_proxy import TrsProxy
 if TYPE_CHECKING:
     from galaxy.config_watchers import ConfigWatchers
     from galaxy.jobs import JobConfiguration
+    from galaxy.managers.api_keys import GalaxyApiKeyManager
     from galaxy.managers.collections import DatasetCollectionManager
     from galaxy.managers.hdas import HDAManager
     from galaxy.managers.histories import HistoryManager
@@ -159,5 +160,5 @@ class StructuredApp(MinimalManagerApp):
     watchers: "ConfigWatchers"
     workflow_scheduling_manager: Any  # 'galaxy.workflow.scheduling_manager.WorkflowSchedulingManager'
     interactivetool_manager: Any
-    api_keys_manager: Any  # 'galaxy.managers.api_keys.ApiKeyManager'
+    api_keys_manager: "GalaxyApiKeyManager"  # 'galaxy.managers.api_keys.ApiKeyManager'
     visualizations_registry: Any  # 'galaxy.visualization.plugins.registry.VisualizationsRegistry'

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -672,9 +672,9 @@ class ToolEvaluator:
                 if self._user and isinstance(self.app, BasicSharedApp):
                     from galaxy.managers import api_keys
 
-                    environment_variable_template = api_keys.ApiKeyManager[model.APIKeys, model.User](
-                        self.app
-                    ).get_or_create_api_key(self._user)
+                    environment_variable_template = api_keys.GalaxyApiKeyManager(self.app).get_or_create_api_key(
+                        self._user
+                    )
                 else:
                     environment_variable_template = ""
                 is_template = False

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -672,7 +672,9 @@ class ToolEvaluator:
                 if self._user and isinstance(self.app, BasicSharedApp):
                     from galaxy.managers import api_keys
 
-                    environment_variable_template = api_keys.ApiKeyManager(self.app).get_or_create_api_key(self._user)
+                    environment_variable_template = api_keys.ApiKeyManager[model.APIKeys, model.User](
+                        self.app
+                    ).get_or_create_api_key(self._user)
                 else:
                     environment_variable_template = ""
                 is_template = False

--- a/lib/galaxy/visualization/genomes.py
+++ b/lib/galaxy/visualization/genomes.py
@@ -380,7 +380,7 @@ class Genomes:
         else:
             dbkey_user = trans.user
 
-        if not self.has_reference_data(dbkey, dbkey_user):
+        if not self.has_reference_data(dbkey, dbkey_user) or not dbkey_user:
             raise ReferenceDataError(f"No reference data for {dbkey}")
 
         #

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -14,6 +14,8 @@ from typing import (
     Any,
     Dict,
     Optional,
+    TYPE_CHECKING,
+    Union,
 )
 from urllib.parse import urlparse
 
@@ -64,6 +66,10 @@ from galaxy.web.framework import (
     url_for,
 )
 from galaxy.web.framework.middleware.static import CacheableStaticURLParser as Static
+
+if TYPE_CHECKING:
+    from galaxy.model import User
+    from galaxy.schema import BootstrapAdminUser
 
 log = logging.getLogger(__name__)
 
@@ -310,7 +316,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
     ) -> None:
         self._app = app
         self.webapp = webapp
-        self.user_manager = app[UserManager]
+        self.user_manager: UserManager = app[UserManager]
         self.session_manager = app[GalaxySessionManager]
         super().__init__(environ)
         config = self.app.config
@@ -544,6 +550,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
         api_key = self.request.params.get("key", None) or self.request.headers.get("x-api-key", None)
         secure_id = self.get_cookie(name=session_cookie)
         api_key_supplied = self.environ.get("is_api_request", False) and api_key
+        user: Optional[Union[User, BootstrapAdminUser]]
         if api_key_supplied:
             # Sessionless API transaction, we just need to associate a user.
             try:

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -81,7 +81,7 @@ DatasetIDPathParam = Annotated[
 ]
 
 DatasetSourceQueryParam: DatasetSourceType = Query(
-    default=DatasetSourceType.hda,
+    default="hda",
     description="Whether this dataset belongs to a history (HDA) or a library (LDDA).",
 )
 
@@ -421,7 +421,7 @@ class FastAPIDatasets:
         dataset_id: HistoryDatasetIDPathParam,
         trans=DependsOnTrans,
         hda_ldda: DatasetSourceType = Query(
-            default=DatasetSourceType.hda,
+            default="hda",
             description=("The type of information about the dataset to be requested."),
         ),
         data_type: Optional[RequestDataType] = Query(

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -39,7 +39,6 @@ from galaxy.schema.schema import (
     AsyncFile,
     AsyncTaskResultSummary,
     DatasetAssociationRoles,
-    DatasetSourceType,
     DeleteHistoryContentPayload,
     DeleteHistoryContentResult,
     HistoryContentBulkOperationPayload,
@@ -1066,7 +1065,7 @@ class FastAPIHistoryContents:
         # values are already validated, use model_construct
         materialize_request = MaterializeDatasetInstanceRequest.model_construct(
             history_id=history_id,
-            source=DatasetSourceType.hda,
+            source="hda",
             content=id,
         )
         rval = self.service.materialize(trans, materialize_request)

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -377,7 +377,7 @@ class FastAPIJobs:
     def parameters_display_by_job(
         self,
         job_id: JobIdPathParam,
-        hda_ldda: Annotated[Optional[DatasetSourceType], DeprecatedHdaLddaQueryParam] = DatasetSourceType.hda,
+        hda_ldda: Annotated[Optional[DatasetSourceType], DeprecatedHdaLddaQueryParam] = "hda",
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> JobDisplayParametersSummary:
         """
@@ -398,7 +398,7 @@ class FastAPIJobs:
     def parameters_display_by_dataset(
         self,
         dataset_id: DatasetIdPathParam,
-        hda_ldda: Annotated[DatasetSourceType, HdaLddaQueryParam] = DatasetSourceType.hda,
+        hda_ldda: Annotated[DatasetSourceType, HdaLddaQueryParam] = "hda",
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> JobDisplayParametersSummary:
         """
@@ -417,7 +417,7 @@ class FastAPIJobs:
     def metrics_by_job(
         self,
         job_id: JobIdPathParam,
-        hda_ldda: Annotated[Optional[DatasetSourceType], DeprecatedHdaLddaQueryParam] = DatasetSourceType.hda,
+        hda_ldda: Annotated[Optional[DatasetSourceType], DeprecatedHdaLddaQueryParam] = "hda",
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> List[Optional[JobMetric]]:
         hda_ldda_str = hda_ldda or "hda"
@@ -433,7 +433,7 @@ class FastAPIJobs:
     def metrics_by_dataset(
         self,
         dataset_id: DatasetIdPathParam,
-        hda_ldda: Annotated[DatasetSourceType, HdaLddaQueryParam] = DatasetSourceType.hda,
+        hda_ldda: Annotated[DatasetSourceType, HdaLddaQueryParam] = "hda",
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> List[Optional[JobMetric]]:
         job = self.service.get_job(trans, dataset_id=dataset_id, hda_ldda=hda_ldda)

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -636,7 +636,7 @@ class FastAPIUsers:
         else:
             raise exceptions.NotImplemented()
         item = user.to_dict(view="element", value_mapper={"total_disk_usage": float})
-        return item
+        return CreatedUserModel(**item)
 
     @router.get(
         "/api/users",

--- a/lib/galaxy/webapps/galaxy/services/authenticate.py
+++ b/lib/galaxy/webapps/galaxy/services/authenticate.py
@@ -13,7 +13,7 @@ from starlette.requests import Request as StartletteRequest
 
 from galaxy import exceptions
 from galaxy.auth import AuthManager
-from galaxy.managers.api_keys import ApiKeyManager
+from galaxy.managers.api_keys import GalaxyApiKeyManager
 from galaxy.managers.users import UserManager
 from galaxy.util import (
     smart_str,
@@ -29,7 +29,7 @@ class APIKeyResponse(BaseModel):
 
 
 class AuthenticationService:
-    def __init__(self, user_manager: UserManager, auth_manager: AuthManager, api_keys_manager: ApiKeyManager):
+    def __init__(self, user_manager: UserManager, auth_manager: AuthManager, api_keys_manager: GalaxyApiKeyManager):
         self._user_manager = user_manager
         self._auth_manager = auth_manager
         self._api_keys_manager = api_keys_manager

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -11,6 +11,7 @@ from typing import (
     List,
     Optional,
     Tuple,
+    TypedDict,
     Union,
 )
 
@@ -32,10 +33,7 @@ from galaxy.datatypes.binary import Binary
 from galaxy.datatypes.dataproviders.exceptions import NoProviderAvailable
 from galaxy.managers.base import ModelSerializer
 from galaxy.managers.context import ProvidesHistoryContext
-from galaxy.managers.datasets import (
-    DatasetAssociationManager,
-    DatasetManager,
-)
+from galaxy.managers.datasets import DatasetManager
 from galaxy.managers.hdas import (
     HDAManager,
     HDASerializer,
@@ -286,6 +284,11 @@ class DeleteDatasetBatchResult(Model):
     )
 
 
+class DatasetManagerByType(TypedDict):
+    hda: HDAManager
+    ldda: LDDAManager
+
+
 class DatasetsService(ServiceBase, UsesVisualizationMixin):
     def __init__(
         self,
@@ -316,7 +319,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         return {"dataset": self.hda_serializer, "dataset_collection": self.hdca_serializer}
 
     @property
-    def dataset_manager_by_type(self) -> Dict[str, DatasetAssociationManager]:
+    def dataset_manager_by_type(self) -> DatasetManagerByType:
         return {"hda": self.hda_manager, "ldda": self.ldda_manager}
 
     def index(

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -610,8 +610,15 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         headers = {}
         rval: Any = ""
         try:
-            dataset_manager = self.dataset_manager_by_type[hda_ldda]
-            dataset_instance = dataset_manager.get_accessible(dataset_id, trans.user)
+            dataset_instance: Union[model.HistoryDatasetAssociation, model.LibraryDatasetDatasetAssociation]
+            if hda_ldda == "hda":
+                hda_manager = self.dataset_manager_by_type[hda_ldda]
+                dataset_instance = hda = hda_manager.get_accessible(dataset_id, trans.user)
+                hda_manager.ensure_dataset_on_disk(trans, hda)
+            else:
+                ldda_manager = self.dataset_manager_by_type[hda_ldda]
+                dataset_instance = ldda = ldda_manager.get_accessible(dataset_id, trans.user)
+                ldda_manager.ensure_dataset_on_disk(trans, ldda)
             if raw:
                 if filename and filename != "index":
                     object_store = trans.app.object_store

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -394,7 +394,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
             rval = self._dataset_in_use_state(dataset)
         else:
             # Default: return dataset as dict.
-            if hda_ldda == DatasetSourceType.hda:
+            if hda_ldda == "hda":
                 return self.hda_serializer.serialize_to_view(
                     dataset, view=serialization_params.view or "detailed", user=trans.user, trans=trans
                 )
@@ -407,7 +407,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         self,
         trans: ProvidesHistoryContext,
         dataset_id: DecodedDatabaseIdField,
-        hda_ldda: DatasetSourceType = DatasetSourceType.hda,
+        hda_ldda: DatasetSourceType = "hda",
     ) -> DatasetStorageDetails:
         """
         Display user-facing storage details related to the objectstore a
@@ -457,7 +457,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         self,
         trans: ProvidesHistoryContext,
         dataset_id: DecodedDatabaseIdField,
-        hda_ldda: DatasetSourceType = DatasetSourceType.hda,
+        hda_ldda: DatasetSourceType = "hda",
     ) -> DatasetInheritanceChain:
         """
         Display inheritance chain for the given dataset.
@@ -475,7 +475,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         trans: ProvidesHistoryContext,
         dataset_id: DecodedDatabaseIdField,
         payload: ComputeDatasetHashPayload,
-        hda_ldda: DatasetSourceType = DatasetSourceType.hda,
+        hda_ldda: DatasetSourceType = "hda",
     ) -> AsyncTaskResultSummary:
         dataset_instance = self.dataset_manager_by_type[hda_ldda].get_accessible(dataset_id, trans.user)
         request = ComputeDatasetHashTaskRequest(
@@ -488,12 +488,13 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         return async_task_summary(result)
 
     def drs_dataset_instance(self, object_id: str) -> Tuple[int, DatasetSourceType]:
+        hda_ldda: DatasetSourceType
         if object_id.startswith("hda-"):
             decoded_object_id = self.decode_id(object_id[len("hda-") :], kind="drs")
-            hda_ldda = DatasetSourceType.hda
+            hda_ldda = "hda"
         elif object_id.startswith("ldda-"):
             decoded_object_id = self.decode_id(object_id[len("ldda-") :], kind="drs")
-            hda_ldda = DatasetSourceType.ldda
+            hda_ldda = "ldda"
         else:
             raise galaxy_exceptions.RequestParameterInvalidException(
                 "Invalid object_id format specified for this Galaxy server"
@@ -552,7 +553,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         trans: ProvidesHistoryContext,
         dataset_id: DecodedDatabaseIdField,
         payload: UpdateDatasetPermissionsPayload,
-        hda_ldda: DatasetSourceType = DatasetSourceType.hda,
+        hda_ldda: DatasetSourceType = "hda",
     ) -> DatasetAssociationRoles:
         """
         Updates permissions of a dataset.
@@ -590,7 +591,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         self,
         trans: ProvidesHistoryContext,
         dataset_id: DecodedDatabaseIdField,
-        hda_ldda: DatasetSourceType = DatasetSourceType.hda,
+        hda_ldda: DatasetSourceType = "hda",
         preview: bool = False,
         filename: Optional[str] = None,
         to_ext: Optional[str] = None,

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -606,7 +606,8 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         headers = {}
         rval: Any = ""
         try:
-            dataset_instance = self.dataset_manager_by_type[hda_ldda].get_accessible(dataset_id, trans.user)
+            dataset_manager = self.dataset_manager_by_type[hda_ldda]
+            dataset_instance = dataset_manager.get_accessible(dataset_id, trans.user)
             if raw:
                 if filename and filename != "index":
                     object_store = trans.app.object_store

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -505,7 +505,8 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         Returns number of histories for the current user.
         """
         current_user = self.user_manager.current_user(trans)
-        if self.user_manager.is_anonymous(current_user):
+        if current_user is None:
+            # user is anonymous
             current_history = self.manager.get_current(trans)
             return 1 if current_history else 0
         return self.manager.get_active_count(current_user)

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -4,6 +4,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Union,
 )
 
 from galaxy import (
@@ -122,7 +123,9 @@ class JobsService(ServiceBase):
         elif dataset_id is not None:
             # Following checks dataset accessible
             if hda_ldda == "hda":
-                dataset_instance = self.hda_manager.get_accessible(id=dataset_id, user=trans.user)
+                dataset_instance: Union[model.HistoryDatasetAssociation, model.LibraryDatasetDatasetAssociation] = (
+                    self.hda_manager.get_accessible(id=dataset_id, user=trans.user)
+                )
             else:
                 dataset_instance = self.hda_manager.ldda_manager.get(trans, id=dataset_id)
             if not dataset_instance.creating_job:

--- a/lib/galaxy/webapps/galaxy/services/quotas.py
+++ b/lib/galaxy/webapps/galaxy/services/quotas.py
@@ -130,7 +130,12 @@ class QuotasService(ServiceBase):
             try:
                 return trans.security.decode_id(item)
             except Exception:
-                return get_user_by_email(trans.sa_session, item).id
+                user = get_user_by_email(trans.sa_session, item)
+                if user:
+                    return user.id
+                else:
+                    # caught in loop below
+                    raise Exception("No user found")
 
         def get_group_id(item):
             try:

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -55,7 +55,7 @@ class UsersService(ServiceBase):
         self,
         security: IdEncodingHelper,
         user_manager: UserManager,
-        api_key_manager: api_keys.ApiKeyManager,
+        api_key_manager: api_keys.GalaxyApiKeyManager,
         user_serializer: UserSerializer,
         user_deserializer: UserDeserializer,
         quota_agent: QuotaAgent,

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -343,6 +343,17 @@ class TestDatasetsApi(ApiTestCase):
         self._assert_status_code_is(display_response, 200)
         assert display_response.text == contents
 
+    def test_display_error_handling(self, history_id):
+        hda1 = self.dataset_populator.create_deferred_hda(
+            history_id, "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bed"
+        )
+        display_response = self._get(f"histories/{history_id}/contents/{hda1['id']}/display", {"raw": "True"})
+        self._assert_status_code_is(display_response, 409)
+        assert (
+            display_response.json()["err_msg"]
+            == "The dataset you are attempting to view has deferred data. You can only use this dataset as input for jobs."
+        )
+
     def test_get_content_as_text(self, history_id):
         contents = textwrap.dedent(
             """\

--- a/lib/tool_shed/managers/api_keys.py
+++ b/lib/tool_shed/managers/api_keys.py
@@ -1,0 +1,6 @@
+from galaxy.managers.api_keys import ApiKeyManager
+from tool_shed.webapp.model import APIKeys, User
+
+
+class ToolShedApiKeyManager(ApiKeyManager[APIKeys, User]):
+    pass

--- a/lib/tool_shed/managers/api_keys.py
+++ b/lib/tool_shed/managers/api_keys.py
@@ -1,5 +1,8 @@
 from galaxy.managers.api_keys import ApiKeyManager
-from tool_shed.webapp.model import APIKeys, User
+from tool_shed.webapp.model import (
+    APIKeys,
+    User,
+)
 
 
 class ToolShedApiKeyManager(ApiKeyManager[APIKeys, User]):

--- a/lib/tool_shed/managers/users.py
+++ b/lib/tool_shed/managers/users.py
@@ -3,6 +3,7 @@ from typing import List
 from sqlalchemy import select
 
 from galaxy.exceptions import RequestParameterInvalidException
+from galaxy.managers.users import BaseUserManager
 from galaxy.model.base import transaction
 from galaxy.security.validate_user_input import (
     validate_email,
@@ -16,6 +17,10 @@ from tool_shed_client.schema import (
     CreateUserRequest,
     UserV2 as ApiUser,
 )
+
+
+class UserManager(BaseUserManager[User]):
+    pass
 
 
 def index(app: ToolShedApp, deleted: bool) -> List[ApiUser]:

--- a/lib/tool_shed/webapp/api2/__init__.py
+++ b/lib/tool_shed/webapp/api2/__init__.py
@@ -28,7 +28,6 @@ from starlette_context import context as request_context
 
 from galaxy.exceptions import AdminRequiredException
 from galaxy.managers.session import GalaxySessionManager
-from galaxy.managers.users import UserManager
 from galaxy.model.base import transaction
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.util import unicodify
@@ -46,6 +45,7 @@ from tool_shed.context import (
     SessionRequestContext,
     SessionRequestContextImpl,
 )
+from tool_shed.managers.users import UserManager
 from tool_shed.structured_app import ToolShedApp
 from tool_shed.webapp import app as tool_shed_app_mod
 from tool_shed.webapp.model import (

--- a/lib/tool_shed/webapp/api2/__init__.py
+++ b/lib/tool_shed/webapp/api2/__init__.py
@@ -7,6 +7,7 @@ from typing import (
     Optional,
     Type,
     TypeVar,
+    Union,
 )
 
 from fastapi import (
@@ -29,6 +30,7 @@ from starlette_context import context as request_context
 from galaxy.exceptions import AdminRequiredException
 from galaxy.managers.session import GalaxySessionManager
 from galaxy.model.base import transaction
+from galaxy.schema import BootstrapAdminUser
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.util import unicodify
 from galaxy.web.framework.decorators import require_admin_message
@@ -88,7 +90,7 @@ def get_api_user(
     user_manager: UserManager = depends(UserManager),
     key: str = Security(api_key_query),
     x_api_key: str = Security(api_key_header),
-) -> Optional[User]:
+) -> Optional[Union[User, BootstrapAdminUser]]:
     api_key = key or x_api_key
     if not api_key:
         return None

--- a/lib/tool_shed/webapp/api2/users.py
+++ b/lib/tool_shed/webapp/api2/users.py
@@ -22,10 +22,10 @@ from galaxy.exceptions import (
     ObjectNotFound,
     RequestParameterInvalidException,
 )
-from galaxy.managers.api_keys import ApiKeyManager
 from galaxy.model.base import transaction
 from galaxy.webapps.base.webapp import create_new_session
 from tool_shed.context import SessionRequestContext
+from tool_shed.managers.api_keys import ToolShedApiKeyManager
 from tool_shed.managers.users import (
     api_create_user,
     get_api_user,
@@ -102,7 +102,7 @@ INVALID_LOGIN_OR_PASSWORD = "Invalid login or password"
 class FastAPIUsers:
     app: ToolShedApp = depends(ToolShedApp)
     user_manager: UserManager = depends(UserManager)
-    api_key_manager: ApiKeyManager = depends(ApiKeyManager)
+    api_key_manager: ToolShedApiKeyManager = depends(ToolShedApiKeyManager)
 
     @router.get(
         "/api/users",

--- a/lib/tool_shed/webapp/api2/users.py
+++ b/lib/tool_shed/webapp/api2/users.py
@@ -23,7 +23,6 @@ from galaxy.exceptions import (
     RequestParameterInvalidException,
 )
 from galaxy.managers.api_keys import ApiKeyManager
-from galaxy.managers.users import UserManager
 from galaxy.model.base import transaction
 from galaxy.webapps.base.webapp import create_new_session
 from tool_shed.context import SessionRequestContext
@@ -31,6 +30,7 @@ from tool_shed.managers.users import (
     api_create_user,
     get_api_user,
     index,
+    UserManager,
 )
 from tool_shed.structured_app import ToolShedApp
 from tool_shed.webapp.model import (

--- a/lib/tool_shed/webapp/app.py
+++ b/lib/tool_shed/webapp/app.py
@@ -22,7 +22,6 @@ from galaxy.config import configure_logging
 from galaxy.managers.api_keys import ApiKeyManager
 from galaxy.managers.citations import CitationsManager
 from galaxy.managers.dbkeys import GenomeBuilds
-from galaxy.managers.users import UserManager
 from galaxy.model.base import SharedModelMapping
 from galaxy.model.tags import CommunityTagHandler
 from galaxy.quota import (
@@ -33,8 +32,13 @@ from galaxy.security import idencoding
 from galaxy.structured_app import BasicSharedApp
 from galaxy.web_stack import application_stack_instance
 from tool_shed.grids.repository_grid_filter_manager import RepositoryGridFilterManager
+from tool_shed.managers.users import UserManager
 from tool_shed.structured_app import ToolShedApp
 from tool_shed.util.hgweb_config import hgweb_config_manager
+from tool_shed.webapp.model import (
+    APIKeys,
+    User,
+)
 from tool_shed.webapp.model.migrations import verify_database
 from . import config
 
@@ -84,7 +88,7 @@ class UniverseApplication(ToolShedApp, SentryClientMixin, HaltableContainer):
         self._register_singleton(mapping.ToolShedModelMapping, model)
         self._register_singleton(scoped_session, self.model.context)
         self.user_manager = self._register_singleton(UserManager, UserManager(self, app_type="tool_shed"))
-        self.api_keys_manager = self._register_singleton(ApiKeyManager)
+        self.api_keys_manager = self._register_singleton(ApiKeyManager[APIKeys, User])
         # initialize the Tool Shed tag handler.
         self.tag_handler = CommunityTagHandler(self)
         # Initialize the Tool Shed tool data tables.  Never pass a configuration file here

--- a/lib/tool_shed/webapp/app.py
+++ b/lib/tool_shed/webapp/app.py
@@ -19,7 +19,6 @@ from galaxy.app import (
     SentryClientMixin,
 )
 from galaxy.config import configure_logging
-from galaxy.managers.api_keys import ApiKeyManager
 from galaxy.managers.citations import CitationsManager
 from galaxy.managers.dbkeys import GenomeBuilds
 from galaxy.model.base import SharedModelMapping
@@ -32,13 +31,10 @@ from galaxy.security import idencoding
 from galaxy.structured_app import BasicSharedApp
 from galaxy.web_stack import application_stack_instance
 from tool_shed.grids.repository_grid_filter_manager import RepositoryGridFilterManager
+from tool_shed.managers.api_keys import ToolShedApiKeyManager
 from tool_shed.managers.users import UserManager
 from tool_shed.structured_app import ToolShedApp
 from tool_shed.util.hgweb_config import hgweb_config_manager
-from tool_shed.webapp.model import (
-    APIKeys,
-    User,
-)
 from tool_shed.webapp.model.migrations import verify_database
 from . import config
 
@@ -88,7 +84,7 @@ class UniverseApplication(ToolShedApp, SentryClientMixin, HaltableContainer):
         self._register_singleton(mapping.ToolShedModelMapping, model)
         self._register_singleton(scoped_session, self.model.context)
         self.user_manager = self._register_singleton(UserManager, UserManager(self, app_type="tool_shed"))
-        self.api_keys_manager = self._register_singleton(ApiKeyManager[APIKeys, User])
+        self.api_keys_manager = self._register_singleton(ToolShedApiKeyManager)
         # initialize the Tool Shed tag handler.
         self.tag_handler = CommunityTagHandler(self)
         # Initialize the Tool Shed tool data tables.  Never pass a configuration file here

--- a/lib/tool_shed/webapp/controllers/user.py
+++ b/lib/tool_shed/webapp/controllers/user.py
@@ -19,6 +19,10 @@ from galaxy.web import url_for
 from galaxy.web.form_builder import CheckboxField
 from galaxy.webapps.galaxy.controllers.user import User as BaseUser
 from tool_shed.webapp.framework.decorators import require_login
+from tool_shed.webapp.model import (
+    APIKeys,
+    User as ToolShedUser,
+)
 
 log = logging.getLogger(__name__)
 
@@ -312,7 +316,7 @@ class User(BaseUser):
         message = escape(util.restore_text(params.get("message", "")))
         status = params.get("status", "done")
         if params.get("new_api_key_button", False):
-            ApiKeyManager(trans.app).create_api_key(trans.user)
+            ApiKeyManager[APIKeys, ToolShedUser](trans.app).create_api_key(trans.user)
             message = "Generated a new web API key"
             status = "done"
         return trans.fill_template(

--- a/lib/tool_shed/webapp/controllers/user.py
+++ b/lib/tool_shed/webapp/controllers/user.py
@@ -7,7 +7,6 @@ from galaxy import (
     util,
     web,
 )
-from galaxy.managers.api_keys import ApiKeyManager
 from galaxy.managers.users import get_user_by_email
 from galaxy.model.base import transaction
 from galaxy.security.validate_user_input import (
@@ -18,11 +17,8 @@ from galaxy.security.validate_user_input import (
 from galaxy.web import url_for
 from galaxy.web.form_builder import CheckboxField
 from galaxy.webapps.galaxy.controllers.user import User as BaseUser
+from tool_shed.managers.api_keys import ToolShedApiKeyManager
 from tool_shed.webapp.framework.decorators import require_login
-from tool_shed.webapp.model import (
-    APIKeys,
-    User as ToolShedUser,
-)
 
 log = logging.getLogger(__name__)
 
@@ -316,7 +312,7 @@ class User(BaseUser):
         message = escape(util.restore_text(params.get("message", "")))
         status = params.get("status", "done")
         if params.get("new_api_key_button", False):
-            ApiKeyManager[APIKeys, ToolShedUser](trans.app).create_api_key(trans.user)
+            ToolShedApiKeyManager(trans.app).create_api_key(trans.user)
             message = "Generated a new web API key"
             status = "done"
         return trans.fill_template(

--- a/lib/tool_shed/webapp/model/__init__.py
+++ b/lib/tool_shed/webapp/model/__init__.py
@@ -96,7 +96,7 @@ class APIKeys(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     create_time: Mapped[Optional[datetime]] = mapped_column(DateTime, default=now)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    key: Mapped[str] = mapped_column(TrimmedString(32), index=True, unique=True)
+    key: Mapped[str] = mapped_column(TrimmedString(32), index=True, unique=True, nullable=True)
     user = relationship("User", back_populates="api_keys")
     deleted: Mapped[Optional[bool]] = mapped_column(Boolean, index=True, default=False)
 

--- a/lib/tool_shed/webapp/model/__init__.py
+++ b/lib/tool_shed/webapp/model/__init__.py
@@ -41,6 +41,7 @@ from sqlalchemy.orm import (
 
 import tool_shed.repository_types.util as rt_util
 from galaxy import util
+from galaxy.model import _HasTable
 from galaxy.model.custom_types import (
     MutableJSONType,
     TrimmedString,
@@ -76,7 +77,7 @@ else:
 mapper_registry = registry()
 
 
-class Base(metaclass=DeclarativeMeta):
+class Base(_HasTable, metaclass=DeclarativeMeta):
     __abstract__ = True
     registry = mapper_registry
     metadata = mapper_registry.metadata

--- a/lib/tool_shed/webapp/model/__init__.py
+++ b/lib/tool_shed/webapp/model/__init__.py
@@ -96,7 +96,7 @@ class APIKeys(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     create_time: Mapped[Optional[datetime]] = mapped_column(DateTime, default=now)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    key: Mapped[Optional[str]] = mapped_column(TrimmedString(32), index=True, unique=True)
+    key: Mapped[str] = mapped_column(TrimmedString(32), index=True, unique=True)
     user = relationship("User", back_populates="api_keys")
     deleted: Mapped[Optional[bool]] = mapped_column(Boolean, index=True, default=False)
 

--- a/test/integration/test_celery_user_rate_limit.py
+++ b/test/integration/test_celery_user_rate_limit.py
@@ -49,8 +49,10 @@ def setup_users(dburl: str, num_users: int = 2):
                 user_ids_to_add = set(expected_user_ids).difference(found_user_ids)
                 for user_id in user_ids_to_add:
                     conn.execute(
-                        text("insert into galaxy_user(id, active, email, password) values (:id, :active, :email, :pw)"),
-                        [{"id": user_id, "active": True, "email": "e", "pw": "p"}],
+                        text(
+                            "insert into galaxy_user(id, active, email, password, username) values (:id, :active, :email, :pw, :username)"
+                        ),
+                        [{"id": user_id, "active": True, "email": "e", "pw": "p", "username": f"u{user_id}"}],
                     )
 
 

--- a/test/integration/test_user_preferences.py
+++ b/test/integration/test_user_preferences.py
@@ -21,6 +21,7 @@ class TestUserPreferences(integration_util.IntegrationTestCase):
         app = cast(Any, self._test_driver.app if self._test_driver else None)
 
         db_user = get_user_by_email(app.model.session, user["email"])
+        assert db_user
 
         # create some initial data
         put(url)

--- a/test/unit/app/jobs/test_job_context.py
+++ b/test/unit/app/jobs/test_job_context.py
@@ -46,7 +46,7 @@ def test_job_context_discover_outputs_flushes_once(mocker):
     sa_session = app.model.context
     # mocker is a pytest-mock fixture
 
-    u = model.User(email="collection@example.com", password="password")
+    u = model.User(email="collection@example.com", password="password", username="collection")
     h = model.History(name="Test History", user=u)
 
     tool = Tool(app)

--- a/test/unit/app/jobs/test_rule_helper.py
+++ b/test/unit/app/jobs/test_rule_helper.py
@@ -64,9 +64,9 @@ def __setup_fixtures(app):
     # user1 has 3 jobs queued and 2 jobs running on cluster1 and one queued and
     # on running job on local. user2 has a queued and running job on the cluster.
     # user3 has no jobs.
-    user1 = model.User(email=USER_EMAIL_1, password="pass1")
-    user2 = model.User(email=USER_EMAIL_2, password="pass2")
-    user3 = model.User(email=USER_EMAIL_2, password="pass2")
+    user1 = model.User(email=USER_EMAIL_1, password="pass1", username="u1")
+    user2 = model.User(email=USER_EMAIL_2, password="pass2", username="u2")
+    user3 = model.User(email=USER_EMAIL_2, password="pass2", username="u3")
 
     app.add(user1, user2, user3)
 

--- a/test/unit/app/managers/test_JobConnectionsManager.py
+++ b/test/unit/app/managers/test_JobConnectionsManager.py
@@ -3,6 +3,8 @@ from sqlalchemy import union
 
 from galaxy.managers.job_connections import JobConnectionsManager
 from galaxy.model import (
+    DatasetCollection,
+    History,
     HistoryDatasetAssociation,
     HistoryDatasetCollectionAssociation,
     Job,
@@ -25,11 +27,19 @@ def job_connections_manager(sa_session) -> JobConnectionsManager:
 
 # =============================================================================
 def setup_connected_dataset(sa_session: galaxy_scoped_session):
+    history = History()
+    sa_session.add(history)
     center_hda = HistoryDatasetAssociation(sa_session=sa_session, create_dataset=True)
     input_hda = HistoryDatasetAssociation(sa_session=sa_session, create_dataset=True)
+    input_dc = DatasetCollection(collection_type="list")
     input_hdca = HistoryDatasetCollectionAssociation()
+    input_hdca.collection = input_dc
     output_hda = HistoryDatasetAssociation(sa_session=sa_session, create_dataset=True)
+    output_dc = DatasetCollection(collection_type="list")
     output_hdca = HistoryDatasetCollectionAssociation()
+    output_hdca.collection = output_dc
+    history.stage_addition([center_hda, input_hda, input_hdca, output_hda, output_hdca])
+    history.add_pending_items()
     input_job = Job()
     output_job = Job()
     input_job.add_output_dataset("output_hda", center_hda)
@@ -55,12 +65,22 @@ def setup_connected_dataset(sa_session: galaxy_scoped_session):
 
 
 def setup_connected_dataset_collection(sa_session: galaxy_scoped_session):
+    history = History()
+    sa_session.add(history)
+    center_dc = DatasetCollection(collection_type="list")
     center_hdca = HistoryDatasetCollectionAssociation()
+    center_hdca.collection = center_dc
     input_hda1 = HistoryDatasetAssociation(sa_session=sa_session, create_dataset=True)
     input_hda2 = HistoryDatasetAssociation(sa_session=sa_session, create_dataset=True)
+    input_dc = DatasetCollection(collection_type="list")
     input_hdca = HistoryDatasetCollectionAssociation()
+    input_hdca.collection = input_dc
     output_hda = HistoryDatasetAssociation(sa_session=sa_session, create_dataset=True)
+    output_dc = DatasetCollection(collection_type="list")
     output_hdca = HistoryDatasetCollectionAssociation()
+    output_hdca.collection = output_dc
+    history.stage_addition([center_hdca, input_hda1, input_hda2, input_hdca, output_hda, output_hdca])
+    history.add_pending_items()
     input_job = Job()
     output_job = Job()
     input_job.add_output_dataset_collection("output_hdca", center_hdca)

--- a/test/unit/app/tools/test_error_reporting.py
+++ b/test/unit/app/tools/test_error_reporting.py
@@ -57,7 +57,7 @@ class TestErrorReporter(TestCase, UsesApp):
         permissions = {access_action: [private_role], manage_action: [private_role]}
         security_agent.set_all_dataset_permissions(hda.dataset, permissions)
 
-        other_user = model.User(email="otheruser@galaxyproject.org", password="mockpass2")
+        other_user = model.User(email="otheruser@galaxyproject.org", password="mockpass2", username="otheruser")
         self._commit_objects([other_user])
         security_agent = self.app.security_agent
         email_path = self.email_path
@@ -125,7 +125,7 @@ class TestErrorReporter(TestCase, UsesApp):
         )
 
     def _setup_model_objects(self):
-        user = model.User(email=TEST_USER_EMAIL, password="mockpass")
+        user = model.User(email=TEST_USER_EMAIL, password="mockpass", username=TEST_USER_EMAIL.split("@")[0])
         job = model.Job()
         job.tool_id = "cat1"
         job.history = model.History()

--- a/test/unit/app/tools/test_history_imp_exp.py
+++ b/test/unit/app/tools/test_history_imp_exp.py
@@ -36,7 +36,7 @@ def t_data_path(name):
 def _run_jihaw_cleanup(archive_dir, app=None):
     app = app or _mock_app()
     job = model.Job()
-    job.user = model.User(email="test@test.org", password="test")
+    job.user = model.User(email="test@test.org", password="test", username="test")
     job.tool_stderr = ""
     jiha = model.JobImportHistoryArchive(job=job, archive_dir=archive_dir)
     app.model.context.current.add_all([job, jiha])
@@ -661,7 +661,7 @@ def _setup_history_for_export(history_name):
     sa_session = app.model.context
 
     email = history_name.replace(" ", "-") + "-user@example.org"
-    u = model.User(email=email, password="password")
+    u = model.User(email=email, password="password", username=email.split("@")[0])
     h = model.History(name=history_name, user=u)
 
     return app, sa_session, h

--- a/test/unit/app/tools/test_toolbox.py
+++ b/test/unit/app/tools/test_toolbox.py
@@ -356,9 +356,7 @@ class TestToolBox(BaseToolBoxTestCase):
         workflow = model.Workflow()
         workflow.stored_workflow = stored_workflow
         stored_workflow.latest_workflow = workflow
-        user = model.User()
-        user.email = "test@example.com"
-        user.password = "passw0rD1"
+        user = model.User(email="test@example.com", password="passw0rD1", username="test")
         stored_workflow.user = user
         self.app.model.context.add(workflow)
         self.app.model.context.add(stored_workflow)

--- a/test/unit/data/model/conftest.py
+++ b/test/unit/data/model/conftest.py
@@ -158,7 +158,9 @@ def make_history_dataset_association(session):
 @pytest.fixture
 def make_history_dataset_collection_association(session):
     def f(**kwd):
+        collection = m.DatasetCollection(collection_type="list")
         model = m.HistoryDatasetCollectionAssociation(**kwd)
+        model.collection = collection
         write_to_db(session, model)
         return model
 

--- a/test/unit/data/model/db/test_history_table_pruner.py
+++ b/test/unit/data/model/db/test_history_table_pruner.py
@@ -55,7 +55,7 @@ def setup_db(
     make_job_import_history_archive(history=histories[20])
     make_job_export_history_archive(history=histories[21])
     make_workflow_invocation(history=histories[22])
-    make_history_dataset_collection_association(history=histories[23])
+    make_history_dataset_collection_association(history=histories[23], hid=histories[23].hid_counter + 1)
     make_history_dataset_association(history=histories[25])
     make_job().history = histories[24]
 

--- a/test/unit/data/model/test_model_discovery.py
+++ b/test/unit/data/model/test_model_discovery.py
@@ -225,7 +225,7 @@ def _import_library_target(target, work_directory):
     with store.DirectoryModelExportStore(temp_directory, app=app, serialize_dataset_objects=True) as export_store:
         persist_target_to_export_store(target, export_store, app.object_store, work_directory)
 
-    u = model.User(email="library@example.com", password="password")
+    u = model.User(email="library@example.com", password="password", username="library")
 
     import_options = store.ImportOptions(allow_dataset_object_edit=True, allow_library_creation=True)
     import_model_store = store.get_import_model_store_for_directory(
@@ -240,7 +240,7 @@ def _import_library_target(target, work_directory):
 def _import_directory_to_history(app, target, work_directory):
     sa_session = app.model.context
 
-    u = model.User(email="collection@example.com", password="password")
+    u = model.User(email="collection@example.com", password="password", username="collection")
     import_history = model.History(name="Test History for Import", user=u)
 
     sa_session = app.model.context

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -312,7 +312,7 @@ def test_import_library_require_permissions():
     app = _mock_app()
     sa_session = app.model.context
 
-    u = model.User(email="collection@example.com", password="password")
+    u = model.User(email="collection@example.com", password="password", username="collection")
 
     library = model.Library(name="my library 1", description="my library description", synopsis="my synopsis")
     root_folder = model.LibraryFolder(name="my library 1", description="folder description")
@@ -340,7 +340,7 @@ def test_import_export_library():
     app = _mock_app()
     sa_session = app.model.context
 
-    u = model.User(email="collection@example.com", password="password")
+    u = model.User(email="collection@example.com", password="password", username="collection")
 
     library = model.Library(name="my library 1", description="my library description", synopsis="my synopsis")
     root_folder = model.LibraryFolder(name="my library 1", description="folder description")
@@ -684,7 +684,7 @@ def test_import_export_edit_collection():
     app = _mock_app()
     sa_session = app.model.context
 
-    u = model.User(email="collection@example.com", password="password")
+    u = model.User(email="collection@example.com", password="password", username="collection")
     h = model.History(name="Test History", user=u)
 
     c1 = model.DatasetCollection(collection_type="list", populated=False)
@@ -761,7 +761,7 @@ def test_import_export_composite_datasets():
     app = _mock_app()
     sa_session = app.model.context
 
-    u = model.User(email="collection@example.com", password="password")
+    u = model.User(email="collection@example.com", password="password", username="collection")
     h = model.History(name="Test History", user=u)
 
     d1 = _create_datasets(sa_session, h, 1, extension="html")[0]
@@ -804,7 +804,7 @@ def test_edit_metadata_files():
     app = _mock_app(store_by="uuid")
     sa_session = app.model.context
 
-    u = model.User(email="collection@example.com", password="password")
+    u = model.User(email="collection@example.com", password="password", username="collection")
     h = model.History(name="Test History", user=u)
 
     d1 = _create_datasets(sa_session, h, 1, extension="bam")[0]
@@ -910,7 +910,7 @@ def _assert_simple_cat_job_imported(imported_history, state="ok"):
 def _setup_simple_cat_job(app, state="ok"):
     sa_session = app.model.context
 
-    u = model.User(email="collection@example.com", password="password")
+    u = model.User(email="collection@example.com", password="password", username="collection")
     h = model.History(name="Test History", user=u)
 
     d1, d2 = _create_datasets(sa_session, h, 2)
@@ -966,7 +966,7 @@ def _setup_invocation(app):
 def _setup_simple_collection_job(app, state="ok"):
     sa_session = app.model.context
 
-    u = model.User(email="collection@example.com", password="password")
+    u = model.User(email="collection@example.com", password="password", username="collection")
     h = model.History(name="Test History", user=u)
 
     d1, d2, d3, d4 = _create_datasets(sa_session, h, 4)
@@ -1170,7 +1170,7 @@ def setup_fixture_context_with_user(
 ) -> StoreFixtureContextWithUser:
     app = _mock_app(store_by=store_by)
     sa_session = app.model.context
-    user = model.User(email=user_email, password="password")
+    user = model.User(email=user_email, password="password", username=user_email.split("@")[0])
     return StoreFixtureContextWithUser(app=app, sa_session=sa_session, user=user)
 
 

--- a/test/unit/data/test_model_copy.py
+++ b/test/unit/data/test_model_copy.py
@@ -88,12 +88,10 @@ def test_history_collection_copy(list_size=NUM_DATASETS):
                 list_elements.append(paired_collection_element)
                 model.context.add_all([forward_dce, reverse_dce, paired_collection_element])
             history_dataset_collection = model.HistoryDatasetCollectionAssociation(collection=list_collection)
-            history_dataset_collection.user = old_history.user
+            history_dataset_collection.user = old_history.username
             model.context.add(history_dataset_collection)
 
             session = model.context
-            with transaction(session):
-                session.commit()
 
             old_history.add_dataset_collection(history_dataset_collection)
             history_dataset_collection.add_item_annotation(
@@ -148,7 +146,7 @@ def _setup_mapping_and_user():
         )
         setup_global_object_store_for_models(object_store)
 
-        u = User(email="historycopy@example.com", password="password")
+        u = User(email="historycopy@example.com", password="password", username="historycopy")
         h1 = History(name="HistoryCopyHistory1", user=u)
         model.context.add_all([u, h1])
         session = model.context

--- a/test/unit/data/test_quota.py
+++ b/test/unit/data/test_quota.py
@@ -16,7 +16,7 @@ class TestPurgeUsage(BaseModelTestCase):
     def setUp(self):
         super().setUp()
         model = self.model
-        u = model.User(email="purge_usage@example.com", password="password")
+        u = model.User(email="purge_usage@example.com", password="password", username=str(uuid.uuid4()))
         u.disk_usage = 25
         self.persist(u)
 
@@ -67,7 +67,8 @@ class TestPurgeUsage(BaseModelTestCase):
 class TestCalculateUsage(BaseModelTestCase):
     def setUp(self):
         model = self.model
-        u = model.User(email=f"calc_usage{uuid.uuid1()}@example.com", password="password")
+        email = f"calc_usage{uuid.uuid1()}@example.com"
+        u = model.User(email, password="password", username=email.split("@")[0])
         self.persist(u)
         h = model.History(name="History for Calculated Usage", user=u)
         self.persist(h)
@@ -359,7 +360,7 @@ class TestQuota(BaseModelTestCase):
         self.quota_agent = DatabaseQuotaAgent(model)
 
     def test_quota(self):
-        u = model.User(email="quota@example.com", password="password")
+        u = model.User(email="quota@example.com", password="password", username="quota")
         self.persist(u)
 
         self._assert_user_quota_is(u, None)
@@ -405,7 +406,7 @@ class TestQuota(BaseModelTestCase):
 
     def test_labeled_quota(self):
         model = self.model
-        u = model.User(email="labeled_quota@example.com", password="password")
+        u = model.User(email="labeled_quota@example.com", password="password", username="labeled_quota")
         self.persist(u)
 
         label1 = "coollabel1"
@@ -456,7 +457,7 @@ class TestQuota(BaseModelTestCase):
 class TestUsage(BaseModelTestCase):
     def test_usage(self):
         model = self.model
-        u = model.User(email="usage@example.com", password="password")
+        u = model.User(email="usage@example.com", password="password", username="usage")
         self.persist(u)
 
         u.adjust_total_disk_usage(123, None)
@@ -466,7 +467,7 @@ class TestUsage(BaseModelTestCase):
 
     def test_labeled_usage(self):
         model = self.model
-        u = model.User(email="labeled.usage@example.com", password="password")
+        u = model.User(email="labeled.usage@example.com", password="password", username="labeled")
         self.persist(u)
         assert len(u.quota_source_usages) == 0
 

--- a/test/unit/test_galaxy_transactions.py
+++ b/test/unit/test_galaxy_transactions.py
@@ -62,7 +62,7 @@ def test_logging_actions_on(transaction):
 
 
 def test_expunge_all(transaction):
-    user = model.User("foo", "bar1")
+    user = model.User("foo", "bar1", username="foo")
     transaction.sa_session.add(user)
 
     user.password = "bar2"

--- a/test/unit/workflows/test_run_parameters.py
+++ b/test/unit/workflows/test_run_parameters.py
@@ -1,3 +1,5 @@
+import uuid
+
 from galaxy import model
 from galaxy.model.base import transaction
 from galaxy.workflow.run_request import (
@@ -89,7 +91,7 @@ def __new_input():
 
 
 def __workflow_fixure(trans):
-    user = model.User(email="testworkflow_params@bx.psu.edu", password="pass")
+    user = model.User(email="testworkflow_params@bx.psu.edu", password="pass", username=str(uuid.uuid4()))
     stored_workflow = model.StoredWorkflow()
     stored_workflow.user = user
     workflow = model.Workflow()

--- a/test/unit/workflows/workflow_support.py
+++ b/test/unit/workflows/workflow_support.py
@@ -28,7 +28,7 @@ class MockTrans:
     @property
     def user(self):
         if self._user is None:
-            self._user = model.User(email="testworkflows@bx.psu.edu", password="password")
+            self._user = model.User(email="testworkflows@bx.psu.edu", password="password", username="testworkflows")
         return self._user
 
 


### PR DESCRIPTION
Most of the return values of the central managers now have type annotations, which has already caught a couple of minor issues (https://github.com/galaxyproject/galaxy/commit/4fdcb1baefed02752369c7e86d244a2986b8c5c4, https://github.com/galaxyproject/galaxy/commit/77af0f6f95d661cd0e6985676b419937e778f7fc and https://github.com/galaxyproject/galaxy/commit/c8d4f1435ff95c97d740d24a80d692afea19f1c1)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
