### PR TITLE
[24.1] Add copy link to published workflow in `WorkflowCard`

### DIFF
--- a/client/src/components/Sharing/Embeds/WorkflowEmbed.vue
+++ b/client/src/components/Sharing/Embeds/WorkflowEmbed.vue
@@ -6,8 +6,8 @@ import { useDebounce } from "@vueuse/core";
 import { BButton, BFormCheckbox, BFormInput, BInputGroup, BInputGroupAppend } from "bootstrap-vue";
 import { computed, reactive, ref } from "vue";
 
-import { getAppRoot } from "@/onload/loadConfig";
 import { copy } from "@/utils/clipboard";
+import { getFullAppUrl } from "@/utils/utils";
 
 import ZoomControl from "@/components/Workflow/Editor/ZoomControl.vue";
 import WorkflowPublished from "@/components/Workflow/Published/WorkflowPublished.vue";
@@ -39,13 +39,8 @@ function onChangePosition(event: Event, xy: "x" | "y") {
     }
 }
 
-const root = computed(() => {
-    const port = window.location.port ? `:${window.location.port}` : "";
-    return `${window.location.protocol}//${window.location.hostname}${port}${getAppRoot()}`;
-});
-
 const embedUrl = computed(() => {
-    let url = `${root.value}published/workflow?id=${props.id}&embed=true`;
+    let url = getFullAppUrl(`published/workflow?id=${props.id}&embed=true`);
     url += `&buttons=${settings.buttons}`;
     url += `&about=${settings.about}`;
     url += `&heading=${settings.heading}`;

--- a/client/src/components/Sharing/SharingPage.vue
+++ b/client/src/components/Sharing/SharingPage.vue
@@ -9,6 +9,7 @@ import { getGalaxyInstance } from "@/app";
 import { useToast } from "@/composables/toast";
 import { getAppRoot } from "@/onload/loadConfig";
 import { errorMessageAsString } from "@/utils/simple-error";
+import { getFullAppUrl } from "@/utils/utils";
 
 import type { Item, ShareOption } from "./item";
 
@@ -52,11 +53,6 @@ const item = ref<Item>({
     extra: defaultExtra(),
 });
 
-const itemRoot = computed(() => {
-    const port = window.location.port ? `:${window.location.port}` : "";
-    return `${window.location.protocol}//${window.location.hostname}${port}${getAppRoot()}`;
-});
-
 const itemUrl = reactive({
     prefix: "",
     slug: "",
@@ -68,7 +64,7 @@ watch(
         if (value) {
             const index = value.lastIndexOf("/");
 
-            itemUrl.prefix = itemRoot.value + value.substring(0, index + 1);
+            itemUrl.prefix = getFullAppUrl(value.substring(0, index + 1));
             itemUrl.slug = value.substring(index + 1);
         }
     },

--- a/client/src/components/Workflow/Published/WorkflowInformation.vue
+++ b/client/src/components/Workflow/Published/WorkflowInformation.vue
@@ -5,8 +5,8 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed } from "vue";
 import { RouterLink } from "vue-router";
 
-import { getAppRoot } from "@/onload/loadConfig";
 import { useUserStore } from "@/stores/userStore";
+import { getFullAppUrl } from "@/utils/utils";
 
 import Heading from "@/components/Common/Heading.vue";
 import CopyToClipboard from "@/components/CopyToClipboard.vue";
@@ -42,17 +42,12 @@ const gravatarSource = computed(
 
 const publishedByUser = computed(() => `/workflows/list_published?owner=${props.workflowInfo?.owner}`);
 
-const root = computed(() => {
-    const port = window.location.port ? `:${window.location.port}` : "";
-    return `${window.location.protocol}//${window.location.hostname}${port}${getAppRoot()}`;
-});
-
 const relativeLink = computed(() => {
     return `/published/workflow?id=${props.workflowInfo.id}`;
 });
 
 const fullLink = computed(() => {
-    return `${root.value}${relativeLink.value.substring(1)}`;
+    return getFullAppUrl(relativeLink.value.substring(1));
 });
 
 const userOwned = computed(() => {

--- a/client/src/components/Workflow/WorkflowActionsExtend.vue
+++ b/client/src/components/Workflow/WorkflowActionsExtend.vue
@@ -84,7 +84,7 @@ function onCopyPublicLink() {
     <div class="workflow-actions-extend flex-gapx-1">
         <BButtonGroup>
             <BButton
-                v-if="!isAnonymous && workflow.published && !workflow.deleted"
+                v-if="workflow.published && !workflow.deleted"
                 id="workflow-copy-public-button"
                 v-b-tooltip.hover.noninteractive
                 :size="buttonSize"

--- a/client/src/components/Workflow/WorkflowActionsExtend.vue
+++ b/client/src/components/Workflow/WorkflowActionsExtend.vue
@@ -9,10 +9,10 @@ import { computed } from "vue";
 import { copyWorkflow, undeleteWorkflow } from "@/components/Workflow/workflows.services";
 import { useConfirmDialog } from "@/composables/confirmDialog";
 import { Toast } from "@/composables/toast";
-import { getAppRoot } from "@/onload/loadConfig";
 import { useUserStore } from "@/stores/userStore";
 import { copy } from "@/utils/clipboard";
 import { withPrefix } from "@/utils/redirect";
+import { getFullAppUrl } from "@/utils/utils";
 
 library.add(faCopy, faDownload, faLink, faShareAlt, faTrashRestore);
 
@@ -66,17 +66,12 @@ async function onRestore() {
     }
 }
 
-const root = computed(() => {
-    const port = window.location.port ? `:${window.location.port}` : "";
-    return `${window.location.protocol}//${window.location.hostname}${port}${getAppRoot()}`;
-});
-
 const relativeLink = computed(() => {
     return `/published/workflow?id=${props.workflow.id}`;
 });
 
 const fullLink = computed(() => {
-    return `${root.value}${relativeLink.value.substring(1)}`;
+    return getFullAppUrl(relativeLink.value.substring(1));
 });
 
 function onCopyPublicLink() {

--- a/client/src/components/Workflow/WorkflowIndicators.vue
+++ b/client/src/components/Workflow/WorkflowIndicators.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faGlobe, faLink, faShieldAlt, faUser, faUsers } from "@fortawesome/free-solid-svg-icons";
+import { faFileImport, faGlobe, faShieldAlt, faUser, faUsers } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BBadge, BButton } from "bootstrap-vue";
 import { computed } from "vue";
@@ -12,7 +12,7 @@ import { copy } from "@/utils/clipboard";
 
 import UtcDate from "@/components/UtcDate.vue";
 
-library.add(faShieldAlt, faLink, faGlobe, faUsers, faUser);
+library.add(faFileImport, faGlobe, faShieldAlt, faUsers, faUser);
 
 interface Props {
     workflow: any;
@@ -116,7 +116,7 @@ function onViewUserPublished() {
             size="sm"
             class="workflow-external-link inline-icon-button"
             :title="sourceTitle">
-            <FontAwesomeIcon :icon="faLink" fixed-width @click="onCopyLink" />
+            <FontAwesomeIcon :icon="faFileImport" fixed-width @click="onCopyLink" />
         </BButton>
 
         <span class="mr-1">

--- a/client/src/utils/utils.test.js
+++ b/client/src/utils/utils.test.js
@@ -101,4 +101,16 @@ describe("test utils", () => {
             ]);
         });
     });
+
+    describe("test getFullAppUrl", () => {
+        it("should return the full app url", () => {
+            const appUrl = Utils.getFullAppUrl();
+            expect(appUrl).toBe("http://localhost/");
+        });
+
+        it("should return the full app url", () => {
+            const appUrl = Utils.getFullAppUrl("home");
+            expect(appUrl).toBe("http://localhost/home");
+        });
+    });
 });

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -475,4 +475,5 @@ export default {
     waitForElementToBePresent,
     wait,
     mergeObjectListsById,
+    getFullAppUrl,
 };

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -442,6 +442,21 @@ export function hasKeys(object: unknown, keys: string[]) {
     }
 }
 
+/**
+ * Get the full URL path of the app
+ *
+ * @param path Path to append to the URL path
+ * @returns Full URL path of the app
+ */
+export function getFullAppUrl(path: string = ""): string {
+    const protocol = window.location.protocol;
+    const hostname = window.location.hostname;
+    const port = window.location.port ? `:${window.location.port}` : "";
+    const appRoot = getAppRoot();
+
+    return `${protocol}//${hostname}${port}${appRoot}${path}`;
+}
+
 export default {
     cssLoadFile,
     get,


### PR DESCRIPTION
Closes #18368. This PR adds a new action button to the `WorkflowCard` which shows on published workflows for copying the link to the workflow on click and also replaces the imported from URL indicator on `WorkflowIndicators` with `faFileImport` that had conflict with the new button icon.

![image](https://github.com/galaxyproject/galaxy/assets/8046843/3dc0fd15-f15f-4490-9314-6f6f3b5a5ec9)
![image](https://github.com/galaxyproject/galaxy/assets/8046843/5e08f6da-fb3b-4d7d-a1d1-09e32f71458c)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
