### PR TITLE
[24.0] Fix userOwnsHistory conditions

### DIFF
--- a/client/src/api/index.test.ts
+++ b/client/src/api/index.test.ts
@@ -1,0 +1,113 @@
+import {
+    type AnonymousUser,
+    type AnyHistory,
+    type HistorySummary,
+    type HistorySummaryExtended,
+    isRegisteredUser,
+    type User,
+    userOwnsHistory,
+} from ".";
+
+const REGISTERED_USER_ID = "fake-user-id";
+const ANOTHER_USER_ID = "another-fake-user-id";
+const ANONYMOUS_USER_ID = null;
+
+const REGISTERED_USER: User = {
+    id: REGISTERED_USER_ID,
+    email: "test@mail.test",
+    tags_used: [],
+    isAnonymous: false,
+    total_disk_usage: 0,
+};
+
+const ANONYMOUS_USER: AnonymousUser = {
+    isAnonymous: true,
+};
+
+const SESSIONLESS_USER = null;
+
+function createFakeHistory<T>(historyId: string = "fake-id", user_id?: string | null): T {
+    const history: AnyHistory = {
+        id: historyId,
+        name: "test",
+        model_class: "History",
+        deleted: false,
+        archived: false,
+        purged: false,
+        published: false,
+        annotation: null,
+        update_time: "2021-09-01T00:00:00.000Z",
+        tags: [],
+        url: `/history/${historyId}`,
+        contents_active: { active: 0, deleted: 0, hidden: 0 },
+        count: 0,
+        size: 0,
+    };
+    if (user_id !== undefined) {
+        (history as HistorySummaryExtended).user_id = user_id;
+    }
+    return history as T;
+}
+
+const HISTORY_OWNED_BY_REGISTERED_USER = createFakeHistory<HistorySummaryExtended>("1234", REGISTERED_USER_ID);
+const HISTORY_OWNED_BY_ANOTHER_USER = createFakeHistory<HistorySummaryExtended>("5678", ANOTHER_USER_ID);
+const HISTORY_OWNED_BY_ANONYMOUS_USER = createFakeHistory<HistorySummaryExtended>("1234", ANONYMOUS_USER_ID);
+const HISTORY_SUMMARY_WITHOUT_USER_ID = createFakeHistory<HistorySummary>("1234");
+
+describe("API Types Helpers", () => {
+    describe("isRegisteredUser", () => {
+        it("should return true for a registered user", () => {
+            expect(isRegisteredUser(REGISTERED_USER)).toBe(true);
+        });
+
+        it("should return false for an anonymous user", () => {
+            expect(isRegisteredUser(ANONYMOUS_USER)).toBe(false);
+        });
+
+        it("should return false for sessionless users", () => {
+            expect(isRegisteredUser(SESSIONLESS_USER)).toBe(false);
+        });
+    });
+
+    describe("isAnonymousUser", () => {
+        it("should return true for an anonymous user", () => {
+            expect(isRegisteredUser(ANONYMOUS_USER)).toBe(false);
+        });
+
+        it("should return false for a registered user", () => {
+            expect(isRegisteredUser(REGISTERED_USER)).toBe(true);
+        });
+
+        it("should return false for sessionless users", () => {
+            expect(isRegisteredUser(SESSIONLESS_USER)).toBe(false);
+        });
+    });
+
+    describe("userOwnsHistory", () => {
+        it("should return true for a registered user owning the history", () => {
+            expect(userOwnsHistory(REGISTERED_USER, HISTORY_OWNED_BY_REGISTERED_USER)).toBe(true);
+        });
+
+        it("should return false for a registered user not owning the history", () => {
+            expect(userOwnsHistory(REGISTERED_USER, HISTORY_OWNED_BY_ANOTHER_USER)).toBe(false);
+        });
+
+        it("should return true for a registered user owning a history without user_id", () => {
+            expect(userOwnsHistory(REGISTERED_USER, HISTORY_SUMMARY_WITHOUT_USER_ID)).toBe(true);
+        });
+
+        it("should return true for an anonymous user owning a history with null user_id", () => {
+            expect(userOwnsHistory(ANONYMOUS_USER, HISTORY_OWNED_BY_ANONYMOUS_USER)).toBe(true);
+        });
+
+        it("should return false for an anonymous user not owning a history", () => {
+            expect(userOwnsHistory(ANONYMOUS_USER, HISTORY_OWNED_BY_REGISTERED_USER)).toBe(false);
+        });
+
+        it("should return false for sessionless users", () => {
+            expect(userOwnsHistory(SESSIONLESS_USER, HISTORY_OWNED_BY_REGISTERED_USER)).toBe(false);
+            expect(userOwnsHistory(SESSIONLESS_USER, HISTORY_SUMMARY_WITHOUT_USER_ID)).toBe(false);
+            expect(userOwnsHistory(SESSIONLESS_USER, HISTORY_OWNED_BY_ANONYMOUS_USER)).toBe(false);
+        });
+    });
+});

--- a/client/src/components/History/Modals/SelectorModal.test.js
+++ b/client/src/components/History/Modals/SelectorModal.test.js
@@ -7,6 +7,8 @@ import { createPinia } from "pinia";
 import { useHistoryStore } from "stores/historyStore";
 import { getLocalVue } from "tests/jest/helpers";
 
+import { useUserStore } from "@/stores/userStore";
+
 import SelectorModal from "./SelectorModal";
 
 const localVue = getLocalVue();
@@ -35,6 +37,14 @@ const PROPS_FOR_MODAL_MULTIPLE_SELECT = {
 
 const CURRENT_HISTORY_INDICATION_TEXT = "(Current)";
 
+const CURRENT_USER = {
+    email: "email",
+    id: "user_id",
+    tags_used: [],
+    isAnonymous: false,
+    total_disk_usage: 0,
+};
+
 describe("History SelectorModal.vue", () => {
     let wrapper;
     let axiosMock;
@@ -60,6 +70,10 @@ describe("History SelectorModal.vue", () => {
                 icon: { template: "<div></div>" },
             },
         });
+
+        const userStore = useUserStore();
+        userStore.setCurrentUser(CURRENT_USER);
+
         historyStore = useHistoryStore();
         axiosMock = new MockAdapter(axios);
         getUpdatedAxiosMock();


### PR DESCRIPTION
The conditions for `userOwnsHistory` and `isRegisteredUser` were not covering all edge cases. Adding tests uncovered some additional typing and logic errors too.

This was detected while using `userOwnsHistory` more broadly in #18234 

#18234 includes these changes but targets 24.1 I thought it would be better to backport this fix.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
