### PR TITLE
[24.1] Merge 24.0 into 24.1

### DIFF
--- a/lib/tool_shed/webapp/model/__init__.py
+++ b/lib/tool_shed/webapp/model/__init__.py
@@ -92,7 +92,7 @@ class APIKeys(Base):
     user_id = Column(ForeignKey("galaxy_user.id"), index=True)
     key = Column(TrimmedString(32), index=True, unique=True)
     user = relationship("User", back_populates="api_keys")
-    deleted = Column(Boolean, index=True, default=False)
+    deleted = Column(Boolean, index=True, default=False, nullable=False)
 
 
 class User(Base, Dictifiable):

--- a/lib/tool_shed/webapp/model/migrations/alembic/versions/1b5bf427db25_add_non_nullable_column_deleted_to_api_.py
+++ b/lib/tool_shed/webapp/model/migrations/alembic/versions/1b5bf427db25_add_non_nullable_column_deleted_to_api_.py
@@ -1,0 +1,43 @@
+"""add non-nullable column deleted to API keys
+
+Revision ID: 1b5bf427db25
+Revises: 969bbf7bcc29
+Create Date: 2024-05-29 21:53:53.516506
+
+"""
+import sqlalchemy as sa
+from sqlalchemy import (
+    Boolean,
+    Column,
+)
+
+from galaxy.model.database_object_names import build_index_name
+from galaxy.model.migrations.util import (
+    add_column,
+    drop_column,
+    drop_index,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "1b5bf427db25"
+down_revision = "969bbf7bcc29"
+branch_labels = None
+depends_on = None
+
+# database object names used in this revision
+table_name = "api_keys"
+column_name = "deleted"
+index_name = build_index_name(table_name, column_name)
+
+
+def upgrade():
+    add_column(
+        table_name, Column(column_name, Boolean(), default=False, index=True, nullable=False, server_default=sa.false())
+    )
+
+
+def downgrade():
+    with transaction():
+        drop_index(index_name, table_name)
+        drop_column(table_name, column_name)


### PR DESCRIPTION
Adjust TS api_keys model
- Boolean datatype dropped since it's inferred from the type hint
- nullable=False added

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
