### PR TITLE
[24.0] Add `GenericItem` error handling

### DIFF
--- a/client/src/components/History/Content/GenericItem.vue
+++ b/client/src/components/History/Content/GenericItem.vue
@@ -82,33 +82,33 @@ export default {
             try {
                 await deleteContent(item, { recursive: recursive });
             } catch (error) {
-                this.onError(error);
+                this.onError(error, "Failed to delete item");
             }
         },
-        onError(e) {
+        onError(e, title = "Error") {
             const error = errorMessageAsString(e, "Dataset operation failed.");
-            Toast.error(error);
+            Toast.error(error, title);
             console.error(error);
         },
         async onUndelete(item) {
             try {
                 await updateContentFields(item, { deleted: false });
             } catch (error) {
-                this.onError(error);
+                this.onError(error, "Failed to undelete item");
             }
         },
         async onHide(item) {
             try {
                 await updateContentFields(item, { visible: false });
             } catch (error) {
-                this.onError(error);
+                this.onError(error, "Failed to hide item");
             }
         },
         async onUnhide(item) {
             try {
                 await updateContentFields(item, { visible: true });
             } catch (error) {
-                this.onError(error);
+                this.onError(error, "Failed to unhide item");
             }
         },
         async onHighlight(item) {
@@ -121,7 +121,7 @@ export default {
             try {
                 await this.applyFilters(history_id, filters);
             } catch (error) {
-                this.onError(error);
+                this.onError(error, "Failed to highlight related items");
             }
         },
     },

--- a/client/src/components/History/Content/GenericItem.vue
+++ b/client/src/components/History/Content/GenericItem.vue
@@ -88,7 +88,6 @@ export default {
         onError(e, title = "Error") {
             const error = errorMessageAsString(e, "Dataset operation failed.");
             Toast.error(error, title);
-            console.error(error);
         },
         async onUndelete(item) {
             try {

--- a/client/src/components/History/Content/GenericItem.vue
+++ b/client/src/components/History/Content/GenericItem.vue
@@ -25,12 +25,14 @@
 
 <script>
 import LoadingSpan from "components/LoadingSpan";
+import { Toast } from "composables/toast";
 import { mapActions } from "pinia";
 
 import { deleteContent, updateContentFields } from "@/components/History/model/queries";
 import { DatasetCollectionProvider, DatasetProvider } from "@/components/providers";
 import { DatasetCollectionElementProvider } from "@/components/providers/storeProviders";
 import { useHistoryStore } from "@/stores/historyStore";
+import { errorMessageAsString } from "@/utils/simple-error";
 
 import ContentItem from "./ContentItem";
 import GenericElement from "./GenericElement";
@@ -76,17 +78,38 @@ export default {
     },
     methods: {
         ...mapActions(useHistoryStore, ["applyFilters"]),
-        onDelete(item, recursive = false) {
-            deleteContent(item, { recursive: recursive });
+        async onDelete(item, recursive = false) {
+            try {
+                await deleteContent(item, { recursive: recursive });
+            } catch (error) {
+                this.onError(error);
+            }
         },
-        onUndelete(item) {
-            updateContentFields(item, { deleted: false });
+        onError(e) {
+            const error = errorMessageAsString(e, "Dataset operation failed.");
+            Toast.error(error);
+            console.error(error);
         },
-        onHide(item) {
-            updateContentFields(item, { visible: false });
+        async onUndelete(item) {
+            try {
+                await updateContentFields(item, { deleted: false });
+            } catch (error) {
+                this.onError(error);
+            }
         },
-        onUnhide(item) {
-            updateContentFields(item, { visible: true });
+        async onHide(item) {
+            try {
+                await updateContentFields(item, { visible: false });
+            } catch (error) {
+                this.onError(error);
+            }
+        },
+        async onUnhide(item) {
+            try {
+                await updateContentFields(item, { visible: true });
+            } catch (error) {
+                this.onError(error);
+            }
         },
         async onHighlight(item) {
             const { history_id } = item;


### PR DESCRIPTION
`GenericItem` was missing a `onError` function. Now, it catches backend errors and displays a `Toast` message for any failed operation. Fixes https://github.com/galaxyproject/galaxy/issues/18176

![image](https://github.com/galaxyproject/galaxy/assets/78516064/40bd2f8c-56b9-405f-80e8-5b3eb94fd517)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
