### PR TITLE
Another shot at tool shed API fixes

### DIFF
--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -250,6 +250,11 @@ class InconsistentDatabase(MessageException):
     err_code = error_codes_by_name["INCONSISTENT_DATABASE"]
 
 
+class InconsistentApplicationState(MessageException):
+    status_code = 500
+    err_code = error_codes_by_name["INCONSISTENT_APPLICATION_STATE"]
+
+
 class InternalServerError(MessageException):
     status_code = 500
     err_code = error_codes_by_name["INTERNAL_SERVER_ERROR"]

--- a/lib/galaxy/exceptions/error_codes.json
+++ b/lib/galaxy/exceptions/error_codes.json
@@ -190,6 +190,11 @@
         "message": "Reference data required for program execution failed to load."
     },
     {
+        "name": "INCONSISTENT_APPLICATION_STATE",
+        "code": 500007,
+        "message": "Inconsistent application state (likely not dbms related) prevented fulfilling the request."
+    },
+    {
         "name": "NOT_IMPLEMENTED",
         "code": 501001,
         "message": "Method is not implemented."

--- a/lib/tool_shed/managers/tools.py
+++ b/lib/tool_shed/managers/tools.py
@@ -149,7 +149,7 @@ def _shed_tool_source_for(
         cloned_ok, error_message = clone_repository(repository_clone_url, work_dir, str(ctx.rev()))
         if error_message:
             raise InternalServerError("Failed to materialize target repository revision")
-        repo_files_dir = repository_metadata.repository.repo_path(trans.app)
+        repo_files_dir = repository_metadata.repository.hg_repository_path(trans.app.config.file_path)
         if not repo_files_dir:
             raise InconsistentApplicationState(
                 f"Failed to resolve repository path from hgweb_config_manager for [{trs_tool_id}], inconsistent repository state or application configuration"

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -231,12 +231,7 @@ def create_repository(
     session = sa_session()
     with transaction(session):
         session.commit()
-    dir = os.path.join(app.config.file_path, *util.directory_hash_id(repository.id))
-    # Define repo name inside hashed directory.
-    final_repository_path = os.path.join(dir, "repo_%d" % repository.id)
-    # Create final repository directory.
-    if not os.path.exists(final_repository_path):
-        os.makedirs(final_repository_path)
+    final_repository_path = repository.ensure_hg_repository_path(app.config.file_path)
     os.rename(repository_path, final_repository_path)
     app.hgweb_config_manager.add_entry(lhs, final_repository_path)
     # Update the repository registry.

--- a/lib/tool_shed/webapp/model/__init__.py
+++ b/lib/tool_shed/webapp/model/__init__.py
@@ -524,6 +524,19 @@ class Repository(Base, Dictifiable):
             os.path.join(hgweb_config_manager.hgweb_repo_prefix, self.user.username, self.name)
         )
 
+    def hg_repository_path(self, repositories_directory: str) -> str:
+        if self.id is None:
+            raise Exception("Attempting to call hg_repository_path before id has been set on repository object")
+        dir = os.path.join(repositories_directory, *util.directory_hash_id(self.id))
+        final_repository_path = os.path.join(dir, "repo_%d" % self.id)
+        return final_repository_path
+
+    def ensure_hg_repository_path(self, repositories_directory: str) -> str:
+        final_repository_path = self.hg_repository_path(repositories_directory)
+        if not os.path.exists(final_repository_path):
+            os.makedirs(final_repository_path)
+        return final_repository_path
+
     def revision(self):
         repo = self.hg_repo
         tip_ctx = repo[repo.changelog.tip()]


### PR DESCRIPTION
Longer term we've got get away from the ugly global data and invalid multi-threading of the ``hgweb_config_manager`` global instance of ``HgWebConfigManager``. 

If this fixes https://github.com/galaxyproject/galaxy/issues/18556 this time - we could replace all our repo_path calculation to skip that object using this mechanism and then... have one process that deals with keeping the hg web stuff in sync and just communicate with it using tasks? I really want Celery on the tool shed servers but I know our admin resources for the tool sheds are already tapped out 😿.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
