### PR TITLE
[23.2] Add toolshed database revision tags for 23.2

### DIFF
--- a/lib/tool_shed/webapp/model/migrations/dbscript.py
+++ b/lib/tool_shed/webapp/model/migrations/dbscript.py
@@ -28,6 +28,8 @@ CONFIG_FILE_ARG = "--toolshed-config"
 REVISION_TAGS = {
     "release_23.1": "1b5bf427db25",
     "23.1": "1b5bf427db25",
+    "release_23.2": "1b5bf427db25",
+    "23.2": "1b5bf427db25",
 }
 
 


### PR DESCRIPTION
No new migrations in release, so hashes are identical.
(same type of PR coming up for 24.0 and 24.1)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
