### PR TITLE
[23.2] Fix one more tool shed unit test

### DIFF
--- a/test/unit/tool_shed/_util.py
+++ b/test/unit/tool_shed/_util.py
@@ -76,6 +76,7 @@ class TestToolShedApp(ToolShedApp):
         hgweb_config_dir = os.path.join(temp_directory, "hgweb")
         safe_makedirs(hgweb_config_dir)
         self.hgweb_config_manager.hgweb_config_dir = hgweb_config_dir
+        self.hgweb_config_manager.hgweb_repo_prefix = "repos/"
         self.config = TestToolShedConfig(temp_directory)
         self.security = IdEncodingHelper(id_secret=self.config.id_secret)
         self.repository_registry = tool_shed.repository_registry.Registry(self)


### PR DESCRIPTION
Seen this after merging 23.2 into 24.0 ...

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
