### PR TITLE
[24.1] Fix resume_paused_jobs if no session provided

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -237,21 +237,17 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             )
         return trans.show_error_message("Cannot purge deleted datasets from this session.")
 
-    @web.expose
+    @web.expose_api_anonymous
     def resume_paused_jobs(self, trans, current=False, ids=None, **kwargs):
-        """Resume paused jobs the active history -- this does not require a logged in user."""
+        """Resume paused jobs for the active history -- this does not require a logged in user."""
         if not ids and string_as_bool(current):
-            histories = [trans.get_history()]
-            refresh_frames = ["history"]
-        else:
-            raise NotImplementedError("You can currently only resume all the datasets of the current history.")
-        for history in histories:
-            history.resume_paused_jobs()
-            trans.sa_session.add(history)
-        with transaction(trans.sa_session):
-            trans.sa_session.commit()
-        return trans.show_ok_message("Your jobs have been resumed.", refresh_frames=refresh_frames)
-        # TODO: used in index.mako
+            history = trans.get_history()
+            if history:
+                history.resume_paused_jobs()
+                return trans.show_ok_message("Your jobs have been resumed.")
+        raise exceptions.RequestParameterInvalidException(
+            "You can currently only resume all the datasets of the current history."
+        )
 
     @web.expose_api
     @web.require_login("rename histories")


### PR DESCRIPTION
No session means no history.
Fixes https://github.com/galaxyproject/galaxy/issues/18639:
```
AttributeError: 'NoneType' object has no attribute 'resume_paused_jobs'
(1 additional frame(s) were not displayed)
...
  File "galaxy/web/framework/middleware/error.py", line 167, in __call__
    app_iter = self.application(environ, sr_checker)
  File "galaxy/web/framework/middleware/statsd.py", line 29, in __call__
    req = self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 174, in __call__
    return self.handle_request(request_id, path_info, environ, start_response)
  File "galaxy/web/framework/base.py", line 268, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/webapps/galaxy/controllers/history.py", line 249, in resume_paused_jobs
    history.resume_paused_jobs()

Uncaught Exception
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
