### PR TITLE
[24.0] Sanitize FormElement error messages

### DIFF
--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -3,8 +3,11 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCaretSquareDown, faCaretSquareUp } from "@fortawesome/free-regular-svg-icons";
 import { faArrowsAltH, faExclamation, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { sanitize } from "dompurify";
 import type { ComputedRef } from "vue";
 import { computed, ref, useAttrs } from "vue";
+
+import { linkify } from "@/utils/utils";
 
 import type { FormParameterAttributes, FormParameterTypes, FormParameterValue } from "./parameterTypes";
 
@@ -181,7 +184,9 @@ const isOptional = computed(() => !isRequired.value && attrs.value["optional"] !
         :class="{ alert: hasAlert, 'alert-info': hasAlert }">
         <div v-if="hasAlert" class="ui-form-error">
             <FontAwesomeIcon class="mr-1" icon="fa-exclamation" />
-            <span class="ui-form-error-text" v-html="props.error || props.warning" />
+            <span
+                class="ui-form-error-text"
+                v-html="linkify(sanitize(props.error || props.warning, { USE_PROFILES: { html: true } }))" />
         </div>
 
         <div class="ui-form-title">


### PR DESCRIPTION
v-html was introduced in https://github.com/galaxyproject/galaxy/commit/6682ca60fe64087a15d3e69c68a2054ca950d538 to show bold items. `FormElement` however is used so widely that it's hard to keep track on whether or not user-modifiable fields are shown, so better safe than sorry.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
