### PR TITLE
[24.0] Fix Invenio credentials handling

### DIFF
--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -7,7 +7,6 @@ from typing import (
 
 from typing_extensions import Unpack
 
-from galaxy.exceptions import AuthenticationRequired
 from galaxy.files import ProvidesUserFileSourcesUserContext
 from galaxy.files.sources import (
     BaseFilesSource,
@@ -193,15 +192,11 @@ class RDMFilesSource(BaseFilesSource):
             effective_props[key] = self._evaluate_prop(val, user_context=user_context)
         return effective_props
 
-    def get_authorization_token(self, user_context: OptionalUserContext) -> str:
+    def get_authorization_token(self, user_context: OptionalUserContext) -> Optional[str]:
         token = None
         if user_context:
             effective_props = self._serialization_props(user_context)
             token = effective_props.get("token")
-        if not token:
-            raise AuthenticationRequired(
-                f"Please provide a personal access token in your user's preferences for '{self.label}'"
-            )
         return token
 
     def get_public_name(self, user_context: OptionalUserContext) -> Optional[str]:

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -217,12 +217,7 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
             },
         }
 
-        headers = self._get_request_headers(user_context)
-        if "Authorization" not in headers:
-            raise Exception(
-                "Cannot create record without authentication token. Please set your personal access token in your Galaxy preferences."
-            )
-
+        headers = self._get_request_headers(user_context, auth_required=True)
         response = requests.post(self.records_url, json=create_record_request, headers=headers)
         self._ensure_response_has_expected_status_code(response, 201)
         record = response.json()
@@ -238,7 +233,7 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
     ):
         record = self._get_draft_record(record_id, user_context=user_context)
         upload_file_url = record["links"]["files"]
-        headers = self._get_request_headers(user_context)
+        headers = self._get_request_headers(user_context, auth_required=True)
 
         # Add file metadata entry
         response = requests.post(upload_file_url, json=[{"key": filename}], headers=headers)
@@ -394,27 +389,37 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         }
 
     def _get_response(
-        self, user_context: OptionalUserContext, request_url: str, params: Optional[Dict[str, Any]] = None
+        self,
+        user_context: OptionalUserContext,
+        request_url: str,
+        params: Optional[Dict[str, Any]] = None,
+        auth_required: bool = False,
     ) -> dict:
-        headers = self._get_request_headers(user_context)
+        headers = self._get_request_headers(user_context, auth_required)
         response = requests.get(request_url, params=params, headers=headers)
         self._ensure_response_has_expected_status_code(response, 200)
         return response.json()
 
-    def _get_request_headers(self, user_context: OptionalUserContext):
+    def _get_request_headers(self, user_context: OptionalUserContext, auth_required: bool = False):
         token = self.plugin.get_authorization_token(user_context)
         headers = {"Authorization": f"Bearer {token}"} if token else {}
+        if auth_required and token is None:
+            self._raise_auth_required()
         return headers
 
     def _ensure_response_has_expected_status_code(self, response, expected_status_code: int):
-        if response.status_code == 403:
-            record_url = response.url.replace("/api", "").replace("/files", "")
-            raise AuthenticationRequired(f"Please make sure you have the necessary permissions to access: {record_url}")
         if response.status_code != expected_status_code:
+            if response.status_code == 403:
+                self._raise_auth_required()
             error_message = self._get_response_error_message(response)
             raise Exception(
                 f"Request to {response.url} failed with status code {response.status_code}: {error_message}"
             )
+
+    def _raise_auth_required(self):
+        raise AuthenticationRequired(
+            f"Please provide a personal access token in your user's preferences for '{self.plugin.label}'"
+        )
 
     def _get_response_error_message(self, response):
         response_json = response.json()


### PR DESCRIPTION
This fixes a regression introduced in #17997 where the user is forced to introduce credentials for Invenio/Zenodo even when just browsing public records.

The credentials are now required only for write operations.

| Before | After |
|--------|-------|
| ![image](https://github.com/galaxyproject/galaxy/assets/46503462/fb06fa1c-dac2-461d-8782-a6c4f2ede72e)   | ![Screenshot from 2024-05-29 16-40-28](https://github.com/galaxyproject/galaxy/assets/46503462/8f45efd9-628c-4c1f-a900-cab90b2aa698)  |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Without setting up your token in the preferences or as an anonymous user
  - Go to `Upload` -> `Choose remote files` -> select an Invenio based file source
  - You should be able to see the records instead of the error message

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
