### PR TITLE
[24.1] Stabilize test_purge_while_job_running test

### DIFF
--- a/test/integration/objectstore/_purged_handling.py
+++ b/test/integration/objectstore/_purged_handling.py
@@ -9,7 +9,7 @@ def purge_while_job_running(dataset_populator: DatasetPopulator, extra_sleep=0):
         response = dataset_populator.run_tool(
             "all_output_types",
             inputs={
-                "sleep_param": 5,
+                "sleep_param": 5 + extra_sleep,
             },
             history_id=history_id,
         )

--- a/test/integration/test_extended_metadata.py
+++ b/test/integration/test_extended_metadata.py
@@ -100,7 +100,7 @@ class TestExtendedMetadataIntegration(integration_util.IntegrationTestCase):
     def test_purge_while_job_running(self):
         # pass extra_sleep, since templating the command line will fail if the output
         # is deleted before remote_tool_eval runs.
-        purge_while_job_running(self.dataset_populator, extra_sleep=4)
+        purge_while_job_running(self.dataset_populator, extra_sleep=10)
 
 
 class TestExtendedMetadataDeferredIntegration(integration_util.IntegrationTestCase):


### PR DESCRIPTION
In the extended_metadata + remote tool_evaluation_strategy the commandline is templated as part of the job, so we need to give the test more time to start running before we delete outputs (as then we can't template the command line anymore).

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
