### PR TITLE
[24.0] Disable password reset for deleted users [GCC2024_COFEST] 

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -613,6 +613,8 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
 
     def get_reset_token(self, trans, email):
         reset_user = get_user_by_email(trans.sa_session, email, self.app.model.User)
+        if reset_user.deleted:
+            return None, None
         if not reset_user and email != email.lower():
             reset_user = self._get_user_by_email_case_insensitive(trans.sa_session, email)
         if reset_user:

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -613,11 +613,9 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
 
     def get_reset_token(self, trans, email):
         reset_user = get_user_by_email(trans.sa_session, email, self.app.model.User)
-        if reset_user and reset_user.deleted:
-            return None, None
         if not reset_user and email != email.lower():
             reset_user = self._get_user_by_email_case_insensitive(trans.sa_session, email)
-        if reset_user:
+        if reset_user and not reset_user.deleted:
             prt = self.app.model.PasswordResetToken(reset_user)
             trans.sa_session.add(prt)
             with transaction(trans.sa_session):

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -613,7 +613,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
 
     def get_reset_token(self, trans, email):
         reset_user = get_user_by_email(trans.sa_session, email, self.app.model.User)
-        if reset_user.deleted:
+        if reset_user and reset_user.deleted:
             return None, None
         if not reset_user and email != email.lower():
             reset_user = self._get_user_by_email_case_insensitive(trans.sa_session, email)

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -233,14 +233,14 @@ class TestUserManager(BaseTestCase):
         assert result is None
 
     def test_reset_email_user_deleted(self):
-            self.trans.app.config.allow_user_deletion = True
-            self.log("should not produce the password reset email if user is deleted")
-            user_email = "user@nopassword.com"
-            user = self.user_manager.create(email=user_email, username="nopassword")
-            self.user_manager.delete(user)
-            assert user.deleted is True
-            message = self.user_manager.send_reset_email(self.trans, {"email": user_email})
-            assert message == "Failed to produce password reset token. User not found."
+        self.trans.app.config.allow_user_deletion = True
+        self.log("should not produce the password reset email if user is deleted")
+        user_email = "user@nopassword.com"
+        user = self.user_manager.create(email=user_email, username="nopassword")
+        self.user_manager.delete(user)
+        assert user.deleted is True
+        message = self.user_manager.send_reset_email(self.trans, {"email": user_email})
+        assert message == "Failed to produce password reset token. User not found."
 
     def test_get_user_by_identity(self):
         # return None if username/email not found

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -232,6 +232,16 @@ class TestUserManager(BaseTestCase):
                 mock_unique_id.assert_called_once()
         assert result is None
 
+    def test_reset_email_user_deleted(self):
+            self.trans.app.config.allow_user_deletion = True
+            self.log("should not produce the password reset email if user is deleted")
+            user_email = "user@nopassword.com"
+            user = self.user_manager.create(email=user_email, username="nopassword")
+            self.user_manager.delete(user)
+            assert user.deleted is True
+            message = self.user_manager.send_reset_email(self.trans, {"email": user_email})
+            assert message == "Failed to produce password reset token. User not found."
+
     def test_get_user_by_identity(self):
         # return None if username/email not found
         assert self.user_manager.get_user_by_identity("xyz") is None


### PR DESCRIPTION
Currently a deleted user can use the reset password functionality. Added a check in the send_reset_email function, deleted users will behave the same way as users that cannot be found. Returning the following error: "Failed to produce password reset token. User not found."

fixes #18195 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Create a user
  2. Log in, log out as user
  3. Log in as admin, delete or delete+purge user
  4. Reset password as user

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
