### PR TITLE
[24.0] Raise ``RequestParameterInvalidException`` if url can't be verified

### DIFF
--- a/lib/galaxy/files/uris.py
+++ b/lib/galaxy/files/uris.py
@@ -6,6 +6,7 @@ import tempfile
 from typing import (
     List,
     Optional,
+    Tuple,
 )
 from urllib.parse import urlparse
 
@@ -78,6 +79,18 @@ def validate_uri_access(uri: str, is_admin: bool, ip_allowlist: List[IpAllowedLi
         raise AdminRequiredException()
 
 
+def split_port(parsed_url: str, url: str) -> Tuple[str, int]:
+    try:
+        idx = parsed_url.rindex(":")
+        # We parse as an int and let this fail ungracefully if parsing
+        # fails because we desire to fail closed rather than open.
+        port = int(parsed_url[idx + 1 :])
+        parsed_url = parsed_url[:idx]
+        return (parsed_url, port)
+    except Exception:
+        raise RequestParameterInvalidException(f"Could not verify url '{url}'.")
+
+
 def validate_non_local(uri: str, ip_allowlist: List[IpAllowedListEntryT]) -> str:
     # If it doesn't look like a URL, ignore it.
     if not (uri.lstrip().startswith("http://") or uri.lstrip().startswith("https://")):
@@ -106,22 +119,14 @@ def validate_non_local(uri: str, ip_allowlist: List[IpAllowedListEntryT]) -> str
             # However if it ends with a ']' then there is no port after it and
             # they've wrapped it in brackets just for fun.
             if "]" in parsed_url and not parsed_url.endswith("]"):
-                # If this +1 throws a range error, we don't care, their url
-                # shouldn't end with a colon.
-                idx = parsed_url.rindex(":")
-                # We parse as an int and let this fail ungracefully if parsing
-                # fails because we desire to fail closed rather than open.
-                port = int(parsed_url[idx + 1 :])
-                parsed_url = parsed_url[:idx]
+                parsed_url, port = split_port(parsed_url=parsed_url, url=url)
             else:
                 # Plain ipv6 without port
                 pass
         else:
             # This should finally be ipv4 with port. It cannot be IPv6 as that
             # was caught by earlier cases, and it cannot be due to credentials.
-            idx = parsed_url.rindex(":")
-            port = int(parsed_url[idx + 1 :])
-            parsed_url = parsed_url[:idx]
+            parsed_url, port = split_port(parsed_url=parsed_url, url=url)
 
     # safe to log out, no credentials/request path, just an IP + port
     log.debug("parsed url %s, port:  %s", parsed_url, port)


### PR DESCRIPTION
Kind of a followup to
https://github.com/galaxyproject/galaxy/pull/18155.

Fixes:
```
ValueError
invalid literal for int() with base 10: 'sequences'
```
For the attempted url `"http://emp-single-end-sequences:sequences"`.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
