### PR TITLE
Update package dev versions

### DIFF
--- a/packages/app/setup.cfg
+++ b/packages/app/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-app
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/auth/setup.cfg
+++ b/packages/auth/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-auth
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/config/setup.cfg
+++ b/packages/config/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-config
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/data/setup.cfg
+++ b/packages/data/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-data
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/files/setup.cfg
+++ b/packages/files/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-files
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/job_execution/setup.cfg
+++ b/packages/job_execution/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-job-execution
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/job_metrics/setup.cfg
+++ b/packages/job_metrics/setup.cfg
@@ -28,7 +28,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-job-metrics
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/meta/setup.cfg
+++ b/packages/meta/setup.cfg
@@ -29,7 +29,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/navigation/setup.cfg
+++ b/packages/navigation/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-navigation
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/objectstore/setup.cfg
+++ b/packages/objectstore/setup.cfg
@@ -28,7 +28,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-objectstore
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/schema/setup.cfg
+++ b/packages/schema/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-schema
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/selenium/setup.cfg
+++ b/packages/selenium/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-selenium
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/test_api/setup.cfg
+++ b/packages/test_api/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-test-api
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/test_base/setup.cfg
+++ b/packages/test_base/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-test-base
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/test_driver/setup.cfg
+++ b/packages/test_driver/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-test-driver
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/test_selenium/setup.cfg
+++ b/packages/test_selenium/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-test-selenium
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/tool_shed/setup.cfg
+++ b/packages/tool_shed/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-tool-shed
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/tool_util/setup.cfg
+++ b/packages/tool_util/setup.cfg
@@ -28,7 +28,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-tool-util
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/tours/setup.cfg
+++ b/packages/tours/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-tours
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/util/setup.cfg
+++ b/packages/util/setup.cfg
@@ -28,7 +28,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-util
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/web_apps/setup.cfg
+++ b/packages/web_apps/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-web-apps
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/web_framework/setup.cfg
+++ b/packages/web_framework/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-web-framework
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True

--- a/packages/web_stack/setup.cfg
+++ b/packages/web_stack/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-web-stack
 url = https://github.com/galaxyproject/galaxy
-version = 23.2.dev0
+version = 24.2.dev0
 
 [options]
 include_package_data = True


### PR DESCRIPTION
I am not sure why the release util script messed this up (I'm investigating). This is a manual fix.

The current working version in the packages' HISTORY.rst files is `24.2.dev0`. I think the version in the `setup.cfg` files should be the same. 
