### PR TITLE
[24.1] Filter data dialog entries by dataset state, only display `ok` state

### DIFF
--- a/client/src/components/DataDialog/DataDialog.vue
+++ b/client/src/components/DataDialog/DataDialog.vue
@@ -23,6 +23,7 @@ interface Record {
 interface Props {
     allowUpload?: boolean;
     callback?: (results: Array<Record>) => void;
+    filterOkState?: boolean;
     format?: string;
     library?: boolean;
     modalStatic?: boolean;
@@ -34,6 +35,7 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
     allowUpload: true,
     callback: () => {},
+    filterOkState: false,
     format: "download",
     library: true,
     modalStatic: false,
@@ -90,7 +92,11 @@ function formatRows() {
 
 /** Returns the default url i.e. the url of the current history **/
 function getHistoryUrl() {
-    return `${getAppRoot()}api/histories/${props.history}/contents?v=dev&q=state-eq&qv=ok&q=deleted&qv=false`;
+    let queryString = "&q=deleted&qv=false";
+    if (props.filterOkState) {
+        queryString += "&q=state-eq&qv=ok";
+    }
+    return `${getAppRoot()}api/histories/${props.history}/contents?v=dev${queryString}`;
 }
 
 /** Called when the modal is hidden */

--- a/client/src/components/DataDialog/DataDialog.vue
+++ b/client/src/components/DataDialog/DataDialog.vue
@@ -90,7 +90,7 @@ function formatRows() {
 
 /** Returns the default url i.e. the url of the current history **/
 function getHistoryUrl() {
-    return `${getAppRoot()}api/histories/${props.history}/contents?deleted=false`;
+    return `${getAppRoot()}api/histories/${props.history}/contents?v=dev&q=state-eq&qv=ok&q=deleted&qv=false`;
 }
 
 /** Called when the modal is hidden */

--- a/client/src/components/Panels/VisualizationPanel.vue
+++ b/client/src/components/Panels/VisualizationPanel.vue
@@ -93,9 +93,10 @@ onMounted(() => {
             <BAlert v-else v-localize variant="info" show> No matching visualization found. </BAlert>
         </div>
         <DataDialog
-            v-if="showDataDialog"
+            v-if="currentHistoryId && showDataDialog"
             format=""
             :history="currentHistoryId"
+            :filter-ok-state="true"
             @onOk="createVisualization"
             @onCancel="showDataDialog = false" />
     </ActivityPanel>


### PR DESCRIPTION
Fixes #18262. This is temporary minimal fix, the long term goal for the next release is to paginate and also enable user specified advanced filtering.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
