### PR TITLE
[24.0] Return generic message for password reset email

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -609,7 +609,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
                     log.debug(body)
                     return f"Failed to submit email. Please contact the administrator: {util.unicodify(e)}"
             else:
-                return "Failed to produce password reset token. User not found."
+                return None
 
     def get_reset_token(self, trans, email):
         reset_user = get_user_by_email(trans.sa_session, email, self.app.model.User)

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -608,8 +608,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
                 except Exception as e:
                     log.debug(body)
                     return f"Failed to submit email. Please contact the administrator: {util.unicodify(e)}"
-            else:
-                return None
+        return None
 
     def get_reset_token(self, trans, email):
         reset_user = get_user_by_email(trans.sa_session, email, self.app.model.User)

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -608,6 +608,8 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
                 except Exception as e:
                     log.debug(body)
                     return f"Failed to submit email. Please contact the administrator: {util.unicodify(e)}"
+        if not reset_user:
+            log.warning(f"Failed to produce password reset token. User with email '{email}' not found.")
         return None
 
     def get_reset_token(self, trans, email):

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -342,7 +342,7 @@ class User(BaseUIController, UsesFormDefinitionsMixin):
         payload = payload or {}
         if message := self.user_manager.send_reset_email(trans, payload):
             return self.message_exception(trans, message)
-        return {"message": "Reset link has been sent to your email."}
+        return {"message": "If an account exists for this email address a confirmation email will be dispatched."}
 
     def __get_redirect_url(self, redirect):
         if not redirect or redirect == "None":

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -240,7 +240,7 @@ class TestUserManager(BaseTestCase):
         self.user_manager.delete(user)
         assert user.deleted is True
         message = self.user_manager.send_reset_email(self.trans, {"email": user_email})
-        assert message == None
+        assert message is None
 
     def test_get_user_by_identity(self):
         # return None if username/email not found

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -240,7 +240,7 @@ class TestUserManager(BaseTestCase):
         self.user_manager.delete(user)
         assert user.deleted is True
         message = self.user_manager.send_reset_email(self.trans, {"email": user_email})
-        assert message == "Failed to produce password reset token. User not found."
+        assert message == None
 
     def test_get_user_by_identity(self):
         # return None if username/email not found


### PR DESCRIPTION
This prevents existence of a user account from being queryable through password reset. We now return `None` and display a generic message regardless of a prt being created or not.

Fixes https://github.com/galaxyproject/galaxy/issues/18475

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
