### PR TITLE
[24.0] Replace busybox:ubuntu-14.04 image with busybox:1.36.1-glibc

### DIFF
--- a/config/job_conf.yml.interactivetools
+++ b/config/job_conf.yml.interactivetools
@@ -41,8 +41,8 @@ execution:
 
       #docker_cmd: /usr/local/custom_docker/docker
       #docker_host:
-      #docker_container_id_override: busybox:ubuntu-14.04
-      #docker_default_container_id: busybox:ubuntu-14.04
+      #docker_container_id_override: busybox:1.36.1-glibc
+      #docker_default_container_id: busybox:1.36.1-glibc
       #require_container: true
       #container_monitor: true
       #container_monitor_result: file

--- a/doc/source/admin/jobs.md
+++ b/doc/source/admin/jobs.md
@@ -159,7 +159,7 @@ execution:
       k8s_namespace: default
       runner: pulsar_k8s
       docker_enabled: true
-      docker_default_container_id: busybox:ubuntu-14.04
+      docker_default_container_id: busybox:1.36.1-glibc
       pulsar_app_config:
         message_queue_url: 'amqp://guest:guest@host.docker.internal:5672//'
     local_environment:

--- a/doc/source/admin/special_topics/interactivetools.rst
+++ b/doc/source/admin/special_topics/interactivetools.rst
@@ -172,8 +172,8 @@ An example ``job_conf.yml`` file as seen in ``config/job_conf.yml.interactivetoo
 
           #docker_cmd: /usr/local/custom_docker/docker
           #docker_host:
-          #docker_container_id_override: busybox:ubuntu-14.04
-          #docker_default_container_id: busybox:ubuntu-14.04
+          #docker_container_id_override: busybox:1.36.1-glibc
+          #docker_default_container_id: busybox:1.36.1-glibc
           #require_container: true
           #container_monitor: true
           #container_monitor_result: file

--- a/doc/source/admin/special_topics/mulled_containers.rst
+++ b/doc/source/admin/special_topics/mulled_containers.rst
@@ -16,7 +16,7 @@ requirement field.
 
     <requirements>
         <!-- Container based dependency handling -->
-        <container type="docker">busybox:ubuntu-14.04</container>
+        <container type="docker">busybox:1.36.1-glibc</container>
         <!-- Conda based dependency handling -->
         <requirement type="package" version="8.22">gnu_coreutils</requirement>
     </requirements>

--- a/lib/galaxy/config/sample/job_conf.sample.yml
+++ b/lib/galaxy/config/sample/job_conf.sample.yml
@@ -513,13 +513,13 @@ execution:
       # trust tool's specified container - a destination wide override
       # can be set. This will cause all jobs on this destination to use
       # that docker image.
-      #docker_container_id_override: busybox:ubuntu-14.04
+      #docker_container_id_override: busybox:1.36.1-glibc
 
       # Likewise, if deployer wants to use docker for isolation and
       # does trust tool's specified container - but also wants tool's not
       # configured to run in a container the following option can provide
       # a fallback. -->
-      #docker_default_container_id: busybox:ubuntu-14.04
+      #docker_default_container_id: busybox:1.36.1-glibc
 
       # If the destination should be secured to only allow containerized jobs
       # the following parameter may be set for the job destination. Some tools
@@ -633,7 +633,7 @@ execution:
         - type: docker
           shell: '/bin/sh'
           resolve_dependencies: false
-          identifier: 'busybox:ubuntu-14.04'
+          identifier: 'busybox:1.36.1-glibc'
         - type: singularity
           shell: '/bin/sh'
           resolve_dependencies: false
@@ -642,7 +642,7 @@ execution:
         - type: docker
           shell: '/bin/sh'
           resolve_dependencies: false
-          identifier: 'busybox:ubuntu-14.04'
+          identifier: 'busybox:1.36.1-glibc'
         - type: singularity
           shell: '/bin/sh'
           resolve_dependencies: false

--- a/lib/galaxy/config/sample/job_conf.xml.sample_advanced
+++ b/lib/galaxy/config/sample/job_conf.xml.sample_advanced
@@ -588,13 +588,13 @@
                trust tool's specified container - a destination wide override
                can be set. This will cause all jobs on this destination to use
                that docker image. -->
-          <!-- <param id="docker_container_id_override">busybox:1.36.1-glibc'</param> -->
+          <!-- <param id="docker_container_id_override">busybox:1.36.1-glibc</param> -->
 
           <!-- Likewise, if deployer wants to use docker for isolation and
                does trust tool's specified container - but also wants tool's not
                configured to run in a container the following option can provide
                a fallback. -->
-          <!-- <param id="docker_default_container_id">busybox:1.36.1-glibc'</param> -->
+          <!-- <param id="docker_default_container_id">busybox:1.36.1-glibc</param> -->
 
           <!-- If the destination should be secured to only allow containerized jobs
                the following parameter may be set for the job destination. Some tools do
@@ -674,11 +674,11 @@
                the enabled container types for this destination will be used.
           -->
           <param id="container_override">
