### PR TITLE
[24.1] Apply statsd arg sanitization to all pages

### DIFF
--- a/lib/galaxy/web/framework/base.py
+++ b/lib/galaxy/web/framework/base.py
@@ -251,8 +251,13 @@ class WebApplication:
                 raise
         trans.controller = controller_name
         trans.action = action
+
+        # Action can still refer to invalid and/or inaccurate paths here, so we use the actual
+        # controller and method names to set the timing key.
+
+        action_tag = getattr(method, "__name__", "default")
         environ["controller_action_key"] = (
-            f"{'api' if environ['is_api_request'] else 'web'}.{controller_name}.{action or 'default'}"
+            f"{'api' if environ['is_api_request'] else 'web'}.{controller_name}.{action_tag}"
         )
         # Combine mapper args and query string / form args and call
         kwargs = trans.request.params.mixed()


### PR DESCRIPTION
The previous sanitization would only run on the `or` portion.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
