### PR TITLE
Undo stack UI

### DIFF
--- a/client/src/components/UndoRedo/UndoRedoStack.vue
+++ b/client/src/components/UndoRedo/UndoRedoStack.vue
@@ -72,6 +72,8 @@ function updateSavedUndoActions() {
             <span class="state-indicator"> start of session </span>
         </div>
 
+        <span class="info"> click an action to undo/redo multiple changes </span>
+
         <label>
             Max saved changes
             <input
@@ -90,6 +92,14 @@ function updateSavedUndoActions() {
 
 <style scoped lang="scss">
 @import "theme/blue.scss";
+
+.info {
+    line-height: 1;
+    margin-bottom: 0.5rem;
+    margin-top: 0.25rem;
+    color: $text-muted;
+    font-style: italic;
+}
 
 .undo-redo-stack {
     width: 100%;

--- a/client/src/components/UndoRedo/UndoRedoStack.vue
+++ b/client/src/components/UndoRedo/UndoRedoStack.vue
@@ -27,6 +27,10 @@ watch(
 
             <span> current state </span>
 
+            <button v-if="currentStore.pendingLazyAction" @click="currentStore.undo">
+                {{ currentStore.pendingLazyAction.name }}
+            </button>
+
             <button
                 v-for="action in [...currentStore.undoActionStack].reverse()"
                 :key="action.id"
@@ -44,6 +48,7 @@ watch(
     .scroll-list {
         display: flex;
         flex-direction: column;
+        overflow-y: auto;
     }
 }
 </style>

--- a/client/src/components/UndoRedo/UndoRedoStack.vue
+++ b/client/src/components/UndoRedo/UndoRedoStack.vue
@@ -1,7 +1,13 @@
 <script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faHistory } from "@fortawesome/free-solid-svg-icons";
 import { ref, watch } from "vue";
 
 import { useUndoRedoStore } from "@/stores/undoRedoStore";
+
+import Heading from "@/components/Common/Heading.vue";
+
+library.add(faHistory);
 
 const props = defineProps<{
     storeId: string;
@@ -17,23 +23,27 @@ watch(
 
 <template>
     <section class="undo-redo-stack">
+        <Heading h2 size="sm" icon="fa-history">Latest Changes</Heading>
+
         <div class="scroll-list">
             <button
                 v-for="action in currentStore.redoActionStack"
                 :key="action.id"
+                class="action future"
                 @click="currentStore.rollForwardTo(action)">
                 {{ action.name }}
             </button>
 
-            <span> current state </span>
+            <span class="current-state"> current state </span>
 
-            <button v-if="currentStore.pendingLazyAction" @click="currentStore.undo">
+            <button v-if="currentStore.pendingLazyAction" class="action lazy" @click="currentStore.undo">
                 {{ currentStore.pendingLazyAction.name }}
             </button>
 
             <button
                 v-for="action in [...currentStore.undoActionStack].reverse()"
                 :key="action.id"
+                class="action past"
                 @click="currentStore.rollBackTo(action)">
                 {{ action.name }}
             </button>
@@ -42,13 +52,80 @@ watch(
 </template>
 
 <style scoped lang="scss">
+@import "theme/blue.scss";
+
 .undo-redo-stack {
     width: 100%;
+
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    overflow-y: hidden;
+
+    display: flex;
+    flex-direction: column;
 
     .scroll-list {
         display: flex;
         flex-direction: column;
         overflow-y: auto;
+    }
+}
+
+.action {
+    text-align: left;
+    background-color: transparent;
+    border: none;
+    padding: 0.1rem;
+    padding-left: 0;
+    line-height: 1.2;
+
+    display: grid;
+    grid-template-columns: 8px auto;
+    align-items: center;
+    gap: 0.5rem;
+
+    &::before {
+        content: "";
+        display: block;
+        height: 2px;
+        background-color: $brand-secondary;
+    }
+
+    &:focus-visible {
+        background-color: $brand-secondary;
+    }
+
+    &.lazy {
+        color: $text-muted;
+    }
+
+    &.future {
+        color: $text-light;
+    }
+
+    &.past {
+        &::before {
+            background-color: $text-light;
+        }
+    }
+}
+
+.current-state {
+    display: grid;
+    grid-template-columns: 1rem auto 1fr;
+    gap: 0.5rem;
+    align-items: center;
+    color: $text-light;
+
+    &::before,
+    &::after {
+        content: "";
+        display: block;
+        height: 2px;
+        background-color: $brand-secondary;
     }
 }
 </style>

--- a/client/src/components/UndoRedo/UndoRedoStack.vue
+++ b/client/src/components/UndoRedo/UndoRedoStack.vue
@@ -1,16 +1,11 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { ref, watch } from "vue";
 
 import { useUndoRedoStore } from "@/stores/undoRedoStore";
 
-import Heading from "@/components/Common/Heading.vue";
-
 const props = defineProps<{
     storeId: string;
-    heading?: string;
 }>();
-
-const heading = computed(() => props.heading ?? "Undo Redo Stack");
 
 const currentStore = ref(useUndoRedoStore(props.storeId));
 
@@ -22,13 +17,20 @@ watch(
 
 <template>
     <section class="undo-redo-stack">
-        <Heading h2 size="sm"> {{ heading }} </Heading>
         <div class="scroll-list">
-            <button v-for="action in currentStore.redoActionStack" :key="action.id">
+            <button
+                v-for="action in currentStore.redoActionStack"
+                :key="action.id"
+                @click="currentStore.rollForwardTo(action)">
                 {{ action.name }}
             </button>
 
-            <button v-for="action in currentStore.undoActionStack" :key="action.id">
+            <span> current state </span>
+
+            <button
+                v-for="action in [...currentStore.undoActionStack].reverse()"
+                :key="action.id"
+                @click="currentStore.rollBackTo(action)">
                 {{ action.name }}
             </button>
         </div>
@@ -37,5 +39,11 @@ watch(
 
 <style scoped lang="scss">
 .undo-redo-stack {
+    width: 100%;
+
+    .scroll-list {
+        display: flex;
+        flex-direction: column;
+    }
 }
 </style>

--- a/client/src/components/UndoRedo/UndoRedoStack.vue
+++ b/client/src/components/UndoRedo/UndoRedoStack.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+
+import { useUndoRedoStore } from "@/stores/undoRedoStore";
+
+import Heading from "@/components/Common/Heading.vue";
+
+const props = defineProps<{
+    storeId: string;
+    heading?: string;
+}>();
+
+const heading = computed(() => props.heading ?? "Undo Redo Stack");
+
+const currentStore = ref(useUndoRedoStore(props.storeId));
+
+watch(
+    () => props.storeId,
+    (id) => (currentStore.value = useUndoRedoStore(id))
+);
+</script>
+
+<template>
+    <section class="undo-redo-stack">
+        <Heading h2 size="sm"> {{ heading }} </Heading>
+        <div class="scroll-list">
+            <button v-for="action in currentStore.redoActionStack" :key="action.id">
+                {{ action.name }}
+            </button>
+
+            <button v-for="action in currentStore.undoActionStack" :key="action.id">
+                {{ action.name }}
+            </button>
+        </div>
+    </section>
+</template>
+
+<style scoped lang="scss">
+.undo-redo-stack {
+}
+</style>

--- a/client/src/components/UndoRedo/UndoRedoStack.vue
+++ b/client/src/components/UndoRedo/UndoRedoStack.vue
@@ -34,7 +34,7 @@ watch(
                 {{ action.name }}
             </button>
 
-            <span class="current-state"> current state </span>
+            <span class="state-indicator"> current state </span>
 
             <button v-if="currentStore.pendingLazyAction" class="action lazy" @click="currentStore.undo">
                 {{ currentStore.pendingLazyAction.name }}
@@ -48,9 +48,13 @@ watch(
                 {{ action.name }}
             </button>
 
+            <span v-if="currentStore.deletedActions.length !== 0" class="state-indicator"> latest saved state </span>
+
             <span v-for="(action, i) in [...currentStore.deletedActions].reverse()" :key="i" class="action dead">
                 {{ action }}
             </span>
+
+            <span class="state-indicator"> start of session </span>
         </div>
 
         <label>
@@ -130,7 +134,7 @@ watch(
     }
 }
 
-.current-state {
+.state-indicator {
     display: grid;
     grid-template-columns: 1rem auto 1fr;
     gap: 0.5rem;

--- a/client/src/components/UndoRedo/UndoRedoStack.vue
+++ b/client/src/components/UndoRedo/UndoRedoStack.vue
@@ -19,6 +19,21 @@ watch(
     () => props.storeId,
     (id) => (currentStore.value = useUndoRedoStore(id))
 );
+
+function onInput(event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    const valueNumber = parseFloat(value);
+    const nonNanValue = isNaN(valueNumber) ? 0 : valueNumber;
+
+    currentStore.value.savedUndoActions = nonNanValue;
+    savedUndoActions.value = nonNanValue;
+}
+
+const savedUndoActions = ref(currentStore.value.savedUndoActions);
+
+function updateSavedUndoActions() {
+    savedUndoActions.value = currentStore.value.savedUndoActions;
+}
 </script>
 
 <template>
@@ -59,7 +74,16 @@ watch(
 
         <label>
             Max saved changes
-            <input v-model.number="currentStore.maxUndoActions" type="number" step="1" min="10" max="10000" />
+            <input
+                :value="savedUndoActions"
+                type="number"
+                step="1"
+                :min="currentStore.minUndoActions"
+                :max="currentStore.maxUndoActions"
+                @input="onInput"
+                @focusin="updateSavedUndoActions"
+                @focusout="updateSavedUndoActions"
+                @keyup.enter="updateSavedUndoActions" />
         </label>
     </section>
 </template>

--- a/client/src/components/UndoRedo/UndoRedoStack.vue
+++ b/client/src/components/UndoRedo/UndoRedoStack.vue
@@ -47,7 +47,16 @@ watch(
                 @click="currentStore.rollBackTo(action)">
                 {{ action.name }}
             </button>
+
+            <span v-for="(action, i) in [...currentStore.deletedActions].reverse()" :key="i" class="action dead">
+                {{ action }}
+            </span>
         </div>
+
+        <label>
+            Max saved changes
+            <input v-model.number="currentStore.maxUndoActions" type="number" step="1" min="10" max="10000" />
+        </label>
     </section>
 </template>
 
@@ -71,6 +80,7 @@ watch(
         display: flex;
         flex-direction: column;
         overflow-y: auto;
+        flex: 1;
     }
 }
 
@@ -109,6 +119,13 @@ watch(
     &.past {
         &::before {
             background-color: $text-light;
+        }
+    }
+
+    &.dead {
+        color: $text-light;
+        &::before {
+            background-color: transparent;
         }
     }
 }

--- a/client/src/components/Workflow/Editor/Actions/stepActions.ts
+++ b/client/src/components/Workflow/Editor/Actions/stepActions.ts
@@ -326,7 +326,7 @@ export class RemoveStepAction extends UndoRedoAction {
     }
 
     get name() {
-        return `remove ${this.step.label ?? this.step.name}`;
+        return `remove step ${this.step.label ?? this.step.name}`;
     }
 
     run() {
@@ -492,7 +492,7 @@ export function useStepActions(
             step,
             key: "position",
             value: position,
-            name: `move "${step.id + 1}: ${step.label ?? step.name}"`,
+            name: `move step "${step.id + 1}: ${step.label ?? step.name}"`,
         });
     }
 
@@ -501,7 +501,7 @@ export function useStepActions(
             step,
             key: "annotation",
             value: annotation,
-            name: `edit annotation of "${step.id + 1}: ${step.label ?? step.name}"`,
+            name: `edit annotation of step "${step.id + 1}: ${step.label ?? step.name}"`,
         });
     }
 
@@ -518,7 +518,7 @@ export function useStepActions(
             step,
             key: "workflow_outputs",
             value: workflowOutputs,
-            name: `edit output label of "${step.id + 1}: ${step.label ?? step.name}"`,
+            name: `edit output label of step "${step.id + 1}: ${step.label ?? step.name}"`,
             actionConstructor,
             keepActionAlive: true,
             timeout: 2000,

--- a/client/src/components/Workflow/Editor/Actions/stepActions.ts
+++ b/client/src/components/Workflow/Editor/Actions/stepActions.ts
@@ -326,7 +326,7 @@ export class RemoveStepAction extends UndoRedoAction {
     }
 
     get name() {
-        return `remove step ${this.step.label ?? this.step.name}`;
+        return `remove step "${this.step.id} ${this.step.label ?? this.step.name}"`;
     }
 
     run() {

--- a/client/src/components/Workflow/Editor/Actions/stepActions.ts
+++ b/client/src/components/Workflow/Editor/Actions/stepActions.ts
@@ -347,6 +347,7 @@ export class CopyStepAction extends UndoRedoAction {
     stepStore;
     stateStore;
     step: NewStep;
+    stepLabel;
     stepId?: number;
     onUndoRedo?: () => void;
 
@@ -356,12 +357,13 @@ export class CopyStepAction extends UndoRedoAction {
         this.stateStore = stateStore;
 
         const labelSet = getLabelSet(stepStore);
+        this.stepLabel = `${step.id + 1}: ${step.label ?? step.name}`;
         this.step = cloneStepWithUniqueLabel(step, labelSet);
         delete this.step.id;
     }
 
     get name() {
-        return `duplicate step ${this.step.label ?? this.step.name}`;
+        return `duplicate step "${this.stepLabel}"`;
     }
 
     run() {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -59,6 +59,12 @@
                         @click="undoRedoStore.redo()">
                         <FontAwesomeIcon icon="fa-arrow-right" />
                     </b-button>
+                    <b-button
+                        title="View Last Changes"
+                        :variant="showInPanel === 'changes' ? 'primary' : 'link'"
+                        @click="toggleShowChanges">
+                        <FontAwesomeIcon icon="fa-history" />
+                    </b-button>
                 </b-button-group>
             </div>
             <WorkflowGraph
@@ -97,8 +103,7 @@
                             @onEdit="onEdit"
                             @onAttributes="showAttributes"
                             @onLint="onLint"
-                            @onUpgrade="onUpgrade"
-                            @onViewChanges="toggleShowChanges" />
+                            @onUpgrade="onUpgrade" />
                     </div>
                 </div>
                 <div ref="rightPanelElement" class="unified-panel-body workflow-right p-2">
@@ -182,7 +187,7 @@
 
 <script>
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faArrowLeft, faArrowRight } from "@fortawesome/free-solid-svg-icons";
+import { faArrowLeft, faArrowRight, faHistory } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { useMagicKeys, whenever } from "@vueuse/core";
 import { logicAnd, logicNot, logicOr } from "@vueuse/math";
@@ -225,7 +230,7 @@ import UndoRedoStack from "@/components/UndoRedo/UndoRedoStack.vue";
 import FormDefault from "@/components/Workflow/Editor/Forms/FormDefault.vue";
 import FormTool from "@/components/Workflow/Editor/Forms/FormTool.vue";
 
-library.add(faArrowLeft, faArrowRight);
+library.add(faArrowLeft, faArrowRight, faHistory);
 
 export default {
     components: {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -107,7 +107,7 @@
                     </div>
                 </div>
                 <div ref="rightPanelElement" class="unified-panel-body workflow-right p-2">
-                    <div v-if="!initialLoading">
+                    <div v-if="!initialLoading" class="position-relative h-100">
                         <UndoRedoStack v-if="showInPanel === 'changes'" :store-id="id" />
                         <FormTool
                             v-else-if="hasActiveNodeTool"

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -61,7 +61,7 @@
                     </b-button>
                     <b-button
                         title="View Last Changes"
-                        :variant="showInPanel === 'changes' ? 'primary' : 'link'"
+                        :variant="showChanges ? 'primary' : 'link'"
                         @click="toggleShowChanges">
                         <FontAwesomeIcon icon="fa-history" />
                     </b-button>
@@ -80,8 +80,7 @@
                 @onCreate="onInsertTool"
                 @onChange="onChange"
                 @onRemove="onRemove"
-                @onUpdateStepPosition="onUpdateStepPosition"
-                @onViewChanges="() => (showInPanel = 'changes')">
+                @onUpdateStepPosition="onUpdateStepPosition">
             </WorkflowGraph>
         </div>
         <FlexPanel side="right">
@@ -101,14 +100,14 @@
                             @onReport="onReport"
                             @onLayout="onLayout"
                             @onEdit="onEdit"
-                            @onAttributes="showAttributes"
+                            @onAttributes="() => showAttributes(true)"
                             @onLint="onLint"
                             @onUpgrade="onUpgrade" />
                     </div>
                 </div>
                 <div ref="rightPanelElement" class="unified-panel-body workflow-right p-2">
                     <div v-if="!initialLoading" class="position-relative h-100">
-                        <UndoRedoStack v-if="showInPanel === 'changes'" :store-id="id" />
+                        <UndoRedoStack v-if="showChanges" :store-id="id" />
                         <FormTool
                             v-else-if="hasActiveNodeTool"
                             :key="activeStep.id"
@@ -154,7 +153,7 @@
                             :license="license"
                             :steps="steps"
                             :datatypes-mapper="datatypesMapper"
-                            @onAttributes="showAttributes"
+                            @onAttributes="() => showAttributes(true)"
                             @onHighlight="onHighlight"
                             @onUnhighlight="onUnhighlight"
                             @onRefactor="onAttemptRefactor"
@@ -302,18 +301,18 @@ export default {
         }
 
         const showInPanel = ref("attributes");
+        const showChanges = ref(false);
 
         function toggleShowChanges() {
-            if (showInPanel.value !== "changes") {
-                ensureParametersSet();
-                stateStore.activeNodeId = null;
-                showInPanel.value = "changes";
-            } else {
-                showAttributes();
-            }
+            ensureParametersSet();
+            showChanges.value = !showChanges.value;
         }
 
-        function showAttributes() {
+        function showAttributes(closeChanges = false) {
+            if (closeChanges) {
+                showChanges.value = false;
+            }
+
             ensureParametersSet();
             stateStore.activeNodeId = null;
             showInPanel.value = "attributes";
@@ -462,6 +461,7 @@ export default {
             parameters,
             ensureParametersSet,
             showInPanel,
+            showChanges,
             toggleShowChanges,
             showAttributes,
             setName,

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -798,6 +798,7 @@ export default {
             this.ensureParametersSet();
             this.stateStore.activeNodeId = null;
             this.showInPanel = "lint";
+            this.showChanges = false;
         },
         onUpgrade() {
             this.onAttemptRefactor([{ action_type: "upgrade_all_steps" }]);

--- a/client/src/components/Workflow/Editor/Options.vue
+++ b/client/src/components/Workflow/Editor/Options.vue
@@ -1,8 +1,24 @@
 <script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faSave } from "@fortawesome/free-regular-svg-icons";
+import {
+    faAlignLeft,
+    faCog,
+    faDownload,
+    faEdit,
+    faHistory,
+    faMagic,
+    faPencilAlt,
+    faPlay,
+    faRecycle,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton, BDropdown, BDropdownItem } from "bootstrap-vue";
 import { computed } from "vue";
 
 import { useConfirmDialog } from "@/composables/confirmDialog";
+
+library.add(faPencilAlt, faEdit, faCog, faAlignLeft, faMagic, faRecycle, faDownload, faPlay, faHistory, faSave);
 
 const emit = defineEmits<{
     (e: "onAttributes"): void;
@@ -15,6 +31,7 @@ const emit = defineEmits<{
     (e: "onUpgrade"): void;
     (e: "onDownload"): void;
     (e: "onRun"): void;
+    (e: "onViewChanges"): void;
 }>();
 
 const props = defineProps<{
@@ -22,6 +39,7 @@ const props = defineProps<{
     hasChanges?: boolean;
     hasInvalidConnections?: boolean;
     requiredReindex?: boolean;
+    currentActivePanel: string;
 }>();
 
 const { confirm } = useConfirmDialog();
@@ -64,6 +82,7 @@ async function onSave() {
     }
 }
 </script>
+
 <template>
     <div class="panel-header-buttons">
         <BButton
@@ -74,9 +93,10 @@ async function onSave() {
             variant="link"
             aria-label="Edit Attributes"
             class="editor-button-attributes"
-            @click="$emit('onAttributes')">
-            <span class="fa fa-pencil-alt" />
+            @click="emit('onAttributes')">
+            <FontAwesomeIcon icon="fa fa-pencil-alt" />
         </BButton>
+
         <b-button-group v-b-tooltip.hover.noninteractive class="editor-button-save-group" :title="saveHover">
             <BButton
                 id="workflow-save-button"
@@ -86,9 +106,10 @@ async function onSave() {
                 class="editor-button-save"
                 :disabled="!isNewTempWorkflow && !hasChanges"
                 @click="onSave">
-                <span class="fa fa-floppy-o" />
+                <FontAwesomeIcon icon="far fa-save" />
             </BButton>
         </b-button-group>
+
         <BButton
             id="workflow-report-button"
             v-b-tooltip.hover.noninteractive
@@ -98,9 +119,10 @@ async function onSave() {
             aria-label="Edit Report"
             class="editor-button-report"
             :disabled="isNewTempWorkflow"
-            @click="$emit('onReport')">
-            <span class="fa fa-edit" />
+            @click="emit('onReport')">
+            <FontAwesomeIcon icon="fa fa-edit" />
         </BButton>
+
         <BDropdown
             id="workflow-options-button"
             v-b-tooltip.hover.noninteractive
@@ -113,18 +135,40 @@ async function onSave() {
             class="editor-button-options"
             :disabled="isNewTempWorkflow">
             <template v-slot:button-content>
-                <span class="fa fa-cog" />
+                <FontAwesomeIcon icon="fa fa-cog" />
             </template>
-            <BDropdownItem href="#" @click="$emit('onSaveAs')"><span class="fa fa-floppy-o" />Save As...</BDropdownItem>
-            <BDropdownItem href="#" @click="$emit('onLayout')"
-                ><span class="fa fa-align-left" />Auto Layout</BDropdownItem
-            >
-            <BDropdownItem href="#" @click="$emit('onLint')"><span class="fa fa-magic" />Best Practices</BDropdownItem>
-            <BDropdownItem href="#" @click="$emit('onUpgrade')"
-                ><span class="fa fa-recycle" />Upgrade Workflow</BDropdownItem
-            >
-            <BDropdownItem href="#" @click="$emit('onDownload')"><span class="fa fa-download" />Download</BDropdownItem>
+
+            <BDropdownItem href="#" @click="emit('onSaveAs')">
+                <FontAwesomeIcon icon="far fa-save" /> Save As...
+            </BDropdownItem>
+
+            <BDropdownItem href="#" @click="emit('onLayout')">
+                <FontAwesomeIcon icon="fa fa-align-left" /> Auto Layout
+            </BDropdownItem>
+
+            <BDropdownItem href="#" @click="emit('onLint')">
+                <FontAwesomeIcon icon="fa fa-magic" /> Best Practices
+            </BDropdownItem>
+
+            <BDropdownItem href="#" @click="emit('onUpgrade')">
+                <FontAwesomeIcon icon="fa fa-recycle" /> Upgrade Workflow
+            </BDropdownItem>
+
+            <BDropdownItem href="#" @click="emit('onDownload')">
+                <FontAwesomeIcon icon="fa fa-download" /> Download
+            </BDropdownItem>
         </BDropdown>
+
+        <BButton
+            v-b-tooltip.hover.noninteractive
+            title="View Last Changes"
+            role="button"
+            :variant="props.currentActivePanel === 'changes' ? 'primary' : 'link'"
+            aria-label="View Last Changes"
+            @click="emit('onViewChanges')">
+            <FontAwesomeIcon icon="fa fa-history" />
+        </BButton>
+
         <BButton
             id="workflow-run-button"
             v-b-tooltip.hover.noninteractive
@@ -134,8 +178,8 @@ async function onSave() {
             aria-label="Run Workflow"
             class="editor-button-run"
             :disabled="isNewTempWorkflow"
-            @click="$emit('onRun')">
-            <span class="fa fa-play" />
+            @click="emit('onRun')">
+            <FontAwesomeIcon icon="fa fa-play" />
         </BButton>
     </div>
 </template>

--- a/client/src/components/Workflow/Editor/Options.vue
+++ b/client/src/components/Workflow/Editor/Options.vue
@@ -18,7 +18,7 @@ import { computed } from "vue";
 
 import { useConfirmDialog } from "@/composables/confirmDialog";
 
-library.add(faPencilAlt, faEdit, faCog, faAlignLeft, faMagic, faRecycle, faDownload, faPlay, faHistory, faSave);
+library.add(faPencilAlt, faEdit, faCog, faAlignLeft, faMagic, faDownload, faPlay, faHistory, faSave, faRecycle);
 
 const emit = defineEmits<{
     (e: "onAttributes"): void;
@@ -31,7 +31,6 @@ const emit = defineEmits<{
     (e: "onUpgrade"): void;
     (e: "onDownload"): void;
     (e: "onRun"): void;
-    (e: "onViewChanges"): void;
 }>();
 
 const props = defineProps<{
@@ -158,16 +157,6 @@ async function onSave() {
                 <FontAwesomeIcon icon="fa fa-download" /> Download
             </BDropdownItem>
         </BDropdown>
-
-        <BButton
-            v-b-tooltip.hover.noninteractive
-            title="View Last Changes"
-            role="button"
-            :variant="props.currentActivePanel === 'changes' ? 'primary' : 'link'"
-            aria-label="View Last Changes"
-            @click="emit('onViewChanges')">
-            <FontAwesomeIcon icon="fa fa-history" />
-        </BButton>
 
         <BButton
             id="workflow-run-button"

--- a/client/src/composables/math.ts
+++ b/client/src/composables/math.ts
@@ -1,0 +1,49 @@
+/**
+ * There are similar functions to those in this module in vue-use, but they only work one-way.
+ * Unlike vue-use, these composables return refs which can be set.
+ */
+
+import { type MaybeRefOrGetter, toValue } from "@vueuse/core";
+import { computed, type Ref } from "vue";
+
+/**
+ * Wraps a number ref, restricting it's values to a given range
+ *
+ * @param ref ref containing a number to wrap
+ * @param min lowest possible value of range
+ * @param max highest possible value of range
+ * @returns clamped ref
+ */
+export function useClamp(ref: Ref<number>, min: MaybeRefOrGetter<number>, max: MaybeRefOrGetter<number>): Ref<number> {
+    const clamp = (value: number) => {
+        return Math.min(Math.max(value, toValue(min)), toValue(max));
+    };
+
+    const clampedRef = computed({
+        get: () => clamp(ref.value),
+        set: (value) => (ref.value = clamp(value)),
+    });
+
+    return clampedRef;
+}
+
+/**
+ * Wraps a number ref, restricting it's values to align to a given step size
+ *
+ * @param ref ref containing a number to wrap
+ * @param stepSize size of steps to restrict value to
+ * @returns wrapped red
+ */
+export function useStep(ref: Ref<number>, stepSize: MaybeRefOrGetter<number> = 1): Ref<number> {
+    const step = (value: number) => {
+        const stepSizeValue = toValue(stepSize);
+        return Math.round(value / stepSizeValue) * stepSizeValue;
+    };
+
+    const steppedRef = computed({
+        get: () => step(ref.value),
+        set: (value) => (ref.value = step(value)),
+    });
+
+    return steppedRef;
+}

--- a/client/src/composables/math.ts
+++ b/client/src/composables/math.ts
@@ -31,7 +31,7 @@ export function useClamp(ref: Ref<number>, min: MaybeRefOrGetter<number>, max: M
  * Wraps a number ref, restricting it's values to align to a given step size
  *
  * @param ref ref containing a number to wrap
- * @param stepSize size of steps to restrict value to
+ * @param [stepSize = 1] size of steps to restrict value to. defaults to 1
  * @returns wrapped red
  */
 export function useStep(ref: Ref<number>, stepSize: MaybeRefOrGetter<number> = 1): Ref<number> {

--- a/client/src/stores/undoRedoStore/index.ts
+++ b/client/src/stores/undoRedoStore/index.ts
@@ -18,11 +18,11 @@ export class ActionOutOfBoundsError extends Error {
     }
 }
 
-export const useUndoRedoStore = defineScopedStore("undoRedoStore", (scope) => {
+export const useUndoRedoStore = defineScopedStore("undoRedoStore", () => {
     const undoActionStack = ref<UndoRedoAction[]>([]);
     const redoActionStack = ref<UndoRedoAction[]>([]);
 
-    const maxUndoActions = useUserLocalStorage(`undoRedoStore-maxUndoActions-${scope}`, 100);
+    const maxUndoActions = useUserLocalStorage(`undoRedoStore-maxUndoActions`, 100);
 
     /** names of actions which were deleted due to maxUndoActions being exceeded */
     const deletedActions = ref<string[]>([]);

--- a/client/src/stores/undoRedoStore/index.ts
+++ b/client/src/stores/undoRedoStore/index.ts
@@ -36,6 +36,8 @@ export const useUndoRedoStore = defineScopedStore("undoRedoStore", () => {
         undoActionStack.value.forEach((action) => action.destroy());
         undoActionStack.value = [];
         deletedActions.value = [];
+        minUndoActions.value = 10;
+        maxUndoActions.value = 10000;
         clearRedoStack();
     }
 

--- a/client/src/stores/undoRedoStore/index.ts
+++ b/client/src/stores/undoRedoStore/index.ts
@@ -30,6 +30,7 @@ export const useUndoRedoStore = defineScopedStore("undoRedoStore", (scope) => {
     function $reset() {
         undoActionStack.value.forEach((action) => action.destroy());
         undoActionStack.value = [];
+        deletedActions.value = [];
         clearRedoStack();
     }
 

--- a/client/src/stores/undoRedoStore/index.ts
+++ b/client/src/stores/undoRedoStore/index.ts
@@ -151,6 +151,7 @@ export const useUndoRedoStore = defineScopedStore("undoRedoStore", () => {
     });
 
     function rollBackTo(action: UndoRedoAction) {
+        flushLazyAction();
         const undoSet = new Set(undoActionStack.value);
 
         if (!undoSet.has(action)) {
@@ -163,6 +164,7 @@ export const useUndoRedoStore = defineScopedStore("undoRedoStore", () => {
     }
 
     function rollForwardTo(action: UndoRedoAction) {
+        flushLazyAction();
         const redoSet = new Set(redoActionStack.value);
 
         if (!redoSet.has(action)) {

--- a/client/src/stores/undoRedoStore/undoRedoAction.ts
+++ b/client/src/stores/undoRedoStore/undoRedoAction.ts
@@ -1,5 +1,12 @@
+let idCounter = 0;
+
 export class UndoRedoAction {
     protected internalName?: string;
+    public id: number;
+
+    constructor() {
+        this.id = idCounter++;
+    }
 
     get name(): string | undefined {
         return this.internalName;

--- a/client/src/stores/workflowEditorCommentStore.ts
+++ b/client/src/stores/workflowEditorCommentStore.ts
@@ -69,6 +69,8 @@ export type WorkflowComment =
     | MarkdownWorkflowComment
     | FreehandWorkflowComment;
 
+export type WorkflowCommentType = WorkflowComment["type"];
+
 interface CommentsMetadata {
     justCreated?: boolean;
     multiSelected?: boolean;


### PR DESCRIPTION
Adds a UI for the undo/redo stack. Allows for quickly scrolling back and forth between multiple changes, and editing how many changes are stored (10 - 10 000 with 100 being default). Also shows what changes were made past the stored changes.

![Screen Shot 2024-07-16 at 16 04 39](https://github.com/user-attachments/assets/41539e5b-0556-4673-8f14-b4337d6fac6f)

Also makes existing action names more descriptive.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
