### PR TITLE
[24.1] fix no-op workflow "relabel" shouldn't result in a notification

### DIFF
--- a/client/src/components/Workflow/Editor/Actions/stepActions.ts
+++ b/client/src/components/Workflow/Editor/Actions/stepActions.ts
@@ -87,8 +87,11 @@ export class LazySetLabelAction extends LazyMutateStepAction<"label"> {
     run() {
         const markdown = this.stateStore.report.markdown ?? "";
         const newMarkdown = replaceLabel(markdown, this.labelType, this.fromValue as string, this.toValue as string);
-        this.stateStore.report.markdown = newMarkdown;
-        this.toast(this.fromValue ?? "", this.toValue ?? "");
+
+        if (markdown !== newMarkdown) {
+            this.stateStore.report.markdown = newMarkdown;
+            this.toast(this.fromValue ?? "", this.toValue ?? "");
+        }
     }
 
     undo() {
@@ -96,8 +99,11 @@ export class LazySetLabelAction extends LazyMutateStepAction<"label"> {
 
         const markdown = this.stateStore.report.markdown ?? "";
         const newMarkdown = replaceLabel(markdown, this.labelType, this.toValue as string, this.fromValue as string);
-        this.stateStore.report.markdown = newMarkdown;
-        this.toast(this.toValue ?? "", this.fromValue ?? "");
+
+        if (markdown !== newMarkdown) {
+            this.stateStore.report.markdown = newMarkdown;
+            this.toast(this.toValue ?? "", this.fromValue ?? "");
+        }
     }
 
     redo() {
@@ -139,8 +145,11 @@ export class LazySetOutputLabelAction extends LazyMutateStepAction<"workflow_out
     run() {
         const markdown = this.stateStore.report.markdown ?? "";
         const newMarkdown = replaceLabel(markdown, "output", this.fromLabel, this.toLabel);
-        this.stateStore.report.markdown = newMarkdown;
-        this.toast(this.fromLabel ?? "", this.toLabel ?? "");
+
+        if (newMarkdown !== markdown) {
+            this.stateStore.report.markdown = newMarkdown;
+            this.toast(this.fromLabel ?? "", this.toLabel ?? "");
+        }
     }
 
     undo() {
@@ -148,9 +157,11 @@ export class LazySetOutputLabelAction extends LazyMutateStepAction<"workflow_out
 
         const markdown = this.stateStore.report.markdown ?? "";
         const newMarkdown = replaceLabel(markdown, "output", this.toLabel, this.fromLabel);
-        this.stateStore.report.markdown = newMarkdown;
 
-        this.toast(this.toLabel ?? "", this.fromLabel ?? "");
+        if (newMarkdown !== markdown) {
+            this.stateStore.report.markdown = newMarkdown;
+            this.toast(this.toLabel ?? "", this.fromLabel ?? "");
+        }
     }
 
     redo() {


### PR DESCRIPTION
closes #18436

adds a check if markdown has changed before emitting a notification

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
