### PR TITLE
Fix some Toolshed 2.0 development paper-cuts

### DIFF
--- a/lib/tool_shed/webapp/frontend/vite.config.ts
+++ b/lib/tool_shed/webapp/frontend/vite.config.ts
@@ -20,4 +20,15 @@ export default defineConfig({
             "@": fileURLToPath(new URL("./src", import.meta.url)),
         },
     },
+    server: {
+        proxy: {
+            "/api": {
+                // This is the URL of the backend server
+                // The address is the default when running `make run_test_backend`
+                target: "http://127.0.0.1:9009/",
+                changeOrigin: true,
+                secure: false,
+            },
+        },
+    },
 })

--- a/lib/tool_shed/webapp/frontend/vite.config.ts
+++ b/lib/tool_shed/webapp/frontend/vite.config.ts
@@ -1,23 +1,23 @@
-import { fileURLToPath } from 'url'
-import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
-import { quasar, transformAssetUrls } from '@quasar/vite-plugin'
+import { fileURLToPath } from "url"
+import { defineConfig } from "vite"
+import vue from "@vitejs/plugin-vue"
+import { quasar, transformAssetUrls } from "@quasar/vite-plugin"
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [
-    vue({
-      template: { transformAssetUrls },
-    }),
+    plugins: [
+        vue({
+            template: { transformAssetUrls },
+        }),
 
-    quasar({
-      sassVariables: 'src/quasar-variables.sass',
-    }),
-  ],
-  build: {},
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
+        quasar({
+            sassVariables: "src/quasar-variables.sass",
+        }),
+    ],
+    build: {},
+    resolve: {
+        alias: {
+            "@": fileURLToPath(new URL("./src", import.meta.url)),
+        },
     },
-  },
 })

--- a/scripts/bootstrap_test_shed.py
+++ b/scripts/bootstrap_test_shed.py
@@ -17,12 +17,10 @@ from typing import (
     Optional,
 )
 
-from galaxy.util import requests
-
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "lib")))
 
-
 from galaxy.tool_shed.util.hg_util import clone_repository
+from galaxy.util import requests
 from tool_shed.test.base.api import ensure_user_with_email
 from tool_shed.test.base.api_util import (
     create_user,


### PR DESCRIPTION
I found some things that drifted away since the last time this was working.

- Added a server proxy entry to `vite.config.ts` to point to the development backend URL `make run_test_backend`.
  - For some reason, in my local setup, only GraphQL could connect to the real backend (localhost:9009), while the API calls tried to connect to localhost:4040 resulting in 404.
- Fix an import issue in `scripts/bootstrap_test_shed.py` introduced inadvertently in a mass refactor.

Still, I can't get `scripts/bootstrap_test_shed.py` to run through in my local setup. There seem to be some missing test files and other development environment-dependent issues around it but it is not critical. It would be cool to have it though :smile: 


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Open a couple of terminals in galaxy/lib/tool_shed/webapp/frontend
  - Start the test server:
    - Run make run_test_backend
      - This successfully starts the server at http://127.0.0.1:9009/
  - Start the frontend in dev mode:
    - Run make dev
      - This starts the client at http://localhost:4040/

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
