### PR TITLE
[24.1] Simplify and fix `useDatatypesMapper`

### DIFF
--- a/client/src/composables/datatypesMapper.ts
+++ b/client/src/composables/datatypesMapper.ts
@@ -11,19 +11,11 @@ export function useDatatypesMapper() {
     const datatypes: Ref<string[]> = ref([]);
 
     async function getDatatypesMapper() {
-        try {
-            await datatypesMapperStore.createMapper();
-            datatypesMapper.value = datatypesMapperStore.datatypesMapper;
-            if (datatypesMapperStore.datatypesMapper) {
-                datatypes.value = datatypesMapperStore.datatypesMapper.datatypes;
-            }
-        } catch (e) {
-            console.error("unable to create datatypes mapper\n", e);
-        } finally {
-            datatypesMapperLoading.value = false;
-        }
-        if (!datatypesMapperStore.datatypesMapper) {
-            throw Error("Error creating datatypesMapper");
+        await datatypesMapperStore.createMapper();
+        datatypesMapperLoading.value = datatypesMapperStore.loading;
+        datatypesMapper.value = datatypesMapperStore.datatypesMapper;
+        if (datatypesMapperStore.datatypesMapper) {
+            datatypes.value = datatypesMapperStore.datatypesMapper.datatypes;
         }
     }
 


### PR DESCRIPTION
The problem was that we'd immediately return if `createMapper` had previously been called in another calling stack. I think we don't need to do any error handling here, and the loading state can simply be `datatypesMapperStore.loading`.

Fixes https://github.com/galaxyproject/galaxy/issues/18549

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
