### PR TITLE
[24.0] Fix ``get_accessible_job`` if called without session

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -260,15 +260,15 @@ class JobManager:
         )
         return self.job_lock()
 
-    def get_accessible_job(self, trans, decoded_job_id) -> Job:
+    def get_accessible_job(self, trans: ProvidesUserContext, decoded_job_id) -> Job:
         job = trans.sa_session.get(Job, decoded_job_id)
         if job is None:
             raise ObjectNotFound()
-        belongs_to_user = (
-            (job.user_id == trans.user.id)
-            if job.user_id and trans.user
-            else (job.session_id == trans.get_galaxy_session().id)
-        )
+        belongs_to_user = False
+        if trans.user:
+            belongs_to_user = job.user_id == trans.user.id
+        elif trans.galaxy_session:
+            belongs_to_user = job.session_id == trans.galaxy_session.id
         if not trans.user_is_admin and not belongs_to_user:
             # Check access granted via output datasets.
             if not job.output_datasets:


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/18399:

```
ExceptionGroup: unhandled errors in a TaskGroup
  File "starlette/_utils.py", line 87, in collapse_excgroups
    yield
  File "starlette/middleware/base.py", line 190, in __call__
    async with anyio.create_task_group() as task_group:
  File "anyio/_backends/_asyncio.py", line 678, in __aexit__
    raise BaseExceptionGroup(

AttributeError: 'NoneType' object has no attribute 'id'
(25 additional frame(s) were not displayed)
...
  File "galaxy/webapps/galaxy/fast_app.py", line 109, in add_x_frame_options
    response = await call_next(request)
  File "galaxy/webapps/galaxy/api/jobs.py", line 261, in common_problems
    job = self.service.get_job(trans=trans, job_id=job_id)
  File "galaxy/webapps/galaxy/services/jobs.py", line 121, in get_job
    return self.job_manager.get_accessible_job(trans, decoded_job_id=job_id)
  File "galaxy/managers/jobs.py", line 271, in get_accessible_job
    else (job.session_id == trans.get_galaxy_session().id)
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
