### PR TITLE
Fixed Podman 5 issue in sample job config file

### DIFF
--- a/config/job_conf.yml.interactivetools.podman
+++ b/config/job_conf.yml.interactivetools.podman
@@ -24,9 +24,9 @@ execution:
       docker_set_user:
 
       # For containers running as root (on the inside)
-      docker_run_extra_arguments: --security-opt label=disable
+      docker_run_extra_arguments: --security-opt label=disable --network slirp4netns:allow_host_loopback=true
       # Should work for containers with non-root user (on the inside)
-      #docker_run_extra_arguments:  --userns=keep-id --security-opt label=disable
+      #docker_run_extra_arguments:  --userns=keep-id --security-opt label=disable --network slirp4netns:allow_host_loopback=true
 
       # Change to home directory of the galaxy user, not the directory of the galaxy installation
       docker_cmd: HOME="/home/galaxy"; podman


### PR DESCRIPTION
Podman 5 by default stopped supporting containers to connect to host server. This PR adds a commandline argument to the sample job config file `job_conf.yml.interactivetools.podman` to re-enable loopback to host. This is needed by many interactive tools to connecting to the Galaxy API running at host

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ x ] Instructions for manual testing are as follows:
Run an interactive tool that contacts the Galaxy API in the host machine, e.g. Jupyter, using the sample config.
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