-              <container type="docker" shell="/bin/sh" resolve_dependencies="false">busybox:1.36.1-glibc'</container>
+              <container type="docker" shell="/bin/sh" resolve_dependencies="false">busybox:1.36.1-glibc</container>
               <container type="singularity" shell="/bin/sh" resolve_dependencies="false">/path/to/default/container</container>
           </param>
           <param id="container">
-              <container type="docker" shell="/bin/sh" resolve_dependencies="false">busybox:1.36.1-glibc'</container>
+              <container type="docker" shell="/bin/sh" resolve_dependencies="false">busybox:1.36.1-glibc</container>
               <container type="singularity" shell="/bin/sh" resolve_dependencies="false">/path/to/default/container</container>
           </param>
         </destination>
@@ -966,7 +966,7 @@
             container ID will be passed along to condor as
             the docker_image submission parameter.
             -->
-            <!-- <param id="docker_default_container_id">busybox:1.36.1-glibc'</param> -->
+            <!-- <param id="docker_default_container_id">busybox:1.36.1-glibc</param> -->
         </destination>
 
         <!-- Jobs can be re-submitted for various reasons (to the same destination or others,

--- a/lib/galaxy/config/sample/job_conf.xml.sample_advanced
+++ b/lib/galaxy/config/sample/job_conf.xml.sample_advanced
@@ -588,13 +588,13 @@
                trust tool's specified container - a destination wide override
                can be set. This will cause all jobs on this destination to use
                that docker image. -->
-          <!-- <param id="docker_container_id_override">busybox:ubuntu-14.04</param> -->
+          <!-- <param id="docker_container_id_override">busybox:1.36.1-glibc'</param> -->
 
           <!-- Likewise, if deployer wants to use docker for isolation and
                does trust tool's specified container - but also wants tool's not
                configured to run in a container the following option can provide
                a fallback. -->
-          <!-- <param id="docker_default_container_id">busybox:ubuntu-14.04</param> -->
+          <!-- <param id="docker_default_container_id">busybox:1.36.1-glibc'</param> -->
 
           <!-- If the destination should be secured to only allow containerized jobs
                the following parameter may be set for the job destination. Some tools do
@@ -674,11 +674,11 @@
                the enabled container types for this destination will be used.
           -->
           <param id="container_override">
-              <container type="docker" shell="/bin/sh" resolve_dependencies="false">busybox:ubuntu-14.04</container>
+              <container type="docker" shell="/bin/sh" resolve_dependencies="false">busybox:1.36.1-glibc'</container>
               <container type="singularity" shell="/bin/sh" resolve_dependencies="false">/path/to/default/container</container>
           </param>
           <param id="container">
-              <container type="docker" shell="/bin/sh" resolve_dependencies="false">busybox:ubuntu-14.04</container>
+              <container type="docker" shell="/bin/sh" resolve_dependencies="false">busybox:1.36.1-glibc'</container>
               <container type="singularity" shell="/bin/sh" resolve_dependencies="false">/path/to/default/container</container>
           </param>
         </destination>
@@ -966,7 +966,7 @@
             container ID will be passed along to condor as
             the docker_image submission parameter.
             -->
-            <!-- <param id="docker_default_container_id">busybox:ubuntu-14.04</param> -->
+            <!-- <param id="docker_default_container_id">busybox:1.36.1-glibc'</param> -->
         </destination>
 
         <!-- Jobs can be re-submitted for various reasons (to the same destination or others,

--- a/lib/galaxy/model/custom_types.py
+++ b/lib/galaxy/model/custom_types.py
@@ -32,7 +32,7 @@ class SafeJsonEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, numpy.int_):
             return int(obj)
-        elif isinstance(obj, numpy.float_):
+        elif isinstance(obj, numpy.float64):
             return float(obj)
         elif isinstance(obj, bytes):
             return unicodify(obj)

--- a/test/functional/tools/catDocker.xml
+++ b/test/functional/tools/catDocker.xml
@@ -1,7 +1,7 @@
 <tool id="catdc" name="Concatenate datasets (in docker)" version="1.0.0">
     <description>tail-to-head</description>
     <requirements>
-        <container type="docker">busybox:ubuntu-14.04</container>
+        <container type="docker">busybox:1.36.1-glibc</container>
     </requirements>
     <command><![CDATA[
 echo "Galaxy slots passed through contain as \$GALAXY_SLOTS" &&

--- a/test/functional/tools/job_environment_default.xml
+++ b/test/functional/tools/job_environment_default.xml
@@ -1,6 +1,6 @@
 <tool id="job_environment_default" name="job_environment_default" version="0.1.0" profile="18.01">
     <requirements>
-        <container type="docker">busybox:ubuntu-14.04</container>
+        <container type="docker">busybox:1.36.1-glibc</container>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 mktemp -d &&

--- a/test/functional/tools/job_environment_default_legacy.xml
+++ b/test/functional/tools/job_environment_default_legacy.xml
@@ -1,6 +1,6 @@
 <tool id="job_environment_default_legacy" name="job_environment_default_legacy" version="0.1.0">
     <requirements>
-        <container type="docker">busybox:ubuntu-14.04</container>
+        <container type="docker">busybox:1.36.1-glibc</container>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 mktemp -d &&

--- a/test/functional/tools/job_environment_explicit_isolated_home.xml
+++ b/test/functional/tools/job_environment_explicit_isolated_home.xml
@@ -1,6 +1,6 @@
 <tool id="job_environment_explicit_isolated_home" name="job_environment_explicit_isolated_home" version="0.1.0">
     <requirements>
-        <container type="docker">busybox:ubuntu-14.04</container>
+        <container type="docker">busybox:1.36.1-glibc</container>
     </requirements>
     <command use_shared_home="false"><![CDATA[
 mktemp -d &&

--- a/test/functional/tools/job_environment_explicit_shared_home.xml
+++ b/test/functional/tools/job_environment_explicit_shared_home.xml
@@ -1,6 +1,6 @@
 <tool id="job_environment_explicit_shared_home" name="job_environment_explicit_shared_home" version="0.1.0" profile="18.01">
     <requirements>
-        <container type="docker">busybox:ubuntu-14.04</container>
+        <container type="docker">busybox:1.36.1-glibc</container>
     </requirements>
     <command use_shared_home="true"><![CDATA[
 mktemp -d &&

--- a/test/functional/tools/tool_directory_docker.xml
+++ b/test/functional/tools/tool_directory_docker.xml
@@ -1,6 +1,6 @@
 <tool id="tool_directory_docker" name="tool_directory_docker" version="1.0.0">
     <requirements>
-        <container type="docker">busybox:ubuntu-14.04</container>
+        <container type="docker">busybox:1.36.1-glibc</container>
     </requirements>
     <command><![CDATA[
 cp '$__tool_directory__/tool_directory.xml' output1

--- a/test/integration/test_coexecution.py
+++ b/test/integration/test_coexecution.py
@@ -66,7 +66,7 @@ execution:
       k8s_namespace: ${k8s_namespace}
       runner: pulsar_k8s
       docker_enabled: true
-      docker_default_container_id: busybox:ubuntu-14.04
+      docker_default_container_id: busybox:1.36.1-glibc
       pulsar_app_config:
         message_queue_url: '${container_amqp_url}'
       env:
@@ -145,7 +145,7 @@ execution:
       runner: pulsar_tes
       tes_url: ${tes_url}
       docker_enabled: true
-      docker_default_container_id: busybox:ubuntu-14.04
+      docker_default_container_id: busybox:1.36.1-glibc
       pulsar_app_config:
         message_queue_url: '${container_amqp_url}'
       env:
@@ -204,7 +204,7 @@ execution:
       runner: pulsar_tes
       tes_url: ${tes_url}
       docker_enabled: true
-      docker_default_container_id: busybox:ubuntu-14.04
+      docker_default_container_id: busybox:1.36.1-glibc
       pulsar_app_config:
         message_queue_url: '${container_amqp_url}'
       env:

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -133,21 +133,21 @@ def job_config(jobs_directory: str) -> Config:
             <param id="limits_cpu">1.1</param>
             <param id="limits_memory">100M</param>
             <param id="docker_enabled">true</param>
-            <param id="docker_default_container_id">busybox:ubuntu-14.04</param>
+            <param id="docker_default_container_id">busybox:1.36.1-glibc</param>
             <env id="SOME_ENV_VAR">42</env>
         </destination>
         <destination id="k8s_destination_walltime_short" runner="k8s_walltime_short">
             <param id="limits_cpu">1.1</param>
             <param id="limits_memory">100M</param>
             <param id="docker_enabled">true</param>
-            <param id="docker_default_container_id">busybox:ubuntu-14.04</param>
+            <param id="docker_default_container_id">busybox:1.36.1-glibc</param>
             <env id="SOME_ENV_VAR">42</env>
         </destination>
         <destination id="k8s_destination_no_cleanup" runner="k8s_no_cleanup">
             <param id="limits_cpu">1.1</param>
             <param id="limits_memory">100M</param>
             <param id="docker_enabled">true</param>
-            <param id="docker_default_container_id">busybox:ubuntu-14.04</param>
+            <param id="docker_default_container_id">busybox:1.36.1-glibc</param>
             <env id="SOME_ENV_VAR">42</env>
         </destination>
         <destination id="local_dest" runner="local">

--- a/test/unit/app/jobs/test_job_configuration.py
+++ b/test/unit/app/jobs/test_job_configuration.py
@@ -322,7 +322,7 @@ class TestAdvancedJobConfXmlParser(BaseJobConfXmlParserTestCase):
         assert len(container) == 2
         container0 = container[0]
         assert container0["type"] == "docker"
-        assert container0["identifier"] == "busybox:ubuntu-14.04"
+        assert container0["identifier"] == "busybox:1.36.1-glibc"
 
         container_override = container_dest.params["container_override"]
         assert len(container_override) == 2


### PR DESCRIPTION
We've (hopefully) reuploaded all docker images with deprecated manifests, but we have no control over this image.
I hope replacing this is as easy as this.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
