### PR TITLE
[24.0] Fix on success redirect

### DIFF
--- a/client/src/components/Tool/ToolSuccess.vue
+++ b/client/src/components/Tool/ToolSuccess.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { BAlert } from "bootstrap-vue";
-import { computed, onMounted } from "vue";
+import { computed } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { useConfig } from "@/composables/config";
@@ -22,13 +22,10 @@ const responseVal = computed(() => jobStore.getLatestResponse);
 const showRecommendation = computed(() => config.value.enable_tool_recommendations);
 const toolName = computed(() => responseVal.value.toolName);
 
-/* lifecyle */
-onMounted(() => {
-    // no response means that no tool was run in this session i.e. no data in the store
-    if (Object.keys(responseVal.value).length === 0) {
-        router.push(`/`);
-    }
-});
+// no data means that no tool was run in this session i.e. no data in the store
+if (Object.keys(responseVal.value).length === 0) {
+    router.push(`/`);
+}
 </script>
 
 <template>

--- a/client/src/components/Tool/ToolSuccess.vue
+++ b/client/src/components/Tool/ToolSuccess.vue
@@ -31,15 +31,15 @@ if (Object.keys(responseVal.value).length === 0) {
 <template>
     <section>
         <BAlert v-if="!jobResponse" variant="info" show>
-            <LoadingSpan message="Waiting on a job response" />
+            <LoadingSpan message="Waiting on data" />
         </BAlert>
         <div v-else>
             <div v-if="jobResponse?.produces_entry_points">
                 <ToolEntryPoints v-for="job in jobResponse.jobs" :key="job.id" :job-id="job.id" />
             </div>
             <ToolSuccessMessage :job-response="jobResponse" :tool-name="toolName" />
+            <Webhook type="tool" :tool-id="jobDef.tool_id" />
+            <ToolRecommendation v-if="showRecommendation" :tool-id="jobDef.tool_id" />
         </div>
-        <Webhook type="tool" :tool-id="jobDef.tool_id" />
-        <ToolRecommendation v-if="showRecommendation" :tool-id="jobDef.tool_id" />
     </section>
 </template>


### PR DESCRIPTION
Follow up to https://github.com/galaxyproject/galaxy/pull/18141, jobDef is also not available if you navigate to https://usegalaxy.org/jobs/submission/success without actually having run a job.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
