### PR TITLE
[24.0] Fix element serialization for collections that aren't populated yet

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/services/dataset_collections.py
@@ -273,7 +273,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
                     hdca_id=self.encode_id(hdca.id),
                     parent_id=self.encode_id(result["object"]["id"]),
                 )
-            else:
+            elif result["element_type"] == DCEType.hda:
                 result["object"]["accessible"] = self.hda_manager.is_accessible(dsc_element.element_object, trans.user)
             return result
 


### PR DESCRIPTION
Fixes
https://github.com/galaxyproject/galaxy/pull/17818#issuecomment-2134060961:
```
AttributeError
'NoneType' object has no attribute 'dataset'
```

MInor followup to #17818 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
