### PR TITLE
Moves Libraries from Masthead to Activity Bar

### DIFF
--- a/client/src/components/Masthead/Masthead.test.js
+++ b/client/src/components/Masthead/Masthead.test.js
@@ -52,7 +52,7 @@ describe("Masthead.vue", () => {
     });
 
     it("should render simple tab item links", () => {
-        expect(wrapper.findAll("li.nav-item").length).toBe(5);
+        expect(wrapper.findAll("li.nav-item").length).toBe(4);
         // Ensure specified link title respected.
         expect(wrapper.find("#help").text()).toBe("Support, Contact, and Community");
         expect(wrapper.find("#help a").attributes("href")).toBe("/about");

--- a/client/src/components/Masthead/Masthead.vue
+++ b/client/src/components/Masthead/Masthead.vue
@@ -86,7 +86,6 @@ onMounted(() => {
             </span>
         </BNavbarNav>
         <BNavbarNav v-if="isConfigLoaded" class="mr-1">
-            <MastheadItem id="library" icon="fa-database" tooltip="Data Libraries" @click="openUrl('/libraries')" />
             <MastheadItem
                 v-if="windowTab"
                 :id="windowTab.id"

--- a/client/src/stores/activitySetup.ts
+++ b/client/src/stores/activitySetup.ts
@@ -124,7 +124,7 @@ export const Activities = [
     },
     {
         anonymous: true,
-        description: "Display and create new Pages.",
+        description: "Display and create new pages.",
         icon: "fa-file-contract",
         id: "pages",
         mutable: false,
@@ -133,6 +133,19 @@ export const Activities = [
         title: "Pages",
         tooltip: "Show all pages",
         to: "/pages/list",
+        visible: true,
+    },
+    {
+        anonymous: false,
+        description: "Display Data Libraries with datasets available to all users.",
+        icon: "fa-database",
+        id: "libraries",
+        mutable: false,
+        optional: true,
+        panel: false,
+        title: "Data Library",
+        tooltip: "Access Data Libraries",
+        to: "/libraries",
         visible: true,
     },
 ];

--- a/client/src/stores/activitySetup.ts
+++ b/client/src/stores/activitySetup.ts
@@ -143,7 +143,7 @@ export const Activities = [
         mutable: false,
         optional: true,
         panel: false,
-        title: "Data Library",
+        title: "Libraries",
         tooltip: "Access Data Libraries",
         to: "/libraries",
         visible: true,

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -1007,7 +1007,7 @@ libraries:
 
   selectors:
     _: '#libraries_list'
-    activity: "#activity-libraries"
+    activity: '#activity-libraries'
     create_new_library_btn: '#create-new-lib'
     permission_library_btn: '.permission_library_btn'
     toolbtn_save_permissions: '.toolbtn_save_permissions'

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -42,7 +42,6 @@ masthead:
 
     help: '#help'
     home: '#analysis'
-    libraries: '#library'
     login: '#user'
     logout: '.dropdown-menu > li > a > .fa-sign-out-alt'
     logged_in_only: '.loggedin-only'
@@ -1008,6 +1007,7 @@ libraries:
 
   selectors:
     _: '#libraries_list'
+    activity: "#activity-libraries"
     create_new_library_btn: '#create-new-lib'
     permission_library_btn: '.permission_library_btn'
     toolbtn_save_permissions: '.toolbtn_save_permissions'

--- a/config/plugins/tours/core.galaxy_ui.yaml
+++ b/config/plugins/tours/core.galaxy_ui.yaml
@@ -122,10 +122,6 @@ steps:
       element: "#analysis"
       intro: "This is the current view. Start your <b>Analysis</b> from here."
 
-    - title: "Data Libraries"
-      component: masthead.libraries
-      intro: "Get access to source data."
-
     - title: "Workflow"
       component: workflows.activity
       intro: "Create, manage, import, export and share your <b>Workflows</b>."

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1323,7 +1323,7 @@ class NavigatesGalaxy(HasDriver):
 
     def libraries_open(self):
         self.home()
-        self.components.masthead.libraries.wait_for_and_click()
+        self.components.libraries.activity.wait_for_and_click()
         self.components.libraries.selector.wait_for_visible()
 
     def libraries_open_with_name(self, name):


### PR DESCRIPTION
This PR is a follow-up to #17927. It moves the libraries icon from the masthead to the activity bar for consistency.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
