### PR TITLE
[24.1] Fix word bleeding in modals, sharing page and history rename

### DIFF
--- a/client/src/components/Common/Heading.vue
+++ b/client/src/components/Common/Heading.vue
@@ -96,6 +96,10 @@ const element = computed(() => {
 <style lang="scss" scoped>
 @import "scss/theme/blue.scss";
 
+.heading {
+    word-break: break-all;
+}
+
 .heading:deep(svg) {
     font-size: 0.75em;
 }

--- a/client/src/components/Form/_form-elements.scss
+++ b/client/src/components/Form/_form-elements.scss
@@ -11,6 +11,10 @@
         word-wrap: break-word;
         font-weight: bold;
 
+        .ui-form-title-text {
+            word-break: break-all;
+        }
+
         .ui-form-title-message {
             font-size: $font-size-base * 0.7;
             font-weight: 300;

--- a/client/src/components/Sharing/EditableUrl.vue
+++ b/client/src/components/Sharing/EditableUrl.vue
@@ -103,11 +103,9 @@ function onCopyOut() {
 @import "theme/blue.scss";
 
 .editable-url {
-    height: 1.5rem;
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
+    word-break: break-all;
 }
+
 .inline-icon-button:disabled:hover {
     background-color: $brand-secondary;
     color: unset;

--- a/client/src/style/scss/overrides.scss
+++ b/client/src/style/scss/overrides.scss
@@ -99,6 +99,10 @@ button {
     overflow: auto;
 }
 
+.modal-title {
+    word-break: break-all;
+}
+
 // Tabs -- border color is hardcoded in navs.scss, change to $btnBorder here
 
 .nav-tabs {


### PR DESCRIPTION
This PR adds a `word-break` style to the `Heading` component, form title text in `FormElement`, the `EditableUrl` component, and all modal titles to prevent text bleeding from the frame.

Fixes #18285 and partially fixes https://github.com/galaxyproject/galaxy/issues/18285#issuecomment-2145437812

### Sharing Page
![image](https://github.com/galaxyproject/galaxy/assets/8046843/26ea73ea-b543-4794-985c-23045b3a9128)

### History Rename
![image](https://github.com/galaxyproject/galaxy/assets/8046843/765c5e61-88da-4c4a-abb6-5c4e237f0bcf)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
