### PR TITLE
[24.1] Revert some requests import changes

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -152,7 +152,6 @@ from galaxy.tours import (
     build_tours_registry,
     ToursRegistry,
 )
-from galaxy.util import user_agent  # noqa: F401
 from galaxy.util import (
     ExecutionTimer,
     heartbeat,

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -26,7 +26,6 @@ from galaxy.files.uris import (
     stream_to_file,
     stream_url_to_file,
 )
-from galaxy.util import user_agent  # noqa: F401
 from galaxy.util import (
     in_directory,
     safe_makedirs,

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -4,13 +4,15 @@ import logging
 import os
 import urllib.parse
 
-from galaxy.util import requests
-
 try:
     import gitlab
 except ImportError:
     gitlab = None
-from galaxy.util import string_as_bool
+
+from galaxy.util import (
+    requests,
+    string_as_bool,
+)
 from .base_git import BaseGitPlugin
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -67,8 +67,6 @@ from typing_extensions import (
     Self,
 )
 
-from galaxy.util import requests
-
 try:
     import grp
 except ImportError:
@@ -125,6 +123,7 @@ except ImportError:
         XML,
     )
 
+from . import requests
 from .custom_logging import get_logger
 from .inflection import Inflector
 from .path import (  # noqa: F401

--- a/lib/galaxy_test/api/test_drs.py
+++ b/lib/galaxy_test/api/test_drs.py
@@ -9,6 +9,8 @@ from urllib.parse import (
     urlparse,
 )
 
+import requests
+
 from galaxy.files import (
     ConfiguredFileSources,
     DictFileSourcesUserContext,
@@ -18,7 +20,6 @@ from galaxy.files.sources.util import (
     fetch_drs_to_file,
     RetryOptions,
 )
-from galaxy.util import requests
 from galaxy.util.config_parsers import parse_allowlist_ips
 from galaxy_test.base.populators import DatasetPopulator
 from ._framework import ApiTestCase

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -7,9 +7,9 @@ from operator import itemgetter
 from unittest import SkipTest
 
 import pytest
+import requests
 from dateutil.parser import isoparse
 
-from galaxy.util import requests
 from galaxy_test.api.test_tools import TestsTools
 from galaxy_test.base.api_asserts import assert_status_code_is_ok
 from galaxy_test.base.populators import (

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -11,9 +11,9 @@ from urllib.parse import (
 )
 
 import pytest
+import requests
 from typing_extensions import Protocol
 
-from galaxy.util import requests
 from galaxy.util.properties import get_from_env
 from .api_asserts import (
     assert_error_code_is,

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -69,6 +69,7 @@ from typing import (
 from uuid import UUID
 
 import cwltest.compare
+import requests
 import yaml
 from bioblend.galaxyclient import GalaxyClient
 from gxformat2 import (
@@ -98,7 +99,6 @@ from galaxy.tool_util.verify.wait import (
 from galaxy.util import (
     DEFAULT_SOCKET_TIMEOUT,
     galaxy_root_path,
-    requests,
     UNKNOWN,
 )
 from galaxy.util.resources import resource_string

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -18,6 +18,7 @@ from typing import (
     TYPE_CHECKING,
 )
 
+import requests
 import yaml
 from gxformat2 import (
     convert_and_import_workflow,
@@ -38,7 +39,6 @@ from galaxy.util import (
     asbool,
     classproperty,
     DEFAULT_SOCKET_TIMEOUT,
-    requests,
 )
 from galaxy.util.unittest_utils import skip_if_github_down
 from galaxy_test.base import populators

--- a/lib/tool_shed/test/base/api_util.py
+++ b/lib/tool_shed/test/base/api_util.py
@@ -9,9 +9,9 @@ from typing import (
 )
 from urllib.parse import urljoin
 
+import requests
 from typing_extensions import Literal
 
-from galaxy.util import requests
 from galaxy_test.base.api_asserts import (
     assert_has_keys,
     assert_status_code_is,

--- a/lib/tool_shed/test/base/populators.py
+++ b/lib/tool_shed/test/base/populators.py
@@ -8,9 +8,9 @@ from typing import (
     Union,
 )
 
+import requests
 from typing_extensions import Protocol
 
-from galaxy.util import requests
 from galaxy.util.resources import (
     as_file,
     resource_path,
@@ -189,7 +189,7 @@ class ToolShedPopulator:
         api_asserts.assert_status_code_is_ok(revisions_response)
         return from_legacy_install_info(revisions_response.json())
 
-    def update_column_maker_repo(self, repository: HasRepositoryId) -> requests.Response:
+    def update_column_maker_repo(self, repository: HasRepositoryId) -> RepositoryUpdate:
         response = self.upload_revision(
             repository,
             COLUMN_MAKER_1_1_1_PATH,
@@ -211,7 +211,7 @@ class ToolShedPopulator:
 
     def upload_revision(
         self, repository: HasRepositoryId, path: Traversable, commit_message: str = DEFAULT_COMMIT_MESSAGE
-    ):
+    ) -> RepositoryUpdate:
         response = self.upload_revision_raw(repository, path, commit_message=commit_message)
         if response.status_code != 200:
             response_json = None

--- a/lib/tool_shed/test/base/twilltestcase.py
+++ b/lib/tool_shed/test/base/twilltestcase.py
@@ -25,6 +25,7 @@ from urllib.parse import (
 )
 
 import pytest
+import requests
 from mercurial import (
     commands,
     hg,
@@ -52,7 +53,6 @@ from galaxy.tool_shed.util.dependency_display import build_manage_repository_dic
 from galaxy.tool_shed.util.repository_util import check_for_updates
 from galaxy.util import (
     DEFAULT_SOCKET_TIMEOUT,
-    requests,
     smart_str,
 )
 from galaxy_test.base.api_asserts import assert_status_code_is_ok

--- a/scripts/api/fetch_to_library.py
+++ b/scripts/api/fetch_to_library.py
@@ -1,9 +1,8 @@
 import argparse
 import json
 
+import requests
 import yaml
-
-from galaxy.util import requests
 
 
 def main():

--- a/scripts/api/search.py
+++ b/scripts/api/search.py
@@ -5,7 +5,7 @@ Sample script for Galaxy Search API
 import json
 import sys
 
-from galaxy.util import requests
+import requests
 
 
 class RemoteGalaxy:

--- a/scripts/api/upload_to_history.py
+++ b/scripts/api/upload_to_history.py
@@ -7,14 +7,7 @@ import json
 import os
 import sys
 
-try:
-    from galaxy.util import requests
-except ImportError:
-    print(
-        "Could not import the requests module. See http://docs.python-requests.org/en/latest/"
-        " or install with 'pip install requests'"
-    )
-    raise
+import requests
 
 
 def upload_file(base_url, api_key, history_id, filepath, **kwargs):

--- a/scripts/resumable_upload.py
+++ b/scripts/resumable_upload.py
@@ -2,10 +2,9 @@
 import os
 
 import click
+import requests
 from tusclient import client
 from tusclient.storage import filestorage
-
-from galaxy.util import requests
 
 UPLOAD_ENDPOINT = "/api/upload/resumable_upload"
 SUBMISSION_ENDPOINT = "/api/tools/fetch"

--- a/scripts/tool_shed/api/common.py
+++ b/scripts/tool_shed/api/common.py
@@ -1,4 +1,4 @@
-from galaxy.util import requests
+import requests
 
 
 def delete(api_key, url, data, return_formatted=True):

--- a/test/integration/test_interactivetools_api.py
+++ b/test/integration/test_interactivetools_api.py
@@ -10,8 +10,8 @@ from typing import (
 )
 
 import pytest
+import requests
 
-from galaxy.util import requests
 from galaxy_test.base import api_asserts
 from galaxy_test.base.populators import (
     DatasetPopulator,

--- a/test/integration/test_job_files.py
+++ b/test/integration/test_job_files.py
@@ -20,6 +20,7 @@ import os
 import tempfile
 from typing import Dict
 
+import requests
 from sqlalchemy import select
 from tusclient import client
 
@@ -28,7 +29,6 @@ from galaxy.model.base import (
     ensure_object_added_to_session,
     transaction,
 )
-from galaxy.util import requests
 from galaxy_test.base import api_asserts
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util

--- a/test/unit/tool_shed/test_shed_index.py
+++ b/test/unit/tool_shed/test_shed_index.py
@@ -6,9 +6,9 @@ from collections import namedtuple
 from io import BytesIO
 
 import pytest
+import requests
 from whoosh import index
 
-from galaxy.util import requests
 from tool_shed.util.shed_index import build_index
 
 URL = "https://github.com/mvdbeek/toolshed-test-data/blob/master/toolshed_community_files.tgz?raw=true"

--- a/test/unit/util/test_get_url.py
+++ b/test/unit/util/test_get_url.py
@@ -1,11 +1,9 @@
 import pytest
+import requests
 import responses
 from werkzeug.wrappers.response import Response
 
-from galaxy.util import (
-    requests,
-    url_get,
-)
+from galaxy.util import url_get
 
 
 @responses.activate
@@ -29,7 +27,7 @@ def test_get_url_retry_after(httpserver):
     attempts = []
 
     def retry_handler(request):
-        attempts.append(requests)
+        attempts.append(request)
         if len(attempts) < 4:
             return Response("try again later", status=429, content_type="text/plain")
         else:

--- a/test/unit/webapps/test_client_disconnect.py
+++ b/test/unit/webapps/test_client_disconnect.py
@@ -5,16 +5,14 @@ import time
 from typing import Optional
 
 import pytest
+import requests
 import uvicorn
 from fastapi import status
 from fastapi.applications import FastAPI
 from requests import ReadTimeout
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from galaxy.util import (
-    requests,
-    sockets,
-)
+from galaxy.util import sockets
 
 error_encountered: Optional[str] = None
 


### PR DESCRIPTION
introduced in https://github.com/galaxyproject/galaxy/pull/18003 . In particular, when using requests in the tests to connect to Galaxy or the ToolShed it's not needed to use the modified headers.

Also:
- Move some imports after conditional imports.
- Fix type annotations in `lib/tool_shed/test/base/populators.py`
- Fix typo bug in `test/unit/util/test_get_url.py`

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
