### PR TITLE
Raise Message Exception when displaying binary data

### DIFF
--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -65,6 +65,7 @@ from galaxy.datatypes.sniff import (
     iter_headers,
     validate_tabular,
 )
+from galaxy.exceptions import InvalidFileFormatError
 from galaxy.util import compression_utils
 from galaxy.util.compression_utils import (
     FileObjType,
@@ -156,12 +157,15 @@ class TabularData(Text):
     def _read_chunk(self, trans, dataset: HasFileName, offset: int, ck_size: Optional[int] = None):
         with compression_utils.get_fileobj(dataset.get_file_name()) as f:
             f.seek(offset)
-            ck_data = f.read(ck_size or trans.app.config.display_chunk_size)
-            if ck_data and ck_data[-1] != "\n":
-                cursor = f.read(1)
-                while cursor and cursor != "\n":
-                    ck_data += cursor
+            try:
+                ck_data = f.read(ck_size or trans.app.config.display_chunk_size)
+                if ck_data and ck_data[-1] != "\n":
                     cursor = f.read(1)
+                    while cursor and cursor != "\n":
+                        ck_data += cursor
+                        cursor = f.read(1)
+            except UnicodeDecodeError:
+                raise InvalidFileFormatError("Dataset appears to contain binary data, cannot display.")
             last_read = f.tell()
         return ck_data, last_read
 


### PR DESCRIPTION
Fixes
https://sentry.galaxyproject.org/share/issue/a8843884527f4e4089b32fd14a2f126d/:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 4: invalid start byte
  File "galaxy/web/framework/middleware/error.py", line 167, in __call__
    app_iter = self.application(environ, sr_checker)
  File "galaxy/web/framework/middleware/statsd.py", line 29, in __call__
    req = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.11/site-packages/paste/httpexceptions.py", line 635, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 174, in __call__
    return self.handle_request(request_id, path_info, environ, start_response)
  File "galaxy/web/framework/base.py", line 263, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/webapps/galaxy/controllers/dataset.py", line 152, in display
    display_data, headers = data.datatype.display_data(
  File "galaxy/datatypes/sequence.py", line 785, in display_data
    "/dataset/large_file.mako", truncated_data=fh.read(max_peek_size), data=dataset
  File "<frozen codecs>", line 322, in decode

```
Which is a BAM file assigned to fastqsanger.gz

![Screenshot 2024-07-05 at 17 16 44](https://github.com/galaxyproject/galaxy/assets/6804901/252e0901-937f-4cd5-910b-9011d5c2e379)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Upload a bam dataset, assign it as fastqsanger.gz and click on the eye icon.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
