### PR TITLE
[PROCEDURES] Minor adjustments to SECURITY.md to reflect that we call yearly releases LTS

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,8 +16,7 @@ The following branches or releases receive security support:
 
 - Development on the `dev` branch, hosted on GitHub, which will become the next release of Galaxy
 - Releases within the past 12 months.
-  - E.g. 16.04 will receive support until 2017-04. As the month changes to 2017-05 it will become unsupported.
-- There are currently no plans for Long Term Support (LTS) releases.
+  - E.g. 24.0 will receive support for a full year, at which point 25.0 will be available.
 
 For unsupported branches:
 


### PR DESCRIPTION
No actual procedure change, but clarify the language around release naming and drop the statement that we have no LTS'es, since we are suggesting the yearly .0 as a major/stability/lts release now.

fixes https://github.com/galaxyproject/galaxy/issues/18167

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
