### PR TITLE
[24.1] Fix typing issue in reused variable

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -259,9 +259,7 @@ class UsersService(ServiceBase):
                 for key, value in user_dict.items():
                     if key in expose_keys:
                         limited_user[key] = value
-                user = LimitedUserModel(**limited_user)
+                rval.append(LimitedUserModel(**limited_user))
             else:
-                user = UserModel(**user_dict)
-
-            rval.append(user)
+                rval.append(UserModel(**user_dict))
         return rval

--- a/test/integration/test_users.py
+++ b/test/integration/test_users.py
@@ -1,15 +1,18 @@
-from typing import ClassVar
+from typing import (
+    ClassVar,
+    Set,
+)
 
 from galaxy_test.driver import integration_util
 
-USER_SUMMARY_KEYS = set(["model_class", "id", "email", "username", "deleted", "active", "last_password_change"])
+USER_SUMMARY_KEYS: Set[str] = {"model_class", "id", "email", "username", "deleted", "active", "last_password_change"}
 
 
 class UsersIntegrationCase(integration_util.IntegrationTestCase):
     expose_user_name: ClassVar[bool]
     expose_user_email: ClassVar[bool]
     expected_regular_user_list_count: ClassVar[int]
-    expected_limited_user_keys: ClassVar[set]
+    expected_limited_user_keys: ClassVar[Set[str]]
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
@@ -57,7 +60,7 @@ class TestExposeUsersIntegration(UsersIntegrationCase):
     expose_user_email = True
 
     # Since we allow to expose user information, all users are returned.
-    expected_limited_user_keys = set(["id", "username", "email"])
+    expected_limited_user_keys = {"id", "username", "email"}
     expected_regular_user_list_count = 3
 
 
@@ -67,7 +70,7 @@ class TestExposeOnlyUserNameIntegration(UsersIntegrationCase):
 
     # When only username is exposed, only that field is returned in the user list.
     # Since we are exposing user information, all users are returned.
-    expected_limited_user_keys = set(["id", "username"])
+    expected_limited_user_keys = {"id", "username"}
     expected_regular_user_list_count = 3
 
 
@@ -77,7 +80,7 @@ class TestExposeOnlyUserEmailIntegration(UsersIntegrationCase):
 
     # When only email is exposed, only that field is returned in the user list.
     # Since we are exposing user information, all users are returned.
-    expected_limited_user_keys = set(["id", "email"])
+    expected_limited_user_keys = {"id", "email"}
     expected_regular_user_list_count = 3
 
 


### PR DESCRIPTION
Follow up to #18329, fixes mypy (and ruff) checks in 24.1
The version of mypy in 24.0 didn't catch this earlier, but nicely, the one in 24.1 does.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
