### PR TITLE
[24.0] Fix seek in slurm memory check

### DIFF
--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -220,7 +220,7 @@ class SlurmJobRunner(DRMAAJobRunner):
                     f.seek(-2048, os.SEEK_END)
                     f.readline()
                 for line in f.readlines():
-                    stripped_line = unicodify(line)
+                    stripped_line = unicodify(line.strip())
                     if stripped_line == SLURM_MEMORY_LIMIT_EXCEEDED_MSG:
                         return OUT_OF_MEMORY_MSG
                     elif any(_ in stripped_line for _ in SLURM_MEMORY_LIMIT_EXCEEDED_PARTIAL_WARNINGS):

--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -7,7 +7,10 @@ import time
 
 from galaxy import model
 from galaxy.jobs.runners.drmaa import DRMAAJobRunner
-from galaxy.util import commands
+from galaxy.util import (
+    commands,
+    unicodify,
+)
 from galaxy.util.custom_logging import get_logger
 
 log = get_logger(__name__)
@@ -212,12 +215,12 @@ class SlurmJobRunner(DRMAAJobRunner):
         """
         try:
             log.debug("Checking %s for exceeded memory message from SLURM", efile_path)
-            with open(efile_path) as f:
+            with open(efile_path, "rb") as f:
                 if os.path.getsize(efile_path) > 2048:
                     f.seek(-2048, os.SEEK_END)
                     f.readline()
                 for line in f.readlines():
-                    stripped_line = line.strip()
+                    stripped_line = unicodify(line)
                     if stripped_line == SLURM_MEMORY_LIMIT_EXCEEDED_MSG:
                         return OUT_OF_MEMORY_MSG
                     elif any(_ in stripped_line for _ in SLURM_MEMORY_LIMIT_EXCEEDED_PARTIAL_WARNINGS):


### PR DESCRIPTION
Fixes
https://sentry.galaxyproject.org/share/issue/e196a12836fe40da83c5e9e24c4c8329/:
```
UnsupportedOperation: can't do nonzero end-relative seeks
  File "galaxy/jobs/runners/slurm.py", line 217, in __check_memory_limit
    f.seek(-2048, os.SEEK_END)
```
which has probably been broken since we moved to python 3.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
