### PR TITLE
[24.0] Fix pca 3d rendering of tabular files and visualization error handling in general

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/visualization.py
+++ b/lib/galaxy/webapps/galaxy/controllers/visualization.py
@@ -242,7 +242,7 @@ class VisualizationController(
         try:
             return plugin.render(trans=trans, embedded=embedded, **kwargs)
         except Exception as exception:
-            self._handle_plugin_error(trans, visualization_name, exception)
+            return self._handle_plugin_error(trans, visualization_name, exception)
 
     def _get_plugin_from_registry(self, trans, visualization_name):
         """


### PR DESCRIPTION
We didn't return the actual rendered error template, so we only got a blank page.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
