### PR TITLE
[24.1] More structured indexing for user data objects.

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -12812,8 +12812,6 @@ export interface components {
             device?: string | null;
             /** Hidden */
             hidden: boolean;
-            /** Id */
-            id: number | string;
             /** Name */
             name?: string | null;
             /** Object Store Id */
@@ -12891,8 +12889,6 @@ export interface components {
             description: string | null;
             /** Hidden */
             hidden: boolean;
-            /** Id */
-            id: string | number;
             /** Name */
             name: string;
             /** Purged */
@@ -15195,7 +15191,7 @@ export interface operations {
             header?: {
                 "run-as"?: string | null;
             };
-            /** @description The index for a persisted UserFileSourceStore object. */
+            /** @description The UUID index for a persisted UserFileSourceStore object. */
             path: {
                 user_file_source_id: string;
             };
@@ -15222,7 +15218,7 @@ export interface operations {
             header?: {
                 "run-as"?: string | null;
             };
-            /** @description The index for a persisted UserFileSourceStore object. */
+            /** @description The UUID index for a persisted UserFileSourceStore object. */
             path: {
                 user_file_source_id: string;
             };
@@ -15257,7 +15253,7 @@ export interface operations {
             header?: {
                 "run-as"?: string | null;
             };
-            /** @description The index for a persisted UserFileSourceStore object. */
+            /** @description The UUID index for a persisted UserFileSourceStore object. */
             path: {
                 user_file_source_id: string;
             };
@@ -21119,7 +21115,7 @@ export interface operations {
             header?: {
                 "run-as"?: string | null;
             };
-            /** @description The identifier used to index a persisted UserObjectStore object. */
+            /** @description The UUID used to identify a persisted UserObjectStore object. */
             path: {
                 user_object_store_id: string;
             };
@@ -21146,7 +21142,7 @@ export interface operations {
             header?: {
                 "run-as"?: string | null;
             };
-            /** @description The identifier used to index a persisted UserObjectStore object. */
+            /** @description The UUID used to identify a persisted UserObjectStore object. */
             path: {
                 user_object_store_id: string;
             };
@@ -21181,7 +21177,7 @@ export interface operations {
             header?: {
                 "run-as"?: string | null;
             };
-            /** @description The identifier used to index a persisted UserObjectStore object. */
+            /** @description The UUID used to identify a persisted UserObjectStore object. */
             path: {
                 user_object_store_id: string;
             };

--- a/client/src/components/ConfigTemplates/test_fixtures.ts
+++ b/client/src/components/ConfigTemplates/test_fixtures.ts
@@ -114,7 +114,6 @@ export const OBJECT_STORE_INSTANCE: UserConcreteObjectStore = {
     secrets: ["oldsecret", "droppedsecret"],
     quota: { enabled: false },
     private: false,
-    id: 4,
     uuid: "112f889f-72d7-4619-a8e8-510a8c685aa7",
     active: true,
     hidden: false,

--- a/client/src/components/FileSources/Instances/EditInstance.vue
+++ b/client/src/components/FileSources/Instances/EditInstance.vue
@@ -13,7 +13,7 @@ import EditSecrets from "./EditSecrets.vue";
 import InstanceForm from "@/components/ConfigTemplates/InstanceForm.vue";
 
 interface Props {
-    instanceId: number | string;
+    instanceId: string;
 }
 
 const props = defineProps<Props>();
@@ -36,7 +36,7 @@ const loadingMessage = "Loading file source template and instance information";
 async function onSubmit(formData: any) {
     if (template.value) {
         const payload = editFormDataToPayload(template.value, formData);
-        const args = { user_file_source_id: String(instance?.value?.id) };
+        const args = { user_file_source_id: String(instance?.value?.uuid) };
         const { data: fileSource } = await update({ ...args, ...payload });
         await onUpdate(fileSource);
     }

--- a/client/src/components/FileSources/Instances/EditSecrets.vue
+++ b/client/src/components/FileSources/Instances/EditSecrets.vue
@@ -19,7 +19,7 @@ async function onUpdate(secretName: string, secretValue: string) {
         secret_name: secretName,
         secret_value: secretValue,
     };
-    const args = { user_file_source_id: String(props.fileSource.id) };
+    const args = { user_file_source_id: String(props.fileSource.uuid) };
     await update({ ...args, ...payload });
 }
 </script>

--- a/client/src/components/FileSources/Instances/InstanceDropdown.vue
+++ b/client/src/components/FileSources/Instances/InstanceDropdown.vue
@@ -15,8 +15,8 @@ interface Props {
 }
 
 const props = defineProps<Props>();
-const routeEdit = computed(() => `/file_source_instances/${props.fileSource.id}/edit`);
-const routeUpgrade = computed(() => `/file_source_instances/${props.fileSource.id}/upgrade`);
+const routeEdit = computed(() => `/file_source_instances/${props.fileSource.uuid}/edit`);
+const routeUpgrade = computed(() => `/file_source_instances/${props.fileSource.uuid}/upgrade`);
 const isUpgradable = computed(() =>
     fileSourceTemplatesStore.canUpgrade(props.fileSource.template_id, props.fileSource.template_version)
 );

--- a/client/src/components/FileSources/Instances/UpgradeForm.vue
+++ b/client/src/components/FileSources/Instances/UpgradeForm.vue
@@ -31,7 +31,7 @@ const loadingMessage = "Loading file source template and instance information";
 
 async function onSubmit(formData: any) {
     const payload = upgradeFormDataToPayload(props.latestTemplate, formData);
-    const args = { user_file_source_id: String(props.instance.id) };
+    const args = { user_file_source_id: String(props.instance.uuid) };
     try {
         const { data: fileSource } = await update({ ...args, ...payload });
         await onUpgrade(fileSource);

--- a/client/src/components/FileSources/Instances/UpgradeInstance.vue
+++ b/client/src/components/FileSources/Instances/UpgradeInstance.vue
@@ -9,7 +9,7 @@ import UpgradeForm from "./UpgradeForm.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 interface Props {
-    instanceId: number | string;
+    instanceId: string;
 }
 
 const props = defineProps<Props>();

--- a/client/src/components/FileSources/Instances/instance.ts
+++ b/client/src/components/FileSources/Instances/instance.ts
@@ -4,7 +4,7 @@ import type { FileSourceTemplateSummary, UserFileSourceModel } from "@/api/fileS
 import { useFileSourceInstancesStore } from "@/stores/fileSourceInstancesStore";
 import { useFileSourceTemplatesStore } from "@/stores/fileSourceTemplatesStore";
 
-export function useInstanceAndTemplate(instanceIdRef: Ref<string | number>) {
+export function useInstanceAndTemplate(instanceIdRef: Ref<string>) {
     const fileSourceTemplatesStore = useFileSourceTemplatesStore();
     const fileSourceInstancesStore = useFileSourceInstancesStore();
     fileSourceInstancesStore.fetchInstances();

--- a/client/src/components/FileSources/Instances/services.ts
+++ b/client/src/components/FileSources/Instances/services.ts
@@ -7,7 +7,7 @@ export const update = fetcher.path("/api/file_source_instances/{user_file_source
 
 export async function hide(instance: UserFileSourceModel) {
     const payload = { hidden: true };
-    const args = { user_file_source_id: String(instance?.id) };
+    const args = { user_file_source_id: String(instance?.uuid) };
     const { data: fileSource } = await update({ ...args, ...payload });
     return fileSource;
 }

--- a/client/src/components/ObjectStore/Instances/EditInstance.vue
+++ b/client/src/components/ObjectStore/Instances/EditInstance.vue
@@ -13,7 +13,7 @@ import EditSecrets from "./EditSecrets.vue";
 import InstanceForm from "@/components/ConfigTemplates/InstanceForm.vue";
 
 interface Props {
-    instanceId: number | string;
+    instanceId: string;
 }
 
 const props = defineProps<Props>();
@@ -36,7 +36,7 @@ const loadingMessage = "Loading storage location template and instance informati
 async function onSubmit(formData: any) {
     if (template.value) {
         const payload = editFormDataToPayload(template.value, formData);
-        const args = { user_object_store_id: String(instance?.value?.id) };
+        const args = { user_object_store_id: String(instance?.value?.uuid) };
         const { data: objectStore } = await update({ ...args, ...payload });
         await onUpdate(objectStore);
     }

--- a/client/src/components/ObjectStore/Instances/EditSecrets.vue
+++ b/client/src/components/ObjectStore/Instances/EditSecrets.vue
@@ -20,7 +20,7 @@ async function onUpdate(secretName: string, secretValue: string) {
         secret_name: secretName,
         secret_value: secretValue,
     };
-    const args = { user_object_store_id: String(props.objectStore.id) };
+    const args = { user_object_store_id: String(props.objectStore.uuid) };
     await update({ ...args, ...payload });
 }
 </script>

--- a/client/src/components/ObjectStore/Instances/InstanceDropdown.vue
+++ b/client/src/components/ObjectStore/Instances/InstanceDropdown.vue
@@ -15,8 +15,8 @@ interface Props {
 }
 
 const props = defineProps<Props>();
-const routeEdit = computed(() => `/object_store_instances/${props.objectStore.id}/edit`);
-const routeUpgrade = computed(() => `/object_store_instances/${props.objectStore.id}/upgrade`);
+const routeEdit = computed(() => `/object_store_instances/${props.objectStore.uuid}/edit`);
+const routeUpgrade = computed(() => `/object_store_instances/${props.objectStore.uuid}/upgrade`);
 const isUpgradable = computed(() =>
     objectStoreTemplatesStore.canUpgrade(props.objectStore.template_id, props.objectStore.template_version)
 );

--- a/client/src/components/ObjectStore/Instances/UpgradeForm.test.ts
+++ b/client/src/components/ObjectStore/Instances/UpgradeForm.test.ts
@@ -59,7 +59,6 @@ const INSTANCE: UserConcreteObjectStore = {
     secrets: ["oldsecret", "droppedsecret"],
     quota: { enabled: false },
     private: false,
-    id: 4,
     uuid: "112f889f-72d7-4619-a8e8-510a8c685aa7",
     active: true,
     hidden: false,

--- a/client/src/components/ObjectStore/Instances/UpgradeForm.vue
+++ b/client/src/components/ObjectStore/Instances/UpgradeForm.vue
@@ -32,7 +32,7 @@ const loadingMessage = "Loading storage location template and instance informati
 
 async function onSubmit(formData: any) {
     const payload = upgradeFormDataToPayload(props.latestTemplate, formData);
-    const args = { user_object_store_id: String(props.instance.id) };
+    const args = { user_object_store_id: String(props.instance.uuid) };
     try {
         const { data: objectStore } = await update({ ...args, ...payload });
         await onUpgrade(objectStore);

--- a/client/src/components/ObjectStore/Instances/UpgradeInstance.vue
+++ b/client/src/components/ObjectStore/Instances/UpgradeInstance.vue
@@ -9,7 +9,7 @@ import UpgradeForm from "./UpgradeForm.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 interface Props {
-    instanceId: number | string;
+    instanceId: string;
 }
 
 const props = defineProps<Props>();

--- a/client/src/components/ObjectStore/Instances/instance.ts
+++ b/client/src/components/ObjectStore/Instances/instance.ts
@@ -6,7 +6,7 @@ import { useObjectStoreTemplatesStore } from "@/stores/objectStoreTemplatesStore
 
 import type { UserConcreteObjectStore } from "./types";
 
-export function useInstanceAndTemplate(instanceIdRef: Ref<string | number>) {
+export function useInstanceAndTemplate(instanceIdRef: Ref<string>) {
     const objectStoreTemplatesStore = useObjectStoreTemplatesStore();
     const objectStoreInstancesStore = useObjectStoreInstancesStore();
     objectStoreInstancesStore.fetchInstances();

--- a/client/src/components/ObjectStore/Instances/services.ts
+++ b/client/src/components/ObjectStore/Instances/services.ts
@@ -8,7 +8,7 @@ export const update = fetcher.path("/api/object_store_instances/{user_object_sto
 
 export async function hide(instance: UserConcreteObjectStore) {
     const payload = { hidden: true };
-    const args = { user_object_store_id: String(instance?.id) };
+    const args = { user_object_store_id: String(instance?.uuid) };
     const { data: objectStore } = await update({ ...args, ...payload });
     return objectStore;
 }

--- a/client/src/stores/fileSourceInstancesStore.ts
+++ b/client/src/stores/fileSourceInstancesStore.ts
@@ -22,7 +22,7 @@ export const useFileSourceInstancesStore = defineStore("fileSourceInstances", {
             return !state.fetched;
         },
         getInstance: (state) => {
-            return (id: number | string) => state.instances.find((i) => i.id.toString() == id.toString());
+            return (uuid: string) => state.instances.find((i) => i.uuid == uuid);
         },
     },
     actions: {

--- a/client/src/stores/objectStoreInstancesStore.test.ts
+++ b/client/src/stores/objectStoreInstancesStore.test.ts
@@ -4,6 +4,7 @@ import { useObjectStoreInstancesStore } from "@/stores/objectStoreInstancesStore
 import { setupTestPinia } from "./testUtils";
 
 const type = "aws_s3" as ObjectStoreTemplateType;
+const UUID = "112f889f-72d7-4619-a8e8-510a8c685aa7";
 const TEST_INSTANCE = {
     type: type,
     name: "moo",
@@ -15,8 +16,7 @@ const TEST_INSTANCE = {
     secrets: [],
     quota: { enabled: false },
     private: false,
-    id: 4,
-    uuid: "112f889f-72d7-4619-a8e8-510a8c685aa7",
+    uuid: UUID,
     active: true,
     hidden: false,
     purged: false,
@@ -45,13 +45,7 @@ describe("Object Store Instances Store", () => {
     it("should allow finding an instance by instance id", () => {
         const objectStoreInstancesStore = useObjectStoreInstancesStore();
         objectStoreInstancesStore.handleInit([TEST_INSTANCE]);
-        expect(objectStoreInstancesStore.getInstance(4)?.name).toBe("moo");
-    });
-
-    it("should allow finding an instance by instance id as string (for props)", () => {
-        const objectStoreInstancesStore = useObjectStoreInstancesStore();
-        objectStoreInstancesStore.handleInit([TEST_INSTANCE]);
-        expect(objectStoreInstancesStore.getInstance("4")?.name).toBe("moo");
+        expect(objectStoreInstancesStore.getInstance(UUID)?.name).toBe("moo");
     });
 
     it("should populate an error with handleError", () => {

--- a/client/src/stores/objectStoreInstancesStore.ts
+++ b/client/src/stores/objectStoreInstancesStore.ts
@@ -22,7 +22,7 @@ export const useObjectStoreInstancesStore = defineStore("objectStoreInstances", 
             return !state.fetched;
         },
         getInstance: (state) => {
-            return (id: number | string) => state.instances.find((i) => i.id.toString() == id.toString());
+            return (uuid: string) => state.instances.find((i) => i.uuid == uuid);
         },
     },
     actions: {

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -435,7 +435,6 @@ class MinimalGalaxyApplication(BasicSharedApp, HaltableContainer, SentryClientMi
             gid=self.config.gid,
             object_store_cache_size=self.config.object_store_cache_size,
             object_store_cache_path=self.config.object_store_cache_path,
-            user_config_templates_index_by=self.config.user_config_templates_index_by,
             user_config_templates_use_saved_configuration=self.config.user_config_templates_use_saved_configuration,
         )
         self._register_singleton(UserObjectStoresAppConfig, app_config)

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -581,19 +581,6 @@ mapping:
         desc: |
           Configured user file source templates embedded into Galaxy's config.
 
-      user_config_templates_index_by:
-        type: str
-        default: 'uuid'
-        required: false
-        enum: ['uuid', 'id']
-        desc: |
-          Configure URIs for user object stores to use either the object ID ('id')
-          or UUIDs ('uuid'). Either is fine really, Galaxy doesn't typically expose
-          database objects by 'id' but there isn't any obvious disadvantage to doing
-          it in this case and it keeps user exposed URIs much smaller. The default of
-          UUID feels a little more like a typical way to do this within Galaxy though.
-          Do not change this value once user object stores have been created.
-
       user_config_templates_use_saved_configuration:
         type: str
         default: 'fallback'

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -10980,7 +10980,8 @@ class UserPreference(Base, RepresentById):
 
 
 class UsesTemplatesAppConfig(Protocol):
-    user_config_templates_index_by: Literal["uuid", "id"]
+    # TODO: delete this config protocol def and uses in dev
+    pass
 
 
 class HasConfigSecrets(RepresentById):
@@ -10990,10 +10991,7 @@ class HasConfigSecrets(RepresentById):
     user: Mapped["User"]
 
     def vault_id_prefix(self, app_config: UsesTemplatesAppConfig) -> str:
-        if app_config.user_config_templates_index_by == "id":
-            id_str = str(self.id)
-        else:
-            id_str = str(self.uuid)
+        id_str = str(self.uuid)
         user_vault_id_prefix = f"{self.secret_config_type}/{id_str}"
         return user_vault_id_prefix
 

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -1369,17 +1369,10 @@ class DistributedObjectStore(NestedObjectStore):
             if not user:
                 return "Supplied object store id is not accessible"
             rest_of_uri = object_store_id.split("://", 1)[1]
-            index_by = self.config.user_config_templates_index_by
-            if index_by == "id":
-                user_object_store_id = int(rest_of_uri)
-                for user_object_store in user.object_stores:
-                    if user_object_store.id == user_object_store_id:
-                        return None
-            else:
-                user_object_store_uuid = rest_of_uri
-                for user_object_store in user.object_stores:
-                    if str(user_object_store.uuid) == user_object_store_uuid:
-                        return None
+            user_object_store_uuid = rest_of_uri
+            for user_object_store in user.object_stores:
+                if str(user_object_store.uuid) == user_object_store_uuid:
+                    return None
             return "Supplied object store id was not found"
         if object_store_id not in self.object_store_ids_allowing_selection():
             return "Supplied object store id is not an allowed object store selection"
@@ -1663,7 +1656,6 @@ def build_object_store_from_config(
 class UserObjectStoresAppConfig(BaseModel):
     object_store_cache_path: str
     object_store_cache_size: int
-    user_config_templates_index_by: Literal["uuid", "id"]
     user_config_templates_use_saved_configuration: Literal["fallback", "preferred", "never"]
     jobs_directory: str
     new_file_path: str

--- a/lib/galaxy/objectstore/unittest_utils/__init__.py
+++ b/lib/galaxy/objectstore/unittest_utils/__init__.py
@@ -108,7 +108,6 @@ def app_config(tmpdir) -> objectstore.UserObjectStoresAppConfig:
         gid=0o077,
         object_store_cache_path=str(tmpdir / "cache"),
         object_store_cache_size=1,
-        user_config_templates_index_by="uuid",
         user_config_templates_use_saved_configuration="fallback",
     )
     return app_config

--- a/lib/galaxy/webapps/galaxy/api/file_sources.py
+++ b/lib/galaxy/webapps/galaxy/api/file_sources.py
@@ -29,7 +29,7 @@ router = Router(tags=["file_sources"])
 
 
 UserFileSourceIdPathParam: str = Path(
-    ..., title="User File Source ID", description="The index for a persisted UserFileSourceStore object."
+    ..., title="User File Source UUID", description="The UUID index for a persisted UserFileSourceStore object."
 )
 
 

--- a/lib/galaxy/webapps/galaxy/api/object_store.py
+++ b/lib/galaxy/webapps/galaxy/api/object_store.py
@@ -49,8 +49,8 @@ ConcreteObjectStoreIdPathParam: str = Path(
 
 UserObjectStoreIdPathParam: str = Path(
     ...,
-    title="User Object Store Identifier",
-    description="The identifier used to index a persisted UserObjectStore object.",
+    title="User Object Store UUID",
+    description="The UUID used to identify a persisted UserObjectStore object.",
 )
 
 SelectableQueryParam: bool = Query(

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1523,7 +1523,7 @@ class BaseDatasetPopulator(BasePopulator):
         api_asserts.assert_status_code_is_ok(response)
         return response.json()
 
-    def upgrade_object_store_raw(self, id: Union[str, int], payload: Dict[str, Any]) -> Response:
+    def upgrade_object_store_raw(self, id: str, payload: Dict[str, Any]) -> Response:
         response = self._put(
             f"/api/object_store_instances/{id}",
             payload,
@@ -1531,7 +1531,7 @@ class BaseDatasetPopulator(BasePopulator):
         )
         return response
 
-    def upgrade_object_store(self, id: Union[str, int], payload: Dict[str, Any]) -> Dict[str, Any]:
+    def upgrade_object_store(self, id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         response = self.upgrade_object_store_raw(id, payload)
         api_asserts.assert_status_code_is_ok(response)
         return response.json()

--- a/test/integration/objectstore/test_per_user.py
+++ b/test/integration/objectstore/test_per_user.py
@@ -174,7 +174,7 @@ class TestPerUserObjectStoreIntegration(BaseUserObjectStoreIntegration):
         assert "faster" in badge_types
         assert "more_secure" in badge_types
         assert "no_quota" in badge_types
-        persisted_object_store_id = object_store_json["id"]
+        persisted_object_store_id = object_store_json["uuid"]
 
         payload = {
             "name": "my new name",
@@ -256,7 +256,7 @@ class TestPerUserObjectStoreWithSecretsIntegration(
         }
         object_store_json = self.dataset_populator.create_object_store(body)
         object_store_id = object_store_json["object_store_id"]
-        persisted_object_store_id = object_store_json["id"]
+        persisted_object_store_id = object_store_json["uuid"]
 
         with self.dataset_populator.test_history() as history_id:
             _, output = self._run_tool_with_object_store_id_and_then_revert(history_id, object_store_id)
@@ -317,7 +317,7 @@ class TestPerUserObjectStoreUpgradesIntegration(BaseUserObjectStoreIntegration):
         assert object_store_json["name"] == "My Upgradable Disk"
         assert object_store_json["template_version"] == 0
 
-        id = object_store_json["id"]
+        id = object_store_json["uuid"]
         object_store_id = object_store_json["object_store_id"]
         assert object_store_id.startswith("user_objects://")
 
@@ -339,7 +339,7 @@ class TestPerUserObjectStoreUpgradesIntegration(BaseUserObjectStoreIntegration):
         assert object_store_json["name"] == "My Upgradable Disk"
         new_object_store_id = object_store_json["object_store_id"]
         assert new_object_store_id == object_store_id
-        assert object_store_json["id"] == id
+        assert object_store_json["uuid"] == id
         assert object_store_json["template_version"] == 1
 
 
@@ -367,7 +367,7 @@ class TestPerUserObjectStoreUpgradesWithSecretsIntegration(
         assert "name" in object_store_json
         assert object_store_json["name"] == "My Upgradable Disk"
         assert object_store_json["template_version"] == 0
-        id = object_store_json["id"]
+        id = object_store_json["uuid"]
         object_store_id = object_store_json["object_store_id"]
 
         secrets = object_store_json["secrets"]

--- a/test/unit/app/managers/test_user_file_sources.py
+++ b/test/unit/app/managers/test_user_file_sources.py
@@ -299,7 +299,6 @@ class TestFileSourcesTestCase(BaseTestCase):
         user_file_source_showed = self.manager.show(self.trans, user_file_source.uuid)
         assert user_file_source_showed
         assert user_file_source_showed.uuid == user_file_source.uuid
-        assert user_file_source_showed.id == user_file_source.id
 
     def test_simple_update(self, tmp_path):
         self._init_managers(tmp_path, config_dict=simple_variable_template(tmp_path))

--- a/test/unit/app/managers/test_user_object_stores.py
+++ b/test/unit/app/managers/test_user_object_stores.py
@@ -120,7 +120,6 @@ class TestUserObjectStoreTestCase(BaseTestCase):
         user_object_store_showed = self.manager.show(self.trans, user_object_store.uuid)
         assert user_object_store_showed
         assert user_object_store_showed.uuid == user_object_store.uuid
-        assert user_object_store_showed.id == user_object_store.id
 
     def test_simple_update(self, tmp_path):
         self._init_managers(tmp_path, config_dict=simple_variable_template(tmp_path))


### PR DESCRIPTION
Builds on #18246 - only the last commit is relevant.

I think I clung to the idea of having two ways to do this too long. I did a bunch of testing with the old way (exposing integer references based on numeric database primary keys). Having a config option that if changed would break everything exisiting is also a symptom of maybe me clinging too hard for too long. It is probably best to drop that before the release is published.

The result of dropping this option is a much cleaner API schema, simpler API objects, and better typing throughout. We can also be more certain of how things entering the Vault are stored - I think being more strucutured about this is good.

Ultimately, the future facing stuff (e.g. OAuth 2.0) is going to require UUIDs so that I can store things like refresh tokens in the store before the object has been fully created.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
