### PR TITLE
Introduce ``galaxy_external_url`` variable

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2279,15 +2279,29 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~
+``galaxy_external_url``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    URL (with schema http/https) of the Galaxy instance as accessible
+    from external networks, including ``galaxy_url_prefix`` if
+    necessary. This URL is used to determine links outside of the web
+    application, e.g. when requesting job finish emails.
+:Default: ``None``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``galaxy_infrastructure_url``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
     URL (with schema http/https) of the Galaxy instance as accessible
-    within your local network. This URL is used as a default by pulsar
-    file staging and Interactive Tool containers for communicating
-    back with Galaxy via the API.
+    within your local network, including ``galaxy_url_prefix`` if
+    necessary. This URL is used as a default by pulsar file staging
+    and Interactive Tool containers for communicating back with Galaxy
+    via the API.
     If you plan to run Interactive Tools make sure the docker
     container can reach this URL.
 :Default: ``http://localhost:8080``

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -706,6 +706,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     enable_tool_shed_check: bool
     galaxy_data_manager_data_path: str
     galaxy_infrastructure_url: str
+    galaxy_external_url: Optional[str]
     hours_between_check: int
     integrated_tool_panel_config: str
     involucro_path: str

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1422,9 +1422,16 @@ galaxy:
   #galaxy_url_prefix: /
 
   # URL (with schema http/https) of the Galaxy instance as accessible
-  # within your local network. This URL is used as a default by pulsar
-  # file staging and Interactive Tool containers for communicating back
-  # with Galaxy via the API.
+  # from external networks, including ``galaxy_url_prefix`` if
+  # necessary. This URL is used to determine links outside of the web
+  # application, e.g. when requesting job finish emails.
+  #galaxy_external_url: null
+
+  # URL (with schema http/https) of the Galaxy instance as accessible
+  # within your local network, including ``galaxy_url_prefix`` if
+  # necessary. This URL is used as a default by pulsar file staging and
+  # Interactive Tool containers for communicating back with Galaxy via
+  # the API.
   # If you plan to run Interactive Tools make sure the docker container
   # can reach this URL.
   #galaxy_infrastructure_url: http://localhost:8080

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -54,6 +54,9 @@ tool_shed:
   # options.
   #whoosh_index_dir: database/toolshed_whoosh_indexes
 
+  # Cache directory for Pydantic model objects.
+  #model_cache_dir: database/model_cache
+
   # For searching repositories at /api/repositories:
   #repo_name_boost: 0.9
 

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -1642,15 +1642,24 @@ mapping:
           URL prefix for Galaxy application. If Galaxy should be served under a prefix set this to
           the desired prefix value.
 
+      galaxy_external_url:
+        type: str
+        required: false
+        desc: |
+          URL (with schema http/https) of the Galaxy instance as accessible
+          from external networks, including ``galaxy_url_prefix`` if necessary.
+          This URL is used to determine links outside of the web application,
+          e.g. when requesting job finish emails.
+
       galaxy_infrastructure_url:
         type: str
         default: http://localhost:8080
         required: false
         desc: |
           URL (with schema http/https) of the Galaxy instance as accessible
-          within your local network. This URL is used as a default by pulsar
-          file staging and Interactive Tool containers for communicating back with
-          Galaxy via the API.
+          within your local network, including ``galaxy_url_prefix`` if necessary.
+          This URL is used as a default by pulsar file staging and Interactive Tool
+          containers for communicating back with Galaxy via the API.
 
           If you plan to run Interactive Tools make sure the docker container
           can reach this URL.

--- a/lib/galaxy/job_execution/actions/post.py
+++ b/lib/galaxy/job_execution/actions/post.py
@@ -53,12 +53,11 @@ class EmailAction(DefaultJobAction):
         try:
             history_id_encoded = app.security.encode_id(job.history_id)
             link_invocation = None
+            galaxy_url = app.config.galaxy_external_url or app.config.galaxy_infrastructure_url
             if job.workflow_invocation_step:
                 invocation_id_encoded = app.security.encode_id(job.workflow_invocation_step.workflow_invocation_id)
-                link_invocation = (
-                    f"{app.config.galaxy_infrastructure_url}/workflows/invocations/report?id={invocation_id_encoded}"
-                )
-            link = f"{app.config.galaxy_infrastructure_url}/histories/view?id={history_id_encoded}"
+                link_invocation = f"{galaxy_url}/workflows/invocations/report?id={invocation_id_encoded}"
+            link = f"{galaxy_url}/histories/view?id={history_id_encoded}"
             to = job.get_user_email()
             subject = f"Galaxy job completion notification from history '{job.history.name}'"
             outdata = ",\n".join(ds.dataset.display_name() for ds in job.output_datasets)

--- a/lib/galaxy/managers/notification.py
+++ b/lib/galaxy/managers/notification.py
@@ -282,7 +282,7 @@ class NotificationManager:
         This kind of notification is not explicitly associated with any specific user but it is accessible by all users.
         """
         self.ensure_notifications_enabled()
-        notification = self._create_notification_model(request)
+        notification = self._create_notification_model(request, self.config.galaxy_external_url)
         self.sa_session.add(notification)
         with transaction(self.sa_session):
             self.sa_session.commit()

--- a/lib/galaxy/webapps/galaxy/services/notifications.py
+++ b/lib/galaxy/webapps/galaxy/services/notifications.py
@@ -57,7 +57,9 @@ class NotificationService(ServiceBase):
         self.notification_manager.ensure_notifications_enabled()
         self._ensure_user_can_send_notifications(sender_context)
         galaxy_url = (
-            str(sender_context.url_builder("/", qualified=True)).rstrip("/") if sender_context.url_builder else None
+            str(sender_context.url_builder("/", qualified=True)).rstrip("/")
+            if sender_context.url_builder
+            else self.notification_manager.config.galaxy_external_url
         )
         request = NotificationCreateRequest.model_construct(
             notification=payload.notification,

--- a/lib/galaxy/webapps/galaxy/services/sharable.py
+++ b/lib/galaxy/webapps/galaxy/services/sharable.py
@@ -117,7 +117,11 @@ class ShareableService:
         base_status = self._get_sharing_status(trans, item)
         status = self.share_with_status_cls.model_construct(**base_status.model_dump(), extra=extra)
         status.errors.extend(errors)
-        galaxy_url = str(trans.url_builder("/", qualified=True)).rstrip("/") if trans.url_builder else None
+        galaxy_url = (
+            str(trans.url_builder("/", qualified=True)).rstrip("/")
+            if trans.url_builder
+            else trans.app.config.galaxy_external_url
+        )
         self._send_notification_to_users(users_to_notify, item, status, galaxy_url)
         return status
 


### PR DESCRIPTION
Would fix https://github.com/galaxyproject/galaxy/issues/18572#issuecomment-2239199496,
and prevent further abuse of galaxy_infrastructure_url, with the
downside that users would receive links that don't correspond to their
subdomain server if they had been using one.

The upside is that URLs can change, so maybe this is preferable over
recording the URL for jobs/invocations/histories etc, and it seems
messy to determine in what context one would like to see e.g.
a job finish message.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
