### PR TITLE
[24.1] Update h5web

### DIFF
--- a/config/plugins/visualizations/h5web/package.json
+++ b/config/plugins/visualizations/h5web/package.json
@@ -8,16 +8,17 @@
     ],
     "license": "AFL-3.0",
     "dependencies": {
-        "@h5web/app": "^8.0.0",
+        "@h5web/app": "^12.0.1",
         "buffer": "^6.0.3",
         "normalize.css": "^8.0.1",
-        "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react": "18.3.1",
+        "react-dom": "18.3.1"
     },
     "scripts": {
         "build": "parcel build src/script.js --dist-dir static"
     },
     "devDependencies": {
-        "parcel": "^2.12.0"
+        "parcel": "^2.12.0",
+        "process": "^0.11.10"
     }
 }

--- a/lib/galaxy_test/selenium/test_visualizations.py
+++ b/lib/galaxy_test/selenium/test_visualizations.py
@@ -47,3 +47,21 @@ class TestVisualizations(SeleniumTestCase):
         with self.visualization_panel():
             self.wait_for_selector("g.nvd3")
             self.screenshot("visualization_plugin_charts_nvd3_bar_landing")
+
+    @managed_history
+    @selenium_test
+    @skip_without_visualization_plugin("h5web")
+    def test_charts_h5web(self):
+        hid = 1
+        self.perform_upload(self.get_filename("chopper.h5"))
+        dataset_component = self.history_panel_click_item_title(hid, wait=True)
+        dataset_component.visualize_button.wait_for_and_click()
+
+        self.components.visualization.plugin_item(id="h5web").wait_for_visible()
+        self.screenshot("visualization_plugins_h5")
+        self.components.visualization.plugin_item(id="h5web").wait_for_and_click()
+
+        with self.visualization_panel():
+            # Look for the h5web-explorer-tree identifier to verify it loads.
+            self.wait_for_selector("#h5web-explorer-tree")
+            self.screenshot("visualization_plugin_charts_h5web_landing")

--- a/lib/galaxy_test/selenium/test_visualizations.py
+++ b/lib/galaxy_test/selenium/test_visualizations.py
@@ -54,6 +54,7 @@ class TestVisualizations(SeleniumTestCase):
     def test_charts_h5web(self):
         hid = 1
         self.perform_upload(self.get_filename("chopper.h5"))
+        self.history_panel_wait_for_hid_ok(hid)
         dataset_component = self.history_panel_click_item_title(hid, wait=True)
         dataset_component.visualize_button.wait_for_and_click()
 

--- a/test/functional/tools/sample_datatypes_conf.xml
+++ b/test/functional/tools/sample_datatypes_conf.xml
@@ -59,5 +59,6 @@
     </datatype>
     <datatype extension="directory" type="galaxy.datatypes.data:Directory">
     </datatype>
+    <datatype extension="h5" type="galaxy.datatypes.binary:H5" mimetype="application/octet-stream" display_in_upload="true"/>
   </registration>
 </datatypes>


### PR DESCRIPTION
We were several major versions out of date and I'm guessing the h5py/h5web python dependencies just got too far ahead of the viz, causing #18530.  In any event, in my local testing with this update it should be compatible with the provider now.

Will follow up with one more commit with better testing of this viz.

![image](https://github.com/user-attachments/assets/c1c18efa-52c4-4ea0-a43a-acd064e1968f)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
