### PR TITLE
[24.1] Display binary data even if text data is expected

### DIFF
--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -774,7 +774,7 @@ class BaseFastq(Sequence):
     ):
         headers = kwd.get("headers", {})
         if preview:
-            with compression_utils.get_fileobj(dataset.get_file_name()) as fh:
+            with compression_utils.get_fileobj(dataset.get_file_name(), "rb") as fh:
                 max_peek_size = 1000000  # 1 MB
                 if os.stat(dataset.get_file_name()).st_size < max_peek_size:
                     mime = "text/plain"

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -154,12 +154,12 @@ class TabularData(Text):
         )
 
     def _read_chunk(self, trans, dataset: HasFileName, offset: int, ck_size: Optional[int] = None):
-        with compression_utils.get_fileobj(dataset.get_file_name()) as f:
+        with compression_utils.get_fileobj(dataset.get_file_name(), "rb") as f:
             f.seek(offset)
             ck_data = f.read(ck_size or trans.app.config.display_chunk_size)
-            if ck_data and ck_data[-1] != "\n":
+            if ck_data and ck_data[-1] != b"\n":
                 cursor = f.read(1)
-                while cursor and cursor != "\n":
+                while cursor and cursor != b"\n":
                     ck_data += cursor
                     cursor = f.read(1)
             last_read = f.tell()


### PR DESCRIPTION
I've been going back and forth on whether we should raise an exception or not, however I think the advantage here is that often you can tell from the binary data what the correct datatype is (e.g. BAM files assigned as fastqsanger.gz will start with "BAM"). We could also raise a message exception that just says "this isn't text data, check your datatype" ... I don't know what's better, but this is easier.

Fixes
https://sentry.galaxyproject.org/share/issue/a8843884527f4e4089b32fd14a2f126d/:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 4: invalid start byte
  File "galaxy/web/framework/middleware/error.py", line 167, in __call__
    app_iter = self.application(environ, sr_checker)
  File "galaxy/web/framework/middleware/statsd.py", line 29, in __call__
    req = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.11/site-packages/paste/httpexceptions.py", line 635, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 174, in __call__
    return self.handle_request(request_id, path_info, environ, start_response)
  File "galaxy/web/framework/base.py", line 263, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/webapps/galaxy/controllers/dataset.py", line 152, in display
    display_data, headers = data.datatype.display_data(
  File "galaxy/datatypes/sequence.py", line 785, in display_data
    "/dataset/large_file.mako", truncated_data=fh.read(max_peek_size), data=dataset
  File "<frozen codecs>", line 322, in decode

```
Which is a BAM file assigned to fastqsanger.gz

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
