### PR TITLE
[24.0] Restrict job_files access to jobs that are not terminal

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/job_files.py
+++ b/lib/galaxy/webapps/galaxy/api/job_files.py
@@ -182,7 +182,7 @@ class JobFilesAPIController(BaseGalaxyAPIController):
 
         # Verify job is active. Don't update the contents of complete jobs.
         job = trans.sa_session.get(Job, job_id)
-        if job.finished:
+        if job.state not in Job.non_ready_states:
             error_message = "Attempting to read or modify the files of a job that has already completed."
             raise exceptions.ItemAccessibilityException(error_message)
         return job

--- a/lib/galaxy/webapps/galaxy/api/job_tokens.py
+++ b/lib/galaxy/webapps/galaxy/api/job_tokens.py
@@ -64,7 +64,7 @@ class FastAPIJobTokens:
 
         # Verify job is active
         job = session.get(Job, job_id)
-        if job.finished:
+        if job.state not in Job.non_ready_states:
             error_message = "Attempting to get oidc token for a job that has already completed."
             raise exceptions.ItemAccessibilityException(error_message)
         return job


### PR DESCRIPTION
That should fix https://sentry.galaxyproject.org/share/issue/c4eb157823c240d5a664ec6517354db2/

This is just noise and has tripped me up multiple times both on the Galaxy and Pulsar side.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
