### PR TITLE
[24.1] Fix "label updated" popup triggers too often

### DIFF
--- a/client/src/stores/undoRedoStore/index.ts
+++ b/client/src/stores/undoRedoStore/index.ts
@@ -108,7 +108,7 @@ export const useUndoRedoStore = defineScopedStore("undoRedoStore", () => {
         }
     }
 
-    function setLazyActionTimeout(timeout: number) {
+    function setLazyActionTimeout(timeout = 1000) {
         clearTimeout(lazyActionTimeout);
         lazyActionTimeout = setTimeout(() => flushLazyAction(), timeout);
     }


### PR DESCRIPTION
fix #18254

Shows the popup less often by committing less actions to the undo stack.
The lazy actions timeout is now longer, and it is reset whenever additional changes are made to the label.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
