### PR TITLE
[24.0] Don't serialize display application links for deleted datasets

### DIFF
--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -617,18 +617,19 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
         """
         hda = item
         display_apps: List[Dict[str, Any]] = []
-        for display_app in hda.get_display_applications(trans).values():
-            app_links = []
-            for link_app in display_app.links.values():
-                app_links.append(
-                    {
-                        "target": link_app.url.get("target_frame", "_blank"),
-                        "href": link_app.get_display_url(hda, trans),
-                        "text": gettext.gettext(link_app.name),
-                    }
-                )
-            if app_links:
-                display_apps.append(dict(label=display_app.name, links=app_links))
+        if hda.state == model.HistoryDatasetAssociation.states.OK and not hda.deleted:
+            for display_app in hda.get_display_applications(trans).values():
+                app_links = []
+                for link_app in display_app.links.values():
+                    app_links.append(
+                        {
+                            "target": link_app.url.get("target_frame", "_blank"),
+                            "href": link_app.get_display_url(hda, trans),
+                            "text": gettext.gettext(link_app.name),
+                        }
+                    )
+                if app_links:
+                    display_apps.append(dict(label=display_app.name, links=app_links))
 
         return display_apps
 
@@ -638,28 +639,30 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
         """
         hda = item
         display_apps: List[Dict[str, Any]] = []
-        if not self.app.config.enable_old_display_applications:
-            return display_apps
+        if (
+            self.app.config.enable_old_display_applications
+            and hda.state == model.HistoryDatasetAssociation.states.OK
+            and not hda.deleted
+        ):
+            display_link_fn = hda.datatype.get_display_links
+            for display_app in hda.datatype.get_display_types():
+                target_frame, display_links = display_link_fn(
+                    hda,
+                    display_app,
+                    self.app,
+                    trans.request.base,
+                )
 
-        display_link_fn = hda.datatype.get_display_links
-        for display_app in hda.datatype.get_display_types():
-            target_frame, display_links = display_link_fn(
-                hda,
-                display_app,
-                self.app,
-                trans.request.base,
-            )
+                if len(display_links) > 0:
+                    display_label = hda.datatype.get_display_label(display_app)
 
-            if len(display_links) > 0:
-                display_label = hda.datatype.get_display_label(display_app)
-
-                app_links = []
-                for display_name, display_link in display_links:
-                    app_links.append(
-                        {"target": target_frame, "href": display_link, "text": gettext.gettext(display_name)}
-                    )
-                if app_links:
-                    display_apps.append(dict(label=display_label, links=app_links))
+                    app_links = []
+                    for display_name, display_link in display_links:
+                        app_links.append(
+                            {"target": target_frame, "href": display_link, "text": gettext.gettext(display_name)}
+                        )
+                    if app_links:
+                        display_apps.append(dict(label=display_label, links=app_links))
 
         return display_apps
 


### PR DESCRIPTION
Doing that often requires datasets on disk, which we shouldn't guarantee for deleted datasets.

Fixes
https://sentry.galaxyproject.org/share/issue/0ae7a9d9ad564054bd11c9a43aa6994c/:
```
Message
Unexpected error
Stack Trace

Newest

FileNotFoundError: [Errno 2] No such file or directory: ''
  File "galaxy/datatypes/interval.py", line 914, in get_estimated_display_viewport
    with compression_utils.get_fileobj(dataset.get_file_name()) as fh:
  File "galaxy/util/compression_utils.py", line 79, in get_fileobj
    return get_fileobj_raw(filename, mode, compressed_formats)[1]
  File "galaxy/util/compression_utils.py", line 139, in get_fileobj_raw
    return compressed_format, open(filename, mode, encoding="utf-8")
```

(Also note how it's very bad to pull in the dataset from an object store just to generate the link if we request the `extended` dataset view ...).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
