### PR TITLE
[24.1] Fix `input_step_parameters` missing values that don't have a label

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -801,12 +801,9 @@ export default {
             this.report.markdown = markdown;
         },
         onRun() {
-            const runUrl = `/workflows/run?id=${this.id}${
-                this.version !== undefined ? `&version=${this.version}` : ""
-            }`;
-            this.onNavigate(runUrl);
+            this.onNavigate(`/workflows/run?id=${this.id}`, false, false, true);
         },
-        async onNavigate(url, forceSave = false, ignoreChanges = false) {
+        async onNavigate(url, forceSave = false, ignoreChanges = false, appendVersion = false) {
             if (this.isNewTempWorkflow) {
                 await this.onCreate();
             } else if (this.hasChanges && !forceSave && !ignoreChanges) {
@@ -819,6 +816,9 @@ export default {
                 await this.onSave();
             }
 
+            if (appendVersion && this.version !== undefined) {
+                url += `&version=${this.version}`;
+            }
             this.hasChanges = false;
             await nextTick();
             this.$router.push(url);

--- a/client/src/components/Workflow/Editor/SaveChangesModal.vue
+++ b/client/src/components/Workflow/Editor/SaveChangesModal.vue
@@ -24,7 +24,7 @@ const busy = ref(false);
 
 const emit = defineEmits<{
     /** Proceed with or without saving the changes */
-    (e: "on-proceed", url: string, forceSave: boolean, ignoreChanges: boolean): void;
+    (e: "on-proceed", url: string, forceSave: boolean, ignoreChanges: boolean, appendVersion: boolean): void;
     /** Update the nav URL prop */
     (e: "update:nav-url", url: string): void;
     /** Update the show modal boolean prop */
@@ -49,13 +49,13 @@ function closeModal() {
 
 function dontSave() {
     busy.value = true;
-    emit("on-proceed", props.navUrl, false, true);
+    emit("on-proceed", props.navUrl, false, true, true);
 }
 
 function saveChanges() {
     busy.value = true;
     closeModal();
-    emit("on-proceed", props.navUrl, true, false);
+    emit("on-proceed", props.navUrl, true, false, true);
 }
 </script>
 

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
@@ -74,7 +74,7 @@
                                 </details>
                                 <ParameterStep
                                     v-else-if="workflowStepType == 'parameter_input'"
-                                    :parameters="[invocation.input_step_parameters[stepDetails.workflow_step_label]]" />
+                                    :parameters="[getParamInput(stepDetails)]" />
                                 <GenericHistoryItem
                                     v-else-if="
                                         isDataStep &&
@@ -208,6 +208,11 @@ export default {
             if (this.workflowStep.workflow_id) {
                 this.fetchWorkflowForInstanceId(this.workflowStep.workflow_id);
             }
+        },
+        getParamInput(stepDetails) {
+            return Object.values(this.invocation.input_step_parameters).find(
+                (param) => param.workflow_step_id === stepDetails.workflow_step_id
+            );
         },
         showJob(id) {
             this.$emit("show-job", id);

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -628,7 +628,7 @@ export function getRouter(Galaxy) {
                         props: (route) => ({
                             invocationId: route.params.invocationId,
                             isFullPage: true,
-                            fromPanel: route.query.from_panel,
+                            fromPanel: Boolean(route.query.from_panel),
                         }),
                     },
                     {

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8923,7 +8923,7 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
             for input_step_parameter in self.input_step_parameters:
                 label = input_step_parameter.workflow_step.label
                 if not label:
-                    continue
+                    label = f"{input_step_parameter.workflow_step.order_index + 1}: Unnamed parameter"
                 input_parameters[label] = {
                     "parameter_value": input_step_parameter.parameter_value,
                     "label": label,


### PR DESCRIPTION
`input_step_parameters` that did not have labels (label=None) were being excluded from the `WorkflowInvocation.to_dict()` result.

This therefore sets the label to `n: Unnamed parameter` for null labels.

Fixes https://github.com/galaxyproject/galaxy/issues/18366

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
