### PR TITLE
[24.0] Fix collection map over status for dragged collections

### DIFF
--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -35,6 +35,7 @@ const props = withDefaults(
         };
         extensions?: Array<string>;
         type?: string;
+        collectionTypes?: Array<string>;
         flavor?: string;
         tag?: string;
     }>(),
@@ -45,6 +46,7 @@ const props = withDefaults(
         value: undefined,
         extensions: () => [],
         type: "data",
+        collectionTypes: undefined,
         flavor: undefined,
         tag: undefined,
     }
@@ -311,14 +313,28 @@ function handleIncoming(incoming: Record<string, unknown>, partial = true) {
                 const newName = v.name ? v.name : newId;
                 const newSrc =
                     v.src || (v.history_content_type === "dataset_collection" ? SOURCE.COLLECTION : SOURCE.DATASET);
-                const newValue = {
+                const newValue: DataOption = {
                     id: newId,
                     src: newSrc,
+                    batch: false,
+                    map_over_type: undefined,
                     hid: newHid,
                     name: newName,
                     keep: true,
                     tags: [],
                 };
+                if (v.collection_type && props.collectionTypes?.length > 0) {
+                    if (!props.collectionTypes.includes(v.collection_type)) {
+                        const mapOverType = props.collectionTypes.find((collectionType) =>
+                            v.collection_type.endsWith(collectionType)
+                        );
+                        if (!mapOverType) {
+                            return false;
+                        }
+                        newValue["batch"] = true;
+                        newValue["map_over_type"] = mapOverType;
+                    }
+                }
                 // Verify that new value has corresponding option
                 const keepKey = `${newId}_${newSrc}`;
                 const existingOptions = props.options && props.options[newSrc];

--- a/client/src/components/Form/Elements/FormData/types.ts
+++ b/client/src/components/Form/Elements/FormData/types.ts
@@ -3,6 +3,7 @@ export type DataOption = {
     hid: number;
     is_dataset?: boolean;
     keep: boolean;
+    batch: boolean;
     map_over_type?: string;
     name: string;
     src: string;

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -288,7 +288,8 @@ const isOptional = computed(() => !isRequired.value && attrs.value["optional"] !
                 :optional="attrs.optional"
                 :options="attrs.options"
                 :tag="attrs.tag"
-                :type="props.type" />
+                :type="props.type"
+                :collection-types="attrs.collection_types" />
             <FormDrilldown
                 v-else-if="props.type === 'drill_down'"
                 :id="id"

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2511,6 +2511,7 @@ class DataCollectionToolParameter(BaseDataToolParameter):
         # create dictionary and fill default parameters
         other_values = other_values or {}
         d = super().to_dict(trans)
+        d["collection_types"] = self.collection_types
         d["extensions"] = self.extensions
         d["multiple"] = self.multiple
         d["options"] = {"hda": [], "hdca": [], "dce": []}


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/12614, which is the source of many templating errors such as
https://sentry.galaxyproject.org/share/issue/008a129bf7e44b3086491789f4bfb07e/:

```
NotFound: cannot find 'forward'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1718305116_116218_60583.py", line 206, in respond
```

If we don't set `batch` and `map_over_type` (this is correctly done by the backend when building the parameter options from the history) we pass
in the whole collection, which likely won't have a `forward` element.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
