### PR TITLE
[24.1] Fix visualizations compatible dataset filtering

### DIFF
--- a/client/src/components/DataDialog/DataDialog.vue
+++ b/client/src/components/DataDialog/DataDialog.vue
@@ -197,6 +197,7 @@ watch(
         :disable-ok="!hasValue"
         :fields="fields"
         :items="items"
+        :total-items="items.length"
         :modal-show="modalShow"
         :multiple="multiple"
         :options-show="optionsShow"

--- a/client/src/components/DataDialog/DataDialog.vue
+++ b/client/src/components/DataDialog/DataDialog.vue
@@ -98,7 +98,7 @@ function getHistoryUrl() {
     if (props.filterOkState) {
         queryString += "&q=state-eq&qv=ok";
     }
-    if (props.filterByTypeIds.length > 0) {
+    if (props.filterByTypeIds && props.filterByTypeIds.length > 0) {
         queryString += `&q=type_id-in&qv=${props.filterByTypeIds.join(",")}`;
     }
     return `${getAppRoot()}api/histories/${props.history}/contents?v=dev${queryString}`;

--- a/client/src/components/DataDialog/DataDialog.vue
+++ b/client/src/components/DataDialog/DataDialog.vue
@@ -24,6 +24,7 @@ interface Props {
     allowUpload?: boolean;
     callback?: (results: Array<Record>) => void;
     filterOkState?: boolean;
+    filterByTypeIds?: string[];
     format?: string;
     library?: boolean;
     modalStatic?: boolean;
@@ -36,6 +37,7 @@ const props = withDefaults(defineProps<Props>(), {
     allowUpload: true,
     callback: () => {},
     filterOkState: false,
+    filterByTypeIds: undefined,
     format: "download",
     library: true,
     modalStatic: false,
@@ -95,6 +97,9 @@ function getHistoryUrl() {
     let queryString = "&q=deleted&qv=false";
     if (props.filterOkState) {
         queryString += "&q=state-eq&qv=ok";
+    }
+    if (props.filterByTypeIds.length > 0) {
+        queryString += `&q=type_id-in&qv=${props.filterByTypeIds.join(",")}`;
     }
     return `${getAppRoot()}api/histories/${props.history}/contents?v=dev${queryString}`;
 }

--- a/config/plugins/visualizations/editor/config/editor.xml
+++ b/config/plugins/visualizations/editor/config/editor.xml
@@ -5,7 +5,7 @@
     <data_sources>
         <data_source>
             <model_class>HistoryDatasetAssociation</model_class>
-            <test type="isinstance" test_attr="datatype" result_type="datatype">data.Data</test>
+            <test type="isinstance" test_attr="datatype" result_type="datatype">data.Text</test>
             <to_param param_attr="id">dataset_id</to_param>
         </data_source>
     </data_sources>


### PR DESCRIPTION
Fixes #18321

This solution may not scale well with potentially huge histories. However, the previous existing approach was similar. We should improve this use case in the `api/plugins/{id}?history_id={history_id}` on dev. I'm not sure if possible, but an alternative could be instead of returning a list of dataset IDs and names from the history and then using those IDs to get all these datasets from the history with more details again, `api/plugins/{id}` could return the list of compatible **datatypes**, and then use this to filter the history contents when browsing. But all this will require changes in the API unless I'm missing something.

This also fixes the datatype associated with the `Editor` visualization in https://github.com/galaxyproject/galaxy/commit/205601fb0d0af7dc5cf531e4b76add4a3ef38605.

![FixVisualizationCompatibleDatasets](https://github.com/galaxyproject/galaxy/assets/46503462/0178c68f-0f00-459f-9937-98edb4b987b4)


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Try to open a visualization in the Activity Bar.
  - If your current history contains datasets compatible with it, only those will show up.
  - Otherwise, a message indicating no datasets are compatible is shown.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
