### PR TITLE
[24.1] Fix history changes switch to simple form

### DIFF
--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -77,46 +77,46 @@ function handleSubmissionError(error: string) {
     submissionError.value = errorMessageAsString(error);
 }
 
-function loadRun() {
-    getRunData(props.workflowId, props.version || undefined)
-        .then((runData) => {
-            const incomingModel = new WorkflowRunModel(runData);
-            simpleForm.value = props.preferSimpleForm;
-            if (simpleForm.value) {
-                // These only work with PJA - the API doesn't evaluate them at
-                // all outside that context currently. The main workflow form renders
-                // these dynamically and takes care of all the validation and setup details
-                // on the frontend. If these are implemented on the backend at some
-                // point this restriction can be lifted.
-                if (incomingModel.hasReplacementParametersInToolForm) {
-                    console.log("cannot render simple workflow form - has ${} values in tool steps");
-                    simpleForm.value = false;
-                }
-                // If there are required parameters in a tool form (a disconnected runtime
-                // input), we have to render the tool form steps and cannot use the
-                // simplified tool form.
-                if (incomingModel.hasOpenToolSteps) {
-                    console.log(
-                        "cannot render simple workflow form - one or more tools have disconnected runtime inputs"
-                    );
-                    simpleForm.value = false;
-                }
-                // Just render the whole form for resource request parameters (kind of
-                // niche - I'm not sure anyone is using these currently anyway).
-                if (incomingModel.hasWorkflowResourceParameters) {
-                    console.log(`Cannot render simple workflow form - workflow resource parameters are configured`);
-                    simpleForm.value = false;
-                }
+async function loadRun() {
+    try {
+        const runData = await getRunData(props.workflowId, props.version || undefined);
+        const incomingModel = new WorkflowRunModel(runData);
+
+        simpleForm.value = props.preferSimpleForm;
+
+        if (simpleForm.value) {
+            // These only work with PJA - the API doesn't evaluate them at
+            // all outside that context currently. The main workflow form renders
+            // these dynamically and takes care of all the validation and setup details
+            // on the frontend. If these are implemented on the backend at some
+            // point this restriction can be lifted.
+            if (incomingModel.hasReplacementParametersInToolForm) {
+                console.log("cannot render simple workflow form - has ${} values in tool steps");
+                simpleForm.value = false;
             }
-            hasUpgradeMessages.value = incomingModel.hasUpgradeMessages;
-            hasStepVersionChanges.value = incomingModel.hasStepVersionChanges;
-            workflowName.value = incomingModel.name;
-            workflowModel.value = incomingModel;
-            loading.value = false;
-        })
-        .catch((response) => {
-            workflowError.value = errorMessageAsString(response);
-        });
+            // If there are required parameters in a tool form (a disconnected runtime
+            // input), we have to render the tool form steps and cannot use the
+            // simplified tool form.
+            if (incomingModel.hasOpenToolSteps) {
+                console.log("cannot render simple workflow form - one or more tools have disconnected runtime inputs");
+                simpleForm.value = false;
+            }
+            // Just render the whole form for resource request parameters (kind of
+            // niche - I'm not sure anyone is using these currently anyway).
+            if (incomingModel.hasWorkflowResourceParameters) {
+                console.log(`Cannot render simple workflow form - workflow resource parameters are configured`);
+                simpleForm.value = false;
+            }
+        }
+
+        hasUpgradeMessages.value = incomingModel.hasUpgradeMessages;
+        hasStepVersionChanges.value = incomingModel.hasStepVersionChanges;
+        workflowName.value = incomingModel.name;
+        workflowModel.value = incomingModel;
+        loading.value = false;
+    } catch (e) {
+        workflowError.value = errorMessageAsString(e);
+    }
 }
 
 async function onImport() {
@@ -124,8 +124,19 @@ async function onImport() {
     router.push(`/workflows/edit?id=${response.id}`);
 }
 
+const advancedForm = ref(false);
+const fromVariant = computed<"simple" | "advanced">(() => {
+    if (advancedForm.value) {
+        return "advanced";
+    } else if (simpleForm.value) {
+        return "simple";
+    } else {
+        return "advanced";
+    }
+});
+
 function showAdvanced() {
-    simpleForm.value = false;
+    advancedForm.value = true;
 }
 
 onMounted(() => {
@@ -185,7 +196,7 @@ defineExpose({
                         Workflow submission failed: {{ submissionError }}
                     </BAlert>
                     <WorkflowRunFormSimple
-                        v-else-if="simpleForm"
+                        v-else-if="fromVariant === 'simple'"
                         :model="workflowModel"
                         :target-history="simpleFormTargetHistory"
                         :use-job-cache="simpleFormUseJobCache"


### PR DESCRIPTION
fixes advanced form resetting #18546

The issue was history changes resetting the simpleForm variable. This fix makes prefer advanced form overrule simple form via a computed.

The loadRun function was reformatted to async for easier debugging.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
