### PR TITLE
[24.0] Decrease log level for expected visualization errors

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/visualization.py
+++ b/lib/galaxy/webapps/galaxy/controllers/visualization.py
@@ -11,6 +11,7 @@ from galaxy import (
     model,
     web,
 )
+from galaxy.exceptions import MessageException
 from galaxy.managers.hdas import HDAManager
 from galaxy.managers.sharable import SlugBuilder
 from galaxy.model.base import transaction
@@ -258,7 +259,10 @@ class VisualizationController(
         """
         Log, raise if debugging; log and show html message if not.
         """
-        log.exception("error rendering visualization (%s)", visualization_name)
+        if isinstance(exception, MessageException):
+            log.debug("error rendering visualization (%s): %s", visualization_name, exception)
+        else:
+            log.exception("error rendering visualization (%s)", visualization_name)
         if trans.debug:
             raise exception
         return trans.show_error_message(


### PR DESCRIPTION
Minor followup to https://github.com/galaxyproject/galaxy/pull/18211. If we've got a MessageException I don't think we need to log this as an error, since we're also showing a reasonable message to the user.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
