### PR TITLE
Fix #18316 (anonymous file sources)

### DIFF
--- a/lib/galaxy/files/__init__.py
+++ b/lib/galaxy/files/__init__.py
@@ -360,6 +360,9 @@ class FileSourcesUserContext(DictifiableFilesSourceContext, Protocol):
     @property
     def app_vault(self) -> Dict[str, Any]: ...
 
+    @property
+    def anonymous(self) -> bool: ...
+
 
 OptionalUserContext = Optional[FileSourcesUserContext]
 
@@ -422,6 +425,10 @@ class ProvidesFileSourcesUserContext(FileSourcesUserContext, FileSourceDictifiab
     def file_sources(self):
         return self.trans.app.file_sources
 
+    @property
+    def anonymous(self) -> bool:
+        return self.trans.anonymous
+
 
 class DictFileSourcesUserContext(FileSourcesUserContext, FileSourceDictifiable):
     def __init__(self, **kwd):
@@ -466,3 +473,7 @@ class DictFileSourcesUserContext(FileSourcesUserContext, FileSourceDictifiable):
     @property
     def file_sources(self):
         return self._kwd.get("file_sources")
+
+    @property
+    def anonymous(self) -> bool:
+        return bool(self._kwd.get("username"))

--- a/lib/galaxy/managers/file_source_instances.py
+++ b/lib/galaxy/managers/file_source_instances.py
@@ -483,6 +483,9 @@ class UserDefinedFileSourcesImpl(UserDefinedFileSources):
         exclude_kind: Optional[Set[PluginKind]] = None,
     ) -> List[FilesSourceProperties]:
         """Write out user file sources as list of config dictionaries."""
+        if user_context.anonymous:
+            return []
+
         as_dicts = []
         for files_source_properties in self._all_user_file_source_properties(user_context):
             plugin_kind = PluginKind.rfs


### PR DESCRIPTION
Broken with #15875 

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Requires main's database problems.
  2. Deploy and open remote files sources as an anonymous user.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
