### PR TITLE
[WIP] Replace instance of deprecated ``utcnow()`` and ``utcfromtimestamp()``

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -8,7 +8,10 @@ import math
 import os
 import re
 import time
-from datetime import datetime
+from datetime import (
+    datetime,
+    timezone,
+)
 
 import yaml
 
@@ -760,7 +763,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                         if self.runner_params.get("k8s_unschedulable_walltime_limit"):
                             creation_time_str = job.obj["metadata"].get("creationTimestamp")
                             creation_time = datetime.strptime(creation_time_str, "%Y-%m-%dT%H:%M:%SZ")
-                            elapsed_seconds = (datetime.utcnow() - creation_time).total_seconds()
+                            elapsed_seconds = (datetime.now(tz=timezone.utc) - creation_time).total_seconds()
                             if elapsed_seconds > self.runner_params["k8s_unschedulable_walltime_limit"]:
                                 return self._handle_unschedulable_job(job, job_state)
                             else:

--- a/lib/galaxy/jobs/runners/state_handlers/resubmit.py
+++ b/lib/galaxy/jobs/runners/state_handlers/resubmit.py
@@ -1,5 +1,8 @@
 import logging
-from datetime import datetime
+from datetime import (
+    datetime,
+    timezone,
+)
 
 from galaxy import model
 from galaxy.jobs.runners import JobState
@@ -123,7 +126,7 @@ class _ExpressionContext:
         if self._lazy_context is None:
             runner_state = getattr(self._job_state, "runner_state", None) or JobState.runner_states.UNKNOWN_ERROR
             attempt = 1
-            now = datetime.utcnow()
+            now = datetime.now(tz=timezone.utc)
             last_running_state = None
             last_queued_state = None
             for state in self._job_state.job_wrapper.get_job().state_history:

--- a/lib/galaxy/managers/notification.py
+++ b/lib/galaxy/managers/notification.py
@@ -1,5 +1,8 @@
 import logging
