### PR TITLE
[24.1] Use name instead of ID for displaying object stores + revise user-facing language in UI

### DIFF
--- a/client/src/components/Common/FilterObjectStoreLink.vue
+++ b/client/src/components/Common/FilterObjectStoreLink.vue
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed, ref } from "vue";
 
 import { ConcreteObjectStoreModel } from "@/api";
+import { useObjectStoreStore } from "@/stores/objectStoreStore";
 
 import ObjectStoreSelect from "./ObjectStoreSelect.vue";
 import SelectModal from "@/components/Dataset/DatasetStorage/SelectModal.vue";
@@ -12,26 +13,28 @@ import SelectModal from "@/components/Dataset/DatasetStorage/SelectModal.vue";
 library.add(faTimes);
 
 interface FilterObjectStoreLinkProps {
-    value: String | null;
+    value?: string;
     objectStores: ConcreteObjectStoreModel[];
 }
 
 const props = defineProps<FilterObjectStoreLinkProps>();
 
+const { getObjectStoreNameById } = useObjectStoreStore();
+
 const showModal = ref(false);
 
 const emit = defineEmits<{
-    (e: "change", objectStoreId: string | null): void;
+    (e: "change", objectStoreId?: string): void;
 }>();
 
-function onSelect(objectStoreId: string | null) {
+function onSelect(objectStoreId?: string) {
     emit("change", objectStoreId);
     showModal.value = false;
 }
 
 const selectionText = computed(() => {
     if (props.value) {
-        return props.value;
+        return getObjectStoreNameById(props.value);
     } else {
         return "(any)";
     }
@@ -45,7 +48,7 @@ const selectionText = computed(() => {
         </SelectModal>
         <b-link href="#" @click="showModal = true">{{ selectionText }}</b-link>
         <span v-if="value" v-b-tooltip.hover title="Remove Filter">
-            <FontAwesomeIcon icon="times" @click="onSelect(null)" />
+            <FontAwesomeIcon icon="times" @click="onSelect(undefined)" />
         </span>
     </span>
 </template>

--- a/client/src/components/FileSources/FileSourceTypeSpan.vue
+++ b/client/src/components/FileSources/FileSourceTypeSpan.vue
@@ -2,7 +2,7 @@
 import { computed } from "vue";
 
 const MESSAGES = {
-    posix: "This is a simple path based object store that assumes the all the relevant paths are already mounted on the Galaxy server and target worker nodes.",
+    posix: "This is a simple path based storage location that assumes the all the relevant paths are already mounted on the Galaxy server and target worker nodes.",
     s3fs: "This is an remote file source plugin based on the Amazon Simple Storage Service (S3) interface. The AWS interface has become an industry standard and many storage vendors support it and use it to expose 'object' based storage.",
 };
 

--- a/client/src/components/ObjectStore/Instances/ManageIndex.vue
+++ b/client/src/components/ObjectStore/Instances/ManageIndex.vue
@@ -59,9 +59,9 @@ function reload() {
             :fixed="true"
             :show-empty="true">
             <template v-slot:empty>
-                <LoadingSpan v-if="loading" message="Loading object store instances" />
+                <LoadingSpan v-if="loading" message="Loading storage location instances" />
                 <b-alert v-else id="no-object-store-instances" variant="info" show>
-                    <div>No object store instances found, click the create button to configure a new one.</div>
+                    <div>No storage location instances found, click the create button to configure a new one.</div>
                 </b-alert>
             </template>
             <template v-slot:cell(badges)="row">

--- a/client/src/components/ObjectStore/ObjectStoreTypeSpan.vue
+++ b/client/src/components/ObjectStore/ObjectStoreTypeSpan.vue
@@ -4,13 +4,13 @@ import { computed } from "vue";
 import { ObjectStoreTemplateType } from "@/api/objectStores";
 
 const MESSAGES = {
-    aws_s3: "This is an object store based on the Amazon Simple Storage Service (S3). Data here is hosted by Amazon.",
+    aws_s3: "This is a storage location based on the Amazon Simple Storage Service (S3). Data here is hosted by Amazon.",
     azure_blob:
-        "This is a Microsoft Azure Blob based object store. More information on Microsoft's Azure Blob Storage can be found at https://azure.microsoft.com/en-us/products/storage/blobs/.",
-    disk: "This is a simple path based object store that assumes the all the relevant paths are already mounted on the Galaxy server and target worker nodes.",
-    boto3: "This is an object store based on the Amazon Simple Storage Service (S3) interface, but likely not stored by Amazon. The AWS interface has become an industry standard and many storage vendors support it and use it to expose object based storage.",
+        "This is a Microsoft Azure Blob based storage location. More information on Microsoft's Azure Blob Storage can be found at https://azure.microsoft.com/en-us/products/storage/blobs/.",
+    disk: "This is a simple path based storage location that assumes the all the relevant paths are already mounted on the Galaxy server and target worker nodes.",
+    boto3: "This is a storage location based on the Amazon Simple Storage Service (S3) interface, but likely not stored by Amazon. The AWS interface has become an industry standard and many storage vendors support it and use it to expose object based storage.",
     generic_s3:
-        "This is an object store based on the Amazon Simple Storage Service (S3) interface, but likely not stored by Amazon. The AWS interface has become an industry standard and many storage vendors support it and use it to expose object based storage.",
+        "This is a storage location based on the Amazon Simple Storage Service (S3) interface, but likely not stored by Amazon. The AWS interface has become an industry standard and many storage vendors support it and use it to expose object based storage.",
 };
 
 interface Props {

--- a/client/src/components/User/DiskUsage/StorageDashboard.vue
+++ b/client/src/components/User/DiskUsage/StorageDashboard.vue
@@ -29,9 +29,9 @@ const texts = reactive({
         buttonText: localize("Explore now"),
     },
     explore_by_objectstore: {
-        title: localize("Visually explore your disk usage by object store"),
+        title: localize("Visually explore your disk usage by storage location"),
         description: localize(
-            "Want to know how the space in your account is being distributed by object store? Here you can explore your disk usage in a visual way by object store."
+            "Want to know how the space in your account is being distributed across storage locations? Here you can explore your disk usage in a visual way by where it is physically stored."
         ),
         icon: "fas fa-hdd fa-6x",
         buttonText: localize("Explore now"),

--- a/client/src/components/User/DiskUsage/Visualizations/HistoryStorageOverview.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/HistoryStorageOverview.vue
@@ -51,14 +51,14 @@ const { isLoading, loadDataOnMount } = useDataLoading();
 const { isAdvanced, toggleAdvanced, inputGroupClasses, faAngleDoubleDown, faAngleDoubleUp } = useAdvancedFiltering();
 const { selectableObjectStores, hasSelectableObjectStores } = useSelectableObjectStores();
 
-const objectStore = ref<string | null>(null);
+const objectStore = ref<string>();
 
 const canEditHistory = computed(() => {
     const history = getHistoryById(props.historyId);
     return (history && !history.purged && !history.archived) ?? false;
 });
 
-function onChangeObjectStore(value: string | null) {
+function onChangeObjectStore(value?: string) {
     objectStore.value = value;
     reloadDataFromServer();
 }
@@ -190,7 +190,7 @@ function onUndelete(datasetId: string) {
                                 </BFormSelect>
                             </BFormGroup>
                             <BFormGroup
-                                v-if="hasSelectableObjectStores"
+                                v-if="selectableObjectStores && hasSelectableObjectStores"
                                 id="input-group-object-store"
                                 label="Storage location:"
                                 label-for="input-object-store"

--- a/client/src/components/User/DiskUsage/Visualizations/HistoryStorageOverview.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/HistoryStorageOverview.vue
@@ -194,7 +194,7 @@ function onUndelete(datasetId: string) {
                                 id="input-group-object-store"
                                 label="Storage location:"
                                 label-for="input-object-store"
-                                description="This will constrain history size calculations to a particular object store.">
+                                description="This will constrain history size calculations to a particular storage location.">
                                 <FilterObjectStoreLink
                                     :object-stores="selectableObjectStores"
                                     :value="objectStore"

--- a/client/src/components/User/DiskUsage/Visualizations/ObjectStoreActions.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/ObjectStoreActions.vue
@@ -39,7 +39,7 @@ function onViewItem() {
                 variant="outline-primary"
                 size="sm"
                 class="mx-2"
-                :title="localize(`Go to the details of this object store`)"
+                :title="localize(`Go to the details of this storage location`)"
                 @click="onViewItem">
                 <FontAwesomeIcon :icon="viewDetailsIcon" />
             </BButton>

--- a/client/src/components/User/DiskUsage/Visualizations/ObjectStoreStorageOverview.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/ObjectStoreStorageOverview.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { useRouter } from "vue-router/composables";
 
+import { useObjectStoreStore } from "@/stores/objectStoreStore";
+import localize from "@/utils/localization";
+
 import { fetchObjectStoreContentsSizeSummary } from "./service";
 import { buildTopNDatasetsBySizeData, byteFormattingForChart, useDataLoading, useDatasetsToDisplay } from "./util";
 
@@ -18,6 +21,8 @@ interface Props {
 const props = defineProps<Props>();
 
 const router = useRouter();
+
+const { getObjectStoreNameById } = useObjectStoreStore();
 
 const {
     numberOfDatasetsToDisplayOptions,
@@ -69,11 +74,11 @@ function onUndelete(datasetId: string) {
 </script>
 
 <template>
-    <OverviewPage title="Object Store Storage Overview">
+    <OverviewPage title="Storage overview by location">
         <p class="text-justify">
-            Here you will find some Graphs displaying the storage taken by datasets in the object store:
-            <b>{{ objectStoreId }}</b
-            >. You can use these graphs to identify the datasets that take the most space in this object store.
+            Here you will find some Graphs displaying the storage taken by datasets in the storage location:
+            <b>{{ getObjectStoreNameById(objectStoreId) }}</b
+            >. You can use these graphs to identify the datasets that take the most space in this storage location.
         </p>
         <WarnDeletedDatasets />
         <div v-if="isLoading" class="text-center">

--- a/client/src/components/User/DiskUsage/Visualizations/ObjectStoresStorageOverview.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/ObjectStoresStorageOverview.vue
@@ -39,10 +39,10 @@ function onViewObjectStore(objectStoreId: string) {
 }
 </script>
 <template>
-    <OverviewPage title="Object Stores Storage Overview">
+    <OverviewPage title="Storage overview by location">
         <p class="text-justify">
-            Here you can find various graphs displaying the storage size taken by all your histories grouped by object
-            store.
+            Here you can find various graphs displaying the storage size taken by all your histories grouped by where
+            they are physically stored.
         </p>
         <WarnDeletedHistories />
         <div v-if="isLoading" class="text-center">
@@ -53,14 +53,14 @@ function onViewObjectStore(objectStoreId: string) {
                 v-if="objectStoresBySizeData"
                 :description="
                     localize(
-                        `This graph displays how your Galaxy data is stored sorted into the object store is stored in. Click on a bar to see more information about the object store.`
+                        `This graph displays how your Galaxy data is stored sorted into the location is stored in. Click on a bar to see more information about the storage location.`
                     )
                 "
                 :data="objectStoresBySizeData"
                 :enable-selection="true"
                 v-bind="byteFormattingForChart">
                 <template v-slot:title>
-                    <b>{{ localize(`Object Stores by Usage`) }}</b>
+                    <b>{{ localize(`Storage locations by Usage`) }}</b>
                 </template>
                 <template v-slot:tooltip="{ data }">
                     <ShowObjectStore v-if="data" :object-store-id="data.id" />

--- a/client/src/components/User/DiskUsage/Visualizations/ObjectStoresStorageOverview.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/ObjectStoresStorageOverview.vue
@@ -20,9 +20,9 @@ const router = useRouter();
 
 const objectStoresBySizeData = ref<DataValuePoint[] | null>(null);
 
-const { isLoading, loadDataOnMount } = useDataLoading();
-
 const { getObjectStoreNameById } = useObjectStoreStore();
+
+const { isLoading, loadDataOnMount } = useDataLoading();
 
 loadDataOnMount(async () => {
     const { data } = await fetchObjectStoreUsages({ user_id: "current" });

--- a/client/src/components/User/DiskUsage/Visualizations/ObjectStoresStorageOverview.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/ObjectStoresStorageOverview.vue
@@ -3,6 +3,7 @@ import { ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { fetchObjectStoreUsages } from "@/api/users";
+import { useObjectStoreStore } from "@/stores/objectStoreStore";
 import localize from "@/utils/localization";
 
 import type { DataValuePoint } from "./Charts";
@@ -21,12 +22,14 @@ const objectStoresBySizeData = ref<DataValuePoint[] | null>(null);
 
 const { isLoading, loadDataOnMount } = useDataLoading();
 
+const { getObjectStoreNameById } = useObjectStoreStore();
+
 loadDataOnMount(async () => {
     const { data } = await fetchObjectStoreUsages({ user_id: "current" });
     const objectStoresBySize = data.sort((a, b) => b.total_disk_usage - a.total_disk_usage);
     objectStoresBySizeData.value = objectStoresBySize.map((objectStore) => ({
         id: objectStore.object_store_id,
-        label: objectStore.object_store_id,
+        label: getObjectStoreNameById(objectStore.object_store_id) ?? objectStore.object_store_id,
         value: objectStore.total_disk_usage,
     }));
 });

--- a/client/src/components/User/DiskUsage/Visualizations/ShowObjectStore.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/ShowObjectStore.vue
@@ -36,13 +36,13 @@ watch(
     }
 );
 fetch();
-const loadingMessage = "Loading object store details";
-const forWhat = "This object store is";
+const loadingMessage = "Loading storage location details";
+const forWhat = "This storage location is";
 </script>
 
 <template>
     <div style="width: 300px">
-        <LoadingSpan v-if="loading" :message="loadingMessage | localize" />
+        <LoadingSpan v-if="loading" v-localize :message="loadingMessage" />
         <DescribeObjectStore v-else-if="objectStore != null" :what="forWhat" :storage-info="objectStore">
         </DescribeObjectStore>
         <b-alert v-else-if="error" show variant="danger">{{ error }}</b-alert>

--- a/client/src/stores/objectStoreStore.ts
+++ b/client/src/stores/objectStoreStore.ts
@@ -27,6 +27,11 @@ export const useObjectStoreStore = defineStore("objectStoreStore", () => {
         }
     }
 
+    function getObjectStoreNameById(objectStoreId: string): string | null {
+        const objectStore = selectableObjectStores.value?.find((store) => store.object_store_id === objectStoreId);
+        return objectStore?.name ?? null;
+    }
+
     loadObjectStores();
 
     return {
@@ -34,5 +39,6 @@ export const useObjectStoreStore = defineStore("objectStoreStore", () => {
         isLoading,
         loadErrorMessage,
         selectableObjectStores,
+        getObjectStoreNameById,
     };
 });


### PR DESCRIPTION
Fixes #18454

In addition to displaying the name instead of the object store ID, this PR revises the user-facing language in a similar way to #17763 but for the new features introduced in 24.1

| Before | After |
|--------|-------|
| ![image](https://github.com/galaxyproject/galaxy/assets/46503462/0228a226-c405-4ae1-89e8-7e121fd413dc) | ![image](https://github.com/galaxyproject/galaxy/assets/46503462/8532c828-9da0-4f35-bed0-2d52e5c71154)  |

There are still some places where we use `storage location` or `storage source` both seem fine to me, not sure with which one we should stick for consistency.



## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
