### PR TITLE
[24.1] Include workflow invocation id in exception logs

### DIFF
--- a/lib/galaxy/schema/invocation.py
+++ b/lib/galaxy/schema/invocation.py
@@ -78,6 +78,21 @@ class FailureReason(str, Enum):
     unexpected_failure = "unexpected_failure"
 
 
+# The reasons below are attached to the invocation and user-actionable.
+# Not included are `unexpected_failure` and `expression_evaluation_failed`.
+# If expression evaluation fails we're not attaching the templated
+# expression to the invocation, as it could contain secrets.
+# If the failure reason is not in `FAILURE_REASONS_EXPECTED` we should
+# log an exception so admins can debug and/or submit bug reports.
+FAILURE_REASONS_EXPECTED = (
+    FailureReason.dataset_failed,
+    FailureReason.collection_failed,
+    FailureReason.job_failed,
+    FailureReason.output_not_found,
+    FailureReason.when_not_boolean,
+)
+
+
 class CancelReason(str, Enum):
     """Possible reasons for a cancelled workflow."""
 

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -25,6 +25,7 @@ from galaxy.model.base import (
 )
 from galaxy.schema.invocation import (
     CancelReason,
+    FAILURE_REASONS_EXPECTED,
     FailureReason,
     InvocationCancellationHistoryDeleted,
     InvocationFailureCollectionFailed,
@@ -252,10 +253,7 @@ class WorkflowInvoker:
                 self.progress.mark_step_outputs_delayed(step, why=de.why)
             except Exception as e:
                 log_function = log.exception
-                if isinstance(e, modules.FailWorkflowEvaluation) and e.why.reason not in (
-                    "unexpected_failure",
-                    "expression_evaluation_failed",
-                ):
+                if isinstance(e, modules.FailWorkflowEvaluation) and e.why.reason in FAILURE_REASONS_EXPECTED:
                     log_function = log.info
                 log_function(
                     "Failed to schedule %s for %s, problem occurred on %s.",

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -251,8 +251,15 @@ class WorkflowInvoker:
                 step_delayed = delayed_steps = True
                 self.progress.mark_step_outputs_delayed(step, why=de.why)
             except Exception as e:
-                log.exception(
-                    "Failed to schedule %s, problem occurred on %s.",
+                log_function = log.exception
+                if isinstance(e, modules.FailWorkflowEvaluation) and e.why.reason not in (
+                    "unexpected_failure",
+                    "expression_evaluation_failed",
+                ):
+                    log_function = log.info
+                log_function(
+                    "Failed to schedule %s for %s, problem occurred on %s.",
+                    self.workflow_invocation.log_str(),
                     self.workflow_invocation.workflow.log_str(),
                     step.log_str(),
                 )


### PR DESCRIPTION
And downgrade "normal" invocation scheduling errors to info.

I was looking at https://sentry.galaxyproject.org/share/issue/d1071f02af6f404884a2efa7f5146ce8/ and it'd be helpful to know the invocation id.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
