### PR TITLE
[24.1] Raise appropriate exception if ldda not found

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -281,7 +281,8 @@ class ToolsService(ServiceBase):
     def _patch_library_dataset(self, trans: ProvidesHistoryContext, v, target_history):
         if isinstance(v, dict) and "id" in v and v.get("src") == "ldda":
             ldda = trans.sa_session.get(LibraryDatasetDatasetAssociation, self.decode_id(v["id"]))
-            assert ldda
+            if not ldda:
+                raise exceptions.ObjectNotFound("Could not find library dataset dataset association.")
             if trans.user_is_admin or trans.app.security_agent.can_access_dataset(
                 trans.get_current_user_roles(), ldda.dataset
             ):


### PR DESCRIPTION
Fixes
https://sentry.galaxyproject.org/share/issue/db137d5e4eae40eea9b0fe85ffac4b19/:

```
AssertionError: null
  File "galaxy/web/framework/decorators.py", line 346, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/api/tools.py", line 593, in create
    return self.service._create(trans, payload, **kwd)
  File "galaxy/webapps/galaxy/services/tools.py", line 155, in _create
    self._patch_library_inputs(trans, inputs, target_history)
  File "galaxy/webapps/galaxy/services/tools.py", line 276, in _patch_library_inputs
    patched = self._patch_library_dataset(trans, value, target_history)
  File "galaxy/webapps/galaxy/services/tools.py", line 284, in _patch_library_dataset
    assert ldda
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
