### PR TITLE
[24.0] Only log error if deleting directory really failed

### DIFF
--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -851,7 +851,12 @@ class DiskObjectStore(ConcreteObjectStore):
         except OSError as ex:
             # Likely a race condition in which we delete the job working directory
             # and another process writes files into that directory.
-            log.critical(f"{self.__get_filename(obj, **kwargs)} delete error {ex}", exc_info=True)
+            # If the path doesn't exist anymore, another rmtree call was successful.
+            path = self.__get_filename(obj, **kwargs)
+            if path is None:
+                return True
+            else:
+                log.critical(f"{path} delete error {ex}", exc_info=True)
         return False
 
     def _get_data(self, obj, start=0, count=-1, **kwargs):


### PR DESCRIPTION
If we can't look up the directory it's safe to assume it really is gone. Fixes `None delete error [Errno 39] Directory not empty: 'outputs_populated'`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
