### PR TITLE
[24.1] Fix history export error handling

### DIFF
--- a/client/src/components/History/Export/HistoryExport.test.ts
+++ b/client/src/components/History/Export/HistoryExport.test.ts
@@ -147,4 +147,25 @@ describe("HistoryExport.vue", () => {
 
         expect(wrapper.find("#zenodo-file-source-tab").exists()).toBe(true);
     });
+
+    it("should not display a fatal error alert if the history is found and loaded", async () => {
+        const wrapper = await mountHistoryExport();
+
+        expect(wrapper.find("#fatal-error-alert").exists()).toBe(false);
+
+        expect(wrapper.find("#history-name").exists()).toBe(true);
+        expect(wrapper.find("#history-export-options").exists()).toBe(true);
+        expect(wrapper.find("#direct-download-tab").exists()).toBe(true);
+    });
+
+    it("should not render the UI and display a fatal error message if the history cannot be found or loaded", async () => {
+        axiosMock.onGet(FAKE_HISTORY_URL).reply(404);
+        const wrapper = await mountHistoryExport();
+
+        expect(wrapper.find("#fatal-error-alert").exists()).toBe(true);
+
+        expect(wrapper.find("#history-name").exists()).toBe(false);
+        expect(wrapper.find("#history-export-options").exists()).toBe(false);
+        expect(wrapper.find("#direct-download-tab").exists()).toBe(false);
+    });
 });

--- a/client/src/components/History/Export/HistoryExport.test.ts
+++ b/client/src/components/History/Export/HistoryExport.test.ts
@@ -1,6 +1,8 @@
 import { createTestingPinia } from "@pinia/testing";
 import { getLocalVue } from "@tests/jest/helpers";
 import { shallowMount } from "@vue/test-utils";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
 import flushPromises from "flush-promises";
 import { setActivePinia } from "pinia";
 
@@ -13,7 +15,6 @@ import {
     FILE_SOURCE_STORE_RECORD,
     RECENT_STS_DOWNLOAD_RECORD,
 } from "@/components/Common/models/testData/exportData";
-import { useHistoryStore } from "@/stores/historyStore";
 
 import HistoryExport from "./HistoryExport.vue";
 
@@ -25,9 +26,20 @@ const mockFetchExportRecords = fetchHistoryExportRecords as jest.MockedFunction<
 mockFetchExportRecords.mockResolvedValue([]);
 
 const FAKE_HISTORY_ID = "fake-history-id";
