### PR TITLE
[24.0] Don't commit in ``DeleteIntermediatesAction``

### DIFF
--- a/lib/galaxy/job_execution/actions/post.py
+++ b/lib/galaxy/job_execution/actions/post.py
@@ -8,7 +8,6 @@ import datetime
 from markupsafe import escape
 
 from galaxy.model import PostJobActionAssociation
-from galaxy.model.base import transaction
 from galaxy.util import send_mail
 from galaxy.util.custom_logging import get_logger
 
@@ -370,8 +369,6 @@ class DeleteIntermediatesAction(DefaultJobAction):
         # POTENTIAL ISSUES:  When many outputs are being finish()ed
         # concurrently, sometimes non-terminal steps won't be cleaned up
         # because of the lag in job state updates.
-        with transaction(sa_session):
-            sa_session.commit()
         if not job.workflow_invocation_step:
             log.debug("This job is not part of a workflow invocation, delete intermediates aborted.")
             return


### PR DESCRIPTION
Doing this can result in HDAs or HDCAs being added to the database without hid or history_id.

Discovered in https://github.com/galaxyproject/galaxy/pull/18129

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
