### PR TITLE
Tighten user notification API response types

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -12902,8 +12902,7 @@ export interface components {
              */
             content:
                 | components["schemas"]["MessageNotificationContent"]
-                | components["schemas"]["NewSharedItemNotificationContent"]
-                | components["schemas"]["BroadcastNotificationContent"];
+                | components["schemas"]["NewSharedItemNotificationContent"];
             /**
              * Create time
              * Format: date-time

--- a/lib/galaxy/schema/notifications.py
+++ b/lib/galaxy/schema/notifications.py
@@ -118,19 +118,29 @@ class NewSharedItemNotificationContent(Model):
     slug: str = Field(..., title="Slug", description="The slug of the shared item. Used for the link to the item.")
 
 
-AnyNotificationContent = Annotated[
+NotificationContentField = Field(
+    default=...,
+    discriminator="category",
+    title="Content",
+    description="The content of the notification. The structure depends on the category.",
+)
+
+AnyUserNotificationContent = Annotated[
     Union[
         MessageNotificationContent,
         NewSharedItemNotificationContent,
+    ],
+    NotificationContentField,
+]
+
+AnyNotificationContent = Annotated[
+    Union[
+        AnyUserNotificationContent,
         BroadcastNotificationContent,
     ],
-    Field(
-        default=...,
-        discriminator="category",
-        title="Content",
-        description="The content of the notification. The structure depends on the category.",
-    ),
+    NotificationContentField,
 ]
+
 
 NotificationIdField = Field(
     ...,
@@ -200,6 +210,7 @@ class UserNotificationResponse(NotificationResponse):
     """A notification response specific to the user."""
 
     category: PersonalNotificationCategory = NotificationCategoryField
+    content: AnyUserNotificationContent
     seen_time: Optional[datetime] = Field(
         None,
         title="Seen time",


### PR DESCRIPTION
Part of #18532

This will exclude "broadcast" as a possible *user notification* response content as `/api/notifications/*` will never return a broadcast notification since we use `/api/notifications/broadcast/*` for those.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
