### PR TITLE
Improvements for K8S deployment (especially ITs)

### DIFF
--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -10,8 +10,67 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  ghcrbuild:
+    name: Build container image for GHCR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # https://stackoverflow.com/questions/59810838/how-to-get-the-short-sha-for-the-github-workflow
+      - name: Set outputs
+        id: commit
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Set branch name
+        id: branch
+        run: |
+          if [[ "$GITHUB_REF" == "refs/tags/"* ]]; then
+            echo "name=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          elif [[ "$GITHUB_REF" == "refs/heads/dev" ]]; then
+            echo "name=dev" >> $GITHUB_OUTPUT
+          elif [[ "$GITHUB_REF" == "refs/heads/release_"* ]]; then
+            echo "name=${GITHUB_REF#refs/heads/release_}-auto" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+      - name: Extract metadata for container image
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{steps.branch.outputs.name}}
+      - name: Build args
+        id: buildargs
+        run: |
+            echo "gitcommit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT 
+            echo "builddate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push container image to ghcr
+        uses: docker/build-push-action@v4
+        with:
+          build-args: |
+              GIT_COMMIT=${{ steps.buildargs.outputs.gitcommit }}
+              BUILD_DATE=${{ steps.buildargs.outputs.builddate }}
+              IMAGE_TAG=${{ steps.branch.outputs.name }}
+          file: .k8s_ci.Dockerfile
+          push: true
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+
   build:
-    name: Build container image
+    name: Build container image for Galaxy repos
     runs-on: ubuntu-latest
     if: github.repository_owner == 'galaxyproject'
     steps:
@@ -58,3 +117,4 @@ jobs:
         uses: actions-hub/docker@master
         with:
           args: push galaxy/galaxy-min:${{ steps.branch.outputs.name }}
+

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -36,7 +36,7 @@ custos-sdk
 chronos-python==1.2.1
 
 # Kubernetes job runner
-pykube-ng==21.3.0
+pykube-ng==23.6.0
 
 # Synnefo / Pithos+ object store client
 kamaki

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -532,8 +532,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 ]
             else:
                 k8s_spec_template["spec"]["tls"] = [
-                    {"hosts": [domain],
-                     "secretName": re.sub("[^a-z0-9-]", "-", domain)} for domain in domains
+                    {"hosts": [domain], "secretName": re.sub("[^a-z0-9-]", "-", domain)} for domain in domains
                 ]
         if self.runner_params.get("k8s_interactivetools_ingress_annotations"):
             new_ann = yaml.safe_load(self.runner_params.get("k8s_interactivetools_ingress_annotations"))

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -435,7 +435,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
     def __get_k8s_ingress_rules_spec(self, ajs, entry_points):
         """This represents the template for the "rules" portion of the Ingress spec."""
-        if "v1beta1" in self.runner_params.get("k8s_ingress_api_version"):
+        if "v1beta1" in self.runner_params["k8s_ingress_api_version"]:
             rules_spec = [
                 {
                     "host": ep["domain"],

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -20,6 +20,7 @@ from galaxy.jobs.runners import (
 )
 from galaxy.jobs.runners.util.pykube_util import (
     deduplicate_entries,
+    DEFAULT_INGRESS_API_VERSION,
     DEFAULT_JOB_API_VERSION,
     delete_ingress,
     delete_job,
@@ -110,6 +111,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             k8s_interactivetools_ingress_annotations=dict(map=str),
             k8s_interactivetools_ingress_class=dict(map=str, default=None),
             k8s_interactivetools_tls_secret=dict(map=str, default=None),
+            k8s_ingress_api_version=dict(map=str, default=DEFAULT_INGRESS_API_VERSION),
         )
 
         if "runner_param_specs" not in kwargs:
@@ -250,6 +252,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         service = Service(self._pykube_api, k8s_service_obj)
         service.create()
         ingress = Ingress(self._pykube_api, k8s_ingress_obj)
+        ingress.version = self.runner_params.get("k8s_ingress_api_version")
         ingress.create()
 
     def __get_overridable_params(self, job_wrapper, param_key):
@@ -430,6 +433,54 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         }
         return k8s_spec_template
 
+    def __get_k8s_ingress_rules_spec(self, ajs, entry_points):
+        """This represents the template for the "rules" portion of the Ingress spec."""
+        if "v1beta1" in self.runner_params.get("k8s_ingress_api_version"):
+            rules_spec = [
+                {
+                    "host": ep["domain"],
+                    "http": {
+                        "paths": [
+                            {
+                                "backend": {
+                                    "serviceName": self.__get_k8s_job_name(
+                                        self.__produce_k8s_job_prefix(), ajs.job_wrapper
+                                    ),
+                                    "servicePort": int(ep["tool_port"]),
+                                },
+                                "path": ep.get("entry_path", "/"),
+                                "pathType": "Prefix",
+                            }
+                        ]
+                    },
+                }
+                for ep in entry_points
+            ]
+        else:
+            rules_spec = [
+                {
+                    "host": ep["domain"],
+                    "http": {
+                        "paths": [
+                            {
+                                "backend": {
+                                    "service": {
+                                        "name": self.__get_k8s_job_name(
+                                            self.__produce_k8s_job_prefix(), ajs.job_wrapper
+                                        ),
+                                        "port": {"number": int(ep["tool_port"])},
+                                    }
+                                },
+                                "path": ep.get("entry_path", "/"),
+                                "pathType": "ImplementationSpecific",
+                            }
+                        ]
+                    },
+                }
+                for ep in entry_points
+            ]
+        return rules_spec
+
     def __get_k8s_ingress_spec(self, ajs):
         """The k8s spec template is nothing but a Ingress spec, except that it is nested and does not have an apiversion
         nor kind."""
@@ -467,30 +518,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 },
                 "annotations": {"app.galaxyproject.org/tool_id": ajs.job_wrapper.tool.id},
             },
