### PR TITLE
[24.0] Fix mounting utility usage of pinia (fixes charts form components)

### DIFF
--- a/client/src/utils/mountVueComponent.js
+++ b/client/src/utils/mountVueComponent.js
@@ -4,7 +4,11 @@
 
 import BootstrapVue from "bootstrap-vue";
 import { iconPlugin, localizationPlugin, vueRxShortcutPlugin } from "components/plugins";
+import { createPinia, getActivePinia, PiniaVuePlugin } from "pinia";
 import Vue from "vue";
+
+// Load Pinia
+Vue.use(PiniaVuePlugin);
 
 // Bootstrap components
 Vue.use(BootstrapVue);
@@ -18,15 +22,25 @@ Vue.use(vueRxShortcutPlugin);
 // font-awesome svg icon registration/loading
 Vue.use(iconPlugin);
 
-export const mountVueComponent = (ComponentDefinition) => {
-    const component = Vue.extend(ComponentDefinition);
-    return (propsData, el) => new component({ propsData, el });
-};
+function getOrCreatePinia() {
+    // We sometimes use this utility mounting function in a context where there
+    // is no existing vue application or pinia store (e.g. individual charts
+    // displayed in an iframe).
+    // To support both use cases, we will create a new pinia store and attach it
+    // to the vue application that is created for the component if missing.
+    return getActivePinia() || createPinia();
+}
 
-export const replaceChildrenWithComponent = (el, ComponentDefinition, propsData = {}) => {
+export function mountVueComponent(ComponentDefinition) {
+    const component = Vue.extend(ComponentDefinition);
+    return function (propsData, el) {
+        return new component({ propsData, el, pinia: getOrCreatePinia() });
+    };
+}
+
+export function replaceChildrenWithComponent(el, ComponentDefinition, propsData = {}) {
     const container = document.createElement("div");
     el.replaceChildren(container);
-    const component = Vue.extend(ComponentDefinition);
-    const mountFn = (propsData, el) => new component({ propsData, el });
+    const mountFn = mountVueComponent(ComponentDefinition);
     return mountFn(propsData, container);
-};
+}


### PR DESCRIPTION
This has changed multiple times in descendant branches (https://github.com/galaxyproject/galaxy/pull/18299, https://github.com/galaxyproject/galaxy/pull/18315, https://github.com/galaxyproject/galaxy/pull/18429 ), so this is a flattened, cleaned up version for application against 24.0.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
