### PR TITLE
De-couple XML from tool interface for test collections.

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -38,6 +38,7 @@ from galaxy import util
 from galaxy.tool_util.parser.interface import (
     AssertionList,
     TestCollectionDef,
+    TestCollectionDefDict,
     TestCollectionOutputDef,
     TestSourceTestOutputColllection,
     ToolSourceTestOutputs,
@@ -1749,7 +1750,8 @@ def expanded_inputs_from_json(expanded_inputs_json: ExpandedToolInputsJsonified)
     loaded_inputs: ExpandedToolInputs = {}
     for key, value in expanded_inputs_json.items():
         if isinstance(value, dict) and value.get("model_class"):
-            loaded_inputs[key] = TestCollectionDef.from_dict(value)
+            collection_def_dict = cast(TestCollectionDefDict, value)
+            loaded_inputs[key] = TestCollectionDef.from_dict(collection_def_dict)
         else:
             loaded_inputs[key] = value
     return loaded_inputs

--- a/lib/galaxy/tool_util/verify/parse.py
+++ b/lib/galaxy/tool_util/verify/parse.py
@@ -10,6 +10,7 @@ from typing import (
 
 from galaxy.tool_util.parser.interface import (
     InputSource,
+    TestCollectionDef,
     ToolSource,
     ToolSourceTest,
     ToolSourceTestInputs,
@@ -246,7 +247,8 @@ def _process_raw_inputs(
                     processed_value = param_value
                 elif param_type == "data_collection":
                     assert "collection" in param_extra
-                    collection_def = param_extra["collection"]
+                    collection_dict = param_extra["collection"]
+                    collection_def = TestCollectionDef.from_dict(collection_dict)
                     for input_dict in collection_def.collect_inputs():
                         name = input_dict["name"]
                         value = input_dict["value"]


### PR DESCRIPTION
Keep more in JSON longer so we can apply less custom model objects for validation and stuff. The interface is returning more pure json now.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
