### PR TITLE
[24.0] Fix Archive header encoding

### DIFF
--- a/lib/galaxy/util/zipstream.py
+++ b/lib/galaxy/util/zipstream.py
@@ -41,7 +41,8 @@ class ZipstreamWrapper:
     def get_headers(self) -> Dict[str, str]:
         headers = {}
         if self.archive_name:
-            headers["Content-Disposition"] = f'attachment; filename="{self.archive_name}.zip"'
+            archive_name = self.archive_name.encode("latin-1", "replace").decode("latin-1")
+            headers["Content-Disposition"] = f'attachment; filename="{archive_name}.zip"'
         if self.upstream_mod_zip:
             headers["X-Archive-Files"] = "zip"
         else:

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -182,6 +182,14 @@ class TestDatasetCollectionsApi(ApiTestCase):
             namelist = archive.namelist()
             assert len(namelist) == 3, f"Expected 3 elements in [{namelist}]"
 
+    def test_download_non_english_characters(self):
+        with self.dataset_populator.test_history() as history_id:
+            name = "دیتاست"
+            payload = self.dataset_collection_populator.create_list_payload(history_id, name=name)
+            hdca_id = self.dataset_populator.fetch(payload, wait=True).json()["outputs"][0]["id"]
+            create_response = self._download_dataset_collection(history_id=history_id, hdca_id=hdca_id)
+            self._assert_status_code_is(create_response, 200)
+
     @requires_new_user
     def test_hda_security(self):
         with self.dataset_populator.test_history(require_new=False) as history_id:


### PR DESCRIPTION
Fix the encoding of the filename in the archive header when downloading a collection with non-English characters.
Fixes #18508.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
