### PR TITLE
Reduce unnecessary requests when browsing tool repositories in Admin Panel

### DIFF
--- a/client/src/components/Toolshed/RepositoryDetails/InstallationActions.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/InstallationActions.vue
@@ -1,9 +1,14 @@
-<script setup>
+<script setup lang="ts">
 import { computed } from "vue";
 
-const props = defineProps({
-    status: String,
-});
+import localize from "@/utils/localization";
+
+interface Props {
+    status?: string;
+    isBusy?: boolean;
+}
+
+const props = defineProps<Props>();
 
 const installState = computed(() => !props.status || props.status === "Uninstalled");
 const uninstallState = computed(() => props.status === "Installed");
@@ -19,7 +24,10 @@ function onReset() {
 
 <template>
     <div>
-        <b-button v-if="installState" variant="primary" class="btn-sm" @click="() => emit('onInstall')">
+        <b-button v-if="isBusy" variant="secondary" class="btn-sm" disabled>
+            <b-spinner small></b-spinner>
+        </b-button>
+        <b-button v-else-if="installState" variant="primary" class="btn-sm" @click="() => emit('onInstall')">
             Install
         </b-button>
         <b-button v-else-if="uninstallState" variant="danger" class="btn-sm" @click="() => emit('onUninstall')">
@@ -29,7 +37,7 @@ function onReset() {
             v-else
             variant="warning"
             class="btn-sm"
-            :title="l('Reset Broken or Stuck Installation')"
+            :title="localize('Reset Broken or Stuck Installation')"
             @click="onReset">
             Reset
         </b-button>

--- a/client/src/components/Toolshed/RepositoryDetails/InstallationActions.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/InstallationActions.vue
@@ -8,11 +8,11 @@ const props = defineProps({
 const installState = computed(() => !props.status || props.status === "Uninstalled");
 const uninstallState = computed(() => props.status === "Installed");
 
-const emit = defineEmits(["onInstall", "onUninstall"]);
+const emit = defineEmits(["onInstall", "onUninstall", "onReset"]);
 
-function onCancel() {
+function onReset() {
     if (window.confirm(`Do you want to reset this repository?`)) {
-        emit("onUninstall");
+        emit("onReset");
     }
 }
 </script>
@@ -30,7 +30,7 @@ function onCancel() {
             variant="warning"
             class="btn-sm"
             :title="l('Reset Broken or Stuck Installation')"
-            @click="onCancel">
+            @click="onReset">
             Reset
         </b-button>
     </div>

--- a/client/src/composables/resourceWatcher.ts
+++ b/client/src/composables/resourceWatcher.ts
@@ -37,13 +37,11 @@ export function useResourceWatcher(watchHandler: WatchResourceHandler, options: 
     let currentPollingInterval = shortPollingInterval;
     let watchTimeout: NodeJS.Timeout | null = null;
     let isEventSetup = false;
-    let cancelled = false;
 
     /**
      * Starts watching the resource by polling the server continuously.
      */
     function startWatchingResource() {
-        cancelled = false;
         stopWatcher();
         tryWatchResource();
     }
@@ -53,7 +51,6 @@ export function useResourceWatcher(watchHandler: WatchResourceHandler, options: 
      */
     function stopWatchingResource() {
         stopWatcher();
-        cancelled = true;
     }
 
     function stopWatcher() {
@@ -69,7 +66,7 @@ export function useResourceWatcher(watchHandler: WatchResourceHandler, options: 
         } catch (error) {
             console.warn(error);
         } finally {
-            if (currentPollingInterval && !cancelled) {
+            if (currentPollingInterval) {
                 watchTimeout = setTimeout(() => {
                     tryWatchResource();
                 }, currentPollingInterval);
@@ -87,9 +84,7 @@ export function useResourceWatcher(watchHandler: WatchResourceHandler, options: 
     function updateThrottle() {
         if (document.visibilityState === "visible") {
             currentPollingInterval = shortPollingInterval;
-            if (!cancelled) {
-                startWatchingResource();
-            }
+            startWatchingResource();
         } else {
             currentPollingInterval = enableBackgroundPolling ? longPollingInterval : undefined;
         }


### PR DESCRIPTION
Fixes #18588

This ensures that a browser tab in the background will not poll for the status.

In addition:
- Converts RepositoryDetails/Index.vue to composition API.
- Makes the install/uninstall button more responsive to avoid multiple clicks

    ### Before
    
    ![ToolInstallBefore](https://github.com/user-attachments/assets/ccd0a310-6e69-46c4-a669-8f953238ca33)
    
    
    ### After
    
    ![ToolInstallAfter](https://github.com/user-attachments/assets/2d6cff44-9ac2-40d6-b27e-78728fbef55c)


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
