### PR TITLE
Allow connecting text param into data column parameter

### DIFF
--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -534,7 +534,18 @@ export class InputParameterTerminal extends BaseInputTerminal {
     }
 
     effectiveType(parameterType: string) {
-        return parameterType == "select" ? "text" : parameterType;
+        let newType: string;
+        switch (parameterType) {
+            case "select":
+                newType = "text";
+                break;
+            case "data_column":
+                newType = "integer";
+                break;
+            default:
+                newType = parameterType;
+        }
+        return newType;
     }
     attachable(other: BaseOutputTerminal) {
         const effectiveThisType = this.effectiveType(this.type);

--- a/lib/galaxy_test/workflow/integer_into_data_column.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/integer_into_data_column.gxwf-tests.yml
@@ -1,0 +1,15 @@
+- doc: |
+    Test to verify text parameter can be connected to data column param
+  job:
+    input:
+      type: File
+      value: 2.tabular
+      file_type: tabular
+    column:
+      value: "2"
+      type: raw
+  outputs:
+    output:
+      asserts:
+        - that: has_line
+          line: "parameter: 2"

--- a/lib/galaxy_test/workflow/integer_into_data_column.gxwf.yml
+++ b/lib/galaxy_test/workflow/integer_into_data_column.gxwf.yml
@@ -1,0 +1,15 @@
+class: GalaxyWorkflow
+inputs:
+  input:
+    type: data
+  column:
+    type: integer
+outputs:
+  output:
+    outputSource: data_column_step/output
+steps:
+  data_column_step:
+    tool_id: gx_data_column
+    in:
+      ref_parameter: input
+      parameter: column


### PR DESCRIPTION
If we really cared we could inspect the data_column param to see if we
should provide integers or column names ... but this is nice as is IMO.

Closes https://github.com/galaxyproject/galaxy/issues/16491
## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
