### PR TITLE
[24.1] Support usage of vue mounting helpers in a context without existing pinia/vue.

### DIFF
--- a/client/src/utils/mountVueComponent.js
+++ b/client/src/utils/mountVueComponent.js
@@ -26,7 +26,7 @@ function getOrCreatePinia() {
     // We sometimes use this utility mounting function in a context where there
     // is no existing vue application or pinia store (e.g. individual charts
     // displayed in an iframe).
-    // To support both use cases, we will a new pinia store and attach it to the
+    // To support both use cases, we will create a new pinia store and attach it to the
     // vue application that is created for the component.
     let pinia = getActivePinia();
     if (!pinia) {

--- a/client/src/utils/mountVueComponent.js
+++ b/client/src/utils/mountVueComponent.js
@@ -4,7 +4,7 @@
 
 import BootstrapVue from "bootstrap-vue";
 import { iconPlugin, localizationPlugin, vueRxShortcutPlugin } from "components/plugins";
-import { getActivePinia, PiniaVuePlugin } from "pinia";
+import { createPinia, getActivePinia, PiniaVuePlugin } from "pinia";
 import Vue from "vue";
 
 // Load Pinia
@@ -22,17 +22,28 @@ Vue.use(vueRxShortcutPlugin);
 // font-awesome svg icon registration/loading
 Vue.use(iconPlugin);
 
+function getOrCreatePinia() {
+    // We sometimes use this utility mounting function in a context where there
+    // is no existing vue application or pinia store (e.g. individual charts
+    // displayed in an iframe).
+    // To support both use cases, we will a new pinia store and attach it to the
+    // vue application that is created for the component.
+    let pinia = getActivePinia();
+    if (!pinia) {
+        pinia = createPinia();
+    }
+    return pinia;
+}
+
 export const mountVueComponent = (ComponentDefinition) => {
     const component = Vue.extend(ComponentDefinition);
-    const pinia = getActivePinia();
-    return (propsData, el) => new component({ propsData, el, pinia });
+    return (propsData, el) => new component({ propsData, el, pinia: getOrCreatePinia() });
 };
 
 export const replaceChildrenWithComponent = (el, ComponentDefinition, propsData = {}) => {
     const container = document.createElement("div");
     el.replaceChildren(container);
     const component = Vue.extend(ComponentDefinition);
-    const pinia = getActivePinia();
-    const mountFn = (propsData, el) => new component({ propsData, el, pinia });
+    const mountFn = (propsData, el) => new component({ propsData, el, pinia: getOrCreatePinia() });
     return mountFn(propsData, container);
 };


### PR DESCRIPTION
This fixes charts initialization, as in #18427 

(following up in dev with a little refactoring, but we'll want to go ahead and get this deployed sooner rather than later)
## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
