### PR TITLE
[24.1] Display error message if not an image in reports

### DIFF
--- a/client/src/components/Dataset/DatasetAsImage/DatasetAsImage.vue
+++ b/client/src/components/Dataset/DatasetAsImage/DatasetAsImage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computedAsync } from "@vueuse/core";
 import { computed } from "vue";
 
 import { type PathDestination, useDatasetPathDestination } from "@/composables/datasetPathDestination";
@@ -24,6 +25,15 @@ const imageUrl = computed(() => {
 
     return pathDestination.value?.fileLink;
 });
+
+const isImage = computedAsync(async () => {
+    if (!imageUrl.value) {
+        return null;
+    }
+    const res = await fetch(imageUrl.value);
+    const buff = await res.blob();
+    return buff.type.startsWith("image/");
+}, null);
 </script>
 
 <template>
@@ -31,6 +41,7 @@ const imageUrl = computed(() => {
         <div v-if="imageUrl" class="w-100 p-2">
             <b-card nobody body-class="p-1">
                 <b-img :src="imageUrl" fluid />
+                <span v-if="!isImage" class="text-danger">This dataset does not appear to be an image.</span>
             </b-card>
         </div>
         <div v-else>


### PR DESCRIPTION
Fixes #18281

Feel free to ignore if this is too overkill... :sweat_smile: 

![image](https://github.com/galaxyproject/galaxy/assets/46503462/de362c7a-c9dd-4287-a2bf-0223ab369f8f)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
