### PR TITLE
[PROCEDURES] Add Alireza to committers group

### DIFF
--- a/doc/source/project/organization.rst
+++ b/doc/source/project/organization.rst
@@ -54,6 +54,7 @@ Members
 - Nuwan Goonasekera (@nuwang)
 - Björn Grüning (@bgruening)
 - Aysam Guerler (@guerler)
+- Alireza Heidari (@itisAliRH)
 - Jennifer Hillman Jackson (@jennaj)
 - David López (@davelopez)
 - Laila Los (@ElectronicBlueberry)


### PR DESCRIPTION
Alireza has been contributing to Galaxy since the end of 2021 and has done some great work mostly on the UI side. His [pull requests](https://github.com/galaxyproject/galaxy/pulls?q=is%3Apr+author%3AitisAliRH+) are nicely split in well-documented commits and he follows up quickly during code review.
He has also done many [PR reviews](https://github.com/galaxyproject/galaxy/pulls?q=is%3Apr+reviewed-by%3AitisAliRH) and  participated in release testing.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
