### PR TITLE
[24.1] Fix file source search query with empty string value

### DIFF
--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -393,6 +393,7 @@ class BaseFilesSource(FilesSource):
         kwd.pop("uri_root", None)
         kwd.pop("type", None)
         kwd.pop("browsable", None)
+        kwd.pop("supports", None)
         return kwd
 
     def to_dict(self, for_serialization=False, user_context: "OptionalUserContext" = None) -> FilesSourceProperties:

--- a/lib/galaxy/files/sources/_pyfilesystem2.py
+++ b/lib/galaxy/files/sources/_pyfilesystem2.py
@@ -111,7 +111,7 @@ class PyFilesystem2FilesSource(BaseFilesSource):
         return (start, end)
 
     def _query_to_filter(self, query: Optional[str]) -> Optional[List[str]]:
-        if query is None:
+        if not query:
             return None
         return [f"*{query}*"]
 

--- a/test/unit/files/test_temp.py
+++ b/test/unit/files/test_temp.py
@@ -131,6 +131,18 @@ def test_search(temp_file_source: TempFilesSource):
     assert result[0]["name"] == "e"
 
 
+def test_query_with_empty_string(temp_file_source: TempFilesSource):
+    recursive = False
+    root_lvl_entries, count = temp_file_source.list("/", recursive=recursive)
+    assert count == 4
+    assert len(root_lvl_entries) == 4
+
+    result, count = temp_file_source.list("/", recursive=recursive, query="")
+    assert count == 4
+    assert len(result) == 4
+    assert result == root_lvl_entries
+
+
 def test_pagination_not_supported_raises(temp_file_source: TempFilesSource):
     TempFilesSource.supports_pagination = False
     recursive = False


### PR DESCRIPTION
Follow-up to #18059

Providing `query=""` as a parameter was constructing the wrong filter `"**"`.
Also `supports` was passed to the file source as a keyword parameter in some circumstances but shouldn't.

Detected in https://github.com/galaxyproject/galaxy/actions/runs/9172325561/job/25219112137?pr=18059

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
