### PR TITLE
[24.0] Serialize purged flag for datasets in collections

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6119,6 +6119,8 @@ export interface components {
              * @constant
              */
             model_class: "HistoryDatasetAssociation";
+            /** Purged */
+            purged: boolean;
             /**
              * State
              * @description The current state of this dataset.

--- a/client/src/stores/collectionElementsStore.test.ts
+++ b/client/src/stores/collectionElementsStore.test.ts
@@ -151,6 +151,7 @@ function mockElement(collectionId: string, i: number): DCESummary {
             history_id: "1",
             tags: [],
             accessible: true,
+            purged: false,
         },
     };
 }

--- a/lib/galaxy/managers/collections_util.py
+++ b/lib/galaxy/managers/collections_util.py
@@ -186,6 +186,7 @@ def dictify_element_reference(
         else:
             object_details["state"] = element_object.state
             object_details["hda_ldda"] = "hda"
+            object_details["purged"] = element_object.purged
             if isinstance(element_object, model.HistoryDatasetAssociation):
                 object_details["history_id"] = element_object.history_id
                 object_details["tags"] = element_object.make_tag_string_list()

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -950,6 +950,7 @@ class HDAObject(Model, WithModelClass):
     tags: List[str]
     copied_from_ldda_id: Optional[EncodedDatabaseIdField] = None
     accessible: Optional[bool] = None
+    purged: bool
     model_config = ConfigDict(extra="allow")
 
 


### PR DESCRIPTION
Fixes #18415

![FixPurgedCollectionElements](https://github.com/galaxyproject/galaxy/assets/46503462/19c5b756-d810-42c5-a4b1-7490d59d7c00)



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
