### PR TITLE
[24.1] Fix selection highlight in Files Dialog when using items provider

### DIFF
--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -322,6 +322,8 @@ async function provideItems(ctx: ItemsProviderContext): Promise<SelectionItem[]>
         );
         const result = response.entries.map(entryToRecord);
         totalItems.value = response.totalMatches;
+        items.value = result;
+        formatRows();
         return result;
     } catch (error) {
         errorMessage.value = errorMessageAsString(error);


### PR DESCRIPTION
Detected while checking #18191

| Before | After |
|--------|-------|
| ![FilesDialogHighlightBroken](https://github.com/galaxyproject/galaxy/assets/46503462/5a148fe7-2616-42d1-876d-8a74530f8195)   | ![FilesDialogHighlightFixed](https://github.com/galaxyproject/galaxy/assets/46503462/9b700127-2b1d-4e5a-bf1f-ec2ed693e774)  |


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Browse one of the file sources using server-side pagination (FTP, Zenodo, etc.)
  - Try to select some items.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
