### PR TITLE
[24.0] Allow in_range validator for selects

### DIFF
--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -94,6 +94,7 @@ PARAMETER_VALIDATOR_TYPE_COMPATIBILITY = {
     ],
     "text": ["regex", "length", "empty_field", "value_in_data_table", "value_not_in_data_table", "expression"],
     "select": [
+        "in_range",
         "no_options",
         "regex",
         "length",


### PR DESCRIPTION
this is for instance needed if we have a data table with version information and we want to restrict the chosen options by the version column.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
