### PR TITLE
[24.0] Use config_section to distinguish between galaxy and ts or other apps

### DIFF
--- a/lib/galaxy/util/properties.py
+++ b/lib/galaxy/util/properties.py
@@ -100,7 +100,7 @@ def load_app_properties(
 ):
     if config_file is None:
         config_file = ini_file
-        config_section = ini_section
+        config_section = config_section or ini_section
 
     # read from file or init w/no file
     if config_file:

--- a/lib/tool_shed/webapp/model/migrations/scripts.py
+++ b/lib/tool_shed/webapp/model/migrations/scripts.py
@@ -28,7 +28,9 @@ def get_dburl_from_file(cwd: str, config_file: Optional[str] = None) -> str:
         cwds = [cwd, os.path.join(cwd, CONFIG_DIR_NAME)]
         config_file = find_config_file(DEFAULT_CONFIG_NAMES, dirs=cwds)
 
-    properties = load_app_properties(config_file=config_file, config_prefix=TOOLSHED_CONFIG_PREFIX)
+    properties = load_app_properties(
+        config_file=config_file, config_prefix=TOOLSHED_CONFIG_PREFIX, config_section="tool_shed"
+    )
     default_url = f"sqlite:///{os.path.join(get_data_dir(properties), 'community.sqlite')}?isolation_level=IMMEDIATE"
     url = properties.get("database_connection", default_url)
     return url


### PR DESCRIPTION
Fix for #18205

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
