### PR TITLE
[24.1] Fix h5ad metadata

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1505,7 +1505,7 @@ class Anndata(H5):
                     count = len(tmp.dtype)
                     size = int(tmp.size)
                 else:
-                    layers = list(tmp.attrs)
+                    layers = list(tmp.keys())
                     count = len(layers)
                     size = lennames
                 return (layers, count, size)


### PR DESCRIPTION
This PR fixes h5ad metadata problem.

The metadata of h5ad is not shown correctly in the history:
![image](https://github.com/user-attachments/assets/480d5d6d-deea-40f4-94f3-87b3927d21ef)


This little change fixes that :)

![image](https://github.com/user-attachments/assets/bd48fa7a-b462-4ffb-b3f8-7654f26d260f)
