### PR TITLE
[23.2] Skip new history creation if user is anonymous and login is required

### DIFF
--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -932,6 +932,10 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
                     self.set_history(history)
                     return history
 
+        # Don't create new history if login required and user is anonymous
+        if self.app.config.require_login and not self.user:
+            return None
+
         # No suitable history found, create a new one.
         return self.new_history()
 


### PR DESCRIPTION
Most straightforward fix for
https://github.com/galaxyproject/galaxy/issues/18317. I have not been able to reproduce the issue itself though, only a single history is being created in my testing.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
