### PR TITLE
[24.1] Fix handler: access to result row items changed in SA2.0

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -999,7 +999,7 @@ class JobHandlerQueue(BaseJobHandlerQueue):
                 .where(and_(model.Job.table.c.state.in_((model.Job.states.QUEUED, model.Job.states.RUNNING))))
                 .group_by(model.Job.table.c.destination_id)
             )
-            for row in result:
+            for row in result.mappings():
                 self.total_job_count_per_destination[row["destination_id"]] = row["job_count"]
 
     def get_total_job_count_per_destination(self):


### PR DESCRIPTION
Ref https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#result-rows-act-like-named-tuples

Fixes:
```
galaxy-test-test_handler.service - Galaxy testtest_handler
...
May 30 12:45:58 galaxy07 galaxyctl[8447]: count_per_id = self.get_total_job_count_per_destination()
May 30 12:45:58 galaxy07 galaxyctl[8447]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
May 30 12:45:58 galaxy07 galaxyctl[8447]: File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/jobs/handler.py", line 1006, in get_total_job_count_per_destination
May 30 12:45:58 galaxy07 galaxyctl[8447]: self.__cache_total_job_count_per_destination()
May 30 12:45:58 galaxy07 galaxyctl[8447]: File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/jobs/handler.py", line 1003, in __cache_total_job_count_per_destination
May 30 12:45:58 galaxy07 galaxyctl[8447]: self.total_job_count_per_destination[row["destination_id"]] = row["job_count"]
May 30 12:45:58 galaxy07 galaxyctl[8447]: ~~~^^^^^^^^^^^^^
May 30 12:45:58 galaxy07 galaxyctl[8447]: File "lib/sqlalchemy/cyextension/resultproxy.pyx", line 54, in sqlalchemy.cyextension.resultproxy.BaseRow.__getitem__
May 30 12:45:58 galaxy07 galaxyctl[8447]: TypeError: tuple indices must be integers or slices, not str
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
