### PR TITLE
Move history multiview item actions to top

### DIFF
--- a/client/src/components/Grid/configs/histories.ts
+++ b/client/src/components/Grid/configs/histories.ts
@@ -1,4 +1,5 @@
 import {
+    faBurn,
     faExchangeAlt,
     faEye,
     faPlus,
@@ -10,7 +11,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { useEventBus } from "@vueuse/core";
 
-import { deleteHistories, deleteHistory, historiesFetcher, undeleteHistories, undeleteHistory } from "@/api/histories";
+import { historiesFetcher } from "@/api/histories";
 import { updateTags } from "@/api/tags";
 import { useHistoryStore } from "@/stores/historyStore";
 import Filtering, { contains, equals, expandNameTag, toBool, type ValidFilter } from "@/utils/filtering";
@@ -70,9 +71,8 @@ const batch: BatchOperationArray = [
             if (confirm(_l(`Are you sure that you want to delete the selected histories?`))) {
                 try {
                     const historyIds = data.map((x) => String(x.id));
-                    await deleteHistories({ ids: historyIds });
                     const historyStore = useHistoryStore();
-                    await historyStore.handleTotalCountChange(data.length, true);
+                    await historyStore.deleteHistories(historyIds);
                     return {
                         status: "success",
                         message: `Deleted ${data.length} histories.`,
@@ -94,9 +94,8 @@ const batch: BatchOperationArray = [
             if (confirm(_l(`Are you sure that you want to restore the selected histories?`))) {
                 try {
                     const historyIds = data.map((x) => String(x.id));
-                    await undeleteHistories({ ids: historyIds });
                     const historyStore = useHistoryStore();
-                    await historyStore.handleTotalCountChange(data.length);
+                    await historyStore.restoreHistories(historyIds);
                     return {
                         status: "success",
                         message: `Restored ${data.length} histories.`,
@@ -112,15 +111,14 @@ const batch: BatchOperationArray = [
     },
     {
         title: "Purge",
-        icon: faTrash,
+        icon: faBurn,
         condition: (data: Array<HistoryEntry>) => !data.some((x) => x.purged),
         handler: async (data: Array<HistoryEntry>) => {
             if (confirm(_l(`Are you sure that you want to permanently delete the selected histories?`))) {
                 try {
                     const historyIds = data.map((x) => String(x.id));
-                    await deleteHistories({ ids: historyIds, purge: true });
                     const historyStore = useHistoryStore();
-                    await historyStore.handleTotalCountChange(data.length, true);
+                    await historyStore.deleteHistories(historyIds, true);
                     return {
                         status: "success",
                         message: `Purged ${data.length} histories.`,
@@ -191,9 +189,8 @@ const fields: FieldArray = [
                 handler: async (data: HistoryEntry) => {
                     if (confirm(_l("Are you sure that you want to delete this history?"))) {
                         try {
-                            await deleteHistory({ history_id: String(data.id) });
                             const historyStore = useHistoryStore();
-                            await historyStore.handleTotalCountChange(1, true);
+                            await historyStore.deleteHistory(String(data.id));
                             return {
                                 status: "success",
                                 message: `'${data.name}' has been deleted.`,
@@ -209,14 +206,13 @@ const fields: FieldArray = [
             },
             {
                 title: "Delete Permanently",
-                icon: faTrash,
+                icon: faBurn,
                 condition: (data: HistoryEntry) => !data.purged,
                 handler: async (data: HistoryEntry) => {
                     if (confirm(_l("Are you sure that you want to permanently delete this history?"))) {
                         try {
-                            await deleteHistory({ history_id: String(data.id), purge: true });
                             const historyStore = useHistoryStore();
-                            await historyStore.handleTotalCountChange(1, true);
+                            await historyStore.deleteHistory(String(data.id), true);
                             return {
                                 status: "success",
                                 message: `'${data.name}' has been permanently deleted.`,
@@ -236,9 +232,8 @@ const fields: FieldArray = [
                 condition: (data: HistoryEntry) => !!data.deleted && !data.purged,
                 handler: async (data: HistoryEntry) => {
                     try {
-                        await undeleteHistory({ history_id: String(data.id) });
                         const historyStore = useHistoryStore();
-                        await historyStore.handleTotalCountChange(1);
+                        await historyStore.restoreHistory(String(data.id));
                         return {
                             status: "success",
                             message: `'${data.name}' has been restored.`,

--- a/client/src/components/Grid/configs/histories.ts
+++ b/client/src/components/Grid/configs/histories.ts
@@ -71,6 +71,8 @@ const batch: BatchOperationArray = [
                 try {
                     const historyIds = data.map((x) => String(x.id));
                     await deleteHistories({ ids: historyIds });
+                    const historyStore = useHistoryStore();
+                    await historyStore.handleTotalCountChange(data.length, true);
                     return {
                         status: "success",
                         message: `Deleted ${data.length} histories.`,
@@ -93,6 +95,8 @@ const batch: BatchOperationArray = [
                 try {
                     const historyIds = data.map((x) => String(x.id));
                     await undeleteHistories({ ids: historyIds });
+                    const historyStore = useHistoryStore();
+                    await historyStore.handleTotalCountChange(data.length);
                     return {
                         status: "success",
                         message: `Restored ${data.length} histories.`,
@@ -115,6 +119,8 @@ const batch: BatchOperationArray = [
                 try {
                     const historyIds = data.map((x) => String(x.id));
                     await deleteHistories({ ids: historyIds, purge: true });
+                    const historyStore = useHistoryStore();
+                    await historyStore.handleTotalCountChange(data.length, true);
                     return {
                         status: "success",
                         message: `Purged ${data.length} histories.`,
@@ -186,6 +192,8 @@ const fields: FieldArray = [
                     if (confirm(_l("Are you sure that you want to delete this history?"))) {
                         try {
                             await deleteHistory({ history_id: String(data.id) });
+                            const historyStore = useHistoryStore();
+                            await historyStore.handleTotalCountChange(1, true);
                             return {
                                 status: "success",
                                 message: `'${data.name}' has been deleted.`,
@@ -207,6 +215,8 @@ const fields: FieldArray = [
                     if (confirm(_l("Are you sure that you want to permanently delete this history?"))) {
                         try {
                             await deleteHistory({ history_id: String(data.id), purge: true });
+                            const historyStore = useHistoryStore();
+                            await historyStore.handleTotalCountChange(1, true);
                             return {
                                 status: "success",
                                 message: `'${data.name}' has been permanently deleted.`,
@@ -227,6 +237,8 @@ const fields: FieldArray = [
                 handler: async (data: HistoryEntry) => {
                     try {
                         await undeleteHistory({ history_id: String(data.id) });
+                        const historyStore = useHistoryStore();
+                        await historyStore.handleTotalCountChange(1);
                         return {
                             status: "success",
                             message: `'${data.name}' has been restored.`,

--- a/client/src/components/History/CurrentHistory/HistoryDetails.vue
+++ b/client/src/components/History/CurrentHistory/HistoryDetails.vue
@@ -11,12 +11,12 @@ import UtcDate from "@/components/UtcDate.vue";
 interface Props {
     history: HistorySummary;
     writeable: boolean;
-    summarized: boolean;
+    summarized?: "both" | "annotation" | "tags" | "none";
 }
 
 const props = withDefaults(defineProps<Props>(), {
     writeable: true,
-    summarized: false,
+    summarized: undefined,
 });
 
 const historyStore = useHistoryStore();

--- a/client/src/components/History/CurrentHistory/HistoryDetails.vue
+++ b/client/src/components/History/CurrentHistory/HistoryDetails.vue
@@ -11,7 +11,7 @@ import UtcDate from "@/components/UtcDate.vue";
 interface Props {
     history: HistorySummary;
     writeable: boolean;
-    summarized?: "both" | "annotation" | "tags" | "none";
+    summarized?: "both" | "annotation" | "tags" | "none" | "hidden";
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/client/src/components/History/CurrentHistory/HistoryDetails.vue
+++ b/client/src/components/History/CurrentHistory/HistoryDetails.vue
@@ -1,17 +1,24 @@
 <script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faArchive, faBurn, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BBadge } from "bootstrap-vue";
 
 import type { HistorySummary } from "@/api";
 import { useHistoryStore } from "@/stores/historyStore";
 
+import type { DetailsLayoutSummarized } from "../Layout/types";
+
 import TextSummary from "@/components/Common/TextSummary.vue";
 import DetailsLayout from "@/components/History/Layout/DetailsLayout.vue";
 import UtcDate from "@/components/UtcDate.vue";
 
+library.add(faArchive, faBurn, faTrash);
+
 interface Props {
     history: HistorySummary;
     writeable: boolean;
-    summarized?: "both" | "annotation" | "tags" | "none" | "hidden";
+    summarized?: DetailsLayoutSummarized;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -52,6 +59,18 @@ function onSave(newDetails: HistorySummary) {
             <BBadge v-b-tooltip pill>
                 <span v-localize>last edited </span>
                 <UtcDate v-if="history.update_time" :date="history.update_time" mode="elapsed" />
+            </BBadge>
+            <BBadge v-if="history.purged" pill class="alert-warning">
+                <FontAwesomeIcon :icon="faBurn" />
+                <span v-localize> Purged</span>
+            </BBadge>
+            <BBadge v-else-if="history.deleted" pill class="alert-danger">
+                <FontAwesomeIcon :icon="faTrash" />
+                <span v-localize> Deleted</span>
+            </BBadge>
+            <BBadge v-if="history.archived" pill class="alert-warning">
+                <FontAwesomeIcon :icon="faArchive" />
+                <span v-localize> Archived</span>
             </BBadge>
         </template>
     </DetailsLayout>

--- a/client/src/components/History/CurrentHistory/HistoryDetails.vue
+++ b/client/src/components/History/CurrentHistory/HistoryDetails.vue
@@ -1,19 +1,12 @@
 <script setup lang="ts">
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { faArchive, faBurn, faTrash } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BBadge } from "bootstrap-vue";
-
 import type { HistorySummary } from "@/api";
 import { useHistoryStore } from "@/stores/historyStore";
 
 import type { DetailsLayoutSummarized } from "../Layout/types";
 
+import HistoryIndicators from "../HistoryIndicators.vue";
 import TextSummary from "@/components/Common/TextSummary.vue";
 import DetailsLayout from "@/components/History/Layout/DetailsLayout.vue";
-import UtcDate from "@/components/UtcDate.vue";
-
-library.add(faArchive, faBurn, faTrash);
 
 interface Props {
     history: HistorySummary;
@@ -56,22 +49,7 @@ function onSave(newDetails: HistorySummary) {
                 no-expand />
         </template>
         <template v-if="summarized" v-slot:update-time>
-            <BBadge v-b-tooltip pill>
-                <span v-localize>last edited </span>
-                <UtcDate v-if="history.update_time" :date="history.update_time" mode="elapsed" />
-            </BBadge>
-            <BBadge v-if="history.purged" pill class="alert-warning">
-                <FontAwesomeIcon :icon="faBurn" />
-                <span v-localize> Purged</span>
-            </BBadge>
-            <BBadge v-else-if="history.deleted" pill class="alert-danger">
-                <FontAwesomeIcon :icon="faTrash" />
-                <span v-localize> Deleted</span>
-            </BBadge>
-            <BBadge v-if="history.archived" pill class="alert-warning">
-                <FontAwesomeIcon :icon="faArchive" />
-                <span v-localize> Archived</span>
-            </BBadge>
+            <HistoryIndicators :history="history" detailed-time />
         </template>
     </DetailsLayout>
 </template>

--- a/client/src/components/History/CurrentHistory/HistoryMessages.vue
+++ b/client/src/components/History/CurrentHistory/HistoryMessages.vue
@@ -32,7 +32,7 @@ const currentUserOwnsHistory = computed(() => {
     <div v-if="hasMessages" class="mx-3 mt-2" data-description="history messages">
         <BAlert v-if="history.purged" :show="history.purged" variant="warning">
             <FontAwesomeIcon :icon="faBurn" fixed-width />
-            {{ localize("History has been purged") }}
+            {{ localize("History has been permanently deleted") }}
         </BAlert>
         <BAlert v-else-if="history.deleted" :show="history.deleted" variant="warning">
             <FontAwesomeIcon :icon="faTrash" fixed-width />

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -225,7 +225,7 @@ function userTitle(title: string) {
                         :title="localize(isDeletedNotPurged ? 'Permanently Delete History' : 'Delete History')"
                         @click="showDeleteModal = !showDeleteModal">
                         <FontAwesomeIcon fixed-width :icon="isDeletedNotPurged ? faBurn : faTrash" class="mr-1" />
-                        <span v-if="isDeletedNotPurged" v-localize>Purge this History</span>
+                        <span v-if="isDeletedNotPurged" v-localize>Permanently Delete History</span>
                         <span v-else v-localize>Delete this History</span>
                     </BDropdownItem>
 
@@ -318,9 +318,9 @@ function userTitle(title: string) {
             @ok="historyStore.secureHistory(history)">
             <h4>
                 History:
-                <b
-                    ><i>{{ history.name }}</i></b
-                >
+                <b>
+                    <i>{{ history.name }}</i>
+                </b>
             </h4>
             <p v-localize>
                 This will make all the data in this history private (excluding library datasets), and will set
@@ -331,7 +331,7 @@ function userTitle(title: string) {
 
         <BModal
             v-model="showDeleteModal"
-            :title="isDeletedNotPurged ? 'Purge History?' : 'Delete History?'"
+            :title="isDeletedNotPurged ? 'Permanently Delete History?' : 'Delete History?'"
             title-tag="h2"
             @ok="onDelete"
             @show="purgeHistory = isDeletedNotPurged">

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -62,13 +62,13 @@ library.add(
 interface Props {
     histories: HistorySummary[];
     history: HistorySummary;
-    title?: string;
     historiesLoading?: boolean;
+    minimal?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
-    title: "Histories",
     historiesLoading: false,
+    minimal: false,
 });
 
 const showSwitchModal = ref(false);
@@ -115,11 +115,14 @@ function userTitle(title: string) {
 
 <template>
     <div>
-        <nav class="d-flex justify-content-between mx-3 my-2" aria-label="current history management">
-            <h2 class="m-1 h-sm">History</h2>
+        <nav
+            :class="{ 'd-flex justify-content-between mx-3 my-2': !props.minimal }"
+            aria-label="current history management">
+            <h2 v-if="!props.minimal" class="m-1 h-sm">History</h2>
 
             <BButtonGroup>
                 <BButton
+                    v-if="!props.minimal"
                     v-b-tooltip.top.hover.noninteractive
                     class="create-hist-btn"
                     data-description="create new history"
@@ -132,6 +135,7 @@ function userTitle(title: string) {
                 </BButton>
 
                 <BButton
+                    v-if="!props.minimal"
                     v-b-tooltip.top.hover.noninteractive
                     data-description="switch to another history"
                     size="sm"
@@ -146,10 +150,11 @@ function userTitle(title: string) {
                     v-b-tooltip.top.hover.noninteractive
                     no-caret
                     size="sm"
-                    variant="link"
+                    :variant="props.minimal ? 'outline-info' : 'link'"
                     toggle-class="text-decoration-none"
                     menu-class="history-options-button-menu"
                     title="History options"
+                    right
                     data-description="history options">
                     <template v-slot:button-content>
                         <FontAwesomeIcon fixed-width :icon="faBars" />
@@ -162,10 +167,12 @@ function userTitle(title: string) {
                             <span>Fetching histories from server</span>
                         </div>
 
-                        <span v-else>You have {{ totalHistoryCount }} histories.</span>
+                        <span v-else-if="!props.minimal">You have {{ totalHistoryCount }} histories.</span>
+                        <span v-else>Manage History</span>
                     </BDropdownText>
 
                     <BDropdownItem
+                        v-if="!props.minimal"
                         data-description="switch to multi history view"
                         :disabled="isAnonymous"
                         :title="userTitle('Open History Multiview')"
@@ -174,7 +181,7 @@ function userTitle(title: string) {
                         <span v-localize>Show Histories Side-by-Side</span>
                     </BDropdownItem>
 
-                    <BDropdownDivider />
+                    <BDropdownDivider v-if="!props.minimal" />
 
                     <BDropdownText v-if="!canEditHistory">
                         This history has been <span class="font-weight-bold">{{ historyState }}</span
@@ -282,6 +289,7 @@ function userTitle(title: string) {
         </nav>
 
         <SelectorModal
+            v-if="!props.minimal"
             v-show="showSwitchModal"
             id="selector-history-modal"
             :histories="histories"

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -71,7 +71,12 @@ const props = withDefaults(defineProps<Props>(), {
     minimal: false,
 });
 
+// modal refs
 const showSwitchModal = ref(false);
+const showDeleteModal = ref(false);
+const showPrivacyModal = ref(false);
+const showCopyModal = ref(false);
+
 const purgeHistory = ref(false);
 
 const userStore = useUserStore();
@@ -202,17 +207,17 @@ function userTitle(title: string) {
                     <BDropdownDivider />
 
                     <BDropdownItem
-                        v-b-modal:copy-current-history-modal
                         :disabled="isAnonymous"
-                        :title="userTitle('Copy History to a New History')">
+                        :title="userTitle('Copy History to a New History')"
+                        @click="showCopyModal = !showCopyModal">
                         <FontAwesomeIcon fixed-width :icon="faCopy" class="mr-1" />
                         <span v-localize>Copy this History</span>
                     </BDropdownItem>
 
                     <BDropdownItem
-                        v-b-modal:delete-history-modal
                         :disabled="!canEditHistory"
-                        :title="localize('Permanently Delete History')">
+                        :title="localize('Permanently Delete History')"
+                        @click="showDeleteModal = !showDeleteModal">
                         <FontAwesomeIcon fixed-width :icon="faTrash" class="mr-1" />
                         <span v-localize>Delete this History</span>
                     </BDropdownItem>
@@ -278,9 +283,9 @@ function userTitle(title: string) {
                     </BDropdownItem>
 
                     <BDropdownItem
-                        v-b-modal:history-privacy-modal
                         :disabled="isAnonymous || !canEditHistory"
-                        :title="userTitle('Make this History Private')">
+                        :title="userTitle('Make this History Private')"
+                        @click="showPrivacyModal = !showPrivacyModal">
                         <FontAwesomeIcon fixed-width :icon="faLock" class="mr-1" />
                         <span v-localize>Make Private</span>
                     </BDropdownItem>
@@ -297,13 +302,19 @@ function userTitle(title: string) {
             :show-modal.sync="showSwitchModal"
             @selectHistory="historyStore.setCurrentHistory($event.id)" />
 
-        <CopyModal id="copy-current-history-modal" :history="history" />
+        <CopyModal :history="history" :show-modal.sync="showCopyModal" />
 
         <BModal
-            id="history-privacy-modal"
+            v-model="showPrivacyModal"
             title="Make History Private"
             title-tag="h2"
             @ok="historyStore.secureHistory(history)">
+            <h4>
+                History:
+                <b
+                    ><i>{{ history.name }}</i></b
+                >
+            </h4>
             <p v-localize>
                 This will make all the data in this history private (excluding library datasets), and will set
                 permissions such that all new data is created as private. Any datasets within that are currently shared
@@ -312,7 +323,7 @@ function userTitle(title: string) {
         </BModal>
 
         <BModal
-            id="delete-history-modal"
+            v-model="showDeleteModal"
             title="Delete History?"
             title-tag="h2"
             @ok="onDelete"

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -3,6 +3,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import {
     faArchive,
     faBars,
+    faBurn,
     faColumns,
     faCopy,
     faExchangeAlt,
@@ -44,6 +45,7 @@ import SelectorModal from "@/components/History/Modals/SelectorModal.vue";
 library.add(
     faArchive,
     faBars,
+    faBurn,
     faColumns,
     faCopy,
     faExchangeAlt,
@@ -87,6 +89,10 @@ const { totalHistoryCount } = storeToRefs(historyStore);
 
 const canEditHistory = computed(() => {
     return canMutateHistory(props.history);
+});
+
+const isDeletedNotPurged = computed(() => {
+    return props.history.deleted && !props.history.purged;
 });
 
 const historyState = computed(() => {
@@ -216,10 +222,11 @@ function userTitle(title: string) {
 
                     <BDropdownItem
                         :disabled="!canEditHistory"
-                        :title="localize('Permanently Delete History')"
+                        :title="localize(isDeletedNotPurged ? 'Permanently Delete History' : 'Delete History')"
                         @click="showDeleteModal = !showDeleteModal">
-                        <FontAwesomeIcon fixed-width :icon="faTrash" class="mr-1" />
-                        <span v-localize>Delete this History</span>
+                        <FontAwesomeIcon fixed-width :icon="isDeletedNotPurged ? faBurn : faTrash" class="mr-1" />
+                        <span v-if="isDeletedNotPurged" v-localize>Purge this History</span>
+                        <span v-else v-localize>Delete this History</span>
                     </BDropdownItem>
 
                     <BDropdownItem
@@ -324,14 +331,14 @@ function userTitle(title: string) {
 
         <BModal
             v-model="showDeleteModal"
-            title="Delete History?"
+            :title="isDeletedNotPurged ? 'Purge History?' : 'Delete History?'"
             title-tag="h2"
             @ok="onDelete"
-            @show="purgeHistory = false">
+            @show="purgeHistory = isDeletedNotPurged">
             <p v-localize>
                 Do you also want to permanently delete the history <i class="ml-1">{{ history.name }}</i>
             </p>
-            <BFormCheckbox id="purge-history" v-model="purgeHistory">
+            <BFormCheckbox id="purge-history" v-model="purgeHistory" :disabled="isDeletedNotPurged">
                 <span v-localize>Yes, permanently delete this history.</span>
             </BFormCheckbox>
         </BModal>

--- a/client/src/components/History/CurrentHistory/HistoryOperations/HistoryOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/HistoryOperations.vue
@@ -12,6 +12,7 @@ library.add(faCheckSquare, faCompress);
 interface Props {
     history: HistorySummaryExtended;
     hasMatches: boolean;
+    editable: boolean;
     expandedCount: number;
     showSelection: boolean;
     isMultiViewItem: boolean;
@@ -32,7 +33,7 @@ function onUpdateOperationStatus(updateTime: number) {
 
 <template>
     <section>
-        <nav class="content-operations d-flex justify-content-between bg-secondary">
+        <nav v-if="editable" class="content-operations d-flex justify-content-between bg-secondary">
             <BButtonGroup>
                 <BButton
                     title="Select Items"
@@ -65,6 +66,17 @@ function onUpdateOperationStatus(updateTime: number) {
                 v-show="!showSelection"
                 :history="history"
                 @update:operation-running="onUpdateOperationStatus" />
+        </nav>
+        <nav v-else-if="isMultiViewItem" class="content-operations bg-secondary">
+            <BButton
+                title="Collapse Items"
+                class="rounded-0"
+                size="sm"
+                variant="link"
+                :disabled="!expandedCount"
+                @click="$emit('collapse-all')">
+                <FontAwesomeIcon :icon="faCompress" fixed-width />
+            </BButton>
         </nav>
     </section>
 </template>

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -84,7 +84,7 @@ const contentItemRefs = computed(() => {
 const currItemFocused = useActiveElement();
 const lastItemId = ref<string | null>(null);
 
-const { currentFilterText, currentHistoryId } = storeToRefs(useHistoryStore());
+const { currentFilterText, currentHistoryId, pinnedHistoriesSummarizedStatus } = storeToRefs(useHistoryStore());
 const { lastCheckedTime, totalMatchesCount, isWatching } = storeToRefs(useHistoryItemsStore());
 
 const historyStore = useHistoryStore();
@@ -141,6 +141,10 @@ const formattedSearchError = computed(() => {
         msg: err_msg,
         typeError: ValueError,
     };
+});
+
+const detailsSummarized = computed(() => {
+    return props.isMultiViewItem ? pinnedHistoriesSummarizedStatus.value : undefined;
 });
 
 const storeFilterText = computed(() => {
@@ -523,7 +527,7 @@ function setItemDragstart(
                     <HistoryDetails
                         :history="history"
                         :writeable="canEditHistory"
-                        :summarized="isMultiViewItem"
+                        :summarized="detailsSummarized"
                         @update:history="historyStore.updateHistory($event)" />
 
                     <HistoryMessages :history="history" :current-user="currentUser" />

--- a/client/src/components/History/HistoryIndicators.vue
+++ b/client/src/components/History/HistoryIndicators.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faArchive, faBurn, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BBadge } from "bootstrap-vue";
+import { storeToRefs } from "pinia";
+
+import { type HistorySummary, userOwnsHistory } from "@/api";
+import { useUserStore } from "@/stores/userStore";
+import localize from "@/utils/localization";
+
+import UtcDate from "../UtcDate.vue";
+
+library.add(faArchive, faBurn, faTrash);
+
+const userStore = useUserStore();
+const { currentUser } = storeToRefs(userStore);
+
+const props = defineProps<{
+    history: HistorySummary;
+    includeCount?: boolean;
+    detailedTime?: boolean;
+}>();
+</script>
+
+<template>
+    <div class="d-flex align-items-center flex-gapx-1">
+        <BBadge v-if="props.includeCount" pill :title="localize('Amount of items in history')">
+            {{ history.count }} {{ localize("items") }}
+        </BBadge>
+        <BBadge v-if="history.update_time" pill :title="localize('Last edited')">
+            <span v-if="props.detailedTime" v-localize>last edited </span>
+            <UtcDate :date="history.update_time" mode="elapsed" />
+        </BBadge>
+        <BBadge v-if="props.history.purged" pill class="alert-warning" title="Permanently deleted">
+            <FontAwesomeIcon :icon="faBurn" fixed-width />
+        </BBadge>
+        <BBadge v-else-if="history.deleted" pill class="alert-danger" title="Deleted">
+            <FontAwesomeIcon :icon="faTrash" fixed-width />
+        </BBadge>
+        <BBadge v-if="history.archived && userOwnsHistory(currentUser, props.history)" pill title="Archived">
+            <FontAwesomeIcon :icon="faArchive" fixed-width />
+        </BBadge>
+    </div>
+</template>

--- a/client/src/components/History/HistoryScrollList.vue
+++ b/client/src/components/History/HistoryScrollList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCheckSquare, faListAlt, faSquare } from "@fortawesome/free-regular-svg-icons";
-import { faArchive, faArrowDown, faBurn, faColumns, faSignInAlt, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faArrowDown, faColumns, faSignInAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { useInfiniteScroll } from "@vueuse/core";
 import { BAlert, BBadge, BButton, BButtonGroup, BListGroup, BListGroupItem, BOverlay } from "bootstrap-vue";
@@ -19,10 +19,10 @@ import localize from "@/utils/localization";
 import { HistoriesFilters } from "./HistoriesFilters";
 
 import TextSummary from "../Common/TextSummary.vue";
+import HistoryIndicators from "./HistoryIndicators.vue";
 import Heading from "@/components/Common/Heading.vue";
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 import ScrollToTopButton from "@/components/ToolsList/ScrollToTopButton.vue";
-import UtcDate from "@/components/UtcDate.vue";
 
 type AdditionalOptions = "set-current" | "multi" | "center";
 type PinnedHistory = { id: string };
@@ -54,7 +54,7 @@ const emit = defineEmits<{
     (e: "update:show-modal", showModal: boolean): void;
 }>();
 
-library.add(faColumns, faSignInAlt, faListAlt, faArrowDown, faCheckSquare, faSquare, faBurn, faTrash, faArchive);
+library.add(faColumns, faSignInAlt, faListAlt, faArrowDown, faCheckSquare, faSquare);
 
 const busy = ref(false);
 const showAdvanced = ref(false);
@@ -277,35 +277,7 @@ async function loadMore(noScroll = false) {
                                     </i>
                                 </div>
                                 <TextSummary v-else component="h4" :description="history.name" one-line-summary />
-                                <div class="d-flex align-items-center flex-gapx-1">
-                                    <BBadge
-                                        v-if="history.purged"
-                                        pill
-                                        class="alert-warning"
-                                        title="Permanently deleted">
-                                        <FontAwesomeIcon :icon="faBurn" fixed-width />
-                                    </BBadge>
-                                    <BBadge v-else-if="history.deleted" pill class="alert-danger" title="Deleted">
-                                        <FontAwesomeIcon :icon="faTrash" fixed-width />
-                                    </BBadge>
-                                    <BBadge
-                                        v-if="history.archived && userOwnsHistory(currentUser, history)"
-                                        pill
-                                        class="alert-warning"
-                                        title="Archived">
-                                        <FontAwesomeIcon :icon="faArchive" fixed-width />
-                                    </BBadge>
-                                    <BBadge pill :title="localize('Amount of items in history')">
-                                        {{ history.count }} {{ localize("items") }}
-                                    </BBadge>
-                                    <BBadge
-                                        v-if="history.update_time"
-                                        v-b-tooltip.noninteractive.hover
-                                        pill
-                                        :title="localize('Last edited')">
-                                        <UtcDate :date="history.update_time" mode="elapsed" />
-                                    </BBadge>
-                                </div>
+                                <HistoryIndicators :history="history" include-count />
                             </div>
 
                             <p v-if="!isMultiviewPanel && history.annotation" class="my-1">{{ history.annotation }}</p>

--- a/client/src/components/History/HistoryScrollList.vue
+++ b/client/src/components/History/HistoryScrollList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCheckSquare, faListAlt, faSquare } from "@fortawesome/free-regular-svg-icons";
-import { faArrowDown, faColumns, faSignInAlt } from "@fortawesome/free-solid-svg-icons";
+import { faArchive, faArrowDown, faBurn, faColumns, faSignInAlt, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { useInfiniteScroll } from "@vueuse/core";
 import { BAlert, BBadge, BButton, BButtonGroup, BListGroup, BListGroupItem, BOverlay } from "bootstrap-vue";
@@ -54,7 +54,7 @@ const emit = defineEmits<{
     (e: "update:show-modal", showModal: boolean): void;
 }>();
 
-library.add(faColumns, faSignInAlt, faListAlt, faArrowDown, faCheckSquare, faSquare);
+library.add(faColumns, faSignInAlt, faListAlt, faArrowDown, faCheckSquare, faSquare, faBurn, faTrash, faArchive);
 
 const busy = ref(false);
 const showAdvanced = ref(false);
@@ -278,6 +278,21 @@ async function loadMore(noScroll = false) {
                                 </div>
                                 <TextSummary v-else component="h4" :description="history.name" one-line-summary />
                                 <div class="d-flex align-items-center flex-gapx-1">
+                                    <BBadge pill>
+                                        <FontAwesomeIcon
+                                            v-if="history.purged"
+                                            title="Purged"
+                                            :icon="faBurn"
+                                            fixed-width />
+                                        <FontAwesomeIcon
+                                            v-else-if="history.deleted"
+                                            title="Deleted"
+                                            :icon="faTrash"
+                                            fixed-width />
+                                    </BBadge>
+                                    <BBadge v-if="history.archived" pill>
+                                        <FontAwesomeIcon title="Archived" :icon="faArchive" fixed-width />
+                                    </BBadge>
                                     <BBadge pill :title="localize('Amount of items in history')">
                                         {{ history.count }} {{ localize("items") }}
                                     </BBadge>

--- a/client/src/components/History/HistoryScrollList.vue
+++ b/client/src/components/History/HistoryScrollList.vue
@@ -278,20 +278,18 @@ async function loadMore(noScroll = false) {
                                 </div>
                                 <TextSummary v-else component="h4" :description="history.name" one-line-summary />
                                 <div class="d-flex align-items-center flex-gapx-1">
-                                    <BBadge pill>
-                                        <FontAwesomeIcon
-                                            v-if="history.purged"
-                                            title="Purged"
-                                            :icon="faBurn"
-                                            fixed-width />
-                                        <FontAwesomeIcon
-                                            v-else-if="history.deleted"
-                                            title="Deleted"
-                                            :icon="faTrash"
-                                            fixed-width />
+                                    <BBadge v-if="history.purged" pill class="alert-warning" title="Purged">
+                                        <FontAwesomeIcon :icon="faBurn" fixed-width />
                                     </BBadge>
-                                    <BBadge v-if="history.archived" pill>
-                                        <FontAwesomeIcon title="Archived" :icon="faArchive" fixed-width />
+                                    <BBadge v-else-if="history.deleted" pill class="alert-danger" title="Deleted">
+                                        <FontAwesomeIcon :icon="faTrash" fixed-width />
+                                    </BBadge>
+                                    <BBadge
+                                        v-if="history.archived && userOwnsHistory(currentUser, history)"
+                                        pill
+                                        class="alert-warning"
+                                        title="Archived">
+                                        <FontAwesomeIcon :icon="faArchive" fixed-width />
                                     </BBadge>
                                     <BBadge pill :title="localize('Amount of items in history')">
                                         {{ history.count }} {{ localize("items") }}

--- a/client/src/components/History/HistoryScrollList.vue
+++ b/client/src/components/History/HistoryScrollList.vue
@@ -278,7 +278,11 @@ async function loadMore(noScroll = false) {
                                 </div>
                                 <TextSummary v-else component="h4" :description="history.name" one-line-summary />
                                 <div class="d-flex align-items-center flex-gapx-1">
-                                    <BBadge v-if="history.purged" pill class="alert-warning" title="Purged">
+                                    <BBadge
+                                        v-if="history.purged"
+                                        pill
+                                        class="alert-warning"
+                                        title="Permanently deleted">
                                         <FontAwesomeIcon :icon="faBurn" fixed-width />
                                     </BBadge>
                                     <BBadge v-else-if="history.deleted" pill class="alert-danger" title="Deleted">

--- a/client/src/components/History/HistoryView.test.js
+++ b/client/src/components/History/HistoryView.test.js
@@ -185,7 +185,9 @@ describe("History center panel View", () => {
         expect(storageDashboardButtonDisabled(wrapper)).toBeFalsy();
 
         // instead we have an alert
-        expect(wrapper.find("[data-description='history messages']").text()).toBe("History has been purged");
+        expect(wrapper.find("[data-description='history messages']").text()).toBe(
+            "History has been permanently deleted"
+        );
     });
 
     it("should not display archived message and should be importable when user is not owner and history is archived", async () => {

--- a/client/src/components/History/Index.vue
+++ b/client/src/components/History/Index.vue
@@ -40,8 +40,7 @@ function onViewCollection(collection: CollectionEntry, currentOffset?: number) {
                 <HistoryNavigation
                     :history="currentHistory"
                     :histories="histories"
-                    :histories-loading="historiesLoading"
-                    title="Histories" />
+                    :histories-loading="historiesLoading" />
             </template>
         </HistoryPanel>
 

--- a/client/src/components/History/Layout/DetailsLayout.vue
+++ b/client/src/components/History/Layout/DetailsLayout.vue
@@ -194,7 +194,8 @@ function selectText() {
 
 <style lang="scss" scoped>
 .summarized-details {
-    margin: 1rem 1rem 0 1rem;
+    margin-top: 1rem;
+    margin-left: 0.5rem;
     max-width: 15rem;
 
     &.both {

--- a/client/src/components/History/Layout/DetailsLayout.vue
+++ b/client/src/components/History/Layout/DetailsLayout.vue
@@ -20,7 +20,7 @@ interface Props {
     writeable?: boolean;
     annotation?: string;
     showAnnotation?: boolean;
-    summarized?: "both" | "annotation" | "tags" | "none";
+    summarized?: "both" | "annotation" | "tags" | "none" | "hidden";
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -125,7 +125,9 @@ function selectText() {
                 v-short="annotation"
                 class="mt-2"
                 data-description="annotation value" />
-            <div v-else-if="summarized" :class="{ annotation: ['both', 'annotation'].includes(summarized) }">
+            <div
+                v-else-if="summarized"
+                :class="{ annotation: ['both', 'annotation'].includes(summarized), hidden: summarized === 'hidden' }">
                 <TextSummary
                     v-if="annotation"
                     :description="annotation"
@@ -135,7 +137,11 @@ function selectText() {
             </div>
             <StatelessTags
                 v-if="tags"
-                :class="{ 'mt-2': !summarized, tags: ['both', 'tags'].includes(summarized) }"
+                :class="{
+                    'mt-2': !summarized,
+                    tags: ['both', 'tags'].includes(summarized),
+                    hidden: summarized === 'hidden',
+                }"
                 :value="tags"
                 disabled
                 :max-visible-tags="summarized ? 1 : 5" />
@@ -205,6 +211,9 @@ function selectText() {
     }
     .annotation {
         min-height: 2rem;
+    }
+    .hidden {
+        display: none;
     }
 }
 </style>

--- a/client/src/components/History/Layout/DetailsLayout.vue
+++ b/client/src/components/History/Layout/DetailsLayout.vue
@@ -194,7 +194,6 @@ function selectText() {
 
 <style lang="scss" scoped>
 .summarized-details {
-    margin-top: 1rem;
     margin-left: 0.5rem;
     max-width: 15rem;
 

--- a/client/src/components/History/Layout/DetailsLayout.vue
+++ b/client/src/components/History/Layout/DetailsLayout.vue
@@ -9,6 +9,8 @@ import { computed, ref } from "vue";
 import { useUserStore } from "@/stores/userStore";
 import l from "@/utils/localization";
 
+import type { DetailsLayoutSummarized } from "./types";
+
 import TextSummary from "@/components/Common/TextSummary.vue";
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 
@@ -20,7 +22,7 @@ interface Props {
     writeable?: boolean;
     annotation?: string;
     showAnnotation?: boolean;
-    summarized?: "both" | "annotation" | "tags" | "none" | "hidden";
+    summarized?: DetailsLayoutSummarized;
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/client/src/components/History/Layout/DetailsLayout.vue
+++ b/client/src/components/History/Layout/DetailsLayout.vue
@@ -20,7 +20,7 @@ interface Props {
     writeable?: boolean;
     annotation?: string;
     showAnnotation?: boolean;
-    summarized?: boolean;
+    summarized?: "both" | "annotation" | "tags" | "none";
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -29,7 +29,7 @@ const props = withDefaults(defineProps<Props>(), {
     writeable: true,
     annotation: undefined,
     showAnnotation: true,
-    summarized: false,
+    summarized: undefined,
 });
 
 const emit = defineEmits(["save"]);
@@ -45,6 +45,20 @@ const localProps = ref<{ name: string; annotation: string | null; tags: string[]
     name: "",
     annotation: "",
     tags: [],
+});
+
+const detailsClass = computed(() => {
+    const classes: Record<string, boolean> = {
+        details: true,
+        "summarized-details": props.summarized && !editing.value,
+        "m-3": !props.summarized || editing.value,
+    };
+
+    if (props.summarized) {
+        classes[props.summarized] = true;
+    }
+
+    return classes;
 });
 
 const editButtonTitle = computed(() => {
@@ -90,10 +104,7 @@ function selectText() {
 </script>
 
 <template>
-    <section
-        class="details"
-        :class="summarized && !editing ? 'summarized-details' : 'm-3'"
-        data-description="edit details">
+    <section :class="detailsClass" data-description="edit details">
         <BButton
             :disabled="isAnonymous || !writeable"
             class="edit-button ml-1 float-right"
@@ -114,7 +125,7 @@ function selectText() {
                 v-short="annotation"
                 class="mt-2"
                 data-description="annotation value" />
-            <div v-else-if="summarized" style="min-height: 2rem">
+            <div v-else-if="summarized" :class="{ annotation: ['both', 'annotation'].includes(summarized) }">
                 <TextSummary
                     v-if="annotation"
                     :description="annotation"
@@ -124,8 +135,7 @@ function selectText() {
             </div>
             <StatelessTags
                 v-if="tags"
-                class="tags"
-                :class="!summarized && 'mt-2'"
+                :class="{ 'mt-2': !summarized, tags: ['both', 'tags'].includes(summarized) }"
                 :value="tags"
                 disabled
                 :max-visible-tags="summarized ? 1 : 5" />
@@ -184,11 +194,16 @@ function selectText() {
 
 <style lang="scss" scoped>
 .summarized-details {
-    min-height: 8.5em;
     margin: 1rem 1rem 0 1rem;
     max-width: 15rem;
 
+    &.both {
+        min-height: 8.5em;
+    }
     .tags {
+        min-height: 2rem;
+    }
+    .annotation {
         min-height: 2rem;
     }
 }

--- a/client/src/components/History/Layout/types.ts
+++ b/client/src/components/History/Layout/types.ts
@@ -1,0 +1,1 @@
+export type DetailsLayoutSummarized = "both" | "annotation" | "tags" | "none" | "hidden";

--- a/client/src/components/History/Modals/CopyModal.vue
+++ b/client/src/components/History/Modals/CopyModal.vue
@@ -20,9 +20,16 @@ import localize from "@/utils/localization";
 
 interface Props {
     history: HistorySummary;
+    showModal?: boolean;
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+    showModal: false,
+});
+
+const emit = defineEmits<{
+    (e: "update:show-modal", value: boolean): void;
+}>();
 
 const userStore = useUserStore();
 const historyStore = useHistoryStore();
@@ -32,6 +39,7 @@ const { currentUser, isAnonymous } = storeToRefs(userStore);
 const name = ref("");
 const copyAll = ref(false);
 const loading = ref(false);
+const localShowModal = ref(props.showModal);
 
 const title = computed(() => {
     return `Copying History: ${props.history.name}`;
@@ -56,6 +64,18 @@ const formValid = computed(() => {
 });
 
 watch(
+    () => props.showModal,
+    (newVal) => {
+        localShowModal.value = newVal;
+    }
+);
+watch(
+    () => localShowModal.value,
+    (newVal) => {
+        emit("update:show-modal", newVal);
+    }
+);
+watch(
     () => props.history,
     (newHistory) => {
         name.value = `Copy of '${newHistory.name}'`;
@@ -74,7 +94,7 @@ async function copy(close: () => void) {
 </script>
 
 <template>
-    <BModal v-bind="$attrs" :title="title" title-tag="h2" v-on="$listeners">
+    <BModal v-model="localShowModal" v-bind="$attrs" :title="title" title-tag="h2" v-on="$listeners">
         <transition name="fade">
             <BAlert v-localize :show="isAnonymous" variant="warning">
                 As an anonymous user, unless you log in or register, you will lose your current history after copying

--- a/client/src/components/History/Multiple/MultipleViewItem.vue
+++ b/client/src/components/History/Multiple/MultipleViewItem.vue
@@ -6,6 +6,7 @@ import { computed, ref } from "vue";
 import { useExtendedHistory } from "@/composables/detailedHistory";
 import { useHistoryStore } from "@/stores/historyStore";
 
+import HistoryNavigation from "../CurrentHistory/HistoryNavigation.vue";
 import CollectionPanel from "@/components/History/CurrentCollection/CollectionPanel.vue";
 import HistoryPanel from "@/components/History/CurrentHistory/HistoryPanel.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
@@ -20,7 +21,7 @@ interface Props {
 const props = defineProps<Props>();
 
 const historyStore = useHistoryStore();
-const { currentHistoryId, pinnedHistories } = storeToRefs(historyStore);
+const { currentHistoryId, histories, historiesLoading, pinnedHistories } = storeToRefs(historyStore);
 
 const { history } = useExtendedHistory(props.source.id);
 
@@ -42,7 +43,37 @@ function onViewCollection(collection: object) {
         </div>
     </div>
 
-    <div v-else id="list-item" class="d-flex flex-column align-items-center w-100">
+    <div v-else id="list-item" class="d-flex flex-column w-100">
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <BButton
+                    size="sm"
+                    class="my-1"
+                    :disabled="sameToCurrent"
+                    :variant="sameToCurrent ? 'disabled' : 'outline-info'"
+                    :title="sameToCurrent ? 'Current History' : 'Switch to this history'"
+                    @click="historyStore.setCurrentHistory(source.id)">
+                    {{ sameToCurrent ? "Current History" : "Switch to" }}
+                </BButton>
+                <BButton
+                    v-if="Object.keys(pinnedHistories).length > 0"
+                    size="sm"
+                    class="my-1"
+                    variant="outline-danger"
+                    title="Hide this history from the list"
+                    @click="historyStore.unpinHistories([source.id])">
+                    Hide
+                </BButton>
+            </div>
+            <HistoryNavigation
+                :history="history"
+                :histories="histories"
+                :histories-loading="historiesLoading"
+                minimal />
+        </div>
+
+        <hr class="w-100 m-1" />
+
         <CollectionPanel
             v-if="selectedCollections.length && selectedCollections[0]?.history_id === source.id"
             :history="history"
@@ -57,28 +88,5 @@ function onViewCollection(collection: object) {
             :show-controls="false"
             is-multi-view-item
             @view-collection="onViewCollection" />
-
-        <hr class="w-100 m-2" />
-
-        <div class="flex-row flex-grow-0">
-            <BButton
-                size="sm"
-                class="my-1"
-                :disabled="sameToCurrent"
-                :variant="sameToCurrent ? 'disabled' : 'outline-info'"
-                :title="sameToCurrent ? 'Current History' : 'Switch to this history'"
-                @click="historyStore.setCurrentHistory(source.id)">
-                {{ sameToCurrent ? "Current History" : "Switch to" }}
-            </BButton>
-            <BButton
-                v-if="Object.keys(pinnedHistories).length > 0"
-                size="sm"
-                class="my-1"
-                variant="outline-danger"
-                title="Hide this history from the list"
-                @click="historyStore.unpinHistories([source.id])">
-                Hide
-            </BButton>
-        </div>
     </div>
 </template>

--- a/client/src/components/History/Multiple/MultipleViewItem.vue
+++ b/client/src/components/History/Multiple/MultipleViewItem.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faTimes } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
@@ -10,6 +13,8 @@ import HistoryNavigation from "../CurrentHistory/HistoryNavigation.vue";
 import CollectionPanel from "@/components/History/CurrentCollection/CollectionPanel.vue";
 import HistoryPanel from "@/components/History/CurrentHistory/HistoryPanel.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
+
+library.add(faTimes);
 
 interface Props {
     source: {
@@ -62,6 +67,7 @@ function onViewCollection(collection: object) {
                     variant="outline-danger"
                     title="Hide this history from the list"
                     @click="historyStore.unpinHistories([source.id])">
+                    <FontAwesomeIcon :icon="faTimes" />
                     Hide
                 </BButton>
             </div>

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -97,6 +97,38 @@ export const useHistoryStore = defineStore("historyStore", () => {
         };
     });
 
+    const pinnedHistoriesSummarizedStatus = computed(() => {
+        let annotation = false;
+        let tags = false;
+        let loaded = true;
+
+        for (const h of pinnedHistories.value) {
+            const history = storedHistories.value[h.id];
+            if (!history) {
+                loaded = false;
+                break;
+            }
+
+            if (history.annotation) {
+                annotation = true;
+            }
+
+            if (history.tags.length > 0) {
+                tags = true;
+            }
+        }
+
+        if (!loaded || (annotation && tags)) {
+            return "both";
+        } else if (annotation) {
+            return "annotation";
+        } else if (tags) {
+            return "tags";
+        } else {
+            return "none";
+        }
+    });
+
     async function setCurrentHistory(historyId: string) {
         const currentHistory = (await setCurrentHistoryOnServer(historyId)) as HistoryDevDetailed;
         selectHistory(currentHistory);
@@ -334,6 +366,11 @@ export const useHistoryStore = defineStore("historyStore", () => {
         currentHistoryId,
         currentFilterText,
         pinnedHistories,
+        /** Returns a string that indicates whether all the pinned histories have annotations,
+         * tags, both, or none of them.
+         * This is used to format the `DetailsLayout` header uniformly for multi-view histories.
+         */
+        pinnedHistoriesSummarizedStatus,
         getHistoryById,
         getHistoryNameById,
         setCurrentHistory,

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -97,42 +97,6 @@ export const useHistoryStore = defineStore("historyStore", () => {
         };
     });
 
-    const pinnedHistoriesSummarizedStatus = computed(() => {
-        let annotation = false;
-        let tags = false;
-        let loaded = true;
-
-        if (pinnedHistories.value.length === 0) {
-            return "hidden";
-        }
-
-        for (const h of pinnedHistories.value) {
-            const history = storedHistories.value[h.id];
-            if (!history) {
-                loaded = false;
-                break;
-            }
-
-            if (history.annotation) {
-                annotation = true;
-            }
-
-            if (history.tags.length > 0) {
-                tags = true;
-            }
-        }
-
-        if (!loaded || (annotation && tags)) {
-            return "both";
-        } else if (annotation) {
-            return "annotation";
-        } else if (tags) {
-            return "tags";
-        } else {
-            return "none";
-        }
-    });
-
     async function setCurrentHistory(historyId: string) {
         const currentHistory = (await setCurrentHistoryOnServer(historyId)) as HistoryDevDetailed;
         selectHistory(currentHistory);
@@ -369,11 +333,7 @@ export const useHistoryStore = defineStore("historyStore", () => {
         currentHistoryId,
         currentFilterText,
         pinnedHistories,
-        /** Returns a string that indicates whether all the pinned histories have annotations,
-         * tags, both, or none of them.
-         * This is used to format the `DetailsLayout` header uniformly for multi-view histories.
-         */
-        pinnedHistoriesSummarizedStatus,
+        storedHistories,
         getHistoryById,
         getHistoryNameById,
         setCurrentHistory,

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -235,7 +235,6 @@ export const useHistoryStore = defineStore("historyStore", () => {
             await createNewHistory();
         }
         del(storedHistories.value, deletedHistory.id);
-        unpinHistories([deletedHistory.id]);
         await handleTotalCountChange(1, true);
     }
 
@@ -389,6 +388,7 @@ export const useHistoryStore = defineStore("historyStore", () => {
         copyHistory,
         createNewHistory,
         deleteHistory,
+        handleTotalCountChange,
         loadCurrentHistory,
         loadHistories,
         loadHistoryById,

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -102,6 +102,10 @@ export const useHistoryStore = defineStore("historyStore", () => {
         let tags = false;
         let loaded = true;
 
+        if (pinnedHistories.value.length === 0) {
+            return "hidden";
+        }
+
         for (const h of pinnedHistories.value) {
             const history = storedHistories.value[h.id];
             if (!history) {


### PR DESCRIPTION
- Moves multiview item actions to the top, and adds a dropdown menu for Managing a pinned history as well
- Adds a `pinnedHistoriesSummarizedStatus` computed ref to `historyStore` that Returns a string that indicates whether all the pinned histories have annotations, tags, both, or none of them. This is used to then adjust the `DetailsLayout` header height accordingly.

![image](https://github.com/galaxyproject/galaxy/assets/78516064/16d76924-bad1-4d85-a7d3-756a5934bab8)

Fixes https://github.com/galaxyproject/galaxy/issues/18210

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
