### PR TITLE
[24.1] Show items with same `hid` but different `id` in history

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -298,7 +298,6 @@ function onUndelete() {
 }
 
 function onDragStart(evt: DragEvent) {
-    console.log(evt);
     emit("drag-start", evt);
 }
 

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -1,7 +1,13 @@
 <script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCheckSquare, faSquare } from "@fortawesome/free-regular-svg-icons";
-import { faArrowCircleDown, faArrowCircleUp, faCheckCircle, faSpinner } from "@fortawesome/free-solid-svg-icons";
+import {
+    faArrowCircleDown,
+    faArrowCircleUp,
+    faCheckCircle,
+    faExchangeAlt,
+    faSpinner,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BBadge, BButton, BCollapse } from "bootstrap-vue";
 import { computed, ref } from "vue";
@@ -21,7 +27,7 @@ import ContentOptions from "./ContentOptions.vue";
 import DatasetDetails from "./Dataset/DatasetDetails.vue";
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 
-library.add(faArrowCircleUp, faArrowCircleDown, faCheckCircle, faSpinner);
+library.add(faArrowCircleUp, faArrowCircleDown, faCheckCircle, faExchangeAlt, faSpinner);
 
 const router = useRouter();
 const route = useRoute();
@@ -400,29 +406,39 @@ function unexpandedClick(event: Event) {
                     <span class="id hid">{{ id }}:</span>
                     <span class="content-title name font-weight-bold">{{ name }}</span>
                 </span>
-                <span v-if="item.purged" class="align-self-start btn-group p-1">
+                <span v-if="item.purged" class="ml-auto align-self-start btn-group p-1">
                     <BBadge variant="secondary" title="This dataset has been permanently deleted">
                         <icon icon="burn" /> Purged
                     </BBadge>
                 </span>
-                <ContentOptions
-                    v-if="!isPlaceholder && !item.purged"
-                    :writable="writable"
-                    :is-dataset="isDataset"
-                    :is-deleted="item.deleted"
-                    :is-history-item="isHistoryItem"
-                    :is-visible="item.visible"
-                    :state="state"
-                    :sub-items-count="item.sub_items?.length || 0"
-                    :item-urls="itemUrls"
-                    :is-sub-item="isSubItem"
-                    :sub-items-visible.sync="subItemsVisible"
-                    @delete="onDelete"
-                    @display="onDisplay"
-                    @showCollectionInfo="onShowCollectionInfo"
-                    @edit="onEdit"
-                    @undelete="onUndelete"
-                    @unhide="emit('unhide')" />
+                <span class="align-self-start btn-group">
+                    <BButton
+                        v-if="item.sub_items?.length && !isSubItem"
+                        title="Show converted items"
+                        tabindex="0"
+                        class="display-btn px-1 align-items-center"
+                        size="sm"
+                        variant="link"
+                        @click.prevent.stop="subItemsVisible = !subItemsVisible">
+                        <FontAwesomeIcon :icon="faExchangeAlt" />
+                        <span class="indicator">{{ item.sub_items?.length }}</span>
+                    </BButton>
+                    <ContentOptions
+                        v-if="!isPlaceholder && !item.purged"
+                        :writable="writable"
+                        :is-dataset="isDataset"
+                        :is-deleted="item.deleted"
+                        :is-history-item="isHistoryItem"
+                        :is-visible="item.visible"
+                        :state="state"
+                        :item-urls="itemUrls"
+                        @delete="onDelete"
+                        @display="onDisplay"
+                        @showCollectionInfo="onShowCollectionInfo"
+                        @edit="onEdit"
+                        @undelete="onUndelete"
+                        @unhide="emit('unhide')" />
+                </span>
             </div>
         </div>
         <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/no-static-element-interactions -->
@@ -470,6 +486,18 @@ function unexpandedClick(event: Event) {
 
     .name {
         word-break: break-all;
+    }
+
+    .indicator {
+        align-items: center;
+        border-radius: 50%;
+        color: $brand-primary;
+        display: flex;
+        justify-content: center;
+        height: 1.2rem;
+        position: absolute;
+        top: -0.3rem;
+        width: 1.2rem;
     }
 
     // improve focus visibility

--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -12,9 +12,6 @@ const props = defineProps({
     isVisible: { type: Boolean, default: true },
     state: { type: String, default: "" },
     itemUrls: { type: Object, required: true },
-    subItemsCount: { type: Number, default: 0 },
-    isSubItem: { type: Boolean, default: false },
-    subItemsVisible: { type: Boolean, default: false },
 });
 
 const emit = defineEmits<{
@@ -24,7 +21,6 @@ const emit = defineEmits<{
     (e: "delete", recursive?: boolean): void;
     (e: "undelete"): void;
     (e: "unhide"): void;
-    (e: "update:sub-items-visible", value: boolean): void;
 }>();
 
 const deleteCollectionMenu: Ref<BDropdown | null> = ref(null);
@@ -91,17 +87,6 @@ function onDisplay($event: MouseEvent) {
             <icon icon="info-circle" />
         </b-button>
         <!-- Common for all content items -->
-        <b-button
-            v-if="subItemsCount && !isSubItem"
-            title="Show associated items"
-            tabindex="0"
-            class="display-btn px-1 align-items-center"
-            size="sm"
-            variant="link"
-            @click.prevent.stop="emit('update:sub-items-visible', !subItemsVisible)">
-            <icon icon="plus" />
-            <span class="indicator">{{ subItemsCount }}</span>
-        </b-button>
         <b-button
             v-if="isDataset"
             :disabled="displayDisabled"
@@ -177,19 +162,4 @@ function onDisplay($event: MouseEvent) {
     font-weight: normal;
 }
 </style>
-
-<style scoped lang="scss">
-@import "theme/blue.scss";
-
-.indicator {
-    align-items: center;
-    border-radius: 50%;
-    color: $brand-primary;
-    display: flex;
-    justify-content: center;
-    height: 1.2rem;
-    position: absolute;
-    top: -0.3rem;
-    width: 1.2rem;
-}
-</style>
+```

--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -12,6 +12,9 @@ const props = defineProps({
     isVisible: { type: Boolean, default: true },
     state: { type: String, default: "" },
     itemUrls: { type: Object, required: true },
+    subItemsCount: { type: Number, default: 0 },
+    isSubItem: { type: Boolean, default: false },
+    subItemsVisible: { type: Boolean, default: false },
 });
 
 const emit = defineEmits<{
@@ -21,6 +24,7 @@ const emit = defineEmits<{
     (e: "delete", recursive?: boolean): void;
     (e: "undelete"): void;
     (e: "unhide"): void;
+    (e: "update:sub-items-visible", value: boolean): void;
 }>();
 
 const deleteCollectionMenu: Ref<BDropdown | null> = ref(null);
@@ -87,6 +91,17 @@ function onDisplay($event: MouseEvent) {
             <icon icon="info-circle" />
         </b-button>
         <!-- Common for all content items -->
+        <b-button
+            v-if="subItemsCount && !isSubItem"
+            title="Show associated items"
+            tabindex="0"
+            class="display-btn px-1 align-items-center"
+            size="sm"
+            variant="link"
+            @click.prevent.stop="emit('update:sub-items-visible', !subItemsVisible)">
+            <icon icon="plus" />
+            <span class="indicator">{{ subItemsCount }}</span>
+        </b-button>
         <b-button
             v-if="isDataset"
             :disabled="displayDisabled"
@@ -162,4 +177,19 @@ function onDisplay($event: MouseEvent) {
     font-weight: normal;
 }
 </style>
-```
+
+<style scoped lang="scss">
+@import "theme/blue.scss";
+
+.indicator {
+    align-items: center;
+    border-radius: 50%;
+    color: $brand-primary;
+    display: flex;
+    justify-content: center;
+    height: 1.2rem;
+    position: absolute;
+    top: -0.3rem;
+    width: 1.2rem;
+}
+</style>

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -650,7 +650,22 @@ function setItemDragstart(
                                     @view-collection="$emit('view-collection', item, currentOffset)"
                                     @delete="onDelete"
                                     @undelete="onUndelete(item)"
-                                    @unhide="onUnhide(item)" />
+                                    @unhide="onUnhide(item)">
+                                    <template v-slot:sub_items="slotProps">
+                                        <div v-if="slotProps.subItemsVisible" class="pl-2 sub-items-content">
+                                            <ContentItem
+                                                v-for="subItem in item.sub_items"
+                                                :id="subItem.hid"
+                                                :key="subItem.id"
+                                                :item="subItem"
+                                                :name="subItem.name"
+                                                :expand-dataset="isExpanded(subItem)"
+                                                :is-dataset="isDataset(subItem)"
+                                                :is-sub-item="true"
+                                                @update:expand-dataset="setExpanded(subItem, $event)" />
+                                        </div>
+                                    </template>
+                                </ContentItem>
                             </template>
                         </ListingLayout>
                     </div>
@@ -659,3 +674,11 @@ function setItemDragstart(
         </SelectedItems>
     </ExpandedItems>
 </template>
+
+<style scoped lang="scss">
+@import "theme/blue.scss";
+
+.sub-items-content {
+    background: $body-bg;
+}
+</style>

--- a/client/src/store/historyStore/model/utilities.js
+++ b/client/src/store/historyStore/model/utilities.js
@@ -1,5 +1,8 @@
 import { set } from "vue";
 
+// TODO: This is a temporary solution to handle compressed files. We need to find a better way to handle this.
+const COMPRESSED_EXTENSIONS = ["tabix", "tar.gz", "zip", "tar.bz2", "fa.gz", "fa.bz2", "_bgzip"];
+
 /* This function merges the existing data with new incoming data. */
 export function mergeArray(id, payload, items, itemKey) {
     if (!items[id]) {
@@ -12,11 +15,44 @@ export function mergeArray(id, payload, items, itemKey) {
             const localItem = itemArray[itemIndex];
             if (localItem.id == item.id) {
                 Object.keys(localItem).forEach((key) => {
-                    localItem[key] = item[key];
+                    // Maybe it's ok to overwrite the `sub_items` key here because that
+                    // array might contain items not returned for current filter?
+                    if (key !== "sub_items") {
+                        localItem[key] = item[key];
+                    }
                 });
+            }
+            // the `item.id` is different with the same `hid`,
+            // so we add a key `sub_items` to this item and add any other related item(s) to it
+            else {
+                // But first, we check a few conditions and based on those, possibly replace the `localItem` with the new item
+                if (
+                    // 1: `localItem` is not in the `payload` (for filter)
+                    !payload.find((p) => p.id === localItem.id) ||
+                    // 2: `localItem` is compressed and the new `item` is not
+                    (localItem.extension &&
+                        item.extension &&
+                        COMPRESSED_EXTENSIONS.some((ext) => localItem.extension.includes(ext)) &&
+                        !COMPRESSED_EXTENSIONS.some((ext) => item.extension.includes(ext)))
+                ) {
+                    set(itemArray, itemIndex, item);
+                    pushSubItem(item, localItem);
+                    localItem.sub_items = [];
+                } else {
+                    pushSubItem(localItem, item);
+                }
             }
         } else {
             set(itemArray, itemIndex, item);
         }
+    }
+}
+
+function pushSubItem(item, subItem) {
+    if (!item.sub_items) {
+        item["sub_items"] = [];
+    }
+    if (!item["sub_items"].find((i) => i.id === subItem.id)) {
+        item["sub_items"].push(subItem);
     }
 }

--- a/client/src/store/historyStore/model/utilities.js
+++ b/client/src/store/historyStore/model/utilities.js
@@ -1,8 +1,5 @@
 import { set } from "vue";
 
-// TODO: This is a temporary solution to handle compressed files. We need to find a better way to handle this.
-const COMPRESSED_EXTENSIONS = ["tabix", "tar.gz", "zip", "tar.bz2", "fa.gz", "fa.bz2", "_bgzip"];
-
 /* This function merges the existing data with new incoming data. */
 export function mergeArray(id, payload, items, itemKey) {
     if (!items[id]) {
@@ -28,12 +25,9 @@ export function mergeArray(id, payload, items, itemKey) {
                 // But first, we check a few conditions and based on those, possibly replace the `localItem` with the new item
                 if (
                     // 1: `localItem` is not in the `payload` (for filter)
-                    !payload.find((p) => p.id === localItem.id) ||
-                    // 2: `localItem` is compressed and the new `item` is not
-                    (localItem.extension &&
-                        item.extension &&
-                        COMPRESSED_EXTENSIONS.some((ext) => localItem.extension.includes(ext)) &&
-                        !COMPRESSED_EXTENSIONS.some((ext) => item.extension.includes(ext)))
+                    new Date(item.create_time) < new Date(localItem.create_time) ||
+                    // 2: `localItem` has fewer keys than the new item
+                    Object.keys(localItem).length < Object.keys(item).length
                 ) {
                     set(itemArray, itemIndex, item);
                     pushSubItem(item, localItem);


### PR DESCRIPTION
This adds a `sub_items` array to history items when they are fetched in the `historyItemsStore`, so that if any history item has other related items with the same hid, they are pushed to this array, and can be shown in the history.

This is based on the current filter and what the `contents` call is returning. If the API is not returning compressed versions of this dataset (for the current filter), then we don't show the "Show converted items" icon until those items are fetched too.

Is this okay, or do we want to go with the expand dataset and see converted versions of it below?

### The expand dataset to see converted items approach:
Problem with the expand-to-fetch approach is that we would have to make another API call to find any other datasets with same hid, different id for each dataset on expansion (other than the `fetchDataset` call right now), and it wouldn't show the "Show converted" icon by default until the user expands the dataset.

### The current implementation (based on filter):
The advantage with doing it the way it is now is that the `HistoryCounter` showing 13 items while 12 are visible is partially solved now because we see the little number on the converted items icon on the dataset (in this e.g.:`1`), proving to the user that the counter is correct - until the user clears the filter and the converted-counter is still there (because we don't reset the `sub_items` array for the new filter).

https://github.com/user-attachments/assets/8c20f497-bc61-438e-bdb5-cabc89c7969f

Fixes https://github.com/galaxyproject/galaxy/issues/17220


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
