### PR TITLE
[24.0] Fix default value to include hidden datasets on history export

### DIFF
--- a/client/src/components/History/Export/ExportOptions.vue
+++ b/client/src/components/History/Export/ExportOptions.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { BCard, BCollapse, BFormCheckbox, BFormGroup, BFormSelect, BLink } from "bootstrap-vue";
+import { BAlert, BCard, BCollapse, BFormCheckbox, BFormGroup, BFormSelect, BLink } from "bootstrap-vue";
 import { computed, reactive, ref } from "vue";
 
 import { AVAILABLE_EXPORT_FORMATS } from "@/api/histories.export";
@@ -75,6 +75,17 @@ function onValueChanged() {
                         @change="onValueChanged">
                         Include Hidden
                     </BFormCheckbox>
+
+                    <BAlert v-if="!localOptions.includeHidden" variant="warning" show class="mt-2 mb-0">
+                        <strong>Warning:</strong> Dataset collections usually have their elements hidden by default.
+                        <br />
+                        <b>
+                            To ensure collections are usable when re-imported, include hidden datasets when exporting
+                            your history.
+                        </b>
+                        <br />
+                        If you are unsure, include hidden datasets.
+                    </BAlert>
                 </BFormGroup>
             </BCard>
         </BCollapse>

--- a/client/src/composables/shortTermStorage.ts
+++ b/client/src/composables/shortTermStorage.ts
@@ -8,7 +8,7 @@ export const DEFAULT_EXPORT_PARAMS: ExportParams = {
     modelStoreFormat: "rocrate.zip",
     includeFiles: true,
     includeDeleted: false,
-    includeHidden: false,
+    includeHidden: true,
 };
 
 interface Options {


### PR DESCRIPTION
The default settings for history export excluded hidden datasets from the export package, but this can potentially make collections unusable when reimporting those histories back.

This sets the default export option to true and adds a warning about the implications of setting it to false.

![image](https://github.com/user-attachments/assets/20c28dde-cbdc-4714-9819-8fe567e807f5)



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
