### PR TITLE
[GCC2024 - CoFest] Workflow editor embed ignore errors

### DIFF
--- a/client/src/components/Sharing/Embeds/WorkflowEmbed.vue
+++ b/client/src/components/Sharing/Embeds/WorkflowEmbed.vue
@@ -28,6 +28,7 @@ const settings = reactive({
     initialY: -20,
     zoom: 1,
     applyStyle: true,
+    ignoreErrors: false,
 });
 
 function onChangePosition(event: Event, xy: "x" | "y") {
@@ -48,6 +49,7 @@ const embedUrl = computed(() => {
     url += `&zoom_controls=${settings.zoomControls}`;
     url += `&initialX=${settings.initialX}&initialY=${settings.initialY}`;
     url += `&zoom=${settings.zoom}`;
+    url += `&ignoreErrors=${settings.ignoreErrors}`;
     return url;
 });
 
@@ -92,6 +94,7 @@ const clipboardTitle = computed(() => (copied.value ? "Copied!" : "Copy URL"));
             <BFormCheckbox v-model="settings.buttons"> Show buttons </BFormCheckbox>
             <BFormCheckbox v-model="settings.minimap"> Show minimap </BFormCheckbox>
             <BFormCheckbox v-model="settings.zoomControls"> Show zoom controls </BFormCheckbox>
+            <BFormCheckbox v-model="settings.ignoreErrors"> Ignore errors </BFormCheckbox>
 
             <label for="embed-position-control" class="control-label">
                 Initial position
@@ -161,7 +164,8 @@ const clipboardTitle = computed(() => (copied.value ? "Copied!" : "Copy URL"));
                 :show-minimap="settings.minimap"
                 :show-zoom-controls="settings.zoomControls"
                 :initial-x="settings.initialX"
-                :initial-y="settings.initialY" />
+                :initial-y="settings.initialY"
+                :ignore-errors="settings.ignoreErrors" />
         </div>
     </div>
 </template>

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -87,7 +87,7 @@
             </span>
         </div>
         <b-alert
-            v-if="!!errors"
+            v-if="!props.ignoreErrors && Boolean(errors)"
             variant="danger"
             show
             class="node-error m-0 rounded-0 rounded-bottom"
@@ -117,6 +117,7 @@
                 :scale="scale"
                 :parent-node="elHtml"
                 :readonly="readonly"
+                :ignore-errors="props.ignoreErrors"
                 @onChange="onChange" />
             <div v-if="!isInvocation && showRule" class="rule" />
             <NodeInvocationText v-if="isInvocation" :invocation-step="invocationStep" />
@@ -137,6 +138,7 @@
                 :datatypes-mapper="datatypesMapper"
                 :parent-node="elHtml"
                 :readonly="readonly"
+                :ignore-errors="props.ignoreErrors"
                 @onDragConnector="onDragConnector"
                 @stopDragging="onStopDragging"
                 @onChange="onChange" />
@@ -193,6 +195,7 @@ const props = defineProps({
     highlight: { type: Boolean, default: false },
     isInvocation: { type: Boolean, default: false },
     readonly: { type: Boolean, default: false },
+    ignoreErrors: { type: Boolean, default: false },
 });
 
 const emit = defineEmits([

--- a/client/src/components/Workflow/Editor/NodeInput.vue
+++ b/client/src/components/Workflow/Editor/NodeInput.vue
@@ -74,6 +74,10 @@ const props = defineProps({
         type: Boolean,
         default: false,
     },
+    ignoreErrors: {
+        type: Boolean,
+        default: false,
+    },
 });
 
 onBeforeUnmount(() => {
@@ -149,7 +153,7 @@ const label = computed(() => props.input.label || props.input.name);
 const hasConnections = computed(() => connections.value.length > 0);
 const rowClass = computed(() => {
     const classes = ["form-row", "dataRow", "input-data-row"];
-    if (!props.blank && props.input?.valid === false) {
+    if (!props.ignoreErrors && !props.blank && props.input?.valid === false) {
         classes.push("form-row-error");
     }
     return classes;

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -52,6 +52,7 @@ const props = defineProps<{
     parentNode: HTMLElement | null;
     readonly: boolean;
     blank: boolean;
+    ignoreErrors?: boolean;
 }>();
 
 const emit = defineEmits(["pan-by", "stopDragging", "onDragConnector"]);
@@ -117,7 +118,7 @@ const label = computed(() => {
 
 const rowClass = computed(() => {
     const classes = ["form-row", "dataRow", "output-data-row"];
-    if ("valid" in props.output && props.output?.valid === false) {
+    if (!props.ignoreErrors && "valid" in props.output && props.output?.valid === false) {
         classes.push("form-row-error");
     }
     return classes;

--- a/client/src/components/Workflow/Editor/SVGConnection.vue
+++ b/client/src/components/Workflow/Editor/SVGConnection.vue
@@ -16,6 +16,10 @@ const props = defineProps({
         type: Object as PropType<TerminalPosition | null>,
         default: null,
     },
+    ignoreErrors: {
+        type: Boolean,
+        default: false,
+    },
 });
 
 const ribbonMargin = 4;
@@ -84,7 +88,7 @@ const outputIsOptional = computed(() => {
 });
 
 const connectionIsValid = computed(() => {
-    return !connectionStore.invalidConnections[getConnectionId(props.connection)];
+    return props.ignoreErrors || !connectionStore.invalidConnections[getConnectionId(props.connection)];
 });
 
 const lineOffsets = computed(() => getLineOffsets(inputIsMappedOver.value, outputIsMappedOver.value));

--- a/client/src/components/Workflow/Editor/WorkflowEdges.vue
+++ b/client/src/components/Workflow/Editor/WorkflowEdges.vue
@@ -14,6 +14,7 @@ const props = defineProps<{
     draggingConnection: TerminalPosition | null;
     draggingTerminal: OutputTerminals | null;
     transform: { x: number; y: number; k: number };
+    ignoreErrors?: boolean;
 }>();
 
 const { connectionStore } = useWorkflowStores();
@@ -56,7 +57,8 @@ function id(connection: Connection) {
                 v-for="connection in connections"
                 :id="id(connection)"
                 :key="key(connection)"
-                :connection="connection" />
+                :connection="connection"
+                :ignore-errors="props.ignoreErrors" />
         </svg>
     </div>
 </template>

--- a/client/src/components/Workflow/Editor/WorkflowGraph.vue
+++ b/client/src/components/Workflow/Editor/WorkflowGraph.vue
@@ -24,7 +24,8 @@
                 <WorkflowEdges
                     :transform="transform"
                     :dragging-terminal="draggingTerminal"
-                    :dragging-connection="draggingPosition" />
+                    :dragging-connection="draggingPosition"
+                    :ignore-errors="props.ignoreErrors" />
                 <WorkflowNode
                     v-for="(step, key) in steps"
                     :id="step.id"
@@ -38,6 +39,7 @@
                     :scroll="scroll"
                     :scale="scale"
                     :readonly="readonly"
+                    :ignore-errors="props.ignoreErrors"
                     :is-invocation="props.isInvocation"
                     @pan-by="panBy"
                     @stopDragging="onStopDragging"
@@ -62,6 +64,7 @@
             :comments="comments"
             :viewport-bounds="elementBounding"
             :viewport-bounding-box="viewportBoundingBox"
+            :ignore-errors="props.ignoreErrors"
             @panBy="panBy"
             @moveTo="moveTo" />
     </div>
@@ -103,6 +106,7 @@ const props = defineProps({
     isInvocation: { type: Boolean, default: false },
     showMinimap: { type: Boolean, default: true },
     showZoomControls: { type: Boolean, default: true },
+    ignoreErrors: { type: Boolean, default: false },
 });
 
 const { stateStore, stepStore } = useWorkflowStores();

--- a/client/src/components/Workflow/Editor/WorkflowMinimap.vue
+++ b/client/src/components/Workflow/Editor/WorkflowMinimap.vue
@@ -92,7 +92,7 @@ function recalculateAABB() {
 
 // redraw if any steps or comments change
 watch(
-    () => [props.steps, props.comments, toolbarStore.inputCatcherPressed],
+    () => [props.steps, props.comments, toolbarStore.inputCatcherPressed, props.ignoreErrors],
     () => {
         if (!toolbarStore.inputCatcherPressed) {
             redraw = true;

--- a/client/src/components/Workflow/Editor/WorkflowMinimap.vue
+++ b/client/src/components/Workflow/Editor/WorkflowMinimap.vue
@@ -23,6 +23,7 @@ const props = defineProps<{
     comments: WorkflowComment[];
     viewportBounds: UseElementBoundingReturn;
     viewportBoundingBox: AxisAlignedBoundingBox;
+    ignoreErrors?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -192,7 +193,7 @@ function renderMinimap() {
             selectedStep = step;
         }
 
-        if (step.errors) {
+        if (!props.ignoreErrors && step.errors) {
             errorSteps.push(step);
         } else {
             okSteps.push(step);

--- a/client/src/components/Workflow/Published/WorkflowPublished.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublished.vue
@@ -42,6 +42,7 @@ interface Props {
     showMinimap?: boolean;
     showButtons?: boolean;
     showZoomControls?: boolean;
+    ignoreErrors?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -239,6 +240,7 @@ onMounted(async () => {
                         :initial-position="initialPosition"
                         :show-minimap="props.showMinimap"
                         :show-zoom-controls="props.showZoomControls"
+                        :ignore-errors="props.ignoreErrors"
                         readonly />
                 </BCard>
 

--- a/client/src/components/Workflow/Published/WorkflowPublished.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublished.vue
@@ -55,6 +55,7 @@ const props = withDefaults(defineProps<Props>(), {
     showMinimap: true,
     showButtons: true,
     showZoomControls: true,
+    ignoreErrors: false,
 });
 
 const userStore = useUserStore();

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -165,6 +165,7 @@ export function getRouter(Galaxy) {
                     showZoomControls: route.query.zoom_controls ? parseBool(route.query.zoom_controls) : undefined,
                     initialX: route.query.initialX ? parseInt(route.query.initialX) : undefined,
                     initialY: route.query.initialY ? parseInt(route.query.initialY) : undefined,
+                    ignoreErrors: route.query.ignoreErrors ? parseBool(route.query.ignoreErrors) : undefined,
                 }),
             },
             {


### PR DESCRIPTION
Adds a flag to the workflow editor embed which sets the workflow editor to ignore errors, and render the workflow with the information available.

Same workflow with flag disabled and enabled:

![image2](https://github.com/galaxyproject/galaxy/assets/44241786/e2c91e38-efb1-43ec-a696-25a3f62e9b54)

![image1](https://github.com/galaxyproject/galaxy/assets/44241786/b0bc2692-7b87-4501-bbcf-ece27b1d050d)

The editor is still missing important information about the tools, which is why this representation is not accurate. It does however give a much better understanding of what the workflow is supposed to do, and serves as a first step towards rendering workflows on any server.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