-            "spec": {
-                "rules": [
-                    {
-                        "host": ep["domain"],
-                        "http": {
-                            "paths": [
-                                {
-                                    "backend": {
-                                        "service": {
-                                            "name": self.__get_k8s_job_name(
-                                                self.__produce_k8s_job_prefix(), ajs.job_wrapper
-                                            ),
-                                            "port": {"number": int(ep["tool_port"])},
-                                        }
-                                    },
-                                    "path": ep.get("entry_path", "/"),
-                                    "pathType": "Prefix",
-                                }
-                            ]
-                        },
-                    }
-                    for ep in entry_points
-                ],
-            },
+            "spec": {"rules": self.__get_k8s_ingress_rules_spec(ajs, entry_points)},
         }
         default_ingress_class = self.runner_params.get("k8s_interactivetools_ingress_class")
         if default_ingress_class:

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -808,7 +808,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                         job_state.running = True
                         job_state.job_wrapper.change_state(model.Job.states.RUNNING)
                     else:
-                        pass
+                        log.debug(f"Job id: {job_state.job_id} with k8s id: {job.name} scheduled and is waiting to start...")
                 return job_state
             elif job_persisted_state == model.Job.states.DELETED:
                 # Job has been deleted via stop_job and job has not been deleted,

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -808,7 +808,9 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                         job_state.running = True
                         job_state.job_wrapper.change_state(model.Job.states.RUNNING)
                     else:
-                        log.debug(f"Job id: {job_state.job_id} with k8s id: {job.name} scheduled and is waiting to start...")
+                        log.debug(
+                            f"Job id: {job_state.job_id} with k8s id: {job.name} scheduled and is waiting to start..."
+                        )
                 return job_state
             elif job_persisted_state == model.Job.states.DELETED:
                 # Job has been deleted via stop_job and job has not been deleted,

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -961,7 +961,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
     def __check_job_pod_running(self, job_state):
         """
-        checks the state of the pod to see if it is unschedulable.
+        checks the state of the pod to see if it is running.
         """
         pods = find_pod_object_by_name(self._pykube_api, job_state.job_id, self.runner_params["k8s_namespace"])
         if not pods.response["items"]:

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -252,7 +252,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         service = Service(self._pykube_api, k8s_service_obj)
         service.create()
         ingress = Ingress(self._pykube_api, k8s_ingress_obj)
-        ingress.version = self.runner_params.get("k8s_ingress_api_version")
+        ingress.version = self.runner_params["k8s_ingress_api_version"]
         ingress.create()
 
     def __get_overridable_params(self, job_wrapper, param_key):

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -532,10 +532,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 ]
             else:
                 k8s_spec_template["spec"]["tls"] = [
-                    {
-                    "hosts": [domain],
-                    "secretName": re.sub("[^a-z0-9-]", "-", domain)
-                    } for domain in domains
+                    {"hosts": [domain],
+                     "secretName": re.sub("[^a-z0-9-]", "-", domain)} for domain in domains
                 ]
         if self.runner_params.get("k8s_interactivetools_ingress_annotations"):
             new_ann = yaml.safe_load(self.runner_params.get("k8s_interactivetools_ingress_annotations"))

