### PR TITLE
[24.0] Fix first_dataset_element type hint

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6507,7 +6507,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
         return elements
 
     @property
-    def first_dataset_element(self) -> Optional[HistoryDatasetAssociation]:
+    def first_dataset_element(self) -> Optional["DatasetCollectionElement"]:
         for element in self.elements:
             if element.is_collection:
                 first_element = element.child_collection.first_dataset_element


### PR DESCRIPTION
Minor bug introduced in https://github.com/galaxyproject/galaxy/pull/18249

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
