### PR TITLE
Improve datasets permissions API schema typing

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -3981,6 +3981,11 @@ export interface components {
             name: string;
         };
         /**
+         * DatasetPermissionAction
+         * @enum {string}
+         */
+        DatasetPermissionAction: "set_permissions" | "make_private" | "remove_restrictions";
+        /**
          * DatasetPermissions
          * @description Role-based permissions for accessing and managing a dataset.
          */
@@ -12272,6 +12277,69 @@ export interface components {
             /** Creator */
             creator?: unknown;
         };
+        /** UpdateDatasetPermissionsPayload */
+        UpdateDatasetPermissionsPayload: {
+            /** Access Ids[] */
+            "access_ids[]"?: string[] | string | null;
+            /**
+             * Action
+             * @description Indicates what action should be performed on the dataset.
+             * @default set_permissions
+             */
+            action?: components["schemas"]["DatasetPermissionAction"] | null;
+            /** Manage Ids[] */
+            "manage_ids[]"?: string[] | string | null;
+            /** Modify Ids[] */
+            "modify_ids[]"?: string[] | string | null;
+        };
+        /** UpdateDatasetPermissionsPayloadAliasB */
+        UpdateDatasetPermissionsPayloadAliasB: {
+            /**
+             * Access IDs
+             * @description A list of role encoded IDs defining roles that should have access permission on the dataset.
+             */
+            access?: string[] | string | null;
+            /**
+             * Action
+             * @description Indicates what action should be performed on the dataset.
+             * @default set_permissions
+             */
+            action?: components["schemas"]["DatasetPermissionAction"] | null;
+            /**
+             * Manage IDs
+             * @description A list of role encoded IDs defining roles that should have manage permission on the dataset.
+             */
+            manage?: string[] | string | null;
+            /**
+             * Modify IDs
+             * @description A list of role encoded IDs defining roles that should have modify permission on the dataset.
+             */
+            modify?: string[] | string | null;
+        };
+        /** UpdateDatasetPermissionsPayloadAliasC */
+        UpdateDatasetPermissionsPayloadAliasC: {
+            /**
+             * Access IDs
+             * @description A list of role encoded IDs defining roles that should have access permission on the dataset.
+             */
+            access_ids?: string[] | string | null;
+            /**
+             * Action
+             * @description Indicates what action should be performed on the dataset.
+             * @default set_permissions
+             */
+            action?: components["schemas"]["DatasetPermissionAction"] | null;
+            /**
+             * Manage IDs
+             * @description A list of role encoded IDs defining roles that should have manage permission on the dataset.
+             */
+            manage_ids?: string[] | string | null;
+            /**
+             * Modify IDs
+             * @description A list of role encoded IDs defining roles that should have modify permission on the dataset.
+             */
+            modify_ids?: string[] | string | null;
+        };
         /**
          * UpdateHistoryContentsBatchPayload
          * @description Contains property values that will be updated for all the history `items` provided.
@@ -14653,7 +14721,10 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json":
+                    | components["schemas"]["UpdateDatasetPermissionsPayload"]
+                    | components["schemas"]["UpdateDatasetPermissionsPayloadAliasB"]
+                    | components["schemas"]["UpdateDatasetPermissionsPayloadAliasC"];
             };
         };
         responses: {
@@ -18165,7 +18236,10 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json":
+                    | components["schemas"]["UpdateDatasetPermissionsPayload"]
+                    | components["schemas"]["UpdateDatasetPermissionsPayloadAliasB"]
+                    | components["schemas"]["UpdateDatasetPermissionsPayloadAliasC"];
             };
         };
         responses: {

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3229,30 +3229,65 @@ class DatasetAssociationRoles(Model):
     )
 
 
-class UpdateDatasetPermissionsPayload(Model):
+class UpdateDatasetPermissionsPayloadBase(Model):
     action: Optional[DatasetPermissionAction] = Field(
         DatasetPermissionAction.set_permissions,
         title="Action",
         description="Indicates what action should be performed on the dataset.",
     )
-    access_ids: Optional[RoleIdList] = Field(
-        [],
-        alias="access_ids[]",  # Added for backward compatibility but it looks really ugly...
+
+
+AccessIdsField = Annotated[
+    Optional[RoleIdList],
+    Field(
+        default=None,
         title="Access IDs",
         description="A list of role encoded IDs defining roles that should have access permission on the dataset.",
-    )
-    manage_ids: Optional[RoleIdList] = Field(
-        [],
-        alias="manage_ids[]",
+    ),
+]
+
+ManageIdsField = Annotated[
+    Optional[RoleIdList],
+    Field(
+        default=None,
         title="Manage IDs",
         description="A list of role encoded IDs defining roles that should have manage permission on the dataset.",
-    )
-    modify_ids: Optional[RoleIdList] = Field(
-        [],
-        alias="modify_ids[]",
+    ),
+]
+
+ModifyIdsField = Annotated[
+    Optional[RoleIdList],
+    Field(
+        default=None,
         title="Modify IDs",
         description="A list of role encoded IDs defining roles that should have modify permission on the dataset.",
-    )
+    ),
+]
+
+
+class UpdateDatasetPermissionsPayload(UpdateDatasetPermissionsPayloadBase):
+    access_ids: Annotated[Optional[RoleIdList], Field(default=None, alias="access_ids[]")] = None
+    manage_ids: Annotated[Optional[RoleIdList], Field(default=None, alias="manage_ids[]")] = None
+    modify_ids: Annotated[Optional[RoleIdList], Field(default=None, alias="modify_ids[]")] = None
+
+
+class UpdateDatasetPermissionsPayloadAliasB(UpdateDatasetPermissionsPayloadBase):
+    access: AccessIdsField = None
+    manage: ManageIdsField = None
+    modify: ModifyIdsField = None
+
+
+class UpdateDatasetPermissionsPayloadAliasC(UpdateDatasetPermissionsPayloadBase):
+    access_ids: AccessIdsField = None
+    manage_ids: ManageIdsField = None
+    modify_ids: ModifyIdsField = None
+
+
+UpdateDatasetPermissionsPayloadAliases = Union[
+    UpdateDatasetPermissionsPayload,
+    UpdateDatasetPermissionsPayloadAliasB,
+    UpdateDatasetPermissionsPayloadAliasC,
+]
 
 
 @partial_model()

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -9,9 +9,7 @@ from io import (
     StringIO,
 )
 from typing import (
-    Any,
     cast,
-    Dict,
     List,
     Optional,
 )
@@ -40,7 +38,6 @@ from galaxy.schema.schema import (
     AsyncTaskResultSummary,
     DatasetAssociationRoles,
     DatasetSourceType,
-    UpdateDatasetPermissionsPayload,
 )
 from galaxy.util.zipstream import ZipstreamWrapper
 from galaxy.webapps.base.api import GalaxyFileResponse
@@ -52,10 +49,11 @@ from galaxy.webapps.galaxy.api import (
 from galaxy.webapps.galaxy.api.common import (
     get_filter_query_params,
     get_query_parameters_from_request_excluding,
-    get_update_permission_payload,
     HistoryDatasetIDPathParam,
     HistoryIDPathParam,
+    normalize_permission_payload,
     query_serialization_params,
+    UpdateDatasetPermissionsBody,
 )
 from galaxy.webapps.galaxy.services.datasets import (
     ComputeDatasetHashPayload,
@@ -235,15 +233,11 @@ class FastAPIDatasets:
     def update_permissions(
         self,
         dataset_id: HistoryDatasetIDPathParam,
+        payload: UpdateDatasetPermissionsBody,
         trans=DependsOnTrans,
-        # Using a generic Dict here as an attempt on supporting multiple aliases for the permissions params.
-        payload: Dict[str, Any] = Body(
-            default=...,
-            examples=[UpdateDatasetPermissionsPayload()],
-        ),
     ) -> DatasetAssociationRoles:
         """Set permissions of the given history dataset to the given role ids."""
-        update_payload = get_update_permission_payload(payload)
+        update_payload = normalize_permission_payload(payload)
         return self.service.update_permissions(trans, dataset_id, update_payload)
 
     @router.get(

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -4,8 +4,6 @@ API operations on the contents of a history.
 
 import logging
 from typing import (
-    Any,
-    Dict,
     List,
     Optional,
     Union,
@@ -51,7 +49,6 @@ from galaxy.schema.schema import (
     MaterializeDatasetInstanceAPIRequest,
     MaterializeDatasetInstanceRequest,
     StoreExportPayload,
-    UpdateDatasetPermissionsPayload,
     UpdateHistoryContentsBatchPayload,
     UpdateHistoryContentsPayload,
     WriteStoreToPayload,
@@ -64,12 +61,13 @@ from galaxy.webapps.galaxy.api import (
 )
 from galaxy.webapps.galaxy.api.common import (
     get_filter_query_params,
-    get_update_permission_payload,
     get_value_filter_query_params,
     HistoryHDCAIDPathParam,
     HistoryIDPathParam,
     HistoryItemIDPathParam,
+    normalize_permission_payload,
     query_serialization_params,
+    UpdateDatasetPermissionsBody,
 )
 from galaxy.webapps.galaxy.services.history_contents import (
     CreateHistoryContentFromStore,
@@ -727,15 +725,11 @@ class FastAPIHistoryContents:
         self,
         history_id: HistoryIDPathParam,
         dataset_id: HistoryItemIDPathParam,
+        payload: UpdateDatasetPermissionsBody,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        # Using a generic Dict here as an attempt on supporting multiple aliases for the permissions params.
-        payload: Dict[str, Any] = Body(
-            default=...,
-            examples=[UpdateDatasetPermissionsPayload().model_dump()],
-        ),
     ) -> DatasetAssociationRoles:
         """Set permissions of the given history dataset to the given role ids."""
-        update_payload = get_update_permission_payload(payload)
+        update_payload = normalize_permission_payload(payload)
         return self.service.update_permissions(trans, dataset_id, update_payload)
 
     @router.put(


### PR DESCRIPTION
Part of #18532

Full schema support for the 3 different aliases (`access`, `access_ids`, `access_ids[]`) to specify roles for dataset permissions. Enables full type check in the client schema.

| Before | After |
|--------|-------|
| ![Screenshot from 2024-07-18 16-10-54](https://github.com/user-attachments/assets/9830f349-f284-4bde-8df0-c29c9a197439)   | ![image](https://github.com/user-attachments/assets/915f04ad-d379-4f86-a1b3-83626b4b6915)  |






## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
