### PR TITLE
Workflow Card Buttons Refactors [GCC2024_COFEST]

### DIFF
--- a/client/src/components/Workflow/WorkflowActions.vue
+++ b/client/src/components/Workflow/WorkflowActions.vue
@@ -63,7 +63,6 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{
     (e: "refreshList", a?: boolean): void;
-    (e: "toggleShowPreview", a?: boolean): void;
 }>();
 
 const userStore = useUserStore();
@@ -146,17 +145,6 @@ const actions: ComputedRef<(AAction | BAction)[]> = computed(() => {
             size: props.buttonSize,
             variant: "link",
             action: () => onToggleBookmark(false),
-        },
-        {
-            condition: true,
-            class: "workflow-view-button",
-            component: "button",
-            title: "View workflow",
-            tooltip: "View workflow",
-            icon: faEye,
-            size: props.buttonSize,
-            variant: "link",
-            onClick: () => emit("toggleShowPreview", true),
         },
     ];
 });

--- a/client/src/components/Workflow/WorkflowActionsExtend.vue
+++ b/client/src/components/Workflow/WorkflowActionsExtend.vue
@@ -18,13 +18,11 @@ library.add(faCopy, faDownload, faLink, faShareAlt, faTrashRestore);
 
 interface Props {
     workflow: any;
-    menu?: boolean;
     published?: boolean;
-    buttonSize?: "sm" | "md" | "lg";
 }
 
 const props = withDefaults(defineProps<Props>(), {
-    buttonSize: "sm",
+    published: false,
 });
 
 const emit = defineEmits<{
@@ -87,7 +85,7 @@ function onCopyPublicLink() {
                 v-if="workflow.published && !workflow.deleted"
                 id="workflow-copy-public-button"
                 v-b-tooltip.hover.noninteractive
-                :size="buttonSize"
+                size="sm"
                 title="Copy link to workflow"
                 variant="outline-primary"
                 @click="onCopyPublicLink">
@@ -99,7 +97,7 @@ function onCopyPublicLink() {
                 v-if="!isAnonymous && !shared && !workflow.deleted"
                 id="workflow-copy-button"
                 v-b-tooltip.hover.noninteractive
-                :size="buttonSize"
+                size="sm"
                 title="Copy"
                 variant="outline-primary"
                 @click="onCopy">
@@ -111,7 +109,7 @@ function onCopyPublicLink() {
                 v-if="!workflow.deleted"
                 id="workflow-download-button"
                 v-b-tooltip.hover.noninteractive
-                :size="buttonSize"
+                size="sm"
                 title="Download workflow in .ga format"
                 variant="outline-primary"
                 :href="downloadUrl">
@@ -123,7 +121,7 @@ function onCopyPublicLink() {
                 v-if="!isAnonymous && !shared && !workflow.deleted"
                 id="workflow-share-button"
                 v-b-tooltip.hover.noninteractive
-                :size="buttonSize"
+                size="sm"
                 title="Share"
                 variant="outline-primary"
                 :to="`/workflows/sharing?id=${workflow.id}`">
@@ -135,7 +133,7 @@ function onCopyPublicLink() {
                 v-if="workflow.deleted"
                 id="restore-button"
                 v-b-tooltip.hover.noninteractive
-                :size="buttonSize"
+                size="sm"
                 title="Restore"
                 variant="outline-primary"
                 @click="onRestore">

--- a/client/src/components/Workflow/WorkflowCard.vue
+++ b/client/src/components/Workflow/WorkflowCard.vue
@@ -2,7 +2,7 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faEdit, faEye, faPen, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton } from "bootstrap-vue";
+import { BButton, BLink } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 
@@ -141,7 +141,12 @@ async function onTagClick(tag: string) {
                 </div>
 
                 <span class="workflow-name font-weight-bold">
-                    {{ workflow.name }}
+                    <BLink
+                        v-b-tooltip.hover.noninteractive
+                        title="Preview Workflow"
+                        @click.stop.prevent="toggleShowPreview(true)">
+                        {{ workflow.name }}
+                    </BLink>
                     <BButton
                         v-if="!shared && !workflow.deleted"
                         v-b-tooltip.hover.noninteractive

--- a/client/src/components/Workflow/WorkflowCard.vue
+++ b/client/src/components/Workflow/WorkflowCard.vue
@@ -144,9 +144,9 @@ async function onTagClick(tag: string) {
                     <BLink
                         v-b-tooltip.hover.noninteractive
                         title="Preview Workflow"
-                        @click.stop.prevent="toggleShowPreview(true)">
-                        {{ workflow.name }}
-                    </BLink>
+                        @click.stop.prevent="toggleShowPreview(true)"
+                        >{{ workflow.name }}</BLink
+                    >
                     <BButton
                         v-if="!shared && !workflow.deleted"
                         v-b-tooltip.hover.noninteractive


### PR DESCRIPTION
This PR refactors workflow card buttons and improves their UI.
Requires #18463

## Workflow Actions Buttons On Hover and Focus (they were not in the same height)
|Before|After|
|---|----|
|![image](https://github.com/galaxyproject/galaxy/assets/8046843/08b33491-5c6f-4929-b4f3-42f256e193f0)|![image](https://github.com/galaxyproject/galaxy/assets/8046843/a1c9ab69-6909-42e6-9d88-59a6e729d61e)|
|![before](https://github.com/galaxyproject/galaxy/assets/8046843/b8472591-65e1-4b37-a843-9d95e52d8b06)|![after](https://github.com/galaxyproject/galaxy/assets/8046843/a7f0bde6-5377-494a-8c32-0716f368f6f7)|

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
