### PR TITLE
[24.0] Fix users API serialization when listing users

### DIFF
--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -349,6 +349,9 @@ class LimitedUserModel(Model):
     email: Optional[str] = None
 
 
+MaybeLimitedUserModel = Union[UserModel, LimitedUserModel]
+
+
 class DiskUsageUserModel(Model):
     total_disk_usage: float = TotalDiskUsageField
     nice_total_disk_usage: str = NiceTotalDiskUsageField

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -55,12 +55,11 @@ from galaxy.schema.schema import (
     FavoriteObjectsSummary,
     FavoriteObjectType,
     FlexibleUserIdType,
-    LimitedUserModel,
+    MaybeLimitedUserModel,
     RemoteUserCreationPayload,
     UserBeaconSetting,
     UserCreationPayload,
     UserDeletionPayload,
-    UserModel,
 )
 from galaxy.security.validate_user_input import (
     validate_email,
@@ -202,7 +201,7 @@ class FastAPIUsers:
         f_email: Optional[str] = FilterEmailQueryParam,
         f_name: Optional[str] = FilterNameQueryParam,
         f_any: Optional[str] = FilterAnyQueryParam,
-    ) -> List[Union[UserModel, LimitedUserModel]]:
+    ) -> List[MaybeLimitedUserModel]:
         return self.service.get_index(trans=trans, deleted=True, f_email=f_email, f_name=f_name, f_any=f_any)
 
     @router.post(
@@ -634,7 +633,7 @@ class FastAPIUsers:
         f_email: Optional[str] = FilterEmailQueryParam,
         f_name: Optional[str] = FilterNameQueryParam,
         f_any: Optional[str] = FilterAnyQueryParam,
-    ) -> List[Union[UserModel, LimitedUserModel]]:
+    ) -> List[MaybeLimitedUserModel]:
         return self.service.get_index(trans=trans, deleted=deleted, f_email=f_email, f_name=f_name, f_any=f_any)
 
     @router.get(

--- a/test/integration/test_users.py
+++ b/test/integration/test_users.py
@@ -5,7 +5,7 @@ from galaxy_test.driver import integration_util
 USER_SUMMARY_KEYS = set(["model_class", "id", "email", "username", "deleted", "active", "last_password_change"])
 
 
-class UsersIntegrationTestCase(integration_util.IntegrationTestCase):
+class UsersIntegrationCase(integration_util.IntegrationTestCase):
     expose_user_name: ClassVar[bool]
     expose_user_email: ClassVar[bool]
     expected_regular_user_list_count: ClassVar[int]
@@ -52,7 +52,7 @@ class UsersIntegrationTestCase(integration_util.IntegrationTestCase):
             self._assert_not_has_keys(user, *unexpected_user_keys)
 
 
-class TestExposeUsersIntegration(UsersIntegrationTestCase):
+class TestExposeUsersIntegration(UsersIntegrationCase):
     expose_user_name = True
     expose_user_email = True
 
@@ -61,7 +61,7 @@ class TestExposeUsersIntegration(UsersIntegrationTestCase):
     expected_regular_user_list_count = 3
 
 
-class TestExposeOnlyUserNameIntegration(UsersIntegrationTestCase):
+class TestExposeOnlyUserNameIntegration(UsersIntegrationCase):
     expose_user_name = True
     expose_user_email = False
 
@@ -71,7 +71,7 @@ class TestExposeOnlyUserNameIntegration(UsersIntegrationTestCase):
     expected_regular_user_list_count = 3
 
 
-class TestExposeOnlyUserEmailIntegration(UsersIntegrationTestCase):
+class TestExposeOnlyUserEmailIntegration(UsersIntegrationCase):
     expose_user_name = False
     expose_user_email = True
 
@@ -81,7 +81,7 @@ class TestExposeOnlyUserEmailIntegration(UsersIntegrationTestCase):
     expected_regular_user_list_count = 3
 
 
-class TestUnexposedUsersIntegration(UsersIntegrationTestCase):
+class TestUnexposedUsersIntegration(UsersIntegrationCase):
     expose_user_name = False
     expose_user_email = False
 

--- a/test/integration/test_users.py
+++ b/test/integration/test_users.py
@@ -1,0 +1,91 @@
+from typing import ClassVar
+
+from galaxy_test.driver import integration_util
+
+USER_SUMMARY_KEYS = set(["model_class", "id", "email", "username", "deleted", "active", "last_password_change"])
+
+
+class UsersIntegrationTestCase(integration_util.IntegrationTestCase):
+    expose_user_name: ClassVar[bool]
+    expose_user_email: ClassVar[bool]
+    expected_regular_user_list_count: ClassVar[int]
+    expected_limited_user_keys: ClassVar[set]
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        config["expose_user_name"] = cls.expose_user_name
+        config["expose_user_email"] = cls.expose_user_email
+
+    def setUp(self):
+        super().setUp()
+        self._setup_users()
+
+    def _setup_users(self):
+        self.user = self._get("users/current").json()
+        self.user2 = self._setup_user("user02@test.gx")
+        self.user3 = self._setup_user("user03@test.gx")
+
+    def test_admin_index(self):
+        all_users_response = self._get("users", admin=True)
+        self._assert_status_code_is(all_users_response, 200)
+        all_users = all_users_response.json()
+        assert len(all_users) == 3
+        for user in all_users:
+            self._assert_has_keys(user, *USER_SUMMARY_KEYS)
+
+    def test_user_index(self):
+        requesting_user_id = self.user["id"]
+        all_users_response = self._get("users")
+        self._assert_status_code_is(all_users_response, 200)
+        all_users = all_users_response.json()
+        assert len(all_users) == self.expected_regular_user_list_count
+
+        unexpected_user_keys = USER_SUMMARY_KEYS - self.expected_limited_user_keys
+        for user in all_users:
+            if user["id"] == requesting_user_id:
+                # Requesting users should be able to see their own information.
+                self._assert_has_keys(user, *USER_SUMMARY_KEYS)
+                continue
+            # The user should be able to see other users information depending on the configuration.
+            self._assert_has_keys(user, *self.expected_limited_user_keys)
+            self._assert_not_has_keys(user, *unexpected_user_keys)
+
+
+class TestExposeUsersIntegration(UsersIntegrationTestCase):
+    expose_user_name = True
+    expose_user_email = True
+
+    # Since we allow to expose user information, all users are returned.
+    expected_limited_user_keys = set(["id", "username", "email"])
+    expected_regular_user_list_count = 3
+
+
+class TestExposeOnlyUserNameIntegration(UsersIntegrationTestCase):
+    expose_user_name = True
+    expose_user_email = False
+
+    # When only username is exposed, only that field is returned in the user list.
+    # Since we are exposing user information, all users are returned.
+    expected_limited_user_keys = set(["id", "username"])
+    expected_regular_user_list_count = 3
+
+
+class TestExposeOnlyUserEmailIntegration(UsersIntegrationTestCase):
+    expose_user_name = False
+    expose_user_email = True
+
+    # When only email is exposed, only that field is returned in the user list.
+    # Since we are exposing user information, all users are returned.
+    expected_limited_user_keys = set(["id", "email"])
+    expected_regular_user_list_count = 3
+
+
+class TestUnexposedUsersIntegration(UsersIntegrationTestCase):
+    expose_user_name = False
+    expose_user_email = False
+
+    # Since no user information is exposed, only the current user should be returned.
+    # And the current user has all fields, so no limited fields.
+    expected_limited_user_keys = set()
+    expected_regular_user_list_count = 1


### PR DESCRIPTION
Fixes #18300

This includes integration tests that passed in 23.1 but not in 24.0. We can target 23.2 if necessary.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
