### PR TITLE
[24.0] Drop redundant error message

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -569,7 +569,8 @@ class JobHandlerQueue(BaseJobHandlerQueue):
                         self.sa_session.add(dataset_assoc.dataset.dataset)
                     self.sa_session.add(job)
                 elif job_state == JOB_ERROR:
-                    log.error("(%d) Error checking job readiness" % job.id)
+                    # A more informative message is shown wherever the job state is set to error
+                    pass
                 else:
                     log.error("(%d) Job in unknown state '%s'" % (job.id, job_state))
                     new_waiting_jobs.append(job.id)


### PR DESCRIPTION
There are only two places in the code where we set the job state to error
(https://github.com/galaxyproject/galaxy/blob/ad9271cf6a33cb2e22bd7bed72f901e5215309da/lib/galaxy/jobs/handler.py#L722, https://github.com/galaxyproject/galaxy/blob/ad9271cf6a33cb2e22bd7bed72f901e5215309da/lib/galaxy/jobs/handler.py#L733) and both log more specific log messages.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
