### PR TITLE
Add "Create" new history button to histories grid

### DIFF
--- a/client/src/components/Grid/GridHistory.vue
+++ b/client/src/components/Grid/GridHistory.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faPlus } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faUpload } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BNav, BNavItem } from "bootstrap-vue";
 
 import historiesGridConfig from "@/components/Grid/configs/histories";
 import historiesPublishedGridConfig from "@/components/Grid/configs/historiesPublished";
 import historiesSharedGridConfig from "@/components/Grid/configs/historiesShared";
+import { useHistoryStore } from "@/stores/historyStore";
 import { useUserStore } from "@/stores/userStore";
 
 import Heading from "@/components/Common/Heading.vue";
@@ -14,8 +16,9 @@ import GridList from "@/components/Grid/GridList.vue";
 import HistoryArchive from "@/components/History/Archiving/HistoryArchive.vue";
 
 const userStore = useUserStore();
+const historyStore = useHistoryStore();
 
-library.add(faPlus);
+library.add(faPlus, faUpload);
 
 interface Props {
     activeList?: "archived" | "my" | "shared" | "published";
@@ -36,10 +39,18 @@ const props = withDefaults(defineProps<Props>(), {
                 <BButton
                     size="sm"
                     variant="outline-primary"
+                    data-description="grid action create new history"
+                    @click="historyStore.createNewHistory()">
+                    <FontAwesomeIcon :icon="faPlus" />
+                    <span v-localize>Create</span>
+                </BButton>
+                <BButton
+                    size="sm"
+                    variant="outline-primary"
                     to="/histories/import"
                     data-description="grid action import new history">
-                    <Icon :icon="faPlus" />
-                    <span v-localize>Import History</span>
+                    <FontAwesomeIcon :icon="faUpload" />
+                    <span v-localize>Import</span>
                 </BButton>
             </div>
         </div>

--- a/client/src/components/Grid/GridPage.vue
+++ b/client/src/components/Grid/GridPage.vue
@@ -22,6 +22,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
     activeList: "my",
+    username: undefined,
 });
 </script>
 
@@ -32,7 +33,7 @@ const props = withDefaults(defineProps<Props>(), {
             <div v-if="!userStore.isAnonymous">
                 <BButton id="page-create" size="sm" variant="outline-primary" to="/pages/create">
                     <Icon :icon="faPlus" />
-                    <span v-localize>Create Page</span>
+                    <span v-localize>Create</span>
                 </BButton>
             </div>
         </div>

--- a/client/src/components/Grid/configs/histories.ts
+++ b/client/src/components/Grid/configs/histories.ts
@@ -6,6 +6,7 @@ import {
     faSignature,
     faTrash,
     faTrashRestore,
+    faUpload,
     faUsers,
 } from "@fortawesome/free-solid-svg-icons";
 import { useEventBus } from "@vueuse/core";
@@ -52,8 +53,16 @@ async function getData(offset: number, limit: number, search: string, sort_by: s
  */
 const actions: ActionArray = [
     {
-        title: "Import New History",
+        title: "Create",
         icon: faPlus,
+        handler: () => {
+            const historyStore = useHistoryStore();
+            historyStore.createNewHistory();
+        },
+    },
+    {
+        title: "Import",
+        icon: faUpload,
         handler: () => {
             emit("/histories/import");
         },


### PR DESCRIPTION
Adds a create button to `GridHistory` and also unifies the icons for this button in other grids.
Fixes https://github.com/galaxyproject/galaxy/issues/18571

_WIP: While the create button is easily added to the grid actions, and it does create a new history and sets it as current, it would be better if the histories grid actually reacted to this and the list was updated/refetched as well. xref https://github.com/galaxyproject/galaxy/issues/17670_

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
