### PR TITLE
[24.1] Reset current page when browsing sub-folders in FilesSources

### DIFF
--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -409,6 +409,7 @@ onMounted(() => {
         :is-busy="isBusy"
         :items="items"
         :items-provider="itemsProvider"
+        :provider-url="currentDirectory?.url"
         :total-items="totalItems"
         :modal-show="modalShow"
         :modal-static="modalStatic"

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -27,6 +27,7 @@ interface Props {
     isEncoded?: boolean;
     items?: SelectionItem[];
     itemsProvider?: ItemsProvider;
+    providerUrl?: string;
     totalItems?: number;
     leafIcon?: string;
     modalShow?: boolean;
@@ -48,6 +49,7 @@ const props = withDefaults(defineProps<Props>(), {
     isEncoded: false,
     items: () => [],
     itemsProvider: undefined,
+    providerUrl: undefined,
     totalItems: 0,
     leafIcon: "fa fa-file-o",
     modalShow: true,
@@ -125,6 +127,16 @@ watch(
     () => props.items,
     () => {
         filtered(props.items);
+    }
+);
+
+watch(
+    () => props.providerUrl,
+    () => {
+        // We need to reset the current page when drilling down sub-folders
+        if (props.itemsProvider !== undefined) {
+            currentPage.value = 1;
+        }
     }
 );
 </script>


### PR DESCRIPTION
Hopefully fixes #18371

Browsing a sub-folder should reset the current page now.

![FilesSourcesBrowseSubfolderPaginationFix](https://github.com/galaxyproject/galaxy/assets/46503462/8c7e530c-222a-4546-ad1d-f97d92310087)


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  Follow the instructions in #18371

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
