### PR TITLE
[24.0] Fix update group API payload model

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -5483,6 +5483,15 @@ export interface components {
              */
             url: string;
         };
+        /** GroupUpdatePayload */
+        GroupUpdatePayload: {
+            /** name of the group */
+            name?: string | null;
+            /** role IDs */
+            role_ids?: string[] | null;
+            /** user IDs */
+            user_ids?: string[] | null;
+        };
         /** GroupUserListResponse */
         GroupUserListResponse: components["schemas"]["GroupUserResponse"][];
         /** GroupUserResponse */
@@ -15135,7 +15144,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["GroupCreatePayload"];
+                "application/json": components["schemas"]["GroupUpdatePayload"];
             };
         };
         responses: {

--- a/lib/galaxy/managers/groups.py
+++ b/lib/galaxy/managers/groups.py
@@ -90,13 +90,18 @@ class GroupsManager:
             self._check_duplicated_group_name(sa_session, name)
             group.name = name
             sa_session.add(group)
-        user_ids = payload.user_ids or []
-        users = get_users_by_ids(sa_session, user_ids)
-        role_ids = payload.role_ids or []
-        roles = get_roles_by_ids(sa_session, role_ids)
-        self._app.security_agent.set_entity_group_associations(
-            groups=[group], roles=roles, users=users, delete_existing_assocs=False
-        )
+
+        users = None
+        if payload.user_ids is not None:
+            users = get_users_by_ids(sa_session, payload.user_ids)
+
+        roles = None
+        if payload.role_ids is not None:
+            roles = get_roles_by_ids(sa_session, payload.role_ids)
+
+        if payload.user_ids is not None or payload.role_ids is not None:
+            self._app.security_agent.set_entity_group_associations(groups=[group], roles=roles, users=users)
+
         with transaction(sa_session):
             sa_session.commit()
 

--- a/lib/galaxy/managers/groups.py
+++ b/lib/galaxy/managers/groups.py
@@ -18,7 +18,10 @@ from galaxy.model import Group
 from galaxy.model.base import transaction
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.schema.fields import Security
-from galaxy.schema.groups import GroupCreatePayload
+from galaxy.schema.groups import (
+    GroupCreatePayload,
+    GroupUpdatePayload,
+)
 from galaxy.structured_app import MinimalManagerApp
 
 
@@ -77,7 +80,7 @@ class GroupsManager:
         item["roles_url"] = self._url_for(trans, "group_roles", group_id=encoded_id)
         return item
 
-    def update(self, trans: ProvidesAppContext, group_id: int, payload: GroupCreatePayload):
+    def update(self, trans: ProvidesAppContext, group_id: int, payload: GroupUpdatePayload):
         """
         Modifies a group.
         """
@@ -87,9 +90,9 @@ class GroupsManager:
             self._check_duplicated_group_name(sa_session, name)
             group.name = name
             sa_session.add(group)
-        user_ids = payload.user_ids
+        user_ids = payload.user_ids or []
         users = get_users_by_ids(sa_session, user_ids)
-        role_ids = payload.role_ids
+        role_ids = payload.role_ids or []
         roles = get_roles_by_ids(sa_session, role_ids)
         self._app.security_agent.set_entity_group_associations(
             groups=[group], roles=roles, users=users, delete_existing_assocs=False

--- a/lib/galaxy/managers/groups.py
+++ b/lib/galaxy/managers/groups.py
@@ -99,8 +99,9 @@ class GroupsManager:
         if payload.role_ids is not None:
             roles = get_roles_by_ids(sa_session, payload.role_ids)
 
-        if payload.user_ids is not None or payload.role_ids is not None:
-            self._app.security_agent.set_entity_group_associations(groups=[group], roles=roles, users=users)
+        self._app.security_agent.set_entity_group_associations(
+            groups=[group], roles=roles, users=users, delete_existing_assocs=False
+        )
 
         with transaction(sa_session):
             sa_session.commit()

--- a/lib/galaxy/managers/roles.py
+++ b/lib/galaxy/managers/roles.py
@@ -162,6 +162,6 @@ class RoleManager(base.ModelManager[model.Role]):
         return role
 
 
-def get_roles_by_ids(session: Session, role_ids):
+def get_roles_by_ids(session: Session, role_ids: List[int]) -> List[Role]:
     stmt = select(Role).where(Role.id.in_(role_ids))
     return session.scalars(stmt).all()

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -874,7 +874,7 @@ class AdminUserFilterParser(base.ModelFilterParser, deletable.PurgableFiltersMix
         self.fn_filter_parsers.update({})
 
 
-def get_users_by_ids(session: Session, user_ids):
+def get_users_by_ids(session: Session, user_ids: List[int]) -> List[User]:
     stmt = select(User).where(User.id.in_(user_ids))
     return session.scalars(stmt).all()
 

--- a/lib/galaxy/schema/groups.py
+++ b/lib/galaxy/schema/groups.py
@@ -9,6 +9,7 @@ from pydantic import (
 )
 from typing_extensions import Literal
 
+from galaxy.schema import partial_model
 from galaxy.schema.fields import (
     DecodedDatabaseIdField,
     EncodedDatabaseIdField,
@@ -69,3 +70,8 @@ class GroupCreatePayload(Model):
         [],
         title="role IDs",
     )
+
+
+@partial_model()
+class GroupUpdatePayload(GroupCreatePayload):
+    pass

--- a/lib/galaxy/webapps/galaxy/api/groups.py
+++ b/lib/galaxy/webapps/galaxy/api/groups.py
@@ -17,6 +17,7 @@ from galaxy.schema.groups import (
     GroupCreatePayload,
     GroupListResponse,
     GroupResponse,
+    GroupUpdatePayload,
 )
 from galaxy.webapps.galaxy.api import (
     depends,
@@ -80,8 +81,8 @@ class FastAPIGroups:
     def update(
         self,
         group_id: Annotated[DecodedDatabaseIdField, Path(...)],
+        payload: Annotated[GroupUpdatePayload, Body(...)],
         trans: ProvidesAppContext = DependsOnTrans,
-        payload: GroupCreatePayload = Body(...),
     ) -> GroupResponse:
         return self.manager.update(trans, group_id, payload)
 

--- a/lib/galaxy_test/api/test_groups.py
+++ b/lib/galaxy_test/api/test_groups.py
@@ -1,4 +1,7 @@
-from typing import Optional
+from typing import (
+    List,
+    Optional,
+)
 
 from galaxy_test.base.populators import DatasetPopulator
 from ._framework import ApiTestCase
@@ -72,37 +75,62 @@ class TestGroupsApi(ApiTestCase):
         self._assert_status_code_is(response, 400)
 
     def test_update(self):
-        group = self.test_create_valid(group_name=f"group-test-{self.dataset_populator.get_random_name()}")
+        user_id = self.dataset_populator.user_id()
+        user_private_role_id = self.dataset_populator.user_private_role_id()
+        original_name = f"group-test-{self.dataset_populator.get_random_name()}"
+        group = self.test_create_valid(group_name=original_name)
+
+        self._assert_group_has_expected_values(
+            group["id"],
+            name=original_name,
+            user_ids=[user_id],
+            role_ids=[user_private_role_id],
+        )
 
         group_id = group["id"]
         updated_name = f"group-test-updated-{self.dataset_populator.get_random_name()}"
         update_response = self._put(f"groups/{group_id}", data={"name": updated_name}, admin=True, json=True)
         self._assert_status_code_is_ok(update_response)
 
-        # Update replace with another user
+        # Only the name should be updated
+        self._assert_group_has_expected_values(
+            group_id,
+            name=updated_name,
+            user_ids=[user_id],
+            role_ids=[user_private_role_id],
+        )
+
+        # Add another user to the group
         another_user_id = None
         with self._different_user():
             another_user_id = self.dataset_populator.user_id()
+            another_role_id = self.dataset_populator.user_private_role_id()
         assert another_user_id is not None
         update_response = self._put(f"groups/{group_id}", data={"user_ids": [another_user_id]}, admin=True, json=True)
         self._assert_status_code_is_ok(update_response)
 
-        # get group and check if it was updated
-        response = self._get(f"groups/{group_id}", admin=True)
-        self._assert_status_code_is_ok(response)
-        users = self._get(f"groups/{group_id}/users", admin=True).json()
-        assert len(users) == 1
-        assert users[0]["id"] == another_user_id
+        # Check if the user was added
+        self._assert_group_has_expected_values(
+            group_id,
+            name=updated_name,
+            user_ids=[user_id, another_user_id],
+            role_ids=[user_private_role_id],
+        )
 
-        # Remove private role from group
-        update_response = self._put(f"groups/{group_id}", data={"role_ids": []}, admin=True, json=True)
+        # Add another role to the group
+        update_response = self._put(f"groups/{group_id}", data={"role_ids": [another_role_id]}, admin=True, json=True)
         self._assert_status_code_is_ok(update_response)
 
-        # get group and check if it was updated
-        response = self._get(f"groups/{group_id}", admin=True)
-        self._assert_status_code_is_ok(response)
-        roles = self._get(f"groups/{group_id}/roles", admin=True).json()
-        assert len(roles) == 0
+        # Check if the role was added
+        self._assert_group_has_expected_values(
+            group_id,
+            name=updated_name,
+            user_ids=[user_id, another_user_id],
+            role_ids=[user_private_role_id, another_role_id],
+        )
+
+        # TODO: Test removing users and roles
+        # Currently not possible because the API can only add users and roles
 
     def test_update_only_admin(self):
         group = self.test_create_valid()
@@ -176,6 +204,18 @@ class TestGroupsApi(ApiTestCase):
         self._assert_has_keys(group, "id", "name", "model_class", "url")
         if assert_id is not None:
             assert group["id"] == assert_id
+
+    def _assert_group_has_expected_values(self, group_id: str, name: str, user_ids: List[str], role_ids: List[str]):
+        group = self._get(f"groups/{group_id}", admin=True).json()
+        assert group["name"] == name
+        users = self._get(f"groups/{group_id}/users", admin=True).json()
+        assert len(users) == len(user_ids)
+        for user in users:
+            assert user["id"] in user_ids
+        roles = self._get(f"groups/{group_id}/roles", admin=True).json()
+        assert len(roles) == len(role_ids)
+        for role in roles:
+            assert role["id"] in role_ids
 
     def _build_valid_group_payload(self, name: Optional[str] = None):
         name = name or self.dataset_populator.get_random_name()

--- a/lib/galaxy_test/api/test_groups.py
+++ b/lib/galaxy_test/api/test_groups.py
@@ -101,8 +101,9 @@ class TestGroupsApi(ApiTestCase):
         )
 
         # Add another user to the group
+        another_user_email = f"user-{self.dataset_populator.get_random_name()}@example.com"
         another_user_id = None
-        with self._different_user():
+        with self._different_user(another_user_email):
             another_user_id = self.dataset_populator.user_id()
             another_role_id = self.dataset_populator.user_private_role_id()
         assert another_user_id is not None

--- a/lib/galaxy_test/api/test_groups.py
+++ b/lib/galaxy_test/api/test_groups.py
@@ -76,10 +76,15 @@ class TestGroupsApi(ApiTestCase):
 
         group_id = group["id"]
         updated_name = f"group-test-updated-{self.dataset_populator.get_random_name()}"
-        update_payload = {
-            "name": updated_name,
-        }
-        update_response = self._put(f"groups/{group_id}", data=update_payload, admin=True, json=True)
+        update_response = self._put(f"groups/{group_id}", data={"name": updated_name}, admin=True, json=True)
+        self._assert_status_code_is_ok(update_response)
+
+        # Update with another user
+        another_user_id = None
+        with self._different_user():
+            another_user_id = self.dataset_populator.user_id()
+        assert another_user_id is not None
+        update_response = self._put(f"groups/{group_id}", data={"user_ids": [another_user_id]}, admin=True, json=True)
         self._assert_status_code_is_ok(update_response)
 
     def test_update_only_admin(self):


### PR DESCRIPTION
All the payload fields should be optional when updating a group. Includes additional API test coverage for this.

Fixes https://github.com/usegalaxy-eu/gpu-access-sync/issues/1
```
Traceback (most recent call last):
  File "process.py", line 75, in <module>
    add_users()
  File "process.py", line 72, in add_users
    gc.update_group(group_id=gpu_group["id"], user_ids=l_user_ids, role_ids=[gpu_role[1]["id"]])
  File "/scratch/shiningpanda/jobs/e3616bad/virtualenvs/d41d8cd9/lib/python3.8/site-packages/bioblend/galaxy/groups/__init__.py", line 105, in update_group
    return self._put(payload=payload, id=group_id)
  File "/scratch/shiningpanda/jobs/e3616bad/virtualenvs/d41d8cd9/lib/python3.8/site-packages/bioblend/galaxy/client.py", line 165, in _put
    return self.gi.make_put_request(url, payload=payload, params=params)
  File "/scratch/shiningpanda/jobs/e3616bad/virtualenvs/d41d8cd9/lib/python3.8/site-packages/bioblend/galaxyclient.py", line 198, in make_put_request
    raise ConnectionError("Unexpected HTTP status code: %s" % r.status_code,
bioblend.ConnectionError: Unexpected HTTP status code: 400: {"err_msg":"Input should be a valid string in ('body', 'name')","err_code":400008,"validation_errors":["{\"type\": \"string_type\", \"loc\": [\"body\", \"name\"], \"msg\": \"Input should be a valid string\", \"input\": null}"]}
```

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
