### PR TITLE
[24.1] Remove linter for unstripped text content for tool xml leaves

### DIFF
--- a/lib/galaxy/tool_util/linters/general.py
+++ b/lib/galaxy/tool_util/linters/general.py
@@ -231,23 +231,6 @@ class ResourceRequirementExpression(Linter):
                 )
 
 
-class TextSpaces(Linter):
-    @classmethod
-    def lint(cls, tool_source: "ToolSource", lint_ctx: "LintContext"):
-        _, tool_node = _tool_xml_and_root(tool_source)
-        if not tool_node:
-            return
-        for node in tool_node.iter():
-            if len(node) > 0:
-                continue
-            if node.text and node.text != node.text.strip():
-                lint_ctx.warn(
-                    f"XML node '{node.tag}' has text with leading or trailing spaces ('{node.text}'!='{node.text.strip()}').",
-                    linter=cls.name(),
-                    node=node,
-                )
-
-
 class BioToolsValid(Linter):
     @classmethod
     def lint(cls, tool_source: "ToolSource", lint_ctx: "LintContext"):

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -7861,7 +7861,7 @@ A tool can have any number of EDAM topic references.
     <xs:sequence>
       <xs:element name="edam_topic" minOccurs="0" maxOccurs="unbounded">
         <xs:simpleType>
-          <xs:restriction base="xs:string">
+          <xs:restriction base="singleLineString">
             <xs:pattern value="topic_[0-9]{4}"></xs:pattern>
           </xs:restriction>
         </xs:simpleType>
@@ -7886,7 +7886,7 @@ A tool can have any number of EDAM operation references.
     <xs:sequence>
       <xs:element name="edam_operation" minOccurs="0" maxOccurs="unbounded">
         <xs:simpleType>
-          <xs:restriction base="xs:string">
+          <xs:restriction base="singleLineString">
             <xs:pattern value="operation_[0-9]{4}"></xs:pattern>
           </xs:restriction>
         </xs:simpleType>
@@ -7921,7 +7921,7 @@ A tool can refer multiple reference IDs.
 information according to a catalog.</xs:documentation>
     </xs:annotation>
     <xs:simpleContent>
-      <xs:extension base="xs:string">
+      <xs:extension base="singleLineString">
         <xs:attribute name="type" type="xrefType" use="required">
           <xs:annotation>
             <xs:documentation xml:lang="en">Type of reference - currently ``bio.tools``, ``bioconductor``, and ``biii`` are
@@ -7944,8 +7944,17 @@ the only supported options.</xs:documentation>
   </xs:simpleType>
 
   <xs:simpleType name="MacroImportType">
-    <xs:restriction base="xs:string">
+    <xs:restriction base="singleLineString">
       <xs:pattern value="[a-zA-Z0-9_\-\.]+.xml"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="singleLineString">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">A string without newline characters.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:whiteSpace value="collapse"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -120,16 +120,6 @@ GENERAL_VALID_NEW_PROFILE_FMT = """
 </tool>
 """
 
-GENERAL_TEXT_SPACES = """
-<tool name="valid name" id="valid_id" version="1.0+galaxy1" profile="21.09">
-    <xrefs>
-        <xref type="bio.tools">
-            bwa
-        </xref>
-    </xrefs>
-</tool>
-"""
-
 GENERAL_VALID_BIOTOOLS = """
 <tool name="valid name" id="valid_id" version="1.0+galaxy1" profile="23.0">
     <xrefs>
@@ -1105,19 +1095,6 @@ def test_general_valid_new_profile_fmt(lint_ctx):
     assert not lint_ctx.info_messages
     assert len(lint_ctx.valid_messages) == 4
     assert not lint_ctx.warn_messages
-    assert not lint_ctx.error_messages
-
-
-def test_general_text_spaces(lint_ctx):
-    tool_source = get_xml_tool_source(GENERAL_TEXT_SPACES)
-    run_lint_module(lint_ctx, general, tool_source)
-    assert (
-        "XML node 'xref' has text with leading or trailing spaces ('\n            bwa\n        '!='bwa')"
-        in lint_ctx.warn_messages
-    )
-    assert not lint_ctx.info_messages
-    assert len(lint_ctx.valid_messages) == 4
-    assert len(lint_ctx.warn_messages) == 1
     assert not lint_ctx.error_messages
 
 
@@ -2168,7 +2145,7 @@ def test_skip_by_module(lint_ctx):
 def test_list_linters():
     linter_names = Linter.list_listers()
     # make sure to add/remove a test for new/removed linters if this number changes
-    assert len(linter_names) == 133
+    assert len(linter_names) == 132
     assert "Linter" not in linter_names
     # make sure that linters from all modules are available
     for prefix in [


### PR DESCRIPTION
reverts #17656

we have to many xml nodes where this is allowed (e.g. command) and limiting the linter to a statically defined list of node types seemed difficult to maintain

replaced this with a change in the xsd that should lead to the automatic removal of surplus white spaces (leading/trailing are removed, multiple whitespaces are replaced by a single space) for some of the node types that were the original motivation for the linter (if this proves useful this could be used for more node types).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
