### PR TITLE
[24.0] Fix listing possibly untitled records in Invenio Plugin

### DIFF
--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -139,7 +139,7 @@ class InvenioRDMFilesSource(RDMFilesSource):
         record = self.repository.create_draft_record(entry_data["name"], public_name, user_context=user_context)
         return {
             "uri": self.repository.to_plugin_uri(record["id"]),
-            "name": record["metadata"]["title"],
+            "name": record["title"],
             "external_link": record["links"]["self_html"],
         }
 
@@ -225,6 +225,7 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         response = requests.post(self.records_url, json=create_record_request, headers=headers)
         self._ensure_response_has_expected_status_code(response, 201)
         record = response.json()
+        record["title"] = self._get_record_title(record)
         return record
 
     def upload_file_to_draft_record(
@@ -331,15 +332,22 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         for record in records:
             uri = self.to_plugin_uri(record_id=record["id"])
             path = self.plugin.to_relative_path(uri)
+            name = self._get_record_title(record)
             rval.append(
                 {
                     "class": "Directory",
-                    "name": record["metadata"]["title"],
+                    "name": name,
                     "uri": uri,
                     "path": path,
                 }
             )
         return rval
+
+    def _get_record_title(self, record: InvenioRecord) -> str:
+        title = record.get("title")
+        if not title and "metadata" in record:
+            title = record["metadata"].get("title")
+        return title or "No title"
 
     def _get_record_files_from_response(self, record_id: str, response: dict) -> List[RemoteFile]:
         files_enabled = response.get("enabled", False)


### PR DESCRIPTION
Fixes https://sentry.galaxyproject.org/share/issue/e3d988bcf5894bb0b96fc5ecbed253b2/

Even if the title is a required attribute, users can save draft records without a title until published.

![image](https://github.com/galaxyproject/galaxy/assets/46503462/95856aa9-587f-49a8-91dc-7985f9e15f32)

This change ensures the record title is always available and provides a default `No title` otherwise.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Manually create a draft record in your Invenio/Zenodo account
  - Save the draft record without a title  
  - Try to list remote records or export to an existing record from Galaxy
  - You should be able to see `No title` records instead of an error when listing.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
