### PR TITLE
[24.0] Add event listeners to multiselects to prevent esc key closing `UploadModal`

### DIFF
--- a/client/src/components/Upload/DefaultBox.vue
+++ b/client/src/components/Upload/DefaultBox.vue
@@ -389,6 +389,7 @@ defineExpose({
             <UploadSelect
                 v-if="isCollection"
                 class="upload-footer-collection-type"
+                title="Select Type"
                 :value="collectionType"
                 :disabled="isRunning"
                 :options="COLLECTION_TYPES"
@@ -406,6 +407,7 @@ defineExpose({
             <span class="upload-footer-title">Reference (set all):</span>
             <UploadSelect
                 class="upload-footer-genome"
+                title="Select Reference"
                 :value="dbKey"
                 :disabled="isRunning"
                 :options="listDbKeys"

--- a/client/src/components/Upload/UploadModal.vue
+++ b/client/src/components/Upload/UploadModal.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { BModal } from "bootstrap-vue";
 import { setIframeEvents } from "components/Upload/utils";
 import { useConfig } from "composables/config";
 import { useUserHistories } from "composables/userHistories";
@@ -71,13 +72,14 @@ defineExpose({
 </script>
 
 <template>
-    <b-modal
+    <BModal
         v-model="showModal"
         :static="options.modalStatic"
         header-class="no-separator"
         modal-class="ui-modal"
         dialog-class="upload-dialog"
         body-class="upload-dialog-body"
+        no-close-on-esc
         no-enforce-focus
         hide-footer>
         <template v-slot:modal-header>
@@ -90,7 +92,7 @@ defineExpose({
             :current-history-id="currentHistoryId"
             v-bind="options"
             @dismiss="dismiss" />
-    </b-modal>
+    </BModal>
 </template>
 
 <style>

--- a/client/src/components/Upload/UploadModal.vue
+++ b/client/src/components/Upload/UploadModal.vue
@@ -18,7 +18,6 @@ const { config, isConfigLoaded } = useConfig();
 
 function getDefaultOptions() {
     const baseOptions = {
-        title: "Upload from Disk or Web",
         modalStatic: true,
         callback: null,
         immediateUpload: false,
@@ -83,7 +82,7 @@ defineExpose({
         no-enforce-focus
         hide-footer>
         <template v-slot:modal-header>
-            <h2 class="title h-sm" tabindex="0">{{ options.title }}</h2>
+            <h2 v-localize class="title h-sm" tabindex="0">Upload from Disk or Web</h2>
         </template>
         <UploadContainer
             v-if="currentHistoryId"

--- a/client/src/components/Upload/UploadModal.vue
+++ b/client/src/components/Upload/UploadModal.vue
@@ -4,7 +4,7 @@ import { setIframeEvents } from "components/Upload/utils";
 import { useConfig } from "composables/config";
 import { useUserHistories } from "composables/userHistories";
 import { storeToRefs } from "pinia";
-import { ref, watch } from "vue";
+import { onBeforeUnmount, onMounted, ref, watch } from "vue";
 
 import { useUserStore } from "@/stores/userStore";
 import { wait } from "@/utils/utils";
@@ -68,10 +68,26 @@ watch(
 defineExpose({
     open,
 });
+
+// Handle escape key press in modal
+// (modal stays open when esc key is pressed in some child components, hence using `no-close-on-esc`)
+const uploadModal = ref(null);
+onMounted(() => {
+    uploadModal.value?.$el.addEventListener("keyup", handleKeyUp);
+});
+onBeforeUnmount(() => {
+    uploadModal.value?.$el.removeEventListener("keyup", handleKeyUp);
+});
+function handleKeyUp(event) {
+    if (event.key === "Escape") {
+        dismiss();
+    }
+}
 </script>
 
 <template>
     <BModal
+        ref="uploadModal"
         v-model="showModal"
         :static="options.modalStatic"
         header-class="no-separator"

--- a/client/src/components/Upload/UploadSelect.vue
+++ b/client/src/components/Upload/UploadSelect.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import Multiselect from "vue-multiselect";
 
 import { uid } from "@/utils/utils";
@@ -47,11 +47,26 @@ const currentValue = computed({
         emit("input", newValue.id);
     },
 });
+
+// prevent the escape key closing behavior from the Upload Modal
+const multiSelectRef = ref(null);
+onMounted(() => {
+    multiSelectRef.value?.$el.addEventListener("keyup", handleKeyUp);
+});
+onBeforeUnmount(() => {
+    multiSelectRef.value?.$el.removeEventListener("keyup", handleKeyUp);
+});
+function handleKeyUp(event) {
+    if (event.key === "Escape") {
+        event.stopImmediatePropagation();
+    }
+}
 </script>
 
 <template>
     <Multiselect
         :id="id"
+        ref="multiSelectRef"
         v-model="currentValue"
         class="upload-settings-select rounded"
         deselect-label=""


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/18440

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
