### PR TITLE
[24.0] Add input extra files to `get_input_fnames`

### DIFF
--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -213,22 +213,26 @@ class JobIO(Dictifiable):
         for value in ds.metadata.values():
             if isinstance(value, MetadataFile):
                 filenames.append(value.get_file_name())
+        if ds.dataset and ds.dataset.extra_files_path_exists():
+            filenames.append(ds.dataset.extra_files_path)
         return filenames
 
-    def get_input_fnames(self) -> List[str]:
+    def get_input_datasets(self) -> List[DatasetInstance]:
         job = self.job
+        return [
+            da.dataset for da in job.input_datasets + job.input_library_datasets if da.dataset
+        ]  # da is JobToInputDatasetAssociation object
+
+    def get_input_fnames(self) -> List[str]:
         filenames = []
-        for da in job.input_datasets + job.input_library_datasets:  # da is JobToInputDatasetAssociation object
-            if da.dataset:
-                filenames.extend(self.get_input_dataset_fnames(da.dataset))
+        for ds in self.get_input_datasets():
+            filenames.extend(self.get_input_dataset_fnames(ds))
         return filenames
 
     def get_input_paths(self) -> List[DatasetPath]:
-        job = self.job
         paths = []
-        for da in job.input_datasets + job.input_library_datasets:  # da is JobToInputDatasetAssociation object
-            if da.dataset:
-                paths.append(self.get_input_path(da.dataset))
+        for ds in self.get_input_datasets():
+            paths.append(self.get_input_path(ds))
         return paths
 
     def get_input_path(self, dataset: DatasetInstance) -> DatasetPath:

--- a/lib/galaxy/jobs/splitters/basic.py
+++ b/lib/galaxy/jobs/splitters/basic.py
@@ -13,7 +13,7 @@ def set_basic_defaults(job_wrapper):
 
 
 def do_split(job_wrapper):
-    if len(job_wrapper.job_io.get_input_fnames()) > 1 or len(job_wrapper.job_io.get_output_fnames()) > 1:
+    if len(job_wrapper.job_io.get_input_datasets()) > 1 or len(job_wrapper.job_io.get_output_fnames()) > 1:
         log.error("The basic splitter is not capable of handling jobs with multiple inputs or outputs.")
         raise Exception("Job Splitting Failed, the basic splitter only handles tools with one input and one output")
     # add in the missing information for splitting the one input and merging the one output


### PR DESCRIPTION
This should fix volume mounts in kubernetes,
which calls:

```
volume_mounts.extend(generate_relative_mounts(data_claim, job_wrapper.job_io.get_input_fnames()))
```
The only other consumers are pbs, using an undocument config option (ahem ...).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
