### PR TITLE
Update plausible script name in mako templates

### DIFF
--- a/lib/tool_shed/webapp/templates/galaxy_client_app.mako
+++ b/lib/tool_shed/webapp/templates/galaxy_client_app.mako
@@ -72,7 +72,7 @@ ${ h.dumps( dictionary, indent=( 2 if trans.debug else 0 ) ) }
 
 <%def name="config_plausible_analytics(plausible_server, plausible_domain)">
     %if plausible_server and plausible_domain:
-        <script async defer data-domain="${plausible_domain}" src="${plausible_server}/js/plausible.js"></script>
+        <script async defer data-domain="${plausible_domain}" src="${plausible_server}/js/script.js"></script>
     %else:
         <script>console.warn("Missing plausible server or plausible domain");</script>
     %endif

--- a/templates/galaxy_client_app.mako
+++ b/templates/galaxy_client_app.mako
@@ -73,7 +73,7 @@ ${ h.dumps( dictionary, indent=( 2 if trans.debug else 0 ) ) }
 
 <%def name="config_plausible_analytics(plausible_server, plausible_domain)">
     %if plausible_server and plausible_domain:
-        <script async defer data-domain="${plausible_domain}" src="${plausible_server}/js/plausible.js"></script>
+        <script async defer data-domain="${plausible_domain}" src="${plausible_server}/js/script.js"></script>
         <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
     %else:
         <script>

--- a/templates/js-app.mako
+++ b/templates/js-app.mako
@@ -22,10 +22,10 @@
             | ${app.config.brand}
             %endif
         </title>
-        
+
         ## relative href for site root
         <link rel="index" href="${ h.url_for( '/' ) }"/>
-        
+
         ## TODO: use loaders to move everything but the essentials below the fold
         ${ h.dist_css(
             'base',
@@ -86,10 +86,10 @@
         ${ galaxy_client.config_google_analytics(app.config.ga_code) }
     %endif
     %if app.config.plausible_server and app.config.plausible_domain:
-            ${ galaxy_client.config_plausible_analytics(app.config.plausible_server, app.config.plausible_domain) }
+        ${ galaxy_client.config_plausible_analytics(app.config.plausible_server, app.config.plausible_domain) }
     %endif
     %if app.config.matomo_server and app.config.matomo_site_id:
-            ${ galaxy_client.config_matomo_analytics(app.config.matomo_server, app.config.matomo_site_id) }
+        ${ galaxy_client.config_matomo_analytics(app.config.matomo_server, app.config.matomo_site_id) }
     %endif
 </%def>
 


### PR DESCRIPTION
Fixes issue: https://github.com/galaxyproject/galaxy/issues/18444

The name was changed from `plausible.js` to `script.js` in the snippet or something like that. When adding a host to the `plausible.galaxyproject.eu` the following snippet `<script defer data-domain="usegalaxy.eu" src="https://plausible.galaxyproject.eu/js/script.js"></script>
` is created that should be added to the `<Head>` of a website. Locally replaced this with `script.js` and the stats are getting collected. 