### PR TITLE
[23.2] Handle all requests error in ``ApiBiotoolsMetadataSource._raw_get_metadata``

### DIFF
--- a/lib/galaxy/tool_util/biotools/source.py
+++ b/lib/galaxy/tool_util/biotools/source.py
@@ -54,12 +54,13 @@ class ApiBiotoolsMetadataSource(BiotoolsMetadataSource):
 
     def _raw_get_metadata(self, biotools_reference) -> Optional[str]:
         api_url = f"https://bio.tools/api/tool/{biotools_reference}?format=json"
-        req = requests.get(api_url, timeout=DEFAULT_SOCKET_TIMEOUT)
-        req.encoding = req.apparent_encoding
-        if req.status_code == 404:
-            return None
-        else:
+        try:
+            req = requests.get(api_url, timeout=DEFAULT_SOCKET_TIMEOUT)
+            req.raise_for_status()
+            req.encoding = req.apparent_encoding
             return req.text
+        except Exception:
+            return None
 
     def get_biotools_metadata(self, biotools_reference: str) -> Optional[BiotoolsEntry]:
         createfunc = functools.partial(self._raw_get_metadata, biotools_reference)


### PR DESCRIPTION
Fix the following traceback when running `planemo lint` if bio.tools is down:

```
File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/galaxy/tool\_util/biotools/source.py", line 69, in get\_biotools\_metadata
return BiotoolsEntry.from\_json(json.loads(content))
^^^^^^^^^^^^^^^^^^^
File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/json/**init**.py", line 346, in loads
return \_default\_decoder.decode(s)
^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/json/decoder.py", line 337, in decode
obj, end = self.raw\_decode(s, idx=\_w(s, 0).end())
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/json/decoder.py", line 355, in raw\_decode
raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