--- a/lib/galaxy/jobs/runners/util/pykube_util.py
+++ b/lib/galaxy/jobs/runners/util/pykube_util.py
@@ -95,11 +95,7 @@ def find_pod_object_by_name(pykube_api, job_name, namespace=None):
 
 
 def is_pod_running(pykube_api, pod, namespace=None):
-    is_running = all(
-        c.get("state", {}).get("running", {}).get("startedAt", False)
-        for c in pod.obj["status"].get("containerStatuses", [])
-    )
-    if pod.obj["status"].get("phase") == "Running" and is_running:
+    if pod.obj["status"].get("phase") == "Running":
         return True
 
     return False

--- a/lib/galaxy/jobs/runners/util/pykube_util.py
+++ b/lib/galaxy/jobs/runners/util/pykube_util.py
@@ -94,6 +94,17 @@ def find_pod_object_by_name(pykube_api, job_name, namespace=None):
     return Pod.objects(pykube_api).filter(selector=f"job-name={job_name}", namespace=namespace)
 
 
+def is_pod_running(pykube_api, pod, namespace=None):
+    is_running = not any(
+        c.get("state", {}).get("running", {}).get("startedAt", False) == False
+        for c in pod.obj["status"].get("containerStatuses", [])
+    )
+    if pod.obj["status"].get("phase") == "Running" and is_running:
+        return True
+
+    return False
+
+
 def is_pod_unschedulable(pykube_api, pod, namespace=None):
     is_unschedulable = any(c.get("reason") == "Unschedulable" for c in pod.obj["status"].get("conditions", []))
     if pod.obj["status"].get("phase") == "Pending" and is_unschedulable:
@@ -311,6 +322,7 @@ __all__ = (
     "find_pod_object_by_name",
     "galaxy_instance_id",
     "HTTPError",
+    "is_pod_running",
     "is_pod_unschedulable",
     "Job",
     "Service",

--- a/lib/galaxy/jobs/runners/util/pykube_util.py
+++ b/lib/galaxy/jobs/runners/util/pykube_util.py
@@ -95,8 +95,8 @@ def find_pod_object_by_name(pykube_api, job_name, namespace=None):
 
 
 def is_pod_running(pykube_api, pod, namespace=None):
-    is_running = not any(
-        c.get("state", {}).get("running", {}).get("startedAt", False) == False
+    is_running = all(
+        c.get("state", {}).get("running", {}).get("startedAt", False)
         for c in pod.obj["status"].get("containerStatuses", [])
     )
     if pod.obj["status"].get("phase") == "Running" and is_running:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2912,8 +2912,7 @@ class InteractiveToolEntryPoint(Base, Dictifiable, RepresentById):
     @property
     def active(self):
         if self.configured and not self.deleted:
-            # FIXME: don't included queued?
-            return not self.job.finished
+            return self.job.running
         return False
 
     @property


### PR DESCRIPTION
1) Adds GHCR build, to get a k8s container image built and pushed to `ghcr.io` under repository owner, with no credentials needed (complementing the DockerHub/Quay.io pushed that are only for `galaxyproject` repo and require credentials). Demonstrated for the Bioconductor fork (https://github.com/Bioconductor/galaxy/pkgs/container/galaxy), and could also be useful for AnVIL fork where it could replace the custom workflow that is currently being used.

2) Updates `pykube-ng` version to latest available, making the deployment compatible with newer versions of Kubernetes (would error out on an API call for ingresses otherwise). It seems `pykube-ng` is not being updated anymore though, and there is an official Kubernetes API client for python now, which should likely be the long-term solution here imo.

3) Add ability to override the TLS secret for ITs' ingress resources, notably useful for easily setting up a wildcard cert instead of relying on `cert-manager` to issue a new certificate per subdomain (which eventually hits the rate limit at least for letsencrypt).

4) Adds ability to override ingress version, currently useful for running on old kubernetes versions (and added back conditional logic to work with old `v1beta1` API version).

I don't remember ITs on Kubernetes being tested, so I didn't really look into adding tests. The changes aren't too complicated though. One thing I did notice is that although default is set [here](https://github.com/galaxyproject/galaxy/compare/dev...Bioconductor:galaxy:dev?expand=1#diff-4b73c7a6546e8d68305e5e776cf411dc3e5db8a53c980a174ee330eaa22a1583R114), `runner_params.get()` still returns `None` when it's not set. Is that a bug in the runner_params parsing?

cc: @nuwang @ksuderman @afgane 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
