### PR TITLE
Consistent type imports, fixes and linting.

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -82,6 +82,11 @@ const baseRules = {
     "import/first": "error",
     "import/newline-after-import": "error",
     "import/no-duplicates": "error",
+
+    "@typescript-eslint/consistent-type-imports": [
+        "error",
+        { prefer: "type-imports", fixStyle: "inline-type-imports" },
+    ],
 };
 
 const baseExtends = [
@@ -134,10 +139,6 @@ module.exports = {
                 "@typescript-eslint/ban-ts-comment": "warn",
                 "@typescript-eslint/no-explicit-any": "warn", // TODO: re-enable this
                 "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "_.+", varsIgnorePattern: "_.+" }],
-                "@typescript-eslint/consistent-type-imports": [
-                    "error",
-                    { prefer: "type-imports", fixStyle: "inline-type-imports" },
-                ],
             },
             parser: "@typescript-eslint/parser",
             parserOptions: {

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -134,7 +134,10 @@ module.exports = {
                 "@typescript-eslint/ban-ts-comment": "warn",
                 "@typescript-eslint/no-explicit-any": "warn", // TODO: re-enable this
                 "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "_.+", varsIgnorePattern: "_.+" }],
-                "@typescript-eslint/consistent-type-imports": "error",
+                "@typescript-eslint/consistent-type-imports": [
+                    "error",
+                    { prefer: "type-imports", fixStyle: "inline-type-imports" },
+                ],
             },
             parser: "@typescript-eslint/parser",
             parserOptions: {

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -134,6 +134,7 @@ module.exports = {
                 "@typescript-eslint/ban-ts-comment": "warn",
                 "@typescript-eslint/no-explicit-any": "warn", // TODO: re-enable this
                 "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "_.+", varsIgnorePattern: "_.+" }],
+                "@typescript-eslint/consistent-type-imports": "error",
             },
             parser: "@typescript-eslint/parser",
             parserOptions: {

--- a/client/src/api/configTemplates.ts
+++ b/client/src/api/configTemplates.ts
@@ -1,4 +1,4 @@
-import type { components } from "@/api/schema/schema";
+import { type components } from "@/api/schema/schema";
 
 export type Instance =
     | components["schemas"]["UserFileSourceModel"]

--- a/client/src/api/datasetCollections.ts
+++ b/client/src/api/datasetCollections.ts
@@ -1,4 +1,4 @@
-import { CollectionEntry, DCESummary, HDCADetailed, HDCASummary, isHDCA } from "@/api";
+import { type CollectionEntry, type DCESummary, type HDCADetailed, type HDCASummary, isHDCA } from "@/api";
 import { fetcher } from "@/api/schema";
 
 const DEFAULT_LIMIT = 50;

--- a/client/src/api/datasets.ts
+++ b/client/src/api/datasets.ts
@@ -1,8 +1,8 @@
 import axios from "axios";
-import type { FetchArgType } from "openapi-typescript-fetch";
+import { type FetchArgType } from "openapi-typescript-fetch";
 
-import { HDADetailed } from "@/api";
-import { components, fetcher } from "@/api/schema";
+import { type HDADetailed } from "@/api";
+import { type components, fetcher } from "@/api/schema";
 import { withPrefix } from "@/utils/redirect";
 
 export const datasetsFetcher = fetcher.path("/api/datasets").method("get").create();

--- a/client/src/api/groups.ts
+++ b/client/src/api/groups.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { components, fetcher } from "@/api/schema";
+import { type components, fetcher } from "@/api/schema";
 
 type GroupModel = components["schemas"]["GroupModel"];
 export async function getAllGroups(): Promise<GroupModel[]> {

--- a/client/src/api/histories.archived.ts
+++ b/client/src/api/histories.archived.ts
@@ -1,4 +1,4 @@
-import type { FetchArgType } from "openapi-typescript-fetch";
+import { type FetchArgType } from "openapi-typescript-fetch";
 
 import { type components, fetcher } from "@/api/schema";
 

--- a/client/src/api/histories.export.ts
+++ b/client/src/api/histories.export.ts
@@ -1,5 +1,4 @@
-import type { components } from "@/api/schema";
-import { fetcher } from "@/api/schema";
+import { type components, fetcher } from "@/api/schema";
 import {
     type ExportRecord,
     ExportRecordModel,

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -1,6 +1,6 @@
 /** Contains type alias and definitions related to Galaxy API models. */
 
-import { components } from "@/api/schema";
+import { type components } from "@/api/schema";
 
 /**
  * Contains minimal information about a History.

--- a/client/src/api/invocations.ts
+++ b/client/src/api/invocations.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 
 import { getAppRoot } from "@/onload";
 
-import { ApiResponse, components, fetcher } from "./schema";
+import { type ApiResponse, type components, fetcher } from "./schema";
 
 export type WorkflowInvocationElementView = components["schemas"]["WorkflowInvocationElementView"];
 export type WorkflowInvocationCollectionView = components["schemas"]["WorkflowInvocationCollectionView"];

--- a/client/src/api/jobs.ts
+++ b/client/src/api/jobs.ts
@@ -1,4 +1,4 @@
-import { components, fetcher } from "@/api/schema";
+import { type components, fetcher } from "@/api/schema";
 
 export type JobDestinationParams = components["schemas"]["JobDestinationParams"];
 

--- a/client/src/api/objectStores.ts
+++ b/client/src/api/objectStores.ts
@@ -1,5 +1,5 @@
 import { fetcher } from "@/api/schema";
-import type { components } from "@/api/schema/schema";
+import { type components } from "@/api/schema/schema";
 
 export type UserConcreteObjectStore = components["schemas"]["UserConcreteObjectStoreModel"];
 

--- a/client/src/api/remoteFiles.ts
+++ b/client/src/api/remoteFiles.ts
@@ -1,4 +1,4 @@
-import type { components } from "@/api/schema";
+import { type components } from "@/api/schema";
 import { fetcher } from "@/api/schema/fetcher";
 
 /** The browsing mode:

--- a/client/src/api/schema/__mocks__/fetcher.ts
+++ b/client/src/api/schema/__mocks__/fetcher.ts
@@ -1,4 +1,4 @@
-import type { paths } from "@/api/schema";
+import { type paths } from "@/api/schema";
 
 jest.mock("@/api/schema", () => ({
     fetcher: mockFetcher,

--- a/client/src/api/schema/fetcher.ts
+++ b/client/src/api/schema/fetcher.ts
@@ -1,11 +1,11 @@
-import { ApiResponse, Fetcher, type Middleware } from "openapi-typescript-fetch";
+import { type ApiResponse, Fetcher, type Middleware } from "openapi-typescript-fetch";
 
 import { getAppRoot } from "@/onload/loadConfig";
 import { rethrowSimple } from "@/utils/simple-error";
 
 import { type paths } from "./schema";
 
-export { ApiResponse };
+export { type ApiResponse };
 
 const rethrowSimpleMiddleware: Middleware = async (url, init, next) => {
     try {

--- a/client/src/api/schema/fetcher.ts
+++ b/client/src/api/schema/fetcher.ts
@@ -1,10 +1,9 @@
-import type { ApiResponse, Middleware } from "openapi-typescript-fetch";
-import { Fetcher } from "openapi-typescript-fetch";
+import { ApiResponse, Fetcher, type Middleware } from "openapi-typescript-fetch";
 
 import { getAppRoot } from "@/onload/loadConfig";
 import { rethrowSimple } from "@/utils/simple-error";
 
-import type { paths } from "./schema";
+import { type paths } from "./schema";
 
 export { ApiResponse };
 

--- a/client/src/api/tags.ts
+++ b/client/src/api/tags.ts
@@ -1,4 +1,4 @@
-import { components, fetcher } from "@/api/schema";
+import { type components, fetcher } from "@/api/schema";
 
 type TaggableItemClass = components["schemas"]["TaggableItemClass"];
 

--- a/client/src/api/workflows.ts
+++ b/client/src/api/workflows.ts
@@ -1,4 +1,4 @@
-import { components, fetcher } from "@/api/schema";
+import { type components, fetcher } from "@/api/schema";
 
 export type StoredWorkflowDetailed = components["schemas"]["StoredWorkflowDetailed"];
 

--- a/client/src/components/Citation/CitationItem.vue
+++ b/client/src/components/Citation/CitationItem.vue
@@ -4,7 +4,7 @@ import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed } from "vue";
 
-import { Citation } from ".";
+import { type Citation } from ".";
 
 library.add(faExternalLinkAlt);
 

--- a/client/src/components/Collections/common/CollectionEditView.vue
+++ b/client/src/components/Collections/common/CollectionEditView.vue
@@ -18,7 +18,7 @@ import localize from "@/utils/localization";
 import { prependPath } from "@/utils/redirect";
 import { errorMessageAsString } from "@/utils/simple-error";
 
-import { HistoryContentBulkOperationPayload, updateHistoryItemsBulk } from "./services";
+import { type HistoryContentBulkOperationPayload, updateHistoryItemsBulk } from "./services";
 
 import ChangeDatatypeTab from "@/components/Collections/common/ChangeDatatypeTab.vue";
 import DatabaseEditTab from "@/components/Collections/common/DatabaseEditTab.vue";

--- a/client/src/components/Common/ExportForm.vue
+++ b/client/src/components/Common/ExportForm.vue
@@ -2,7 +2,7 @@
 import { BButton, BCol, BFormGroup, BFormInput, BRow } from "bootstrap-vue";
 import { computed, ref } from "vue";
 
-import { FilterFileSourcesOptions } from "@/api/remoteFiles";
+import { type FilterFileSourcesOptions } from "@/api/remoteFiles";
 import localize from "@/utils/localization";
 
 import FilesInput from "@/components/FilesDialog/FilesInput.vue";

--- a/client/src/components/Common/ExportRDMForm.test.ts
+++ b/client/src/components/Common/ExportRDMForm.test.ts
@@ -1,8 +1,8 @@
 import { getLocalVue } from "@tests/jest/helpers";
-import { mount, Wrapper } from "@vue/test-utils";
+import { mount, type Wrapper } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 
-import { type BrowsableFilesSourcePlugin, CreatedEntry } from "@/api/remoteFiles";
+import { type BrowsableFilesSourcePlugin, type CreatedEntry } from "@/api/remoteFiles";
 import { mockFetcher } from "@/api/schema/__mocks__";
 
 import ExportRDMForm from "./ExportRDMForm.vue";

--- a/client/src/components/Common/ExportRDMForm.vue
+++ b/client/src/components/Common/ExportRDMForm.vue
@@ -3,10 +3,10 @@ import { BButton, BCard, BFormGroup, BFormInput, BFormRadio, BFormRadioGroup } f
 import { computed, ref } from "vue";
 
 import {
-    BrowsableFilesSourcePlugin,
-    CreatedEntry,
+    type BrowsableFilesSourcePlugin,
+    type CreatedEntry,
     createRemoteEntry,
-    FilterFileSourcesOptions,
+    type FilterFileSourcesOptions,
 } from "@/api/remoteFiles";
 import { useToast } from "@/composables/toast";
 import localize from "@/utils/localization";

--- a/client/src/components/Common/ExportRecordDOILink.vue
+++ b/client/src/components/Common/ExportRecordDOILink.vue
@@ -2,7 +2,7 @@
 import axios from "axios";
 import { ref, watch } from "vue";
 
-import { BrowsableFilesSourcePlugin } from "@/api/remoteFiles";
+import { type BrowsableFilesSourcePlugin } from "@/api/remoteFiles";
 import { useFileSources } from "@/composables/fileSources";
 
 import DOILink from "./DOILink.vue";

--- a/client/src/components/Common/ExportRecordDetails.vue
+++ b/client/src/components/Common/ExportRecordDetails.vue
@@ -12,7 +12,7 @@ import { BAlert, BButton } from "bootstrap-vue";
 import { computed } from "vue";
 
 import type { ColorVariant } from ".";
-import { ExportRecord } from "./models/exportRecordModel";
+import { type ExportRecord } from "./models/exportRecordModel";
 
 import Heading from "@/components/Common/Heading.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";

--- a/client/src/components/Common/FilterMenu.test.ts
+++ b/client/src/components/Common/FilterMenu.test.ts
@@ -1,6 +1,6 @@
 import { createTestingPinia } from "@pinia/testing";
 import { getLocalVue } from "@tests/jest/helpers";
-import { mount, Wrapper } from "@vue/test-utils";
+import { mount, type Wrapper } from "@vue/test-utils";
 
 import { HistoryFilters } from "@/components/History/HistoryFilters";
 import { WorkflowFilters } from "@/components/Workflow/List/WorkflowFilters";

--- a/client/src/components/Common/FilterMenuDropdown.vue
+++ b/client/src/components/Common/FilterMenuDropdown.vue
@@ -6,7 +6,7 @@ import { BButton, BDropdown, BDropdownItem, BInputGroup, BInputGroupAppend, BMod
 import { capitalize } from "lodash";
 import { computed, onMounted, ref, type UnwrapRef, watch } from "vue";
 
-import { QuotaUsage } from "@/components/User/DiskUsage/Quota/model";
+import { type QuotaUsage } from "@/components/User/DiskUsage/Quota/model";
 import { type FilterType, type ValidFilter } from "@/utils/filtering";
 import { errorMessageAsString } from "@/utils/simple-error";
 

--- a/client/src/components/Common/FilterMenuMultiTags.vue
+++ b/client/src/components/Common/FilterMenuMultiTags.vue
@@ -2,7 +2,7 @@
 import { BInputGroup } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
 
-import { ValidFilter } from "@/utils/filtering";
+import { type ValidFilter } from "@/utils/filtering";
 
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 

--- a/client/src/components/Common/FilterMenuObjectStore.vue
+++ b/client/src/components/Common/FilterMenuObjectStore.vue
@@ -2,7 +2,7 @@
 import { computed, ref, watch } from "vue";
 
 import { useSelectableObjectStores } from "@/composables/useObjectStores";
-import { ValidFilter } from "@/utils/filtering";
+import { type ValidFilter } from "@/utils/filtering";
 
 import FilterObjectStoreLink from "./FilterObjectStoreLink.vue";
 

--- a/client/src/components/Common/FilterObjectStoreLink.vue
+++ b/client/src/components/Common/FilterObjectStoreLink.vue
@@ -4,7 +4,7 @@ import { faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed, ref } from "vue";
 
-import { ConcreteObjectStoreModel } from "@/api";
+import { type ConcreteObjectStoreModel } from "@/api";
 import { useObjectStoreStore } from "@/stores/objectStoreStore";
 
 import ObjectStoreSelect from "./ObjectStoreSelect.vue";

--- a/client/src/components/Common/ObjectStoreSelect.vue
+++ b/client/src/components/Common/ObjectStoreSelect.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ConcreteObjectStoreModel } from "@/api";
+import { type ConcreteObjectStoreModel } from "@/api";
 
 import ObjectStoreSelectButton from "@/components/ObjectStore/ObjectStoreSelectButton.vue";
 import ObjectStoreSelectButtonDescribePopover from "@/components/ObjectStore/ObjectStoreSelectButtonDescribePopover.vue";

--- a/client/src/components/Common/PersistentTaskProgressMonitorAlert.test.ts
+++ b/client/src/components/Common/PersistentTaskProgressMonitorAlert.test.ts
@@ -1,10 +1,10 @@
 import { shallowMount } from "@vue/test-utils";
 import { type PropType, ref } from "vue";
 
-import { TaskMonitor } from "@/composables/genericTaskMonitor";
+import { type TaskMonitor } from "@/composables/genericTaskMonitor";
 import {
     type MonitoringData,
-    MonitoringRequest,
+    type MonitoringRequest,
     usePersistentProgressTaskMonitor,
 } from "@/composables/persistentProgressMonitor";
 

--- a/client/src/components/Common/PersistentTaskProgressMonitorAlert.vue
+++ b/client/src/components/Common/PersistentTaskProgressMonitorAlert.vue
@@ -5,8 +5,8 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BLink } from "bootstrap-vue";
 import { computed, watch } from "vue";
 
-import { TaskMonitor } from "@/composables/genericTaskMonitor";
-import { MonitoringRequest, usePersistentProgressTaskMonitor } from "@/composables/persistentProgressMonitor";
+import { type TaskMonitor } from "@/composables/genericTaskMonitor";
+import { type MonitoringRequest, usePersistentProgressTaskMonitor } from "@/composables/persistentProgressMonitor";
 import { useShortTermStorage } from "@/composables/shortTermStorage";
 
 import UtcDate from "@/components/UtcDate.vue";

--- a/client/src/components/Common/models/exportRecordModel.ts
+++ b/client/src/components/Common/models/exportRecordModel.ts
@@ -1,6 +1,6 @@
 import { formatDistanceToNow, parseISO } from "date-fns";
 
-import type { components } from "@/api/schema";
+import { type components } from "@/api/schema";
 
 type ExportObjectRequestMetadata = components["schemas"]["ExportObjectRequestMetadata"];
 

--- a/client/src/components/Common/models/testData/exportData.ts
+++ b/client/src/components/Common/models/testData/exportData.ts
@@ -1,4 +1,4 @@
-import type { components } from "@/api/schema";
+import { type components } from "@/api/schema";
 import { ExportRecordModel } from "@/components/Common/models/exportRecordModel";
 
 type ObjectExportTaskResponse = components["schemas"]["ObjectExportTaskResponse"];

--- a/client/src/components/ConfigTemplates/EditSecretsForm.vue
+++ b/client/src/components/ConfigTemplates/EditSecretsForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { TemplateSummary } from "@/api/configTemplates";
+import { type TemplateSummary } from "@/api/configTemplates";
 
 import VaultSecret from "./VaultSecret.vue";
 import FormCard from "@/components/Form/FormCard.vue";

--- a/client/src/components/ConfigTemplates/InstanceForm.test.ts
+++ b/client/src/components/ConfigTemplates/InstanceForm.test.ts
@@ -1,7 +1,7 @@
 import { shallowMount } from "@vue/test-utils";
 import { getLocalVue } from "tests/jest/helpers";
 
-import { FormEntry } from "./formUtil";
+import { type FormEntry } from "./formUtil";
 
 import InstanceForm from "./InstanceForm.vue";
 

--- a/client/src/components/ConfigTemplates/formUtil.test.ts
+++ b/client/src/components/ConfigTemplates/formUtil.test.ts
@@ -1,4 +1,4 @@
-import { TemplateVariable } from "@/api/configTemplates";
+import { type TemplateVariable } from "@/api/configTemplates";
 
 import { createTemplateForm, templateVariableFormEntry, upgradeForm } from "./formUtil";
 import {

--- a/client/src/components/ConfigTemplates/formUtil.ts
+++ b/client/src/components/ConfigTemplates/formUtil.ts
@@ -1,12 +1,12 @@
-import type {
-    Instance,
-    PluginStatus,
-    SecretData,
-    TemplateSecret,
-    TemplateSummary,
-    TemplateVariable,
-    VariableData,
-    VariableValueType,
+import {
+    type Instance,
+    type PluginStatus,
+    type SecretData,
+    type TemplateSecret,
+    type TemplateSummary,
+    type TemplateVariable,
+    type VariableData,
+    type VariableValueType,
 } from "@/api/configTemplates";
 import { markup } from "@/components/ObjectStore/configurationMarkdown";
 

--- a/client/src/components/ConfigTemplates/test_fixtures.ts
+++ b/client/src/components/ConfigTemplates/test_fixtures.ts
@@ -1,6 +1,6 @@
-import type { FileSourceTemplateSummary } from "@/api/fileSources";
-import type { UserConcreteObjectStore } from "@/components/ObjectStore/Instances/types";
-import type { ObjectStoreTemplateSummary } from "@/components/ObjectStore/Templates/types";
+import { type FileSourceTemplateSummary } from "@/api/fileSources";
+import { type UserConcreteObjectStore } from "@/components/ObjectStore/Instances/types";
+import { type ObjectStoreTemplateSummary } from "@/components/ObjectStore/Templates/types";
 
 export const STANDARD_OBJECT_STORE_TEMPLATE: ObjectStoreTemplateSummary = {
     type: "aws_s3",

--- a/client/src/components/Dataset/DatasetIndex/DatasetIndex.vue
+++ b/client/src/components/Dataset/DatasetIndex/DatasetIndex.vue
@@ -2,7 +2,7 @@
 import { computed } from "vue";
 
 import type { DatasetExtraFiles } from "@/api/datasets";
-import { PathDestination, useDatasetPathDestination } from "@/composables/datasetPathDestination";
+import { type PathDestination, useDatasetPathDestination } from "@/composables/datasetPathDestination";
 
 interface Props {
     historyDatasetId: string;

--- a/client/src/components/Dataset/DatasetList.vue
+++ b/client/src/components/Dataset/DatasetList.vue
@@ -3,7 +3,7 @@ import { BAlert, BTable } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, onMounted, ref } from "vue";
 
-import { HDASummary } from "@/api";
+import { type HDASummary } from "@/api";
 import { copyDataset, getDatasets } from "@/api/datasets";
 import { updateTags } from "@/api/tags";
 import { useHistoryStore } from "@/stores/historyStore";

--- a/client/src/components/Dataset/DatasetName.vue
+++ b/client/src/components/Dataset/DatasetName.vue
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BLink } from "bootstrap-vue";
 import { computed } from "vue";
 
-import { HDASummary } from "@/api";
+import { type HDASummary } from "@/api";
 
 library.add(faCaretDown, faCopy, faEye, faTimesCircle, faPause);
 

--- a/client/src/components/Dataset/DatasetStorage/DatasetStorage.vue
+++ b/client/src/components/Dataset/DatasetStorage/DatasetStorage.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 
-import { DatasetStorageDetails } from "@/api";
+import { type DatasetStorageDetails } from "@/api";
 import { fetchDatasetStorage } from "@/api/datasets";
 import { errorMessageAsString } from "@/utils/simple-error";
 

--- a/client/src/components/Dataset/DatasetStorage/RelocateDialog.vue
+++ b/client/src/components/Dataset/DatasetStorage/RelocateDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ConcreteObjectStoreModel } from "@/api";
+import { type ConcreteObjectStoreModel } from "@/api";
 
 import ObjectStoreSelectButton from "@/components/ObjectStore/ObjectStoreSelectButton.vue";
 import ObjectStoreSelectButtonDescribePopover from "@/components/ObjectStore/ObjectStoreSelectButtonDescribePopover.vue";

--- a/client/src/components/Dataset/DatasetStorage/RelocateLink.vue
+++ b/client/src/components/Dataset/DatasetStorage/RelocateLink.vue
@@ -3,7 +3,7 @@ import { BButton } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 
-import { ConcreteObjectStoreModel, DatasetStorageDetails } from "@/api";
+import { type ConcreteObjectStoreModel, type DatasetStorageDetails } from "@/api";
 import { updateObjectStore } from "@/api/objectStores";
 import { useObjectStoreStore } from "@/stores/objectStoreStore";
 

--- a/client/src/components/DatasetInformation/DatasetDetails.vue
+++ b/client/src/components/DatasetInformation/DatasetDetails.vue
@@ -6,7 +6,7 @@ import { onMounted, onUnmounted, ref } from "vue";
 
 import { type HDADetailed } from "@/api";
 import { fetchDatasetDetails } from "@/api/datasets";
-import { fetchJobDetails, JobDetails } from "@/api/jobs";
+import { fetchJobDetails, type JobDetails } from "@/api/jobs";
 import { useConfig } from "@/composables/config";
 import { useUserStore } from "@/stores/userStore";
 import { stateIsTerminal } from "@/utils/utils";

--- a/client/src/components/DatasetInformation/DatasetError.vue
+++ b/client/src/components/DatasetInformation/DatasetError.vue
@@ -2,14 +2,20 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faBug } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { AxiosError } from "axios";
+import { type AxiosError } from "axios";
 import { BAlert, BButton } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, onMounted, ref } from "vue";
 
 import { type HDADetailed } from "@/api";
 import { fetchDatasetDetails } from "@/api/datasets";
-import { fetchJobCommonProblems, fetchJobDetails, JobDetails, JobInputSummary, postJobErrorReport } from "@/api/jobs";
+import {
+    fetchJobCommonProblems,
+    fetchJobDetails,
+    type JobDetails,
+    type JobInputSummary,
+    postJobErrorReport,
+} from "@/api/jobs";
 import { useMarkdown } from "@/composables/markdown";
 import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";

--- a/client/src/components/DatasetInformation/DatasetInformation.test.ts
+++ b/client/src/components/DatasetInformation/DatasetInformation.test.ts
@@ -1,5 +1,5 @@
 import { getLocalVue } from "@tests/jest/helpers";
-import { mount, Wrapper } from "@vue/test-utils";
+import { mount, type Wrapper } from "@vue/test-utils";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import { format, parseISO } from "date-fns";

--- a/client/src/components/Datatypes/model.ts
+++ b/client/src/components/Datatypes/model.ts
@@ -1,4 +1,4 @@
-import type { components } from "@/api/schema";
+import { type components } from "@/api/schema";
 
 export type DatatypesCombinedMap = components["schemas"]["DatatypesCombinedMap"];
 

--- a/client/src/components/Datatypes/test_fixtures.ts
+++ b/client/src/components/Datatypes/test_fixtures.ts
@@ -2,8 +2,7 @@
 import DatatypesJson from "@tests/test-data/json/datatypes.json";
 import DatatypesMappingJson from "@tests/test-data/json/datatypes.mapping.json";
 
-import type { DatatypesCombinedMap } from "./model";
-import { DatatypesMapperModel } from "./model";
+import { type DatatypesCombinedMap, DatatypesMapperModel } from "./model";
 
 export const typesAndMappingResponse: DatatypesCombinedMap = {
     datatypes: DatatypesJson,

--- a/client/src/components/FileSources/Instances/instance.ts
+++ b/client/src/components/FileSources/Instances/instance.ts
@@ -1,6 +1,6 @@
 import { computed, type Ref } from "vue";
 
-import type { FileSourceTemplateSummary, UserFileSourceModel } from "@/api/fileSources";
+import { type FileSourceTemplateSummary, type UserFileSourceModel } from "@/api/fileSources";
 import { useFileSourceInstancesStore } from "@/stores/fileSourceInstancesStore";
 import { useFileSourceTemplatesStore } from "@/stores/fileSourceTemplatesStore";
 

--- a/client/src/components/FileSources/Instances/services.ts
+++ b/client/src/components/FileSources/Instances/services.ts
@@ -1,4 +1,4 @@
-import type { UserFileSourceModel } from "@/api/fileSources";
+import { type UserFileSourceModel } from "@/api/fileSources";
 import { fetcher } from "@/api/schema/fetcher";
 
 export const create = fetcher.path("/api/file_source_instances").method("post").create();

--- a/client/src/components/FilesDialog/FilesDialog.test.ts
+++ b/client/src/components/FilesDialog/FilesDialog.test.ts
@@ -1,11 +1,10 @@
 import { createTestingPinia } from "@pinia/testing";
-import { mount, Wrapper } from "@vue/test-utils";
+import { mount, type Wrapper } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { getLocalVue } from "tests/jest/helpers";
 
 import { mockFetcher } from "@/api/schema/__mocks__";
-import type { SelectionItem } from "@/components/SelectionDialog/selectionTypes";
-import { SELECTION_STATES } from "@/components/SelectionDialog/selectionTypes";
+import { SELECTION_STATES, type SelectionItem } from "@/components/SelectionDialog/selectionTypes";
 
 /**
  * The following imports mock a remote file resource directory structure,
@@ -27,6 +26,7 @@ import { SELECTION_STATES } from "@/components/SelectionDialog/selectionTypes";
  * |-- file1
  * |-- file2
  */
+import { type RemoteFilesList } from "./testingData";
 import {
     directory1RecursiveResponse,
     directory1Response,
@@ -34,7 +34,6 @@ import {
     directoryId,
     ftpId,
     pdbResponse,
-    RemoteFilesList,
     rootId,
     rootResponse,
     someErrorText,

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -5,15 +5,15 @@ import Vue, { computed, onMounted, ref } from "vue";
 import {
     browseRemoteFiles,
     fetchFileSources,
-    FileSourceBrowsingMode,
-    FilterFileSourcesOptions,
-    RemoteEntry,
+    type FileSourceBrowsingMode,
+    type FilterFileSourcesOptions,
+    type RemoteEntry,
 } from "@/api/remoteFiles";
 import { UrlTracker } from "@/components/DataDialog/utilities";
 import { fileSourcePluginToItem, isSubPath } from "@/components/FilesDialog/utilities";
 import {
-    ItemsProvider,
-    ItemsProviderContext,
+    type ItemsProvider,
+    type ItemsProviderContext,
     SELECTION_STATES,
     type SelectionItem,
 } from "@/components/SelectionDialog/selectionTypes";

--- a/client/src/components/FilesDialog/FilesInput.vue
+++ b/client/src/components/FilesDialog/FilesInput.vue
@@ -2,10 +2,10 @@
 import { BFormInput } from "bootstrap-vue";
 import { computed } from "vue";
 
-import { FileSourceBrowsingMode, FilterFileSourcesOptions } from "@/api/remoteFiles";
+import { type FileSourceBrowsingMode, type FilterFileSourcesOptions } from "@/api/remoteFiles";
 import { filesDialog } from "@/utils/data";
 
-import { SelectionItem } from "../SelectionDialog/selectionTypes";
+import { type SelectionItem } from "../SelectionDialog/selectionTypes";
 
 interface Props {
     value: string;

--- a/client/src/components/FilesDialog/testingData.ts
+++ b/client/src/components/FilesDialog/testingData.ts
@@ -1,4 +1,4 @@
-import { BrowsableFilesSourcePlugin } from "@/api/remoteFiles";
+import { type BrowsableFilesSourcePlugin } from "@/api/remoteFiles";
 
 export const ftpId = "_ftp";
 export const rootId = "pdb-gzip";

--- a/client/src/components/FilesDialog/utilities.ts
+++ b/client/src/components/FilesDialog/utilities.ts
@@ -1,6 +1,6 @@
-import type { BrowsableFilesSourcePlugin } from "@/api/remoteFiles";
+import { type BrowsableFilesSourcePlugin } from "@/api/remoteFiles";
 
-import type { SelectionItem } from "../SelectionDialog/selectionTypes";
+import { type SelectionItem } from "../SelectionDialog/selectionTypes";
 
 export const isSubPath = (originPath: string, destinationPath: string) => {
     return subPathCondition(ensureTrailingSlash(originPath), ensureTrailingSlash(destinationPath));

--- a/client/src/components/Form/Elements/FormSelectMany/FormSelectMany.test.ts
+++ b/client/src/components/Form/Elements/FormSelectMany/FormSelectMany.test.ts
@@ -3,9 +3,9 @@ import "./worker/__mocks__/selectMany";
 import { createTestingPinia } from "@pinia/testing";
 import { getLocalVue } from "@tests/jest/helpers";
 import { mount } from "@vue/test-utils";
-import { PropType } from "vue";
+import { type PropType } from "vue";
 
-import type { SelectOption } from "./worker/selectMany";
+import { type SelectOption } from "./worker/selectMany";
 
 import FormSelectMany from "./FormSelectMany.vue";
 

--- a/client/src/components/Form/Elements/FormSelectMany/useHighlight.ts
+++ b/client/src/components/Form/Elements/FormSelectMany/useHighlight.ts
@@ -2,7 +2,7 @@ import { type Ref, ref, watch } from "vue";
 
 import { assertDefined } from "@/utils/assertions";
 
-import type { SelectOption } from "./worker/selectMany";
+import { type SelectOption } from "./worker/selectMany";
 
 /**
  * Handles logic required for highlighting options

--- a/client/src/components/Form/Elements/FormSelectMany/worker/__mocks__/selectMany.ts
+++ b/client/src/components/Form/Elements/FormSelectMany/worker/__mocks__/selectMany.ts
@@ -1,6 +1,6 @@
 import { reactive, ref, watch } from "vue";
 
-import type { SelectOption, useSelectMany as UseSelectMany } from "../selectMany";
+import { type SelectOption, type useSelectMany as UseSelectMany } from "../selectMany";
 import { main } from "../selectManyMain";
 
 jest.mock("@/components/Form/Elements/FormSelectMany/worker/selectMany", () => ({

--- a/client/src/components/Form/Elements/FormSelectMany/worker/filterOptions.ts
+++ b/client/src/components/Form/Elements/FormSelectMany/worker/filterOptions.ts
@@ -1,4 +1,4 @@
-import { SelectOption } from "./selectMany";
+import { type SelectOption } from "./selectMany";
 
 export function filterOptions(options: SelectOption[], filter: string | RegExp, caseSensitive: boolean) {
     let filteredSelectOptions;

--- a/client/src/components/Form/Elements/FormSelectMany/worker/selectMany.d.ts
+++ b/client/src/components/Form/Elements/FormSelectMany/worker/selectMany.d.ts
@@ -1,4 +1,4 @@
-import type { Ref } from "vue";
+import { type Ref } from "vue";
 
 export type SelectValue = Record<string, unknown> | string | number | null;
 

--- a/client/src/components/Form/Elements/FormSelectMany/worker/selectManyMain.ts
+++ b/client/src/components/Form/Elements/FormSelectMany/worker/selectManyMain.ts
@@ -1,7 +1,7 @@
-import type { UnwrapNestedRefs } from "vue";
+import { type UnwrapNestedRefs } from "vue";
 
 import { filterOptions } from "./filterOptions";
-import type { SelectOption, SelectValue, UseSelectManyOptions, UseSelectManyReturn } from "./selectMany";
+import { type SelectOption, type SelectValue, type UseSelectManyOptions, type UseSelectManyReturn } from "./selectMany";
 
 export function main(options: UnwrapNestedRefs<UseSelectManyOptions>): UnwrapNestedRefs<UseSelectManyReturn> {
     const unselectedOptionsFiltered: SelectOption[] = [];

--- a/client/src/components/GDateTime.vue
+++ b/client/src/components/GDateTime.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { BFormInput, BInputGroup } from "bootstrap-vue";
-import { Tuple } from "types/utilityTypes";
+import { type Tuple } from "types/utilityTypes";
 import { computed } from "vue";
 
 const props = defineProps<{

--- a/client/src/components/Grid/GridList.vue
+++ b/client/src/components/Grid/GridList.vue
@@ -7,7 +7,14 @@ import { BAlert, BButton, BCard, BFormCheckbox, BOverlay, BPagination } from "bo
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRouter } from "vue-router/composables";
 
-import { BatchOperation, FieldEntry, FieldHandler, GridConfig, Operation, RowData } from "./configs/types";
+import {
+    type BatchOperation,
+    type FieldEntry,
+    type FieldHandler,
+    type GridConfig,
+    type Operation,
+    type RowData,
+} from "./configs/types";
 
 import HelpText from "../Help/HelpText.vue";
 import SwitchToHistoryLink from "../History/SwitchToHistoryLink.vue";

--- a/client/src/components/Grid/configs/adminForms.ts
+++ b/client/src/components/Grid/configs/adminForms.ts
@@ -8,7 +8,7 @@ import _l from "@/utils/localization";
 import { withPrefix } from "@/utils/redirect";
 import { errorMessageAsString } from "@/utils/simple-error";
 
-import type { ActionArray, FieldArray, GridConfig } from "./types";
+import { type ActionArray, type FieldArray, type GridConfig } from "./types";
 
 const { emit } = useEventBus<string>("grid-router-push");
 

--- a/client/src/components/Grid/configs/adminGroups.ts
+++ b/client/src/components/Grid/configs/adminGroups.ts
@@ -8,7 +8,7 @@ import _l from "@/utils/localization";
 import { withPrefix } from "@/utils/redirect";
 import { errorMessageAsString } from "@/utils/simple-error";
 
-import type { ActionArray, FieldArray, GridConfig } from "./types";
+import { type ActionArray, type FieldArray, type GridConfig } from "./types";
 
 const { emit } = useEventBus<string>("grid-router-push");
 

--- a/client/src/components/Grid/configs/adminQuotas.ts
+++ b/client/src/components/Grid/configs/adminQuotas.ts
@@ -8,7 +8,7 @@ import _l from "@/utils/localization";
 import { withPrefix } from "@/utils/redirect";
 import { errorMessageAsString } from "@/utils/simple-error";
 
-import type { ActionArray, FieldArray, GridConfig } from "./types";
+import { type ActionArray, type FieldArray, type GridConfig } from "./types";
 
 const { emit } = useEventBus<string>("grid-router-push");
 

--- a/client/src/components/Grid/configs/adminRoles.ts
+++ b/client/src/components/Grid/configs/adminRoles.ts
@@ -8,7 +8,7 @@ import _l from "@/utils/localization";
 import { withPrefix } from "@/utils/redirect";
 import { errorMessageAsString } from "@/utils/simple-error";
 
-import type { ActionArray, FieldArray, GridConfig } from "./types";
+import { type ActionArray, type FieldArray, type GridConfig } from "./types";
 
 const { emit } = useEventBus<string>("grid-router-push");
 

--- a/client/src/components/Grid/configs/adminUsers.ts
+++ b/client/src/components/Grid/configs/adminUsers.ts
@@ -15,13 +15,13 @@ import { useEventBus } from "@vueuse/core";
 import axios from "axios";
 
 import { createApiKey, deleteUser, recalculateDiskUsageByUserId, sendActivationEmail, undeleteUser } from "@/api/users";
-import type { GalaxyConfiguration } from "@/stores/configurationStore";
+import { type GalaxyConfiguration } from "@/stores/configurationStore";
 import Filtering, { contains, equals, toBool, type ValidFilter } from "@/utils/filtering";
 import _l from "@/utils/localization";
 import { withPrefix } from "@/utils/redirect";
 import { errorMessageAsString } from "@/utils/simple-error";
 
-import type { ActionArray, FieldArray, GridConfig } from "./types";
+import { type ActionArray, type FieldArray, type GridConfig } from "./types";
 
 const { emit } = useEventBus<string>("grid-router-push");
 

--- a/client/src/components/Grid/configs/histories.ts
+++ b/client/src/components/Grid/configs/histories.ts
@@ -17,7 +17,7 @@ import Filtering, { contains, equals, expandNameTag, toBool, type ValidFilter } 
 import _l from "@/utils/localization";
 import { errorMessageAsString, rethrowSimple } from "@/utils/simple-error";
 
-import type { ActionArray, BatchOperationArray, FieldArray, GridConfig } from "./types";
+import { type ActionArray, type BatchOperationArray, type FieldArray, type GridConfig } from "./types";
 
 const { emit } = useEventBus<string>("grid-router-push");
 

--- a/client/src/components/Grid/configs/historiesPublished.ts
+++ b/client/src/components/Grid/configs/historiesPublished.ts
@@ -5,7 +5,7 @@ import { historiesFetcher } from "@/api/histories";
 import Filtering, { contains, expandNameTag, type ValidFilter } from "@/utils/filtering";
 import _l from "@/utils/localization";
 
-import type { FieldArray, GridConfig } from "./types";
+import { type FieldArray, type GridConfig } from "./types";
 
 const { emit } = useEventBus<string>("grid-router-push");
 

--- a/client/src/components/Grid/configs/historiesShared.ts
+++ b/client/src/components/Grid/configs/historiesShared.ts
@@ -7,7 +7,7 @@ import Filtering, { contains, expandNameTag, type ValidFilter } from "@/utils/fi
 import _l from "@/utils/localization";
 import { rethrowSimple } from "@/utils/simple-error";
 
-import type { FieldArray, GridConfig } from "./types";
+import { type FieldArray, type GridConfig } from "./types";
 
 const { emit } = useEventBus<string>("grid-router-push");
 

--- a/client/src/components/Grid/configs/invocations.ts
+++ b/client/src/components/Grid/configs/invocations.ts
@@ -2,12 +2,12 @@ import { faPlay, faPlus } from "@fortawesome/free-solid-svg-icons";
 import { useEventBus } from "@vueuse/core";
 
 import { invocationsFetcher, type WorkflowInvocation } from "@/api/invocations";
-import type { StoredWorkflowDetailed } from "@/api/workflows";
+import { type StoredWorkflowDetailed } from "@/api/workflows";
 import { useHistoryStore } from "@/stores/historyStore";
 import { useWorkflowStore } from "@/stores/workflowStore";
 import _l from "@/utils/localization";
 
-import type { ActionArray, FieldArray, GridConfig } from "./types";
+import { type ActionArray, type FieldArray, type GridConfig } from "./types";
 
 const { emit } = useEventBus<string>("grid-router-push");
 

--- a/client/src/components/Grid/configs/invocationsHistory.ts
+++ b/client/src/components/Grid/configs/invocationsHistory.ts
@@ -2,12 +2,12 @@ import { faArrowLeft, faPlay } from "@fortawesome/free-solid-svg-icons";
 import { useEventBus } from "@vueuse/core";
 
 import { invocationsFetcher, type WorkflowInvocation } from "@/api/invocations";
-import type { StoredWorkflowDetailed } from "@/api/workflows";
+import { type StoredWorkflowDetailed } from "@/api/workflows";
 import { useUserStore } from "@/stores/userStore";
 import { useWorkflowStore } from "@/stores/workflowStore";
 import _l from "@/utils/localization";
 
-import type { ActionArray, FieldArray, GridConfig } from "./types";
+import { type ActionArray, type FieldArray, type GridConfig } from "./types";
 
 const { emit } = useEventBus<string>("grid-router-push");
 

--- a/client/src/components/Grid/configs/invocationsWorkflow.ts
+++ b/client/src/components/Grid/configs/invocationsWorkflow.ts
@@ -2,13 +2,13 @@ import { faArrowLeft, faEye, faPlay } from "@fortawesome/free-solid-svg-icons";
 import { useEventBus } from "@vueuse/core";
 
 import { invocationsFetcher, type WorkflowInvocation } from "@/api/invocations";
-import type { StoredWorkflowDetailed } from "@/api/workflows";
+import { type StoredWorkflowDetailed } from "@/api/workflows";
 import { useHistoryStore } from "@/stores/historyStore";
 import { useUserStore } from "@/stores/userStore";
 import { useWorkflowStore } from "@/stores/workflowStore";
 import _l from "@/utils/localization";
 
-import type { ActionArray, FieldArray, GridConfig } from "./types";
+import { type ActionArray, type FieldArray, type GridConfig } from "./types";
 
 const { emit } = useEventBus<string>("grid-router-push");
 

--- a/client/src/components/Grid/configs/pages.ts
+++ b/client/src/components/Grid/configs/pages.ts
@@ -6,7 +6,7 @@ import Filtering, { contains, equals, toBool, type ValidFilter } from "@/utils/f
 import _l from "@/utils/localization";
 import { errorMessageAsString } from "@/utils/simple-error";
 
-import type { ActionArray, FieldArray, GridConfig } from "./types";
+import { type ActionArray, type FieldArray, type GridConfig } from "./types";
 
 const { emit } = useEventBus<string>("grid-router-push");
 

--- a/client/src/components/Grid/configs/pagesPublished.ts
+++ b/client/src/components/Grid/configs/pagesPublished.ts
@@ -4,7 +4,7 @@ import { useEventBus } from "@vueuse/core";
 import { fetcher } from "@/api/schema";
 import Filtering, { contains, type ValidFilter } from "@/utils/filtering";
 
-import type { ActionArray, FieldArray, GridConfig } from "./types";
+import { type ActionArray, type FieldArray, type GridConfig } from "./types";
 
 const { emit } = useEventBus<string>("grid-router-push");
 

--- a/client/src/components/Grid/configs/types.ts
+++ b/client/src/components/Grid/configs/types.ts
@@ -1,7 +1,7 @@
-import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import { type IconDefinition } from "@fortawesome/fontawesome-svg-core";
 
-import type { GalaxyConfiguration } from "@/stores/configurationStore";
-import Filtering from "@/utils/filtering";
+import { type GalaxyConfiguration } from "@/stores/configurationStore";
+import type Filtering from "@/utils/filtering";
 
 export interface Action {
     title: string;

--- a/client/src/components/Grid/configs/visualizations.ts
+++ b/client/src/components/Grid/configs/visualizations.ts
@@ -8,7 +8,7 @@ import Filtering, { contains, equals, expandNameTag, toBool, type ValidFilter } 
 import { withPrefix } from "@/utils/redirect";
 import { errorMessageAsString, rethrowSimple } from "@/utils/simple-error";
 
-import type { ActionArray, FieldArray, GridConfig } from "./types";
+import { type ActionArray, type FieldArray, type GridConfig } from "./types";
 
 const { emit } = useEventBus<string>("grid-router-push");
 

--- a/client/src/components/Grid/configs/visualizationsPublished.ts
+++ b/client/src/components/Grid/configs/visualizationsPublished.ts
@@ -4,7 +4,7 @@ import { fetcher } from "@/api/schema";
 import Filtering, { contains, expandNameTag, type ValidFilter } from "@/utils/filtering";
 import { withPrefix } from "@/utils/redirect";
 
-import type { FieldArray, GridConfig } from "./types";
+import { type FieldArray, type GridConfig } from "./types";
 
 /**
  * Api endpoint handlers

--- a/client/src/components/History/Archiving/ArchivedHistoryCard.vue
+++ b/client/src/components/History/Archiving/ArchivedHistoryCard.vue
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BBadge, BButton, BButtonGroup } from "bootstrap-vue";
 import { computed } from "vue";
 
-import { ArchivedHistorySummary } from "@/api/histories.archived";
+import { type ArchivedHistorySummary } from "@/api/histories.archived";
 import localize from "@/utils/localization";
 
 import ExportRecordDOILink from "@/components/Common/ExportRecordDOILink.vue";

--- a/client/src/components/History/Archiving/HistoryArchive.vue
+++ b/client/src/components/History/Archiving/HistoryArchive.vue
@@ -4,7 +4,7 @@ import { computed, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import {
-    ArchivedHistorySummary,
+    type ArchivedHistorySummary,
     fetchArchivedHistories,
     reimportArchivedHistoryFromExportRecord,
 } from "@/api/histories.archived";

--- a/client/src/components/History/Archiving/HistoryArchiveExportSelector.test.ts
+++ b/client/src/components/History/Archiving/HistoryArchiveExportSelector.test.ts
@@ -5,7 +5,7 @@ import { BFormCheckbox } from "bootstrap-vue";
 import flushPromises from "flush-promises";
 import { getLocalVue } from "tests/jest/helpers";
 
-import type { HistorySummary } from "@/api";
+import { type HistorySummary } from "@/api";
 import { mockFetcher } from "@/api/schema/__mocks__";
 import {
     FAILED_FILE_SOURCE_STORE_RESPONSE,

--- a/client/src/components/History/Archiving/HistoryArchiveWizard.test.ts
+++ b/client/src/components/History/Archiving/HistoryArchiveWizard.test.ts
@@ -4,7 +4,7 @@ import flushPromises from "flush-promises";
 import { setActivePinia } from "pinia";
 import { getLocalVue } from "tests/jest/helpers";
 
-import type { HistorySummary } from "@/api";
+import { type HistorySummary } from "@/api";
 import { mockFetcher } from "@/api/schema/__mocks__";
 import { useHistoryStore } from "@/stores/historyStore";
 

--- a/client/src/components/History/Content/Collection/CollectionProgress.vue
+++ b/client/src/components/History/Content/Collection/CollectionProgress.vue
@@ -2,7 +2,7 @@
 at components/JobStates/CollectionJobStates but it relies on the backbone data
 model, so probably has to go eventually.-->
 <script setup lang="ts">
-import { JobStateSummary } from "./JobStateSummary";
+import { type JobStateSummary } from "./JobStateSummary";
 
 interface Props {
     summary: JobStateSummary;

--- a/client/src/components/History/Content/Dataset/DatasetDownload.test.ts
+++ b/client/src/components/History/Content/Dataset/DatasetDownload.test.ts
@@ -1,6 +1,6 @@
 import { getLocalVue } from "@tests/jest/helpers";
-import { mount, Wrapper } from "@vue/test-utils";
-import Vue from "vue";
+import { mount, type Wrapper } from "@vue/test-utils";
+import type Vue from "vue";
 
 import DatasetDownload from "./DatasetDownload.vue";
 

--- a/client/src/components/History/Content/model/stateTypes.d.ts
+++ b/client/src/components/History/Content/model/stateTypes.d.ts
@@ -1,4 +1,4 @@
-import { STATES } from "./states";
+import { type STATES } from "./states";
 
 export type State = {
     status: string;

--- a/client/src/components/History/Content/model/states.ts
+++ b/client/src/components/History/Content/model/states.ts
@@ -1,4 +1,4 @@
-import type { components } from "@/api/schema";
+import { type components } from "@/api/schema";
 
 type DatasetState = components["schemas"]["DatasetState"];
 // The 'failed' state is for the collection job state summary, not a dataset state.

--- a/client/src/components/History/CurrentCollection/CollectionOperations.vue
+++ b/client/src/components/History/CurrentCollection/CollectionOperations.vue
@@ -2,7 +2,7 @@
 import { computed } from "vue";
 import { useRouter } from "vue-router/composables";
 
-import { HDCADetailed } from "@/api";
+import { type HDCADetailed } from "@/api";
 import { getAppRoot } from "@/onload/loadConfig";
 
 const router = useRouter();

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionStatus.test.ts
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionStatus.test.ts
@@ -1,4 +1,4 @@
-import { shallowMount, Wrapper } from "@vue/test-utils";
+import { shallowMount, type Wrapper } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { getLocalVue } from "tests/jest/helpers";
 

--- a/client/src/components/History/Export/HistoryExport.test.ts
+++ b/client/src/components/History/Export/HistoryExport.test.ts
@@ -6,9 +6,9 @@ import MockAdapter from "axios-mock-adapter";
 import flushPromises from "flush-promises";
 import { setActivePinia } from "pinia";
 
-import type { HistorySummary } from "@/api";
+import { type HistorySummary } from "@/api";
 import { fetchHistoryExportRecords } from "@/api/histories.export";
-import type { FilesSourcePlugin } from "@/api/remoteFiles";
+import { type FilesSourcePlugin } from "@/api/remoteFiles";
 import { mockFetcher } from "@/api/schema/__mocks__";
 import {
     EXPIRED_STS_DOWNLOAD_RECORD,

--- a/client/src/components/History/Export/HistoryExport.vue
+++ b/client/src/components/History/Export/HistoryExport.vue
@@ -12,7 +12,7 @@ import {
     reimportHistoryFromRecord,
 } from "@/api/histories.export";
 import type { ColorVariant } from "@/components/Common";
-import { areEqual, ExportParams, ExportRecord } from "@/components/Common/models/exportRecordModel";
+import { areEqual, type ExportParams, type ExportRecord } from "@/components/Common/models/exportRecordModel";
 import { useConfirmDialog } from "@/composables/confirmDialog";
 import { useFileSources } from "@/composables/fileSources";
 import { DEFAULT_EXPORT_PARAMS, useShortTermStorage } from "@/composables/shortTermStorage";

--- a/client/src/components/History/Multiple/MultipleViewList.vue
+++ b/client/src/components/History/Multiple/MultipleViewList.vue
@@ -6,7 +6,7 @@ import { computed, type Ref, ref } from "vue";
 //@ts-ignore missing typedefs
 import VirtualList from "vue-virtual-scroll-list";
 
-import { HistoryItemSummary, isHistoryItem } from "@/api";
+import { type HistoryItemSummary, isHistoryItem } from "@/api";
 import { copyDataset } from "@/api/datasets";
 import { useAnimationFrameResizeObserver } from "@/composables/sensors/animationFrameResizeObserver";
 import { useAnimationFrameScroll } from "@/composables/sensors/animationFrameScroll";

--- a/client/src/components/History/SwitchToHistoryLink.vue
+++ b/client/src/components/History/SwitchToHistoryLink.vue
@@ -6,7 +6,7 @@ import { BLink } from "bootstrap-vue";
 import { computed } from "vue";
 import { useRouter } from "vue-router/composables";
 
-import { HistorySummary } from "@/api";
+import { type HistorySummary } from "@/api";
 import { useHistoryStore } from "@/stores/historyStore";
 
 import LoadingSpan from "@/components/LoadingSpan.vue";

--- a/client/src/components/JobParameters/JobParameters.test.ts
+++ b/client/src/components/JobParameters/JobParameters.test.ts
@@ -1,4 +1,4 @@
-import { mount, Wrapper } from "@vue/test-utils";
+import { mount, type Wrapper } from "@vue/test-utils";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import flushPromises from "flush-promises";

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <FolderTopBar
-            :canAddLibraryItem="canAddLibraryItem"
+            :can-add-library-item="canAddLibraryItem"
             :folder-contents="folderContents"
             :include-deleted.sync="includeDeleted"
             :folder_id="currentFolderId"

--- a/client/src/components/Login/ChangePassword.test.ts
+++ b/client/src/components/Login/ChangePassword.test.ts
@@ -1,4 +1,4 @@
-import { mount, Wrapper } from "@vue/test-utils";
+import { mount, type Wrapper } from "@vue/test-utils";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import { getLocalVue } from "tests/jest/helpers";

--- a/client/src/components/Login/RegisterForm.test.ts
+++ b/client/src/components/Login/RegisterForm.test.ts
@@ -1,5 +1,5 @@
 import { getLocalVue } from "@tests/jest/helpers";
-import { mount, Wrapper } from "@vue/test-utils";
+import { mount, type Wrapper } from "@vue/test-utils";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 

--- a/client/src/components/Markdown/Elements/JobSelection.vue
+++ b/client/src/components/Markdown/Elements/JobSelection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { SelectOption } from "./handlesMappingJobs";
+import { type SelectOption } from "./handlesMappingJobs";
 
 interface JobSelectionProps {
     jobId?: string;

--- a/client/src/components/Markdown/Elements/handlesMappingJobs.ts
+++ b/client/src/components/Markdown/Elements/handlesMappingJobs.ts
@@ -1,5 +1,5 @@
 import { format, parseISO } from "date-fns";
-import { computed, Ref, ref, watch } from "vue";
+import { computed, type Ref, ref, watch } from "vue";
 
 import { fetcher } from "@/api/schema";
 

--- a/client/src/components/Markdown/LabelSelector.vue
+++ b/client/src/components/Markdown/LabelSelector.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { WorkflowLabel } from "./labels";
+import { type WorkflowLabel } from "./labels";
 
 interface LabelSelectorProps {
     hasLabels: boolean;

--- a/client/src/components/Markdown/MarkdownDialog.vue
+++ b/client/src/components/Markdown/MarkdownDialog.vue
@@ -9,7 +9,7 @@ import { jobsFetcher } from "@/api/jobs";
 import { workflowsFetcher } from "@/api/workflows";
 import { useHistoryStore } from "@/stores/historyStore";
 
-import { WorkflowLabel, WorkflowLabels } from "./labels";
+import { type WorkflowLabel, type WorkflowLabels } from "./labels";
 
 import MarkdownSelector from "./MarkdownSelector.vue";
 import MarkdownVisualization from "./MarkdownVisualization.vue";

--- a/client/src/components/Markdown/MarkdownSelector.vue
+++ b/client/src/components/Markdown/MarkdownSelector.vue
@@ -2,7 +2,7 @@
 import { BModal } from "bootstrap-vue";
 import { computed, ref } from "vue";
 
-import { WorkflowLabel } from "./labels";
+import { type WorkflowLabel } from "./labels";
 
 import LabelSelector from "./LabelSelector.vue";
 

--- a/client/src/components/Notifications/NotificationActions.test.ts
+++ b/client/src/components/Notifications/NotificationActions.test.ts
@@ -3,9 +3,9 @@ import { getLocalVue } from "@tests/jest/helpers";
 import { mount, type Wrapper } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { setActivePinia } from "pinia";
-import Vue from "vue";
+import type Vue from "vue";
 
-import type { UserNotification } from "@/api/notifications";
+import { type UserNotification } from "@/api/notifications";
 import { generateMessageNotification, generateNewSharedItemNotification } from "@/components/Notifications/test-utils";
 import { useNotificationsStore } from "@/stores/notificationsStore";
 

--- a/client/src/components/Notifications/test-utils.ts
+++ b/client/src/components/Notifications/test-utils.ts
@@ -1,9 +1,9 @@
-import type {
-    MessageNotification,
-    NewSharedItemNotificationContentItemType,
-    NotificationVariants,
-    SharedItemNotification,
-    UserNotification,
+import {
+    type MessageNotification,
+    type NewSharedItemNotificationContentItemType,
+    type NotificationVariants,
+    type SharedItemNotification,
+    type UserNotification,
 } from "@/api/notifications";
 
 export function generateRandomItemType() {

--- a/client/src/components/ObjectStore/Instances/CreateForm.test.ts
+++ b/client/src/components/ObjectStore/Instances/CreateForm.test.ts
@@ -2,9 +2,9 @@ import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { getLocalVue } from "tests/jest/helpers";
 
-import { PluginStatus } from "@/api/configTemplates";
+import { type PluginStatus } from "@/api/configTemplates";
 import { mockFetcher } from "@/api/schema/__mocks__";
-import type { ObjectStoreTemplateSummary } from "@/components/ObjectStore/Templates/types";
+import { type ObjectStoreTemplateSummary } from "@/components/ObjectStore/Templates/types";
 
 import CreateForm from "./CreateForm.vue";
 

--- a/client/src/components/ObjectStore/Instances/UpgradeForm.test.ts
+++ b/client/src/components/ObjectStore/Instances/UpgradeForm.test.ts
@@ -3,9 +3,9 @@ import flushPromises from "flush-promises";
 import { getLocalVue, injectTestRouter } from "tests/jest/helpers";
 
 import { mockFetcher } from "@/api/schema/__mocks__";
-import type { ObjectStoreTemplateSummary } from "@/components/ObjectStore/Templates/types";
+import { type ObjectStoreTemplateSummary } from "@/components/ObjectStore/Templates/types";
 
-import type { UserConcreteObjectStore } from "./types";
+import { type UserConcreteObjectStore } from "./types";
 
 import UpgradeForm from "./UpgradeForm.vue";
 

--- a/client/src/components/ObjectStore/Instances/instance.ts
+++ b/client/src/components/ObjectStore/Instances/instance.ts
@@ -1,10 +1,10 @@
 import { computed, type Ref } from "vue";
 
-import type { ObjectStoreTemplateSummary } from "@/components/ObjectStore/Templates/types";
+import { type ObjectStoreTemplateSummary } from "@/components/ObjectStore/Templates/types";
 import { useObjectStoreInstancesStore } from "@/stores/objectStoreInstancesStore";
 import { useObjectStoreTemplatesStore } from "@/stores/objectStoreTemplatesStore";
 
-import type { UserConcreteObjectStore } from "./types";
+import { type UserConcreteObjectStore } from "./types";
 
 export function useInstanceAndTemplate(instanceIdRef: Ref<string>) {
     const objectStoreTemplatesStore = useObjectStoreTemplatesStore();

--- a/client/src/components/ObjectStore/Instances/services.ts
+++ b/client/src/components/ObjectStore/Instances/services.ts
@@ -1,6 +1,6 @@
 import { fetcher } from "@/api/schema/fetcher";
 
-import type { UserConcreteObjectStore } from "./types";
+import { type UserConcreteObjectStore } from "./types";
 
 export const create = fetcher.path("/api/object_store_instances").method("post").create();
 export const test = fetcher.path("/api/object_store_instances/test").method("post").create();

--- a/client/src/components/ObjectStore/Instances/types.ts
+++ b/client/src/components/ObjectStore/Instances/types.ts
@@ -1,4 +1,4 @@
-import type { components } from "@/api/schema/schema";
+import { type components } from "@/api/schema/schema";
 
 export type UserConcreteObjectStore = components["schemas"]["UserConcreteObjectStoreModel"];
 export type CreateInstancePayload = components["schemas"]["CreateInstancePayload"];

--- a/client/src/components/ObjectStore/ObjectStoreTypeSpan.vue
+++ b/client/src/components/ObjectStore/ObjectStoreTypeSpan.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-import { ObjectStoreTemplateType } from "@/api/objectStores";
+import { type ObjectStoreTemplateType } from "@/api/objectStores";
 
 const MESSAGES = {
     aws_s3: "This is a storage location based on the Amazon Simple Storage Service (S3). Data here is hosted by Amazon.",

--- a/client/src/components/ObjectStore/SelectObjectStore.vue
+++ b/client/src/components/ObjectStore/SelectObjectStore.vue
@@ -2,7 +2,7 @@
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 
-import { ConcreteObjectStoreModel } from "@/api";
+import { type ConcreteObjectStoreModel } from "@/api";
 import { useStorageLocationConfiguration } from "@/composables/storageLocation";
 import { useObjectStoreStore } from "@/stores/objectStoreStore";
 

--- a/client/src/components/ObjectStore/Templates/types.ts
+++ b/client/src/components/ObjectStore/Templates/types.ts
@@ -1,4 +1,4 @@
-import type { components } from "@/api/schema/schema";
+import { type components } from "@/api/schema/schema";
 
 export type ObjectStoreTemplateSummary = components["schemas"]["ObjectStoreTemplateSummary"];
 export type ObjectStoreTemplateSummaries = ObjectStoreTemplateSummary[];

--- a/client/src/components/ObjectStore/types.ts
+++ b/client/src/components/ObjectStore/types.ts
@@ -1,3 +1,3 @@
-import type { components } from "@/api/schema";
+import { type components } from "@/api/schema";
 
 export type ConcreteObjectStoreModel = components["schemas"]["ConcreteObjectStoreModel"];

--- a/client/src/components/PageEditor/ObjectPermissions.vue
+++ b/client/src/components/PageEditor/ObjectPermissions.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import axios from "axios";
-import Vue, { computed, Ref, ref, watch } from "vue";
+import Vue, { computed, type Ref, ref, watch } from "vue";
 
 import { fetchCollectionSummary } from "@/api/datasetCollections";
 import { enableLink, sharing } from "@/api/histories";

--- a/client/src/components/PageEditor/object-permission-composables.ts
+++ b/client/src/components/PageEditor/object-permission-composables.ts
@@ -1,4 +1,4 @@
-import { computed, Ref, ref } from "vue";
+import { computed, type Ref, ref } from "vue";
 
 import { referencedObjects } from "@/components/Markdown/parse";
 

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -3,7 +3,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { faEye, faEyeSlash } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { storeToRefs } from "pinia";
-import { computed, ComputedRef, type PropType, type Ref, ref } from "vue";
+import { computed, type ComputedRef, type PropType, type Ref, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { getGalaxyInstance } from "@/app";
@@ -11,7 +11,7 @@ import { useGlobalUploadModal } from "@/composables/globalUploadModal";
 import { getAppRoot } from "@/onload/loadConfig";
 import { type Tool, type ToolSection as ToolSectionType } from "@/stores/toolStore";
 import { useToolStore } from "@/stores/toolStore";
-import { Workflow, type Workflow as WorkflowType } from "@/stores/workflowStore";
+import { type Workflow, type Workflow as WorkflowType } from "@/stores/workflowStore";
 import localize from "@/utils/localization";
 
 import { filterTools, getValidPanelItems, getValidToolsInCurrentView, getValidToolsInEachSection } from "./utilities";

--- a/client/src/components/Popper/usePopper.ts
+++ b/client/src/components/Popper/usePopper.ts
@@ -1,6 +1,5 @@
 import { createPopper } from "@popperjs/core";
-import type { Ref } from "vue";
-import { onMounted, onUnmounted, onUpdated, ref, unref, watch } from "vue";
+import { onMounted, onUnmounted, onUpdated, type Ref, ref, unref, watch } from "vue";
 
 export type MaybeRef<T> = T | Ref<T>;
 

--- a/client/src/components/SelectionDialog/BasicSelectionDialog.vue
+++ b/client/src/components/SelectionDialog/BasicSelectionDialog.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, type Ref, ref } from "vue";
 
-import { ApiResponse } from "@/api/schema";
+import { type ApiResponse } from "@/api/schema";
 import { type SelectionItem } from "@/components/SelectionDialog/selectionTypes";
 import { errorMessageAsString } from "@/utils/simple-error";
 

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BButton, BLink, BModal, BPagination, BSpinner, BTable } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
 
-import { ItemsProvider, SELECTION_STATES } from "@/components/SelectionDialog/selectionTypes";
+import { type ItemsProvider, SELECTION_STATES } from "@/components/SelectionDialog/selectionTypes";
 
 import { type FieldEntry, type SelectionItem } from "./selectionTypes";
 

--- a/client/src/components/Tool/helpForumUrls.ts
+++ b/client/src/components/Tool/helpForumUrls.ts
@@ -1,6 +1,6 @@
-import { computed, Ref } from "vue";
+import { computed, type Ref } from "vue";
 
-import { components } from "@/api/schema";
+import { type components } from "@/api/schema";
 import { useConfigStore } from "@/stores/configurationStore";
 
 export type HelpForumTopic = components["schemas"]["HelpForumTopic"];

--- a/client/src/components/User/DiskUsage/DiskUsageSummary.test.ts
+++ b/client/src/components/User/DiskUsage/DiskUsageSummary.test.ts
@@ -7,7 +7,7 @@ import { mockFetcher } from "@/api/schema/__mocks__";
 import { getCurrentUser } from "@/stores/users/queries";
 import { useUserStore } from "@/stores/userStore";
 
-import { UserQuotaUsageData } from "./Quota/model";
+import { type UserQuotaUsageData } from "./Quota/model";
 
 import DiskUsageSummary from "./DiskUsageSummary.vue";
 

--- a/client/src/components/User/DiskUsage/DiskUsageSummary.vue
+++ b/client/src/components/User/DiskUsage/DiskUsageSummary.vue
@@ -9,7 +9,7 @@ import { useUserStore } from "@/stores/userStore";
 import { errorMessageAsString } from "@/utils/simple-error";
 import { bytesToString } from "@/utils/utils";
 
-import { QuotaUsage } from "./Quota/model";
+import { type QuotaUsage } from "./Quota/model";
 import { fetch } from "./Quota/services";
 
 import QuotaUsageSummary from "@/components/User/DiskUsage/Quota/QuotaUsageSummary.vue";

--- a/client/src/components/User/DiskUsage/Management/Cleanup/categories.ts
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/categories.ts
@@ -12,7 +12,7 @@ import {
     fetchDiscardedHistories,
     fetchDiscardedHistoriesSummary,
 } from "../services";
-import type { CleanupCategory } from "./model";
+import { type CleanupCategory } from "./model";
 
 export function useCleanupCategories() {
     const cleanupCategories = ref<CleanupCategory[]>([

--- a/client/src/components/User/DiskUsage/Management/Cleanup/model/CleanableSummary.ts
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/model/CleanableSummary.ts
@@ -1,4 +1,4 @@
-import type { components } from "@/api/schema";
+import { type components } from "@/api/schema";
 import { bytesToString } from "@/utils/utils";
 
 type CleanableItemsSummaryResponse = components["schemas"]["CleanableItemsSummary"];

--- a/client/src/components/User/DiskUsage/Management/Cleanup/model/CleanupCategory.ts
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/model/CleanupCategory.ts
@@ -1,4 +1,4 @@
-import type { CleanupOperation } from ".";
+import { type CleanupOperation } from ".";
 
 /**
  * Defines a new category to display in the Storage Management Dashboard to

--- a/client/src/components/User/DiskUsage/Management/Cleanup/model/CleanupOperation.ts
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/model/CleanupOperation.ts
@@ -1,7 +1,7 @@
-import type { components } from "@/api/schema";
+import { type components } from "@/api/schema";
 
-import type { CleanableSummary } from "./CleanableSummary";
-import type { CleanupResult } from "./CleanupResult";
+import { type CleanableSummary } from "./CleanableSummary";
+import { type CleanupResult } from "./CleanupResult";
 
 export type CleanableItem = components["schemas"]["StoredItem"];
 export type SortableKey = "name" | "size" | "update_time";

--- a/client/src/components/User/DiskUsage/Management/Cleanup/model/CleanupResult.ts
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/model/CleanupResult.ts
@@ -1,7 +1,7 @@
-import type { components } from "@/api/schema";
+import { type components } from "@/api/schema";
 import { bytesToString } from "@/utils/utils";
 
-import type { CleanableItem } from "./CleanupOperation";
+import { type CleanableItem } from "./CleanupOperation";
 
 export type StorageItemsCleanupResult = components["schemas"]["StorageItemsCleanupResult"];
 

--- a/client/src/components/User/DiskUsage/Quota/QuotaUsageBar.vue
+++ b/client/src/components/User/DiskUsage/Quota/QuotaUsageBar.vue
@@ -3,7 +3,7 @@ import { computed, ref } from "vue";
 
 import localize from "@/utils/localization";
 
-import { DEFAULT_QUOTA_SOURCE_LABEL, QuotaUsage } from "./model/QuotaUsage";
+import { DEFAULT_QUOTA_SOURCE_LABEL, type QuotaUsage } from "./model/QuotaUsage";
 
 interface QuotaUsageBarProps {
     quotaUsage: QuotaUsage;

--- a/client/src/components/User/DiskUsage/Quota/model/QuotaUsage.ts
+++ b/client/src/components/User/DiskUsage/Quota/model/QuotaUsage.ts
@@ -1,4 +1,4 @@
-import type { components } from "@/api/schema";
+import { type components } from "@/api/schema";
 import { bytesToString } from "@/utils/utils";
 
 export const DEFAULT_QUOTA_SOURCE_LABEL = "Default";

--- a/client/src/components/User/DiskUsage/Quota/model/index.ts
+++ b/client/src/components/User/DiskUsage/Quota/model/index.ts
@@ -1,1 +1,1 @@
-export { QuotaUsage, UserQuotaUsageData } from "./QuotaUsage";
+export { QuotaUsage, type UserQuotaUsageData } from "./QuotaUsage";

--- a/client/src/components/User/DiskUsage/Quota/services.ts
+++ b/client/src/components/User/DiskUsage/Quota/services.ts
@@ -1,6 +1,6 @@
 import { fetchQuotaUsages } from "@/api/users";
 
-import { QuotaUsage, UserQuotaUsageData } from "./model/index";
+import { QuotaUsage, type UserQuotaUsageData } from "./model/index";
 
 export async function fetch() {
     const { data } = await fetchQuotaUsages({ user_id: "current" });

--- a/client/src/components/User/DiskUsage/Visualizations/Charts/BarChart.test.ts
+++ b/client/src/components/User/DiskUsage/Visualizations/Charts/BarChart.test.ts
@@ -1,6 +1,6 @@
 import { mount } from "@vue/test-utils";
 
-import type { DataValuePoint } from ".";
+import { type DataValuePoint } from ".";
 
 import BarChart from "./BarChart.vue";
 

--- a/client/src/components/User/DiskUsage/Visualizations/Charts/formatters.ts
+++ b/client/src/components/User/DiskUsage/Visualizations/Charts/formatters.ts
@@ -1,6 +1,6 @@
 import { bytesToString } from "@/utils/utils";
 
-import type { DataValuePoint } from ".";
+import { type DataValuePoint } from ".";
 
 export function bytesLabelFormatter(dataPoint?: DataValuePoint | null): string {
     return dataPoint ? `${dataPoint.label}: ${bytesToString(dataPoint.value)}` : "No data";

--- a/client/src/components/User/DiskUsage/Visualizations/util.ts
+++ b/client/src/components/User/DiskUsage/Visualizations/util.ts
@@ -6,7 +6,7 @@ import { useConfirmDialog } from "@/composables/confirmDialog";
 import { useToast } from "@/composables/toast";
 import localize from "@/utils/localization";
 
-import type { DataValuePoint } from "./Charts";
+import { type DataValuePoint } from "./Charts";
 import { bytesLabelFormatter, bytesValueFormatter } from "./Charts/formatters";
 import { type ItemSizeSummary, purgeDatasetById, undeleteDatasetById } from "./service";
 

--- a/client/src/components/User/Notifications/NotificationsPreferences.vue
+++ b/client/src/components/User/Notifications/NotificationsPreferences.vue
@@ -8,7 +8,7 @@ import { computed, ref, watch } from "vue";
 import {
     getNotificationsPreferencesFromServer,
     updateNotificationsPreferencesOnServer,
-    UserNotificationPreferencesExtended,
+    type UserNotificationPreferencesExtended,
 } from "@/api/notifications.preferences";
 import { useConfig } from "@/composables/config";
 import { Toast } from "@/composables/toast";

--- a/client/src/components/Workflow/Editor/Actions/actions.test.ts
+++ b/client/src/components/Workflow/Editor/Actions/actions.test.ts
@@ -1,6 +1,6 @@
 import { createPinia, setActivePinia } from "pinia";
 
-import { LazyUndoRedoAction, UndoRedoAction, useUndoRedoStore } from "@/stores/undoRedoStore";
+import { LazyUndoRedoAction, type UndoRedoAction, useUndoRedoStore } from "@/stores/undoRedoStore";
 import { useConnectionStore } from "@/stores/workflowConnectionStore";
 import { useWorkflowCommentStore } from "@/stores/workflowEditorCommentStore";
 import { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";

--- a/client/src/components/Workflow/Editor/Actions/cloneStep.ts
+++ b/client/src/components/Workflow/Editor/Actions/cloneStep.ts
@@ -1,4 +1,4 @@
-import type { Step, WorkflowStepStore } from "@/stores/workflowStepStore";
+import { type Step, type WorkflowStepStore } from "@/stores/workflowStepStore";
 
 /**
  * Copies a step and increments a trailing number in it's label,

--- a/client/src/components/Workflow/Editor/Actions/commentActions.ts
+++ b/client/src/components/Workflow/Editor/Actions/commentActions.ts
@@ -1,9 +1,9 @@
 import { LazyUndoRedoAction, UndoRedoAction } from "@/stores/undoRedoStore";
-import type {
-    BaseWorkflowComment,
-    WorkflowComment,
-    WorkflowCommentColor,
-    WorkflowCommentStore,
+import {
+    type BaseWorkflowComment,
+    type WorkflowComment,
+    type WorkflowCommentColor,
+    type WorkflowCommentStore,
 } from "@/stores/workflowEditorCommentStore";
 
 class CommentAction extends UndoRedoAction {

--- a/client/src/components/Workflow/Editor/Actions/mockData.ts
+++ b/client/src/components/Workflow/Editor/Actions/mockData.ts
@@ -1,7 +1,7 @@
-import { FreehandWorkflowComment, WorkflowComment } from "@/stores/workflowEditorCommentStore";
-import type { Step } from "@/stores/workflowStepStore";
+import { type FreehandWorkflowComment, type WorkflowComment } from "@/stores/workflowEditorCommentStore";
+import { type Step } from "@/stores/workflowStepStore";
 
-import type { Workflow } from "../modules/model";
+import { type Workflow } from "../modules/model";
 
 export function mockToolStep(id: number): Step {
     return {

--- a/client/src/components/Workflow/Editor/Actions/stepActions.ts
+++ b/client/src/components/Workflow/Editor/Actions/stepActions.ts
@@ -1,10 +1,10 @@
 import { replaceLabel } from "@/components/Markdown/parse";
 import { useToast } from "@/composables/toast";
 import { useRefreshFromStore } from "@/stores/refreshFromStore";
-import { LazyUndoRedoAction, UndoRedoAction, UndoRedoStore } from "@/stores/undoRedoStore";
-import { Connection, WorkflowConnectionStore } from "@/stores/workflowConnectionStore";
-import { WorkflowStateStore } from "@/stores/workflowEditorStateStore";
-import type { NewStep, Step, WorkflowStepStore } from "@/stores/workflowStepStore";
+import { LazyUndoRedoAction, UndoRedoAction, type UndoRedoStore } from "@/stores/undoRedoStore";
+import { type Connection, type WorkflowConnectionStore } from "@/stores/workflowConnectionStore";
+import { type WorkflowStateStore } from "@/stores/workflowEditorStateStore";
+import { type NewStep, type Step, type WorkflowStepStore } from "@/stores/workflowStepStore";
 import { assertDefined } from "@/utils/assertions";
 
 import { cloneStepWithUniqueLabel, getLabelSet } from "./cloneStep";

--- a/client/src/components/Workflow/Editor/Actions/workflowActions.ts
+++ b/client/src/components/Workflow/Editor/Actions/workflowActions.ts
@@ -1,4 +1,4 @@
-import { LazyUndoRedoAction, UndoRedoAction, UndoRedoStore } from "@/stores/undoRedoStore";
+import { LazyUndoRedoAction, UndoRedoAction, type UndoRedoStore } from "@/stores/undoRedoStore";
 import { useConnectionStore } from "@/stores/workflowConnectionStore";
 import {
     useWorkflowCommentStore,
@@ -9,8 +9,8 @@ import { useWorkflowStateStore, type WorkflowStateStore } from "@/stores/workflo
 import { type Step, useWorkflowStepStore, type WorkflowStepStore } from "@/stores/workflowStepStore";
 import { ensureDefined } from "@/utils/assertions";
 
-import { defaultPosition } from "../composables/useDefaultStepPosition";
-import { fromSimple, Workflow } from "../modules/model";
+import { type defaultPosition } from "../composables/useDefaultStepPosition";
+import { fromSimple, type Workflow } from "../modules/model";
 import { cloneStepWithUniqueLabel, getLabelSet } from "./cloneStep";
 
 export class LazySetValueAction<T> extends LazyUndoRedoAction {

--- a/client/src/components/Workflow/Editor/Comments/WorkflowComment.test.ts
+++ b/client/src/components/Workflow/Editor/Comments/WorkflowComment.test.ts
@@ -3,8 +3,8 @@ import { mount, shallowMount } from "@vue/test-utils";
 import { setActivePinia } from "pinia";
 import { nextTick } from "vue";
 
-import type { LazyUndoRedoAction, UndoRedoAction } from "@/stores/undoRedoStore";
-import type { TextWorkflowComment } from "@/stores/workflowEditorCommentStore";
+import { type LazyUndoRedoAction, type UndoRedoAction } from "@/stores/undoRedoStore";
+import { type TextWorkflowComment } from "@/stores/workflowEditorCommentStore";
 
 import MarkdownComment from "./MarkdownComment.vue";
 import TextComment from "./TextComment.vue";

--- a/client/src/components/Workflow/Editor/Draggable.vue
+++ b/client/src/components/Workflow/Editor/Draggable.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import type { ZoomTransform } from "d3-zoom";
 import { storeToRefs } from "pinia";
-import type { type PropType, Ref } from "vue";
-import { computed, inject, reactive, ref } from "vue";
+import { computed, inject, type PropType, reactive, type Ref, ref } from "vue";
 
 import { useAnimationFrameSize } from "@/composables/sensors/animationFrameSize";
 import { useAnimationFrameThrottle } from "@/composables/throttle";

--- a/client/src/components/Workflow/Editor/Draggable.vue
+++ b/client/src/components/Workflow/Editor/Draggable.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import type { ZoomTransform } from "d3-zoom";
 import { storeToRefs } from "pinia";
-import type { Ref } from "vue";
-import { computed, inject, PropType, reactive, ref } from "vue";
+import type { type PropType, Ref } from "vue";
+import { computed, inject, reactive, ref } from "vue";
 
 import { useAnimationFrameSize } from "@/composables/sensors/animationFrameSize";
 import { useAnimationFrameThrottle } from "@/composables/throttle";

--- a/client/src/components/Workflow/Editor/NodeOutput.test.ts
+++ b/client/src/components/Workflow/Editor/NodeOutput.test.ts
@@ -4,7 +4,7 @@ import { getLocalVue } from "tests/jest/helpers";
 import { nextTick, ref } from "vue";
 
 import { testDatatypesMapper } from "@/components/Datatypes/test_fixtures";
-import { UndoRedoStore, useUndoRedoStore } from "@/stores/undoRedoStore";
+import { type UndoRedoStore, useUndoRedoStore } from "@/stores/undoRedoStore";
 import { useConnectionStore } from "@/stores/workflowConnectionStore";
 import { type Step, type Steps, useWorkflowStepStore } from "@/stores/workflowStepStore";
 

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -11,7 +11,17 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import type { UseElementBoundingReturn, UseScrollReturn } from "@vueuse/core";
-import { computed, ComputedRef, nextTick, onBeforeUnmount, type Ref, ref, toRefs, type UnwrapRef, watch } from "vue";
+import {
+    computed,
+    type ComputedRef,
+    nextTick,
+    onBeforeUnmount,
+    type Ref,
+    ref,
+    toRefs,
+    type UnwrapRef,
+    watch,
+} from "vue";
 
 import type { DatatypesMapperModel } from "@/components/Datatypes/model";
 import { useWorkflowStores } from "@/composables/workflowStores";

--- a/client/src/components/Workflow/Editor/Tools/useToolLogic.ts
+++ b/client/src/components/Workflow/Editor/Tools/useToolLogic.ts
@@ -2,7 +2,7 @@ import simplify from "simplify-js";
 import { ref, watch } from "vue";
 
 import { useWorkflowStores } from "@/composables/workflowStores";
-import type { BaseWorkflowComment } from "@/stores/workflowEditorCommentStore";
+import { type BaseWorkflowComment } from "@/stores/workflowEditorCommentStore";
 import { assertDefined } from "@/utils/assertions";
 import { match } from "@/utils/utils";
 

--- a/client/src/components/Workflow/Editor/composables/d3Zoom.ts
+++ b/client/src/components/Workflow/Editor/composables/d3Zoom.ts
@@ -1,10 +1,9 @@
-import type { UseScrollReturn } from "@vueuse/core";
+import { type UseScrollReturn } from "@vueuse/core";
 import { select } from "d3-selection";
 import { type D3ZoomEvent, zoom, zoomIdentity } from "d3-zoom";
-import type { Ref } from "vue";
-import { ref, watch } from "vue";
+import { type Ref, ref, watch } from "vue";
 
-import type { XYPosition } from "@/stores/workflowEditorStateStore";
+import { type XYPosition } from "@/stores/workflowEditorStateStore";
 
 // if element is draggable it may implement its own drag handler,
 // but d3zoom would call preventDefault

--- a/client/src/components/Workflow/Editor/composables/multiSelect.ts
+++ b/client/src/components/Workflow/Editor/composables/multiSelect.ts
@@ -1,7 +1,7 @@
 import { computed, type Ref } from "vue";
 
 import { useWorkflowStores } from "@/composables/workflowStores";
-import type { Step } from "@/stores/workflowStepStore";
+import { type Step } from "@/stores/workflowStepStore";
 import { ensureDefined } from "@/utils/assertions";
 
 import { ClearSelectionAction } from "../Actions/workflowActions";

--- a/client/src/components/Workflow/Editor/composables/relativePosition.ts
+++ b/client/src/components/Workflow/Editor/composables/relativePosition.ts
@@ -1,4 +1,4 @@
-import type { ZoomTransform } from "d3-zoom";
+import { type ZoomTransform } from "d3-zoom";
 import { inject, onScopeDispose, type Ref, ref, watch } from "vue";
 
 /**

--- a/client/src/components/Workflow/Editor/composables/useDefaultStepPosition.ts
+++ b/client/src/components/Workflow/Editor/composables/useDefaultStepPosition.ts
@@ -1,6 +1,6 @@
-import type { UseElementBoundingReturn } from "@vueuse/core";
-import type { ZoomTransform } from "d3-zoom";
-import type { UnwrapRef } from "vue";
+import { type UseElementBoundingReturn } from "@vueuse/core";
+import { type ZoomTransform } from "d3-zoom";
+import { type UnwrapRef } from "vue";
 
 type ElementBounding = UnwrapRef<UseElementBoundingReturn>;
 

--- a/client/src/components/Workflow/Editor/composables/useNodePosition.ts
+++ b/client/src/components/Workflow/Editor/composables/useNodePosition.ts
@@ -1,7 +1,7 @@
 import { useElementBounding } from "@vueuse/core";
 import { type ComputedRef, onUnmounted, type Ref, unref, watch } from "vue";
 
-import type { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
+import { type useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
 
 export function useNodePosition(
     nodeRef: Ref<HTMLElement | null>,

--- a/client/src/components/Workflow/Editor/composables/useStepProps.ts
+++ b/client/src/components/Workflow/Editor/composables/useStepProps.ts
@@ -1,7 +1,7 @@
 import { toRefs } from "@vueuse/core";
 import { computed, type Ref } from "vue";
 
-import type { Step } from "@/stores/workflowStepStore";
+import { type Step } from "@/stores/workflowStepStore";
 
 export function useStepProps(step: Ref<Step>) {
     const {

--- a/client/src/components/Workflow/Editor/composables/useTerminal.ts
+++ b/client/src/components/Workflow/Editor/composables/useTerminal.ts
@@ -1,9 +1,9 @@
 import { computed, type Ref, ref, watch } from "vue";
 
-import type { DatatypesMapperModel } from "@/components/Datatypes/model";
+import { type DatatypesMapperModel } from "@/components/Datatypes/model";
 import { terminalFactory } from "@/components/Workflow/Editor/modules/terminals";
 import { useWorkflowStores } from "@/composables/workflowStores";
-import type { Step, TerminalSource } from "@/stores/workflowStepStore";
+import { type Step, type TerminalSource } from "@/stores/workflowStepStore";
 
 export function useTerminal(
     stepId: Ref<Step["id"]>,

--- a/client/src/components/Workflow/Editor/composables/useUniqueLabelError.ts
+++ b/client/src/components/Workflow/Editor/composables/useUniqueLabelError.ts
@@ -1,6 +1,6 @@
 import { ref } from "vue";
 
-import type { useWorkflowStepStore } from "@/stores/workflowStepStore";
+import { type useWorkflowStepStore } from "@/stores/workflowStepStore";
 
 export function useUniqueLabelError(
     workflowStateStore: ReturnType<typeof useWorkflowStepStore>,

--- a/client/src/components/Workflow/Editor/composables/viewportBoundingBox.ts
+++ b/client/src/components/Workflow/Editor/composables/viewportBoundingBox.ts
@@ -1,4 +1,4 @@
-import type { UseElementBoundingReturn } from "@vueuse/core";
+import { type UseElementBoundingReturn } from "@vueuse/core";
 import { type Ref, ref, unref, watch } from "vue";
 
 import { useAnimationFrameThrottle } from "@/composables/throttle";

--- a/client/src/components/Workflow/Editor/modules/canvasDraw.ts
+++ b/client/src/components/Workflow/Editor/modules/canvasDraw.ts
@@ -1,14 +1,14 @@
 import { curveCatmullRom, line } from "d3";
 
 import * as commentColors from "@/components/Workflow/Editor/Comments/colors";
-import type {
-    FrameWorkflowComment,
-    FreehandWorkflowComment,
-    MarkdownWorkflowComment,
-    TextWorkflowComment,
+import {
+    type FrameWorkflowComment,
+    type FreehandWorkflowComment,
+    type MarkdownWorkflowComment,
+    type TextWorkflowComment,
 } from "@/stores/workflowEditorCommentStore";
-import type { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
-import type { Step } from "@/stores/workflowStepStore";
+import { type useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
+import { type Step } from "@/stores/workflowStepStore";
 
 export function drawBoxComments(
     ctx: CanvasRenderingContext2D,

--- a/client/src/components/Workflow/Editor/modules/layout.ts
+++ b/client/src/components/Workflow/Editor/modules/layout.ts
@@ -2,7 +2,7 @@ import ELK from "elkjs/lib/elk.bundled.js";
 
 import { useConnectionStore } from "@/stores/workflowConnectionStore";
 import { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
-import type { Step } from "@/stores/workflowStepStore";
+import { type Step } from "@/stores/workflowStepStore";
 import { assertDefined } from "@/utils/assertions";
 
 const elk = new ELK();

--- a/client/src/components/Workflow/Editor/modules/linting.ts
+++ b/client/src/components/Workflow/Editor/modules/linting.ts
@@ -1,7 +1,7 @@
-import type { DatatypesMapperModel } from "@/components/Datatypes/model";
-import type { UntypedParameters } from "@/components/Workflow/Editor/modules/parameters";
-import type { useWorkflowStores } from "@/composables/workflowStores";
-import type { Step, Steps } from "@/stores/workflowStepStore";
+import { type DatatypesMapperModel } from "@/components/Datatypes/model";
+import { type UntypedParameters } from "@/components/Workflow/Editor/modules/parameters";
+import { type useWorkflowStores } from "@/composables/workflowStores";
+import { type Step, type Steps } from "@/stores/workflowStepStore";
 import { assertDefined } from "@/utils/assertions";
 
 import { terminalFactory } from "./terminals";

--- a/client/src/components/Workflow/Editor/modules/parameters.ts
+++ b/client/src/components/Workflow/Editor/modules/parameters.ts
@@ -1,4 +1,4 @@
-import type { PostJobAction, Step, Steps } from "@/stores/workflowStepStore";
+import { type PostJobAction, type Step, type Steps } from "@/stores/workflowStepStore";
 import Utils from "@/utils/utils";
 
 class UntypedParameterReference {

--- a/client/src/components/Workflow/Editor/modules/terminals.test.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.test.ts
@@ -6,7 +6,13 @@ import { useConnectionStore } from "@/stores/workflowConnectionStore";
 import { useWorkflowCommentStore } from "@/stores/workflowEditorCommentStore";
 import { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
 import { useWorkflowEditorToolbarStore } from "@/stores/workflowEditorToolbarStore";
-import { DataOutput, Step, Steps, type TerminalSource, useWorkflowStepStore } from "@/stores/workflowStepStore";
+import {
+    type DataOutput,
+    type Step,
+    type Steps,
+    type TerminalSource,
+    useWorkflowStepStore,
+} from "@/stores/workflowStepStore";
 
 import { advancedSteps, simpleSteps } from "../test_fixtures";
 import {

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -1,16 +1,16 @@
 import EventEmitter from "events";
 
-import type { DatatypesMapperModel } from "@/components/Datatypes/model";
-import type { useWorkflowStores } from "@/composables/workflowStores";
+import { type DatatypesMapperModel } from "@/components/Datatypes/model";
+import { type useWorkflowStores } from "@/composables/workflowStores";
 import { type Connection, type ConnectionId, getConnectionId } from "@/stores/workflowConnectionStore";
-import type {
-    CollectionOutput,
-    DataCollectionStepInput,
-    DataOutput,
-    DataStepInput,
-    ParameterOutput,
-    ParameterStepInput,
-    TerminalSource,
+import {
+    type CollectionOutput,
+    type DataCollectionStepInput,
+    type DataOutput,
+    type DataStepInput,
+    type ParameterOutput,
+    type ParameterStepInput,
+    type TerminalSource,
 } from "@/stores/workflowStepStore";
 import { assertDefined } from "@/utils/assertions";
 

--- a/client/src/components/Workflow/Editor/modules/zoomLevels.ts
+++ b/client/src/components/Workflow/Editor/modules/zoomLevels.ts
@@ -1,4 +1,4 @@
-import type { Last } from "types/utilityTypes";
+import { type Last } from "types/utilityTypes";
 
 export const zoomLevels = [
     0.1, 0.2, 0.25, 0.33, 0.5, 0.67, 0.75, 0.8, 0.9, 1, 1.1, 1.25, 1.33, 1.5, 2, 2.5, 3, 4, 5,

--- a/client/src/components/Workflow/Editor/test_fixtures.ts
+++ b/client/src/components/Workflow/Editor/test_fixtures.ts
@@ -1,7 +1,7 @@
-import type { UseElementBoundingReturn } from "@vueuse/core";
+import { type UseElementBoundingReturn } from "@vueuse/core";
 import { reactive, toRefs } from "vue";
 
-import type { Steps } from "@/stores/workflowStepStore";
+import { type Steps } from "@/stores/workflowStepStore";
 
 import * as _advancedSteps from "./test-data/parameter_steps.json";
 import * as _simpleSteps from "./test-data/simple_steps.json";

--- a/client/src/components/Workflow/Invocation/Export/ActionButton.vue
+++ b/client/src/components/Workflow/Invocation/Export/ActionButton.vue
@@ -2,7 +2,7 @@
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { ref } from "vue";
 
-import { InvocationExportPluginAction } from "./model";
+import { type InvocationExportPluginAction } from "./model";
 
 const modal = ref();
 

--- a/client/src/components/Workflow/Invocation/Export/ExportButton.vue
+++ b/client/src/components/Workflow/Invocation/Export/ExportButton.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { IconDefinition, library } from "@fortawesome/fontawesome-svg-core";
+import { type IconDefinition, library } from "@fortawesome/fontawesome-svg-core";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton } from "bootstrap-vue";

--- a/client/src/components/Workflow/Invocation/Export/InvocationExportPluginCard.test.ts
+++ b/client/src/components/Workflow/Invocation/Export/InvocationExportPluginCard.test.ts
@@ -4,7 +4,7 @@ import MockAdapter from "axios-mock-adapter";
 import flushPromises from "flush-promises";
 import { getLocalVue } from "tests/jest/helpers";
 
-import { InvocationExportPlugin } from "./model";
+import { type InvocationExportPlugin } from "./model";
 
 import InvocationExportPluginCard from "./InvocationExportPluginCard.vue";
 

--- a/client/src/components/Workflow/Invocation/Export/InvocationExportPluginCard.vue
+++ b/client/src/components/Workflow/Invocation/Export/InvocationExportPluginCard.vue
@@ -6,12 +6,12 @@ import { BButtonGroup, BButtonToolbar, BCard, BCardTitle } from "bootstrap-vue";
 import { computed, provide, ref } from "vue";
 
 import { useMarkdown } from "@/composables/markdown";
-import { MonitoringRequest } from "@/composables/persistentProgressMonitor";
+import { type MonitoringRequest } from "@/composables/persistentProgressMonitor";
 import { useShortTermStorageMonitor } from "@/composables/shortTermStorageMonitor";
 import { useTaskMonitor } from "@/composables/taskMonitor";
 import { Toast } from "@/composables/toast";
 
-import { InvocationExportPlugin } from "./model";
+import { type InvocationExportPlugin } from "./model";
 
 import ActionButton from "./ActionButton.vue";
 import PersistentTaskProgressMonitorAlert from "@/components/Common/PersistentTaskProgressMonitorAlert.vue";

--- a/client/src/components/Workflow/Invocation/Export/Plugins/BioComputeObject/BioComputeObjectExportPlugin.ts
+++ b/client/src/components/Workflow/Invocation/Export/Plugins/BioComputeObject/BioComputeObjectExportPlugin.ts
@@ -1,7 +1,7 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faDatabase } from "@fortawesome/free-solid-svg-icons";
 
-import { InvocationExportPlugin } from "../../model";
+import { type InvocationExportPlugin } from "../../model";
 
 import SendForm from "./SendForm.vue";
 

--- a/client/src/components/Workflow/Invocation/Export/Plugins/DefaultFileExportPlugin.ts
+++ b/client/src/components/Workflow/Invocation/Export/Plugins/DefaultFileExportPlugin.ts
@@ -1,4 +1,4 @@
-import { InvocationExportPlugin } from "../model";
+import { type InvocationExportPlugin } from "../model";
 
 export const DEFAULT_FILE_EXPORT_PLUGIN: InvocationExportPlugin = {
     id: "default-file",

--- a/client/src/components/Workflow/Invocation/Export/Plugins/ROCrateExportPlugin.ts
+++ b/client/src/components/Workflow/Invocation/Export/Plugins/ROCrateExportPlugin.ts
@@ -1,4 +1,4 @@
-import { InvocationExportPlugin } from "../model";
+import { type InvocationExportPlugin } from "../model";
 
 export const RO_CRATE_EXPORT_PLUGIN: InvocationExportPlugin = {
     id: "ro-crate",

--- a/client/src/components/Workflow/Invocation/Export/model.ts
+++ b/client/src/components/Workflow/Invocation/Export/model.ts
@@ -1,6 +1,6 @@
-import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import { type IconDefinition } from "@fortawesome/fontawesome-svg-core";
 
-import type { ExportParams } from "@/components/Common/models/exportRecordModel";
+import { type ExportParams } from "@/components/Common/models/exportRecordModel";
 /**
  * Defines a UI plugin that can export a workflow invocation to a particular format.
  */

--- a/client/src/components/Workflow/redirectPath.ts
+++ b/client/src/components/Workflow/redirectPath.ts
@@ -1,4 +1,4 @@
-import type { RawLocation } from "vue-router";
+import { type RawLocation } from "vue-router";
 
 import { Toast } from "@/composables/toast";
 

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationOverview.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationOverview.vue
@@ -2,7 +2,7 @@
 import { BAlert, BButton } from "bootstrap-vue";
 import { computed } from "vue";
 
-import { InvocationJobsSummary, InvocationStep, WorkflowInvocationElementView } from "@/api/invocations";
+import { type InvocationJobsSummary, type InvocationStep, type WorkflowInvocationElementView } from "@/api/invocations";
 import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
 import { getRootFromIndexLink } from "@/onload";
 import { withPrefix } from "@/utils/redirect";

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.ts
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.ts
@@ -1,5 +1,5 @@
 import { createTestingPinia } from "@pinia/testing";
-import { mount, shallowMount, Wrapper } from "@vue/test-utils";
+import { mount, shallowMount, type Wrapper } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { PiniaVuePlugin, setActivePinia } from "pinia";
 import { getLocalVue } from "tests/jest/helpers";

--- a/client/src/components/WorkflowInvocationState/util.ts
+++ b/client/src/components/WorkflowInvocationState/util.ts
@@ -1,4 +1,4 @@
-import { InvocationJobsSummary } from "@/api/invocations";
+import { type InvocationJobsSummary } from "@/api/invocations";
 
 export const NON_TERMINAL_STATES = ["new", "queued", "running", "waiting"];
 export const ERROR_STATES = ["error", "deleted"];

--- a/client/src/components/admin/Notifications/BroadcastCard.vue
+++ b/client/src/components/admin/Notifications/BroadcastCard.vue
@@ -14,7 +14,7 @@ import { computed } from "vue";
 
 import { useConfirmDialog } from "@/composables/confirmDialog";
 import { useMarkdown } from "@/composables/markdown";
-import { BroadcastNotification } from "@/stores/broadcastsStore";
+import { type BroadcastNotification } from "@/stores/broadcastsStore";
 
 import Heading from "@/components/Common/Heading.vue";
 import UtcDate from "@/components/UtcDate.vue";

--- a/client/src/components/admin/Notifications/BroadcastsList.test.ts
+++ b/client/src/components/admin/Notifications/BroadcastsList.test.ts
@@ -5,7 +5,7 @@ import flushPromises from "flush-promises";
 import { setActivePinia } from "pinia";
 
 import { mockFetcher } from "@/api/schema/__mocks__";
-import { BroadcastNotification } from "@/stores/broadcastsStore";
+import { type BroadcastNotification } from "@/stores/broadcastsStore";
 
 import { generateNewBroadcast } from "./test.utils";
 

--- a/client/src/components/admin/Notifications/BroadcastsList.vue
+++ b/client/src/components/admin/Notifications/BroadcastsList.vue
@@ -8,7 +8,7 @@ import { useRouter } from "vue-router/composables";
 
 import { fetchAllBroadcasts, updateBroadcast } from "@/api/notifications.broadcast";
 import { Toast } from "@/composables/toast";
-import { BroadcastNotification } from "@/stores/broadcastsStore";
+import { type BroadcastNotification } from "@/stores/broadcastsStore";
 
 import BroadcastCard from "./BroadcastCard.vue";
 import Heading from "@/components/Common/Heading.vue";

--- a/client/src/components/admin/Notifications/NotificationForm.test.ts
+++ b/client/src/components/admin/Notifications/NotificationForm.test.ts
@@ -3,7 +3,7 @@ import { getLocalVue } from "@tests/jest/helpers";
 import { mount, type Wrapper } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { setActivePinia } from "pinia";
-import Vue from "vue";
+import type Vue from "vue";
 
 import NotificationForm from "./NotificationForm.vue";
 

--- a/client/src/components/admin/Notifications/NotificationForm.vue
+++ b/client/src/components/admin/Notifications/NotificationForm.vue
@@ -7,7 +7,7 @@ import { computed, type Ref, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { getAllGroups } from "@/api/groups";
-import { NotificationCreateRequest, sendNotification } from "@/api/notifications";
+import { type NotificationCreateRequest, sendNotification } from "@/api/notifications";
 import { getAllRoles } from "@/api/roles";
 import { type components } from "@/api/schema";
 import { getAllUsers } from "@/api/users";

--- a/client/src/composables/datasetPermissions.ts
+++ b/client/src/composables/datasetPermissions.ts
@@ -1,6 +1,5 @@
-import { AxiosResponse } from "axios";
-import type { Ref } from "vue";
-import { computed, ref } from "vue";
+import { type AxiosResponse } from "axios";
+import { computed, type Ref, ref } from "vue";
 
 import { useToast } from "@/composables/toast";
 import { errorMessageAsString } from "@/utils/simple-error";

--- a/client/src/composables/datatypes.ts
+++ b/client/src/composables/datatypes.ts
@@ -1,5 +1,4 @@
-import type { Ref } from "vue";
-import { ref } from "vue";
+import { type Ref, ref } from "vue";
 
 import { datatypesFetcher, edamDataFetcher, edamFormatsFetcher } from "@/api/datatypes";
 

--- a/client/src/composables/datatypesMapper.ts
+++ b/client/src/composables/datatypesMapper.ts
@@ -1,7 +1,6 @@
-import type { Ref } from "vue";
-import { ref } from "vue";
+import { type Ref, ref } from "vue";
 
-import type { DatatypesMapperModel } from "@/components/Datatypes/model";
+import { type DatatypesMapperModel } from "@/components/Datatypes/model";
 import { useDatatypesMapperStore } from "@/stores/datatypesMapperStore";
 
 export function useDatatypesMapper() {

--- a/client/src/composables/fileSources.ts
+++ b/client/src/composables/fileSources.ts
@@ -1,6 +1,6 @@
 import { onMounted, readonly, ref } from "vue";
 
-import { BrowsableFilesSourcePlugin, FilterFileSourcesOptions } from "@/api/remoteFiles";
+import { type BrowsableFilesSourcePlugin, type FilterFileSourcesOptions } from "@/api/remoteFiles";
 import { useFileSourcesStore } from "@/stores/fileSourcesStore";
 
 /**

--- a/client/src/composables/filter/filter.d.ts
+++ b/client/src/composables/filter/filter.d.ts
@@ -1,5 +1,5 @@
-import type { MaybeRefOrGetter } from "@vueuse/core";
-import type { Ref } from "vue";
+import { type MaybeRefOrGetter } from "@vueuse/core";
+import { type Ref } from "vue";
 
 /**
  * Reactively filter an array of objects, by comparing `filter` to all `fields`.

--- a/client/src/composables/hashedUserId.ts
+++ b/client/src/composables/hashedUserId.ts
@@ -2,7 +2,7 @@ import { useLocalStorage } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import { computed, type Ref, ref, watch } from "vue";
 
-import type { GenericUser } from "@/api";
+import { type GenericUser } from "@/api";
 import { useUserStore } from "@/stores/userStore";
 
 async function hash32(value: string): Promise<string> {

--- a/client/src/composables/keyedCache.ts
+++ b/client/src/composables/keyedCache.ts
@@ -1,7 +1,7 @@
-import { MaybeRefOrGetter, toValue } from "@vueuse/core";
+import { type MaybeRefOrGetter, toValue } from "@vueuse/core";
 import { computed, del, type Ref, ref, set, unref } from "vue";
 
-import type { ApiResponse } from "@/api/schema";
+import { type ApiResponse } from "@/api/schema";
 
 /**
  * Parameters for fetching an item from the server.

--- a/client/src/composables/persistentProgressMonitor.test.ts
+++ b/client/src/composables/persistentProgressMonitor.test.ts
@@ -1,9 +1,9 @@
 import { ref } from "vue";
 
-import { TaskMonitor } from "@/composables/genericTaskMonitor";
+import { type TaskMonitor } from "@/composables/genericTaskMonitor";
 import {
-    MonitoringData,
-    MonitoringRequest,
+    type MonitoringData,
+    type MonitoringRequest,
     usePersistentProgressTaskMonitor,
 } from "@/composables/persistentProgressMonitor";
 

--- a/client/src/composables/persistentProgressMonitor.ts
+++ b/client/src/composables/persistentProgressMonitor.ts
@@ -1,7 +1,7 @@
 import { StorageSerializers, useLocalStorage } from "@vueuse/core";
 import { computed, watch } from "vue";
 
-import type { TaskMonitor } from "./genericTaskMonitor";
+import { type TaskMonitor } from "./genericTaskMonitor";
 
 type TaskType = "task" | "short_term_storage";
 

--- a/client/src/composables/route.ts
+++ b/client/src/composables/route.ts
@@ -1,4 +1,4 @@
-import { MaybeRefOrGetter, toValue } from "@vueuse/core";
+import { type MaybeRefOrGetter, toValue } from "@vueuse/core";
 import { computed } from "vue";
 import { useRoute } from "vue-router/composables";
 

--- a/client/src/composables/sensors/animationFrameResizeObserver.ts
+++ b/client/src/composables/sensors/animationFrameResizeObserver.ts
@@ -1,5 +1,4 @@
-import type { MaybeRefOrGetter } from "@vueuse/core";
-import { resolveUnref } from "@vueuse/core";
+import { type MaybeRefOrGetter, resolveUnref } from "@vueuse/core";
 
 import { useAnimationFrame } from "./animationFrame";
 

--- a/client/src/composables/sensors/animationFrameScroll.ts
+++ b/client/src/composables/sensors/animationFrameScroll.ts
@@ -1,5 +1,4 @@
-import type { MaybeRefOrGetter } from "@vueuse/core";
-import { resolveUnref } from "@vueuse/core";
+import { type MaybeRefOrGetter, resolveUnref } from "@vueuse/core";
 import { reactive, ref } from "vue";
 
 import { useAnimationFrame } from "./animationFrame";

--- a/client/src/composables/shortTermStorage.ts
+++ b/client/src/composables/shortTermStorage.ts
@@ -1,7 +1,7 @@
 import { readonly, ref, watch } from "vue";
 
 import { fetcher } from "@/api/schema";
-import { ExportParams, StoreExportPayload } from "@/components/Common/models/exportRecordModel";
+import { type ExportParams, type StoreExportPayload } from "@/components/Common/models/exportRecordModel";
 import { withPrefix } from "@/utils/redirect";
 
 import { useShortTermStorageMonitor } from "./shortTermStorageMonitor";

--- a/client/src/composables/toast.ts
+++ b/client/src/composables/toast.ts
@@ -1,5 +1,6 @@
 import type Vue from "vue";
-import { type Ref, ref } from "vue";
+import { type Ref } from "vue";
+import { ref } from "vue";
 
 import type ToastComponentFile from "@/components/Toast";
 

--- a/client/src/composables/useActiveElement.ts
+++ b/client/src/composables/useActiveElement.ts
@@ -1,5 +1,5 @@
 // https://github.com/vueuse/vueuse/blob/main/packages/core/_configurable.ts
-import type { ConfigurableWindow, MaybeElementRef, UseFocusWithinReturn } from "@vueuse/core";
+import { type ConfigurableWindow, type MaybeElementRef, type UseFocusWithinReturn } from "@vueuse/core";
 import { unrefElement, useEventListener } from "@vueuse/core";
 import { computedWithControl, isClient } from "@vueuse/shared";
 import { computed } from "vue";

--- a/client/src/composables/useInvocationGraph.ts
+++ b/client/src/composables/useInvocationGraph.ts
@@ -14,8 +14,8 @@ import { stepJobsSummaryFetcher, type StepJobSummary, type WorkflowInvocationEle
 import { isWorkflowInput } from "@/components/Workflow/constants";
 import { fromSimple } from "@/components/Workflow/Editor/modules/model";
 import { getWorkflowFull } from "@/components/Workflow/workflows.services";
-import type { Step } from "@/stores/workflowStepStore";
-import type { Workflow } from "@/stores/workflowStore";
+import { type Step } from "@/stores/workflowStepStore";
+import { type Workflow } from "@/stores/workflowStore";
 import { rethrowSimple } from "@/utils/simple-error";
 
 import { provideScopedWorkflowStores } from "./workflowStores";

--- a/client/src/composables/userLocalStorage.ts
+++ b/client/src/composables/userLocalStorage.ts
@@ -1,7 +1,7 @@
 import { useLocalStorage } from "@vueuse/core";
 import { computed, customRef, type Ref, ref } from "vue";
 
-import type { GenericUser } from "@/api";
+import { type GenericUser } from "@/api";
 
 import { useHashedUserId } from "./hashedUserId";
 

--- a/client/src/stores/broadcastsStore.ts
+++ b/client/src/stores/broadcastsStore.ts
@@ -2,7 +2,7 @@ import { defineStore } from "pinia";
 import { computed, ref, set } from "vue";
 
 import { fetchAllBroadcasts } from "@/api/notifications.broadcast";
-import type { components } from "@/api/schema";
+import { type components } from "@/api/schema";
 import { useUserLocalStorage } from "@/composables/userLocalStorage";
 import { mergeObjectListsById } from "@/utils/utils";
 

--- a/client/src/stores/collectionAttributesStore.test.ts
+++ b/client/src/stores/collectionAttributesStore.test.ts
@@ -1,7 +1,7 @@
 import flushPromises from "flush-promises";
 import { createPinia, setActivePinia } from "pinia";
 
-import type { DatasetCollectionAttributes } from "@/api";
+import { type DatasetCollectionAttributes } from "@/api";
 import { mockFetcher } from "@/api/schema/__mocks__";
 
 import { useCollectionAttributesStore } from "./collectionAttributesStore";

--- a/client/src/stores/collectionAttributesStore.ts
+++ b/client/src/stores/collectionAttributesStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 
-import type { DatasetCollectionAttributes } from "@/api";
+import { type DatasetCollectionAttributes } from "@/api";
 import { fetchCollectionAttributes } from "@/api/datasetCollections";
 import { useKeyedCache } from "@/composables/keyedCache";
 

--- a/client/src/stores/collectionElementsStore.test.ts
+++ b/client/src/stores/collectionElementsStore.test.ts
@@ -1,9 +1,9 @@
 import flushPromises from "flush-promises";
 import { createPinia, setActivePinia } from "pinia";
 
-import type { DCESummary, HDCASummary } from "@/api";
+import { type DCESummary, type HDCASummary } from "@/api";
 import { mockFetcher } from "@/api/schema/__mocks__";
-import { DCEEntry, useCollectionElementsStore } from "@/stores/collectionElementsStore";
+import { type DCEEntry, useCollectionElementsStore } from "@/stores/collectionElementsStore";
 
 jest.mock("@/api/schema");
 

--- a/client/src/stores/collectionElementsStore.ts
+++ b/client/src/stores/collectionElementsStore.ts
@@ -1,8 +1,7 @@
 import { defineStore } from "pinia";
 import { computed, del, ref, set } from "vue";
 
-import type { CollectionEntry, DCESummary, HDCASummary, HistoryContentItemBase } from "@/api";
-import { isHDCA } from "@/api";
+import { type CollectionEntry, type DCESummary, type HDCASummary, type HistoryContentItemBase, isHDCA } from "@/api";
 import { fetchCollectionDetails, fetchElementsFromCollection } from "@/api/datasetCollections";
 import { ensureDefined } from "@/utils/assertions";
 import { ActionSkippedError, LastQueue } from "@/utils/lastQueue";

--- a/client/src/stores/configTemplatesUtil.ts
+++ b/client/src/stores/configTemplatesUtil.ts
@@ -1,4 +1,4 @@
-import type { TemplateSummary } from "@/api/configTemplates";
+import { type TemplateSummary } from "@/api/configTemplates";
 
 export function findTemplate<T extends TemplateSummary>(
     templates: T[],

--- a/client/src/stores/datasetExtraFilesStore.ts
+++ b/client/src/stores/datasetExtraFilesStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 
-import { DatasetExtraFiles, fetchDatasetExtraFiles } from "@/api/datasets";
+import { type DatasetExtraFiles, fetchDatasetExtraFiles } from "@/api/datasets";
 import { useKeyedCache } from "@/composables/keyedCache";
 
 export const useDatasetExtraFilesStore = defineStore("datasetExtraFilesStore", () => {

--- a/client/src/stores/datasetStore.ts
+++ b/client/src/stores/datasetStore.ts
@@ -3,7 +3,7 @@ import { computed, set } from "vue";
 
 import { type DatasetEntry, type HDADetailed, type HistoryContentItemBase, isInaccessible } from "@/api";
 import { fetchDataset } from "@/api/datasets";
-import { ApiResponse } from "@/api/schema";
+import { type ApiResponse } from "@/api/schema";
 import { useKeyedCache } from "@/composables/keyedCache";
 
 async function fetchDatasetDetails(params: { id: string }): Promise<ApiResponse<HDADetailed>> {

--- a/client/src/stores/datatypesMapperStore.ts
+++ b/client/src/stores/datatypesMapperStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
 
 import { getDatatypesMapper } from "@/components/Datatypes";
-import type { DatatypesMapperModel } from "@/components/Datatypes/model";
+import { type DatatypesMapperModel } from "@/components/Datatypes/model";
 import { rethrowSimple } from "@/utils/simple-error";
 
 interface State {

--- a/client/src/stores/fileSourceInstancesStore.ts
+++ b/client/src/stores/fileSourceInstancesStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
 
 import { fetcher } from "@/api/schema/fetcher";
-import type { components } from "@/api/schema/schema";
+import { type components } from "@/api/schema/schema";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 const getFileSourceInstances = fetcher.path("/api/file_source_instances").method("get").create();

--- a/client/src/stores/fileSourceTemplatesStore.ts
+++ b/client/src/stores/fileSourceTemplatesStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
 
 import { fetcher } from "@/api/schema/fetcher";
-import type { components } from "@/api/schema/schema";
+import { type components } from "@/api/schema/schema";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import { canUpgrade, findTemplate, getLatestVersion, getLatestVersionMap } from "./configTemplatesUtil";

--- a/client/src/stores/historyItemsStore.ts
+++ b/client/src/stores/historyItemsStore.ts
@@ -8,7 +8,7 @@ import { reverse } from "lodash";
 import { defineStore } from "pinia";
 import { computed, ref, set } from "vue";
 
-import type { HistoryItemSummary } from "@/api";
+import { type HistoryItemSummary } from "@/api";
 import { HistoryFilters } from "@/components/History/HistoryFilters";
 import { mergeArray } from "@/store/historyStore/model/utilities";
 import { ActionSkippedError, LastQueue } from "@/utils/lastQueue";

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -1,12 +1,12 @@
 import { defineStore } from "pinia";
 import { computed, del, ref, set } from "vue";
 
-import type {
-    AnyHistory,
-    HistoryContentsStats,
-    HistoryDevDetailed,
-    HistorySummary,
-    HistorySummaryExtended,
+import {
+    type AnyHistory,
+    type HistoryContentsStats,
+    type HistoryDevDetailed,
+    type HistorySummary,
+    type HistorySummaryExtended,
 } from "@/api";
 import { historyFetcher } from "@/api/histories";
 import { archiveHistory, unarchiveHistory } from "@/api/histories.archived";

--- a/client/src/stores/notificationsStore.ts
+++ b/client/src/stores/notificationsStore.ts
@@ -1,11 +1,13 @@
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 
-import type { NotificationChanges, UserNotification, UserNotificationsBatchUpdateRequest } from "@/api/notifications";
 import {
     loadNotificationsFromServer,
     loadNotificationsStatus,
+    type NotificationChanges,
     updateBatchNotificationsOnServer,
+    type UserNotification,
+    type UserNotificationsBatchUpdateRequest,
 } from "@/api/notifications";
 import { useResourceWatcher } from "@/composables/resourceWatcher";
 import { mergeObjectListsById } from "@/utils/utils";

--- a/client/src/stores/objectStoreInstancesStore.ts
+++ b/client/src/stores/objectStoreInstancesStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
 
 import { fetcher } from "@/api/schema/fetcher";
-import type { components } from "@/api/schema/schema";
+import { type components } from "@/api/schema/schema";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 const getObjectStoreInstances = fetcher.path("/api/object_store_instances").method("get").create();

--- a/client/src/stores/objectStoreStore.ts
+++ b/client/src/stores/objectStoreStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 
-import { ConcreteObjectStoreModel } from "@/api";
+import { type ConcreteObjectStoreModel } from "@/api";
 import { getSelectableObjectStores } from "@/api/objectStores";
 import { errorMessageAsString } from "@/utils/simple-error";
 

--- a/client/src/stores/objectStoreTemplatesStore.ts
+++ b/client/src/stores/objectStoreTemplatesStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
 
 import { fetcher } from "@/api/schema/fetcher";
-import type { components } from "@/api/schema/schema";
+import { type components } from "@/api/schema/schema";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import { canUpgrade, findTemplate, getLatestVersion, getLatestVersionMap } from "./configTemplatesUtil";

--- a/client/src/stores/toolStore.ts
+++ b/client/src/stores/toolStore.ts
@@ -4,9 +4,9 @@
 
 import axios from "axios";
 import { defineStore } from "pinia";
-import Vue, { computed, Ref, ref, shallowRef } from "vue";
+import Vue, { computed, type Ref, ref, shallowRef } from "vue";
 
-import { createWhooshQuery, filterTools, types_to_icons } from "@/components/Panels/utilities";
+import { createWhooshQuery, filterTools, type types_to_icons } from "@/components/Panels/utilities";
 import { useUserLocalStorage } from "@/composables/userLocalStorage";
 import { getAppRoot } from "@/onload/loadConfig";
 import { rethrowSimple } from "@/utils/simple-error";

--- a/client/src/stores/undoRedoStore/index.ts
+++ b/client/src/stores/undoRedoStore/index.ts
@@ -2,7 +2,7 @@ import { computed, ref } from "vue";
 
 import { defineScopedStore } from "@/stores/scopedStore";
 
-import { LazyUndoRedoAction, UndoRedoAction } from "./undoRedoAction";
+import { type LazyUndoRedoAction, UndoRedoAction } from "./undoRedoAction";
 
 export { LazyUndoRedoAction, UndoRedoAction } from "./undoRedoAction";
 

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 
-import type { AnonymousUser, User } from "@/api";
+import { type AnonymousUser, type User } from "@/api";
 import { useUserLocalStorage } from "@/composables/userLocalStorage";
 import { useHistoryStore } from "@/stores/historyStore";
 import {

--- a/client/src/stores/workflowConnectionStore.test.ts
+++ b/client/src/stores/workflowConnectionStore.test.ts
@@ -1,9 +1,13 @@
 import { createPinia, setActivePinia } from "pinia";
 
-import type { Connection, InputTerminal, OutputTerminal } from "@/stores/workflowConnectionStore";
-import { getTerminalId, useConnectionStore } from "@/stores/workflowConnectionStore";
-import type { NewStep } from "@/stores/workflowStepStore";
-import { useWorkflowStepStore } from "@/stores/workflowStepStore";
+import {
+    type Connection,
+    getTerminalId,
+    type InputTerminal,
+    type OutputTerminal,
+    useConnectionStore,
+} from "@/stores/workflowConnectionStore";
+import { type NewStep, useWorkflowStepStore } from "@/stores/workflowStepStore";
 
 const workflowStepZero: NewStep = {
     input_connections: {},

--- a/client/src/stores/workflowEditorCommentStore.test.ts
+++ b/client/src/stores/workflowEditorCommentStore.test.ts
@@ -1,9 +1,9 @@
 import { createPinia, setActivePinia } from "pinia";
 
 import {
-    FrameWorkflowComment,
+    type FrameWorkflowComment,
     type FreehandWorkflowComment,
-    MarkdownWorkflowComment,
+    type MarkdownWorkflowComment,
     type TextWorkflowComment,
     useWorkflowCommentStore,
 } from "./workflowEditorCommentStore";

--- a/client/src/stores/workflowEditorCommentStore.ts
+++ b/client/src/stores/workflowEditorCommentStore.ts
@@ -1,6 +1,6 @@
 import { computed, del, ref, set } from "vue";
 
-import type { Color } from "@/components/Workflow/Editor/Comments/colors";
+import { type Color } from "@/components/Workflow/Editor/Comments/colors";
 import {
     AxisAlignedBoundingBox,
     type Rectangle,
@@ -9,14 +9,14 @@ import {
     vecMin,
     vecReduceFigures,
     vecSubtract,
-    Vector,
+    type Vector,
 } from "@/components/Workflow/Editor/modules/geometry";
 import { assertDefined } from "@/utils/assertions";
 import { hasKeys, match } from "@/utils/utils";
 
 import { defineScopedStore } from "./scopedStore";
 import { useWorkflowStateStore } from "./workflowEditorStateStore";
-import { Step, useWorkflowStepStore } from "./workflowStepStore";
+import { type Step, useWorkflowStepStore } from "./workflowStepStore";
 
 export type WorkflowCommentColor = Color | "none";
 

--- a/client/src/stores/workflowEditorStateStore.ts
+++ b/client/src/stores/workflowEditorStateStore.ts
@@ -1,8 +1,7 @@
-import type { UseElementBoundingReturn } from "@vueuse/core";
-import type { UnwrapRef } from "vue";
-import { computed, reactive, ref, set } from "vue";
+import { type UseElementBoundingReturn } from "@vueuse/core";
+import { computed, reactive, ref, set, type UnwrapRef } from "vue";
 
-import type { OutputTerminals } from "@/components/Workflow/Editor/modules/terminals";
+import { type OutputTerminals } from "@/components/Workflow/Editor/modules/terminals";
 import reportDefault from "@/components/Workflow/Editor/reportDefault";
 
 import { defineScopedStore } from "./scopedStore";

--- a/client/src/stores/workflowEditorToolbarStore.ts
+++ b/client/src/stores/workflowEditorToolbarStore.ts
@@ -1,11 +1,11 @@
 import { useMagicKeys } from "@vueuse/core";
 import { computed, onScopeDispose, reactive, ref, watch } from "vue";
 
-import { Rectangle } from "@/components/Workflow/Editor/modules/geometry";
+import { type Rectangle } from "@/components/Workflow/Editor/modules/geometry";
 import { useUserLocalStorage } from "@/composables/userLocalStorage";
 
 import { defineScopedStore } from "./scopedStore";
-import { WorkflowCommentColor } from "./workflowEditorCommentStore";
+import { type WorkflowCommentColor } from "./workflowEditorCommentStore";
 
 export type CommentTool = "textComment" | "markdownComment" | "frameComment" | "freehandComment" | "freehandEraser";
 export type EditorTool = "pointer" | "boxSelect" | CommentTool;

--- a/client/src/stores/workflowStepStore.test.ts
+++ b/client/src/stores/workflowStepStore.test.ts
@@ -1,7 +1,6 @@
 import { createPinia, setActivePinia } from "pinia";
 
-import type { NewStep, StepInputConnection } from "@/stores/workflowStepStore";
-import { useWorkflowStepStore } from "@/stores/workflowStepStore";
+import { type NewStep, type StepInputConnection, useWorkflowStepStore } from "@/stores/workflowStepStore";
 
 import { useConnectionStore } from "./workflowConnectionStore";
 

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -1,6 +1,6 @@
 import { computed, del, ref, set } from "vue";
 
-import type { CollectionTypeDescriptor } from "@/components/Workflow/Editor/modules/collectionTypeDescription";
+import { type CollectionTypeDescriptor } from "@/components/Workflow/Editor/modules/collectionTypeDescription";
 import { type Connection, getConnectionId, useConnectionStore } from "@/stores/workflowConnectionStore";
 import { assertDefined } from "@/utils/assertions";
 

--- a/client/src/stores/workflowStore.ts
+++ b/client/src/stores/workflowStore.ts
@@ -3,7 +3,7 @@ import { defineStore } from "pinia";
 import { computed, ref, set } from "vue";
 
 import { getAppRoot } from "@/onload/loadConfig";
-import type { Steps } from "@/stores/workflowStepStore";
+import { type Steps } from "@/stores/workflowStepStore";
 
 export interface Workflow {
     name: string;

--- a/client/src/utils/filtering.ts
+++ b/client/src/utils/filtering.ts
@@ -10,7 +10,7 @@
  */
 
 import { isEqual, omit } from "lodash";
-import type { DefineComponent } from "vue";
+import { type DefineComponent } from "vue";
 
 export type Converter<T> = (value: T) => T;
 type Handler<T> = (v: T, q: T) => boolean;

--- a/client/src/utils/navigation/schema.ts
+++ b/client/src/utils/navigation/schema.ts
@@ -1,5 +1,4 @@
-import type { Component, SelectorTemplate } from "./index";
-import { ROOT_COMPONENT as raw_root_component } from "./index";
+import { type Component, ROOT_COMPONENT as raw_root_component, type SelectorTemplate } from "./index";
 
 interface Root_messages extends Component {
     all: SelectorTemplate;


### PR DESCRIPTION
Popping this out of the vue3 branch and adding enforcement to try to cut down on the noise when rebasing/fixing that up during a final push.

This addresses situations like this, where we haven't been explicit when importing types in ts:

```diff
- import { mount, Wrapper } from "@vue/test-utils";
+ import { mount, type Wrapper } from "@vue/test-utils";
```

I opted for the 'inline' syntax, vs the following option where one would have two distinct imports from the module:
```diff
- import { mount, Wrapper } from "@vue/test-utils";
+ import { mount } from "@vue/test-utils";
+ import type { Wrapper } from "@vue/test-utils";
```

This does not (yet) attempt to automatically address something like this:

```
import type { GetComponentPropTypes } from "types/utilityTypes";
```

Which I guess an argument could be made for consistently using the form:

```
import { type GetComponentPropTypes } from "types/utilityTypes";
```



More info/options at https://typescript-eslint.io/rules/consistent-type-imports/

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
