### PR TITLE
[24.0] Emit warning when user-cancelled job already complete

### DIFF
--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -382,7 +382,14 @@ class DRMAAJobRunner(AsynchronousJobRunner):
                 commands.execute(cmd)
             log.info(f"({job.id}/{ext_id}) Removed from DRM queue at user's request")
         except drmaa.InvalidJobException:
-            log.exception(f"({job.id}/{ext_id}) User killed running job, but it was already dead")
+            log.warning(f"({job.id}/{ext_id}) User killed running job, but it was already dead")
+        except drmaa.InternalException as e:
+            if "already completing or completed" in str(e):
+                log.warning("({job.id}/{ext_id}) User killed running job, but job already terminal in DRM queue")
+            else:
+                log.exception(
+                    f"({job.id}/{ext_id}) User killed running job, but error encountered removing from DRM queue"
+                )
         except commands.CommandLineException as e:
             log.error(f"({job.id}/{ext_id}) User killed running job, but command execution failed: {unicodify(e)}")
         except Exception:

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -385,7 +385,7 @@ class DRMAAJobRunner(AsynchronousJobRunner):
             log.warning(f"({job.id}/{ext_id}) User killed running job, but it was already dead")
         except drmaa.InternalException as e:
             if "already completing or completed" in str(e):
-                log.warning("({job.id}/{ext_id}) User killed running job, but job already terminal in DRM queue")
+                log.warning(f"({job.id}/{ext_id}) User killed running job, but job already terminal in DRM queue")
             else:
                 log.exception(
                     f"({job.id}/{ext_id}) User killed running job, but error encountered removing from DRM queue"


### PR DESCRIPTION
Seems perfectly reasonable and expected.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
