### PR TITLE
Better Typing for Tool Execution Plumbing

### DIFF
--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -547,7 +547,7 @@ class DatasetAssociationManager(
         if overwrite:
             self.overwrite_metadata(data)
 
-        job, *_ = self.app.datatypes_registry.set_external_metadata_tool.tool_action.execute(
+        job, *_ = self.app.datatypes_registry.set_external_metadata_tool.tool_action.execute_via_trans(
             self.app.datatypes_registry.set_external_metadata_tool,
             trans,
             incoming={"input1": data, "validate": validate},
@@ -883,7 +883,7 @@ class DatasetAssociationDeserializer(base.ModelDeserializer, deletable.PurgableD
         assert (
             trans
         ), "Logic error in Galaxy, deserialize_datatype not send a transation object"  # TODO: restructure this for stronger typing
-        job, *_ = self.app.datatypes_registry.set_external_metadata_tool.tool_action.execute(
+        job, *_ = self.app.datatypes_registry.set_external_metadata_tool.tool_action.execute_via_trans(
             self.app.datatypes_registry.set_external_metadata_tool, trans, incoming={"input1": item}, overwrite=False
         )  # overwrite is False as per existing behavior
         trans.app.job_manager.enqueue(job, tool=trans.app.datatypes_registry.set_external_metadata_tool)

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -424,7 +424,7 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
 
         # Run job to do export.
         history_exp_tool = trans.app.toolbox.get_tool(export_tool_id)
-        job, *_ = history_exp_tool.execute(trans, incoming=params, history=history, set_output_hid=True)
+        job, *_ = history_exp_tool.execute(trans, incoming=params, history=history)
         trans.app.job_manager.enqueue(job, tool=history_exp_tool)
         return job
 

--- a/lib/galaxy/tools/actions/data_manager.py
+++ b/lib/galaxy/tools/actions/data_manager.py
@@ -1,7 +1,27 @@
 import logging
+from typing import Optional
 
+from galaxy.model import (
+    History,
+    Job,
+)
 from galaxy.model.base import transaction
-from . import DefaultToolAction
+from galaxy.model.dataset_collections.matching import MatchingCollections
+from galaxy.tools.execute import (
+    DatasetCollectionElementsSliceT,
+    DEFAULT_DATASET_COLLECTION_ELEMENTS,
+    DEFAULT_JOB_CALLBACK,
+    DEFAULT_PREFERRED_OBJECT_STORE_ID,
+    DEFAULT_RERUN_REMAP_JOB_ID,
+    DEFAULT_SET_OUTPUT_HID,
+    JobCallbackT,
+    ToolParameterRequestInstanceT,
+)
+from galaxy.tools.execution_helpers import ToolExecutionCache
+from . import (
+    DefaultToolAction,
+    ToolActionExecuteResult,
+)
 
 log = logging.getLogger(__name__)
 
@@ -9,8 +29,41 @@ log = logging.getLogger(__name__)
 class DataManagerToolAction(DefaultToolAction):
     """Tool action used for Data Manager Tools"""
 
-    def execute(self, tool, trans, **kwds):
-        rval = super().execute(tool, trans, **kwds)
+    def execute(
+        self,
+        tool,
+        trans,
+        incoming: Optional[ToolParameterRequestInstanceT] = None,
+        history: Optional[History] = None,
+        job_params=None,
+        rerun_remap_job_id: Optional[int] = DEFAULT_RERUN_REMAP_JOB_ID,
+        execution_cache: Optional[ToolExecutionCache] = None,
+        dataset_collection_elements: Optional[DatasetCollectionElementsSliceT] = DEFAULT_DATASET_COLLECTION_ELEMENTS,
+        completed_job: Optional[Job] = None,
+        collection_info: Optional[MatchingCollections] = None,
+        job_callback: Optional[JobCallbackT] = DEFAULT_JOB_CALLBACK,
+        preferred_object_store_id: Optional[str] = DEFAULT_PREFERRED_OBJECT_STORE_ID,
+        set_output_hid: bool = DEFAULT_SET_OUTPUT_HID,
+        flush_job: bool = True,
+        skip: bool = False,
+    ) -> ToolActionExecuteResult:
+        rval = super().execute(
+            tool,
+            trans,
+            incoming=incoming,
+            history=history,
+            job_params=job_params,
+            rerun_remap_job_id=rerun_remap_job_id,
+            execution_cache=execution_cache,
+            dataset_collection_elements=dataset_collection_elements,
+            completed_job=completed_job,
+            collection_info=collection_info,
+            job_callback=job_callback,
+            preferred_object_store_id=preferred_object_store_id,
+            set_output_hid=set_output_hid,
+            flush_job=flush_job,
+            skip=skip,
+        )
         if isinstance(rval, tuple) and len(rval) >= 2 and isinstance(rval[0], trans.app.model.Job):
             assoc = trans.app.model.DataManagerJobAssociation(job=rval[0], data_manager_id=tool.data_manager_id)
             trans.sa_session.add(assoc)

--- a/lib/galaxy/tools/actions/history_imp_exp.py
+++ b/lib/galaxy/tools/actions/history_imp_exp.py
@@ -2,10 +2,30 @@ import datetime
 import logging
 import os
 import tempfile
+from typing import Optional
 
 from galaxy.job_execution.setup import create_working_directory_for_job
+from galaxy.model import (
+    History,
+    Job,
+)
 from galaxy.model.base import transaction
-from galaxy.tools.actions import ToolAction
+from galaxy.model.dataset_collections.matching import MatchingCollections
+from galaxy.tools.actions import (
+    ToolAction,
+    ToolActionExecuteResult,
+)
+from galaxy.tools.execute import (
+    DatasetCollectionElementsSliceT,
+    DEFAULT_DATASET_COLLECTION_ELEMENTS,
+    DEFAULT_JOB_CALLBACK,
+    DEFAULT_PREFERRED_OBJECT_STORE_ID,
+    DEFAULT_RERUN_REMAP_JOB_ID,
+    DEFAULT_SET_OUTPUT_HID,
+    JobCallbackT,
+    ToolParameterRequestInstanceT,
+)
+from galaxy.tools.execution_helpers import ToolExecutionCache
 from galaxy.tools.imp_exp import (
     JobExportHistoryArchiveWrapper,
     JobImportHistoryArchiveWrapper,
@@ -18,9 +38,26 @@ log = logging.getLogger(__name__)
 class ImportHistoryToolAction(ToolAction):
     """Tool action used for importing a history to an archive."""
 
-    produces_real_jobs = True
+    produces_real_jobs: bool = True
 
-    def execute(self, tool, trans, incoming=None, set_output_hid=False, overwrite=True, history=None, **kwargs):
+    def execute(
+        self,
+        tool,
+        trans,
+        incoming: Optional[ToolParameterRequestInstanceT] = None,
+        history: Optional[History] = None,
+        job_params=None,
+        rerun_remap_job_id: Optional[int] = DEFAULT_RERUN_REMAP_JOB_ID,
+        execution_cache: Optional[ToolExecutionCache] = None,
+        dataset_collection_elements: Optional[DatasetCollectionElementsSliceT] = DEFAULT_DATASET_COLLECTION_ELEMENTS,
+        completed_job: Optional[Job] = None,
+        collection_info: Optional[MatchingCollections] = None,
+        job_callback: Optional[JobCallbackT] = DEFAULT_JOB_CALLBACK,
+        preferred_object_store_id: Optional[str] = DEFAULT_PREFERRED_OBJECT_STORE_ID,
+        set_output_hid: bool = DEFAULT_SET_OUTPUT_HID,
+        flush_job: bool = True,
+        skip: bool = False,
+    ) -> ToolActionExecuteResult:
         #
         # Create job.
         #
@@ -78,9 +115,26 @@ class ImportHistoryToolAction(ToolAction):
 class ExportHistoryToolAction(ToolAction):
     """Tool action used for exporting a history to an archive."""
 
-    produces_real_jobs = True
+    produces_real_jobs: bool = True
 
-    def execute(self, tool, trans, incoming=None, set_output_hid=False, overwrite=True, history=None, **kwargs):
+    def execute(
+        self,
+        tool,
+        trans,
+        incoming: Optional[ToolParameterRequestInstanceT] = None,
+        history: Optional[History] = None,
+        job_params=None,
+        rerun_remap_job_id: Optional[int] = DEFAULT_RERUN_REMAP_JOB_ID,
+        execution_cache: Optional[ToolExecutionCache] = None,
+        dataset_collection_elements: Optional[DatasetCollectionElementsSliceT] = DEFAULT_DATASET_COLLECTION_ELEMENTS,
+        completed_job: Optional[Job] = None,
+        collection_info: Optional[MatchingCollections] = None,
+        job_callback: Optional[JobCallbackT] = DEFAULT_JOB_CALLBACK,
+        preferred_object_store_id: Optional[str] = DEFAULT_PREFERRED_OBJECT_STORE_ID,
+        set_output_hid: bool = DEFAULT_SET_OUTPUT_HID,
+        flush_job: bool = True,
+        skip: bool = False,
+    ) -> ToolActionExecuteResult:
         trans.check_user_activation()
         #
         # Get history to export.

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -1,10 +1,32 @@
 import logging
 import os
 from json import dumps
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
 
 from galaxy.job_execution.datasets import DatasetPath
 from galaxy.metadata import get_metadata_compute_strategy
+from galaxy.model import (
+    History,
+    Job,
+    User,
+)
 from galaxy.model.base import transaction
+from galaxy.model.dataset_collections.matching import MatchingCollections
+from galaxy.tools.execute import (
+    DatasetCollectionElementsSliceT,
+    DEFAULT_DATASET_COLLECTION_ELEMENTS,
+    DEFAULT_JOB_CALLBACK,
+    DEFAULT_PREFERRED_OBJECT_STORE_ID,
+    DEFAULT_RERUN_REMAP_JOB_ID,
+    DEFAULT_SET_OUTPUT_HID,
+    JobCallbackT,
+    ToolParameterRequestInstanceT,
+)
+from galaxy.tools.execution_helpers import ToolExecutionCache
 from galaxy.util import asbool
 from . import ToolAction
 
@@ -14,27 +36,35 @@ log = logging.getLogger(__name__)
 class SetMetadataToolAction(ToolAction):
     """Tool action used for setting external metadata on an existing dataset"""
 
-    produces_real_jobs = False
+    produces_real_jobs: bool = False
+    set_output_hid: bool = False
 
     def execute(
-        self, tool, trans, incoming=None, set_output_hid=False, overwrite=True, history=None, job_params=None, **kwargs
+        self,
+        tool,
+        trans,
+        incoming: Optional[ToolParameterRequestInstanceT] = None,
+        history: Optional[History] = None,
+        job_params=None,
+        rerun_remap_job_id: Optional[int] = DEFAULT_RERUN_REMAP_JOB_ID,
+        execution_cache: Optional[ToolExecutionCache] = None,
+        dataset_collection_elements: Optional[DatasetCollectionElementsSliceT] = DEFAULT_DATASET_COLLECTION_ELEMENTS,
+        completed_job: Optional[Job] = None,
+        collection_info: Optional[MatchingCollections] = None,
+        job_callback: Optional[JobCallbackT] = DEFAULT_JOB_CALLBACK,
+        preferred_object_store_id: Optional[str] = DEFAULT_PREFERRED_OBJECT_STORE_ID,
+        set_output_hid: bool = DEFAULT_SET_OUTPUT_HID,
+        flush_job: bool = True,
+        skip: bool = False,
     ):
         """
         Execute using a web transaction.
         """
-        trans.check_user_activation()
-        session = trans.get_galaxy_session()
-        session_id = session and session.id
-        history_id = trans.history and trans.history.id
-        incoming = incoming or {}
-        job, odict = self.execute_via_app(
+        overwrite = True
+        job, odict = self.execute_via_trans(
             tool,
-            trans.app,
-            session_id,
-            history_id,
-            trans.user,
+            trans,
             incoming,
-            set_output_hid,
             overwrite,
             history,
             job_params,
@@ -43,18 +73,43 @@ class SetMetadataToolAction(ToolAction):
         trans.log_event(f"Added set external metadata job to the job queue, id: {str(job.id)}", tool_id=job.tool_id)
         return job, odict
 
+    def execute_via_trans(
+        self,
+        tool,
+        trans,
+        incoming: Optional[Dict[str, Any]],
+        overwrite: bool = True,
+        history: Optional[History] = None,
+        job_params: Optional[Dict[str, Any]] = None,
+    ):
+        trans.check_user_activation()
+        session = trans.get_galaxy_session()
+        session_id = session and session.id
+        history_id = trans.history and trans.history.id
+        incoming = incoming or {}
+        return self.execute_via_app(
+            tool,
+            trans.app,
+            session_id,
+            history_id,
+            trans.user,
+            incoming,
+            overwrite,
+            history,
+            job_params,
+        )
+
     def execute_via_app(
         self,
         tool,
         app,
-        session_id,
-        history_id,
-        user=None,
-        incoming=None,
-        set_output_hid=False,
-        overwrite=True,
-        history=None,
-        job_params=None,
+        session_id: Optional[int],
+        history_id: Optional[int],
+        user: Optional[User] = None,
+        incoming: Optional[Dict[str, Any]] = None,
+        overwrite: bool = True,
+        history: Optional[History] = None,
+        job_params: Optional[Dict[str, Any]] = None,
     ):
         """
         Execute using application.

--- a/lib/galaxy/tools/actions/model_operations.py
+++ b/lib/galaxy/tools/actions/model_operations.py
@@ -1,12 +1,32 @@
 import logging
-from typing import TYPE_CHECKING
+from typing import (
+    Optional,
+    TYPE_CHECKING,
+)
 
+from galaxy.model import (
+    History,
+    Job,
+)
+from galaxy.model.dataset_collections.matching import MatchingCollections
 from galaxy.objectstore import ObjectStorePopulator
 from galaxy.tools.actions import (
     DefaultToolAction,
     OutputCollections,
-    ToolExecutionCache,
+    OutputDatasetsT,
+    ToolActionExecuteResult,
 )
+from galaxy.tools.execute import (
+    DatasetCollectionElementsSliceT,
+    DEFAULT_DATASET_COLLECTION_ELEMENTS,
+    DEFAULT_JOB_CALLBACK,
+    DEFAULT_PREFERRED_OBJECT_STORE_ID,
+    DEFAULT_RERUN_REMAP_JOB_ID,
+    DEFAULT_SET_OUTPUT_HID,
+    JobCallbackT,
+    ToolParameterRequestInstanceT,
+)
+from galaxy.tools.execution_helpers import ToolExecutionCache
 
 if TYPE_CHECKING:
     from galaxy.managers.context import ProvidesUserContext
@@ -15,7 +35,7 @@ log = logging.getLogger(__name__)
 
 
 class ModelOperationToolAction(DefaultToolAction):
-    produces_real_jobs = False
+    produces_real_jobs: bool = False
 
     def check_inputs_ready(self, tool, trans, incoming, history, execution_cache=None, collection_info=None):
         if execution_cache is None:
@@ -32,17 +52,20 @@ class ModelOperationToolAction(DefaultToolAction):
         self,
         tool,
         trans,
-        incoming=None,
-        set_output_hid=False,
-        overwrite=True,
-        history=None,
+        incoming: Optional[ToolParameterRequestInstanceT] = None,
+        history: Optional[History] = None,
         job_params=None,
-        execution_cache=None,
-        collection_info=None,
-        job_callback=None,
-        skip=False,
-        **kwargs,
-    ):
+        rerun_remap_job_id: Optional[int] = DEFAULT_RERUN_REMAP_JOB_ID,
+        execution_cache: Optional[ToolExecutionCache] = None,
+        dataset_collection_elements: Optional[DatasetCollectionElementsSliceT] = DEFAULT_DATASET_COLLECTION_ELEMENTS,
+        completed_job: Optional[Job] = None,
+        collection_info: Optional[MatchingCollections] = None,
+        job_callback: Optional[JobCallbackT] = DEFAULT_JOB_CALLBACK,
+        preferred_object_store_id: Optional[str] = DEFAULT_PREFERRED_OBJECT_STORE_ID,
+        set_output_hid: bool = DEFAULT_SET_OUTPUT_HID,
+        flush_job: bool = True,
+        skip: bool = False,
+    ) -> ToolActionExecuteResult:
         incoming = incoming or {}
         trans.check_user_activation()
 
@@ -65,7 +88,7 @@ class ModelOperationToolAction(DefaultToolAction):
         # wrapped params are used by change_format action and by output.label; only perform this wrapping once, as needed
         wrapped_params = self._wrapped_params(trans, tool, incoming)
 
-        out_data = {}
+        out_data: OutputDatasetsT = {}
         input_collections = {k: v[0][0] for k, v in inp_dataset_collections.items()}
         output_collections = OutputCollections(
             trans,
@@ -73,7 +96,7 @@ class ModelOperationToolAction(DefaultToolAction):
             tool=tool,
             tool_action=self,
             input_collections=input_collections,
-            dataset_collection_elements=kwargs.get("dataset_collection_elements", None),
+            dataset_collection_elements=dataset_collection_elements,
             on_text=on_text,
             incoming=incoming,
             params=wrapped_params.params,

--- a/lib/galaxy/tools/actions/upload.py
+++ b/lib/galaxy/tools/actions/upload.py
@@ -1,14 +1,34 @@
 import json
 import logging
 import os
+from typing import Optional
 
 from galaxy.exceptions import RequestParameterMissingException
+from galaxy.model import (
+    History,
+    Job,
+)
 from galaxy.model.base import transaction
+from galaxy.model.dataset_collections.matching import MatchingCollections
 from galaxy.model.dataset_collections.structure import UninitializedTree
 from galaxy.tools.actions import upload_common
+from galaxy.tools.execute import (
+    DatasetCollectionElementsSliceT,
+    DEFAULT_DATASET_COLLECTION_ELEMENTS,
+    DEFAULT_JOB_CALLBACK,
+    DEFAULT_PREFERRED_OBJECT_STORE_ID,
+    DEFAULT_RERUN_REMAP_JOB_ID,
+    DEFAULT_SET_OUTPUT_HID,
+    JobCallbackT,
+    ToolParameterRequestInstanceT,
+)
+from galaxy.tools.execution_helpers import ToolExecutionCache
 from galaxy.util import ExecutionTimer
 from galaxy.util.bunch import Bunch
-from . import ToolAction
+from . import (
+    ToolAction,
+    ToolActionExecuteResult,
+)
 
 log = logging.getLogger(__name__)
 
@@ -16,7 +36,24 @@ log = logging.getLogger(__name__)
 class BaseUploadToolAction(ToolAction):
     produces_real_jobs = True
 
-    def execute(self, tool, trans, incoming=None, history=None, **kwargs):
+    def execute(
+        self,
+        tool,
+        trans,
+        incoming: Optional[ToolParameterRequestInstanceT] = None,
+        history: Optional[History] = None,
+        job_params=None,
+        rerun_remap_job_id: Optional[int] = DEFAULT_RERUN_REMAP_JOB_ID,
+        execution_cache: Optional[ToolExecutionCache] = None,
+        dataset_collection_elements: Optional[DatasetCollectionElementsSliceT] = DEFAULT_DATASET_COLLECTION_ELEMENTS,
+        completed_job: Optional[Job] = None,
+        collection_info: Optional[MatchingCollections] = None,
+        job_callback: Optional[JobCallbackT] = DEFAULT_JOB_CALLBACK,
+        preferred_object_store_id: Optional[str] = DEFAULT_PREFERRED_OBJECT_STORE_ID,
+        set_output_hid: bool = DEFAULT_SET_OUTPUT_HID,
+        flush_job: bool = True,
+        skip: bool = False,
+    ) -> ToolActionExecuteResult:
         trans.check_user_activation()
         incoming = incoming or {}
         dataset_upload_inputs = []

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -29,7 +29,7 @@ from galaxy.model.dataset_collections.structure import (
     tool_output_to_structure,
 )
 from galaxy.tool_util.parser import ToolOutputCollectionPart
-from galaxy.tools.actions import (
+from galaxy.tools.execution_helpers import (
     filter_output,
     on_text_for_names,
     ToolExecutionCache,

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -45,14 +45,30 @@ SINGLE_EXECUTION_SUCCESS_MESSAGE = "Tool ${tool_id} created job ${job_id}"
 BATCH_EXECUTION_MESSAGE = "Created ${job_count} job(s) for tool ${tool_id} request"
 
 
+CompletedJobsT = Dict[int, Optional[model.Job]]
+JobCallbackT = Callable
+WorkflowResourceParametersT = Dict[str, Any]
+# Input dictionary from the API, may include map/reduce instructions
+ToolParameterRequestT = Dict[str, Any]
+# Input dictionary extracted from a tool request for running a tool individually
+ToolParameterRequestInstanceT = Dict[str, Any]
+DatasetCollectionElementsSliceT = Dict[str, model.DatasetCollectionElement]
+DEFAULT_USE_CACHED_JOB = False
+DEFAULT_PREFERRED_OBJECT_STORE_ID: Optional[str] = None
+DEFAULT_RERUN_REMAP_JOB_ID: Optional[int] = None
+DEFAULT_JOB_CALLBACK: Optional[JobCallbackT] = None
+DEFAULT_DATASET_COLLECTION_ELEMENTS: Optional[DatasetCollectionElementsSliceT] = None
+DEFAULT_SET_OUTPUT_HID: bool = True
+
+
 class PartialJobExecution(Exception):
-    def __init__(self, execution_tracker):
+    def __init__(self, execution_tracker: "ExecutionTracker"):
         self.execution_tracker = execution_tracker
 
 
 class MappingParameters(NamedTuple):
-    param_template: Dict[str, Any]
-    param_combinations: List[Dict[str, Any]]
+    param_template: ToolParameterRequestT
+    param_combinations: List[ToolParameterRequestInstanceT]
 
 
 def execute(
@@ -60,15 +76,15 @@ def execute(
     tool: "Tool",
     mapping_params: MappingParameters,
     history: model.History,
-    rerun_remap_job_id: Optional[int] = None,
-    preferred_object_store_id: Optional[str] = None,
+    rerun_remap_job_id: Optional[int] = DEFAULT_RERUN_REMAP_JOB_ID,
+    preferred_object_store_id: Optional[str] = DEFAULT_PREFERRED_OBJECT_STORE_ID,
     collection_info: Optional[MatchingCollections] = None,
     workflow_invocation_uuid: Optional[str] = None,
     invocation_step: Optional[model.WorkflowInvocationStep] = None,
     max_num_jobs: Optional[int] = None,
-    job_callback: Optional[Callable] = None,
-    completed_jobs: Optional[Dict[int, Optional[model.Job]]] = None,
-    workflow_resource_parameters: Optional[Dict[str, Any]] = None,
+    job_callback: Optional[JobCallbackT] = DEFAULT_JOB_CALLBACK,
+    completed_jobs: Optional[CompletedJobsT] = None,
+    workflow_resource_parameters: Optional[WorkflowResourceParametersT] = None,
     validate_outputs: bool = False,
 ):
     """
@@ -95,7 +111,7 @@ def execute(
         )
     execution_cache = ToolExecutionCache(trans)
 
-    def execute_single_job(execution_slice, completed_job, skip=False):
+    def execute_single_job(execution_slice: "ExecutionSlice", completed_job: Optional[model.Job], skip: bool = False):
         job_timer = tool.app.execution_timer_factory.get_timer(
             "internals.galaxy.tools.execute.job_single", SINGLE_EXECUTION_SUCCESS_MESSAGE
         )
@@ -124,8 +140,8 @@ def execute(
             execution_cache,
             completed_job,
             collection_info,
-            job_callback=job_callback,
-            preferred_object_store_id=preferred_object_store_id,
+            job_callback,
+            preferred_object_store_id,
             flush_job=False,
             skip=skip,
         )
@@ -225,7 +241,17 @@ def execute(
 
 
 class ExecutionSlice:
-    def __init__(self, job_index, param_combination, dataset_collection_elements=None):
+    job_index: int
+    param_combination: ToolParameterRequestInstanceT
+    dataset_collection_elements: Optional[DatasetCollectionElementsSliceT]
+    history: Optional[model.History]
+
+    def __init__(
+        self,
+        job_index: int,
+        param_combination: ToolParameterRequestInstanceT,
+        dataset_collection_elements: Optional[DatasetCollectionElementsSliceT] = DEFAULT_DATASET_COLLECTION_ELEMENTS,
+    ):
         self.job_index = job_index
         self.param_combination = param_combination
         self.dataset_collection_elements = dataset_collection_elements

--- a/lib/galaxy/tools/execution_helpers.py
+++ b/lib/galaxy/tools/execution_helpers.py
@@ -3,6 +3,7 @@
 Lower-level things that prevent interwoven dependencies between tool code,
 tool execution code, and tool action code.
 """
+
 import logging
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/tools/execution_helpers.py
+++ b/lib/galaxy/tools/execution_helpers.py
@@ -1,0 +1,70 @@
+"""Helpers meant to assist tool execution.
+
+Lower-level things that prevent interwoven dependencies between tool code,
+tool execution code, and tool action code.
+"""
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class ToolExecutionCache:
+    """An object meant to cache calculation caused by repeatedly evaluting
+    the same tool by the same user with slightly different parameters.
+    """
+
+    def __init__(self, trans):
+        self.trans = trans
+        self.current_user_roles = trans.get_current_user_roles()
+        self.chrom_info = {}
+        self.cached_collection_elements = {}
+
+    def get_chrom_info(self, tool_id, input_dbkey):
+        genome_builds = self.trans.app.genome_builds
+        custom_build_hack_get_len_from_fasta_conversion = tool_id != "CONVERTER_fasta_to_len"
+        if custom_build_hack_get_len_from_fasta_conversion and input_dbkey in self.chrom_info:
+            return self.chrom_info[input_dbkey]
+
+        chrom_info_pair = genome_builds.get_chrom_info(
+            input_dbkey,
+            trans=self.trans,
+            custom_build_hack_get_len_from_fasta_conversion=custom_build_hack_get_len_from_fasta_conversion,
+        )
+        if custom_build_hack_get_len_from_fasta_conversion:
+            self.chrom_info[input_dbkey] = chrom_info_pair
+
+        return chrom_info_pair
+
+
+def filter_output(tool, output, incoming):
+    for filter in output.filters:
+        try:
+            if not eval(filter.text.strip(), globals(), incoming):
+                return True  # do not create this dataset
+        except Exception as e:
+            log.debug(f"Tool {tool.id} output {output.name}: dataset output filter ({filter.text}) failed: {e}")
+    return False
+
+
+def on_text_for_names(input_names):
+    # input_names may contain duplicates... this is because the first value in
+    # multiple input dataset parameters will appear twice once as param_name
+    # and once as param_name1.
+    unique_names = []
+    for name in input_names:
+        if name not in unique_names:
+            unique_names.append(name)
+    input_names = unique_names
+
+    # Build name for output datasets based on tool name and input names
+    if len(input_names) == 0:
+        on_text = ""
+    elif len(input_names) == 1:
+        on_text = input_names[0]
+    elif len(input_names) == 2:
+        on_text = "{} and {}".format(*input_names)
+    elif len(input_names) == 3:
+        on_text = "{}, {}, and {}".format(*input_names)
+    else:
+        on_text = "{}, {}, and others".format(*input_names[:2])
+    return on_text

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -52,12 +52,12 @@ from galaxy.tools import (
     DefaultToolState,
     get_safe_version,
 )
-from galaxy.tools.actions import filter_output
 from galaxy.tools.execute import (
     execute,
     MappingParameters,
     PartialJobExecution,
 )
+from galaxy.tools.execution_helpers import filter_output
 from galaxy.tools.expressions import do_eval
 from galaxy.tools.parameters import (
     check_param,

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -2512,6 +2512,8 @@ class TestToolsApi(ApiTestCase, TestsTools):
                 ],
                 wait=True,
             )
+            details = self.dataset_populator.get_history_dataset_details(history_id, hid=2)
+            assert details["extension"] == "fasta"
             self._assert_status_code_is(response, 200)
             hdca_id = response.json()["outputs"][0]["id"]
             inputs = {

--- a/test/unit/app/tools/test_actions.py
+++ b/test/unit/app/tools/test_actions.py
@@ -14,8 +14,8 @@ from galaxy.tool_util.parser.xml import parse_change_format
 from galaxy.tools.actions import (
     DefaultToolAction,
     determine_output_format,
-    on_text_for_names,
 )
+from galaxy.tools.execution_helpers import on_text_for_names
 from galaxy.util import XML
 from galaxy.util.unittest import TestCase
 
@@ -140,7 +140,7 @@ class TestDefaultToolAction(TestCase, tools_support.UsesTools):
         if incoming is None:
             incoming = dict(param1="moo")
         self._init_tool(contents)
-        job, out_data, _ = self.action.execute(
+        job, out_data, *_ = self.action.execute(
             tool=self.tool,
             trans=self.trans,
             history=self.history,


### PR DESCRIPTION
The latest mypy upgrade (xref https://github.com/galaxyproject/galaxy/pull/18608 ) is going to force us to clean up some of the typing around tool execution and in particular conflicting type signatures around the execute method of ToolAction subclasses. That PR is already getting large and I think cleaning up the typing around tool execution is a bit intricate - so I was hoping to do it in its own PR ahead of that one.

I think ``SetMetadataToolAction.execute`` was doing the most mangling of the type execute signature. Adding a overwrite argument. I have tried to refactor access to the internals of that so that consumers can call them with an overwrite argument that isn't through the generic ``execute`` method. ~Additionally, I've tried to make ``set_output_hid`` a class variable instead of an argument since it seems we were mostly changing it via changing the default arguments to subclass ``execute`` methods - which is problematic.~ (This didn't work - I've reworked everything to put ``set_output_hid`` back into the argument list.)

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
