### PR TITLE
[22.05] pin bleach to 5.0.1

### DIFF
--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -25,7 +25,7 @@ beaker==1.11.0
 billiard==3.6.4.0; python_version >= "3.7"
 bioblend==0.17.0; python_version >= "3.7"
 black==22.3.0; python_full_version >= "3.6.2"
-bleach==5.0.0; python_version >= "3.7"
+bleach==5.0.1; python_version >= "3.7"
 boltons==21.0.0
 boto==2.49.0
 bx-python==0.8.13; python_version >= "3.7"

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -20,7 +20,7 @@ bdbag==1.6.3; (python_version >= "2.7" and python_full_version < "3.0.0") or (py
 beaker==1.11.0
 billiard==3.6.4.0; python_version >= "3.7"
 bioblend==0.17.0; python_version >= "3.7"
-bleach==5.0.0; python_version >= "3.7"
+bleach==5.0.1; python_version >= "3.7"
 boltons==21.0.0
 boto==2.49.0
 bx-python==0.8.13; python_version >= "3.7"


### PR DESCRIPTION
22.05 is currently failing planemo tests (e.g. [here](https://github.com/galaxyproject/planemo/actions/runs/9724415960/job/26840604434?pr=1463)) because bleach 5.0.0 has an error in its requirements that has been fixed here https://github.com/mozilla/bleach/pull/655

- 22.01 used bleach 4.x and 
- 23.0 used already 5.0.1 (but it is missing (?) in the dev requirements)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
