### PR TITLE
[24.1] Shows en alert when tool is not installed

### DIFF
--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -129,7 +129,7 @@ const isHidden = computed(() => attrs.value["hidden"]);
 const elementId = computed(() => `form-element-${props.id}`);
 const hasAlert = computed(() => Boolean(props.error || props.warning));
 const showPreview = computed(() => (collapsed.value && attrs.value["collapsible_preview"]) || props.disabled);
-const showField = computed(() => !collapsed.value && !props.disabled);
+const showField = computed(() => !collapsed.value);
 
 const previewText = computed(() => attrs.value["text_value"]);
 const helpText = computed(() => {
@@ -308,7 +308,7 @@ const isOptional = computed(() => !isRequired.value && attrs.value["optional"] !
                 v-else-if="props.type === 'tags'"
                 v-model="currentValue"
                 :placeholder="props.attributes?.placeholder" />
-            <FormInput v-else :id="props.id" v-model="currentValue" :area="attrs['area']" />
+            <FormInput v-else :id="props.id" v-model="currentValue" :disabled="props.disabled" :area="attrs['area']" />
         </div>
 
         <div v-if="showPreview" class="ui-form-preview pt-1 pl-2 mt-1">{{ previewText }}</div>

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -129,7 +129,7 @@ const showHelpForum = computed(() => isConfigLoaded.value && config.value.enable
     <div class="position-relative">
         <div class="underlay sticky-top" />
 
-        <div v-if="!props.options && !props.id" class="sticky-top">
+        <div v-if="!props.options?.id" class="sticky-top">
             <BAlert variant="danger" class="tool-header px-2 py-1" show>
                 <span class="tool-header-name">
                     <FontAwesomeIcon :icon="faWrench" fixed-width />

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -1,105 +1,73 @@
-<script setup>
+<script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faWrench } from "@fortawesome/free-solid-svg-icons";
+import { faHdd, faWrench } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import Heading from "components/Common/Heading";
-import FormMessage from "components/Form/FormMessage";
-import ToolFooter from "components/Tool/ToolFooter";
-import ToolHelp from "components/Tool/ToolHelp";
-import { getAppRoot } from "onload/loadConfig";
+import { BButton, BButtonGroup, BModal } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 
 import { useStorageLocationConfiguration } from "@/composables/storageLocation";
+import { getAppRoot } from "@/onload/loadConfig";
 import { useConfigStore } from "@/stores/configurationStore";
 import { useUserStore } from "@/stores/userStore";
 
-import ToolSelectPreferredObjectStore from "./ToolSelectPreferredObjectStore";
-import ToolTargetPreferredObjectStorePopover from "./ToolTargetPreferredObjectStorePopover";
+import Heading from "@/components/Common/Heading.vue";
+import FormMessage from "@/components/Form/FormMessage.vue";
+import ToolFavoriteButton from "@/components/Tool/Buttons/ToolFavoriteButton.vue";
+import ToolOptionsButton from "@/components/Tool/Buttons/ToolOptionsButton.vue";
+import ToolVersionsButton from "@/components/Tool/Buttons/ToolVersionsButton.vue";
+import ToolFooter from "@/components/Tool/ToolFooter.vue";
+import ToolHelp from "@/components/Tool/ToolHelp.vue";
+import ToolHelpForum from "@/components/Tool/ToolHelpForum.vue";
+import ToolSelectPreferredObjectStore from "@/components/Tool/ToolSelectPreferredObjectStore.vue";
+import ToolTargetPreferredObjectStorePopover from "@/components/Tool/ToolTargetPreferredObjectStorePopover.vue";
+import ToolTutorialRecommendations from "@/components/Tool/ToolTutorialRecommendations.vue";
 
-import ToolHelpForum from "./ToolHelpForum.vue";
-import ToolTutorialRecommendations from "./ToolTutorialRecommendations.vue";
-import ToolFavoriteButton from "components/Tool/Buttons/ToolFavoriteButton.vue";
-import ToolOptionsButton from "components/Tool/Buttons/ToolOptionsButton.vue";
-import ToolVersionsButton from "components/Tool/Buttons/ToolVersionsButton.vue";
+library.add(faHdd, faWrench);
 
-library.add(faWrench);
+interface Props {
+    id: string;
+    title: string;
+    messageText: string;
+    version?: string;
+    stepError?: string;
+    disabled?: boolean;
+    description?: string;
+    messageVariant?: string;
+    preferredObjectStoreId?: string;
+    options?: { [key: string]: any };
+    allowObjectStoreSelection?: boolean;
+}
 
-const props = defineProps({
-    id: {
-        type: String,
-        required: true,
-    },
-    version: {
-        type: String,
-        required: false,
-        default: "1.0",
-    },
-    title: {
-        type: String,
-        required: true,
-    },
-    description: {
-        type: String,
-        required: false,
-        default: "",
-    },
-    options: {
-        type: Object,
-        required: true,
-    },
-    messageText: {
-        type: String,
-        required: true,
-    },
-    messageVariant: {
-        type: String,
-        default: "info",
-    },
-    disabled: {
-        type: Boolean,
-        default: false,
-    },
-    allowObjectStoreSelection: {
-        type: Boolean,
-        default: false,
-    },
-    preferredObjectStoreId: {
-        type: String,
-        default: null,
-    },
-    stepError: {
-        type: String,
-        default: "Tool is not available",
-    },
+const props = withDefaults(defineProps<Props>(), {
+    version: "1.0",
+    stepError: "Tool is not available",
+    disabled: false,
+    description: "",
+    messageVariant: "info",
+    preferredObjectStoreId: undefined,
+    options: undefined,
+    allowObjectStoreSelection: false,
 });
 
-const emit = defineEmits(["onChangeVersion", "updatePreferredObjectStoreId"]);
-
-function onChangeVersion(v) {
-    emit("onChangeVersion", v);
-}
-
-const errorText = ref(null);
-
-watch(
-    () => props.id,
-    () => {
-        errorText.value = null;
-    }
-);
-
-function onSetError(e) {
-    errorText.value = e;
-}
+const emit = defineEmits<{
+    (e: "onChangeVersion", v: string): void;
+    (e: "updatePreferredObjectStoreId", selectedToolPreferredObjectStoreId?: string): void;
+}>();
 
 const { isOnlyPreference } = useStorageLocationConfiguration();
 const { currentUser, isAnonymous } = storeToRefs(useUserStore());
 const { isLoaded: isConfigLoaded, config } = storeToRefs(useConfigStore());
+
+const errorText = ref<string>("");
+const showPreferredObjectStoreModal = ref(false);
+const toolPreferredObjectStoreId = ref<string>(props.preferredObjectStoreId);
+
+const root = computed(() => getAppRoot());
 const hasUser = computed(() => !isAnonymous.value);
 const versions = computed(() => props.options?.versions);
 const showVersions = computed(() => props.options?.versions?.length > 1);
-
+const showHelpForum = computed(() => isConfigLoaded.value && config.value.enable_help_forum_tool_panel_integration);
 const storageLocationModalTitle = computed(() => {
     if (isOnlyPreference.value) {
         return "Tool Execution Preferred Storage Location";
@@ -108,25 +76,35 @@ const storageLocationModalTitle = computed(() => {
     }
 });
 
-const root = computed(() => getAppRoot());
-const showPreferredObjectStoreModal = ref(false);
-const toolPreferredObjectStoreId = ref(props.preferredObjectStoreId);
+function onSetError(e: string) {
+    errorText.value = e;
+}
+
+function onChangeVersion(v: string) {
+    emit("onChangeVersion", v);
+}
 
 function onShowObjectStoreSelect() {
     showPreferredObjectStoreModal.value = true;
 }
 
-function onUpdatePreferredObjectStoreId(selectedToolPreferredObjectStoreId) {
+function onUpdatePreferredObjectStoreId(selectedToolPreferredObjectStoreId: string) {
     showPreferredObjectStoreModal.value = false;
     toolPreferredObjectStoreId.value = selectedToolPreferredObjectStoreId;
+
     emit("updatePreferredObjectStoreId", selectedToolPreferredObjectStoreId);
 }
 
-const showHelpForum = computed(() => isConfigLoaded.value && config.value.enable_help_forum_tool_panel_integration);
+watch(
+    () => props.id,
+    () => {
+        errorText.value = "";
+    }
+);
 </script>
 
 <template>
-    <div class="position-relative">
+    <div class="tool-card-container">
         <div class="underlay sticky-top" />
 
         <div v-if="!props.options?.id" class="sticky-top">
@@ -156,19 +134,22 @@ const showHelpForum = computed(() => isConfigLoaded.value && config.value.enable
                 </div>
 
                 <div class="d-flex flex-nowrap align-items-start flex-gapx-1">
-                    <b-button-group class="tool-card-buttons">
+                    <BButtonGroup class="tool-card-buttons">
                         <ToolFavoriteButton v-if="props.id && hasUser" :id="props.id" @onSetError="onSetError" />
+
                         <ToolVersionsButton
                             v-if="showVersions"
                             :version="props.version"
                             :versions="versions"
                             @onChangeVersion="onChangeVersion" />
+
                         <ToolOptionsButton
                             v-if="props.id"
                             :id="props.id"
                             :sharable-url="props.options?.sharable_url"
                             :options="props.options" />
-                        <b-button
+
+                        <BButton
                             v-if="allowObjectStoreSelection"
                             id="tool-storage"
                             role="button"
@@ -176,14 +157,16 @@ const showHelpForum = computed(() => isConfigLoaded.value && config.value.enable
                             size="sm"
                             class="float-right tool-storage"
                             @click="onShowObjectStoreSelect">
-                            <span class="fa fa-hdd" />
-                        </b-button>
+                            <FontAwesomeIcon :icon="faHdd" fixed-width />
+                        </BButton>
+
                         <ToolTargetPreferredObjectStorePopover
                             v-if="allowObjectStoreSelection"
                             :tool-preferred-object-store-id="toolPreferredObjectStoreId"
                             :user="currentUser">
                         </ToolTargetPreferredObjectStorePopover>
-                        <b-modal
+
+                        <BModal
                             v-model="showPreferredObjectStoreModal"
                             :title="storageLocationModalTitle"
                             modal-class="tool-preferred-object-store-modal"
@@ -194,8 +177,9 @@ const showHelpForum = computed(() => isConfigLoaded.value && config.value.enable
                                 :tool-preferred-object-store-id="toolPreferredObjectStoreId"
                                 :root="root"
                                 @updated="onUpdatePreferredObjectStoreId" />
-                        </b-modal>
-                    </b-button-group>
+                        </BModal>
+                    </BButtonGroup>
+
                     <slot name="header-buttons" />
                 </div>
             </div>
@@ -203,8 +187,11 @@ const showHelpForum = computed(() => isConfigLoaded.value && config.value.enable
 
         <div id="tool-card-body">
             <FormMessage variant="danger" :message="errorText" :persistent="true" />
+
             <FormMessage :variant="props.messageVariant" :message="props.messageText" />
+
             <slot name="body" />
+
             <div v-if="props.disabled" class="portlet-backdrop" />
         </div>
 
@@ -213,6 +200,7 @@ const showHelpForum = computed(() => isConfigLoaded.value && config.value.enable
         <div v-if="props.options">
             <div v-if="props.options.help" class="mt-2 mb-4">
                 <Heading h2 separator bold size="sm"> Help </Heading>
+
                 <ToolHelp :content="props.options.help" />
             </div>
 
@@ -238,37 +226,35 @@ const showHelpForum = computed(() => isConfigLoaded.value && config.value.enable
 <style lang="scss" scoped>
 @import "scss/theme/blue.scss";
 
-.tool-header {
-    display: flex;
-    flex-direction: column;
+.tool-card-container {
+    .tool-header {
+        display: flex;
+        flex-direction: column;
 
-    word-break: break-all;
+        word-break: break-all;
 
-    .tool-header-name {
-        font-weight: bold;
+        .tool-header-name {
+            font-weight: bold;
+        }
     }
-}
 
-.underlay::after {
-    content: "";
-    display: block;
-    position: absolute;
-    top: -$margin-h;
-    left: -0.5rem;
-    right: -0.5rem;
-    height: 50px;
-    background: linear-gradient($white 75%, change-color($white, $alpha: 0));
-}
+    .underlay::after {
+        content: "";
+        display: block;
+        position: absolute;
+        top: -$margin-h;
+        left: -0.5rem;
+        right: -0.5rem;
+        height: 50px;
+        background: linear-gradient($white 75%, change-color($white, $alpha: 0));
+    }
 
-.fa-wrench {
-    cursor: unset;
-}
+    .tool-card-buttons {
+        height: 2em;
+    }
 
-.tool-card-buttons {
-    height: 2em;
-}
-
-.portlet-backdrop {
-    display: block;
+    .portlet-backdrop {
+        display: block;
+    }
 }
 </style>

--- a/client/src/components/Workflow/Editor/Forms/FormTool.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.vue
@@ -1,6 +1,6 @@
 <template>
     <ToolCard
-        :id="configForm?.id || ''"
+        :id="configForm?.id || step.content_id"
         :version="configForm?.version"
         :title="configForm?.name || step.name"
         :description="configForm?.description"
@@ -12,25 +12,22 @@
         @onUpdateFavorites="onUpdateFavorites">
         <template v-slot:body>
             <FormElement
-                v-if="hasData"
                 id="__label"
+                :disabled="!hasData"
                 :value="label"
                 title="Label"
                 help="Add a step label."
                 :error="uniqueErrorLabel"
                 @input="onLabel" />
             <FormElement
-                v-if="hasData"
                 id="__annotation"
+                :disabled="!hasData"
                 :value="annotation"
                 title="Step Annotation"
                 :area="true"
                 help="Add an annotation or notes to this step. Annotations are available when a workflow is viewed."
                 @input="onAnnotation" />
-            <FormConditional
-                v-if="hasData"
-                :step="step"
-                @onUpdateStep="(id, step) => $emit('onUpdateStep', id, step)" />
+            <FormConditional :step="step" @onUpdateStep="(id, step) => $emit('onUpdateStep', id, step)" />
             <div v-if="inputs.length" class="mt-2 mb-4">
                 <Heading h2 separator bold size="sm"> Tool Parameters </Heading>
                 <FormDisplay

--- a/client/src/components/Workflow/Editor/Forms/FormTool.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.vue
@@ -1,17 +1,18 @@
 <template>
     <ToolCard
-        v-if="hasData"
-        :id="configForm.id"
-        :version="configForm.version"
-        :title="configForm.name"
-        :description="configForm.description"
+        :id="configForm?.id || ''"
+        :version="configForm?.version"
+        :title="configForm?.name || step.name"
+        :description="configForm?.description"
         :options="configForm"
         :message-text="messageText"
         :message-variant="messageVariant"
+        :step-error="step.errors"
         @onChangeVersion="onChangeVersion"
         @onUpdateFavorites="onUpdateFavorites">
         <template v-slot:body>
             <FormElement
+                v-if="hasData"
                 id="__label"
                 :value="label"
                 title="Label"
@@ -19,14 +20,18 @@
                 :error="uniqueErrorLabel"
                 @input="onLabel" />
             <FormElement
+                v-if="hasData"
                 id="__annotation"
                 :value="annotation"
                 title="Step Annotation"
                 :area="true"
                 help="Add an annotation or notes to this step. Annotations are available when a workflow is viewed."
                 @input="onAnnotation" />
-            <FormConditional :step="step" @onUpdateStep="(id, step) => $emit('onUpdateStep', id, step)" />
-            <div class="mt-2 mb-4">
+            <FormConditional
+                v-if="hasData"
+                :step="step"
+                @onUpdateStep="(id, step) => $emit('onUpdateStep', id, step)" />
+            <div v-if="inputs.length" class="mt-2 mb-4">
                 <Heading h2 separator bold size="sm"> Tool Parameters </Heading>
                 <FormDisplay
                     :id="id"
@@ -38,7 +43,7 @@
                     :workflow-building-mode="true"
                     @onChange="onChange" />
             </div>
-            <div class="mt-2 mb-4">
+            <div v-if="stepOutputs.length" class="mt-2 mb-4">
                 <Heading h2 separator bold size="sm"> Additional Options </Heading>
                 <FormSection
                     :id="stepId"
@@ -141,7 +146,12 @@ export default {
             return !!this.configForm?.id;
         },
         inputs() {
-            const inputs = this.configForm.inputs;
+            const inputs = this.configForm?.inputs;
+
+            if (!inputs) {
+                return [];
+            }
+
             Utils.deepEach(inputs, (input) => {
                 if (input.type) {
                     if (["data", "data_collection"].indexOf(input.type) != -1) {
@@ -169,7 +179,7 @@ export default {
             return inputs;
         },
         errors() {
-            return this.configForm.errors;
+            return this.configForm?.errors || { ...this.step.errors };
         },
     },
     methods: {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -104,7 +104,7 @@
                             v-if="hasActiveNodeTool"
                             :key="activeStep.id"
                             :step="activeStep"
-                            :datatypes="datatypes"
+                            :data-types="datatypes"
                             @onChangePostJobActions="onChangePostJobActions"
                             @onAnnotation="onAnnotation"
                             @onLabel="onLabel"


### PR DESCRIPTION
Fixes #18260

![image](https://github.com/galaxyproject/galaxy/assets/8046843/f97a6c00-fb85-43e4-a80f-cd1ddbb2118c)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
