### PR TITLE
[23.2] Add ``hgweb_repo_prefix`` attribute to ``TestToolShedConfig``

### DIFF
--- a/test/unit/tool_shed/_util.py
+++ b/test/unit/tool_shed/_util.py
@@ -46,6 +46,7 @@ class TestToolShedConfig:
     file_path: str
     id_secret: str = "thisistheshedunittestsecret"
     smtp_server: Optional[str] = None
+    hgweb_repo_prefix = "repos/"
     config_hg_for_dev = False
 
     def __init__(self, temp_directory):


### PR DESCRIPTION
Fix the following error in unit tests:

```
AttributeError: 'TestToolShedConfig' object has no attribute 'hgweb_repo_prefix'
```

caused by merging commit b00beec3d26b7dff76b32d56078bf7c90eff915b forward.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
