### PR TITLE
[24.1] Prevent job submission if input collection element is deleted

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6500,6 +6500,14 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
         return q
 
     @property
+    def elements_deleted(self):
+        stmt = self._build_nested_collection_attributes_stmt(
+            hda_attributes=("deleted",), dataset_attributes=("deleted",)
+        )
+        stmt = exists(stmt).where(or_(HistoryDatasetAssociation.deleted == true(), Dataset.deleted == true()))
+        return object_session(self).execute(select(stmt)).scalar()
+
+    @property
     def dataset_states_and_extensions_summary(self):
         if not hasattr(self, "_dataset_states_and_extensions_summary"):
             stmt = self._build_nested_collection_attributes_stmt(


### PR DESCRIPTION
The previous behavior was that we'd create the job, then pause it after the job handler loop would determine that any job input dataset association points at a deleted dataset, which I believe doesn't always work, as we won't always have the job input dataset association. This however also gives much quicker feedback to the user and is more explicit (won't have to look at the dataset info message to see that an input dataset has been deleted).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
