### PR TITLE
[23.1] Add revision tags for TS migration in 23.1

### DIFF
--- a/lib/tool_shed/webapp/model/migrations/dbscript.py
+++ b/lib/tool_shed/webapp/model/migrations/dbscript.py
@@ -26,8 +26,8 @@ CONFIG_FILE_ARG = "--toolshed-config"
 # then using 231 as a partial revision identifier like `sh manage_toolshed_db.sh upgrade 231`
 # will map to release 23.1 instead of revision 231xxxxxxxxx.
 REVISION_TAGS = {
-    "release_23.1": "base",
-    "23.1": "base",
+    "release_23.1": "1b5bf427db25",
+    "23.1": "1b5bf427db25",
 }
 
 


### PR DESCRIPTION
The 1b5bf427db25 migration was added in #18267, now we need to adjust the tags used with the `manage_toolshed_db.sh` script.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
