### PR TITLE
Rip repository_registry out of tool shed 2.0

### DIFF
--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -250,6 +250,11 @@ class InconsistentDatabase(MessageException):
     err_code = error_codes_by_name["INCONSISTENT_DATABASE"]
 
 
+class InconsistentApplicationState(MessageException):
+    status_code = 500
+    err_code = error_codes_by_name["INCONSISTENT_APPLICATION_STATE"]
+
+
 class InternalServerError(MessageException):
     status_code = 500
     err_code = error_codes_by_name["INTERNAL_SERVER_ERROR"]

--- a/lib/galaxy/exceptions/error_codes.json
+++ b/lib/galaxy/exceptions/error_codes.json
@@ -190,6 +190,11 @@
         "message": "Reference data required for program execution failed to load."
     },
     {
+        "name": "INCONSISTENT_APPLICATION_STATE",
+        "code": 500007,
+        "message": "Inconsistent application state (likely not dbms related) prevented fulfilling the request."
+    },
+    {
         "name": "NOT_IMPLEMENTED",
         "code": 501001,
         "message": "Method is not implemented."

--- a/lib/tool_shed/managers/categories.py
+++ b/lib/tool_shed/managers/categories.py
@@ -59,9 +59,7 @@ class CategoryManager:
 
     def to_dict(self, category: Category) -> Dict[str, Any]:
         category_dict = category.to_dict(view="collection", value_mapper=get_value_mapper(self.app))
-        category_dict["repositories"] = self.app.repository_registry.viewable_repositories_and_suites_by_category.get(
-            category.name, 0
-        )
+        category_dict["repositories"] = category.active_repository_count()
         category_dict["url"] = web.url_for(
             controller="categories", action="show", id=self.app.security.encode_id(category.id)
         )

--- a/lib/tool_shed/managers/tools.py
+++ b/lib/tool_shed/managers/tools.py
@@ -149,7 +149,7 @@ def _shed_tool_source_for(
         cloned_ok, error_message = clone_repository(repository_clone_url, work_dir, str(ctx.rev()))
         if error_message:
             raise InternalServerError("Failed to materialize target repository revision")
-        repo_files_dir = repository_metadata.repository.repo_path(trans.app)
+        repo_files_dir = repository_metadata.repository.hg_repository_path(trans.app.config.file_path)
         if not repo_files_dir:
             raise InconsistentApplicationState(
                 f"Failed to resolve repository path from hgweb_config_manager for [{trs_tool_id}], inconsistent repository state or application configuration"

--- a/lib/tool_shed/structured_app.py
+++ b/lib/tool_shed/structured_app.py
@@ -4,7 +4,7 @@ from galaxy.structured_app import BasicSharedApp
 
 if TYPE_CHECKING:
     from tool_shed.managers.model_cache import ModelCache
-    from tool_shed.repository_registry import Registry as RepositoryRegistry
+    from tool_shed.repository_registry import RegistryInterface
     from tool_shed.repository_types.registry import Registry as RepositoryTypesRegistry
     from tool_shed.util.hgweb_config import HgWebConfigManager
     from tool_shed.webapp.model import mapping
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class ToolShedApp(BasicSharedApp):
     repository_types_registry: "RepositoryTypesRegistry"
     model: "mapping.ToolShedModelMapping"
-    repository_registry: "RepositoryRegistry"
+    repository_registry: "RegistryInterface"
     hgweb_config_manager: "HgWebConfigManager"
     security_agent: "CommunityRBACAgent"
     model_cache: "ModelCache"

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -231,12 +231,7 @@ def create_repository(
     session = sa_session()
     with transaction(session):
         session.commit()
-    dir = os.path.join(app.config.file_path, *util.directory_hash_id(repository.id))
-    # Define repo name inside hashed directory.
-    final_repository_path = os.path.join(dir, "repo_%d" % repository.id)
-    # Create final repository directory.
-    if not os.path.exists(final_repository_path):
-        os.makedirs(final_repository_path)
+    final_repository_path = repository.ensure_hg_repository_path(app.config.file_path)
     os.rename(repository_path, final_repository_path)
     app.hgweb_config_manager.add_entry(lhs, final_repository_path)
     # Update the repository registry.

--- a/lib/tool_shed/webapp/app.py
+++ b/lib/tool_shed/webapp/app.py
@@ -108,7 +108,10 @@ class UniverseApplication(ToolShedApp, SentryClientMixin, HaltableContainer):
         self.hgweb_config_manager.hgweb_config_dir = self.config.hgweb_config_dir
         self.hgweb_config_manager.hgweb_repo_prefix = self.config.hgweb_repo_prefix
         # Initialize the repository registry.
-        self.repository_registry = tool_shed.repository_registry.Registry(self)
+        if config.SHED_API_VERSION != "v2":
+            self.repository_registry = tool_shed.repository_registry.Registry(self)
+        else:
+            self.repository_registry = tool_shed.repository_registry.NullRepositoryRegistry(self)
         # Configure Sentry client if configured
         self.configure_sentry_client()
         #  used for cachebusting -- refactor this into a *SINGLE* UniverseApplication base.

--- a/lib/tool_shed/webapp/buildapp.py
+++ b/lib/tool_shed/webapp/buildapp.py
@@ -26,8 +26,7 @@ from galaxy.webapps.base.webapp import (
     GalaxyWebTransaction,
 )
 from galaxy.webapps.util import wrap_if_allowed
-
-SHED_API_VERSION = os.environ.get("TOOL_SHED_API_VERSION", "v1")
+from .config import SHED_API_VERSION
 
 log = logging.getLogger(__name__)
 

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -27,6 +27,7 @@ from galaxy.version import (
 log = logging.getLogger(__name__)
 
 TOOLSHED_APP_NAME = "tool_shed"
+SHED_API_VERSION = os.environ.get("TOOL_SHED_API_VERSION", "v1")
 
 
 class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):

--- a/lib/tool_shed/webapp/fast_app.py
+++ b/lib/tool_shed/webapp/fast_app.py
@@ -166,7 +166,7 @@ def initialize_fast_app(gx_webapp, tool_shed_app):
     app = get_fastapi_instance()
     add_exception_handler(app)
     add_request_id_middleware(app)
-    from .buildapp import SHED_API_VERSION
+    from .config import SHED_API_VERSION
 
     def mount_static(directory: Path):
         name = directory.name

--- a/lib/tool_shed/webapp/model/__init__.py
+++ b/lib/tool_shed/webapp/model/__init__.py
@@ -524,6 +524,19 @@ class Repository(Base, Dictifiable):
             os.path.join(hgweb_config_manager.hgweb_repo_prefix, self.user.username, self.name)
         )
 
+    def hg_repository_path(self, repositories_directory: str) -> str:
+        if self.id is None:
+            raise Exception("Attempting to call hg_repository_path before id has been set on repository object")
+        dir = os.path.join(repositories_directory, *util.directory_hash_id(self.id))
+        final_repository_path = os.path.join(dir, "repo_%d" % self.id)
+        return final_repository_path
+
+    def ensure_hg_repository_path(self, repositories_directory: str) -> str:
+        final_repository_path = self.hg_repository_path(repositories_directory)
+        if not os.path.exists(final_repository_path):
+            os.makedirs(final_repository_path)
+        return final_repository_path
+
     def revision(self):
         repo = self.hg_repo
         tip_ctx = repo[repo.changelog.tip()]

--- a/test/unit/tool_shed/_util.py
+++ b/test/unit/tool_shed/_util.py
@@ -33,6 +33,7 @@ from tool_shed.webapp.model import (
     Category,
     mapping,
     Repository,
+    RepositoryCategoryAssociation,
     User,
 )
 from tool_shed_client.schema import CreateCategoryRequest
@@ -195,3 +196,12 @@ def create_category(provides_repositories: ProvidesRepositoriesContext, create: 
 
     request = CreateCategoryRequest(**create)
     return CategoryManager(provides_repositories.app).create(provides_repositories, request)
+
+
+def attach_category(provides_repositories: ProvidesRepositoriesContext, repository: Repository, category: Category):
+    assoc = RepositoryCategoryAssociation(
+        repository=repository,
+        category=category,
+    )
+    provides_repositories.sa_session.add(assoc)
+    provides_repositories.sa_session.flush()

--- a/test/unit/tool_shed/test_graphql.py
+++ b/test/unit/tool_shed/test_graphql.py
@@ -12,12 +12,9 @@ from tool_shed.context import (
     ProvidesUserContext,
 )
 from tool_shed.webapp.graphql.schema import schema
-from tool_shed.webapp.model import (
-    Category,
-    Repository,
-    RepositoryCategoryAssociation,
-)
+from tool_shed.webapp.model import Repository
 from ._util import (
+    attach_category,
     create_category,
     repository_fixture,
     upload_directories_to_repository,
@@ -108,15 +105,6 @@ def test_simple_repositories(provides_repositories: ProvidesRepositoriesContext,
     repos = _assert_result_data_has_key(result, "repositories")
     repository_names = [r["name"] for r in repos]
     assert new_repository.name in repository_names
-
-
-def attach_category(provides_repositories: ProvidesRepositoriesContext, repository: Repository, category: Category):
-    assoc = RepositoryCategoryAssociation(
-        repository=repository,
-        category=category,
-    )
-    provides_repositories.sa_session.add(assoc)
-    provides_repositories.sa_session.flush()
 
 
 def test_relay_repos_by_category(provides_repositories: ProvidesRepositoriesContext, new_repository: Repository):

--- a/test/unit/tool_shed/test_repository_utils.py
+++ b/test/unit/tool_shed/test_repository_utils.py
@@ -5,6 +5,8 @@ from tool_shed.webapp.model import (
     User,
 )
 from ._util import (
+    attach_category,
+    create_category,
     repository_fixture,
     TEST_DATA_FILES,
     TestToolShedApp,
@@ -81,6 +83,27 @@ def test_upload_dry_run_ok(provides_repositories: ProvidesRepositoriesContext, n
     assert files_removed == 0
     new_tip = new_repository.tip()
     assert old_tip == new_tip
+
+
+def test_category_count(provides_repositories: ProvidesRepositoriesContext, new_repository: Repository):
+    category = create_category(provides_repositories, {"name": "test_category_count_1"})
+    attach_category(provides_repositories, new_repository, category)
+
+    category = new_repository.categories[0].category
+    assert category.active_repository_count() == 1
+
+    tar_resource = TEST_DATA_FILES.joinpath("column_maker/column_maker.tar")
+    upload_ok, *_ = upload_tar(
+        provides_repositories,
+        new_repository.user.username,
+        new_repository,
+        tar_resource,
+        commit_message="Commit Message",
+    )
+    assert upload_ok
+
+    category = new_repository.categories[0].category
+    assert category.active_repository_count() == 1
 
 
 def test_upload_dry_run_failed(provides_repositories: ProvidesRepositoriesContext, new_repository: Repository):


### PR DESCRIPTION
We don't need any of this for the new UI and only used one small thing for the API that I have just replaced with a live database query. Should dramatically speed up the tool shed startup and reduce the complexity of repository operations at runtime.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
