### PR TITLE
[23.1] Make toolshed repo permissions world-readable

### DIFF
--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -208,6 +208,9 @@ def create_repository(
         dir=app.config.file_path,
         prefix=f"{repository.user.username}-{repository.name}",
     )
+    # Created directory is readable, writable, and searchable only by the creating user ID,
+    # but we need to make it world-readable so non-shed user can serve files (e.g. hgweb run as different user).
+    os.chmod(repository_path, util.RWXR_XR_X)
     # Create the local repository.
     init_repository(repo_path=repository_path)
     # Create a .hg/hgrc file for the local repository.


### PR DESCRIPTION
Fixes cloning from newly created repositories if external hgweb process runs as different user.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
