### PR TITLE
[24.1] Return error when following a link to a non-ready display application

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -708,7 +708,13 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                             display_link.prepare_display()
                         preparable_steps = display_link.get_prepare_steps()
                     else:
-                        raise Exception(f"Attempted a view action ({app_action}) on a non-ready display application")
+                        # Ideally we should respond with 202 in both cases.
+                        # Since we don't exactly know if any consumer relies on this we'll just keep continuing to
+                        # respond with a 500 status code.
+                        trans.response.status = 500
+                        return trans.show_error_message(
+                            f"Attempted a view action ({app_action}) on a non-ready display application"
+                        )
             return trans.fill_template_mako(
                 "dataset/display_application/display.mako",
                 msg=msg,


### PR DESCRIPTION
Weird, but better than an internal server error IMO.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
