### PR TITLE
[24.0] Don't set dataset peek for errored jobs

### DIFF
--- a/lib/galaxy/datatypes/molecules.py
+++ b/lib/galaxy/datatypes/molecules.py
@@ -1546,8 +1546,12 @@ class GRO(GenericMolFile):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
             dataset.peek = get_file_peek(dataset.get_file_name())
-            atom_number = int(dataset.peek.split("\n")[1])
-            dataset.blurb = f"{atom_number} atoms"
+            peek_lines = dataset.peek.split("\n")
+            try:
+                atom_number = int(peek_lines[1])
+                dataset.blurb = f"{atom_number} atoms"
+            except (ValueError, IndexError):
+                dataset.blurb = "file does not look like valid GRO file."
         else:
             dataset.peek = "file does not exist"
             dataset.blurb = "file purged from disk"

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1786,13 +1786,14 @@ class MinimalJobWrapper(HasResourceParameters):
                     working_directory=self.working_directory,
                     remote_metadata_directory=remote_metadata_directory,
                 )
-            line_count = context.get("line_count", None)
-            try:
-                # Certain datatype's set_peek methods contain a line_count argument
-                dataset.set_peek(line_count=line_count)
-            except TypeError:
-                # ... and others don't
-                dataset.set_peek()
+            if final_job_state != job.states.ERROR:
+                line_count = context.get("line_count", None)
+                try:
+                    # Certain datatype's set_peek methods contain a line_count argument
+                    dataset.set_peek(line_count=line_count)
+                except TypeError:
+                    # ... and others don't
+                    dataset.set_peek()
         else:
             # Handle purged datasets.
             dataset.blurb = "empty"

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1788,12 +1788,7 @@ class MinimalJobWrapper(HasResourceParameters):
                 )
             if final_job_state != job.states.ERROR:
                 line_count = context.get("line_count", None)
-                try:
-                    # Certain datatype's set_peek methods contain a line_count argument
-                    dataset.set_peek(line_count=line_count)
-                except TypeError:
-                    # ... and others don't
-                    dataset.set_peek()
+                dataset.set_peek(line_count=line_count)
         else:
             # Handle purged datasets.
             dataset.blurb = "empty"

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -506,12 +506,7 @@ def set_metadata_portable(
                     dataset.dataset.uuid = context["uuid"]
                 if not final_job_state == Job.states.ERROR:
                     line_count = context.get("line_count", None)
-                    try:
-                        # Certain datatype's set_peek methods contain a line_count argument
-                        dataset.set_peek(line_count=line_count)
-                    except TypeError:
-                        # ... and others don't
-                        dataset.set_peek()
+                    dataset.set_peek(line_count=line_count)
                 for context_key in TOOL_PROVIDED_JOB_METADATA_KEYS:
                     if context_key in context:
                         context_value = context[context_key]

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4652,8 +4652,16 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
             # extension is None
             return "data"
 
-    def set_peek(self, **kwd):
-        return self.datatype.set_peek(self, **kwd)
+    def set_peek(self, line_count=None, **kwd):
+        try:
+            # Certain datatype's set_peek methods contain a line_count argument
+            return self.datatype.set_peek(self, line_count=line_count, **kwd)
+        except TypeError:
+            # ... and others don't
+            return self.datatype.set_peek(self, **kwd)
+        except Exception:
+            # Never fail peek setting, but do log exception so datatype logic can be fixed
+            log.exception("Setting peek failed")
 
     def init_meta(self, copy_from=None):
         return self.datatype.init_meta(self, copy_from=copy_from)


### PR DESCRIPTION
This is consistent with the extended metadata logic, and prevents:
```
Message
Job wrapper finish method failed
Stack Trace

Newest

IndexError
list index out of range
```
which only makes it harder to diagnose the actual error, which in the
case of https://sentry.galaxyproject.org/share/issue/831261683ce642a4976efa20a9a0e55c/
is `\nslurmstepd: error: *** JOB 1910486 ON js2-gpu-small0 CANCELLED AT 2024-05-26T23:30:00 DUE TO TIME LIMIT ***\n`

Also merges line_count handling to common method, never fail further processing of the job if `set_peek` fails and fix gro set_peek method to produce a blurb indicating that the file is likely not a valid GRO file. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
