### PR TITLE
[24.0] Drop unnecessary escaping for workflow name and annotation

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -22,7 +22,6 @@ from fastapi import (
     status,
 )
 from gxformat2._yaml import ordered_dump
-from markupsafe import escape
 from pydantic import (
     UUID1,
     UUID4,
@@ -87,7 +86,6 @@ from galaxy.tool_shed.galaxy_install.install_manager import InstallRepositoryMan
 from galaxy.tools import recommendations
 from galaxy.tools.parameters import populate_state
 from galaxy.tools.parameters.workflow_utils import workflow_building_modes
-from galaxy.util.sanitize_html import sanitize_html
 from galaxy.version import VERSION
 from galaxy.web import (
     expose_api,
@@ -270,7 +268,7 @@ class WorkflowsAPIController(
                         )
                         import_source = "URL"
                     except Exception:
-                        raise exceptions.MessageException(f"Failed to open URL '{escape(archive_source)}'.")
+                        raise exceptions.MessageException(f"Failed to open URL '{archive_source}'.")
             elif hasattr(archive_file, "file"):
                 uploaded_file = archive_file.file
                 uploaded_file_name = uploaded_file.name
@@ -450,7 +448,7 @@ class WorkflowsAPIController(
             name_updated = new_workflow_name and new_workflow_name != stored_workflow.name
             steps_updated = "steps" in workflow_dict
             if name_updated and not steps_updated:
-                sanitized_name = sanitize_html(new_workflow_name or old_workflow.name)
+                sanitized_name = new_workflow_name or old_workflow.name
                 if not sanitized_name:
                     raise exceptions.MessageException("Workflow must have a valid name.")
                 workflow = old_workflow.copy(user=trans.user)
@@ -474,7 +472,7 @@ class WorkflowsAPIController(
                 require_flush = True
 
             if "annotation" in workflow_dict and not steps_updated:
-                newAnnotation = sanitize_html(workflow_dict["annotation"])
+                newAnnotation = workflow_dict["annotation"]
                 self.add_item_annotation(trans.sa_session, trans.user, stored_workflow, newAnnotation)
                 require_flush = True
 
@@ -601,7 +599,7 @@ class WorkflowsAPIController(
         workflow = workflow.latest_workflow
 
         response = {
-            "message": f"Workflow '{escape(workflow.name)}' imported successfully.",
+            "message": f"Workflow '{workflow.name}' imported successfully.",
             "status": "success",
             "id": trans.security.encode_id(workflow_id),
         }


### PR DESCRIPTION
These shouldn't ever have been escaped before storing in the database, this should've always just been applied on the way out. We also don't need to do that anymore since we don't use `v-html` for these fields.

Fixes https://github.com/galaxyproject/galaxy/issues/18354

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
