### PR TITLE
[24.0] Fix submitted value in workflow run form if data is constrained by tag filter

### DIFF
--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -417,7 +417,10 @@ const matchedValues = computed(() => {
                 const options = props.options[entry.src] || [];
                 const option = options.find((v) => v.id === entry.id && v.src === entry.src);
                 if (option) {
-                    values.push({ ...option, name: option.name || entry.id });
+                    const accepted = !props.tag || option.tags?.includes(props.tag);
+                    if (accepted) {
+                        values.push({ ...option, name: option.name || entry.id });
+                    }
                 }
             }
         });
@@ -426,7 +429,7 @@ const matchedValues = computed(() => {
 });
 
 onMounted(() => {
-    if (props.value) {
+    if (props.value && matchedValues.value.length > 0) {
         $emit("input", createValue(matchedValues.value));
     } else {
         $emit("input", createValue(currentValue.value));

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -37,7 +37,7 @@ const props = defineProps({
         default: "Select Value",
     },
     value: {
-        type: String as PropType<SelectValue | SelectValue[]>,
+        type: [String, Array] as PropType<SelectValue | SelectValue[]>,
         default: null,
     },
 });

--- a/lib/galaxy_test/base/workflow_fixtures.py
+++ b/lib/galaxy_test/base/workflow_fixtures.py
@@ -1177,3 +1177,43 @@ steps:
           format: txt
           location: https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bed
 """
+
+WORKFLOW_WITH_DATA_TAG_FILTER = r"""{
+    "a_galaxy_workflow": "true",
+    "annotation": null,
+    "comments": [],
+    "format-version": "0.1",
+    "name": "Export WF4 Assembly HiC (imported from URL) (imported from uploaded file)",
+    "steps": {
+        "0": {
+            "annotation": "With dataset tag : genomescope_model ",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "With dataset tag : genomescope_model ",
+                    "name": "Genomescope Model"
+                }
+            ],
+            "label": "Genomescope Model",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 0,
+                "top": 0
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"format\": [\"txt\"], \"tag\": \"genomescope_model\"}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "a165c531-371f-4073-9cdd-85ce3506586f",
+            "when": null,
+            "workflow_outputs": []
+        }
+    },
+    "tags": [],
+    "uuid": "03a95ebe-af1e-4628-ac2f-e7553babfb2f",
+    "version": 3
+}"""

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -1,4 +1,5 @@
 import json
+from uuid import uuid4
 
 import yaml
 from selenium.webdriver.common.by import By
@@ -14,6 +15,7 @@ from galaxy_test.base.workflow_fixtures import (
     WORKFLOW_SIMPLE_CAT_TWICE,
     WORKFLOW_WITH_CUSTOM_REPORT_1,
     WORKFLOW_WITH_CUSTOM_REPORT_1_TEST_DATA,
+    WORKFLOW_WITH_DATA_TAG_FILTER,
     WORKFLOW_WITH_DYNAMIC_OUTPUT_COLLECTION,
     WORKFLOW_WITH_OLD_TOOL_VERSION,
     WORKFLOW_WITH_RULES_1,
@@ -307,6 +309,24 @@ steps: {}
         workflow_run.run_workflow_disabled.wait_for_absent()
         input_element.clear()
         workflow_run.run_workflow_disabled.wait_for_present()
+
+    @selenium_test
+    @managed_history
+    def test_workflow_run_tag_filter(self):
+        history_id = self.current_history_id()
+        dataset = self.dataset_populator.new_dataset(history_id, wait=True)
+        self.dataset_populator.tag_dataset(history_id, dataset["id"], tags=["genomescope_model"])
+        # Add another possible input that should not be selected
+        self.dataset_populator.new_dataset(history_id, wait=True)
+        wf = json.loads(WORKFLOW_WITH_DATA_TAG_FILTER)
+        wf["name"] = str(uuid4())
+        workflow_id = self.workflow_populator.create_workflow(wf)
+        self.workflow_run_with_name(wf["name"])
+        self.workflow_run_submit()
+        self.sleep_for(self.wait_types.HISTORY_POLL)
+        invocations = self.workflow_populator.workflow_invocations(workflow_id=workflow_id)
+        invocation = self.workflow_populator.get_invocation(invocations[-1]["id"])
+        assert invocation["inputs"]["0"]["id"] == dataset["id"]
 
     def _assert_has_3_lines_after_run(self, hid):
         self.workflow_run_wait_for_ok(hid=hid)


### PR DESCRIPTION
Fixes an issue reported by @abueg, where inputs in the workflow run form appear to be correctly filtered by the tag value, but upon submission the unfiltered default value is used. The included selenium test recapitulates this.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
