### PR TITLE
[24.1] Improve relabel identifiers message when number of columns is not 2

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -3812,8 +3812,14 @@ class RelabelFromFileTool(DatabaseOperationTool):
         if how_type == "tabular":
             # We have a tabular file, where the first column is an existing element identifier,
             # and the second column is the new element identifier.
+            new_labels_dict = {}
             source_new_label = (line.strip().split("\t") for line in new_labels)
-            new_labels_dict = dict(source_new_label)
+            for i, label_pair in enumerate(source_new_label):
+                if not len(label_pair) == 2:
+                    raise exceptions.MessageException(
+                        f"Relabel mapping file line {i + 1} contains {len(label_pair)} columns, but 2 are required"
+                    )
+                new_labels_dict[label_pair[0]] = label_pair[1]
             for dce in hdca.collection.elements:
                 dce_object = dce.element_object
                 element_identifier = dce.element_identifier


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/18633:
```
ValueError: dictionary update sequence element #4 has length 1; 2 is required
  File "galaxy/tools/__init__.py", line 1969, in handle_single_execution
    rval = self.execute(
  File "galaxy/tools/__init__.py", line 2066, in execute
    return self.tool_action.execute(
  File "galaxy/tools/actions/model_operations.py", line 89, in execute
    self._produce_outputs(
  File "galaxy/tools/actions/model_operations.py", line 120, in _produce_outputs
    tool.produce_outputs(
  File "galaxy/tools/__init__.py", line 3816, in produce_outputs
    new_labels_dict = dict(source_new_label)

Exception caught while attempting to execute tool with id '__RELABEL_FROM_FILE__':
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
