### PR TITLE
[24.0] Fix Legacy HTML page view

### DIFF
--- a/client/src/components/PageDisplay/PageHtml.vue
+++ b/client/src/components/PageDisplay/PageHtml.vue
@@ -32,7 +32,7 @@ export default {
             if (content) {
                 const vDom = document.createElement("div");
                 vDom.innerHTML = content;
-                const children = Object.values(vDom.children);
+                const children = Array.from(vDom.children);
                 children.forEach((child) => {
                     if (child.classList.contains("embedded-item")) {
                         const splitId = child.id.split("-");

--- a/client/src/components/PageDisplay/PageHtml.vue
+++ b/client/src/components/PageDisplay/PageHtml.vue
@@ -32,7 +32,7 @@ export default {
             if (content) {
                 const vDom = document.createElement("div");
                 vDom.innerHTML = content;
-                const children = vDom.children;
+                const children = Object.values(vDom.children);
                 children.forEach((child) => {
                     if (child.classList.contains("embedded-item")) {
                         const splitId = child.id.split("-");


### PR DESCRIPTION
`.children` is a HTMLCollection object which doesn't have a forEach interface. I confirmed this renders a few old style pages successfully.

Fixes https://github.com/galaxyproject/galaxy/issues/18144

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