-from datetime import datetime
+from datetime import (
+    datetime,
+    timezone,
+)
 from enum import Enum
 from typing import (
     cast,
@@ -135,7 +138,7 @@ class NotificationManager:
 
     @property
     def _now(self):
-        return datetime.utcnow()
+        return datetime.now(tz=timezone.utc)
 
     @property
     def _notification_is_active(self):

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -8,7 +8,10 @@ import random
 import re
 import string
 import time
-from datetime import datetime
+from datetime import (
+    datetime,
+    timezone,
+)
 from typing import (
     Any,
     Dict,
@@ -469,13 +472,13 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
             return None, "Please provide a token or a user and password."
         if token:
             token_result = trans.sa_session.get(self.app.model.PasswordResetToken, token)
-            if not token_result or not token_result.expiration_time > datetime.utcnow():
+            if not token_result or not token_result.expiration_time > datetime.now(tz=timezone.utc):
                 return None, "Invalid or expired password reset token, please request a new one."
             user = token_result.user
             message = self.__set_password(trans, user, password, confirm)
             if message:
                 return None, message
-            token_result.expiration_time = datetime.utcnow()
+            token_result.expiration_time = datetime.now(tz=timezone.utc)
             trans.sa_session.add(token_result)
             return user, "Password has been changed. Token has been invalidated."
         else:
@@ -546,7 +549,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         template_context = {
             "name": escape(username),
             "user_email": escape(email),
-            "date": datetime.utcnow().strftime("%D"),
+            "date": datetime.now(tz=timezone.utc).strftime("%D"),
             "hostname": trans.request.host,
             "activation_url": activation_link,
             "terms_url": self.app.config.terms_url,

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -3,6 +3,7 @@ import socket
 from datetime import (
     datetime,
     timedelta,
+    timezone,
 )
 from typing import List
 
@@ -1643,7 +1644,7 @@ class HostAgent(RBACAgent):
                     % (hda.id, hdadaa.site)
                 )
                 return False  # remote addr is not in the server list
-            if (datetime.utcnow() - hdadaa.update_time) > timedelta(seconds=60):
+            if (datetime.now(tz=timezone.utc) - hdadaa.update_time) > timedelta(seconds=60):
                 log.debug(
                     "Denying access to private dataset with hda: %i.  Authorization was granted, but has expired."
                     % hda.id
@@ -1662,7 +1663,7 @@ class HostAgent(RBACAgent):
         )
         hdadaa = self.sa_session.scalars(stmt).first()
         if hdadaa:
-            hdadaa.update_time = datetime.utcnow()
+            hdadaa.update_time = datetime.now(tz=timezone.utc)
         else:
             hdadaa = self.model.HistoryDatasetAssociationDisplayAtAuthorization(hda=hda, user=user, site=site)
         self.sa_session.add(hdadaa)

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -7,6 +7,7 @@ import os
 from datetime import (
     datetime,
     timedelta,
+    timezone,
 )
 
 try:
@@ -327,7 +328,7 @@ class AzureBlobObjectStore(CachingConcreteObjectStore):
                     container_name=self.container_name,
                     blob_name=rel_path,
                     permission=BlobSasPermissions(read=True),
-                    expiry=datetime.utcnow() + timedelta(hours=1),
+                    expiry=datetime.now(tz=timezone.utc) + timedelta(hours=1),
                 )
                 return f"{url}?{token}"
             except AzureHttpError:

--- a/lib/galaxy/tools/error_reports/plugins/influxdb.py
+++ b/lib/galaxy/tools/error_reports/plugins/influxdb.py
@@ -1,7 +1,10 @@
 """The module describes the ``influxdb`` error plugin plugin."""
 
-import datetime
 import logging
+from datetime import (
+    datetime,
+    timezone,
+)
 
 try:
     import influxdb
@@ -41,7 +44,7 @@ class InfluxDBPlugin(ErrorPlugin):
             [
                 {
                     "measurement": "galaxy_tool_error",
-                    "time": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "time": datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                     "fields": {"value": 1},
                     "tags": {
                         "exit_code": job.exit_code,

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -587,7 +587,7 @@ def pretty_print_time_interval(time=False, precise=False, utc=False):
     credit: http://stackoverflow.com/questions/1551382/user-friendly-time-format-in-python
     """
     if utc:
-        now = datetime.utcnow()
+        now = datetime.now(tz=timezone.utc)
     else:
         now = datetime.now()
     if isinstance(time, (int, float)):

--- a/lib/galaxy/web/framework/helpers/__init__.py
+++ b/lib/galaxy/web/framework/helpers/__init__.py
@@ -9,6 +9,7 @@ GalaxyWebTransaction in galaxy/webapps/base/webapp.py
 from datetime import (
     datetime,
     timedelta,
+    timezone,
 )
 
 from babel import default_locale
@@ -28,14 +29,14 @@ def time_ago(x):
     Convert a datetime to a string.
     """
     # If the date is more than one week ago, then display the actual date instead of in words
-    if datetime.utcnow() - x > timedelta(weeks=1):  # Greater than a week difference
+    if datetime.now(tz=timezone.utc) - x > timedelta(weeks=1):  # Greater than a week difference
         return x.strftime("%b %d, %Y")
     else:
         # Workaround https://github.com/python-babel/babel/issues/137
         kwargs = {}
         if not default_locale("LC_TIME"):
             kwargs["locale"] = "en_US_POSIX"
-        return format_timedelta(x - datetime.utcnow(), threshold=1, add_direction=True, **kwargs)  # type: ignore[arg-type] # https://github.com/python/mypy/issues/9676
+        return format_timedelta(x - datetime.now(tz=timezone.utc), threshold=1, add_direction=True, **kwargs)  # type: ignore[arg-type] # https://github.com/python/mypy/issues/9676
 
 
 def iff(a, b, c):

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -2,9 +2,12 @@
 OAuth 2.0 and OpenID Connect Authentication and Authorization Controller.
 """
 
-import datetime
 import json
 import logging
+from datetime import (
+    datetime,
+    timezone,
+)
 
 import jwt
 
@@ -57,7 +60,7 @@ class OIDC(JSAppLauncher):
                         "id": trans.app.security.encode_id(token.id),
                         "provider": token.provider,
                         "email": userinfo["email"],
-                        "expiration": str(datetime.datetime.utcfromtimestamp(userinfo["exp"])),
+                        "expiration": str(datetime.fromtimestamp(userinfo["exp"], timezone.utc)),
                     }
                 )
             except Exception:

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -6,6 +6,7 @@ import logging
 from datetime import (
     datetime,
     timedelta,
+    timezone,
 )
 from urllib.parse import unquote
 
@@ -242,7 +243,7 @@ class User(BaseUIController, UsesFormDefinitionsMixin):
         #  Activation is forced and the user is not active yet. Check the grace period.
         activation_grace_period = trans.app.config.activation_grace_period
         delta = timedelta(hours=int(activation_grace_period))
-        time_difference = datetime.utcnow() - create_time
+        time_difference = datetime.now(tz=timezone.utc) - create_time
         return time_difference > delta or activation_grace_period == 0
 
     @web.expose

--- a/lib/galaxy/webapps/reports/controllers/home.py
+++ b/lib/galaxy/webapps/reports/controllers/home.py
@@ -3,6 +3,7 @@ import logging
 from datetime import (
     datetime,
     timedelta,
+    timezone,
 )
 
 import sqlalchemy as sa
@@ -21,7 +22,7 @@ class HomePage(BaseUIController, ReportQueryBuilder):
     @web.expose
     def run_stats(self, trans, **kwd):
         message = ""
-        end_date = datetime.utcnow()
+        end_date = datetime.now(tz=timezone.utc)
         end_date = datetime(end_date.year, end_date.month, end_date.day, end_date.hour)
         end_date_buffer = datetime(end_date.year, end_date.month, end_date.day, end_date.hour + 1)
         start_hours = end_date - timedelta(1)

--- a/lib/galaxy/webapps/reports/controllers/jobs.py
+++ b/lib/galaxy/webapps/reports/controllers/jobs.py
@@ -6,6 +6,7 @@ from datetime import (
     date,
     datetime,
     timedelta,
+    timezone,
 )
 from math import (
     ceil,
@@ -409,7 +410,7 @@ class Jobs(BaseUIController, ReportQueryBuilder):
         monitor_user_id = get_monitor_id(trans, monitor_email)
 
         # If specified_date is not received, we'll default to the current month
-        specified_date = kwd.get("specified_date", datetime.utcnow().strftime("%Y-%m-%d"))
+        specified_date = kwd.get("specified_date", datetime.now(tz=timezone.utc).strftime("%Y-%m-%d"))
         specified_month = specified_date[:7]
 
         year, month = map(int, specified_month.split("-"))
@@ -519,7 +520,7 @@ class Jobs(BaseUIController, ReportQueryBuilder):
         monitor_user_id = get_monitor_id(trans, monitor_email)
 
         # If specified_date is not received, we'll default to the current month
-        specified_date = kwd.get("specified_date", datetime.utcnow().strftime("%Y-%m-%d"))
+        specified_date = kwd.get("specified_date", datetime.now(tz=timezone.utc).strftime("%Y-%m-%d"))
         specified_month = specified_date[:7]
         year, month = map(int, specified_month.split("-"))
         start_date = date(year, month, 1)
@@ -1237,7 +1238,7 @@ class Jobs(BaseUIController, ReportQueryBuilder):
         monitor_user_id = get_monitor_id(trans, monitor_email)
 
         tool_id = params.get("tool_id", "Add a column1")
-        specified_date = params.get("specified_date", datetime.utcnow().strftime("%Y-%m-%d"))
+        specified_date = params.get("specified_date", datetime.now(tz=timezone.utc).strftime("%Y-%m-%d"))
         q = (
             sa.select(
                 self.select_month(model.Job.table.c.create_time).label("date"),

--- a/lib/galaxy/webapps/reports/controllers/system.py
+++ b/lib/galaxy/webapps/reports/controllers/system.py
@@ -3,6 +3,7 @@ import shutil
 from datetime import (
     datetime,
     timedelta,
+    timezone,
 )
 from decimal import Decimal
 
@@ -72,7 +73,7 @@ class System(BaseUIController):
         message = ""
         if params.userless_histories_days:
             userless_histories_days = int(params.userless_histories_days)
-            cutoff_time = datetime.utcnow() - timedelta(days=userless_histories_days)
+            cutoff_time = datetime.now(tz=timezone.utc) - timedelta(days=userless_histories_days)
             history_count = 0
             dataset_count = 0
             stmt = select(model.History).filter(
@@ -104,7 +105,7 @@ class System(BaseUIController):
         message = ""
         if params.deleted_histories_days:
             deleted_histories_days = int(params.deleted_histories_days)
-            cutoff_time = datetime.utcnow() - timedelta(days=deleted_histories_days)
+            cutoff_time = datetime.now(tz=timezone.utc) - timedelta(days=deleted_histories_days)
             history_count = 0
             dataset_count = 0
             disk_space = 0
@@ -146,7 +147,7 @@ class System(BaseUIController):
         message = ""
         if params.deleted_datasets_days:
             deleted_datasets_days = int(params.deleted_datasets_days)
-            cutoff_time = datetime.utcnow() - timedelta(days=deleted_datasets_days)
+            cutoff_time = datetime.now(tz=timezone.utc) - timedelta(days=deleted_datasets_days)
             dataset_count = 0
             disk_space = 0
             stmt = select(model.Dataset).filter(

--- a/lib/galaxy/webapps/reports/controllers/users.py
+++ b/lib/galaxy/webapps/reports/controllers/users.py
@@ -5,6 +5,7 @@ from datetime import (
     date,
     datetime,
     timedelta,
+    timezone,
 )
 
 import sqlalchemy as sa
@@ -67,7 +68,7 @@ class Users(BaseUIController, ReportQueryBuilder):
     def specified_month(self, trans, **kwd):
         message = escape(util.restore_text(kwd.get("message", "")))
         # If specified_date is not received, we'll default to the current month
-        specified_date = kwd.get("specified_date", datetime.utcnow().strftime("%Y-%m-%d"))
+        specified_date = kwd.get("specified_date", datetime.now(tz=timezone.utc).strftime("%Y-%m-%d"))
         specified_month = specified_date[:7]
         year, month = map(int, specified_month.split("-"))
         start_date = date(year, month, 1)
@@ -107,7 +108,7 @@ class Users(BaseUIController, ReportQueryBuilder):
     def specified_date(self, trans, **kwd):
         message = escape(util.restore_text(kwd.get("message", "")))
         # If specified_date is not received, we'll default to the current month
-        specified_date = kwd.get("specified_date", datetime.utcnow().strftime("%Y-%m-%d"))
+        specified_date = kwd.get("specified_date", datetime.now(tz=timezone.utc).strftime("%Y-%m-%d"))
         year, month, day = map(int, specified_date.split("-"))
         start_date = date(year, month, day)
         end_date = start_date + timedelta(days=1)
@@ -168,7 +169,7 @@ class Users(BaseUIController, ReportQueryBuilder):
         days_not_logged_in = kwd.get("days_not_logged_in", 90)
         if not days_not_logged_in:
             days_not_logged_in = 0
-        cutoff_time = datetime.utcnow() - timedelta(days=int(days_not_logged_in))
+        cutoff_time = datetime.now(tz=timezone.utc) - timedelta(days=int(days_not_logged_in))
         users = []
 
         stmt = select(galaxy.model.User).filter(galaxy.model.User.deleted == false()).order_by(galaxy.model.User.email)

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -1,8 +1,12 @@
-import datetime
 import json
 import os
 import time
 import urllib.parse
+from datetime import (
+    datetime,
+    timedelta,
+    timezone,
+)
 from operator import itemgetter
 from unittest import SkipTest
 
@@ -86,13 +90,13 @@ class TestJobsApi(ApiTestCase, TestsTools):
 
     @pytest.mark.require_new_history
     def test_index_date_filter(self, history_id):
-        two_weeks_ago = (datetime.datetime.utcnow() - datetime.timedelta(14)).isoformat()
-        last_week = (datetime.datetime.utcnow() - datetime.timedelta(7)).isoformat()
-        before = datetime.datetime.utcnow().isoformat()
+        two_weeks_ago = (datetime.now(tz=timezone.utc) - timedelta(14)).isoformat()
+        last_week = (datetime.now(tz=timezone.utc) - timedelta(7)).isoformat()
+        before = datetime.now(tz=timezone.utc).isoformat()
         today = before[:10]
-        tomorrow = (datetime.datetime.utcnow() + datetime.timedelta(1)).isoformat()[:10]
+        tomorrow = (datetime.now(tz=timezone.utc) + timedelta(1)).isoformat()[:10]
         self.__history_with_new_dataset(history_id)
-        after = datetime.datetime.utcnow().isoformat()
+        after = datetime.now(tz=timezone.utc).isoformat()
 
         # Test using dates
         jobs = self.__jobs_index(data={"date_range_min": today, "date_range_max": tomorrow})

--- a/scripts/cleanup_datasets/admin_cleanup_datasets.py
+++ b/scripts/cleanup_datasets/admin_cleanup_datasets.py
@@ -47,6 +47,7 @@ from collections import defaultdict
 from datetime import (
     datetime,
     timedelta,
+    timezone,
 )
 from time import strftime
 
@@ -167,7 +168,7 @@ def main():
     config = galaxy.config.Configuration(**app_properties)
 
     app = CleanupDatasetsApplication(config)
-    cutoff_time = datetime.utcnow() - timedelta(days=args.days)
+    cutoff_time = datetime.now(tz=timezone.utc) - timedelta(days=args.days)
     now = strftime("%Y-%m-%d %H:%M:%S")
 
     print("##########################################")

--- a/scripts/cleanup_datasets/cleanup_datasets.py
+++ b/scripts/cleanup_datasets/cleanup_datasets.py
@@ -9,6 +9,7 @@ import time
 from datetime import (
     datetime,
     timedelta,
+    timezone,
 )
 from time import strftime
 
@@ -186,7 +187,7 @@ def main():
     app_properties = app_properties_from_args(args, legacy_config_override=config_override)
     config = galaxy.config.Configuration(**app_properties)
     app = CleanupDatasetsApplication(config)
-    cutoff_time = datetime.utcnow() - timedelta(days=args.days)
+    cutoff_time = datetime.now(tz=timezone.utc) - timedelta(days=args.days)
     now = strftime("%Y-%m-%d %H:%M:%S")
 
     log.info("##########################################")

--- a/scripts/tool_shed/deprecate_repositories_without_metadata.py
+++ b/scripts/tool_shed/deprecate_repositories_without_metadata.py
@@ -10,6 +10,7 @@ import time
 from datetime import (
     datetime,
     timedelta,
+    timezone,
 )
 from optparse import OptionParser
 from time import strftime
@@ -77,7 +78,7 @@ def main():
     config = tool_shed_config.Configuration(**config_dict)
 
     app = DeprecateRepositoriesApplication(config)
-    cutoff_time = datetime.utcnow() - timedelta(days=options.days)
+    cutoff_time = datetime.now(tz=timezone.utc) - timedelta(days=options.days)
     now = strftime("%Y-%m-%d %H:%M:%S")
     print("\n####################################################################################")
     print("# %s - Handling stuff older than %i days" % (now, options.days))

--- a/templates/webapps/reports/index.mako
+++ b/templates/webapps/reports/index.mako
@@ -25,7 +25,7 @@
 
 <%def name="left_panel()">
     <%
-        from datetime import datetime
+        from datetime import datetime, timezone
         from time import mktime, strftime, localtime
     %>
     <div class="unified-panel-header" unselectable="on">
@@ -44,7 +44,7 @@
                 </div>
                 <div class="toolSectionBody">
                     <div class="toolSectionBg">
-                        <div class="toolTitle"><a target="galaxy_main" href="${h.url_for( controller='jobs', action='specified_date_handler', specified_date=datetime.utcnow().strftime( "%Y-%m-%d" ), sort_id='default', order='default' )}">Today's jobs</a></div>
+                        <div class="toolTitle"><a target="galaxy_main" href="${h.url_for( controller='jobs', action='specified_date_handler', specified_date=datetime.now(tz=timezone.utc).strftime( "%Y-%m-%d" ), sort_id='default', order='default' )}">Today's jobs</a></div>
                         <div class="toolTitle"><a target="galaxy_main" href="${h.url_for( controller='jobs', action='specified_month_all', sort_id='default', order='default' )}">Jobs per day this month</a></div>
                         <div class="toolTitle"><a target="galaxy_main" href="${h.url_for( controller='jobs', action='specified_month_in_error', sort_id='default', order='default' )}">Jobs in error per day this month</a></div>
                         <div class="toolTitle"><a target="galaxy_main" href="${h.url_for( controller='jobs', action='specified_date_handler', operation='unfinished', sort_id='default', order='default' )}">All unfinished jobs</a></div>

--- a/test/integration/test_fluent_metrics.py
+++ b/test/integration/test_fluent_metrics.py
@@ -1,5 +1,8 @@
 import json
-from datetime import datetime
+from datetime import (
+    datetime,
+    timezone,
+)
 
 from galaxy_test.driver import integration_util
 
@@ -29,7 +32,7 @@ class TestFluentMetricsIntegration(integration_util.IntegrationTestCase):
         metrics = [
             {
                 "namespace": "api-test",
-                "time": f"{datetime.utcnow().isoformat()}Z",
+                "time": f"{datetime.now(tz=timezone.utc).isoformat()}Z",
                 "level": 1,
                 "args": json.dumps({"arg01": "test"}),
             }

--- a/test/integration/test_notifications.py
+++ b/test/integration/test_notifications.py
@@ -1,6 +1,7 @@
 from datetime import (
     datetime,
     timedelta,
+    timezone,
 )
 from typing import (
     Any,
@@ -64,7 +65,7 @@ class NotificationsIntegrationBase(IntegrationTestCase):
         user1 = self._create_test_user()
         user2 = self._create_test_user()
 
-        before_creating_notifications = datetime.utcnow()
+        before_creating_notifications = datetime.now(tz=timezone.utc)
 
         # Only user1 will receive this notification
         subject1 = f"notification_{uuid4()}"
@@ -84,7 +85,7 @@ class NotificationsIntegrationBase(IntegrationTestCase):
         created_response_3 = self._send_broadcast_notification("test_notification_status 3")
         assert created_response_3["total_notifications_sent"] == 1
 
-        after_creating_notifications = datetime.utcnow()
+        after_creating_notifications = datetime.now(tz=timezone.utc)
 
         # The default user should have received only the broadcasted notifications
         status = self._get_notifications_status_since(before_creating_notifications)
@@ -161,7 +162,7 @@ class NotificationsIntegrationBase(IntegrationTestCase):
         user1 = self._create_test_user()
         user2 = self._create_test_user()
 
-        before_creating_notifications = datetime.utcnow()
+        before_creating_notifications = datetime.now(tz=timezone.utc)
 
         subject = f"notification_{uuid4()}"
         created_response = self._send_test_notification_to(
@@ -268,8 +269,8 @@ class NotificationsIntegrationBase(IntegrationTestCase):
         assert updated_response["source"] == "updated_source"
 
     def test_admins_get_all_broadcasted_even_inactive(self):
-        tomorrow = datetime.utcnow() + timedelta(days=1)
-        yesterday = datetime.utcnow() - timedelta(days=1)
+        tomorrow = datetime.now(tz=timezone.utc) + timedelta(days=1)
+        yesterday = datetime.now(tz=timezone.utc) - timedelta(days=1)
         self._send_broadcast_notification(subject="Active")
         self._send_broadcast_notification(subject="Scheduled", publication_time=tomorrow)
         self._send_broadcast_notification(subject="Expired", expiration_time=yesterday)

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -4,7 +4,10 @@ User Manager testing.
 Executable directly using: python -m test.unit.managers.test_UserManager
 """
 
-from datetime import datetime
+from datetime import (
+    datetime,
+    timezone,
+)
 from unittest.mock import patch
 
 from sqlalchemy import (
@@ -168,7 +171,7 @@ class TestUserManager(BaseTestCase):
         )
         assert check_password(default_password, user2.password)
         assert not check_password(changed_password, user2.password)
-        prt.expiration_time = datetime.utcnow()
+        prt.expiration_time = datetime.now(tz=timezone.utc)
         user, message = self.user_manager.change_password(
             self.trans, token=prt.token, password=default_password, confirm=default_password
         )


### PR DESCRIPTION
For "Support Python 3.13 and Numpy 2" cofest topic with @nsoranzo 

ref https://github.com/galaxyproject/galaxy/issues/16854

These functions will be deprecated with python 3.12 https://docs.python.org/3/whatsnew/3.12.html#deprecated

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
