### PR TITLE
[24.0] Delay tool form rendering until config is loaded

### DIFF
--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="currentUser && currentHistoryId">
+    <div v-if="currentUser && currentHistoryId && isConfigLoaded">
         <b-alert :show="messageShow" :variant="messageVariant">
             {{ messageText }}
         </b-alert>


### PR DESCRIPTION
The config typically is already loaded once you hit the tool form, so this shouldn't cause a delay, and we already do the same effectively for the current user and current history id.

Fixes https://github.com/galaxyproject/galaxy/issues/18139
```
TypeError: e.config is null
  at $b (webpack://@galaxyproject/galaxy-client/./src/components/Tool/ToolForm.vue?5639:1:1709)
  at Vue.prototype._render (webpack://@galaxyproject/galaxy-client/./node_modules/vue/dist/vue.esm.js:2540:28)
  at updateComponent (webpack://@galaxyproject/galaxy-client/./node_modules/vue/dist/vue.esm.js:2980:27)
  at Watcher.prototype.get (webpack://@galaxyproject/galaxy-client/./node_modules/vue/dist/vue.esm.js:4164:33)
  at Watcher.prototype.run (webpack://@galaxyproject/galaxy-client/./node_modules/vue/dist/vue.esm.js:4240:30)
...
(3 additional frame(s) were not displayed)
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
