### PR TITLE
Improve password reset UI/UX [GCC2024_COFEST]

### DIFF
--- a/client/src/components/Login/LoginForm.vue
+++ b/client/src/components/Login/LoginForm.vue
@@ -97,7 +97,7 @@ async function submitLogin() {
         }
 
         if (response.data.expired_user) {
-            window.location.href = withPrefix(`/root/login?expired_user=${response.data.expired_user}`);
+            window.location.href = withPrefix(`/login/start?expired_user=${response.data.expired_user}`);
         } else if (connectExternalProvider.value) {
             window.location.href = withPrefix("/user/external_ids?connect_external=true");
         } else if (response.data.redirect) {
@@ -123,20 +123,6 @@ async function submitLogin() {
 
 function setRedirect(url: string) {
     localStorage.setItem("redirect_url", url);
-}
-
-async function resetLogin() {
-    loading.value = true;
-    try {
-        const response = await axios.post(withPrefix("/user/reset_password"), { email: login.value });
-        messageVariant.value = "info";
-        messageText.value = response.data.message;
-    } catch (e) {
-        messageVariant.value = "danger";
-        messageText.value = errorMessageAsString(e, "Password reset failed for an unknown reason.");
-    } finally {
-        loading.value = false;
-    }
 }
 
 function returnToLogin() {
@@ -205,7 +191,7 @@ function returnToLogin() {
                                                 v-localize
                                                 href="javascript:void(0)"
                                                 role="button"
-                                                @click.prevent="resetLogin">
+                                                @click.prevent="router.push('/login/reset_password')">
                                                 Click here to reset your password.
                                             </a>
                                         </BFormText>

--- a/client/src/components/Login/LoginForm.vue
+++ b/client/src/components/Login/LoginForm.vue
@@ -191,7 +191,12 @@ function returnToLogin() {
                                                 v-localize
                                                 href="javascript:void(0)"
                                                 role="button"
-                                                @click.prevent="router.push('/login/reset_password')">
+                                                @click.prevent="
+                                                    router.push({
+                                                        path: '/login/reset_password',
+                                                        query: { email: login },
+                                                    })
+                                                ">
                                                 Click here to reset your password.
                                             </a>
                                         </BFormText>

--- a/client/src/entry/analysis/modules/ResetPassword.test.ts
+++ b/client/src/entry/analysis/modules/ResetPassword.test.ts
@@ -7,26 +7,6 @@ import ResetPassword from "./ResetPassword.vue";
 
 const localVue = getLocalVue(true);
 
-const configMock = {
-    allow_user_creation: true,
-    enable_oidc: true,
-    mailing_join_addr: "mailing_join_addr",
-    prefer_custos_login: true,
-    registration_warning_message: "registration_warning_message",
-    server_mail_configured: true,
-    show_welcome_with_login: true,
-    terms_url: "terms_url",
-    welcome_url: "welcome_url",
-};
-
-jest.mock("app/singleton");
-jest.mock("@/composables/config", () => ({
-    useConfig: jest.fn(() => ({
-        config: configMock,
-        isConfigLoaded: true,
-    })),
-}));
-
 const mockRouter = (query: object) => ({
     currentRoute: {
         query,

--- a/client/src/entry/analysis/modules/ResetPassword.test.ts
+++ b/client/src/entry/analysis/modules/ResetPassword.test.ts
@@ -1,12 +1,9 @@
-import { createTestingPinia } from "@pinia/testing";
 import { getLocalVue } from "@tests/jest/helpers";
 import { mount } from "@vue/test-utils";
-import { setActivePinia } from "pinia";
-
-import { getGalaxyInstance } from "@/app/singleton";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
 
 import ResetPassword from "./ResetPassword.vue";
-import assert from "assert";
 
 const localVue = getLocalVue(true);
 
@@ -26,7 +23,6 @@ jest.mock("app/singleton");
 jest.mock("@/composables/config", () => ({
     useConfig: jest.fn(() => ({
         config: configMock,
-
         isConfigLoaded: true,
     })),
 }));
@@ -37,15 +33,10 @@ const mockRouter = (query: object) => ({
     },
 });
 
-(getGalaxyInstance as jest.Mock).mockReturnValue({ session_csrf_token: "session_csrf_token" });
-
 function mountResetPassword(routerQuery: object = {}) {
-    const pinia = createTestingPinia();
-    setActivePinia(pinia);
-
     return mount(ResetPassword, {
         localVue,
-        pinia,
+        attachTo: document.body,
         mocks: {
             $router: mockRouter(routerQuery),
         },
@@ -53,17 +44,73 @@ function mountResetPassword(routerQuery: object = {}) {
 }
 
 describe("ResetPassword", () => {
-    it("ResetPassword index attribute matching", async () => {
-        const wrapper = mountResetPassword({
-            redirect: "redirect_url",
-        });
+    it("query", async () => {
+        const email = "test";
+        const wrapper = mountResetPassword({ email: "test" });
+
         const emailField = wrapper.find("#reset-email");
+        const emailValue = (emailField.element as HTMLInputElement).value;
+        expect(emailValue).toBe(email);
+    });
+
+    it("button text", async () => {
+        const wrapper = mountResetPassword();
         const submitButton = wrapper.find("#reset-password");
-        const testEmail = "eihfeuh";
+        (expect(submitButton.text()) as any).toBeLocalizationOf("Send password reset email");
+    });
 
-        emailField.setValue(testEmail);
-        const emailValue = emailField.element.textContent;
-        expect(emailValue).toBe(testEmail);
+    it("validate email", async () => {
+        const wrapper = mountResetPassword();
+        const submitButton = wrapper.find("#reset-password");
+        const emailField = wrapper.find("#reset-email");
+        const emailElement = emailField.element as HTMLInputElement;
 
+        let email = "";
+        await emailField.setValue(email);
+        expect(emailElement.value).toBe(email);
+        await submitButton.trigger("click");
+        expect(emailElement.checkValidity()).toBe(false);
+
+        email = "test";
+        await emailField.setValue(email);
+        expect(emailElement.value).toBe(email);
+        await submitButton.trigger("click");
+        expect(emailElement.checkValidity()).toBe(false);
+
+        email = "test@test.com";
+        await emailField.setValue(email);
+        expect(emailElement.value).toBe(email);
+        await submitButton.trigger("click");
+        expect(emailElement.checkValidity()).toBe(true);
+    });
+
+    it("display success message", async () => {
+        const wrapper = mountResetPassword({ email: "test@test.com" });
+        const mockAxios = new MockAdapter(axios);
+        const submitButton = wrapper.find("#reset-password");
+
+        mockAxios.onPost("/user/reset_password").reply(200, {
+            message: "Reset link has been sent to your email.",
+        });
+        await submitButton.trigger("click");
+        setTimeout(async () => {
+            const alertSuccess = wrapper.find("#reset-password-alert");
+            expect(alertSuccess.text()).toBe("Reset link has been sent to your email.");
+        });
+    });
+
+    it("display error message", async () => {
+        const wrapper = mountResetPassword({ email: "test@test.com" });
+        const submitButton = wrapper.find("#reset-password");
+
+        const mockAxios = new MockAdapter(axios);
+        mockAxios.onPost("/user/reset_password").reply(400, {
+            err_msg: "Please provide your email.",
+        });
+        await submitButton.trigger("click");
+        setTimeout(async () => {
+            const alertError = wrapper.find("#reset-password-alert");
+            expect(alertError.text()).toBe("Please provide your email.");
+        });
     });
 });

--- a/client/src/entry/analysis/modules/ResetPassword.test.ts
+++ b/client/src/entry/analysis/modules/ResetPassword.test.ts
@@ -1,0 +1,64 @@
+import { createTestingPinia } from "@pinia/testing";
+import { getLocalVue } from "@tests/jest/helpers";
+import { mount } from "@vue/test-utils";
+import { setActivePinia } from "pinia";
+
+import { getGalaxyInstance } from "@/app/singleton";
+
+import ResetPassword from "./ResetPassword.vue";
+
+const localVue = getLocalVue(true);
+
+const configMock = {
+    allow_user_creation: true,
+    enable_oidc: true,
+    mailing_join_addr: "mailing_join_addr",
+    prefer_custos_login: true,
+    registration_warning_message: "registration_warning_message",
+    server_mail_configured: true,
+    show_welcome_with_login: true,
+    terms_url: "terms_url",
+    welcome_url: "welcome_url",
+};
+
+jest.mock("app/singleton");
+jest.mock("@/composables/config", () => ({
+    useConfig: jest.fn(() => ({
+        config: configMock,
+
+        isConfigLoaded: true,
+    })),
+}));
+
+const mockRouter = (query: object) => ({
+    currentRoute: {
+        query,
+    },
+});
+
+(getGalaxyInstance as jest.Mock).mockReturnValue({ session_csrf_token: "session_csrf_token" });
+
+function mountResetPassword(routerQuery: object = {}) {
+    const pinia = createTestingPinia();
+    setActivePinia(pinia);
+
+    return mount(ResetPassword, {
+        localVue,
+        pinia,
+        mocks: {
+            $router: mockRouter(routerQuery),
+        },
+    });
+}
+
+describe("ResetPassword", () => {
+    it("ResetPassword index attribute matching", async () => {
+        const wrapper = mountResetPassword({
+            redirect: "redirect_url",
+        });
+
+        console.log("wrapper:", wrapper.html());
+        const emailForm = wrapper.find("#reset-email");
+        console.log("emailForm:", emailForm.element);
+    });
+});

--- a/client/src/entry/analysis/modules/ResetPassword.test.ts
+++ b/client/src/entry/analysis/modules/ResetPassword.test.ts
@@ -6,6 +6,7 @@ import { setActivePinia } from "pinia";
 import { getGalaxyInstance } from "@/app/singleton";
 
 import ResetPassword from "./ResetPassword.vue";
+import assert from "assert";
 
 const localVue = getLocalVue(true);
 
@@ -56,9 +57,13 @@ describe("ResetPassword", () => {
         const wrapper = mountResetPassword({
             redirect: "redirect_url",
         });
+        const emailField = wrapper.find("#reset-email");
+        const submitButton = wrapper.find("#reset-password");
+        const testEmail = "eihfeuh";
 
-        console.log("wrapper:", wrapper.html());
-        const emailForm = wrapper.find("#reset-email");
-        console.log("emailForm:", emailForm.element);
+        emailField.setValue(testEmail);
+        const emailValue = emailField.element.textContent;
+        expect(emailValue).toBe(testEmail);
+
     });
 });

--- a/client/src/entry/analysis/modules/ResetPassword.vue
+++ b/client/src/entry/analysis/modules/ResetPassword.vue
@@ -35,16 +35,18 @@ async function resetLogin() {
             <div class="row justify-content-md-center">
                 <div class="col col-lg-6">
                     <BForm @submit.prevent="resetLogin">
-                        <BAlert v-if="!!message" class="mt-2" :variant="messageVariant" show>
+                        <BAlert v-if="!!message" id="reset-password-alert" class="mt-2" :variant="messageVariant" show>
                             {{ message }}
                         </BAlert>
 
                         <BCard header="Reset your password">
                             <BFormGroup label="Email Address">
-                                <BFormInput id="reset-email" v-model="email" type="email" />
+                                <BFormInput id="reset-email" v-model="email" type="email" name="email" required />
                             </BFormGroup>
 
-                            <BButton type="submit">Reset your password</BButton>
+                            <BButton id="reset-password" v-localize type="submit" :disabled="loading"
+                                >Send password reset email</BButton
+                            >
                         </BCard>
                     </BForm>
                 </div>

--- a/client/src/entry/analysis/modules/ResetPassword.vue
+++ b/client/src/entry/analysis/modules/ResetPassword.vue
@@ -2,12 +2,15 @@
 import axios from "axios";
 import { BAlert, BButton, BCard, BForm, BFormGroup, BFormInput } from "bootstrap-vue";
 import { ref } from "vue";
+import { useRouter } from "vue-router/composables";
 
 import { withPrefix } from "@/utils/redirect";
 import { errorMessageAsString } from "@/utils/simple-error";
 
+const router = useRouter();
+
 const loading = ref(false);
-const email = ref("");
+const email = ref(router.currentRoute.query.email || "");
 const message = ref("");
 const messageVariant = ref("info");
 

--- a/client/src/entry/analysis/modules/ResetPassword.vue
+++ b/client/src/entry/analysis/modules/ResetPassword.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import axios from "axios";
+import { BAlert, BButton, BCard, BForm, BFormGroup, BFormInput } from "bootstrap-vue";
+import { ref } from "vue";
+
+import { withPrefix } from "@/utils/redirect";
+import { errorMessageAsString } from "@/utils/simple-error";
+
+const loading = ref(false);
+const email = ref("");
+const message = ref("");
+const messageVariant = ref("info");
+
+async function resetLogin() {
+    loading.value = true;
+    try {
+        const response = await axios.post(withPrefix("/user/reset_password"), { email: email.value });
+        messageVariant.value = "info";
+        message.value = response.data.message;
+    } catch (e) {
+        messageVariant.value = "danger";
+        message.value = errorMessageAsString(e, "Password reset failed for an unknown reason.");
+    } finally {
+        loading.value = false;
+    }
+}
+</script>
+
+<template>
+    <div class="container">
+        <div class="justify-content-md-center">
+            <BForm @submit.prevent="resetLogin">
+                <BAlert v-if="!!message" class="mt-2" :variant="messageVariant" show>
+                    {{ message }}
+                </BAlert>
+
+                <BCard header="Reset your password">
+                    <BFormGroup label="Email Address">
+                        <BFormInput v-model="email" type="email" />
+                    </BFormGroup>
+
+                    <BButton type="submit">Reset your password</BButton>
+                </BCard>
+            </BForm>
+        </div>
+    </div>
+</template>

--- a/client/src/entry/analysis/modules/ResetPassword.vue
+++ b/client/src/entry/analysis/modules/ResetPassword.vue
@@ -36,7 +36,7 @@ async function resetLogin() {
 
                 <BCard header="Reset your password">
                     <BFormGroup label="Email Address">
-                        <BFormInput v-model="email" type="email" />
+                        <BFormInput id="reset-email" v-model="email" type="email" />
                     </BFormGroup>
 
                     <BButton type="submit">Reset your password</BButton>

--- a/client/src/entry/analysis/modules/ResetPassword.vue
+++ b/client/src/entry/analysis/modules/ResetPassword.vue
@@ -27,21 +27,25 @@ async function resetLogin() {
 </script>
 
 <template>
-    <div class="container">
-        <div class="justify-content-md-center">
-            <BForm @submit.prevent="resetLogin">
-                <BAlert v-if="!!message" class="mt-2" :variant="messageVariant" show>
-                    {{ message }}
-                </BAlert>
+    <div class="overflow-auto m-3">
+        <div class="container">
+            <div class="row justify-content-md-center">
+                <div class="col col-lg-6">
+                    <BForm @submit.prevent="resetLogin">
+                        <BAlert v-if="!!message" class="mt-2" :variant="messageVariant" show>
+                            {{ message }}
+                        </BAlert>
 
-                <BCard header="Reset your password">
-                    <BFormGroup label="Email Address">
-                        <BFormInput id="reset-email" v-model="email" type="email" />
-                    </BFormGroup>
+                        <BCard header="Reset your password">
+                            <BFormGroup label="Email Address">
+                                <BFormInput id="reset-email" v-model="email" type="email" />
+                            </BFormGroup>
 
-                    <BButton type="submit">Reset your password</BButton>
-                </BCard>
-            </BForm>
+                            <BButton type="submit">Reset your password</BButton>
+                        </BCard>
+                    </BForm>
+                </div>
+            </div>
         </div>
     </div>
 </template>

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -45,6 +45,7 @@ import Analysis from "entry/analysis/modules/Analysis";
 import CenterFrame from "entry/analysis/modules/CenterFrame";
 import Home from "entry/analysis/modules/Home";
 import Login from "entry/analysis/modules/Login";
+import ResetPassword from "entry/analysis/modules/ResetPassword";
 import WorkflowEditorModule from "entry/analysis/modules/WorkflowEditor";
 import AdminRoutes from "entry/analysis/routes/admin-routes";
 import LibraryRoutes from "entry/analysis/routes/library-routes";
@@ -123,6 +124,12 @@ export function getRouter(Galaxy) {
             {
                 path: "/login/start",
                 component: Login,
+                redirect: redirectLoggedIn(),
+            },
+            /** Login entry route */
+            {
+                path: "/login/reset_password",
+                component: ResetPassword,
                 redirect: redirectLoggedIn(),
             },
             /** Page editor */

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -130,6 +130,7 @@ export function getRouter(Galaxy) {
             {
                 path: "/login/reset_password",
                 component: ResetPassword,
+                props: (route) => ({ email: route.query.email }),
                 redirect: redirectLoggedIn(),
             },
             /** Page editor */


### PR DESCRIPTION
Currently, password reset uses the login name/email field as an email field and the password reset link as a submit button. This dual purpose of the login form is not intuitive and can result in confusing error messages.

This PR adds a route for password reset at /login/reset_password, accessible from the reset password link at login/start.

In addition to this, the user experience for users with an expired password has been improved by sending them directly to the password change form. Previously, the redirect sent them to /root/login which just redirected them back to /login/start, dropping the query parameters along the way. This forced them to go through the token-based password reset flow instead of the expired id + current password flow that is already supported on both the frontend and backend.

![image](https://github.com/galaxyproject/galaxy/assets/8182113/fd793c80-781d-48c6-ad7e-15e7a3ecdc34)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Go to the login page
  2. Click on reset password
  3. Enter your email

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
