### PR TITLE
[24.0] Fix `make all histories private` with immutable histories

### DIFF
--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -243,7 +243,7 @@ export default {
                     _l(
                         "WARNING: This will make all datasets (excluding library datasets) for which you have " +
                             "'management' permissions, in all of your histories " +
-                            "private, and will set permissions such that all " +
+                            "private (including archived and purged), and will set permissions such that all " +
                             "of your new data in these histories is created as private.  Any " +
                             "datasets within that are currently shared will need " +
                             "to be re-shared or published.  Are you sure you " +

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -192,21 +192,17 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             trans.app.security_agent.permitted_actions.DATASET_ACCESS: [private_role],
         }
         for history in histories:
-            try:
-                # Set default role for history to private
-                trans.app.security_agent.history_set_default_permissions(history, private_permissions)
-                # Set private role for all datasets
-                for hda in history.datasets:
-                    if (
-                        not hda.dataset.library_associations
-                        and not trans.app.security_agent.dataset_is_private_to_user(trans, hda.dataset)
-                        and trans.app.security_agent.can_manage_dataset(user_roles, hda.dataset)
-                    ):
-                        # If it's not private to me, and I can manage it, set fixed private permissions.
-                        trans.app.security_agent.set_all_dataset_permissions(hda.dataset, private_permissions)
-            except Exception:
-                log.exception("Error making datasets private.")
-                continue
+            # Set default role for history to private
+            trans.app.security_agent.history_set_default_permissions(history, private_permissions)
+            # Set private role for all datasets
+            for hda in history.datasets:
+                if (
+                    not hda.dataset.library_associations
+                    and not trans.app.security_agent.dataset_is_private_to_user(trans, hda.dataset)
+                    and trans.app.security_agent.can_manage_dataset(user_roles, hda.dataset)
+                ):
+                    # If it's not private to me, and I can manage it, set fixed private permissions.
+                    trans.app.security_agent.set_all_dataset_permissions(hda.dataset, private_permissions)
         return {
             "message": f"Success, requested permissions have been changed in {'all histories' if all_histories else history.name}."
         }

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -192,20 +192,24 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             trans.app.security_agent.permitted_actions.DATASET_ACCESS: [private_role],
         }
         for history in histories:
-            self.history_manager.error_unless_mutable(history)
-            # Set default role for history to private
-            trans.app.security_agent.history_set_default_permissions(history, private_permissions)
-            # Set private role for all datasets
-            for hda in history.datasets:
-                if (
-                    not hda.dataset.library_associations
-                    and not trans.app.security_agent.dataset_is_private_to_user(trans, hda.dataset)
-                    and trans.app.security_agent.can_manage_dataset(user_roles, hda.dataset)
-                ):
-                    # If it's not private to me, and I can manage it, set fixed private permissions.
-                    trans.app.security_agent.set_all_dataset_permissions(hda.dataset, private_permissions)
-                    if not trans.app.security_agent.dataset_is_private_to_user(trans, hda.dataset):
-                        raise exceptions.InternalServerError("An error occurred and the dataset is NOT private.")
+            try:
+                self.history_manager.error_unless_mutable(history)
+                # Set default role for history to private
+                trans.app.security_agent.history_set_default_permissions(history, private_permissions)
+                # Set private role for all datasets
+                for hda in history.datasets:
+                    if (
+                        not hda.dataset.library_associations
+                        and not trans.app.security_agent.dataset_is_private_to_user(trans, hda.dataset)
+                        and trans.app.security_agent.can_manage_dataset(user_roles, hda.dataset)
+                    ):
+                        # If it's not private to me, and I can manage it, set fixed private permissions.
+                        trans.app.security_agent.set_all_dataset_permissions(hda.dataset, private_permissions)
+                        if not trans.app.security_agent.dataset_is_private_to_user(trans, hda.dataset):
+                            raise exceptions.InternalServerError("An error occurred and the dataset is NOT private.")
+            except Exception:
+                log.exception("Error making datasets private.")
+                continue
         return {
             "message": f"Success, requested permissions have been changed in {'all histories' if all_histories else history.name}."
         }

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -204,8 +204,6 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
                     ):
                         # If it's not private to me, and I can manage it, set fixed private permissions.
                         trans.app.security_agent.set_all_dataset_permissions(hda.dataset, private_permissions)
-                        if not trans.app.security_agent.dataset_is_private_to_user(trans, hda.dataset):
-                            raise exceptions.InternalServerError("An error occurred and the dataset is NOT private.")
             except Exception:
                 log.exception("Error making datasets private.")
                 continue

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -123,7 +123,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             )
         )
 
-    @web.legacy_expose_api
+    @web.expose_api
     @web.require_login("changing default permissions")
     def permissions(self, trans, payload=None, **kwd):
         """
@@ -131,7 +131,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
         """
         history_id = kwd.get("id")
         if not history_id:
-            return self.message_exception(trans, f"Invalid history id ({str(history_id)}) received")
+            raise exceptions.RequestParameterMissingException("No history id received")
         history = self.history_manager.get_owned(self.decode_id(history_id), trans.user, current_history=trans.history)
         if trans.request.method == "GET":
             inputs = []
@@ -166,7 +166,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             trans.app.security_agent.history_set_default_permissions(history, permissions)
             return {"message": "Default history '%s' dataset permissions have been changed." % history.name}
 
-    @web.legacy_expose_api
+    @web.expose_api
     @web.require_login("make datasets private")
     def make_private(self, trans, history_id=None, all_histories=False, **kwd):
         """
@@ -184,7 +184,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             if history:
                 histories.append(history)
         if not histories:
-            return self.message_exception(trans, "Invalid history or histories specified.")
+            raise exceptions.RequestParameterMissingException("No history or histories specified.")
         private_role = trans.app.security_agent.get_private_user_role(trans.user)
         user_roles = trans.user.all_roles()
         private_permissions = {
@@ -256,12 +256,12 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
         return trans.show_ok_message("Your jobs have been resumed.", refresh_frames=refresh_frames)
         # TODO: used in index.mako
 
-    @web.legacy_expose_api
+    @web.expose_api
     @web.require_login("rename histories")
     def rename(self, trans, payload=None, **kwd):
         id = kwd.get("id")
         if not id:
-            return self.message_exception(trans, "No history id received for renaming.")
+            raise exceptions.RequestParameterMissingException("No history id received for renaming.")
         user = trans.get_user()
         id = listify(id)
         histories = []

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -193,7 +193,6 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
         }
         for history in histories:
             try:
-                self.history_manager.error_unless_mutable(history)
                 # Set default role for history to private
                 trans.app.security_agent.history_set_default_permissions(history, private_permissions)
                 # Set private role for all datasets


### PR DESCRIPTION
Fixes #18146

I'm still on the fence if archived histories should be altered, but I guess it is ok since the confirmation message now mentions it.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
