### PR TITLE
Implemented the generic OIDC backend from python-social-auth into Gal…

### DIFF
--- a/client/src/components/User/ExternalIdentities/ExternalLogin.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalLogin.vue
@@ -257,7 +257,7 @@ function getIdpPreference() {
                     <span v-else-if="iDPInfo['custom_button_text']">
                         <BButton class="d-block mt-3" @click="submitOIDCLogin(idp)">
                             <i :class="oIDCIdps[idp]" />
-                            Sign in with {{ iDPInfo['custom_button_text'] }}
+                            Sign in with {{ iDPInfo["custom_button_text"] }}
                         </BButton>
                     </span>
                     <span v-else>

--- a/client/src/components/User/ExternalIdentities/ExternalLogin.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalLogin.vue
@@ -254,6 +254,12 @@ function getIdpPreference() {
                             <img :src="iDPInfo['icon']" height="45" :alt="idp" />
                         </BButton>
                     </span>
+                    <span v-else-if="iDPInfo['custom_button_text']">
+                        <BButton class="d-block mt-3" @click="submitOIDCLogin(idp)">
+                            <i :class="oIDCIdps[idp]" />
+                            Sign in with {{ iDPInfo['custom_button_text'] }}
+                        </BButton>
+                    </span>
                     <span v-else>
                         <BButton class="d-block mt-3" @click="submitOIDCLogin(idp)">
                             <i :class="oIDCIdps[idp]" />

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -137,8 +137,10 @@ class AuthnzManager:
                 if idp in BACKENDS_NAME:
                     self.oidc_backends_config[idp] = self._parse_idp_config(child)
                     self.oidc_backends_implementation[idp] = "psa"
-                    self.app.config.oidc[idp] = {"icon": self._get_idp_icon(idp),
-                                                 "custom_button_text": self._get_idp_button_text(idp)}
+                    self.app.config.oidc[idp] = {
+                        "icon": self._get_idp_icon(idp),
+                        "custom_button_text": self._get_idp_button_text(idp),
+                    }
                 elif idp in KEYCLOAK_BACKENDS:
                     self.oidc_backends_config[idp] = self._parse_custos_config(child)
                     self.oidc_backends_implementation[idp] = "custos"

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -108,6 +108,9 @@ class AuthnzManager:
     def _get_idp_icon(self, idp):
         return self.oidc_backends_config[idp].get("icon") or DEFAULT_OIDC_IDP_ICONS.get(idp)
 
+    def _get_idp_button_text(self, idp):
+        return self.oidc_backends_config[idp].get("custom_button_text")
+
     def _parse_oidc_backends_config(self, config_file):
         self.oidc_backends_config = {}
         self.oidc_backends_implementation = {}
@@ -134,7 +137,8 @@ class AuthnzManager:
                 if idp in BACKENDS_NAME:
                     self.oidc_backends_config[idp] = self._parse_idp_config(child)
                     self.oidc_backends_implementation[idp] = "psa"
-                    self.app.config.oidc[idp] = {"icon": self._get_idp_icon(idp)}
+                    self.app.config.oidc[idp] = {"icon": self._get_idp_icon(idp),
+                                                 "custom_button_text": self._get_idp_button_text(idp)}
                 elif idp in KEYCLOAK_BACKENDS:
                     self.oidc_backends_config[idp] = self._parse_custos_config(child)
                     self.oidc_backends_implementation[idp] = "custos"
@@ -171,6 +175,10 @@ class AuthnzManager:
             rtv["extra_scopes"] = listify(config_xml.find("extra_scopes").text)
         if config_xml.find("tenant_id") is not None:
             rtv["tenant_id"] = config_xml.find("tenant_id").text
+        if config_xml.find("oidc_endpoint") is not None:
+            rtv["oidc_endpoint"] = config_xml.find("oidc_endpoint").text
+        if config_xml.find("custom_button_text") is not None:
+            rtv["custom_button_text"] = config_xml.find("custom_button_text").text
         if config_xml.find("pkce_support") is not None:
             rtv["pkce_support"] = asbool(config_xml.find("pkce_support").text)
         if config_xml.find("accepted_audiences") is not None:

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -45,6 +45,7 @@ BACKENDS = {
     "okta": "social_core.backends.okta_openidconnect.OktaOpenIdConnect",
     "azure": "social_core.backends.azuread_tenant.AzureADV2TenantOAuth2",
     "egi_checkin": "social_core.backends.egi_checkin.EGICheckinOpenIdConnect",
+    "oidc": "social_core.backends.open_id_connect.OpenIdConnectAuth",
 }
 
 BACKENDS_NAME = {
@@ -54,6 +55,7 @@ BACKENDS_NAME = {
     "okta": "okta-openidconnect",
     "azure": "azuread-v2-tenant-oauth2",
     "egi_checkin": "egi-checkin",
+    "oidc": "oidc",
 }
 
 AUTH_PIPELINE = (
@@ -133,6 +135,7 @@ class PSAAuthnz(IdentityProvider):
         self.config["KEY"] = oidc_backend_config.get("client_id")
         self.config["SECRET"] = oidc_backend_config.get("client_secret")
         self.config["TENANT_ID"] = oidc_backend_config.get("tenant_id")
+        self.config["OIDC_ENDPOINT"] = oidc_backend_config.get("oidc_endpoint")
         self.config["redirect_uri"] = oidc_backend_config.get("redirect_uri")
         self.config["EXTRA_SCOPES"] = oidc_backend_config.get("extra_scopes")
         if oidc_backend_config.get("prompt") is not None:

--- a/lib/galaxy/authnz/xsd/oidc_backends_config.xsd
+++ b/lib/galaxy/authnz/xsd/oidc_backends_config.xsd
@@ -121,6 +121,20 @@
                                     </xs:documentation>
                                 </xs:annotation>
                             </xs:element>
+                            <xs:element name="oidc_endpoint" minOccurs="0" type="xs:anyURI">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        OIDC endpoint for the IdP
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="custom_button_text" minOccurs="0" type="xs:string">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Can be used to set a custom text value for the "Sign in with " button for your chosen IdP.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
                             <xs:element name="pkce_support" minOccurs="0" type="xs:boolean">
                                 <xs:annotation>
                                     <xs:documentation>

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -201,6 +201,26 @@ Please mind `http` and `https`.
         <tenant_id> ... </tenant_id>
     </provider>
 
+    <provider name="oidc">
+        <!-- This example section uses the generic OIDC backend from python-social-auth. This should work with any provider that
+        supports the OIDC standard.
+        -->
+        <client_id> ... </client_id>
+        <client_secret> ... </client_secret>
+        <redirect_uri>http://localhost:8080/authnz/oidc/callback</redirect_uri>
+        <oidc_endpoint> ... </oidc_endpoint>
+        <!-- enter the url of a OIDC endpoint that supports autoconfiguration here. Enter the URL minus the ".well-known/openid-configuration" part.
+        For example: If the complete url pointing to your endpoint's autoconfig file is "https:example.com/my-realm/.well-known/openid-configuration",
+        then simply enter "https://example.com/my-realm".
+         -->
+         <custom_button_text> ... </custom_button_text>
+         <!-- This is an optional field where you can provide a custom text for the sign in button on the Galaxy front page
+          that you can click to authenticate with your IdP. If you don't provide a custom button text, the sign in button
+          will just read the default value of your IdP name. For example: "Sign in with oidc" or "Sign in with Azure".
+          However, if for example you enter the value "your university account" here, the button will display "Sign in with your university account".
+         -->
+    </provider>
+
     <!-- Documentation: https://docs.egi.eu/providers/check-in/sp -->
     <provider name="egi_checkin">
 	<!-- Client id and secret can be obtained by registering your client at EGI Check-in


### PR DESCRIPTION
Adds generic OIDC IdP authentication capability to Galaxy and the option to provide more meaningful descriptive texts to IdP sign-in buttons on the Galaxy login page.

* Implemented the generic OIDC backend from python-social-auth. See _https://python-social-auth.readthedocs.io/en/latest/backends/oidc.html_
* This allows Galaxy to use any IdP that supports the "generic" OIDC standard, as opposed to more specific IdPs like Azure or Google.
* The added benefit of including this back-end as one of the IdP authentication options is that any IdP that supports the generic OIDC standard can be used for authentication.
* For example: At Naturalis our use-case for needing this psa back-end is to authenticate with our third-party authentication/authorization provider called “SRAM” (See _https://sram.surf.nl/_). This provider supports the OIDC standard which means that with the changes made in this pull-request, it is fairly easy to connect Galaxy to this service (or any IdP that supports OIDC) for authorization.
* Hopefully making this psa back-end available through this pull-request will not only be useful to us at Naturalis, but also maybe to other Galaxy admins that want to connect to an IdP that supports generic OIDC.
* In addition, I’ve also implemented a feature that allows a Galaxy admin to set a custom text for an IdP sign-in button. The added benefit of this is so that one is not tied to the standard button text like “Sign in with Azure” or “Sign in with Oidc” but can for example make the button read “Sign in with your university account”, or whatever one prefers. This custom text can be set by providing your preferred text using the <custom_button_text> element in the **oidc_backends_config.xml** file. When this element is omitted, the default button text will be used.
* This feature is especially useful when providing multiple IdPs for authentication because it is more useful for end-users to differentiate between the available sign-in buttons when they contain more meaningful descriptions.
* I’ve also documented these new features to the **oidc_backends_condig.xml.sample** file to make it easy for other admins to figure out how to configure their generic OIDC IdP for Galaxy or to rename the text of their sign-in buttons.

Feel free to let me know if there are any questions about the above or suggestions for changes to the code that I submitted.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Any IdP that supports the generic OIDC standard and provides an autoconfig file should be able to be configured as an authentication provider for Galaxy by modifying the  oidc_backends_config.xml file. For example:
```
    <provider name="oidc">
        <client_id> [your client_id here] </client_id>
        <client_secret> [your client_secret here] </client_secret>
        <redirect_uri>https://localhost:8080/authnz/oidc/callback</redirect_uri>
        <oidc_endpoint>https://my-idp.example.com</oidc_endpoint>
        <custom_button_text>with your university account</custom_button_text>
    </provider>
```

I tested this myself successfully against both a locally installed Keycloak server and our third-party "SRAM" IdP provider in production which both support the OIDC standard by providing a .well-known/openid-configuration file that Galaxy/python-social-auth can use for auto-configuration.



## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
