### PR TITLE
 Expand pre-checks of user file source & object store configs

### DIFF
--- a/client/src/api/configTemplates.ts
+++ b/client/src/api/configTemplates.ts
@@ -17,6 +17,12 @@ export type SecretData = { [key: string]: string };
 export type PluginAspectStatus = components["schemas"]["PluginAspectStatus"];
 export type PluginStatus = components["schemas"]["PluginStatus"];
 
+export type CreateInstancePayload = components["schemas"]["CreateInstancePayload"];
+export type UpgradeInstancePayload = components["schemas"]["UpgradeInstancePayload"];
+export type TestUpgradeInstancePayload = components["schemas"]["TestUpgradeInstancePayload"];
+export type UpdateInstancePayload = components["schemas"]["UpdateInstancePayload"];
+export type TestUpdateInstancePayload = components["schemas"]["TestUpdateInstancePayload"];
+
 export interface TemplateSummary {
     description: string | null;
     hidden?: boolean;

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -12651,8 +12651,6 @@ export interface components {
             device?: string | null;
             /** Hidden */
             hidden: boolean;
-            /** Id */
-            id: number | string;
             /** Name */
             name?: string | null;
             /** Object Store Id */
@@ -12730,8 +12728,6 @@ export interface components {
             description: string | null;
             /** Hidden */
             hidden: boolean;
-            /** Id */
-            id: string | number;
             /** Name */
             name: string;
             /** Purged */
@@ -14972,7 +14968,7 @@ export interface operations {
             header?: {
                 "run-as"?: string | null;
             };
-            /** @description The index for a persisted UserFileSourceStore object. */
+            /** @description The UUID index for a persisted UserFileSourceStore object. */
             path: {
                 user_file_source_id: string;
             };
@@ -14999,7 +14995,7 @@ export interface operations {
             header?: {
                 "run-as"?: string | null;
             };
-            /** @description The index for a persisted UserFileSourceStore object. */
+            /** @description The UUID index for a persisted UserFileSourceStore object. */
             path: {
                 user_file_source_id: string;
             };
@@ -15034,7 +15030,7 @@ export interface operations {
             header?: {
                 "run-as"?: string | null;
             };
-            /** @description The index for a persisted UserFileSourceStore object. */
+            /** @description The UUID index for a persisted UserFileSourceStore object. */
             path: {
                 user_file_source_id: string;
             };
@@ -20896,7 +20892,7 @@ export interface operations {
             header?: {
                 "run-as"?: string | null;
             };
-            /** @description The identifier used to index a persisted UserObjectStore object. */
+            /** @description The UUID used to identify a persisted UserObjectStore object. */
             path: {
                 user_object_store_id: string;
             };
@@ -20923,7 +20919,7 @@ export interface operations {
             header?: {
                 "run-as"?: string | null;
             };
-            /** @description The identifier used to index a persisted UserObjectStore object. */
+            /** @description The UUID used to identify a persisted UserObjectStore object. */
             path: {
                 user_object_store_id: string;
             };
@@ -20958,7 +20954,7 @@ export interface operations {
             header?: {
                 "run-as"?: string | null;
             };
-            /** @description The identifier used to index a persisted UserObjectStore object. */
+            /** @description The UUID used to identify a persisted UserObjectStore object. */
             path: {
                 user_object_store_id: string;
             };

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -315,12 +315,18 @@ export interface paths {
         post: operations["file_sources__test_new_instance_configuration"];
     };
     "/api/file_source_instances/{user_file_source_id}": {
-        /** Get a list of persisted file source instances defined by the requesting user. */
+        /** Get a persisted user file source instance. */
         get: operations["file_sources__instances_get"];
         /** Update or upgrade user file source instance. */
         put: operations["file_sources__instances_update"];
         /** Purge user file source instance. */
         delete: operations["file_sources__instances_purge"];
+    };
+    "/api/file_source_instances/{user_file_source_id}/test": {
+        /** Test a file source instance and return status. */
+        get: operations["file_sources__instances_test_instance"];
+        /** Test updating or upgrading user file source instance. */
+        post: operations["file_sources__test_instances_update"];
     };
     "/api/file_source_templates": {
         /** Get a list of file source templates available to build user defined file sources from */
@@ -1266,12 +1272,18 @@ export interface paths {
         post: operations["object_stores__test_new_instance_configuration"];
     };
     "/api/object_store_instances/{user_object_store_id}": {
-        /** Get a persisted object store instances owned by the requesting user. */
+        /** Get a persisted user object store instance. */
         get: operations["object_stores__instances_get"];
         /** Update or upgrade user object store instance. */
         put: operations["object_stores__instances_update"];
         /** Purge user object store instance. */
         delete: operations["object_stores__instances_purge"];
+    };
+    "/api/object_store_instances/{user_object_store_id}/test": {
+        /** Get a persisted user object store instance. */
+        get: operations["object_stores__instances_test_instance"];
+        /** Test updating or upgrading user object source instance. */
+        post: operations["object_stores__test_instances_update"];
     };
     "/api/object_store_templates": {
         /** Get a list of object store templates available to build user defined object stores from */
@@ -11980,6 +11992,26 @@ export interface components {
              */
             type: "string";
         };
+        /** TestUpdateInstancePayload */
+        TestUpdateInstancePayload: {
+            /** Variables */
+            variables?: {
+                [key: string]: (string | boolean | number) | undefined;
+            } | null;
+        };
+        /** TestUpgradeInstancePayload */
+        TestUpgradeInstancePayload: {
+            /** Secrets */
+            secrets: {
+                [key: string]: string | undefined;
+            };
+            /** Template Version */
+            template_version: number;
+            /** Variables */
+            variables: {
+                [key: string]: (string | boolean | number) | undefined;
+            };
+        };
         /** ToolDataDetails */
         ToolDataDetails: {
             /**
@@ -14962,7 +14994,7 @@ export interface operations {
         };
     };
     file_sources__instances_get: {
-        /** Get a list of persisted file source instances defined by the requesting user. */
+        /** Get a persisted user file source instance. */
         parameters: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -15038,6 +15070,67 @@ export interface operations {
         responses: {
             /** @description Successful Response */
             204: never;
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    file_sources__instances_test_instance: {
+        /** Test a file source instance and return status. */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string | null;
+            };
+            /** @description The UUID index for a persisted UserFileSourceStore object. */
+            path: {
+                user_file_source_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["PluginStatus"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    file_sources__test_instances_update: {
+        /** Test updating or upgrading user file source instance. */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string | null;
+            };
+            /** @description The UUID index for a persisted UserFileSourceStore object. */
+            path: {
+                user_file_source_id: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json":
+                    | components["schemas"]["TestUpgradeInstancePayload"]
+                    | components["schemas"]["TestUpdateInstancePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["PluginStatus"];
+                };
+            };
             /** @description Validation Error */
             422: {
                 content: {
@@ -20886,7 +20979,7 @@ export interface operations {
         };
     };
     object_stores__instances_get: {
-        /** Get a persisted object store instances owned by the requesting user. */
+        /** Get a persisted user object store instance. */
         parameters: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -20962,6 +21055,67 @@ export interface operations {
         responses: {
             /** @description Successful Response */
             204: never;
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    object_stores__instances_test_instance: {
+        /** Get a persisted user object store instance. */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string | null;
+            };
+            /** @description The UUID used to identify a persisted UserObjectStore object. */
+            path: {
+                user_object_store_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["PluginStatus"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    object_stores__test_instances_update: {
+        /** Test updating or upgrading user object source instance. */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string | null;
+            };
+            /** @description The UUID used to identify a persisted UserObjectStore object. */
+            path: {
+                user_object_store_id: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json":
+                    | components["schemas"]["TestUpgradeInstancePayload"]
+                    | components["schemas"]["TestUpdateInstancePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["PluginStatus"];
+                };
+            };
             /** @description Validation Error */
             422: {
                 content: {

--- a/client/src/components/ConfigTemplates/ActionSummary.vue
+++ b/client/src/components/ConfigTemplates/ActionSummary.vue
@@ -1,0 +1,29 @@
+<script lang="ts" setup>
+import { BAlert, BButton } from "bootstrap-vue";
+import { ref } from "vue";
+
+import type { PluginStatus } from "@/api/configTemplates";
+
+import ConfigurationTestSummaryModal from "@/components/ConfigTemplates/ConfigurationTestSummaryModal.vue";
+
+interface Props {
+    error: String | null;
+    testResults?: PluginStatus;
+    errorDataDescription: string;
+}
+
+const showTestResults = ref(false);
+defineProps<Props>();
+</script>
+
+<template>
+    <div>
+        <ConfigurationTestSummaryModal v-model="showTestResults" :test-results="testResults" />
+        <BAlert v-if="error" variant="danger" class="configuration-instance-error" show>
+            <span :data-description="errorDataDescription">
+                {{ error }}
+            </span>
+            <BButton variant="link" @click="showTestResults = true">View configuration test status.</BButton>
+        </BAlert>
+    </div>
+</template>

--- a/client/src/components/ConfigTemplates/ConfigurationTestItem.vue
+++ b/client/src/components/ConfigTemplates/ConfigurationTestItem.vue
@@ -1,0 +1,32 @@
+<script lang="ts" setup>
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faCheckSquare, faSquare, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BListGroupItem, BSpinner } from "bootstrap-vue";
+
+import type { PluginAspectStatus } from "@/api/configTemplates";
+
+library.add(faCheckSquare, faTimes, faSquare);
+
+interface Props {
+    status?: PluginAspectStatus;
+}
+
+defineProps<Props>();
+</script>
+
+<template>
+    <BListGroupItem href="#" class="d-flex align-items-center">
+        <BSpinner v-if="status == undefined" class="mr-3" label="Testing...."></BSpinner>
+        <FontAwesomeIcon
+            v-else-if="status.state == 'ok'"
+            class="mr-3 text-success"
+            icon="fas fa-check-square"
+            size="lg" />
+        <FontAwesomeIcon v-else-if="status.state == 'not_ok'" class="mr-3 text-warning" icon="fas fa-times" size="lg" />
+        <FontAwesomeIcon v-else-if="status.state == 'unknown'" class="mr-3 text-info" icon="fas fa-square" size="lg" />
+        <span v-if="status && status.message" class="mr-auto">
+            {{ status.message }}
+        </span>
+    </BListGroupItem>
+</template>

--- a/client/src/components/ConfigTemplates/ConfigurationTestSummary.vue
+++ b/client/src/components/ConfigTemplates/ConfigurationTestSummary.vue
@@ -1,0 +1,21 @@
+<script lang="ts" setup>
+import { BListGroup } from "bootstrap-vue";
+
+import type { PluginStatus } from "@/api/configTemplates";
+
+import ConfigurationTestItem from "./ConfigurationTestItem.vue";
+
+interface Props {
+    testResults?: PluginStatus;
+}
+
+defineProps<Props>();
+</script>
+
+<template>
+    <BListGroup v-if="testResults">
+        <ConfigurationTestItem :status="testResults?.template_definition" />
+        <ConfigurationTestItem :status="testResults?.template_settings" />
+        <ConfigurationTestItem :status="testResults?.connection" />
+    </BListGroup>
+</template>

--- a/client/src/components/ConfigTemplates/ConfigurationTestSummaryModal.vue
+++ b/client/src/components/ConfigTemplates/ConfigurationTestSummaryModal.vue
@@ -1,0 +1,39 @@
+<script lang="ts" setup>
+import { BAlert, BModal } from "bootstrap-vue";
+import { ref, watch } from "vue";
+
+import type { PluginStatus } from "@/api/configTemplates";
+
+import ConfigurationTestSummary from "./ConfigurationTestSummary.vue";
+
+interface Props {
+    value: boolean;
+    testResults?: PluginStatus;
+    error?: string;
+}
+
+const props = defineProps<Props>();
+
+const show = ref(props.value);
+
+watch(props, () => {
+    show.value = props.value;
+});
+
+const emit = defineEmits<{
+    (e: "input", value: boolean): void;
+}>();
+
+watch(show, () => {
+    emit("input", show.value);
+});
+</script>
+
+<template>
+    <BModal v-model="show" title="Configuration Test Summary" hide-footer>
+        <BAlert v-if="error" variant="danger" show dismissible>
+            {{ error || "" }}
+        </BAlert>
+        <ConfigurationTestSummary :test-results="testResults" />
+    </BModal>
+</template>

--- a/client/src/components/ConfigTemplates/ForceActionButton.vue
+++ b/client/src/components/ConfigTemplates/ForceActionButton.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { BButton } from "bootstrap-vue";
+
+interface Props {
+    action: string;
+}
+
+defineProps<Props>();
+
+const emit = defineEmits<{
+    (e: "click"): void;
+}>();
+</script>
+
+<template>
+    <BButton variant="link" @click="emit('click')">I know what I am doing, force {{ action.toLowerCase() }}.</BButton>
+</template>

--- a/client/src/components/ConfigTemplates/InstanceDropdown.test.ts
+++ b/client/src/components/ConfigTemplates/InstanceDropdown.test.ts
@@ -19,7 +19,7 @@ describe("InstanceDropdown", () => {
         });
         const menu = wrapper.find(".dropdown-menu");
         const links = menu.findAll("button.dropdown-item");
-        expect(links.length).toBe(2);
+        expect(links.length).toBe(3);
     });
 
     it("should render a drop down with upgrade if upgrade available as an option", async () => {
@@ -35,6 +35,6 @@ describe("InstanceDropdown", () => {
         });
         const menu = wrapper.find(".dropdown-menu");
         const links = menu.findAll("button.dropdown-item");
-        expect(links.length).toBe(3);
+        expect(links.length).toBe(4);
     });
 });

--- a/client/src/components/ConfigTemplates/InstanceDropdown.vue
+++ b/client/src/components/ConfigTemplates/InstanceDropdown.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faArrowUp, faCaretDown, faEdit, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faArrowUp, faCaretDown, faEdit, faStethoscope, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { useRouter } from "vue-router/composables";
 
@@ -12,7 +12,7 @@ interface Props {
     isUpgradable: boolean;
 }
 
-library.add(faArrowUp, faCaretDown, faEdit, faTrash);
+library.add(faArrowUp, faCaretDown, faEdit, faStethoscope, faTrash);
 
 const router = useRouter();
 
@@ -20,6 +20,7 @@ defineProps<Props>();
 
 const emit = defineEmits<{
     (e: "remove"): void;
+    (e: "test"): void;
 }>();
 </script>
 
@@ -52,6 +53,10 @@ const emit = defineEmits<{
                 @click.prevent="router.push(routeEdit)">
                 <FontAwesomeIcon icon="edit" />
                 <span v-localize>Edit configuration</span>
+            </button>
+            <button class="dropdown-item" @keypress="emit('test')" @click.prevent="emit('test')">
+                <FontAwesomeIcon icon="stethoscope" />
+                <span v-localize>Test instance</span>
             </button>
             <button class="dropdown-item" @keypress="emit('remove')" @click.prevent="emit('remove')">
                 <FontAwesomeIcon icon="trash" />

--- a/client/src/components/ConfigTemplates/InstanceDropdown.vue
+++ b/client/src/components/ConfigTemplates/InstanceDropdown.vue
@@ -42,7 +42,7 @@ const emit = defineEmits<{
                 :href="routeUpgrade"
                 @keypress="router.push(routeUpgrade)"
                 @click.prevent="router.push(routeUpgrade)">
-                <FontAwesomeIcon icon="arrowUp" />
+                <FontAwesomeIcon icon="arrow-up" />
                 <span v-localize>Upgrade</span>
             </button>
             <button

--- a/client/src/components/ConfigTemplates/InstanceForm.vue
+++ b/client/src/components/ConfigTemplates/InstanceForm.vue
@@ -3,6 +3,7 @@ import { BButton } from "bootstrap-vue";
 
 import { type FormEntry } from "./formUtil";
 
+import ForceActionButton from "./ForceActionButton.vue";
 import FormCard from "@/components/Form/FormCard.vue";
 import FormDisplay from "@/components/Form/FormDisplay.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
@@ -12,14 +13,18 @@ interface Props {
     inputs?: Array<FormEntry>; // not fully reactive so make sure to not mutate this array
     submitTitle: string;
     loadingMessage: string;
+    busy: boolean;
+    showForceActionButton?: boolean;
 }
 
 withDefaults(defineProps<Props>(), {
     inputs: undefined,
+    showForceActionButton: false,
 });
 
 const emit = defineEmits<{
     (e: "onSubmit", formData: any): void;
+    (e: "onForceSubmit", formData: any): void;
 }>();
 
 let formData: any;
@@ -30,6 +35,10 @@ function onChange(incoming: any) {
 
 async function handleSubmit() {
     emit("onSubmit", formData);
+}
+
+async function handleForceSubmit() {
+    emit("onForceSubmit", formData);
 }
 </script>
 <template>
@@ -42,9 +51,11 @@ async function handleSubmit() {
                 </template>
             </FormCard>
             <div class="mt-3">
-                <BButton id="submit" variant="primary" class="mr-1" @click="handleSubmit">
+                <BButton id="submit" variant="primary" class="mr-1" :disabled="busy" @click="handleSubmit">
                     {{ submitTitle }}
                 </BButton>
+                <ForceActionButton v-show="showForceActionButton" :action="submitTitle" @click="handleForceSubmit">
+                </ForceActionButton>
             </div>
         </div>
     </div>

--- a/client/src/components/ConfigTemplates/formUtil.ts
+++ b/client/src/components/ConfigTemplates/formUtil.ts
@@ -1,4 +1,5 @@
 import type {
+    CreateInstancePayload,
     Instance,
     PluginStatus,
     SecretData,
@@ -139,7 +140,7 @@ export function createTemplateForm(template: TemplateSummary, what: string): For
     return form;
 }
 
-export function createFormDataToPayload(template: TemplateSummary, formData: any) {
+export function createFormDataToPayload(template: TemplateSummary, formData: any): CreateInstancePayload {
     const variables = template.variables ?? [];
     const secrets = template.secrets ?? [];
     const variableData: VariableData = {};

--- a/client/src/components/ConfigTemplates/routing.ts
+++ b/client/src/components/ConfigTemplates/routing.ts
@@ -1,0 +1,18 @@
+import { useRouter } from "vue-router/composables";
+
+export function buildInstanceRoutingComposable(index: string) {
+    return () => {
+        const router = useRouter();
+
+        async function goToIndex(query: Record<"message", string>) {
+            router.push({
+                path: index,
+                query: query,
+            });
+        }
+
+        return {
+            goToIndex,
+        };
+    };
+}

--- a/client/src/components/ConfigTemplates/test_fixtures.ts
+++ b/client/src/components/ConfigTemplates/test_fixtures.ts
@@ -1,3 +1,4 @@
+import type { PluginStatus } from "@/api/configTemplates";
 import type { FileSourceTemplateSummary } from "@/api/fileSources";
 import type { UserConcreteObjectStore } from "@/components/ObjectStore/Instances/types";
 import type { ObjectStoreTemplateSummary } from "@/components/ObjectStore/Templates/types";
@@ -118,4 +119,19 @@ export const OBJECT_STORE_INSTANCE: UserConcreteObjectStore = {
     active: true,
     hidden: false,
     purged: false,
+};
+
+export const OK_PLUGIN_STATUS: PluginStatus = {
+    template_definition: {
+        state: "ok",
+        message: "ok",
+    },
+    template_settings: {
+        state: "ok",
+        message: "ok",
+    },
+    connection: {
+        state: "ok",
+        message: "ok",
+    },
 };

--- a/client/src/components/ConfigTemplates/test_fixtures.ts
+++ b/client/src/components/ConfigTemplates/test_fixtures.ts
@@ -114,7 +114,6 @@ export const OBJECT_STORE_INSTANCE: UserConcreteObjectStore = {
     secrets: ["oldsecret", "droppedsecret"],
     quota: { enabled: false },
     private: false,
-    id: 4,
     uuid: "112f889f-72d7-4619-a8e8-510a8c685aa7",
     active: true,
     hidden: false,

--- a/client/src/components/ConfigTemplates/useConfigurationTesting.ts
+++ b/client/src/components/ConfigTemplates/useConfigurationTesting.ts
@@ -1,0 +1,313 @@
+import { computed, type Ref, ref } from "vue";
+
+import type {
+    CreateInstancePayload,
+    Instance,
+    PluginStatus,
+    TemplateSummary,
+    TestUpdateInstancePayload,
+    TestUpgradeInstancePayload,
+    UpdateInstancePayload,
+    UpgradeInstancePayload,
+} from "@/api/configTemplates";
+import { buildInstanceRoutingComposable } from "@/components/ConfigTemplates/routing";
+import { errorMessageAsString } from "@/utils/simple-error";
+
+import {
+    createFormDataToPayload,
+    createTemplateForm,
+    editFormDataToPayload,
+    editTemplateForm,
+    type FormEntry,
+    pluginStatusToErrorMessage,
+    upgradeForm,
+    upgradeFormDataToPayload,
+} from "./formUtil";
+
+import ActionSummary from "./ActionSummary.vue";
+import ConfigurationTestSummaryModal from "@/components/ConfigTemplates/ConfigurationTestSummaryModal.vue";
+import InstanceForm from "@/components/ConfigTemplates/InstanceForm.vue";
+
+type InstanceRoutingComposableType = ReturnType<typeof buildInstanceRoutingComposable>;
+
+export function useConfigurationTesting() {
+    const testRunning = ref<boolean>(false);
+    const testResults = ref<PluginStatus | undefined>(undefined);
+
+    return {
+        testRunning,
+        testResults,
+    };
+}
+
+export function useConfigurationTemplateCreation<T extends TemplateSummary, R>(
+    what: string,
+    template: Ref<T>,
+    test: (payload: CreateInstancePayload) => Promise<{ data: PluginStatus }>,
+    create: (payload: CreateInstancePayload) => Promise<{ data: R }>,
+    onCreate: (result: R) => unknown
+) {
+    const error = ref<string | null>(null);
+    const { testRunning, testResults } = useConfigurationTesting();
+
+    async function onSubmit(formData: any) {
+        const payload = createFormDataToPayload(template.value, formData);
+        let pluginStatus;
+        try {
+            testRunning.value = true;
+            const response = await test(payload);
+            pluginStatus = response["data"];
+            testResults.value = pluginStatus;
+        } catch (e) {
+            error.value = "Failed to verify configuration: " + errorMessageAsString(e);
+            return;
+        } finally {
+            testRunning.value = false;
+        }
+        const testError = pluginStatusToErrorMessage(pluginStatus);
+        if (testError) {
+            error.value = testError;
+            return;
+        }
+        try {
+            const { data: userObject } = await create(payload);
+            onCreate(userObject);
+        } catch (e) {
+            error.value = errorMessageAsString(e);
+            return;
+        }
+    }
+
+    const inputs = computed<FormEntry[]>(() => {
+        return createTemplateForm(template.value, what);
+    });
+
+    const submitTitle = "Create";
+    const loadingMessage = `Loading ${what} template and instance information`;
+
+    return {
+        ActionSummary,
+        error,
+        inputs,
+        InstanceForm,
+        onSubmit,
+        submitTitle,
+        loadingMessage,
+        testRunning,
+        testResults,
+    };
+}
+
+export function useInstanceTesting<R extends Instance>(
+    testInstance: (id: string) => Promise<{ data: PluginStatus }>
+) {
+    const showTestResults = ref(false);
+    const testResults = ref<PluginStatus | undefined>(undefined);
+    const testingError = ref<string | undefined>(undefined);
+
+    async function test(instance: R) {
+        testResults.value = undefined;
+        testingError.value = undefined;
+        showTestResults.value = true;
+        try {
+            const { data } = await testInstance(instance.uuid);
+            testResults.value = data;
+        } catch (e) {
+            testingError.value = errorMessageAsString(e);
+        }
+    }
+
+    return {
+        ConfigurationTestSummaryModal,
+        showTestResults,
+        testResults,
+        testingError,
+        test,
+    };
+}
+
+export function useConfigurationTemplateEdit<T extends TemplateSummary, R extends Instance>(
+    what: string,
+    instance: Ref<R | null>,
+    template: Ref<T | null>,
+    testUpdate: (payload: TestUpdateInstancePayload) => Promise<{ data: PluginStatus }>,
+    update: (payload: UpdateInstancePayload) => Promise<{ data: R }>,
+    useRouting: InstanceRoutingComposableType
+) {
+    const { testRunning, testResults } = useConfigurationTesting();
+    const showForceActionButton = ref<boolean>(false);
+
+    const { goToIndex } = useRouting();
+
+    async function onUpdate(objectStore: R) {
+        const message = `Updated ${what} ${objectStore.name}`;
+        goToIndex({ message });
+    }
+
+    const inputs = computed<Array<FormEntry> | undefined>(() => {
+        const realizedInstance = instance.value;
+        const realizedTemplate = template.value;
+        if (!realizedInstance || !realizedTemplate) {
+            return undefined;
+        }
+        return editTemplateForm(realizedTemplate, what, realizedInstance);
+    });
+
+    const error = ref<string | null>(null);
+    const hasSecrets = computed(() => instance.value?.secrets && instance.value?.secrets.length > 0);
+    const submitTitle = "Update Settings";
+    const loadingMessage = `Loading ${what} template and instance information`;
+
+    async function onSubmit(formData: any) {
+        if (template.value) {
+            const payload = editFormDataToPayload(template.value, formData);
+
+            let pluginStatus;
+            try {
+                testRunning.value = true;
+                showForceActionButton.value = false;
+                const response = await testUpdate(payload);
+                pluginStatus = response["data"];
+                testResults.value = pluginStatus;
+            } catch (e) {
+                error.value = errorMessageAsString(e);
+                showForceActionButton.value = true;
+                return;
+            } finally {
+                testRunning.value = false;
+            }
+            const testError = pluginStatusToErrorMessage(pluginStatus);
+            if (testError) {
+                error.value = testError;
+                showForceActionButton.value = true;
+                return;
+            }
+
+            try {
+                const response = await update(payload);
+                await onUpdate(response["data"]);
+            } catch (e) {
+                error.value = errorMessageAsString(e);
+                return;
+            }
+        }
+    }
+
+    async function onForceSubmit(formData: any) {
+        if (template.value) {
+            const payload = editFormDataToPayload(template.value, formData);
+            try {
+                const response = await update(payload);
+                await onUpdate(response["data"]);
+            } catch (e) {
+                error.value = errorMessageAsString(e);
+                return;
+            }
+        }
+    }
+
+    return {
+        error,
+        ActionSummary,
+        inputs,
+        InstanceForm,
+        hasSecrets,
+        loadingMessage,
+        onForceSubmit,
+        onSubmit,
+        showForceActionButton,
+        submitTitle,
+        testResults,
+        testRunning,
+    };
+}
+
+export function useConfigurationTemplateUpgrade<T extends TemplateSummary, R extends Instance>(
+    what: string,
+    instance: Ref<R>,
+    template: Ref<T>,
+    testUpdate: (payload: TestUpgradeInstancePayload) => Promise<{ data: PluginStatus }>,
+    update: (payload: UpgradeInstancePayload) => Promise<{ data: R }>,
+    useRouting: InstanceRoutingComposableType
+) {
+    const { goToIndex } = useRouting();
+
+    async function onUpgrade(objectStore: R) {
+        const message = `Upgraded ${what} ${objectStore.name}`;
+        goToIndex({ message });
+    }
+
+    const error = ref<string | null>(null);
+    const { testRunning, testResults } = useConfigurationTesting();
+    const showForceActionButton = ref<boolean>(false);
+
+    const submitTitle = "Upgrade Configuration";
+    const loadingMessage = `Loading latest ${what} template and instance information`;
+
+    const inputs = computed<Array<FormEntry> | undefined>(() => {
+        const realizedInstance = instance.value;
+        const realizedLatestTemplate = template.value;
+        if (!realizedInstance || !realizedLatestTemplate) {
+            return undefined;
+        }
+        const form = upgradeForm(realizedLatestTemplate, realizedInstance);
+        return form;
+    });
+
+    async function onSubmit(formData: any) {
+        const payload = upgradeFormDataToPayload(template.value, formData);
+        let pluginStatus;
+        try {
+            testRunning.value = true;
+            showForceActionButton.value = false;
+            const response = await testUpdate(payload);
+            pluginStatus = response["data"];
+            testResults.value = pluginStatus;
+        } catch (e) {
+            showForceActionButton.value = true;
+            error.value = errorMessageAsString(e);
+            return;
+        } finally {
+            testRunning.value = false;
+        }
+        const testError = pluginStatusToErrorMessage(pluginStatus);
+        if (testError) {
+            error.value = testError;
+            showForceActionButton.value = true;
+            return;
+        }
+
+        try {
+            const response = await update(payload);
+            await onUpgrade(response["data"]);
+        } catch (e) {
+            error.value = errorMessageAsString(e);
+            return;
+        }
+    }
+
+    async function onForceSubmit(formData: any) {
+        const payload = upgradeFormDataToPayload(template.value, formData);
+        try {
+            const response = await update(payload);
+            await onUpgrade(response["data"]);
+        } catch (e) {
+            error.value = errorMessageAsString(e);
+            return;
+        }
+    }
+
+    return {
+        error,
+        ActionSummary,
+        inputs,
+        InstanceForm,
+        loadingMessage,
+        onForceSubmit,
+        onSubmit,
+        submitTitle,
+        showForceActionButton,
+        testResults,
+        testRunning,
+    };
+}

--- a/client/src/components/FileSources/Instances/CreateForm.vue
+++ b/client/src/components/FileSources/Instances/CreateForm.vue
@@ -1,63 +1,39 @@
 <script lang="ts" setup>
-import { BAlert } from "bootstrap-vue";
-import { computed, ref } from "vue";
+import { toRef } from "vue";
 
 import type { FileSourceTemplateSummary, UserFileSourceModel } from "@/api/fileSources";
-import {
-    createFormDataToPayload,
-    createTemplateForm,
-    pluginStatusToErrorMessage,
-} from "@/components/ConfigTemplates/formUtil";
-import { errorMessageAsString } from "@/utils/simple-error";
+import { useConfigurationTemplateCreation } from "@/components/ConfigTemplates/useConfigurationTesting";
 
 import { create, test } from "./services";
-
-import InstanceForm from "@/components/ConfigTemplates/InstanceForm.vue";
 
 interface CreateFormProps {
     template: FileSourceTemplateSummary;
 }
-const error = ref<string | null>(null);
 const props = defineProps<CreateFormProps>();
 const title = "Create a new file source for your data";
-const submitTitle = "Submit";
-const loadingMessage = "Loading file source template and instance information";
-
-const inputs = computed(() => {
-    return createTemplateForm(props.template, "file source");
-});
-
-async function onSubmit(formData: any) {
-    const payload = createFormDataToPayload(props.template, formData);
-    const { data: pluginStatus } = await test(payload);
-    const testError = pluginStatusToErrorMessage(pluginStatus);
-    if (testError) {
-        error.value = testError;
-        return;
-    }
-    try {
-        const { data: fileSource } = await create(payload);
-        emit("created", fileSource);
-    } catch (e) {
-        error.value = errorMessageAsString(e);
-        return;
-    }
-}
 
 const emit = defineEmits<{
     (e: "created", fileSource: UserFileSourceModel): void;
 }>();
+
+const { ActionSummary, error, inputs, InstanceForm, onSubmit, submitTitle, loadingMessage, testRunning, testResults } =
+    useConfigurationTemplateCreation(
+        "file source",
+        toRef(props, "template"),
+        test,
+        create,
+        (fileSource: UserFileSourceModel) => emit("created", fileSource)
+    );
 </script>
 <template>
     <div id="create-file-source-landing">
-        <BAlert v-if="error" variant="danger" class="file-source-instance-creation-error" show>
-            {{ error }}
-        </BAlert>
+        <ActionSummary error-data-description="file-source-creation-error" :test-results="testResults" :error="error" />
         <InstanceForm
             :inputs="inputs"
             :title="title"
             :submit-title="submitTitle"
             :loading-message="loadingMessage"
+            :busy="testRunning"
             @onSubmit="onSubmit" />
     </div>
 </template>

--- a/client/src/components/FileSources/Instances/EditInstance.vue
+++ b/client/src/components/FileSources/Instances/EditInstance.vue
@@ -13,7 +13,7 @@ import EditSecrets from "./EditSecrets.vue";
 import InstanceForm from "@/components/ConfigTemplates/InstanceForm.vue";
 
 interface Props {
-    instanceId: number | string;
+    instanceId: string;
 }
 
 const props = defineProps<Props>();
@@ -36,7 +36,7 @@ const loadingMessage = "Loading file source template and instance information";
 async function onSubmit(formData: any) {
     if (template.value) {
         const payload = editFormDataToPayload(template.value, formData);
-        const args = { user_file_source_id: String(instance?.value?.id) };
+        const args = { user_file_source_id: String(instance?.value?.uuid) };
         const { data: fileSource } = await update({ ...args, ...payload });
         await onUpdate(fileSource);
     }

--- a/client/src/components/FileSources/Instances/EditSecrets.vue
+++ b/client/src/components/FileSources/Instances/EditSecrets.vue
@@ -19,7 +19,7 @@ async function onUpdate(secretName: string, secretValue: string) {
         secret_name: secretName,
         secret_value: secretValue,
     };
-    const args = { user_file_source_id: String(props.fileSource.id) };
+    const args = { user_file_source_id: String(props.fileSource.uuid) };
     await update({ ...args, ...payload });
 }
 </script>

--- a/client/src/components/FileSources/Instances/InstanceDropdown.vue
+++ b/client/src/components/FileSources/Instances/InstanceDropdown.vue
@@ -15,8 +15,8 @@ interface Props {
 }
 
 const props = defineProps<Props>();
-const routeEdit = computed(() => `/file_source_instances/${props.fileSource.id}/edit`);
-const routeUpgrade = computed(() => `/file_source_instances/${props.fileSource.id}/upgrade`);
+const routeEdit = computed(() => `/file_source_instances/${props.fileSource.uuid}/edit`);
+const routeUpgrade = computed(() => `/file_source_instances/${props.fileSource.uuid}/upgrade`);
 const isUpgradable = computed(() =>
     fileSourceTemplatesStore.canUpgrade(props.fileSource.template_id, props.fileSource.template_version)
 );

--- a/client/src/components/FileSources/Instances/InstanceDropdown.vue
+++ b/client/src/components/FileSources/Instances/InstanceDropdown.vue
@@ -28,6 +28,7 @@ async function onRemove() {
 
 const emit = defineEmits<{
     (e: "entryRemoved"): void;
+    (e: "test"): void;
 }>();
 </script>
 
@@ -38,5 +39,6 @@ const emit = defineEmits<{
         :is-upgradable="isUpgradable"
         :route-upgrade="routeUpgrade"
         :route-edit="routeEdit"
+        @test="emit('test')"
         @remove="onRemove" />
 </template>

--- a/client/src/components/FileSources/Instances/ManageIndex.vue
+++ b/client/src/components/FileSources/Instances/ManageIndex.vue
@@ -3,8 +3,11 @@ import { BTable } from "bootstrap-vue";
 import { computed } from "vue";
 
 import { DESCRIPTION_FIELD, NAME_FIELD, TEMPLATE_FIELD, TYPE_FIELD } from "@/components/ConfigTemplates/fields";
+import { useInstanceTesting } from "@/components/ConfigTemplates/useConfigurationTesting";
 import { useFiltering } from "@/components/ConfigTemplates/useInstanceFiltering";
 import { useFileSourceInstancesStore } from "@/stores/fileSourceInstancesStore";
+
+import { testInstance } from "./services";
 
 import InstanceDropdown from "./InstanceDropdown.vue";
 import ManageIndexHeader from "@/components/ConfigTemplates/ManageIndexHeader.vue";
@@ -30,10 +33,17 @@ fileSourceInstancesStore.fetchInstances();
 function reload() {
     fileSourceInstancesStore.fetchInstances();
 }
+
+const { ConfigurationTestSummaryModal, showTestResults, testResults, test, testingError } = useInstanceTesting(
+    (id: string) => {
+        return testInstance({ user_file_source_id: id });
+    }
+);
 </script>
 
 <template>
     <div>
+        <ConfigurationTestSummaryModal v-model="showTestResults" :error="testingError" :test-results="testResults" />
         <ManageIndexHeader
             :message="message"
             create-button-id="file-source-create"
@@ -58,7 +68,7 @@ function reload() {
                 </b-alert>
             </template>
             <template v-slot:cell(name)="row">
-                <InstanceDropdown :file-source="row.item" @entryRemoved="reload" />
+                <InstanceDropdown :file-source="row.item" @entryRemoved="reload" @test="test(row.item)" />
             </template>
             <template v-slot:cell(type)="row">
                 <FileSourceTypeSpan :type="row.item.type" />

--- a/client/src/components/FileSources/Instances/UpgradeForm.vue
+++ b/client/src/components/FileSources/Instances/UpgradeForm.vue
@@ -1,63 +1,55 @@
 <script setup lang="ts">
-import { BAlert } from "bootstrap-vue";
-import { computed, ref } from "vue";
+import { computed, toRef } from "vue";
 
+import type { TestUpgradeInstancePayload, UpgradeInstancePayload } from "@/api/configTemplates";
 import type { FileSourceTemplateSummary, UserFileSourceModel } from "@/api/fileSources";
-import { type FormEntry, upgradeForm, upgradeFormDataToPayload } from "@/components/ConfigTemplates/formUtil";
-import { errorMessageAsString } from "@/utils/simple-error";
+import { useConfigurationTemplateUpgrade } from "@/components/ConfigTemplates/useConfigurationTesting";
 
 import { useInstanceRouting } from "./routing";
-import { update } from "./services";
-
-import InstanceForm from "@/components/ConfigTemplates/InstanceForm.vue";
+import { testUpdate, update } from "./services";
 
 interface Props {
     instance: UserFileSourceModel;
     latestTemplate: FileSourceTemplateSummary;
 }
 
-const error = ref<string | null>(null);
 const props = defineProps<Props>();
 
-const inputs = computed<Array<FormEntry> | undefined>(() => {
-    const realizedInstance: UserFileSourceModel = props.instance;
-    const realizedLatestTemplate = props.latestTemplate;
-    const form = upgradeForm(realizedLatestTemplate, realizedInstance);
-    return form;
-});
 const title = computed(() => `Upgrade File Source ${props.instance.name}`);
-const submitTitle = "Update Settings";
-const loadingMessage = "Loading file source template and instance information";
 
-async function onSubmit(formData: any) {
-    const payload = upgradeFormDataToPayload(props.latestTemplate, formData);
-    const args = { user_file_source_id: String(props.instance.uuid) };
-    try {
-        const { data: fileSource } = await update({ ...args, ...payload });
-        await onUpgrade(fileSource);
-    } catch (e) {
-        error.value = errorMessageAsString(e);
-        return;
-    }
-}
-
-const { goToIndex } = useInstanceRouting();
-
-async function onUpgrade(fileSource: UserFileSourceModel) {
-    const message = `Upgraded file source ${fileSource.name}`;
-    goToIndex({ message });
-}
+const {
+    error,
+    ActionSummary,
+    inputs,
+    InstanceForm,
+    loadingMessage,
+    onForceSubmit,
+    onSubmit,
+    testRunning,
+    testResults,
+    showForceActionButton,
+    submitTitle,
+} = useConfigurationTemplateUpgrade(
+    "file source",
+    toRef(props, "instance"),
+    toRef(props, "latestTemplate"),
+    (payload: TestUpgradeInstancePayload) =>
+        testUpdate({ user_file_source_id: props.instance.uuid, ...payload }),
+    (payload: UpgradeInstancePayload) => update({ user_file_source_id: props.instance.uuid, ...payload }),
+    useInstanceRouting
+);
 </script>
 <template>
     <div>
-        <BAlert v-if="error" variant="danger" class="file-source-instance-upgrade-error" show>
-            {{ error }}
-        </BAlert>
+        <ActionSummary error-data-description="file-source-upgrade-error" :test-results="testResults" :error="error" />
         <InstanceForm
             :inputs="inputs"
             :title="title"
             :submit-title="submitTitle"
             :loading-message="loadingMessage"
+            :busy="testRunning"
+            :show-force-action-button="showForceActionButton"
+            @onForceSubmit="onForceSubmit"
             @onSubmit="onSubmit" />
     </div>
 </template>

--- a/client/src/components/FileSources/Instances/UpgradeForm.vue
+++ b/client/src/components/FileSources/Instances/UpgradeForm.vue
@@ -31,7 +31,7 @@ const loadingMessage = "Loading file source template and instance information";
 
 async function onSubmit(formData: any) {
     const payload = upgradeFormDataToPayload(props.latestTemplate, formData);
-    const args = { user_file_source_id: String(props.instance.id) };
+    const args = { user_file_source_id: String(props.instance.uuid) };
     try {
         const { data: fileSource } = await update({ ...args, ...payload });
         await onUpgrade(fileSource);

--- a/client/src/components/FileSources/Instances/UpgradeInstance.vue
+++ b/client/src/components/FileSources/Instances/UpgradeInstance.vue
@@ -9,7 +9,7 @@ import UpgradeForm from "./UpgradeForm.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 interface Props {
-    instanceId: number | string;
+    instanceId: string;
 }
 
 const props = defineProps<Props>();

--- a/client/src/components/FileSources/Instances/instance.ts
+++ b/client/src/components/FileSources/Instances/instance.ts
@@ -4,7 +4,7 @@ import type { FileSourceTemplateSummary, UserFileSourceModel } from "@/api/fileS
 import { useFileSourceInstancesStore } from "@/stores/fileSourceInstancesStore";
 import { useFileSourceTemplatesStore } from "@/stores/fileSourceTemplatesStore";
 
-export function useInstanceAndTemplate(instanceIdRef: Ref<string | number>) {
+export function useInstanceAndTemplate(instanceIdRef: Ref<string>) {
     const fileSourceTemplatesStore = useFileSourceTemplatesStore();
     const fileSourceInstancesStore = useFileSourceInstancesStore();
     fileSourceInstancesStore.fetchInstances();

--- a/client/src/components/FileSources/Instances/routing.ts
+++ b/client/src/components/FileSources/Instances/routing.ts
@@ -1,16 +1,3 @@
-import { useRouter } from "vue-router/composables";
+import { buildInstanceRoutingComposable } from "@/components/ConfigTemplates/routing";
 
-export function useInstanceRouting() {
-    const router = useRouter();
-
-    async function goToIndex(query: Record<"message", string>) {
-        router.push({
-            path: "/file_source_instances/index",
-            query: query,
-        });
-    }
-
-    return {
-        goToIndex,
-    };
-}
+export const useInstanceRouting = buildInstanceRoutingComposable("/file_source_instances/index");

--- a/client/src/components/FileSources/Instances/services.ts
+++ b/client/src/components/FileSources/Instances/services.ts
@@ -3,7 +3,12 @@ import { fetcher } from "@/api/schema/fetcher";
 
 export const create = fetcher.path("/api/file_source_instances").method("post").create();
 export const test = fetcher.path("/api/file_source_instances/test").method("post").create();
+export const testInstance = fetcher
+    .path("/api/file_source_instances/{user_file_source_id}/test")
+    .method("get")
+    .create();
 export const update = fetcher.path("/api/file_source_instances/{user_file_source_id}").method("put").create();
+export const testUpdate = fetcher.path("/api/file_source_instances/{user_file_source_id}/test").method("post").create();
 
 export async function hide(instance: UserFileSourceModel) {
     const payload = { hidden: true };

--- a/client/src/components/FileSources/Instances/services.ts
+++ b/client/src/components/FileSources/Instances/services.ts
@@ -7,7 +7,7 @@ export const update = fetcher.path("/api/file_source_instances/{user_file_source
 
 export async function hide(instance: UserFileSourceModel) {
     const payload = { hidden: true };
-    const args = { user_file_source_id: String(instance?.id) };
+    const args = { user_file_source_id: String(instance?.uuid) };
     const { data: fileSource } = await update({ ...args, ...payload });
     return fileSource;
 }

--- a/client/src/components/ObjectStore/Instances/CreateForm.test.ts
+++ b/client/src/components/ObjectStore/Instances/CreateForm.test.ts
@@ -2,8 +2,8 @@ import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { getLocalVue } from "tests/jest/helpers";
 
-import { PluginStatus } from "@/api/configTemplates";
 import { mockFetcher } from "@/api/schema/__mocks__";
+import { OK_PLUGIN_STATUS } from "@/components/ConfigTemplates/test_fixtures";
 import type { ObjectStoreTemplateSummary } from "@/components/ObjectStore/Templates/types";
 
 import CreateForm from "./CreateForm.vue";
@@ -58,21 +58,6 @@ const SIMPLE_TEMPLATE: ObjectStoreTemplateSummary = {
     badges: [],
 };
 
-const FAKE_PLUGIN_STATUS: PluginStatus = {
-    template_definition: {
-        state: "ok",
-        message: "ok",
-    },
-    template_settings: {
-        state: "ok",
-        message: "ok",
-    },
-    connection: {
-        state: "ok",
-        message: "ok",
-    },
-};
-
 describe("CreateForm", () => {
     it("should render a form with admin markdown converted to HTML in help", async () => {
         const wrapper = mount(CreateForm, {
@@ -99,7 +84,7 @@ describe("CreateForm", () => {
             },
             localVue,
         });
-        mockFetcher.path("/api/object_store_instances/test").method("post").mock({ data: FAKE_PLUGIN_STATUS });
+        mockFetcher.path("/api/object_store_instances/test").method("post").mock({ data: OK_PLUGIN_STATUS });
         mockFetcher.path("/api/object_store_instances").method("post").mock({ data: FAKE_OBJECT_STORE });
         await flushPromises();
         const nameForElement = wrapper.find("#form-element-_meta_name");
@@ -119,7 +104,7 @@ describe("CreateForm", () => {
             },
             localVue,
         });
-        mockFetcher.path("/api/object_store_instances/test").method("post").mock({ data: FAKE_PLUGIN_STATUS });
+        mockFetcher.path("/api/object_store_instances/test").method("post").mock({ data: OK_PLUGIN_STATUS });
         mockFetcher
             .path("/api/object_store_instances")
             .method("post")
@@ -130,12 +115,13 @@ describe("CreateForm", () => {
         const nameForElement = wrapper.find("#form-element-_meta_name");
         nameForElement.find("input").setValue("My New Name");
         const submitElement = wrapper.find("#submit");
-        expect(wrapper.find(".object-store-instance-creation-error").exists()).toBe(false);
+        expect(wrapper.find("[data-description='object-store-creation-error']").exists()).toBe(false);
         submitElement.trigger("click");
         await flushPromises();
         const emitted = wrapper.emitted("created") || [];
         expect(emitted).toHaveLength(0);
-        const errorEl = wrapper.find(".object-store-instance-creation-error");
+        const errorEl = wrapper.find("[data-description='object-store-creation-error']");
+        console.log(wrapper.html());
         expect(errorEl.exists()).toBe(true);
         expect(errorEl.html()).toContain("Error creating this");
     });

--- a/client/src/components/ObjectStore/Instances/CreateForm.vue
+++ b/client/src/components/ObjectStore/Instances/CreateForm.vue
@@ -1,65 +1,43 @@
 <script lang="ts" setup>
-import { BAlert } from "bootstrap-vue";
-import { computed, ref } from "vue";
+import { toRef } from "vue";
 
-import {
-    createFormDataToPayload,
-    createTemplateForm,
-    type FormEntry,
-    pluginStatusToErrorMessage,
-} from "@/components/ConfigTemplates/formUtil";
+import { useConfigurationTemplateCreation } from "@/components/ConfigTemplates/useConfigurationTesting";
 import type { UserConcreteObjectStore } from "@/components/ObjectStore/Instances/types";
 import type { ObjectStoreTemplateSummary } from "@/components/ObjectStore/Templates/types";
-import { errorMessageAsString } from "@/utils/simple-error";
 
 import { create, test } from "./services";
-
-import InstanceForm from "@/components/ConfigTemplates/InstanceForm.vue";
 
 interface CreateFormProps {
     template: ObjectStoreTemplateSummary;
 }
-const error = ref<string | null>(null);
 const props = defineProps<CreateFormProps>();
 const title = "Create a new storage location for your data";
-const submitTitle = "Submit";
-const loadingMessage = "Loading storage location template and instance information";
-
-const inputs = computed<Array<FormEntry>>(() => {
-    return createTemplateForm(props.template, "storage location");
-});
-
-async function onSubmit(formData: any) {
-    const payload = createFormDataToPayload(props.template, formData);
-    const { data: pluginStatus } = await test(payload);
-    const testError = pluginStatusToErrorMessage(pluginStatus);
-    if (testError) {
-        error.value = testError;
-        return;
-    }
-    try {
-        const { data: objectStore } = await create(payload);
-        emit("created", objectStore);
-    } catch (e) {
-        error.value = errorMessageAsString(e);
-        return;
-    }
-}
 
 const emit = defineEmits<{
     (e: "created", objectStore: UserConcreteObjectStore): void;
 }>();
+
+const { ActionSummary, error, inputs, InstanceForm, onSubmit, submitTitle, loadingMessage, testRunning, testResults } =
+    useConfigurationTemplateCreation(
+        "storage location",
+        toRef(props, "template"),
+        test,
+        create,
+        (instance: UserConcreteObjectStore) => emit("created", instance)
+    );
 </script>
 <template>
     <div id="create-object-store-landing">
-        <BAlert v-if="error" variant="danger" class="object-store-instance-creation-error" show>
-            {{ error }}
-        </BAlert>
+        <ActionSummary
+            error-data-description="object-store-creation-error"
+            :test-results="testResults"
+            :error="error" />
         <InstanceForm
             :inputs="inputs"
             :title="title"
             :submit-title="submitTitle"
             :loading-message="loadingMessage"
+            :busy="testRunning"
             @onSubmit="onSubmit" />
     </div>
 </template>

--- a/client/src/components/ObjectStore/Instances/EditInstance.vue
+++ b/client/src/components/ObjectStore/Instances/EditInstance.vue
@@ -2,15 +2,14 @@
 import { BTab, BTabs } from "bootstrap-vue";
 import { computed, ref } from "vue";
 
-import { editFormDataToPayload, editTemplateForm, type FormEntry } from "@/components/ConfigTemplates/formUtil";
+import type { TestUpdateInstancePayload, UpdateInstancePayload } from "@/api/configTemplates";
+import { useConfigurationTemplateEdit } from "@/components/ConfigTemplates/useConfigurationTesting";
 
 import { useInstanceAndTemplate } from "./instance";
 import { useInstanceRouting } from "./routing";
-import { update } from "./services";
-import type { UserConcreteObjectStore } from "./types";
+import { testUpdate, update } from "./services";
 
 import EditSecrets from "./EditSecrets.vue";
-import InstanceForm from "@/components/ConfigTemplates/InstanceForm.vue";
 
 interface Props {
     instanceId: string;
@@ -19,45 +18,48 @@ interface Props {
 const props = defineProps<Props>();
 const { instance, template } = useInstanceAndTemplate(ref(props.instanceId));
 
-const inputs = computed<Array<FormEntry> | undefined>(() => {
-    template.value;
-    instance.value;
-    if (template.value && instance.value) {
-        return editTemplateForm(template.value, "storage location", instance.value);
-    }
-    return undefined;
-});
-
 const title = computed(() => `Edit Storage Location ${instance.value?.name} Settings`);
-const hasSecrets = computed(() => instance.value?.secrets && instance.value?.secrets.length > 0);
-const submitTitle = "Update Settings";
-const loadingMessage = "Loading storage location template and instance information";
+const errorDataDescription = "object-store-update-error";
 
-async function onSubmit(formData: any) {
-    if (template.value) {
-        const payload = editFormDataToPayload(template.value, formData);
-        const args = { user_object_store_id: String(instance?.value?.uuid) };
-        const { data: objectStore } = await update({ ...args, ...payload });
-        await onUpdate(objectStore);
-    }
-}
-
-const { goToIndex } = useInstanceRouting();
-
-async function onUpdate(objectStore: UserConcreteObjectStore) {
-    const message = `Updated storage location ${objectStore.name}`;
-    goToIndex({ message });
-}
+const {
+    error,
+    hasSecrets,
+    ActionSummary,
+    inputs,
+    InstanceForm,
+    loadingMessage,
+    onForceSubmit,
+    onSubmit,
+    testRunning,
+    testResults,
+    showForceActionButton,
+    submitTitle,
+} = useConfigurationTemplateEdit(
+    "storage location",
+    instance,
+    template,
+    (payload: TestUpdateInstancePayload) =>
+        testUpdate({ user_object_store_id: props.instanceId, ...payload }),
+    (payload: UpdateInstancePayload) => update({ user_object_store_id: props.instanceId, ...payload }),
+    useInstanceRouting
+);
 </script>
 <template>
     <div>
         <BTabs v-if="hasSecrets">
             <BTab title="Settings" active>
+                <ActionSummary
+                    :error-data-description="errorDataDescription"
+                    :test-results="testResults"
+                    :error="error" />
                 <InstanceForm
                     :inputs="inputs"
                     :title="title"
                     :submit-title="submitTitle"
                     :loading-message="loadingMessage"
+                    :busy="testRunning"
+                    :show-force-action-button="showForceActionButton"
+                    @onForceSubmit="onForceSubmit"
                     @onSubmit="onSubmit" />
             </BTab>
             <BTab title="Secrets">
@@ -66,12 +68,17 @@ async function onUpdate(objectStore: UserConcreteObjectStore) {
                 </div>
             </BTab>
         </BTabs>
-        <InstanceForm
-            v-else
-            :inputs="inputs"
-            :title="title"
-            :submit-title="submitTitle"
-            :loading-message="loadingMessage"
-            @onSubmit="onSubmit" />
+        <div v-else>
+            <ActionSummary :error-data-description="errorDataDescription" :test-results="testResults" :error="error" />
+            <InstanceForm
+                :inputs="inputs"
+                :title="title"
+                :submit-title="submitTitle"
+                :loading-message="loadingMessage"
+                :busy="testRunning"
+                :show-force-action-button="showForceActionButton"
+                @onForceSubmit="onForceSubmit"
+                @onSubmit="onSubmit" />
+        </div>
     </div>
 </template>

--- a/client/src/components/ObjectStore/Instances/EditInstance.vue
+++ b/client/src/components/ObjectStore/Instances/EditInstance.vue
@@ -13,7 +13,7 @@ import EditSecrets from "./EditSecrets.vue";
 import InstanceForm from "@/components/ConfigTemplates/InstanceForm.vue";
 
 interface Props {
-    instanceId: number | string;
+    instanceId: string;
 }
 
 const props = defineProps<Props>();
@@ -36,7 +36,7 @@ const loadingMessage = "Loading storage location template and instance informati
 async function onSubmit(formData: any) {
     if (template.value) {
         const payload = editFormDataToPayload(template.value, formData);
-        const args = { user_object_store_id: String(instance?.value?.id) };
+        const args = { user_object_store_id: String(instance?.value?.uuid) };
         const { data: objectStore } = await update({ ...args, ...payload });
         await onUpdate(objectStore);
     }

--- a/client/src/components/ObjectStore/Instances/EditSecrets.vue
+++ b/client/src/components/ObjectStore/Instances/EditSecrets.vue
@@ -20,7 +20,7 @@ async function onUpdate(secretName: string, secretValue: string) {
         secret_name: secretName,
         secret_value: secretValue,
     };
-    const args = { user_object_store_id: String(props.objectStore.id) };
+    const args = { user_object_store_id: String(props.objectStore.uuid) };
     await update({ ...args, ...payload });
 }
 </script>

--- a/client/src/components/ObjectStore/Instances/InstanceDropdown.vue
+++ b/client/src/components/ObjectStore/Instances/InstanceDropdown.vue
@@ -15,8 +15,8 @@ interface Props {
 }
 
 const props = defineProps<Props>();
-const routeEdit = computed(() => `/object_store_instances/${props.objectStore.id}/edit`);
-const routeUpgrade = computed(() => `/object_store_instances/${props.objectStore.id}/upgrade`);
+const routeEdit = computed(() => `/object_store_instances/${props.objectStore.uuid}/edit`);
+const routeUpgrade = computed(() => `/object_store_instances/${props.objectStore.uuid}/upgrade`);
 const isUpgradable = computed(() =>
     objectStoreTemplatesStore.canUpgrade(props.objectStore.template_id, props.objectStore.template_version)
 );

--- a/client/src/components/ObjectStore/Instances/InstanceDropdown.vue
+++ b/client/src/components/ObjectStore/Instances/InstanceDropdown.vue
@@ -28,6 +28,7 @@ async function onRemove() {
 
 const emit = defineEmits<{
     (e: "entryRemoved"): void;
+    (e: "test"): void;
 }>();
 </script>
 
@@ -38,5 +39,6 @@ const emit = defineEmits<{
         :is-upgradable="isUpgradable"
         :route-upgrade="routeUpgrade"
         :route-edit="routeEdit"
+        @test="emit('test')"
         @remove="onRemove" />
 </template>

--- a/client/src/components/ObjectStore/Instances/ManageIndex.vue
+++ b/client/src/components/ObjectStore/Instances/ManageIndex.vue
@@ -4,9 +4,12 @@ import { computed } from "vue";
 
 import type { UserConcreteObjectStore } from "@/api/objectStores";
 import { DESCRIPTION_FIELD, NAME_FIELD, TEMPLATE_FIELD, TYPE_FIELD } from "@/components/ConfigTemplates/fields";
+import { useInstanceTesting } from "@/components/ConfigTemplates/useConfigurationTesting";
 import { useFiltering } from "@/components/ConfigTemplates/useInstanceFiltering";
 import { useObjectStoreInstancesStore } from "@/stores/objectStoreInstancesStore";
 import _l from "@/utils/localization";
+
+import { testInstance } from "./services";
 
 import InstanceDropdown from "./InstanceDropdown.vue";
 import ManageIndexHeader from "@/components/ConfigTemplates/ManageIndexHeader.vue";
@@ -39,6 +42,12 @@ objectStoreInstancesStore.fetchInstances();
 function reload() {
     objectStoreInstancesStore.fetchInstances();
 }
+
+const { ConfigurationTestSummaryModal, showTestResults, testResults, test, testingError } = useInstanceTesting(
+    (id: string) => {
+        return testInstance({ user_object_store_id: id });
+    }
+);
 </script>
 
 <template>
@@ -48,6 +57,7 @@ function reload() {
             create-button-id="object-store-create"
             create-route="/object_store_instances/create">
         </ManageIndexHeader>
+        <ConfigurationTestSummaryModal v-model="showTestResults" :error="testingError" :test-results="testResults" />
         <BTable
             id="user-object-stores-index"
             no-sort-reset
@@ -68,7 +78,7 @@ function reload() {
                 <ObjectStoreBadges size="1x" :badges="row.item.badges" />
             </template>
             <template v-slot:cell(name)="row">
-                <InstanceDropdown :object-store="row.item" @entryRemoved="reload" />
+                <InstanceDropdown :object-store="row.item" @entryRemoved="reload" @test="test(row.item)" />
             </template>
             <template v-slot:cell(type)="row">
                 <ObjectStoreTypeSpan :type="row.item.type" />

--- a/client/src/components/ObjectStore/Instances/UpgradeForm.test.ts
+++ b/client/src/components/ObjectStore/Instances/UpgradeForm.test.ts
@@ -59,7 +59,6 @@ const INSTANCE: UserConcreteObjectStore = {
     secrets: ["oldsecret", "droppedsecret"],
     quota: { enabled: false },
     private: false,
-    id: 4,
     uuid: "112f889f-72d7-4619-a8e8-510a8c685aa7",
     active: true,
     hidden: false,

--- a/client/src/components/ObjectStore/Instances/UpgradeForm.test.ts
+++ b/client/src/components/ObjectStore/Instances/UpgradeForm.test.ts
@@ -3,6 +3,7 @@ import flushPromises from "flush-promises";
 import { getLocalVue, injectTestRouter } from "tests/jest/helpers";
 
 import { mockFetcher } from "@/api/schema/__mocks__";
+import { OK_PLUGIN_STATUS } from "@/components/ConfigTemplates/test_fixtures";
 import type { ObjectStoreTemplateSummary } from "@/components/ObjectStore/Templates/types";
 
 import type { UserConcreteObjectStore } from "./types";
@@ -109,6 +110,10 @@ describe("UpgradeForm", () => {
             localVue,
             router,
         });
+        mockFetcher
+            .path("/api/object_store_instances/{user_object_store_id}/test")
+            .method("post")
+            .mock({ data: OK_PLUGIN_STATUS });
         mockFetcher.path("/api/object_store_instances/{user_object_store_id}").method("put").mock({ data: INSTANCE });
         await flushPromises();
         const submitElement = wrapper.find("#submit");
@@ -129,6 +134,10 @@ describe("UpgradeForm", () => {
             router,
         });
         mockFetcher
+            .path("/api/object_store_instances/{user_object_store_id}/test")
+            .method("post")
+            .mock({ data: OK_PLUGIN_STATUS });
+        mockFetcher
             .path("/api/object_store_instances/{user_object_store_id}")
             .method("put")
             .mock(() => {
@@ -136,12 +145,12 @@ describe("UpgradeForm", () => {
             });
         await flushPromises();
         const submitElement = wrapper.find("#submit");
-        expect(wrapper.find(".object-store-instance-upgrade-error").exists()).toBe(false);
+        expect(wrapper.find("[data-description='object-store-upgrade-error']").exists()).toBe(false);
         submitElement.trigger("click");
         await flushPromises();
         const emitted = wrapper.emitted("created") || [];
         expect(emitted).toHaveLength(0);
-        const errorEl = wrapper.find(".object-store-instance-upgrade-error");
+        const errorEl = wrapper.find("[data-description='object-store-upgrade-error']");
         expect(errorEl.exists()).toBe(true);
         expect(errorEl.html()).toContain("problem upgrading");
     });

--- a/client/src/components/ObjectStore/Instances/UpgradeForm.vue
+++ b/client/src/components/ObjectStore/Instances/UpgradeForm.vue
@@ -1,64 +1,56 @@
 <script setup lang="ts">
-import { BAlert } from "bootstrap-vue";
-import { computed, ref } from "vue";
+import { computed, toRef } from "vue";
 
-import { type FormEntry, upgradeForm, upgradeFormDataToPayload } from "@/components/ConfigTemplates/formUtil";
-import { errorMessageAsString } from "@/utils/simple-error";
+import type { TestUpgradeInstancePayload, UpgradeInstancePayload } from "@/api/configTemplates";
+import { useConfigurationTemplateUpgrade } from "@/components/ConfigTemplates/useConfigurationTesting";
 
 import type { ObjectStoreTemplateSummary } from "../Templates/types";
 import { useInstanceRouting } from "./routing";
-import { update } from "./services";
+import { testUpdate, update } from "./services";
 import type { UserConcreteObjectStore } from "./types";
-
-import InstanceForm from "@/components/ConfigTemplates/InstanceForm.vue";
 
 interface Props {
     instance: UserConcreteObjectStore;
     latestTemplate: ObjectStoreTemplateSummary;
 }
 
-const error = ref<string | null>(null);
 const props = defineProps<Props>();
 
-const inputs = computed<Array<FormEntry> | undefined>(() => {
-    const realizedInstance: UserConcreteObjectStore = props.instance;
-    const realizedLatestTemplate = props.latestTemplate;
-    const form = upgradeForm(realizedLatestTemplate, realizedInstance);
-    return form;
-});
 const title = computed(() => `Upgrade Object Store ${props.instance.name}`);
-const submitTitle = "Update Settings";
-const loadingMessage = "Loading storage location template and instance information";
 
-async function onSubmit(formData: any) {
-    const payload = upgradeFormDataToPayload(props.latestTemplate, formData);
-    const args = { user_object_store_id: String(props.instance.uuid) };
-    try {
-        const { data: objectStore } = await update({ ...args, ...payload });
-        await onUpgrade(objectStore);
-    } catch (e) {
-        error.value = errorMessageAsString(e);
-        return;
-    }
-}
-
-const { goToIndex } = useInstanceRouting();
-
-async function onUpgrade(objectStore: UserConcreteObjectStore) {
-    const message = `Upgraded storage location ${objectStore.name}`;
-    goToIndex({ message });
-}
+const {
+    error,
+    ActionSummary,
+    inputs,
+    InstanceForm,
+    loadingMessage,
+    showForceActionButton,
+    onForceSubmit,
+    onSubmit,
+    testRunning,
+    testResults,
+    submitTitle,
+} = useConfigurationTemplateUpgrade(
+    "storage location",
+    toRef(props, "instance"),
+    toRef(props, "latestTemplate"),
+    (payload: TestUpgradeInstancePayload) =>
+        testUpdate({ user_object_store_id: props.instance.uuid, ...payload }),
+    (payload: UpgradeInstancePayload) => update({ user_object_store_id: props.instance.uuid, ...payload }),
+    useInstanceRouting
+);
 </script>
 <template>
     <div>
-        <BAlert v-if="error" variant="danger" class="object-store-instance-upgrade-error" show>
-            {{ error }}
-        </BAlert>
+        <ActionSummary error-data-description="object-store-upgrade-error" :test-results="testResults" :error="error" />
         <InstanceForm
             :inputs="inputs"
             :title="title"
             :submit-title="submitTitle"
             :loading-message="loadingMessage"
+            :busy="testRunning"
+            :show-force-action-button="showForceActionButton"
+            @onForceSubmit="onForceSubmit"
             @onSubmit="onSubmit" />
     </div>
 </template>

--- a/client/src/components/ObjectStore/Instances/UpgradeForm.vue
+++ b/client/src/components/ObjectStore/Instances/UpgradeForm.vue
@@ -32,7 +32,7 @@ const loadingMessage = "Loading storage location template and instance informati
 
 async function onSubmit(formData: any) {
     const payload = upgradeFormDataToPayload(props.latestTemplate, formData);
-    const args = { user_object_store_id: String(props.instance.id) };
+    const args = { user_object_store_id: String(props.instance.uuid) };
     try {
         const { data: objectStore } = await update({ ...args, ...payload });
         await onUpgrade(objectStore);

--- a/client/src/components/ObjectStore/Instances/UpgradeInstance.vue
+++ b/client/src/components/ObjectStore/Instances/UpgradeInstance.vue
@@ -9,7 +9,7 @@ import UpgradeForm from "./UpgradeForm.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 interface Props {
-    instanceId: number | string;
+    instanceId: string;
 }
 
 const props = defineProps<Props>();

--- a/client/src/components/ObjectStore/Instances/instance.ts
+++ b/client/src/components/ObjectStore/Instances/instance.ts
@@ -6,7 +6,7 @@ import { useObjectStoreTemplatesStore } from "@/stores/objectStoreTemplatesStore
 
 import type { UserConcreteObjectStore } from "./types";
 
-export function useInstanceAndTemplate(instanceIdRef: Ref<string | number>) {
+export function useInstanceAndTemplate(instanceIdRef: Ref<string>) {
     const objectStoreTemplatesStore = useObjectStoreTemplatesStore();
     const objectStoreInstancesStore = useObjectStoreInstancesStore();
     objectStoreInstancesStore.fetchInstances();

--- a/client/src/components/ObjectStore/Instances/routing.ts
+++ b/client/src/components/ObjectStore/Instances/routing.ts
@@ -1,16 +1,3 @@
-import { useRouter } from "vue-router/composables";
+import { buildInstanceRoutingComposable } from "@/components/ConfigTemplates/routing";
 
-export function useInstanceRouting() {
-    const router = useRouter();
-
-    async function goToIndex(query: Record<"message", string>) {
-        router.push({
-            path: "/object_store_instances/index",
-            query: query,
-        });
-    }
-
-    return {
-        goToIndex,
-    };
-}
+export const useInstanceRouting = buildInstanceRoutingComposable("/object_store_instances/index");

--- a/client/src/components/ObjectStore/Instances/services.ts
+++ b/client/src/components/ObjectStore/Instances/services.ts
@@ -8,7 +8,7 @@ export const update = fetcher.path("/api/object_store_instances/{user_object_sto
 
 export async function hide(instance: UserConcreteObjectStore) {
     const payload = { hidden: true };
-    const args = { user_object_store_id: String(instance?.id) };
+    const args = { user_object_store_id: String(instance?.uuid) };
     const { data: objectStore } = await update({ ...args, ...payload });
     return objectStore;
 }

--- a/client/src/components/ObjectStore/Instances/services.ts
+++ b/client/src/components/ObjectStore/Instances/services.ts
@@ -4,7 +4,15 @@ import type { UserConcreteObjectStore } from "./types";
 
 export const create = fetcher.path("/api/object_store_instances").method("post").create();
 export const test = fetcher.path("/api/object_store_instances/test").method("post").create();
+export const testInstance = fetcher
+    .path("/api/object_store_instances/{user_object_store_id}/test")
+    .method("get")
+    .create();
 export const update = fetcher.path("/api/object_store_instances/{user_object_store_id}").method("put").create();
+export const testUpdate = fetcher
+    .path("/api/object_store_instances/{user_object_store_id}/test")
+    .method("post")
+    .create();
 
 export async function hide(instance: UserConcreteObjectStore) {
     const payload = { hidden: true };

--- a/client/src/stores/fileSourceInstancesStore.ts
+++ b/client/src/stores/fileSourceInstancesStore.ts
@@ -22,7 +22,7 @@ export const useFileSourceInstancesStore = defineStore("fileSourceInstances", {
             return !state.fetched;
         },
         getInstance: (state) => {
-            return (id: number | string) => state.instances.find((i) => i.id.toString() == id.toString());
+            return (uuid: string) => state.instances.find((i) => i.uuid == uuid);
         },
     },
     actions: {

--- a/client/src/stores/objectStoreInstancesStore.test.ts
+++ b/client/src/stores/objectStoreInstancesStore.test.ts
@@ -4,6 +4,7 @@ import { useObjectStoreInstancesStore } from "@/stores/objectStoreInstancesStore
 import { setupTestPinia } from "./testUtils";
 
 const type = "aws_s3" as ObjectStoreTemplateType;
+const UUID = "112f889f-72d7-4619-a8e8-510a8c685aa7";
 const TEST_INSTANCE = {
     type: type,
     name: "moo",
@@ -15,8 +16,7 @@ const TEST_INSTANCE = {
     secrets: [],
     quota: { enabled: false },
     private: false,
-    id: 4,
-    uuid: "112f889f-72d7-4619-a8e8-510a8c685aa7",
+    uuid: UUID,
     active: true,
     hidden: false,
     purged: false,
@@ -45,13 +45,7 @@ describe("Object Store Instances Store", () => {
     it("should allow finding an instance by instance id", () => {
         const objectStoreInstancesStore = useObjectStoreInstancesStore();
         objectStoreInstancesStore.handleInit([TEST_INSTANCE]);
-        expect(objectStoreInstancesStore.getInstance(4)?.name).toBe("moo");
-    });
-
-    it("should allow finding an instance by instance id as string (for props)", () => {
-        const objectStoreInstancesStore = useObjectStoreInstancesStore();
-        objectStoreInstancesStore.handleInit([TEST_INSTANCE]);
-        expect(objectStoreInstancesStore.getInstance("4")?.name).toBe("moo");
+        expect(objectStoreInstancesStore.getInstance(UUID)?.name).toBe("moo");
     });
 
     it("should populate an error with handleError", () => {

--- a/client/src/stores/objectStoreInstancesStore.ts
+++ b/client/src/stores/objectStoreInstancesStore.ts
@@ -22,7 +22,7 @@ export const useObjectStoreInstancesStore = defineStore("objectStoreInstances", 
             return !state.fetched;
         },
         getInstance: (state) => {
-            return (id: number | string) => state.instances.find((i) => i.id.toString() == id.toString());
+            return (uuid: string) => state.instances.find((i) => i.uuid == uuid);
         },
     },
     actions: {

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -434,7 +434,6 @@ class MinimalGalaxyApplication(BasicSharedApp, HaltableContainer, SentryClientMi
             gid=self.config.gid,
             object_store_cache_size=self.config.object_store_cache_size,
             object_store_cache_path=self.config.object_store_cache_path,
-            user_config_templates_index_by=self.config.user_config_templates_index_by,
             user_config_templates_use_saved_configuration=self.config.user_config_templates_use_saved_configuration,
         )
         self._register_singleton(UserObjectStoresAppConfig, app_config)

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -581,19 +581,6 @@ mapping:
         desc: |
           Configured user file source templates embedded into Galaxy's config.
 
-      user_config_templates_index_by:
-        type: str
-        default: 'uuid'
-        required: false
-        enum: ['uuid', 'id']
-        desc: |
-          Configure URIs for user object stores to use either the object ID ('id')
-          or UUIDs ('uuid'). Either is fine really, Galaxy doesn't typically expose
-          database objects by 'id' but there isn't any obvious disadvantage to doing
-          it in this case and it keeps user exposed URIs much smaller. The default of
-          UUID feels a little more like a typical way to do this within Galaxy though.
-          Do not change this value once user object stores have been created.
-
       user_config_templates_use_saved_configuration:
         type: str
         default: 'fallback'

--- a/lib/galaxy/files/templates/examples/testing_multi_version_with_secrets.yml
+++ b/lib/galaxy/files/templates/examples/testing_multi_version_with_secrets.yml
@@ -1,0 +1,34 @@
+# a template with multiple versions that could be coherent for unit/integration
+# testing upgrading object stores templates
+- id: secure_disk
+  version: 0
+  name: Secure Disk
+  description: Secure Disk Bound to You
+  secrets:
+    sec1:
+      help: This is my test secret.
+  configuration:
+    type: posix
+    root: '/data/secure/{{ user.username }}/{{ secrets.sec1 }}/aftersec'
+- id: secure_disk
+  version: 1
+  name: Secure Disk
+  description: Secure Disk Bound to You
+  secrets:
+    sec1:
+      help: This is my test secret.
+    sec2:
+      help: This is my test secret 2.
+  configuration:
+    type: posix
+    root: '/data/secure/{{ user.username }}/{{ secrets.sec1 }}/{{ secrets.sec2 }}'
+- id: secure_disk
+  version: 2
+  name: Secure Disk
+  description: Secure Disk Bound to You
+  secrets:
+    sec2:
+      help: This is my test secret 2.
+  configuration:
+    type: posix
+    root: '/data/secure/{{ user.username }}/newbar/{{ secrets.sec2 }}'

--- a/lib/galaxy/managers/file_source_instances.py
+++ b/lib/galaxy/managers/file_source_instances.py
@@ -8,6 +8,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    Union,
 )
 from uuid import uuid4
 
@@ -58,27 +59,35 @@ from galaxy.util.config_templates import (
     PluginStatus,
     settings_exception_to_status,
     status_template_definition,
+    TemplateReference,
     TemplateVariableValueType,
     validate_no_extra_secrets_defined,
     validate_no_extra_variables_defined,
 )
 from galaxy.util.plugin_config import plugin_source_from_dict
 from ._config_templates import (
+    CanTestPluginStatus,
     CreateInstancePayload,
     ModifyInstancePayload,
     prepare_environment,
-    prepare_environment_from_root,
+    prepare_template_parameters_for_testing,
     purge_template_instance,
     recover_secrets,
     save_template_instance,
     sort_templates,
+    TestModifyInstancePayload,
+    TestUpdateInstancePayload,
+    TestUpgradeInstancePayload,
+    to_template_reference,
     update_instance_secret,
     update_template_instance,
     updated_template_variables,
     UpdateInstancePayload,
     UpdateInstanceSecretPayload,
+    UpdateTestTarget,
     upgrade_secrets,
     UpgradeInstancePayload,
+    UpgradeTestTarget,
 )
 
 log = logging.getLogger(__name__)
@@ -165,9 +174,7 @@ class FileSourceInstancesManager:
         self, trans: ProvidesUserContext, id: str, payload: UpgradeInstancePayload
     ) -> UserFileSourceModel:
         persisted_file_source = self._get(trans, id)
-        template = self._get_template(persisted_file_source, payload.template_version)
-        validate_no_extra_variables_defined(payload.variables, template)
-        validate_no_extra_secrets_defined(payload.secrets, template)
+        template = self._get_and_validate_target_upgrade_template(persisted_file_source, payload)
         persisted_file_source.template_version = template.version
         persisted_file_source.template_definition = template.model_dump()
         actual_variables = updated_template_variables(
@@ -179,6 +186,14 @@ class FileSourceInstancesManager:
         upgrade_secrets(trans, persisted_file_source, template, payload, self._app_config)
         self._save(persisted_file_source)
         return self._to_model(trans, persisted_file_source)
+
+    def _get_and_validate_target_upgrade_template(
+        self, persisted_file_source: UserFileSource, payload: Union[UpgradeInstancePayload, TestUpgradeInstancePayload]
+    ) -> FileSourceTemplate:
+        template = self._get_template(persisted_file_source, payload.template_version)
+        validate_no_extra_variables_defined(payload.variables, template)
+        validate_no_extra_secrets_defined(payload.secrets, template)
+        return template
 
     def _update_instance(
         self, trans: ProvidesUserContext, id: str, payload: UpdateInstancePayload
@@ -229,8 +244,46 @@ class FileSourceInstancesManager:
         self._save(persisted_file_source)
         return self._to_model(trans, persisted_file_source)
 
+    def test_modify_instance(
+        self, trans: ProvidesUserContext, id: str, payload: TestModifyInstancePayload
+    ) -> PluginStatus:
+        persisted_file_source = self._get(trans, id)
+        if isinstance(payload, TestUpgradeInstancePayload):
+            return self._plugin_status_for_upgrade(trans, payload, persisted_file_source)
+        else:
+            assert isinstance(payload, TestUpdateInstancePayload)
+            return self._plugin_status_for_update(trans, payload, persisted_file_source)
+
+    def _plugin_status_for_update(
+        self, trans: ProvidesUserContext, payload: TestUpdateInstancePayload, persisted_file_source: UserFileSource
+    ) -> PluginStatus:
+        template = self._get_template(persisted_file_source)
+        target = UpdateTestTarget(persisted_file_source, payload)
+        return self._plugin_status_for_template(trans, target, template)
+
+    def _plugin_status_for_upgrade(
+        self, trans: ProvidesUserContext, payload: TestUpgradeInstancePayload, persisted_file_source: UserFileSource
+    ) -> PluginStatus:
+        template = self._get_and_validate_target_upgrade_template(persisted_file_source, payload)
+        target = UpgradeTestTarget(persisted_file_source, payload)
+        return self._plugin_status_for_template(trans, target, template)
+
+    def plugin_status_for_instance(self, trans: ProvidesUserContext, id: str):
+        persisted_file_source = self._get(trans, id)
+        return self._plugin_status(trans, persisted_file_source, to_template_reference(persisted_file_source))
+
     def plugin_status(self, trans: ProvidesUserContext, payload: CreateInstancePayload) -> PluginStatus:
-        template = self._catalog.find_template(payload)
+        return self._plugin_status(trans, payload, payload)
+
+    def _plugin_status(
+        self, trans: ProvidesUserContext, payload: CanTestPluginStatus, template_reference: TemplateReference
+    ):
+        template = self._catalog.find_template(template_reference)
+        return self._plugin_status_for_template(trans, payload, template)
+
+    def _plugin_status_for_template(
+        self, trans: ProvidesUserContext, payload: CanTestPluginStatus, template: FileSourceTemplate
+    ):
         template_definition_status = status_template_definition(template)
         status_kwds = {"template_definition": template_definition_status}
         if template_definition_status.is_not_ok:
@@ -254,38 +307,36 @@ class FileSourceInstancesManager:
     def _template_settings_status(
         self,
         trans: ProvidesUserContext,
-        payload: CreateInstancePayload,
+        payload: CanTestPluginStatus,
         template: FileSourceTemplate,
     ) -> Tuple[Optional[FileSourceConfiguration], PluginAspectStatus]:
-        secrets = payload.secrets
-        variables = payload.variables
-        environment = prepare_environment_from_root(template.environment, self._app_vault, self._app_config)
-        user_details = trans.user.config_template_details()
-
+        template_parameters = prepare_template_parameters_for_testing(
+            trans, template, payload, self._app_vault, self._app_config
+        )
         configuration = None
         exception = None
         try:
-            configuration = template_to_configuration(
-                template,
-                variables=variables,
-                secrets=secrets,
-                user_details=user_details,
-                environment=environment,
-            )
+            configuration = template_to_configuration(template, **template_parameters)
         except Exception as e:
             exception = e
         return configuration, settings_exception_to_status(exception)
 
     def _connection_status(
-        self, trans: ProvidesUserContext, payload: CreateInstancePayload, configuration: FileSourceConfiguration
+        self, trans: ProvidesUserContext, payload: CanTestPluginStatus, configuration: FileSourceConfiguration
     ) -> Tuple[Optional[BaseFilesSource], PluginAspectStatus]:
         file_source = None
         exception = None
+        if isinstance(payload, (UpgradeTestTarget, UpdateTestTarget)):
+            label = payload.instance.name
+            doc = payload.instance.description
+        else:
+            label = payload.name
+            doc = payload.description
         try:
             file_source_properties = configuration_to_file_source_properties(
                 configuration,
-                label=payload.name,
-                doc=payload.description,
+                label=label,
+                doc=doc,
                 id=uuid4().hex,
             )
             file_source = self._resolver._file_source(file_source_properties)
@@ -500,6 +551,9 @@ __all__ = (
     "CreateInstancePayload",
     "FileSourceInstancesManager",
     "ModifyInstancePayload",
+    "TestModifyInstancePayload",
+    "TestUpgradeInstancePayload",
+    "TestUpdateInstancePayload",
     "UpdateInstancePayload",
     "UpdateInstanceSecretPayload",
     "UpgradeInstancePayload",

--- a/lib/galaxy/managers/object_store_instances.py
+++ b/lib/galaxy/managers/object_store_instances.py
@@ -13,6 +13,7 @@ from typing import (
     List,
     Optional,
     Tuple,
+    Union,
 )
 from uuid import uuid4
 
@@ -47,26 +48,34 @@ from galaxy.util.config_templates import (
     PluginStatus,
     settings_exception_to_status,
     status_template_definition,
+    TemplateReference,
     TemplateVariableValueType,
     validate_no_extra_secrets_defined,
     validate_no_extra_variables_defined,
 )
 from ._config_templates import (
+    CanTestPluginStatus,
     CreateInstancePayload,
     ModifyInstancePayload,
     prepare_environment,
-    prepare_environment_from_root,
+    prepare_template_parameters_for_testing,
     purge_template_instance,
     recover_secrets,
     save_template_instance,
     sort_templates,
+    TestModifyInstancePayload,
+    TestUpdateInstancePayload,
+    TestUpgradeInstancePayload,
+    to_template_reference,
     update_instance_secret,
     update_template_instance,
     updated_template_variables,
     UpdateInstancePayload,
     UpdateInstanceSecretPayload,
+    UpdateTestTarget,
     upgrade_secrets,
     UpgradeInstancePayload,
+    UpgradeTestTarget,
 )
 
 log = logging.getLogger(__name__)
@@ -124,11 +133,9 @@ class ObjectStoreInstancesManager:
         self, trans: ProvidesUserContext, id: str, payload: UpgradeInstancePayload
     ) -> UserConcreteObjectStoreModel:
         persisted_object_store = self._get(trans, id)
-        template = self._get_template(persisted_object_store, payload.template_version)
+        template = self._get_and_validate_target_upgrade_template(persisted_object_store, payload)
         persisted_object_store.template_version = template.version
         persisted_object_store.template_definition = template.model_dump()
-        validate_no_extra_variables_defined(payload.variables, template)
-        validate_no_extra_secrets_defined(payload.secrets, template)
         actual_variables = updated_template_variables(
             payload.variables,
             persisted_object_store,
@@ -138,6 +145,16 @@ class ObjectStoreInstancesManager:
         upgrade_secrets(trans, persisted_object_store, template, payload, self._app_config)
         self._save(persisted_object_store)
         return self._to_model(trans, persisted_object_store)
+
+    def _get_and_validate_target_upgrade_template(
+        self,
+        persisted_object_store: UserObjectStore,
+        payload: Union[UpgradeInstancePayload, TestUpgradeInstancePayload],
+    ) -> ObjectStoreTemplate:
+        template = self._get_template(persisted_object_store, payload.template_version)
+        validate_no_extra_variables_defined(payload.variables, template)
+        validate_no_extra_secrets_defined(payload.secrets, template)
+        return template
 
     def _update_instance(
         self, trans: ProvidesUserContext, id: str, payload: UpdateInstancePayload
@@ -216,8 +233,46 @@ class ObjectStoreInstancesManager:
             raise ItemOwnershipException()
         return user_object_store
 
+    def test_modify_instance(
+        self, trans: ProvidesUserContext, id: str, payload: TestModifyInstancePayload
+    ) -> PluginStatus:
+        persisted_object_store = self._get(trans, id)
+        if isinstance(payload, TestUpgradeInstancePayload):
+            return self._plugin_status_for_upgrade(trans, payload, persisted_object_store)
+        else:
+            assert isinstance(payload, TestUpdateInstancePayload)
+            return self._plugin_status_for_update(trans, payload, persisted_object_store)
+
+    def _plugin_status_for_update(
+        self, trans: ProvidesUserContext, payload: TestUpdateInstancePayload, persisted_object_store: UserObjectStore
+    ) -> PluginStatus:
+        template = self._get_template(persisted_object_store)
+        target = UpdateTestTarget(persisted_object_store, payload)
+        return self._plugin_status_for_template(trans, target, template)
+
+    def _plugin_status_for_upgrade(
+        self, trans: ProvidesUserContext, payload: TestUpgradeInstancePayload, persisted_object_store: UserObjectStore
+    ) -> PluginStatus:
+        template = self._get_and_validate_target_upgrade_template(persisted_object_store, payload)
+        target = UpgradeTestTarget(persisted_object_store, payload)
+        return self._plugin_status_for_template(trans, target, template)
+
+    def plugin_status_for_instance(self, trans: ProvidesUserContext, id: str):
+        persisted_object_store = self._get(trans, id)
+        return self._plugin_status(trans, persisted_object_store, to_template_reference(persisted_object_store))
+
     def plugin_status(self, trans: ProvidesUserContext, payload: CreateInstancePayload) -> PluginStatus:
-        template = self._catalog.find_template(payload)
+        return self._plugin_status(trans, payload, payload)
+
+    def _plugin_status(
+        self, trans: ProvidesUserContext, payload: CanTestPluginStatus, template_reference: TemplateReference
+    ):
+        template = self._catalog.find_template(template_reference)
+        return self._plugin_status_for_template(trans, payload, template)
+
+    def _plugin_status_for_template(
+        self, trans: ProvidesUserContext, payload: CanTestPluginStatus, template: ObjectStoreTemplate
+    ):
         template_definition_status = status_template_definition(template)
         status_kwds = {"template_definition": template_definition_status}
         if template_definition_status.is_not_ok:
@@ -241,30 +296,23 @@ class ObjectStoreInstancesManager:
     def _template_settings_status(
         self,
         trans: ProvidesUserContext,
-        payload: CreateInstancePayload,
+        payload: CanTestPluginStatus,
         template: ObjectStoreTemplate,
     ) -> Tuple[Optional[ObjectStoreConfiguration], PluginAspectStatus]:
-        secrets = payload.secrets
-        variables = payload.variables
-        environment = prepare_environment_from_root(template.environment, self._app_vault, self._app_config)
-        user_details = trans.user.config_template_details()
+        template_parameters = prepare_template_parameters_for_testing(
+            trans, template, payload, self._app_vault, self._app_config
+        )
 
         configuration = None
         exception = None
         try:
-            configuration = template_to_configuration(
-                template,
-                variables=variables,
-                secrets=secrets,
-                user_details=user_details,
-                environment=environment,
-            )
+            configuration = template_to_configuration(template, **template_parameters)
         except Exception as e:
             exception = e
         return configuration, settings_exception_to_status(exception)
 
     def _connection_status(
-        self, trans: ProvidesUserContext, payload: CreateInstancePayload, configuration: ObjectStoreConfiguration
+        self, trans: ProvidesUserContext, payload: CanTestPluginStatus, configuration: ObjectStoreConfiguration
     ) -> Tuple[Optional[BaseObjectStore], PluginAspectStatus]:
         object_store = None
         exception = None
@@ -352,6 +400,9 @@ class UserObjectStoreResolverImpl(BaseUserObjectStoreResolver):
 __all__ = (
     "CreateInstancePayload",
     "ModifyInstancePayload",
+    "TestUpgradeInstancePayload",
+    "TestUpdateInstancePayload",
+    "TestModifyInstancePayload",
     "UpdateInstancePayload",
     "UpdateInstanceSecretPayload",
     "UpgradeInstancePayload",

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -10939,7 +10939,8 @@ class UserPreference(Base, RepresentById):
 
 
 class UsesTemplatesAppConfig(Protocol):
-    user_config_templates_index_by: Literal["uuid", "id"]
+    # TODO: delete this config protocol def and uses in dev
+    pass
 
 
 class HasConfigSecrets(RepresentById):
@@ -10949,10 +10950,7 @@ class HasConfigSecrets(RepresentById):
     user: Mapped["User"]
 
     def vault_id_prefix(self, app_config: UsesTemplatesAppConfig) -> str:
-        if app_config.user_config_templates_index_by == "id":
-            id_str = str(self.id)
-        else:
-            id_str = str(self.uuid)
+        id_str = str(self.uuid)
         user_vault_id_prefix = f"{self.secret_config_type}/{id_str}"
         return user_vault_id_prefix
 

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -1364,17 +1364,10 @@ class DistributedObjectStore(NestedObjectStore):
             if not user:
                 return "Supplied object store id is not accessible"
             rest_of_uri = object_store_id.split("://", 1)[1]
-            index_by = self.config.user_config_templates_index_by
-            if index_by == "id":
-                user_object_store_id = int(rest_of_uri)
-                for user_object_store in user.object_stores:
-                    if user_object_store.id == user_object_store_id:
-                        return None
-            else:
-                user_object_store_uuid = rest_of_uri
-                for user_object_store in user.object_stores:
-                    if str(user_object_store.uuid) == user_object_store_uuid:
-                        return None
+            user_object_store_uuid = rest_of_uri
+            for user_object_store in user.object_stores:
+                if str(user_object_store.uuid) == user_object_store_uuid:
+                    return None
             return "Supplied object store id was not found"
         if object_store_id not in self.object_store_ids_allowing_selection():
             return "Supplied object store id is not an allowed object store selection"
@@ -1658,7 +1651,6 @@ def build_object_store_from_config(
 class UserObjectStoresAppConfig(BaseModel):
     object_store_cache_path: str
     object_store_cache_size: int
-    user_config_templates_index_by: Literal["uuid", "id"]
     user_config_templates_use_saved_configuration: Literal["fallback", "preferred", "never"]
     jobs_directory: str
     new_file_path: str

--- a/lib/galaxy/objectstore/unittest_utils/__init__.py
+++ b/lib/galaxy/objectstore/unittest_utils/__init__.py
@@ -108,7 +108,6 @@ def app_config(tmpdir) -> objectstore.UserObjectStoresAppConfig:
         gid=0o077,
         object_store_cache_path=str(tmpdir / "cache"),
         object_store_cache_size=1,
-        user_config_templates_index_by="uuid",
         user_config_templates_use_saved_configuration="fallback",
     )
     return app_config

--- a/lib/galaxy/webapps/galaxy/api/file_sources.py
+++ b/lib/galaxy/webapps/galaxy/api/file_sources.py
@@ -29,7 +29,7 @@ router = Router(tags=["file_sources"])
 
 
 UserFileSourceIdPathParam: str = Path(
-    ..., title="User File Source ID", description="The index for a persisted UserFileSourceStore object."
+    ..., title="User File Source UUID", description="The UUID index for a persisted UserFileSourceStore object."
 )
 
 

--- a/lib/galaxy/webapps/galaxy/api/file_sources.py
+++ b/lib/galaxy/webapps/galaxy/api/file_sources.py
@@ -14,6 +14,7 @@ from galaxy.managers.file_source_instances import (
     CreateInstancePayload,
     FileSourceInstancesManager,
     ModifyInstancePayload,
+    TestModifyInstancePayload,
     UserFileSourceModel,
 )
 from galaxy.util.config_templates import PluginStatus
@@ -96,6 +97,18 @@ class FastAPIFileSources:
     ) -> UserFileSourceModel:
         return self.file_source_instances_manager.show(trans, user_file_source_id)
 
+    @router.get(
+        "/api/file_source_instances/{user_file_source_id}/test",
+        summary="Test a file source instance and return status.",
+        operation_id="file_sources__instances_test_instance",
+    )
+    def instance_test(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        user_file_source_id: str = UserFileSourceIdPathParam,
+    ) -> PluginStatus:
+        return self.file_source_instances_manager.plugin_status_for_instance(trans, user_file_source_id)
+
     @router.put(
         "/api/file_source_instances/{user_file_source_id}",
         summary="Update or upgrade user file source instance.",
@@ -108,6 +121,19 @@ class FastAPIFileSources:
         payload: ModifyInstancePayload = Body(...),
     ) -> UserFileSourceModel:
         return self.file_source_instances_manager.modify_instance(trans, user_file_source_id, payload)
+
+    @router.post(
+        "/api/file_source_instances/{user_file_source_id}/test",
+        summary="Test updating or upgrading user file source instance.",
+        operation_id="file_sources__test_instances_update",
+    )
+    def test_update_instance(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        user_file_source_id: str = UserFileSourceIdPathParam,
+        payload: TestModifyInstancePayload = Body(...),
+    ) -> PluginStatus:
+        return self.file_source_instances_manager.test_modify_instance(trans, user_file_source_id, payload)
 
     @router.delete(
         "/api/file_source_instances/{user_file_source_id}",

--- a/lib/galaxy/webapps/galaxy/api/file_sources.py
+++ b/lib/galaxy/webapps/galaxy/api/file_sources.py
@@ -86,7 +86,7 @@ class FastAPIFileSources:
 
     @router.get(
         "/api/file_source_instances/{user_file_source_id}",
-        summary="Get a list of persisted file source instances defined by the requesting user.",
+        summary="Get a persisted user file source instance.",
         operation_id="file_sources__instances_get",
     )
     def instances_show(

--- a/lib/galaxy/webapps/galaxy/api/object_store.py
+++ b/lib/galaxy/webapps/galaxy/api/object_store.py
@@ -49,8 +49,8 @@ ConcreteObjectStoreIdPathParam: str = Path(
 
 UserObjectStoreIdPathParam: str = Path(
     ...,
-    title="User Object Store Identifier",
-    description="The identifier used to index a persisted UserObjectStore object.",
+    title="User Object Store UUID",
+    description="The UUID used to identify a persisted UserObjectStore object.",
 )
 
 SelectableQueryParam: bool = Query(

--- a/lib/galaxy/webapps/galaxy/api/object_store.py
+++ b/lib/galaxy/webapps/galaxy/api/object_store.py
@@ -25,6 +25,7 @@ from galaxy.managers.object_store_instances import (
     CreateInstancePayload,
     ModifyInstancePayload,
     ObjectStoreInstancesManager,
+    TestModifyInstancePayload,
     UserConcreteObjectStoreModel,
 )
 from galaxy.objectstore import (
@@ -135,6 +136,18 @@ class FastAPIObjectStore:
         return self.object_store_instance_manager.show(trans, user_object_store_id)
 
     @router.get(
+        "/api/object_store_instances/{user_object_store_id}/test",
+        summary="Get a persisted user object store instance.",
+        operation_id="object_stores__instances_test_instance",
+    )
+    def instance_test(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        user_object_store_id: str = UserObjectStoreIdPathParam,
+    ) -> PluginStatus:
+        return self.object_store_instance_manager.plugin_status_for_instance(trans, user_object_store_id)
+
+    @router.get(
         "/api/object_stores/{object_store_id}",
         summary="Get information about a concrete object store configured with Galaxy.",
     )
@@ -157,6 +170,19 @@ class FastAPIObjectStore:
         payload: ModifyInstancePayload = Body(...),
     ) -> UserConcreteObjectStoreModel:
         return self.object_store_instance_manager.modify_instance(trans, user_object_store_id, payload)
+
+    @router.post(
+        "/api/object_store_instances/{user_object_store_id}/test",
+        summary="Test updating or upgrading user object source instance.",
+        operation_id="object_stores__test_instances_update",
+    )
+    def test_update_instance(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        user_file_source_id: str = UserObjectStoreIdPathParam,
+        payload: TestModifyInstancePayload = Body(...),
+    ) -> PluginStatus:
+        return self.object_store_instance_manager.test_modify_instance(trans, user_file_source_id, payload)
 
     @router.delete(
         "/api/object_store_instances/{user_object_store_id}",

--- a/lib/galaxy/webapps/galaxy/api/object_store.py
+++ b/lib/galaxy/webapps/galaxy/api/object_store.py
@@ -124,7 +124,7 @@ class FastAPIObjectStore:
 
     @router.get(
         "/api/object_store_instances/{user_object_store_id}",
-        summary="Get a persisted object store instances owned by the requesting user.",
+        summary="Get a persisted user object store instance.",
         operation_id="object_stores__instances_get",
     )
     def instances_show(

--- a/test/integration/objectstore/test_per_user.py
+++ b/test/integration/objectstore/test_per_user.py
@@ -103,6 +103,18 @@ class BaseUserObjectStoreIntegration(BaseObjectStoreIntegrationTestCase):
         object_store_id = object_store_json["object_store_id"]
         assert object_store_id.startswith("user_objects://")
 
+        response = self.dataset_populator._get(f"object_store_instances/{object_store_json['id']}/test")
+        response.raise_for_status()
+        from galaxy.util.config_templates import PluginStatus
+
+        status = PluginStatus.model_validate(response.json())
+        assert status.connection
+        assert not status.connection.is_not_ok
+        assert status.template_definition
+        assert not status.template_definition.is_not_ok
+        assert status.template_settings
+        assert not status.template_settings.is_not_ok
+
         object_stores = self.dataset_populator.selectable_object_stores()
         after_selectable_object_store_count = len(object_stores)
         assert after_selectable_object_store_count == before_selectable_object_store_count + 1

--- a/test/unit/app/managers/test_user_file_sources.py
+++ b/test/unit/app/managers/test_user_file_sources.py
@@ -299,7 +299,6 @@ class TestFileSourcesTestCase(BaseTestCase):
         user_file_source_showed = self.manager.show(self.trans, user_file_source.uuid)
         assert user_file_source_showed
         assert user_file_source_showed.uuid == user_file_source.uuid
-        assert user_file_source_showed.id == user_file_source.id
 
     def test_simple_update(self, tmp_path):
         self._init_managers(tmp_path, config_dict=simple_variable_template(tmp_path))

--- a/test/unit/app/managers/test_user_object_stores.py
+++ b/test/unit/app/managers/test_user_object_stores.py
@@ -120,7 +120,6 @@ class TestUserObjectStoreTestCase(BaseTestCase):
         user_object_store_showed = self.manager.show(self.trans, user_object_store.uuid)
         assert user_object_store_showed
         assert user_object_store_showed.uuid == user_object_store.uuid
-        assert user_object_store_showed.id == user_object_store.id
 
     def test_simple_update(self, tmp_path):
         self._init_managers(tmp_path, config_dict=simple_variable_template(tmp_path))

--- a/test/unit/files/test_template_models.py
+++ b/test/unit/files/test_template_models.py
@@ -299,6 +299,7 @@ def test_examples_parse():
     _assert_example_parses("templating_override.yml")
     _assert_example_parses("admin_secrets.yml")
     _assert_example_parses("admin_secrets_with_defaults.yml")
+    _assert_example_parses("testing_multi_version_with_secrets.yml")
 
 
 def _assert_example_parses(filename: str):


### PR DESCRIPTION
A really expansive version of what I had in mind for the first big section in https://github.com/galaxyproject/galaxy/issues/18128.

- UI (checklist) for detailed display of errors - in follow up PRs I'll add "writability" check to the checklist but one can imagine a lot of room for growing this (screenshot 3)
- UI option to test configuration from management menu. (screenshot 4)
- API + UI for checking configuration before upgrading to new version of template (with unit tests).
- API + UI for checking configuration before updating current template's settings (with unit tests).
- Add an option during update/upgrade to allow forcing the update even if configuration doesn't validate - I don't allow creation of invalid things, but if there are problems with an existing thing - admins and power users should have recourse. It is their data. (screenshot 2)
- General unit test expansion for the backend and refactoring the frontend toward composables to reduce the duplication between the object store and file source versions of the various forms.

------

A simple file source pointing at a public S3 bucket - inside edit setting form (pre-existing functionality)

<img width="1081" alt="Screenshot 2024-05-24 at 11 40 50 AM" src="https://github.com/galaxyproject/galaxy/assets/216771/1fe598ba-fc95-4439-94ff-867ff4091bad">

-----

Alert (existing in 24.1 for only create but now works during update and upgrade also) with new button to expand full information in all three contexts along with the ability to force save anyway when the alert is visible:

<img width="1080" alt="Screenshot 2024-05-24 at 11 34 46 AM" src="https://github.com/galaxyproject/galaxy/assets/216771/fb0cd1a8-fdae-4ac5-a24f-f3f61dfc21d0">

------

Expanded Checklist for Detailed View when that button is clicked (or when menu option is clicked from index)

<img width="795" alt="Screenshot 2024-05-24 at 11 34 14 AM" src="https://github.com/galaxyproject/galaxy/assets/216771/98cefdd0-7753-4a01-890e-c8514050fd07">

------

New Menu Option to Test Instance Configuration

<img width="241" alt="Screenshot 2024-05-24 at 11 34 21 AM" src="https://github.com/galaxyproject/galaxy/assets/216771/a7fb7b27-279e-41b6-bcea-85b0cacbf49a">

-------

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