-const FAKE_HISTORY = {
+const FAKE_HISTORY_URL = `/api/histories/${FAKE_HISTORY_ID}`;
+const FAKE_HISTORY: HistorySummary = {
     id: FAKE_HISTORY_ID,
     name: "fake-history-name",
+    annotation: "fake-history-annotation",
+    archived: false,
+    deleted: false,
+    purged: false,
+    published: false,
+    model_class: "History",
+    tags: [],
+    count: 0,
+    update_time: "2021-09-01T00:00:00.000Z",
+    url: FAKE_HISTORY_URL,
 };
 
 const REMOTE_FILES_API_ENDPOINT = new RegExp("/api/remote_files/plugins");
@@ -48,13 +60,6 @@ const REMOTE_FILES_API_RESPONSE: FilesSourcePlugin[] = [
 async function mountHistoryExport() {
     const pinia = createTestingPinia({ stubActions: false });
     setActivePinia(pinia);
-    const historyStore = useHistoryStore(pinia);
-
-    // the mocking method described in the pinia docs does not work in vue2
-    // this is a work-around
-    jest.spyOn(historyStore, "getHistoryById").mockImplementation(
-        (_history_id: string) => FAKE_HISTORY as HistorySummary
-    );
 
     const wrapper = shallowMount(HistoryExport as object, {
         propsData: { historyId: FAKE_HISTORY_ID },
@@ -66,8 +71,12 @@ async function mountHistoryExport() {
 }
 
 describe("HistoryExport.vue", () => {
+    let axiosMock: MockAdapter;
+
     beforeEach(async () => {
         mockFetcher.path(REMOTE_FILES_API_ENDPOINT).method("get").mock({ data: [] });
+        axiosMock = new MockAdapter(axios);
+        axiosMock.onGet(FAKE_HISTORY_URL).reply(200, FAKE_HISTORY);
     });
 
     it("should render the history name", async () => {

--- a/client/src/components/History/Export/HistoryExport.vue
+++ b/client/src/components/History/Export/HistoryExport.vue
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BButton, BCard, BTab, BTabs } from "bootstrap-vue";
 import { computed, onMounted, ref, watch } from "vue";
 
+import type { AnyHistory } from "@/api";
 import {
     exportHistoryToFileSource,
     fetchHistoryExportRecords,
@@ -62,6 +63,8 @@ const POLLING_DELAY = 3000;
 const exportParams = ref(DEFAULT_EXPORT_PARAMS);
 const isLoadingRecords = ref(true);
 const exportRecords = ref<ExportRecord[]>([]);
+const history = ref<AnyHistory>();
+const isLoadingHistory = ref(true);
 
 const historyName = computed(() => history.value?.name ?? props.historyId);
 const defaultFileName = computed(() => `(Galaxy History) ${historyName.value}`);
@@ -84,18 +87,16 @@ const availableRecordsMessage = computed(() =>
 
 const historyStore = useHistoryStore();
 
-const history = computed(() => {
-    const history = historyStore.getHistoryById(props.historyId);
-    return history;
-});
-
-const errorMessage = ref<string | undefined>(undefined);
-const actionMessage = ref<string | undefined>(undefined);
-const actionMessageVariant = ref<ColorVariant | undefined>(undefined);
+const isFatalError = ref(false);
+const errorMessage = ref<string>();
+const actionMessage = ref<string>();
+const actionMessageVariant = ref<ColorVariant>();
 const zenodoSource = computed(() => getFileSourceById("zenodo"));
 
 onMounted(async () => {
-    updateExports();
+    if (await loadHistory()) {
+        updateExports();
+    }
 });
 
 watch(isExportTaskRunning, (newValue, oldValue) => {
@@ -104,6 +105,22 @@ watch(isExportTaskRunning, (newValue, oldValue) => {
         updateExports();
     }
 });
+
+async function loadHistory() {
+    isLoadingHistory.value = true;
+    try {
+        history.value =
+            historyStore.getHistoryById(props.historyId, false) ??
+            (await historyStore.loadHistoryById(props.historyId));
+        return true;
+    } catch (error) {
+        errorMessage.value = errorMessageAsString(error);
+        isFatalError.value = true;
+        return false;
+    } finally {
+        isLoadingHistory.value = false;
+    }
+}
 
 async function updateExports() {
     isLoadingRecords.value = true;
@@ -159,16 +176,15 @@ async function reimportFromRecord(record: ExportRecord) {
         `Do you really want to import a new copy of this history exported ${record.elapsedTime}?`
     );
     if (confirmed) {
-        reimportHistoryFromRecord(record)
-            .then(() => {
-                actionMessageVariant.value = "info";
-                actionMessage.value =
-                    "The history is being imported in the background. Check your histories after a while to find it.";
-            })
-            .catch((reason) => {
-                actionMessageVariant.value = "danger";
-                actionMessage.value = reason;
-            });
+        try {
+            await reimportHistoryFromRecord(record);
+            actionMessageVariant.value = "info";
+            actionMessage.value =
+                "The history is being imported in the background. Check your histories after a while to find it.";
+        } catch (error) {
+            actionMessageVariant.value = "danger";
+            actionMessage.value = errorMessageAsString(error);
+        }
     }
 }
 
@@ -188,140 +204,150 @@ function updateExportParams(newParams: ExportParams) {
         <FontAwesomeIcon icon="file-export" size="2x" class="text-primary float-left mr-2" />
         <h1 class="h-lg">
             Export
-            <LoadingSpan v-if="!history" spinner-only />
+            <b v-if="isFatalError" class="text-danger">Error</b>
+            <LoadingSpan v-else-if="!history" spinner-only />
             <b v-else id="history-name">{{ historyName }}</b>
         </h1>
 
-        <ExportOptions
-            id="history-export-options"
-            class="mt-3"
-            :export-params="exportParams"
-            @onValueChanged="updateExportParams" />
-
-        <h2 class="h-md mt-3">How do you want to export this history?</h2>
-        <BCard no-body class="mt-3">
-            <BTabs pills card vertical>
-                <BTab id="direct-download-tab" title="to direct download" title-link-class="tab-export-to-link" active>
-                    <p>
-                        Here you can generate a temporal download for your history. When your download link expires or
-                        your history changes you can re-generate it again.
-                    </p>
-
-                    <BAlert show variant="warning">
-                        History archive downloads can expire and are removed at regular intervals. For permanent
-                        storage, export to a <b>remote file</b> or download and then import the archive on another
-                        Galaxy server.
-                    </BAlert>
-
-                    <BButton
-                        class="gen-direct-download-btn"
-                        :disabled="!canGenerateDownload"
-                        variant="primary"
-                        @click="prepareDownload">
-                        Generate direct download
-                    </BButton>
-
-                    <span v-if="isPreparingDownload">
-                        <LoadingSpan message="Galaxy is preparing your download, this will likely take a while" />
-                    </span>
-                    <BAlert v-else-if="isLatestExportRecordReadyToDownload" variant="success" class="mt-3" show>
-                        The latest export record is ready. Use the download button below to download it or change the
-                        advanced export options above to generate a new one.
-                    </BAlert>
-                </BTab>
-                <BTab
-                    v-if="hasWritableFileSources"
-                    id="file-source-tab"
-                    title="to remote file"
-                    title-link-class="tab-export-to-file">
-                    <p>
-                        If you need a "more permanent" way of storing your history archive you can export it directly to
-                        one of the available remote file sources here. You will be able to re-import it later as long as
-                        it remains available on the remote server.
-                    </p>
-
-                    <ExportToFileSourceForm
-                        what="history"
-                        :clear-input-after-export="true"
-                        @export="doExportToFileSource" />
-                </BTab>
-                <BTab
-                    v-if="hasWritableRDMFileSources"
-                    id="rdm-file-source-tab"
-                    title="to RDM repository"
-                    title-link-class="tab-export-to-rdm-repo">
-                    <p>You can <b>upload your history</b> to one of the available RDM repositories here.</p>
-
-                    <RDMCredentialsInfo what="history export archive" />
-
-                    <ExportToRDMRepositoryForm
-                        what="history"
-                        :default-filename="defaultFileName"
-                        :default-record-name="historyName"
-                        :clear-input-after-export="true"
-                        @export="doExportToFileSource" />
-                </BTab>
-                <BTab
-                    v-if="zenodoSource"
-                    id="zenodo-file-source-tab"
-                    title="to ZENODO"
-                    title-link-class="tab-export-to-zenodo-repo">
-                    <div class="zenodo-info">
-                        <img
-                            src="https://raw.githubusercontent.com/zenodo/zenodo/master/zenodo/modules/theme/static/img/logos/zenodo-gradient-square.svg"
-                            alt="ZENODO Logo" />
-                        <p>
-                            <ExternalLink href="https://zenodo.org"><b>Zenodo</b></ExternalLink> is a general-purpose
-                            open repository developed under the
-                            <ExternalLink href="https://www.openaire.eu">European OpenAIRE</ExternalLink> program and
-                            operated by <ExternalLink href="https://home.cern">CERN</ExternalLink>. It allows
-                            researchers to deposit research papers, data sets, research software, reports, and any other
-                            research related digital artefacts. For each submission, a persistent
-                            <b>digital object identifier (DOI)</b> is minted, which makes the stored items easily
-                            citeable.
-                        </p>
-                    </div>
-
-                    <RDMCredentialsInfo what="history export archive" selected-repository="ZENODO" />
-                    <ExportToRDMRepositoryForm
-                        what="history"
-                        :default-filename="defaultFileName"
-                        :default-record-name="historyName"
-                        :clear-input-after-export="true"
-                        :file-source="zenodoSource"
-                        @export="doExportToFileSource">
-                    </ExportToRDMRepositoryForm>
-                </BTab>
-            </BTabs>
-        </BCard>
-
-        <BAlert v-if="errorMessage" id="last-export-record-error-alert" variant="danger" class="mt-3" show>
+        <BAlert v-if="isFatalError" id="fatal-error-alert" variant="danger" class="mt-3" show>
             {{ errorMessage }}
         </BAlert>
-        <div v-else-if="latestExportRecord">
-            <h2 class="h-md mt-3">Export Records</h2>
-            <BCard>
-                <ExportRecordDetails
-                    :record="latestExportRecord"
-                    object-type="history"
-                    :action-message="actionMessage"
-                    :action-message-variant="actionMessageVariant"
-                    @onDownload="downloadFromRecord"
-                    @onCopyDownloadLink="copyDownloadLinkFromRecord"
-                    @onReimport="reimportFromRecord"
-                    @onActionMessageDismissed="onActionMessageDismissedFromRecord" />
-                <ExportRecordTable
-                    v-if="hasPreviousExports"
-                    id="previous-export-records"
-                    :records="previousExportRecords"
-                    class="mt-3"
-                    @onDownload="downloadFromRecord"
-                    @onReimport="reimportFromRecord" />
+        <div v-if="history">
+            <ExportOptions
+                id="history-export-options"
+                class="mt-3"
+                :export-params="exportParams"
+                @onValueChanged="updateExportParams" />
+
+            <h2 class="h-md mt-3">How do you want to export this history?</h2>
+            <BCard no-body class="mt-3">
+                <BTabs pills card vertical>
+                    <BTab
+                        id="direct-download-tab"
+                        title="to direct download"
+                        title-link-class="tab-export-to-link"
+                        active>
+                        <p>
+                            Here you can generate a temporal download for your history. When your download link expires
+                            or your history changes you can re-generate it again.
+                        </p>
+
+                        <BAlert show variant="warning">
+                            History archive downloads can expire and are removed at regular intervals. For permanent
+                            storage, export to a <b>remote file</b> or download and then import the archive on another
+                            Galaxy server.
+                        </BAlert>
+
+                        <BButton
+                            class="gen-direct-download-btn"
+                            :disabled="!canGenerateDownload"
+                            variant="primary"
+                            @click="prepareDownload">
+                            Generate direct download
+                        </BButton>
+
+                        <span v-if="isPreparingDownload">
+                            <LoadingSpan message="Galaxy is preparing your download, this will likely take a while" />
+                        </span>
+                        <BAlert v-else-if="isLatestExportRecordReadyToDownload" variant="success" class="mt-3" show>
+                            The latest export record is ready. Use the download button below to download it or change
+                            the advanced export options above to generate a new one.
+                        </BAlert>
+                    </BTab>
+                    <BTab
+                        v-if="hasWritableFileSources"
+                        id="file-source-tab"
+                        title="to remote file"
+                        title-link-class="tab-export-to-file">
+                        <p>
+                            If you need a "more permanent" way of storing your history archive you can export it
+                            directly to one of the available remote file sources here. You will be able to re-import it
+                            later as long as it remains available on the remote server.
+                        </p>
+
+                        <ExportToFileSourceForm
+                            what="history"
+                            :clear-input-after-export="true"
+                            @export="doExportToFileSource" />
+                    </BTab>
+                    <BTab
+                        v-if="hasWritableRDMFileSources"
+                        id="rdm-file-source-tab"
+                        title="to RDM repository"
+                        title-link-class="tab-export-to-rdm-repo">
+                        <p>You can <b>upload your history</b> to one of the available RDM repositories here.</p>
+
+                        <RDMCredentialsInfo what="history export archive" />
+
+                        <ExportToRDMRepositoryForm
+                            what="history"
+                            :default-filename="defaultFileName"
+                            :default-record-name="historyName"
+                            :clear-input-after-export="true"
+                            @export="doExportToFileSource" />
+                    </BTab>
+                    <BTab
+                        v-if="zenodoSource"
+                        id="zenodo-file-source-tab"
+                        title="to ZENODO"
+                        title-link-class="tab-export-to-zenodo-repo">
+                        <div class="zenodo-info">
+                            <img
+                                src="https://raw.githubusercontent.com/zenodo/zenodo/master/zenodo/modules/theme/static/img/logos/zenodo-gradient-square.svg"
+                                alt="ZENODO Logo" />
+                            <p>
+                                <ExternalLink href="https://zenodo.org"><b>Zenodo</b></ExternalLink> is a
+                                general-purpose open repository developed under the
+                                <ExternalLink href="https://www.openaire.eu">European OpenAIRE</ExternalLink> program
+                                and operated by <ExternalLink href="https://home.cern">CERN</ExternalLink>. It allows
+                                researchers to deposit research papers, data sets, research software, reports, and any
+                                other research related digital artefacts. For each submission, a persistent
+                                <b>digital object identifier (DOI)</b> is minted, which makes the stored items easily
+                                citeable.
+                            </p>
+                        </div>
+
+                        <RDMCredentialsInfo what="history export archive" selected-repository="ZENODO" />
+                        <ExportToRDMRepositoryForm
+                            what="history"
+                            :default-filename="defaultFileName"
+                            :default-record-name="historyName"
+                            :clear-input-after-export="true"
+                            :file-source="zenodoSource"
+                            @export="doExportToFileSource">
+                        </ExportToRDMRepositoryForm>
+                    </BTab>
+                </BTabs>
             </BCard>
+
+            <BAlert v-if="errorMessage" id="last-export-record-error-alert" variant="danger" class="mt-3" show>
+                {{ errorMessage }}
+            </BAlert>
+            <div v-else-if="latestExportRecord">
+                <h2 class="h-md mt-3">Export Records</h2>
+                <BCard>
+                    <ExportRecordDetails
+                        :record="latestExportRecord"
+                        object-type="history"
+                        :action-message="actionMessage"
+                        :action-message-variant="actionMessageVariant"
+                        @onDownload="downloadFromRecord"
+                        @onCopyDownloadLink="copyDownloadLinkFromRecord"
+                        @onReimport="reimportFromRecord"
+                        @onActionMessageDismissed="onActionMessageDismissedFromRecord" />
+                    <ExportRecordTable
+                        v-if="hasPreviousExports"
+                        id="previous-export-records"
+                        :records="previousExportRecords"
+                        class="mt-3"
+                        @onDownload="downloadFromRecord"
+                        @onReimport="reimportFromRecord" />
+                </BCard>
+            </div>
+            <BAlert v-else id="no-export-records-alert" variant="info" class="mt-3" show>
+                {{ availableRecordsMessage }}
+            </BAlert>
         </div>
-        <BAlert v-else id="no-export-records-alert" variant="info" class="mt-3" show>
-            {{ availableRecordsMessage }}
-        </BAlert>
     </span>
 </template>
 

--- a/client/src/store/historyStore/model/watchHistory.test.js
+++ b/client/src/store/historyStore/model/watchHistory.test.js
@@ -93,7 +93,7 @@ describe("watchHistory", () => {
             await watchHistoryOnce();
         } catch (error) {
             console.log(error);
-            expect(error.response.status).toBe(500);
+            expect(error.message).toContain("500");
         }
         // Need to reset axios mock here. Smells like a bug,
         // maybe in axios-mock-adapter, maybe on our side

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -73,10 +73,12 @@ export const useHistoryStore = defineStore("historyStore", () => {
         }
     });
 
-    /** Returns history from storedHistories, will load history if not in store */
+    /** Returns history from storedHistories, will load history if not in store by default.
+     * If shouldFetchIfMissing is false, will return null if history is not in store.
+     */
     const getHistoryById = computed(() => {
-        return (historyId: string) => {
-            if (!storedHistories.value[historyId]) {
+        return (historyId: string, shouldFetchIfMissing = true) => {
+            if (!storedHistories.value[historyId] && shouldFetchIfMissing) {
                 // TODO: Try to remove this as it can cause computed side effects
                 loadHistoryById(historyId);
             }

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -24,6 +24,7 @@ import {
     setCurrentHistoryOnServer,
     updateHistoryFields,
 } from "@/stores/services/history.services";
+import { rethrowSimple } from "@/utils/simple-error";
 import { sortByObjectProp } from "@/utils/sorting";
 
 const PAGINATION_LIMIT = 10;
@@ -209,7 +210,7 @@ export const useHistoryStore = defineStore("historyStore", () => {
             selectHistory(history);
             return history;
         } catch (error) {
-            console.error(error);
+            rethrowSimple(error);
         }
     }
 
@@ -257,7 +258,7 @@ export const useHistoryStore = defineStore("historyStore", () => {
                     await handleTotalCountChange(histories.length);
                 }
             } catch (error) {
-                console.error(error);
+                rethrowSimple(error);
             } finally {
                 setHistoriesLoading(false);
             }
@@ -272,7 +273,7 @@ export const useHistoryStore = defineStore("historyStore", () => {
                 setHistory(history);
                 return history;
             } catch (error) {
-                console.error(error);
+                rethrowSimple(error);
             } finally {
                 isLoadingHistory.delete(historyId);
             }
@@ -321,7 +322,7 @@ export const useHistoryStore = defineStore("historyStore", () => {
             setHistory(contentStats);
             return contentStats;
         } catch (error) {
-            console.error(error);
+            rethrowSimple(error);
         }
     }
 


### PR DESCRIPTION
Fixes #18238

It does change a bit how we handle errors in `historyStore.ts` to rethrow instead of just logging into the console.

| Before | After |
|--------|-------|
| ![image](https://github.com/galaxyproject/galaxy/assets/46503462/318c1ca0-442a-44cb-8c0b-c394adc6fdc9)   | ![image](https://github.com/galaxyproject/galaxy/assets/46503462/9ebb4e48-4acf-42a5-8312-7584d06dd4d1)  |






## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
