### PR TITLE
[24.0] Set minimum weasyprint version

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -288,6 +288,10 @@ class ConditionalDependencies:
         # See notes in ./conditional-requirements.txt for more information.
         return os.environ.get("GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT") == "1"
 
+    def check_pydyf(self):
+        # See notes in ./conditional-requirements.txt for more information.
+        return os.environ.get("GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT") == "1" and sys.version_info < (3, 9)
+
     def check_custos_sdk(self):
         return "custos" == self.vault_type
 

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -290,7 +290,7 @@ class ConditionalDependencies:
 
     def check_pydyf(self):
         # See notes in ./conditional-requirements.txt for more information.
-        return os.environ.get("GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT") == "1" and sys.version_info < (3, 9)
+        return os.environ.get("GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT") == "1"
 
     def check_custos_sdk(self):
         return "custos" == self.vault_type

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -61,7 +61,7 @@ weasyprint>=61.2
 # not compatible with the last weasyprint version that still supports python 3.8.
 # This dependency is ignored on python >= 3.9 and should be removed when deprecating
 # support for python 3.8.
-pydyf<0.12; python_version<"3.9"
+pydyf<0.11; python_version<"3.9"
 
 # AWS Batch runner
 boto3

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -61,7 +61,7 @@ weasyprint>=61.2
 # not compatible with the last weasyprint version that still supports python 3.8.
 # This dependency is ignored on python >= 3.9 and should be removed when deprecating
 # support for python 3.8.
-pydyf==0.10.0
+pydyf<0.12; python_version<"3.9"
 
 # AWS Batch runner
 boto3

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -56,7 +56,12 @@ tensorflow==2.9.3
 # xref https://github.com/galaxyproject/galaxy/pull/9651
 # Run run.sh or common_startup script with GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT=1
 # to install weasyprint as part of Galaxy's conditonal dependency instalation process.
-weasyprint>=62.3
+weasyprint>=61.2
+# We pin the transitive weasyprint dependency pydyf here because newer versions are
+# not compatible with the last weasyprint version that still supports python 3.8.
+# This dependency is ignored on python >= 3.9 and should be removed when deprecating
+# support for python 3.8.
+pydyf==0.10.0
 
 # AWS Batch runner
 boto3

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -56,7 +56,7 @@ tensorflow==2.9.3
 # xref https://github.com/galaxyproject/galaxy/pull/9651
 # Run run.sh or common_startup script with GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT=1
 # to install weasyprint as part of Galaxy's conditonal dependency instalation process.
-weasyprint
+weasyprint>=62.3
 
 # AWS Batch runner
 boto3


### PR DESCRIPTION
We're not pinning transitive conditional dependencies, and a new pydyf version, which is a dependency of weasyprint, had a new release with a breaking change, see (https://github.com/Kozea/WeasyPrint/issues/2200).

Newer releases of weasyprint have introduced max version pins, so I think we're ok with just setting a minimum version here.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
