### PR TITLE
[24.0] Don't fail metadata if we only have an extra output files dir

### DIFF
--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -409,15 +409,22 @@ def set_metadata_portable(
                 external_filename = unnamed_id_to_path.get(dataset_instance_id, dataset_filename_override)
                 if not os.path.exists(external_filename):
                     matches = glob.glob(external_filename)
-                    assert len(matches) == 1, f"{len(matches)} file(s) matched by output glob '{external_filename}'"
-                    external_filename = matches[0]
-                    assert safe_contains(
-                        tool_job_working_directory, external_filename
-                    ), f"Cannot collect output '{external_filename}' from outside of working directory"
-                    created_from_basename = os.path.relpath(
-                        external_filename, os.path.join(tool_job_working_directory, "working")
-                    )
-                    dataset.dataset.created_from_basename = created_from_basename
+                    if matches:
+                        assert len(matches) == 1, f"{len(matches)} file(s) matched by output glob '{external_filename}'"
+                        external_filename = matches[0]
+                        assert safe_contains(
+                            tool_job_working_directory, external_filename
+                        ), f"Cannot collect output '{external_filename}' from outside of working directory"
+                        created_from_basename = os.path.relpath(
+                            external_filename, os.path.join(tool_job_working_directory, "working")
+                        )
+                        dataset.dataset.created_from_basename = created_from_basename
+                    elif os.path.exists(dataset_path_to_extra_path(external_filename)):
+                        # Only output extra files dir, but no primary output file, that's fine
+                        pass
+                    else:
+                        raise Exception(f"Output file '{external_filename}' not found")
+
                 # override filename if we're dealing with outputs to working directory and dataset is not linked to
                 link_data_only = metadata_params.get("link_data_only")
                 if not link_data_only:

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -421,6 +421,9 @@ def set_metadata_portable(
                         dataset.dataset.created_from_basename = created_from_basename
                     elif os.path.exists(dataset_path_to_extra_path(external_filename)):
                         # Only output extra files dir, but no primary output file, that's fine
+                        if dataset.datatype.composite_type == "auto_primary_file":
+                            with open(external_filename, "wb"):
+                                pass
                         pass
                     else:
                         raise Exception(f"Output file '{external_filename}' not found")

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -420,11 +420,12 @@ def set_metadata_portable(
                         )
                         dataset.dataset.created_from_basename = created_from_basename
                     elif os.path.exists(dataset_path_to_extra_path(external_filename)):
-                        # Only output extra files dir, but no primary output file, that's fine
-                        if dataset.datatype.composite_type == "auto_primary_file":
-                            with open(external_filename, "wb"):
-                                pass
-                        pass
+                        # Only output is extra files dir, but no primary output file, that's fine,
+                        # but make sure we create an empty primary output file. It's a little
+                        # weird to do this, but it does indicate that there's nothing wrong with the file,
+                        # as opposed to perhaps a storage issue.
+                        with open(external_filename, "wb"):
+                            pass
                     else:
                         raise Exception(f"Output file '{external_filename}' not found")
 

--- a/test/functional/tools/composite_output.xml
+++ b/test/functional/tools/composite_output.xml
@@ -1,6 +1,5 @@
 <tool id="composite_output" name="composite_output" version="1.0.0">
     <command><![CDATA[
-touch '$output' &&
 mkdir '$output.extra_files_path' &&
 cp '$input.extra_files_path'/* '$output.extra_files_path' &&
 cp '$input.extra_files_path'/Log '$output.extra_files_path'/second_log &&

--- a/test/functional/tools/composite_output_tests.xml
+++ b/test/functional/tools/composite_output_tests.xml
@@ -3,7 +3,6 @@
   <command>
     mkdir '$output.files_path';
     mkdir '$output.files_path/output';
-    touch '$output';
     cp '$input.extra_files_path'/* '$output.files_path';
     echo "1 2 3" > '$output.files_path/md5out';
     echo "1" > '$output.extra_files_path/output/1';


### PR DESCRIPTION
This used to be fine in some deployments, and not in others. I think this is fine, considering we got the extra output files dir the job completed successfully. We expect this for composite datasets with `auto_primary_file`, but other cases like directory datatypes could also be doing this.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
