### PR TITLE
Adapt DRMAA job runner to push env vars to jobs

### DIFF
--- a/lib/galaxy/config/sample/job_conf.xml.sample_advanced
+++ b/lib/galaxy/config/sample/job_conf.xml.sample_advanced
@@ -12,6 +12,14 @@
         <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner"/>
         <plugin id="pbs" type="runner" load="galaxy.jobs.runners.pbs:PBSJobRunner" workers="2"/>
         <plugin id="drmaa" type="runner" load="galaxy.jobs.runners.drmaa:DRMAAJobRunner">
+            <!-- Additional environment variables can be pushed by drmaa when submitting the job,
+                 using the following job_environment_variables parameter. -->
+            <!--
+            <param id="job_environment_variables">
+              HTTPS_PROXY=my.proxy.domain.org:8080
+              VAR3=environment_variable_example_content
+            </param>
+            -->
             <!-- Different DRMs handle successfully completed jobs differently,
                  these options can be changed to handle such differences. Defaults are
                  shown. -->


### PR DESCRIPTION
What : adapt DRMAA job runner to push environment variables to jobs. Change sample config files accordingly.
Why : on our galaxy instance which submits jobs onto an hpc slurm cluster, when the jobs need to get data from internet, it needs an http proxy to be set via environment variables. As slurm munge does not load variables defined in the user profile, and as galaxy uses libdrmaa to submit the jobs which accepts in the job template a parameter listing the env vars to add, the fix was quite obvious.

- [x] Instructions for manual testing are as follows:
  1. Adapt your config file following the example from job_conf.xml.sample_advanced to add environment variables
  2. Use galaxy to submit a job on the cluster ; the job should dump its environment.
  3. Check in the job output that the additional environment variables are present.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
