### PR TITLE
[24.1] Also check dataset.deleted when determining if data can be displayed

### DIFF
--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -193,7 +193,8 @@ class Interval(Tabular):
     def displayable(self, dataset: DatasetProtocol) -> bool:
         try:
             return (
-                not dataset.dataset.purged
+                not dataset.deleted
+                and not dataset.dataset.purged
                 and dataset.has_data()
                 and dataset.state == dataset.states.OK
                 and dataset.metadata.columns > 0

--- a/lib/galaxy/datatypes/protocols.py
+++ b/lib/galaxy/datatypes/protocols.py
@@ -16,6 +16,10 @@ class HasCreatingJob(Protocol):
     def creating_job(self): ...
 
 
+class HasDeleted(Protocol):
+    deleted: bool
+
+
 class HasExt(Protocol):
     @property
     def ext(self): ...
@@ -55,6 +59,7 @@ class HasExtraFilesAndMetadata(HasExtraFilesPath, HasMetadata, Protocol): ...
 
 class DatasetProtocol(
     HasCreatingJob,
+    HasDeleted,
     HasExt,
     HasExtraFilesPath,
     HasFileName,

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -134,7 +134,8 @@ class TabularData(Text):
     def displayable(self, dataset: DatasetProtocol) -> bool:
         try:
             return (
-                not dataset.dataset.purged
+                not dataset.deleted
+                and not dataset.dataset.purged
                 and dataset.has_data()
                 and dataset.state == dataset.states.OK
                 and dataset.metadata.columns > 0


### PR DESCRIPTION
This is being called when serialising HDAs in the poller if the HDA is expanded.
When we purge via celery we set the HDA to deleted, flush and purge async, so it is possible that the async task removes the dataset from disk while the ORM object in the poller still is in non-purged state.

I think this fixes
https://sentry.galaxyproject.org/share/issue/0ae7a9d9ad564054bd11c9a43aa6994c/:
```
FileNotFoundError: [Errno 2] No such file or directory: ''
  File "galaxy/datatypes/interval.py", line 914, in get_estimated_display_viewport
    with compression_utils.get_fileobj(dataset.get_file_name()) as fh:
  File "galaxy/util/compression_utils.py", line 79, in get_fileobj
    return get_fileobj_raw(filename, mode, compressed_formats)[1]
  File "galaxy/util/compression_utils.py", line 139, in get_fileobj_raw
    return compressed_format, open(filename, mode, encoding="utf-8")
```
The error occurred at the same second as the last update to the history_dataset_association.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
