### PR TITLE
[24.0] Fix Edit Dataset UI when there is an error retrieving the dataset

### DIFF
--- a/client/src/components/DatasetInformation/DatasetAttributes.test.js
+++ b/client/src/components/DatasetInformation/DatasetAttributes.test.js
@@ -33,6 +33,31 @@ async function buildWrapper(conversion_disable = false) {
     return wrapper;
 }
 
+async function buildWrapperWithError(error) {
+    const wrapper = mount(DatasetAttributes, {
+        propsData: {
+            datasetId: "dataset_id",
+            messageText: error,
+            messageVariant: "danger",
+        },
+        computed: {
+            hasError() {
+                return true;
+            },
+        },
+        localVue,
+        stubs: {
+            DatasetAttributesProvider: MockProvider({
+                result: null,
+            }),
+            FontAwesomeIcon: false,
+            FormElement: false,
+        },
+    });
+    await flushPromises();
+    return wrapper;
+}
+
 describe("DatasetAttributes", () => {
     it("check rendering", async () => {
         const axiosMock = new MockAdapter(axios);
@@ -60,5 +85,16 @@ describe("DatasetAttributes", () => {
         expect(wrapper.findAll("#permission_text").length).toBe(1);
         expect(wrapper.findAll(".tab-pane").length).toBe(3);
         expect(wrapper.findAll(".ui-portlet-section").length).toBe(1);
+    });
+
+    it("doesn't render edit controls with error", async () => {
+        const wrapper = await buildWrapperWithError("error");
+        expect(wrapper.findAll("button").length).toBe(0);
+        expect(wrapper.findAll("#attribute_text").length).toBe(0);
+        expect(wrapper.findAll("#conversion_text").length).toBe(0);
+        expect(wrapper.findAll("#datatype_text").length).toBe(0);
+        expect(wrapper.findAll("#permission_text").length).toBe(0);
+        expect(wrapper.findAll(".tab-pane").length).toBe(0);
+        expect(wrapper.findAll(".ui-portlet-section").length).toBe(0);
     });
 });

--- a/client/src/components/DatasetInformation/DatasetAttributes.vue
+++ b/client/src/components/DatasetInformation/DatasetAttributes.vue
@@ -5,7 +5,7 @@
             {{ messageText | l }}
         </b-alert>
         <DatasetAttributesProvider :id="datasetId" v-slot="{ result, loading }" @error="onError">
-            <div v-if="!loading" class="mt-3">
+            <div v-if="!loading && !hasError" class="mt-3">
                 <b-tabs>
                     <b-tab v-if="!result['attribute_disable']">
                         <template v-slot:title>
@@ -120,6 +120,11 @@ export default {
             messageVariant: null,
             formData: {},
         };
+    },
+    computed: {
+        hasError() {
+            return this.messageVariant === "danger";
+        },
     },
     methods: {
         onAttribute(data) {


### PR DESCRIPTION
Fixes #18149

| Before | After |
|--------|-------|
| ![image](https://github.com/galaxyproject/galaxy/assets/46503462/cb979688-8483-46ba-90a3-1d515176cc48)   | ![image](https://github.com/galaxyproject/galaxy/assets/46503462/96b01e12-6245-4000-9189-b72ec9b4710e)  |



## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
