### PR TITLE
[24.0] Fix import all datasets from library folder

### DIFF
--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -210,6 +210,9 @@ export default {
             // logic from legacy code
             return !!(this.contains_file_or_folder && Galaxy.user);
         },
+        totalRows: function () {
+            return this.metadata?.total_rows ?? 0;
+        },
     },
     created() {
         const Galaxy = getGalaxyInstance();
@@ -241,7 +244,8 @@ export default {
                 const selected = await this.services.getFilteredFolderContents(
                     this.folder_id,
                     this.unselected,
-                    this.$parent.searchText
+                    this.$parent.searchText,
+                    this.totalRows
                 );
                 this.$emit("setBusy", false);
                 return selected;

--- a/client/src/components/Libraries/LibraryFolder/services.js
+++ b/client/src/components/Libraries/LibraryFolder/services.js
@@ -30,12 +30,13 @@ export class Services {
         }
     }
 
-    async getFilteredFolderContents(id, excluded, searchText) {
+    async getFilteredFolderContents(id, excluded, searchText, limit) {
         // The intent of this method is to get folder contents applying
-        // seachText filters only; we explicitly set limit to 0
+        // seachText filters only; limit should match the total number of
+        // items in the folder, so that all items are returned.
         const config = {
             params: {
-                limit: 0,
+                limit,
             },
         };
         searchText = searchText?.trim();


### PR DESCRIPTION
Pass the total number of rows as limit, since using limit=0 is not valid anymore for consistency.

Fixes #18666

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Follow the instruction in  #18666

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
