### PR TITLE
[24.1] Change `ActivityPanel` go to button to primary

### DIFF
--- a/client/src/components/Panels/ActivityPanel.vue
+++ b/client/src/components/Panels/ActivityPanel.vue
@@ -39,6 +39,7 @@ const hasGoToAll = computed(
             <BButton
                 v-if="hasGoToAll"
                 class="activity-panel-footer"
+                variant="primary"
                 :data-description="`props.mainButtonText button`"
                 :to="props.href"
                 size="sm"


### PR DESCRIPTION
Tiny change that reverts the button's color to primary

| Before | After |
| ---- | ---- |
| ![go_to_btn_secondary](https://github.com/galaxyproject/galaxy/assets/78516064/36277f74-c960-4f95-86f6-ab42917d4816) | ![go_to_btn_primary](https://github.com/galaxyproject/galaxy/assets/78516064/ba101486-5792-469d-9a6e-ac3ee429b301) |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
