### PR TITLE
[24.0] Fix anonymous user job retrieval logic

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -127,12 +127,15 @@ class JobManager:
         search = payload.search
         order_by = payload.order_by
 
-        if trans.user is None:
-            # If the user is anonymous we can only return jobs for the current session history
-            if trans.galaxy_session and trans.galaxy_session.current_history_id:
-                history_id = trans.galaxy_session.current_history_id
-            else:
-                return None
+        if (
+            trans.user is None
+            and history_id is None
+            and trans.galaxy_session
+            and trans.galaxy_session.current_history_id
+        ):
+            # If the user is anonymous and no specific history_id was provided
+            # we can only return jobs from the history in the current session
+            history_id = trans.galaxy_session.current_history_id
 
         def build_and_apply_filters(stmt, objects, filter_func):
             if objects is not None:

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -82,8 +82,6 @@ class JobsService(ServiceBase):
         )
         jobs = self.job_manager.index_query(trans, payload)
         out: List[Dict[str, Any]] = []
-        if jobs is None:
-            return out
         for job in jobs.yield_per(model.YIELD_PER_ROWS):
             # TODO: optimize if this crucial
             if check_security_of_jobs and not security_check(trans, job.history, check_accessible=True):


### PR DESCRIPTION
Follow up to #18333

For anonymous users, if a history_id is provided, do not override it with the current session history; instead, rely on the history accessibility.

Hopefully addresses https://github.com/galaxyproject/galaxy/pull/18333#discussion_r1631483259

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
