### PR TITLE
[24.0] Make sure that all Linter subclasses are imported for listing them

### DIFF
--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -109,6 +109,8 @@ class Linter(ABC):
         submodules.import_submodules(galaxy.tool_util.linters)
         return [s.__name__ for s in cls.__subclasses__()]
 
+    list_listers = list_linters  # deprecated alias
+
 
 class LintMessage:
     """

--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -101,7 +101,6 @@ class Linter(ABC):
         """
         return cls.__name__
 
-    @classmethod
     def list_linters(cls) -> List[str]:
         """
         list the names of all linter derived from Linter
@@ -109,8 +108,10 @@ class Linter(ABC):
         submodules.import_submodules(galaxy.tool_util.linters)
         return [s.__name__ for s in cls.__subclasses__()]
 
-    @classmethod
     list_listers = list_linters  # deprecated alias
+
+
+Linter.list_listers = classmethod(Linter.list_listers)
 
 
 class LintMessage:

--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -102,7 +102,7 @@ class Linter(ABC):
         return cls.__name__
 
     @classmethod
-    def list_listers(cls) -> List[str]:
+    def list_linters(cls) -> List[str]:
         """
         list the names of all linter derived from Linter
         """

--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -106,6 +106,7 @@ class Linter(ABC):
         """
         list the names of all linter derived from Linter
         """
+        submodules.import_submodules(galaxy.tool_util.linters)
         return [s.__name__ for s in cls.__subclasses__()]
 
 

--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -109,6 +109,7 @@ class Linter(ABC):
         submodules.import_submodules(galaxy.tool_util.linters)
         return [s.__name__ for s in cls.__subclasses__()]
 
+    @classmethod
     list_listers = list_linters  # deprecated alias
 
 

--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -101,6 +101,7 @@ class Linter(ABC):
         """
         return cls.__name__
 
+    @classmethod
     def list_linters(cls) -> List[str]:
         """
         list the names of all linter derived from Linter
@@ -108,10 +109,13 @@ class Linter(ABC):
         submodules.import_submodules(galaxy.tool_util.linters)
         return [s.__name__ for s in cls.__subclasses__()]
 
-    list_listers = list_linters  # deprecated alias
+    list_listers: Callable[[], List[str]]  # deprecated alias
 
 
-Linter.list_listers = classmethod(Linter.list_listers)
+# Define the `list_listers` alias outside of the `Linter` class so that
+# @classmethod's change to `list_linters`s signature has taken effect and mypy
+# doesn't report an [assignment] error
+Linter.list_listers = Linter.list_linters
 
 
 class LintMessage:


### PR DESCRIPTION
Otherwise planemo prints out an error `Unknown linter type(s) ....` (and continues anyway ... but I think we should fix this).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
