### PR TITLE
[24.1] Ensure datatypes match on dragging elements into FormData

### DIFF
--- a/client/src/components/Form/Elements/FormData/FormData.test.js
+++ b/client/src/components/Form/Elements/FormData/FormData.test.js
@@ -3,6 +3,8 @@ import { mount } from "@vue/test-utils";
 import { PiniaVuePlugin } from "pinia";
 import { dispatchEvent, getLocalVue } from "tests/jest/helpers";
 
+import { testDatatypesMapper } from "@/components/Datatypes/test_fixtures";
+import { useDatatypesMapperStore } from "@/stores/datatypesMapperStore";
 import { useEventStore } from "@/stores/eventStore";
 
 import MountTarget from "./FormData.vue";
@@ -15,6 +17,8 @@ let eventStore;
 function createTarget(propsData) {
     const pinia = createTestingPinia({ stubActions: false });
     eventStore = useEventStore();
+    const datatypesStore = useDatatypesMapperStore();
+    datatypesStore.datatypesMapper = testDatatypesMapper;
     return mount(MountTarget, {
         localVue,
         propsData,

--- a/client/src/components/Form/FormElement.test.js
+++ b/client/src/components/Form/FormElement.test.js
@@ -30,7 +30,7 @@ describe("FormElement", () => {
         const error = wrapper.find(".ui-form-error-text");
         expect(error.text()).toBe("error_text");
 
-        await wrapper.setProps({ error: "" });
+        await wrapper.setProps({ error: undefined });
         const no_error = wrapper.findAll(".ui-form-error");
         expect(no_error.length).toBe(0);
 

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -127,7 +127,7 @@ function onConnect() {
 
 const isHidden = computed(() => attrs.value["hidden"]);
 const elementId = computed(() => `form-element-${props.id}`);
-const hasAlert = computed(() => Boolean(props.error || props.warning));
+const hasAlert = computed(() => alerts.value.length > 0);
 const showPreview = computed(() => (collapsed.value && attrs.value["collapsible_preview"]) || props.disabled);
 const showField = computed(() => !collapsed.value && !props.disabled);
 
@@ -174,6 +174,16 @@ const isEmpty = computed(() => {
 const isRequired = computed(() => attrs.value["optional"] === false);
 const isRequiredType = computed(() => props.type !== "boolean");
 const isOptional = computed(() => !isRequired.value && attrs.value["optional"] !== undefined);
+const formAlert = ref<string>();
+const alerts = computed(() => {
+    return [formAlert.value, props.error, props.warning]
+        .filter((v) => v !== undefined && v !== null)
+        .map((v) => linkify(sanitize(v!, { USE_PROFILES: { html: true } })));
+});
+
+function onAlert(value: string | undefined) {
+    formAlert.value = value;
+}
 </script>
 
 <template>
@@ -182,11 +192,9 @@ const isOptional = computed(() => !isRequired.value && attrs.value["optional"] !
         :id="elementId"
         class="ui-form-element section-row"
         :class="{ alert: hasAlert, 'alert-info': hasAlert }">
-        <div v-if="hasAlert" class="ui-form-error">
+        <div v-for="(alert, index) in alerts" :key="index" class="ui-form-error">
             <FontAwesomeIcon class="mr-1" icon="fa-exclamation" />
-            <span
-                class="ui-form-error-text"
-                v-html="linkify(sanitize(props.error || props.warning, { USE_PROFILES: { html: true } }))" />
+            <span class="ui-form-error-text" v-html="alert" />
         </div>
 
         <div class="ui-form-title">
@@ -288,7 +296,8 @@ const isOptional = computed(() => !isRequired.value && attrs.value["optional"] !
                 :optional="attrs.optional"
                 :options="attrs.options"
                 :tag="attrs.tag"
-                :type="props.type" />
+                :type="props.type"
+                @alert="onAlert" />
             <FormDrilldown
                 v-else-if="props.type === 'drill_down'"
                 :id="id"


### PR DESCRIPTION
This is pretty common source of cheetah templating issues where tool authors assume (correctly, IMO) only datatypes allowed in the format attribute of an input dataset are allowed.
Here's a hypothetical example:

```
#if input.is_of_type('cram'):
  # set index = $input.cram_index
#else if input.is_of_type('bam'):
  # set index = $input.cram_index
#end if
ln -s '$index' input.index
```
This is going to fail if a user drags e.g. a txt dataset into the input.

Another way things can fail is if an input datatypes should contain extra files, but doesn't, for instance in
https://sentry.galaxyproject.org/share/issue/73d7bd51dd2d418e96d563f0ac2383f0/:

```
Exception: __action_for_transfer called on non-existent file - [None]
  File "galaxy/jobs/runners/pulsar.py", line 446, in queue_job
    external_job_id = pulsar_submit_job(client, client_job_description, remote_job_config)
  File "pulsar/client/staging/up.py", line 39, in submit_job
    file_stager = FileStager(client, client_job_description, job_config)
  File "pulsar/client/staging/up.py", line 148, in __init__
    self.__upload_input_files()
  File "pulsar/client/staging/up.py", line 264, in __upload_input_files
    self.__upload_input_metadata_file(client_input.action_source)
  File "pulsar/client/staging/up.py", line 287, in __upload_input_metadata_file
    self.transfer_tracker.handle_transfer_source(input_action_source, path_type.INPUT, name=remote_name)
  File "pulsar/client/staging/up.py", line 495, in handle_transfer_source
    action = self.__action_for_transfer(source, type, contents)
  File "pulsar/client/staging/up.py", line 551, in __action_for_transfer
    raise Exception(message)
```

Fixes https://github.com/galaxyproject/galaxy/issues/8202

We can now easily change datatypes in batch if necessary, this shouldn't be an argument to not properly implement datatype filtering.

![not_acceptable](https://github.com/galaxyproject/galaxy/assets/6804901/f26d5830-8831-43ef-b804-41524825c880)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
