### PR TITLE
add beacon credentials to galaxy

### DIFF
--- a/test/integration/user_preferences_extra_conf.yml
+++ b/test/integration/user_preferences_extra_conf.yml
@@ -3,7 +3,7 @@ preferences:
         description: Your own Beacon2 account
         inputs:
             - name: db_auth_source
-              label: Beacon Database authentication source
+              label: Beacon Database Authentication Source
               type: text
               required: False
             - name: db_user

--- a/test/integration/user_preferences_extra_conf.yml
+++ b/test/integration/user_preferences_extra_conf.yml
@@ -1,23 +1,17 @@
 preferences:
-    vaulttestsection:
-        description: A dummy extra prefs section
+    beacon2_account:
+        description: Your own Beacon2 account
         inputs:
-            - name: client_id
-              label: Client ID
+            - name: db_auth_source
+              label: Beacon Database authentication source
               type: text
-              required: True
-            - name: client_secret
-              label: Client Secret
+              required: False
+            - name: db_user
+              label: Beacon Database Username
+              type: text
+              required: False
+            - name: db_password
+              label: Beacon Database Password
               type: password
               store: vault
-              required: True
-            - name: access_token
-              label: Access token
-              type: password
-              store: vault
-              required: True
-            - name: refresh_token
-              label: Refresh Token
-              type: secret
-              store: vault
-              required: True
+              required: False


### PR DESCRIPTION
I am aiming to add Beacon credentials to Galaxy to wrap my tools into tools IUC 

The Galaxy expects to keep the credentials to the Galaxu UI like this. 

![image](https://github.com/user-attachments/assets/3af6407e-c0cd-4e07-9763-1f63bd5f7ef2)

For the tools you can find them in 

https://github.com/galaxyproject/tools-iuc/pull/6028

```
`<xml name="configfile">
        <configfiles>
            <configfile name="credentials"><![CDATA[
            #set $db_auth_source = $__user__.extra_preferences.get('beacon2_account|db_auth_source', "")
            #set $db_user = $__user__.extra_preferences.get('beacon2_account|db_user', "")
            #set $db_password = $__user__.extra_preferences.get('beacon2_account|db_password', "")
            #if $db_user == "" or $db_password == "" or $db_auth_source == "":
                #set $db_auth_source = "admin"
                #set $db_user = "root"
                #set $db_password = "example"
            #end if
            {
                "db_auth_source": "$db_auth_source",
                "db_user": "$db_user",
                "db_password": "$db_password"
            }
            ]]></configfile>
    </configfiles>`
```



how the are extracted from the tool will be like this 



```
--db-auth-source `jq -r .db_auth_source '$credentials'` 
--db-user `jq -r .db_user '$credentials'`
--db-password `jq -r .db_password '$credentials'`
```


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
