### PR TITLE
Display DOIs in Archived Histories

### DIFF
--- a/client/src/api/remoteFiles.ts
+++ b/client/src/api/remoteFiles.ts
@@ -28,15 +28,15 @@ export interface FilterFileSourcesOptions {
     exclude?: FileSourcePluginKind[];
 }
 
-const getRemoteFilesPlugins = fetcher.path("/api/remote_files/plugins").method("get").create();
+const remoteFilesPluginsFetcher = fetcher.path("/api/remote_files/plugins").method("get").create();
 
 /**
  * Get the list of available file sources from the server that can be browsed.
  * @param options The options to filter the file sources.
  * @returns The list of available (browsable) file sources from the server.
  */
-export async function getFileSources(options: FilterFileSourcesOptions = {}): Promise<BrowsableFilesSourcePlugin[]> {
-    const { data } = await getRemoteFilesPlugins({
+export async function fetchFileSources(options: FilterFileSourcesOptions = {}): Promise<BrowsableFilesSourcePlugin[]> {
+    const { data } = await remoteFilesPluginsFetcher({
         browsable_only: true,
         include_kind: options.include,
         exclude_kind: options.exclude,

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -2638,6 +2638,11 @@ export interface components {
              */
             doc: string;
             /**
+             * Extra
+             * @description Extra configuration options that the plugin may serialize. This is plugin specific.
+             */
+            extra?: Record<string, never> | null;
+            /**
              * ID
              * @description The `FilesSource` plugin identifier
              */
@@ -2672,7 +2677,6 @@ export interface components {
              * @description Whether this files source plugin allows write access.
              */
             writable: boolean;
-            [key: string]: unknown | undefined;
         };
         /** BulkOperationItemError */
         BulkOperationItemError: {
@@ -5211,6 +5215,11 @@ export interface components {
              * @description Documentation or extended description for this plugin.
              */
             doc: string;
+            /**
+             * Extra
+             * @description Extra configuration options that the plugin may serialize. This is plugin specific.
+             */
+            extra?: Record<string, never> | null;
             /**
              * ID
              * @description The `FilesSource` plugin identifier

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -2638,11 +2638,6 @@ export interface components {
              */
             doc: string;
             /**
-             * Extra
-             * @description Extra configuration options that the plugin may serialize. This is plugin specific.
-             */
-            extra?: Record<string, never> | null;
-            /**
              * ID
              * @description The `FilesSource` plugin identifier
              */
@@ -2672,6 +2667,11 @@ export interface components {
              * @description The URI root used by this type of plugin.
              */
             uri_root: string;
+            /**
+             * URL
+             * @description Optional URL that might be provided by some plugins to link to the remote source.
+             */
+            url?: string | null;
             /**
              * Writeable
              * @description Whether this files source plugin allows write access.
@@ -5216,11 +5216,6 @@ export interface components {
              */
             doc: string;
             /**
-             * Extra
-             * @description Extra configuration options that the plugin may serialize. This is plugin specific.
-             */
-            extra?: Record<string, never> | null;
-            /**
              * ID
              * @description The `FilesSource` plugin identifier
              */
@@ -5245,6 +5240,11 @@ export interface components {
              * @description The type of the plugin.
              */
             type: string;
+            /**
+             * URL
+             * @description Optional URL that might be provided by some plugins to link to the remote source.
+             */
+            url?: string | null;
             /**
              * Writeable
              * @description Whether this files source plugin allows write access.

--- a/client/src/components/Common/DOILink.vue
+++ b/client/src/components/Common/DOILink.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faLink } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BBadge } from "bootstrap-vue";
+import { computed } from "vue";
+
+library.add(faLink);
+
+interface Props {
+    doi: string;
+}
+
+const props = defineProps<Props>();
+
+const doiLink = computed(() => `https://doi.org/${props.doi}`);
+</script>
+
+<template>
+    <BBadge class="doi-badge">
+        <FontAwesomeIcon :icon="faLink" />
+        <a :href="doiLink" target="_blank" rel="noopener noreferrer">{{ props.doi }}</a>
+    </BBadge>
+</template>
+
+<style scoped>
+.doi-badge {
+    font-size: 1rem;
+}
+</style>

--- a/client/src/components/Common/ExportRecordDOILink.vue
+++ b/client/src/components/Common/ExportRecordDOILink.vue
@@ -26,27 +26,28 @@ watch(isLoadingFileSources, async (isLoading) => {
     }
 });
 
-async function getDOIFromExportRecordUri(targetUri?: string) {
-    if (!targetUri) {
+async function getDOIFromExportRecordUri(uri?: string) {
+    if (!uri) {
         return undefined;
     }
 
-    const fileSource = getFileSourceByUri(targetUri);
+    const fileSource = getFileSourceByUri(uri);
     if (!fileSource) {
-        console.debug("No file source found for URI: ", targetUri);
+        console.debug("No file source found for URI: ", uri);
         return undefined;
     }
-    if (!fileSource.url) {
-        console.debug("Invalid file source for URI: ", targetUri);
+    const repositoryUrl = fileSource.extra?.url;
+    if (!repositoryUrl) {
+        console.debug("Invalid repository URL for file source: ", fileSource);
         return undefined;
     }
-    const recordId = getRecordIdFromUri(targetUri);
+    const recordId = getRecordIdFromUri(uri);
     if (!recordId) {
-        console.debug("No record ID found for URI: ", targetUri);
+        console.debug("No record ID found for URI: ", uri);
         return undefined;
     }
-    const recordUrl = `${fileSource.url}/api/records/${recordId}`;
-    return getDOIFromRecordUrl(recordUrl);
+    const recordUrl = `${repositoryUrl}/api/records/${recordId}`;
+    return getDOIFromInvenioRecordUrl(recordUrl);
 }
 
 function getRecordIdFromUri(targetUri?: string): string | undefined {
@@ -56,7 +57,7 @@ function getRecordIdFromUri(targetUri?: string): string | undefined {
     return targetUri.split("//")[1]?.split("/")[1];
 }
 
-async function getDOIFromRecordUrl(recordUrl?: string): Promise<string | undefined> {
+async function getDOIFromInvenioRecordUrl(recordUrl?: string): Promise<string | undefined> {
     if (!recordUrl) {
         return undefined;
     }

--- a/client/src/components/Common/ExportRecordDOILink.vue
+++ b/client/src/components/Common/ExportRecordDOILink.vue
@@ -26,6 +26,12 @@ watch(isLoadingFileSources, async (isLoading) => {
     }
 });
 
+/**
+ * Gets the DOI from an export record URI.
+ * The URI should be in the format: `<scheme>://<source-id>/<record-id>/<file-name>`.
+ * @param uri The target URI of the export record to get the DOI from.
+ * @returns The DOI or undefined if it could not be retrieved.
+ */
 async function getDOIFromExportRecordUri(uri?: string) {
     if (!uri) {
         return undefined;
@@ -50,6 +56,12 @@ async function getDOIFromExportRecordUri(uri?: string) {
     return getDOIFromInvenioRecordUrl(recordUrl);
 }
 
+/**
+ * Extracts the record ID from a URI.
+ * The URI should be in the format: `<scheme>://<source-id>/<record-id>/<file-name>`.
+ * @param targetUri The URI to extract the record ID from.
+ * @returns The record ID or undefined if it could not be extracted.
+ */
 function getRecordIdFromUri(targetUri?: string): string | undefined {
     if (!targetUri) {
         return undefined;
@@ -57,6 +69,11 @@ function getRecordIdFromUri(targetUri?: string): string | undefined {
     return targetUri.split("//")[1]?.split("/")[1];
 }
 
+/**
+ * Gets the DOI from an Invenio record URL.
+ * @param recordUrl The URL of the record to get the DOI from.
+ * @returns The DOI or undefined if it could not be retrieved.
+ */
 async function getDOIFromInvenioRecordUrl(recordUrl?: string): Promise<string | undefined> {
     if (!recordUrl) {
         return undefined;

--- a/client/src/components/Common/ExportRecordDOILink.vue
+++ b/client/src/components/Common/ExportRecordDOILink.vue
@@ -41,7 +41,7 @@ async function getDOIFromExportRecordUri(uri?: string) {
         console.debug("No file source found for URI: ", uri);
         return undefined;
     }
-    const repositoryUrl = fileSource.extra?.url;
+    const repositoryUrl = fileSource.url;
     if (!repositoryUrl) {
         console.debug("Invalid repository URL for file source: ", fileSource);
         return undefined;

--- a/client/src/components/Common/ExportRecordDOILink.vue
+++ b/client/src/components/Common/ExportRecordDOILink.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import axios from "axios";
+import { ref, watch } from "vue";
+
+import { BrowsableFilesSourcePlugin } from "@/api/remoteFiles";
+import { useFileSources } from "@/composables/fileSources";
+
+import DOILink from "./DOILink.vue";
+
+// TODO: This should be using a store so we don't have to load file sources in every component
+const { getFileSourceByUri, isLoading: isLoadingFileSources } = useFileSources({ include: ["rdm"] });
+
+interface Props {
+    exportRecordUri?: string;
+    rdmFileSources?: BrowsableFilesSourcePlugin[];
+}
+
+const props = defineProps<Props>();
+
+const doi = ref<string | undefined>(undefined);
+
+// File sources need to be loaded before we can get the DOI
+watch(isLoadingFileSources, async (isLoading) => {
+    if (!isLoading) {
+        doi.value = await getDOIFromExportRecordUri(props.exportRecordUri);
+    }
+});
+
+async function getDOIFromExportRecordUri(targetUri?: string) {
+    if (!targetUri) {
+        return undefined;
+    }
+
+    const fileSource = getFileSourceByUri(targetUri);
+    if (!fileSource) {
+        console.debug("No file source found for URI: ", targetUri);
+        return undefined;
+    }
+    if (!fileSource.url) {
+        console.debug("Invalid file source for URI: ", targetUri);
+        return undefined;
+    }
+    const recordId = getRecordIdFromUri(targetUri);
+    if (!recordId) {
+        console.debug("No record ID found for URI: ", targetUri);
+        return undefined;
+    }
+    const recordUrl = `${fileSource.url}/api/records/${recordId}`;
+    return getDOIFromRecordUrl(recordUrl);
+}
+
+function getRecordIdFromUri(targetUri?: string): string | undefined {
+    if (!targetUri) {
+        return undefined;
+    }
+    return targetUri.split("//")[1]?.split("/")[1];
+}
+
+async function getDOIFromRecordUrl(recordUrl?: string): Promise<string | undefined> {
+    if (!recordUrl) {
+        return undefined;
+    }
+
+    try {
+        const response = await axios.get(recordUrl);
+        if (response.status !== 200) {
+            console.debug("Failed to get record from URL: ", recordUrl);
+            return undefined;
+        }
+        const record = response.data;
+        if (!record?.doi) {
+            console.debug("No DOI found in record: ", record);
+            return undefined;
+        }
+        return record.doi;
+    } catch (error) {
+        console.warn("Failed to get record from URL: ", recordUrl, error);
+        return undefined;
+    }
+}
+</script>
+
+<template>
+    <DOILink v-if="doi" :doi="doi" />
+</template>

--- a/client/src/components/Common/ExportRecordDOILink.vue
+++ b/client/src/components/Common/ExportRecordDOILink.vue
@@ -7,7 +7,6 @@ import { useFileSources } from "@/composables/fileSources";
 
 import DOILink from "./DOILink.vue";
 
-// TODO: This should be using a store so we don't have to load file sources in every component
 const { getFileSourceByUri, isLoading: isLoadingFileSources } = useFileSources({ include: ["rdm"] });
 
 interface Props {

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -4,9 +4,9 @@ import Vue, { computed, onMounted, ref } from "vue";
 
 import {
     browseRemoteFiles,
+    fetchFileSources,
     FileSourceBrowsingMode,
     FilterFileSourcesOptions,
-    getFileSources,
     RemoteEntry,
 } from "@/api/remoteFiles";
 import { UrlTracker } from "@/components/DataDialog/utilities";
@@ -231,7 +231,7 @@ function load(record?: SelectionItem) {
     undoShow.value = !urlTracker.value.atRoot();
     if (urlTracker.value.atRoot() || errorMessage.value) {
         errorMessage.value = undefined;
-        getFileSources(props.filterOptions)
+        fetchFileSources(props.filterOptions)
             .then((results) => {
                 const convertedItems = results
                     .filter((item) => !props.requireWritable || item.writable)

--- a/client/src/components/History/Archiving/ArchivedHistoryCard.vue
+++ b/client/src/components/History/Archiving/ArchivedHistoryCard.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faCopy, faEye, faUndo } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BBadge, BButton, BButtonGroup } from "bootstrap-vue";
+import { computed } from "vue";
+
+import { ArchivedHistorySummary } from "@/api/histories.archived";
+import localize from "@/utils/localization";
+
+import Heading from "@/components/Common/Heading.vue";
+import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
+import UtcDate from "@/components/UtcDate.vue";
+
+interface Props {
+    history: ArchivedHistorySummary;
+}
+
+const props = defineProps<Props>();
+
+const canImportCopy = computed(() => props.history.export_record_data?.target_uri !== undefined);
+
+const emit = defineEmits<{
+    (e: "onView", history: ArchivedHistorySummary): void;
+    (e: "onRestore", history: ArchivedHistorySummary): void;
+    (e: "onImportCopy", history: ArchivedHistorySummary): void;
+}>();
+
+library.add(faUndo, faCopy, faEye);
+
+function onViewHistoryInCenterPanel() {
+    emit("onView", props.history);
+}
+
+async function onRestoreHistory() {
+    emit("onRestore", props.history);
+}
+
+async function onImportCopy() {
+    emit("onImportCopy", props.history);
+}
+</script>
+
+<template>
+    <div class="archived-history-card">
+        <div class="d-flex justify-content-between align-items-center">
+            <Heading h3 inline bold size="sm">
+                {{ history.name }}
+            </Heading>
+
+            <div class="d-flex align-items-center flex-gapx-1 badges">
+                <BBadge v-if="history.published" v-b-tooltip pill :title="localize('This history is public.')">
+                    {{ localize("Published") }}
+                </BBadge>
+                <BBadge v-if="!history.purged" v-b-tooltip pill :title="localize('Amount of items in history')">
+                    {{ history.count }} {{ localize("items") }}
+                </BBadge>
+                <BBadge
+                    v-if="history.export_record_data"
+                    v-b-tooltip
+                    pill
+                    :title="
+                        localize(
+                            'This history has an associated export record containing a snapshot of the history that can be used to import a copy of the history.'
+                        )
+                    ">
+                    {{ localize("Snapshot available") }}
+                </BBadge>
+                <BBadge v-b-tooltip pill :title="localize('Last edited/archived')">
+                    <UtcDate :date="history.update_time" mode="elapsed" />
+                </BBadge>
+            </div>
+        </div>
+
+        <div class="d-flex justify-content-start align-items-center mt-1">
+            <BButtonGroup class="actions">
+                <BButton
+                    v-b-tooltip
+                    :title="localize('View this history')"
+                    variant="link"
+                    class="p-0 px-1"
+                    @click.stop="onViewHistoryInCenterPanel">
+                    <FontAwesomeIcon :icon="faEye" size="lg" />
+                    View
+                </BButton>
+                <BButton
+                    v-b-tooltip
+                    :title="localize('Unarchive this history and move it back to your active histories')"
+                    variant="link"
+                    class="p-0 px-1"
+                    @click.stop="onRestoreHistory">
+                    <FontAwesomeIcon :icon="faUndo" size="lg" />
+                    Unarchive
+                </BButton>
+
+                <BButton
+                    v-if="canImportCopy"
+                    v-b-tooltip
+                    :title="localize('Import a new copy of this history from the associated export record')"
+                    variant="link"
+                    class="p-0 px-1"
+                    @click.stop="onImportCopy">
+                    <FontAwesomeIcon :icon="faCopy" size="lg" />
+                    Import Copy
+                </BButton>
+            </BButtonGroup>
+        </div>
+
+        <p v-if="history.annotation" class="my-1">{{ history.annotation }}</p>
+
+        <StatelessTags class="my-1" :value="history.tags" :disabled="true" :max-visible-tags="10" />
+    </div>
+</template>
+
+<style scoped>
+.badges {
+    font-size: 1rem;
+}
+</style>

--- a/client/src/components/History/Archiving/ArchivedHistoryCard.vue
+++ b/client/src/components/History/Archiving/ArchivedHistoryCard.vue
@@ -8,6 +8,7 @@ import { computed } from "vue";
 import { ArchivedHistorySummary } from "@/api/histories.archived";
 import localize from "@/utils/localization";
 
+import ExportRecordDOILink from "@/components/Common/ExportRecordDOILink.vue";
 import Heading from "@/components/Common/Heading.vue";
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 import UtcDate from "@/components/UtcDate.vue";
@@ -45,7 +46,7 @@ async function onImportCopy() {
     <div class="archived-history-card">
         <div class="d-flex justify-content-between align-items-center">
             <Heading h3 inline bold size="sm">
-                {{ history.name }}
+                {{ history.name }} <ExportRecordDOILink :export-record-uri="history.export_record_data?.target_uri" />
             </Heading>
 
             <div class="d-flex align-items-center flex-gapx-1 badges">

--- a/client/src/components/History/Archiving/HistoryArchive.vue
+++ b/client/src/components/History/Archiving/HistoryArchive.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { faCopy, faEye, faUndo } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BBadge, BButton, BButtonGroup, BListGroup, BListGroupItem, BPagination } from "bootstrap-vue";
+import { BAlert, BListGroup, BListGroupItem, BPagination } from "bootstrap-vue";
 import { computed, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router/composables";
 
@@ -17,10 +14,8 @@ import { useHistoryStore } from "@/stores/historyStore";
 import localize from "@/utils/localization";
 
 import DelayedInput from "@/components/Common/DelayedInput.vue";
-import Heading from "@/components/Common/Heading.vue";
+import ArchivedHistoryCard from "@/components/History/Archiving/ArchivedHistoryCard.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
-import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
-import UtcDate from "@/components/UtcDate.vue";
 
 const router = useRouter();
 const historyStore = useHistoryStore();
@@ -40,8 +35,6 @@ const noResults = computed(() => totalRows.value === 0);
 const hasFilters = computed(() => searchText.value !== "");
 const noHistoriesMatchingFilter = computed(() => hasFilters.value && noResults.value);
 const showPagination = computed(() => totalRows.value > perPage.value && !isLoading.value && !noResults.value);
-
-library.add(faUndo, faCopy, faEye);
 
 onMounted(async () => {
     loadArchivedHistories();
@@ -67,10 +60,6 @@ async function loadArchivedHistories() {
     totalRows.value = result.totalMatches;
     archivedHistories.value = result.histories;
     isLoading.value = false;
-}
-
-function canImportCopy(history: ArchivedHistorySummary) {
-    return history.export_record_data?.target_uri !== undefined;
 }
 
 function onViewHistoryInCenterPanel(history: ArchivedHistorySummary) {
@@ -153,80 +142,11 @@ async function onImportCopy(history: ArchivedHistorySummary) {
             </BAlert>
             <BListGroup v-else>
                 <BListGroupItem v-for="history in archivedHistories" :key="history.id" :data-pk="history.id">
-                    <div class="d-flex justify-content-between align-items-center">
-                        <Heading h3 inline bold size="sm">
-                            {{ history.name }}
-                        </Heading>
-
-                        <div class="d-flex align-items-center flex-gapx-1 badges">
-                            <BBadge
-                                v-if="history.published"
-                                v-b-tooltip
-                                pill
-                                :title="localize('This history is public.')">
-                                {{ localize("Published") }}
-                            </BBadge>
-                            <BBadge
-                                v-if="!history.purged"
-                                v-b-tooltip
-                                pill
-                                :title="localize('Amount of items in history')">
-                                {{ history.count }} {{ localize("items") }}
-                            </BBadge>
-                            <BBadge
-                                v-if="history.export_record_data"
-                                v-b-tooltip
-                                pill
-                                :title="
-                                    localize(
-                                        'This history has an associated export record containing a snapshot of the history that can be used to import a copy of the history.'
-                                    )
-                                ">
-                                {{ localize("Snapshot available") }}
-                            </BBadge>
-                            <BBadge v-b-tooltip pill :title="localize('Last edited/archived')">
-                                <UtcDate :date="history.update_time" mode="elapsed" />
-                            </BBadge>
-                        </div>
-                    </div>
-
-                    <div class="d-flex justify-content-start align-items-center mt-1">
-                        <BButtonGroup class="actions">
-                            <BButton
-                                v-b-tooltip
-                                :title="localize('View this history')"
-                                variant="link"
-                                class="p-0 px-1"
-                                @click.stop="() => onViewHistoryInCenterPanel(history)">
-                                <FontAwesomeIcon icon="fa-eye" size="lg" />
-                                View
-                            </BButton>
-                            <BButton
-                                v-b-tooltip
-                                :title="localize('Unarchive this history and move it back to your active histories')"
-                                variant="link"
-                                class="p-0 px-1"
-                                @click.stop="() => onRestoreHistory(history)">
-                                <FontAwesomeIcon icon="fa-undo" size="lg" />
-                                Unarchive
-                            </BButton>
-
-                            <BButton
-                                v-if="canImportCopy(history)"
-                                v-b-tooltip
-                                :title="localize('Import a new copy of this history from the associated export record')"
-                                variant="link"
-                                class="p-0 px-1"
-                                @click.stop="() => onImportCopy(history)">
-                                <FontAwesomeIcon icon="fa-copy" size="lg" />
-                                Import Copy
-                            </BButton>
-                        </BButtonGroup>
-                    </div>
-
-                    <p v-if="history.annotation" class="my-1">{{ history.annotation }}</p>
-
-                    <StatelessTags class="my-1" :value="history.tags" :disabled="true" :max-visible-tags="10" />
+                    <ArchivedHistoryCard
+                        :history="history"
+                        @onView="onViewHistoryInCenterPanel"
+                        @onRestore="onRestoreHistory"
+                        @onImportCopy="onImportCopy" />
                 </BListGroupItem>
             </BListGroup>
             <BPagination
@@ -238,9 +158,3 @@ async function onImportCopy(history: ArchivedHistorySummary) {
         </div>
     </section>
 </template>
-
-<style scoped>
-.badges {
-    font-size: 1rem;
-}
-</style>

--- a/client/src/components/History/Archiving/HistoryArchiveWizard.test.ts
+++ b/client/src/components/History/Archiving/HistoryArchiveWizard.test.ts
@@ -39,7 +39,7 @@ const ARCHIVED_TEST_HISTORY = {
 const REMOTE_FILES_API_ENDPOINT = new RegExp("/api/remote_files/plugins");
 
 async function mountComponentWithHistory(history?: HistorySummary) {
-    const pinia = createTestingPinia();
+    const pinia = createTestingPinia({ stubActions: false });
     setActivePinia(pinia);
     const historyStore = useHistoryStore(pinia);
 
@@ -50,6 +50,7 @@ async function mountComponentWithHistory(history?: HistorySummary) {
     const wrapper = shallowMount(HistoryArchiveWizard, {
         propsData: { historyId: TEST_HISTORY_ID },
         localVue,
+        pinia,
     });
     await flushPromises();
     return wrapper;

--- a/client/src/components/History/Export/HistoryExport.test.ts
+++ b/client/src/components/History/Export/HistoryExport.test.ts
@@ -46,7 +46,7 @@ const REMOTE_FILES_API_RESPONSE: FilesSourcePlugin[] = [
 ];
 
 async function mountHistoryExport() {
-    const pinia = createTestingPinia();
+    const pinia = createTestingPinia({ stubActions: false });
     setActivePinia(pinia);
     const historyStore = useHistoryStore(pinia);
 

--- a/client/src/components/HistoryExport/Index.test.js
+++ b/client/src/components/HistoryExport/Index.test.js
@@ -1,3 +1,4 @@
+import { createTestingPinia } from "@pinia/testing";
 import { shallowMount } from "@vue/test-utils";
 import { getLocalVue } from "tests/jest/helpers";
 
@@ -19,11 +20,13 @@ describe("Index.vue", () => {
 
     it("should render tabs", () => {
         // just make sure the component renders to catch obvious big errors
+        const pinia = createTestingPinia();
         const wrapper = shallowMount(Index, {
             propsData: {
                 historyId: "test_id",
             },
             localVue,
+            pinia,
         });
         expect(wrapper.exists("b-tabs-stub")).toBeTruthy();
     });

--- a/client/src/components/HistoryImport.vue
+++ b/client/src/components/HistoryImport.vue
@@ -88,7 +88,7 @@ import { getAppRoot } from "onload/loadConfig";
 import { errorMessageAsString } from "utils/simple-error";
 import Vue, { ref, watch } from "vue";
 
-import { getFileSources } from "@/api/remoteFiles";
+import { fetchFileSources } from "@/api/remoteFiles";
 
 import ExternalLink from "./ExternalLink";
 
@@ -163,7 +163,7 @@ export default {
     },
     methods: {
         async initialize() {
-            const fileSources = await getFileSources();
+            const fileSources = await fetchFileSources();
             this.hasFileSources = fileSources.length > 0;
             this.initializing = false;
         },

--- a/client/src/composables/fileSources.test.ts
+++ b/client/src/composables/fileSources.test.ts
@@ -1,3 +1,4 @@
+import { createTestingPinia } from "@pinia/testing";
 import { shallowMount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { defineComponent } from "vue";
@@ -28,7 +29,8 @@ const TestComponent = defineComponent({
 });
 
 function setupWrapper(): any {
-    return shallowMount(TestComponent, {});
+    const pinia = createTestingPinia({ stubActions: false });
+    return shallowMount(TestComponent, { pinia });
 }
 
 describe("useFileSources", () => {

--- a/client/src/composables/fileSources.ts
+++ b/client/src/composables/fileSources.ts
@@ -22,6 +22,11 @@ export function useFileSources(options: FilterFileSourcesOptions = {}) {
         return fileSources.value.find((fs) => fs.id === id);
     }
 
+    function getFileSourceByUri(uri: string) {
+        const sourceId = uri.split("://")[1]?.split("/")[0] ?? "";
+        return getFileSourceById(sourceId);
+    }
+
     return {
         /**
          * The list of available file sources from the server.
@@ -42,5 +47,12 @@ export function useFileSources(options: FilterFileSourcesOptions = {}) {
          * @returns The file source with the given ID, if found.
          */
         getFileSourceById,
+        /**
+         * Get the file source that matches the given URI.
+         *
+         * @param uri - The URI to match.
+         * @returns The file source that matches the given URI, if found.
+         */
+        getFileSourceByUri,
     };
 }

--- a/client/src/composables/fileSources.ts
+++ b/client/src/composables/fileSources.ts
@@ -1,6 +1,7 @@
 import { onMounted, readonly, ref } from "vue";
 
-import { BrowsableFilesSourcePlugin, FilterFileSourcesOptions, getFileSources } from "@/api/remoteFiles";
+import { BrowsableFilesSourcePlugin, FilterFileSourcesOptions } from "@/api/remoteFiles";
+import { useFileSourcesStore } from "@/stores/fileSourcesStore";
 
 /**
  * Composable for accessing and working with file sources.
@@ -8,12 +9,14 @@ import { BrowsableFilesSourcePlugin, FilterFileSourcesOptions, getFileSources } 
  * @param options - The options to filter the file sources.
  */
 export function useFileSources(options: FilterFileSourcesOptions = {}) {
+    const fileSourcesStore = useFileSourcesStore();
+
     const isLoading = ref(true);
     const hasWritable = ref(false);
     const fileSources = ref<BrowsableFilesSourcePlugin[]>([]);
 
     onMounted(async () => {
-        fileSources.value = await getFileSources(options);
+        fileSources.value = await fileSourcesStore.getFileSources(options);
         hasWritable.value = fileSources.value.some((fs) => fs.writable);
         isLoading.value = false;
     });

--- a/client/src/stores/fileSourcesStore.ts
+++ b/client/src/stores/fileSourcesStore.ts
@@ -1,0 +1,29 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+
+import { type BrowsableFilesSourcePlugin, fetchFileSources, type FilterFileSourcesOptions } from "@/api/remoteFiles";
+
+export const useFileSourcesStore = defineStore("fileSourcesStore", () => {
+    const cachedFileSources = ref<{
+        [key: string]: BrowsableFilesSourcePlugin[] | Promise<BrowsableFilesSourcePlugin[]>;
+    }>({});
+
+    async function getFileSources(options: FilterFileSourcesOptions = {}): Promise<BrowsableFilesSourcePlugin[]> {
+        const cacheKey = getCacheKey(options);
+        if (cachedFileSources.value[cacheKey] === undefined) {
+            cachedFileSources.value[cacheKey] = fetchFileSources(options);
+        }
+        if (cachedFileSources.value[cacheKey] instanceof Promise) {
+            cachedFileSources.value[cacheKey] = await cachedFileSources.value[cacheKey]!;
+        }
+        return cachedFileSources.value[cacheKey]!;
+    }
+
+    function getCacheKey(options: FilterFileSourcesOptions) {
+        return JSON.stringify(options);
+    }
+
+    return {
+        getFileSources,
+    };
+});

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -299,6 +299,7 @@ class FilesSource(SingleFileSource, SupportsBrowsing):
 
 class BaseFilesSource(FilesSource):
     plugin_kind: ClassVar[PluginKind] = PluginKind.rfs  # Remote File Source by default, override in subclasses
+    serialize_extra_props: ClassVar[List[str]] = []  # Extra properties safe to serialize
 
     def get_browsable(self) -> bool:
         # Check whether the list method has been overridden
@@ -376,6 +377,9 @@ class BaseFilesSource(FilesSource):
             rval["uri_root"] = self.get_uri_root()
         if for_serialization:
             rval.update(self._serialization_props(user_context=user_context))
+        if self.serialize_extra_props:
+            for prop in self.serialize_extra_props:
+                rval[prop] = getattr(self, prop, None)
         return rval
 
     def to_dict_time(self, ctime):

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -9,6 +9,7 @@ from enum import Enum
 from typing import (
     Any,
     ClassVar,
+    Dict,
     List,
     Optional,
     Set,
@@ -96,6 +97,7 @@ class FilesSourceProperties(TypedDict):
     uri_root: NotRequired[str]
     type: NotRequired[str]
     browsable: NotRequired[bool]
+    extra: NotRequired[Dict[str, Any]]
 
 
 @dataclass
@@ -378,8 +380,10 @@ class BaseFilesSource(FilesSource):
         if for_serialization:
             rval.update(self._serialization_props(user_context=user_context))
         if self.serialize_extra_props:
+            extra_props = {}
             for prop in self.serialize_extra_props:
-                rval[prop] = getattr(self, prop, None)
+                extra_props[prop] = getattr(self, prop, None)
+            rval["extra"] = extra_props
         return rval
 
     def to_dict_time(self, ctime):

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -135,15 +135,15 @@ class RDMFilesSource(BaseFilesSource):
     """
 
     plugin_kind = PluginKind.rdm
+    serialize_extra_props = ["url"]
 
     def __init__(self, **kwd: Unpack[RDMFilesSourceProperties]):
         props = self._parse_common_config_opts(kwd)
-        base_url = props.get("url")
-        if not base_url:
+        self.url = props.get("url")
+        if not self.url:
             raise Exception("URL for RDM repository must be provided in configuration")
-        self._repository_url = base_url
         self._props = props
-        self._repository_interactor = self.get_repository_interactor(base_url)
+        self._repository_interactor = self.get_repository_interactor(self.url)
 
     @property
     def repository(self) -> RDMRepositoryInteractor:

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -21,7 +21,6 @@ log = logging.getLogger(__name__)
 
 
 class RDMFilesSourceProperties(FilesSourceProperties):
-    url: str
     token: str
     public_name: str
 
@@ -135,7 +134,6 @@ class RDMFilesSource(BaseFilesSource):
     """
 
     plugin_kind = PluginKind.rdm
-    serialize_extra_props = ["url"]
 
     def __init__(self, **kwd: Unpack[RDMFilesSourceProperties]):
         props = self._parse_common_config_opts(kwd)
@@ -148,6 +146,9 @@ class RDMFilesSource(BaseFilesSource):
     @property
     def repository(self) -> RDMRepositoryInteractor:
         return self._repository_interactor
+
+    def get_url(self) -> Optional[str]:
+        return self.url
 
     def get_repository_interactor(self, repository_url: str) -> RDMRepositoryInteractor:
         """Returns an interactor compatible with the given repository URL.

--- a/lib/galaxy/schema/remote_files.py
+++ b/lib/galaxy/schema/remote_files.py
@@ -8,7 +8,6 @@ from typing import (
 )
 
 from pydantic import (
-    ConfigDict,
     Field,
     RootModel,
 )

--- a/lib/galaxy/schema/remote_files.py
+++ b/lib/galaxy/schema/remote_files.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import (
     Any,
+    Dict,
     List,
     Optional,
     Union,
@@ -82,6 +83,11 @@ class FilesSourcePlugin(Model):
         title="Requires groups",
         description="Only users belonging to the groups specified here can access this files source.",
     )
+    extra: Optional[Dict[str, Any]] = Field(
+        None,
+        title="Extra",
+        description="Extra configuration options that the plugin may serialize. This is plugin specific.",
+    )
 
 
 class BrowsableFilesSourcePlugin(FilesSourcePlugin):
@@ -92,7 +98,6 @@ class BrowsableFilesSourcePlugin(FilesSourcePlugin):
         description="The URI root used by this type of plugin.",
         examples=["gximport://"],
     )
-    model_config = ConfigDict(extra="allow")
 
 
 class FilesSourcePluginList(RootModel):

--- a/lib/galaxy/schema/remote_files.py
+++ b/lib/galaxy/schema/remote_files.py
@@ -1,7 +1,6 @@
 from enum import Enum
 from typing import (
     Any,
-    Dict,
     List,
     Optional,
     Union,
@@ -82,10 +81,10 @@ class FilesSourcePlugin(Model):
         title="Requires groups",
         description="Only users belonging to the groups specified here can access this files source.",
     )
-    extra: Optional[Dict[str, Any]] = Field(
+    url: Optional[str] = Field(
         None,
-        title="Extra",
-        description="Extra configuration options that the plugin may serialize. This is plugin specific.",
+        title="URL",
+        description="Optional URL that might be provided by some plugins to link to the remote source.",
     )
 
 


### PR DESCRIPTION
When a history has been archived preserving the data in an external RDM repository like Zenodo, we can display its [Document Object Identifier](https://www.doi.org/) on it.

![image](https://github.com/galaxyproject/galaxy/assets/46503462/55bc266c-6b80-41fe-bb9d-a1a9d8df2ceb)

<del>This PR also allows FilesSource plugins to serialize extra properties defined in the `serialize_extra_props` class variable. This adds flexibility to customize the information we want to serialize for the file source. In this particular case, we serialize to the `extra` fields the repository URL associated with the RDM file source so it can be used to fetch the DOI information.</del> We decided to replace the `extra` field with directly serializing the `url` for simplicity even if not all file sources might use it.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Setup an RDM file source like in #18022
  - Archive a history creating an export record in that file source.
  - **[Important]** make sure **the record is published and has a DOI** (a fake one using the Zenodo Sandbox is fine but links won't resolve). 
  - The DOI should appear in your Archived Histories.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
