### PR TITLE
[24.0] Reset content-length for unhandled exceptions

### DIFF
--- a/lib/galaxy/web/framework/base.py
+++ b/lib/galaxy/web/framework/base.py
@@ -264,6 +264,7 @@ class WebApplication:
         except Exception as e:
             body = self.handle_controller_exception(e, trans, method, **kwargs)
             if not body:
+                trans.response.headers.pop("content-length", None)
                 raise
         body_renderer = body_renderer or self._render_body
         return body_renderer(trans, body, environ, start_response)


### PR DESCRIPTION
This prevents `ProtocolError` caused by the error middleware not being able to reset the content length. Only affects routes that explicitly set the content-length and don't have a default response handler.

This is effectively the case when using `web.expose`. To test this, make sure you get Galaxy's error middleware output in the browser and your console if you apply the diff below and navigate to http://127.0.0.1:8080/dataset/imp.
```diff
diff --git a/lib/galaxy/webapps/galaxy/controllers/dataset.py b/lib/galaxy/webapps/galaxy/controllers/dataset.py
index c95d9df788..92b04684d3 100644
--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -456,6 +456,8 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
     def imp(self, trans, dataset_id=None, **kwd):
         """Import another user's dataset via a shared URL; dataset is added to user's current history."""
         # Set referer message.
+        trans.response.headers["content-length"] = 0
+        trans = None
         referer = trans.request.referer
         if referer and not referer.startswith(f"{trans.request.application_url}{url_for('/login')}"):
             referer_message = f"<a href='{escape(referer)}'>return to the previous page</a>"

```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
