### PR TITLE
Simplified Workflow Centric UI (Attempt 3)

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -134,7 +134,7 @@ function onToggleSidebar(toggle: string = "", to: string | null = null) {
 
 const syncActivities = () => {
     activityStore.sync();
-    if (config.value && config.value.client_mode == "minimal_workflow") {
+    if (config.value && ["workflow_centric", "workflow_runner"].indexOf(config.value.client_mode) >= 0) {
         userStore.untoggleToolbarIfNeeded();
     }
 };

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -132,11 +132,21 @@ function onToggleSidebar(toggle: string = "", to: string | null = null) {
     userStore.toggleSideBar(toggle);
 }
 
+const syncActivities = () => {
+    activityStore.sync();
+    if (config.value && config.value.client_mode == "minimal_workflow") {
+        userStore.untoggleToolbarIfNeeded();
+    }
+};
+
 watch(
     () => hashedUserId.value,
-    () => {
-        activityStore.sync();
-    }
+    syncActivities,
+);
+
+watch(
+    isConfigLoaded,
+    syncActivities,
 );
 </script>
 

--- a/client/src/components/Workflow/List/WorkflowCard.vue
+++ b/client/src/components/Workflow/List/WorkflowCard.vue
@@ -27,11 +27,13 @@ interface Props {
     workflow: any;
     gridView?: boolean;
     publishedView?: boolean;
+    allowWorkflowManagement?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
     gridView: false,
     publishedView: false,
+    allowWorkflowManagement: true,
 });
 
 const emit = defineEmits<{
@@ -134,6 +136,7 @@ async function onTagClick(tag: string) {
                     <WorkflowActions
                         :workflow="workflow"
                         :published="publishedView"
+                        :allow-workflow-management="allowWorkflowManagement"
                         @refreshList="emit('refreshList', true)"
                         @toggleShowPreview="toggleShowPreview" />
                 </div>
@@ -185,7 +188,7 @@ async function onTagClick(tag: string) {
 
                     <div class="workflow-edit-run-buttons">
                         <BButton
-                            v-if="!isAnonymous && !shared"
+                            v-if="!isAnonymous && !shared && allowWorkflowManagement"
                             v-b-tooltip.hover.noninteractive
                             :disabled="workflow.deleted"
                             size="sm"
@@ -198,7 +201,7 @@ async function onTagClick(tag: string) {
                         </BButton>
 
                         <AsyncButton
-                            v-else
+                            v-else-if="allowWorkflowManagement"
                             v-b-tooltip.hover.noninteractive
                             size="sm"
                             :disabled="isAnonymous"

--- a/client/src/components/Workflow/List/WorkflowList.vue
+++ b/client/src/components/Workflow/List/WorkflowList.vue
@@ -28,13 +28,13 @@ type WorkflowsList = Record<string, never>[];
 
 interface Props {
     activeList?: "my" | "shared_with_me" | "published";
-    advancedOptions?: boolean;
+    clientMode?: "full" | "workflow_centric" | "workflow_runner";
     initialFilterText?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
     activeList: "my",
-    advancedOptions: true,
+    clientMode: "full",
     initialFilterText: "",
 });
 
@@ -89,6 +89,7 @@ const validFilters = computed(() => workflowFilters.value.getValidFilters(rawFil
 const invalidFilters = computed(() => workflowFilters.value.getValidFilters(rawFilters.value, true).invalidFilters);
 const isSurroundedByQuotes = computed(() => /^["'].*["']$/.test(filterText.value));
 const hasInvalidFilters = computed(() => !isSurroundedByQuotes.value && Object.keys(invalidFilters.value).length > 0);
+const allowWorkflowManagement = computed(() => props.clientMode == "full");
 
 function updateFilterValue(filterKey: string, newValue: any) {
     const currentFilterText = filterText.value;
@@ -222,10 +223,10 @@ onMounted(() => {
             <div class="d-flex flex-gapx-1">
                 <Heading h1 separator inline size="xl" class="flex-grow-1 mb-2">Workflows</Heading>
 
-                <WorkflowListActions :advanced-options="advancedOptions" />
+                <WorkflowListActions v-if="allowWorkflowManagement" />
             </div>
 
-            <BNav pills justified class="mb-2">
+            <BNav pills justified class="mb-2" v-if="allowWorkflowManagement">
                 <BNavItem id="my" :active="activeList === 'my'" :disabled="userStore.isAnonymous" to="/workflows/list">
                     My workflows
                     <LoginRequired v-if="userStore.isAnonymous" target="my" title="Manage your workflows" />
@@ -233,7 +234,6 @@ onMounted(() => {
 
                 <BNavItem
                     id="shared-with-me"
-                    v-if="advancedOptions"
                     :active="sharedWithMe"
                     :disabled="userStore.isAnonymous"
                     to="/workflows/list_shared_with_me">
@@ -262,7 +262,7 @@ onMounted(() => {
                 </template>
             </FilterMenu>
 
-            <ListHeader ref="listHeader" :show-view-toggle="advancedOptions">
+            <ListHeader ref="listHeader" :show-view-toggle="allowWorkflowManagement">
                 <template v-slot:extra-filter>
                     <div v-if="activeList === 'my'">
                         Filter:
@@ -346,6 +346,7 @@ onMounted(() => {
                 :published-view="published"
                 :grid-view="view === 'grid'"
                 :class="view === 'grid' ? 'grid-view' : 'list-view'"
+                :allow-workflow-management="allowWorkflowManagement"
                 @refreshList="load"
                 @tagClick="(tag) => updateFilterValue('tag', `'${tag}'`)"
                 @update-filter="updateFilterValue" />

--- a/client/src/components/Workflow/List/WorkflowList.vue
+++ b/client/src/components/Workflow/List/WorkflowList.vue
@@ -28,10 +28,14 @@ type WorkflowsList = Record<string, never>[];
 
 interface Props {
     activeList?: "my" | "shared_with_me" | "published";
+    advancedOptions?: boolean;
+    initialFilterText?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
     activeList: "my",
+    advancedOptions: true,
+    initialFilterText: "",
 });
 
 const router = useRouter();
@@ -194,6 +198,16 @@ watch([filterText, sortBy, sortDesc, showBookmarked], async () => {
     await load(true);
 });
 
+watch(
+    props,
+    () => {
+        if(props.initialFilterText && filterText.value == "") {
+            filterText.value = props.initialFilterText;
+        }
+    },
+    { immediate: true },
+);
+
 onMounted(() => {
     if (router.currentRoute.query.owner) {
         updateFilterValue("user", `'${router.currentRoute.query.owner}'`);
@@ -208,7 +222,7 @@ onMounted(() => {
             <div class="d-flex flex-gapx-1">
                 <Heading h1 separator inline size="xl" class="flex-grow-1 mb-2">Workflows</Heading>
 
-                <WorkflowListActions />
+                <WorkflowListActions :advanced-options="advancedOptions" />
             </div>
 
             <BNav pills justified class="mb-2">
@@ -219,6 +233,7 @@ onMounted(() => {
 
                 <BNavItem
                     id="shared-with-me"
+                    v-if="advancedOptions"
                     :active="sharedWithMe"
                     :disabled="userStore.isAnonymous"
                     to="/workflows/list_shared_with_me">
@@ -247,7 +262,7 @@ onMounted(() => {
                 </template>
             </FilterMenu>
 
-            <ListHeader ref="listHeader" show-view-toggle>
+            <ListHeader ref="listHeader" :show-view-toggle="advancedOptions">
                 <template v-slot:extra-filter>
                     <div v-if="activeList === 'my'">
                         Filter:

--- a/client/src/components/Workflow/List/WorkflowListActions.vue
+++ b/client/src/components/Workflow/List/WorkflowListActions.vue
@@ -17,6 +17,12 @@ const userStore = useUserStore();
 
 const { isAnonymous } = storeToRefs(userStore);
 
+interface Props {
+    advancedOptions: boolean;
+}
+
+const props = defineProps<Props>();
+
 const createButtonTitle = computed(() => {
     if (isAnonymous.value) {
         return "Log in to create workflow";
@@ -47,6 +53,7 @@ function navigateToOldCreate() {
             <BButton
                 id="workflow-create"
                 v-b-tooltip.hover.noninteractive
+                v-if="advancedOptions"
                 size="sm"
                 :title="createButtonTitle"
                 variant="outline-primary"

--- a/client/src/entry/analysis/modules/Analysis.vue
+++ b/client/src/entry/analysis/modules/Analysis.vue
@@ -1,10 +1,12 @@
 <script setup>
-import { onMounted, onUnmounted, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { usePanels } from "@/composables/usePanels";
+import { useConfig } from "@/composables/config";
 
 import CenterFrame from "./CenterFrame.vue";
+import WorkflowLanding from "./WorkflowLanding.vue";
 import ActivityBar from "@/components/ActivityBar/ActivityBar.vue";
 import HistoryIndex from "@/components/History/Index.vue";
 import FlexPanel from "@/components/Panels/FlexPanel.vue";
@@ -13,6 +15,16 @@ import DragAndDropModal from "@/components/Upload/DragAndDropModal.vue";
 const router = useRouter();
 const showCenter = ref(false);
 const { showPanels } = usePanels();
+const { config, isConfigLoaded } = useConfig();
+
+const showHistoryPanel = computed(() => {
+    return showPanels.value && config.value && config.value.client_mode == "full";
+});
+
+const showWorkflowCenter = computed(() => {
+    console.log(config.value && config.value.client_mode);
+    return config.value && config.value.client_mode == "minimal_workflow";
+});
 
 // methods
 function hideCenter() {
@@ -44,7 +56,7 @@ onUnmounted(() => {
                 <router-view :key="$route.fullPath" class="h-100" />
             </div>
         </div>
-        <FlexPanel v-if="showPanels" side="right">
+        <FlexPanel v-if="showHistoryPanel" side="right">
             <HistoryIndex />
         </FlexPanel>
         <DragAndDropModal />

--- a/client/src/entry/analysis/modules/Analysis.vue
+++ b/client/src/entry/analysis/modules/Analysis.vue
@@ -21,11 +21,6 @@ const showHistoryPanel = computed(() => {
     return showPanels.value && config.value && config.value.client_mode == "full";
 });
 
-const showWorkflowCenter = computed(() => {
-    console.log(config.value && config.value.client_mode);
-    return config.value && config.value.client_mode == "minimal_workflow";
-});
-
 // methods
 function hideCenter() {
     showCenter.value = false;

--- a/client/src/entry/analysis/modules/Home.vue
+++ b/client/src/entry/analysis/modules/Home.vue
@@ -3,6 +3,9 @@
         <ToolForm v-if="isTool && !isUpload" v-bind="toolParams" />
         <WorkflowRun v-else-if="isWorkflow" v-bind="workflowParams" />
         <div v-else-if="isController" :src="controllerParams" />
+        <div v-else-if="isWorkflowLanding">
+            <WorkflowLanding initial-filter-text="config.simplified_workflow_landing_initial_tags" />
+        </div>
         <CenterFrame v-else src="/welcome" />
     </div>
 </template>
@@ -10,6 +13,7 @@
 <script>
 import ToolForm from "components/Tool/ToolForm";
 import WorkflowRun from "components/Workflow/Run/WorkflowRun";
+import WorkflowLanding from "./WorkflowLanding";
 import decodeUriComponent from "decode-uri-component";
 import CenterFrame from "entry/analysis/modules/CenterFrame";
 
@@ -18,6 +22,7 @@ export default {
         CenterFrame,
         ToolForm,
         WorkflowRun,
+        WorkflowLanding,
     },
     props: {
         config: {
@@ -30,6 +35,9 @@ export default {
         },
     },
     computed: {
+        isWorkflowLanding() {
+            return this.config.client_mode == "minimal_workflow";
+        },
         isController() {
             return this.query.m_c && this.query.m_a;
         },

--- a/client/src/entry/analysis/modules/Home.vue
+++ b/client/src/entry/analysis/modules/Home.vue
@@ -3,8 +3,8 @@
         <ToolForm v-if="isTool && !isUpload" v-bind="toolParams" />
         <WorkflowRun v-else-if="isWorkflow" v-bind="workflowParams" />
         <div v-else-if="isController" :src="controllerParams" />
-        <div v-else-if="isWorkflowLanding">
-            <WorkflowLanding initial-filter-text="config.simplified_workflow_landing_initial_tags" />
+        <div v-else-if="isWorkflowCentric">
+            <WorkflowLanding :client-mode="config.client_mode" :initial-filter-text="config.simplified_workflow_landing_initial_filter_text" />
         </div>
         <CenterFrame v-else src="/welcome" />
     </div>
@@ -35,8 +35,8 @@ export default {
         },
     },
     computed: {
-        isWorkflowLanding() {
-            return this.config.client_mode == "minimal_workflow";
+        isWorkflowCentric() {
+            return ["workflow_centric", "workflow_runner"].indexOf(this.config.client_mode) >= 0;
         },
         isController() {
             return this.query.m_c && this.query.m_a;

--- a/client/src/entry/analysis/modules/WorkflowLanding.vue
+++ b/client/src/entry/analysis/modules/WorkflowLanding.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
 interface Props {
     initialFilterText: string;
+    clientMode: string;
 }
+
+defineProps<Props>()
 
 import WorkflowList from "@/components/Workflow/WorkflowList.vue";
 </script>
 
 <template>
     <div>
-        <WorkflowList active-list="published" :advanced-options="false" :initial-filter-text="initialFilterText" />
+        <WorkflowList active-list="published" :client-mode="clientMode" :initial-filter-text="initialFilterText" />
     </div>
 </template>

--- a/client/src/entry/analysis/modules/WorkflowLanding.vue
+++ b/client/src/entry/analysis/modules/WorkflowLanding.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+interface Props {
+    initialFilterText: string;
+}
+
+import WorkflowList from "@/components/Workflow/WorkflowList.vue";
+</script>
+
+<template>
+    <div>
+        <WorkflowList active-list="published" :advanced-options="false" :initial-filter-text="initialFilterText" />
+    </div>
+</template>

--- a/client/src/stores/activitySetup.ts
+++ b/client/src/stores/activitySetup.ts
@@ -4,12 +4,24 @@
 import { type ClientMode, type Activity, type RawActivity } from "@/stores/activityStore";
 import { type EventData } from "@/stores/eventStore";
 
-function unlessMinimalWorkflow(clientMode: ClientMode): boolean {
-    return !(clientMode == "minimal_workflow");
+function isWorkflowCentric(clientMode: ClientMode) : boolean {
+    return ["workflow_centric", "workflow_runner"].indexOf(clientMode) >= 0;
 }
 
-function ifMinimalWorkflow(clientMode: ClientMode): boolean {
-    return !(clientMode == "minimal_workflow");
+function unlessWorkflowCentric(clientMode: ClientMode): boolean {
+    if (isWorkflowCentric(clientMode)) {
+        return false;
+    } else {
+        return true;
+    }
+}
+
+function ifWorkflowCentric(clientMode: ClientMode): boolean {
+    if (isWorkflowCentric(clientMode)) {
+        return true;
+    } else {
+        return false;
+    }
 }
 
 export const ActivitiesRaw: RawActivity[] = [
@@ -19,12 +31,12 @@ export const ActivitiesRaw: RawActivity[] = [
         icon: "fa-laptop",
         id: "interactivetools",
         mutable: false,
-        optional: ifMinimalWorkflow,
+        optional: ifWorkflowCentric,
         panel: false,
         title: "Interactive Tools",
         tooltip: "Show active interactive tools",
         to: "/interactivetool_entry_points/list",
-        visible: unlessMinimalWorkflow,
+        visible: unlessWorkflowCentric,
     },
     {
         anonymous: true,
@@ -32,12 +44,12 @@ export const ActivitiesRaw: RawActivity[] = [
         icon: "upload",
         id: "upload",
         mutable: false,
-        optional: ifMinimalWorkflow,
+        optional: ifWorkflowCentric,
         panel: false,
         title: "Upload",
         to: null,
         tooltip: "Download from URL or upload files from disk",
-        visible: unlessMinimalWorkflow,
+        visible: unlessWorkflowCentric,
     },
     {
         anonymous: true,
@@ -45,12 +57,12 @@ export const ActivitiesRaw: RawActivity[] = [
         icon: "wrench",
         id: "tools",
         mutable: false,
-        optional: ifMinimalWorkflow,
+        optional: ifWorkflowCentric,
         panel: true,
         title: "Tools",
         to: "/tools",
         tooltip: "Search and run tools",
-        visible: unlessMinimalWorkflow,
+        visible: unlessWorkflowCentric,
     },
     {
         anonymous: true,
@@ -89,7 +101,7 @@ export const ActivitiesRaw: RawActivity[] = [
         title: "Visualization",
         to: null,
         tooltip: "Visualize datasets",
-        visible: unlessMinimalWorkflow,
+        visible: unlessWorkflowCentric,
     },
     {
         anonymous: true,
@@ -102,7 +114,7 @@ export const ActivitiesRaw: RawActivity[] = [
         title: "Histories",
         tooltip: "Show all histories",
         to: "/histories/list",
-        visible: unlessMinimalWorkflow,
+        visible: unlessWorkflowCentric,
     },
     {
         anonymous: false,
@@ -115,7 +127,7 @@ export const ActivitiesRaw: RawActivity[] = [
         title: "History Multiview",
         tooltip: "Select histories to show in History Multiview",
         to: "/histories/view_multiple",
-        visible: unlessMinimalWorkflow,
+        visible: unlessWorkflowCentric,
     },
     {
         anonymous: false,
@@ -128,7 +140,7 @@ export const ActivitiesRaw: RawActivity[] = [
         title: "Datasets",
         tooltip: "Show all datasets",
         to: "/datasets/list",
-        visible: unlessMinimalWorkflow,
+        visible: unlessWorkflowCentric,
     },
     {
         anonymous: true,
@@ -141,7 +153,7 @@ export const ActivitiesRaw: RawActivity[] = [
         title: "Pages",
         tooltip: "Show all pages",
         to: "/pages/list",
-        visible: unlessMinimalWorkflow,
+        visible: unlessWorkflowCentric,
     },
     {
         anonymous: false,

--- a/client/src/stores/activitySetup.ts
+++ b/client/src/stores/activitySetup.ts
@@ -1,22 +1,30 @@
 /**
  * List of built-in activities
  */
-import { type Activity } from "@/stores/activityStore";
+import { type ClientMode, type Activity, type RawActivity } from "@/stores/activityStore";
 import { type EventData } from "@/stores/eventStore";
 
-export const Activities = [
+function unlessMinimalWorkflow(clientMode: ClientMode): boolean {
+    return !(clientMode == "minimal_workflow");
+}
+
+function ifMinimalWorkflow(clientMode: ClientMode): boolean {
+    return !(clientMode == "minimal_workflow");
+}
+
+export const ActivitiesRaw: RawActivity[] = [
     {
         anonymous: false,
         description: "Displays currently running interactive tools (ITs), if these are enabled by the administrator.",
         icon: "fa-laptop",
         id: "interactivetools",
         mutable: false,
-        optional: false,
+        optional: ifMinimalWorkflow,
         panel: false,
         title: "Interactive Tools",
         tooltip: "Show active interactive tools",
         to: "/interactivetool_entry_points/list",
-        visible: true,
+        visible: unlessMinimalWorkflow,
     },
     {
         anonymous: true,
@@ -24,12 +32,12 @@ export const Activities = [
         icon: "upload",
         id: "upload",
         mutable: false,
-        optional: false,
+        optional: ifMinimalWorkflow,
         panel: false,
         title: "Upload",
         to: null,
         tooltip: "Download from URL or upload files from disk",
-        visible: true,
+        visible: unlessMinimalWorkflow,
     },
     {
         anonymous: true,
@@ -37,12 +45,12 @@ export const Activities = [
         icon: "wrench",
         id: "tools",
         mutable: false,
-        optional: false,
+        optional: ifMinimalWorkflow,
         panel: true,
         title: "Tools",
-        to: null,
+        to: "/tools",
         tooltip: "Search and run tools",
-        visible: true,
+        visible: unlessMinimalWorkflow,
     },
     {
         anonymous: true,
@@ -81,7 +89,7 @@ export const Activities = [
         title: "Visualization",
         to: null,
         tooltip: "Visualize datasets",
-        visible: true,
+        visible: unlessMinimalWorkflow,
     },
     {
         anonymous: true,
@@ -94,7 +102,7 @@ export const Activities = [
         title: "Histories",
         tooltip: "Show all histories",
         to: "/histories/list",
-        visible: true,
+        visible: unlessMinimalWorkflow,
     },
     {
         anonymous: false,
@@ -107,7 +115,7 @@ export const Activities = [
         title: "History Multiview",
         tooltip: "Select histories to show in History Multiview",
         to: "/histories/view_multiple",
-        visible: true,
+        visible: unlessMinimalWorkflow,
     },
     {
         anonymous: false,
@@ -120,7 +128,7 @@ export const Activities = [
         title: "Datasets",
         tooltip: "Show all datasets",
         to: "/datasets/list",
-        visible: true,
+        visible: unlessMinimalWorkflow,
     },
     {
         anonymous: true,
@@ -133,7 +141,7 @@ export const Activities = [
         title: "Pages",
         tooltip: "Show all pages",
         to: "/pages/list",
-        visible: true,
+        visible: unlessMinimalWorkflow,
     },
     {
         anonymous: false,
@@ -149,6 +157,25 @@ export const Activities = [
         visible: true,
     },
 ];
+
+function resolveActivity(activity: RawActivity, clientMode: ClientMode) : Activity {
+    let optional = activity.optional;
+    let visible = activity.visible;
+    if (typeof optional === 'function') {
+        optional = optional(clientMode);
+    }
+    if (typeof visible === 'function') {
+        visible = visible(clientMode);
+    }
+    return { ...activity, optional, visible};
+}
+
+export function getActivities(clientMode: ClientMode) {
+    const resolve = (activity: RawActivity) => {
+        return resolveActivity(activity, clientMode);
+    }
+    return ActivitiesRaw.map(resolve);
+}
 
 export function convertDropData(data: EventData): Activity | null {
     if (data.history_content_type === "dataset") {

--- a/client/src/stores/activityStore.ts
+++ b/client/src/stores/activityStore.ts
@@ -35,7 +35,7 @@ export interface Activity {
     visible: boolean;
 }
 
-export type ClientMode = "full" | "minimal_workflow";
+export type ClientMode = "full" | "workflow_centric" | "workflow_runner";
 
 // config materializes a RawActivity into an Activity
 export interface RawActivity {

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -146,6 +146,12 @@ export const useUserStore = defineStore("userStore", () => {
         };
     }
 
+    function untoggleToolbarIfNeeded() {
+        if (toggledSideBar.value == "tools") {
+            toggledSideBar.value = "";
+        }
+    }
+
     return {
         currentUser,
         currentPreferences,
@@ -163,6 +169,7 @@ export const useUserStore = defineStore("userStore", () => {
         addFavoriteTool,
         removeFavoriteTool,
         toggleSideBar,
+        untoggleToolbarIfNeeded,
         $reset,
     };
 });

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3134,6 +3134,24 @@ mapping:
           When false, the most recently added compatible item in the history will
           be used for each "Set at Runtime" input, independent of others in the workflow.
 
+      client_mode:
+        type: str
+        default: 'full'
+        enum: ['full', 'minimal_workflow']
+        required: false
+        per_host: true
+        desc: |
+          Set this to 'minimal_workflow' to turn on the simplified Galaxy workflow
+          UI.
+
+      simplified_workflow_landing_initial_tags:
+        type: str
+        default: null
+        required: false
+        per_host: true
+        desc: |
+          I will write this in later.
+
       simplified_workflow_run_ui:
         type: str
         default: 'prefer'

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3137,20 +3137,30 @@ mapping:
       client_mode:
         type: str
         default: 'full'
-        enum: ['full', 'minimal_workflow']
+        enum: ['full', 'workflow_centric', 'workflow_runner']
         required: false
         per_host: true
         desc: |
-          Set this to 'minimal_workflow' to turn on the simplified Galaxy workflow
-          UI.
+          This will change the modality and focus on the client UI. The traditional
+          full Galaxy with default activity bar is the default of 'full'.
+          'workflow_centric' & 'workflow_runner' yield client applications
+          that are geared to center a collection of workflows in Galaxy and attempts
+          to hide the concept of histories from users. The 'workflow_centric' view
+          still allows the user to manage & edit a collection of their own workflows.
+          'workflow_runner' is a mode that disables workflow management to even further
+          simplify the UI - this may be appropriate for instances that really just want
+          enable particular workflows as-is.
 
-      simplified_workflow_landing_initial_tags:
+      simplified_workflow_landing_initial_filter_text:
         type: str
         default: null
         required: false
         per_host: true
         desc: |
-          I will write this in later.
+          If the Galaxy client is in 'workflow_centric' or 'workflow_runner' "client mode",
+          this controls the initial filtering of the workflow search textbox. This can
+          be used to foreground workflows in the published workflow list by tar (e.g. 'tag:XXX')
+          or username (e.g. 'username:XXXX').
 
       simplified_workflow_run_ui:
         type: str

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -165,7 +165,7 @@ class ConfigSerializer(base.ModelSerializer):
             "enable_beta_markdown_export": _use_config,
             "enable_beacon_integration": _use_config,
             "client_mode": _use_config,
-            "simplified_workflow_landing_initial_tags": _use_config,
+            "simplified_workflow_landing_initial_filter_text": _use_config,
             "simplified_workflow_run_ui": _use_config,
             "simplified_workflow_run_ui_target_history": _use_config,
             "simplified_workflow_run_ui_job_cache": _use_config,

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -164,6 +164,8 @@ class ConfigSerializer(base.ModelSerializer):
             "enable_unique_workflow_defaults": _use_config,
             "enable_beta_markdown_export": _use_config,
             "enable_beacon_integration": _use_config,
+            "client_mode": _use_config,
+            "simplified_workflow_landing_initial_tags": _use_config,
             "simplified_workflow_run_ui": _use_config,
             "simplified_workflow_run_ui_target_history": _use_config,
             "simplified_workflow_run_ui_job_cache": _use_config,


### PR DESCRIPTION
A large group of us outlined the idea in details years ago in http://bit.ly/simplified-workflow-ui. The idea was brought up and highlighted by @bwlang again during this year's GCC panel. The document walks through a bunch of choices and options and outlines why histories and uploads are not required. This PR is my latest landing attempt for a simplified workflow-centric interface to Galaxy. The page show the workflows available to the users and allow access to invocations. Since the original idea we've added a customizable activity bar, per-subdomain client side configuration options, and vastly improved the workflow invocation view so this idea should be stronger than ever and less disruptive to implement.

Previous attempts at https://github.com/galaxyproject/galaxy/pull/9030 and https://github.com/galaxyproject/galaxy/issues/9109 are probably not interesting but xref-ing. This attempt builds on top of @guerler's latest Masthead work in #17927.

The screenshot of the new landing is:

<img width="1769" alt="Screenshot 2024-06-28 at 4 19 53 AM" src="https://github.com/galaxyproject/galaxy/assets/216771/033b8d9f-470d-4289-8600-ec91534c0d46">

The two relevant config options are:

- ``client_mode: 'workflow_runner'`` (or ``workflow_centric``)
- ``simplified_workflow_landing_initial_filter_text: 'tag:iwc'``

These options can both be set on a per subdomain basis so we could create ``iwc.usegalaxy.org`` with all the published IWC workflows available and easily runnable. The filter text is configurable so other sites could filter by username in addition to tags for instance. This idea isn't just to highlight IWC workflows - we've seen projects with comparable ideas built on top of Galaxy like this (e.g. Galaksio, Refinery, etc..) for years and well before we had an IWC.

# A note on ``workflow_runner`` vs ``workflow_centric``

Projects like Galaksio were explicitly created to only allow specific workflows to be run. The is mode I'm aiming to implement with ``workflow_runner``. This mode disables a bunch of workflow management features (importing, seeing your workflows, editing workflows) that we should have a modality for but probably isn't what we want for a more typical Galaxy - where editing and sharing workflows are important activities we want to encourage. For this I've implemented a second client mode called ``workflow_centric``.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Set those config options and try it out.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
