### PR TITLE
[PROCEDURES] remove davebx from committers list

### DIFF
--- a/doc/source/project/organization.rst
+++ b/doc/source/project/organization.rst
@@ -46,7 +46,6 @@ Members
 - Dannon Baker (@dannon)
 - Matthias Bernt (@bernt-matthias)
 - Daniel Blankenberg (@blankenberg)
-- Dave Bouvier (@davebx)
 - Martin Čech (@martenson)
 - John Chilton (@jmchilton)
 - Nate Coraor (@natefoo)


### PR DESCRIPTION
> Periodically, active members may review this group and request that inactive members are removed - this should not be interpreted as a condemnation of these inactive members but merely as a reflection of the desire to keep this group focused enough to remain effective.

@davebx has been inactive on the project for more than a year. I've reached out to him in February but his email address does not exist anymore. I don't think he would mind, but if you have a channel to him please feel free to contact him to confirm.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
