### PR TITLE
[24.0] Fix error message when accessing restricted Zenodo records

### DIFF
--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -408,9 +408,8 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
 
     def _ensure_response_has_expected_status_code(self, response, expected_status_code: int):
         if response.status_code == 403:
-            raise AuthenticationRequired(
-                f"Please make sure you have the necessary permissions to access the requested resource."
-            )
+            record_url = response.url.replace("/api", "").replace("/files", "")
+            raise AuthenticationRequired(f"Please make sure you have the necessary permissions to access: {record_url}")
         if response.status_code != expected_status_code:
             error_message = self._get_response_error_message(response)
             raise Exception(

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -15,6 +15,7 @@ from typing_extensions import (
     TypedDict,
 )
 
+from galaxy.exceptions import AuthenticationRequired
 from galaxy.files.sources import (
     Entry,
     EntryData,
@@ -406,6 +407,10 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         return headers
 
     def _ensure_response_has_expected_status_code(self, response, expected_status_code: int):
+        if response.status_code == 403:
+            raise AuthenticationRequired(
+                f"Please make sure you have the necessary permissions to access the requested resource."
+            )
         if response.status_code != expected_status_code:
             error_message = self._get_response_error_message(response)
             raise Exception(


### PR DESCRIPTION
Zenodo allows publishing records that have "restricted" access to the files.

![image](https://github.com/galaxyproject/galaxy/assets/46503462/473e07a5-305e-40a9-9cad-e8f597c8147e)


This fix makes the error message more obvious when browsing one of those restricted records providing a URL for verification.

## Before
![Screenshot from 2024-05-17 10-07-49](https://github.com/galaxyproject/galaxy/assets/46503462/5ed5ab9c-ad1b-4ce6-874e-28839fb34424)

## After
![image](https://github.com/galaxyproject/galaxy/assets/46503462/08a315f5-fe2d-4634-b1ab-62ee3fb1dd89)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
