### PR TITLE
[24.0] Really allow in-range validator for txt

### DIFF
--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -165,7 +165,7 @@ class InRangeValidator(ExpressionValidator):
             op1 = "<"
         if self.exclude_max:
             op2 = "<"
-        expression = f"float('{self.min}') {op1} value {op2} float('{self.max}')"
+        expression = f"float('{self.min}') {op1} float(value) {op2} float('{self.max}')"
         if message is None:
             message = f"Value ('%s') must {'not ' if negate == 'true' else ''}fulfill {expression}"
         super().__init__(message, expression, negate)

--- a/test/unit/app/tools/test_parameter_validation.py
+++ b/test/unit/app/tools/test_parameter_validation.py
@@ -217,11 +217,11 @@ class TestParameterValidation(BaseParameterTestCase):
         )
         p.validate(10)
         with self.assertRaisesRegex(
-            ValueError, r"Parameter blah: Value \('15'\) must not fulfill float\('10'\) < float(value) <= float\('20'\)"
+            ValueError, r"Parameter blah: Value \('15'\) must not fulfill float\('10'\) < float\(value\) <= float\('20'\)"
         ):
             p.validate(15)
         with self.assertRaisesRegex(
-            ValueError, r"Parameter blah: Value \('20'\) must not fulfill float\('10'\) < float(value) <= float\('20'\)"
+            ValueError, r"Parameter blah: Value \('20'\) must not fulfill float\('10'\) < float\(value\) <= float\('20'\)"
         ):
             p.validate(20)
         p.validate(21)

--- a/test/unit/app/tools/test_parameter_validation.py
+++ b/test/unit/app/tools/test_parameter_validation.py
@@ -217,11 +217,11 @@ class TestParameterValidation(BaseParameterTestCase):
         )
         p.validate(10)
         with self.assertRaisesRegex(
-            ValueError, r"Parameter blah: Value \('15'\) must not fulfill float\('10'\) < value <= float\('20'\)"
+            ValueError, r"Parameter blah: Value \('15'\) must not fulfill float\('10'\) < float(value) <= float\('20'\)"
         ):
             p.validate(15)
         with self.assertRaisesRegex(
-            ValueError, r"Parameter blah: Value \('20'\) must not fulfill float\('10'\) < value <= float\('20'\)"
+            ValueError, r"Parameter blah: Value \('20'\) must not fulfill float\('10'\) < float(value) <= float\('20'\)"
         ):
             p.validate(20)
         p.validate(21)


### PR DESCRIPTION
just enabling the linter https://github.com/galaxyproject/galaxy/pull/18403 was not sufficient

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
