### PR TITLE
[24.1] Allow drag and drop for collection elements

### DIFF
--- a/client/src/api/datasets.ts
+++ b/client/src/api/datasets.ts
@@ -67,7 +67,7 @@ export async function purgeDataset(datasetId: string) {
 }
 
 const datasetCopy = fetcher.path("/api/histories/{history_id}/contents/{type}s").method("post").create();
-export type HistoryContentsArgs = FetchArgType<typeof datasetCopy>;
+type HistoryContentsArgs = FetchArgType<typeof datasetCopy>;
 export async function copyDataset(
     datasetId: HistoryContentsArgs["content"],
     historyId: HistoryContentsArgs["history_id"],
@@ -95,3 +95,6 @@ export async function fetchDatasetAttributes(datasetId: string) {
 
     return data;
 }
+
+export type HistoryContentType = components["schemas"]["HistoryContentType"];
+export type HistoryContentSource = components["schemas"]["HistoryContentSource"];

--- a/client/src/api/datasets.ts
+++ b/client/src/api/datasets.ts
@@ -67,7 +67,7 @@ export async function purgeDataset(datasetId: string) {
 }
 
 const datasetCopy = fetcher.path("/api/histories/{history_id}/contents/{type}s").method("post").create();
-type HistoryContentsArgs = FetchArgType<typeof datasetCopy>;
+export type HistoryContentsArgs = FetchArgType<typeof datasetCopy>;
 export async function copyDataset(
     datasetId: HistoryContentsArgs["content"],
     historyId: HistoryContentsArgs["history_id"],

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -232,7 +232,7 @@ export function isHistoryItem(item: object): item is HistoryItemSummary {
     return item && "history_content_type" in item;
 }
 
-export function isCollectionItem(item: object): item is DCESummary {
+export function isDCE(item: object): item is DCESummary {
     return item && "element_type" in item;
 }
 

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -232,6 +232,10 @@ export function isHistoryItem(item: object): item is HistoryItemSummary {
     return item && "history_content_type" in item;
 }
 
+export function isCollectionItem(item: object): item is DCESummary {
+    return item && "element_type" in item;
+}
+
 type QuotaUsageResponse = components["schemas"]["UserQuotaUsage"];
 
 /** Represents a registered user.**/

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -129,6 +129,14 @@ export interface DCECollection extends DCESummary {
 }
 
 /**
+ * DatasetCollectionElement specific type for datasets.
+ */
+export interface DCEDataset extends DCESummary {
+    element_type: "hda";
+    object: HDAObject;
+}
+
+/**
  * Contains summary information about a HDCA (HistoryDatasetCollectionAssociation).
  *
  * HDCAs are (top level only) history items that contains information about the association
@@ -147,6 +155,8 @@ export type HDCADetailed = components["schemas"]["HDCADetailed"];
  * DatasetCollections are immutable and contain one or more DCEs.
  */
 export type DCObject = components["schemas"]["DCObject"];
+
+export type HDAObject = components["schemas"]["HDAObject"];
 
 export type DatasetCollectionAttributes = components["schemas"]["DatasetCollectionAttributesResult"];
 
@@ -185,6 +195,13 @@ export function isHDCA(entry?: CollectionEntry): entry is HDCASummary {
  */
 export function isCollectionElement(element: DCESummary): element is DCECollection {
     return element.element_type === "dataset_collection";
+}
+
+/**
+ * Returns true if the given element of a collection is a Dataset.
+ */
+export function isDatasetElement(element: DCESummary): element is DCEDataset {
+    return element.element_type === "hda";
 }
 
 /**

--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BButton, BButtonGroup, BCollapse, BFormCheckbox, BTooltip } from "bootstrap-vue";
 import { computed, onMounted, type Ref, ref, watch } from "vue";
 
+import { isDatasetElement, isDCE } from "@/api";
 import { getGalaxyInstance } from "@/app";
 import { useDatatypesMapper } from "@/composables/datatypesMapper";
 import { useUid } from "@/composables/utils/uid";
@@ -314,11 +315,21 @@ function handleIncoming(incoming: Record<string, unknown>, partial = true) {
             const incomingValues: Array<DataOption> = [];
             values.forEach((v) => {
                 // Map incoming objects to data option values
+                let newSrc;
+                if (isDCE(v)) {
+                    if (isDatasetElement(v)) {
+                        newSrc = SOURCE.DATASET;
+                        v = v.object;
+                    } else {
+                        newSrc = SOURCE.COLLECTION_ELEMENT;
+                    }
+                } else {
+                    newSrc =
+                        v.src || (v.history_content_type === "dataset_collection" ? SOURCE.COLLECTION : SOURCE.DATASET);
+                }
                 const newHid = v.hid;
                 const newId = v.id;
                 const newName = v.name ? v.name : newId;
-                const newSrc =
-                    v.src || (v.history_content_type === "dataset_collection" ? SOURCE.COLLECTION : SOURCE.DATASET);
                 const newValue: DataOption = {
                     id: newId,
                     src: newSrc,

--- a/client/src/components/History/CurrentCollection/CollectionPanel.vue
+++ b/client/src/components/History/CurrentCollection/CollectionPanel.vue
@@ -8,6 +8,7 @@ import { canMutateHistory, isCollectionElement, isHDCA } from "@/api";
 import ExpandedItems from "@/components/History/Content/ExpandedItems";
 import { updateContentFields } from "@/components/History/model/queries";
 import { useCollectionElementsStore } from "@/stores/collectionElementsStore";
+import { setItemDragstart } from "@/utils/setDrag";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import CollectionDetails from "./CollectionDetails.vue";
@@ -164,6 +165,7 @@ watch(
                                 :expand-dataset="isExpanded(item)"
                                 :is-dataset="item.element_type == 'hda'"
                                 :filterable="filterable"
+                                @drag-start="setItemDragstart(item, $event)"
                                 @update:expand-dataset="setExpanded(item, $event)"
                                 @view-collection="onViewDatasetCollectionElement(item)" />
                         </template>

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -11,7 +11,7 @@ import {
     isHistoryItem,
     userOwnsHistory,
 } from "@/api";
-import { copyDataset, HistoryContentsArgs } from "@/api/datasets";
+import { copyDataset, type HistoryContentSource, type HistoryContentType } from "@/api/datasets";
 import ExpandedItems from "@/components/History/Content/ExpandedItems";
 import SelectedItems from "@/components/History/Content/SelectedItems";
 import { HistoryFilters } from "@/components/History/HistoryFilters";
@@ -399,8 +399,8 @@ async function onDrop() {
     try {
         // iterate over the data array and copy each item to the current history
         for (const item of data) {
-            let dataSource: HistoryContentsArgs["source"];
-            let type: HistoryContentsArgs["type"];
+            let dataSource: HistoryContentSource;
+            let type: HistoryContentType;
             let id: string;
             if (isHistoryItem(item)) {
                 dataSource = item.history_content_type === "dataset" ? "hda" : "hdca";

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -88,7 +88,8 @@ const historyStore = useHistoryStore();
 const historyItemsStore = useHistoryItemsStore();
 const { currentUser } = storeToRefs(useUserStore());
 
-const { showDropZone, onDragEnter, onDragLeave, onDragOver, onDrop } = useHistoryDragDrop(props.history.id);
+const historyIdComputed = computed(() => props.history.id);
+const { showDropZone, onDragEnter, onDragLeave, onDragOver, onDrop } = useHistoryDragDrop(historyIdComputed);
 
 const currentUserOwnsHistory = computed(() => {
     return userOwnsHistory(currentUser.value, props.history);

--- a/client/src/components/History/Multiple/MultipleViewList.vue
+++ b/client/src/components/History/Multiple/MultipleViewList.vue
@@ -6,15 +6,14 @@ import { computed, type Ref, ref } from "vue";
 //@ts-ignore missing typedefs
 import VirtualList from "vue-virtual-scroll-list";
 
-import { HistoryItemSummary, isHistoryItem } from "@/api";
-import { copyDataset } from "@/api/datasets";
 import { useAnimationFrameResizeObserver } from "@/composables/sensors/animationFrameResizeObserver";
 import { useAnimationFrameScroll } from "@/composables/sensors/animationFrameScroll";
 import { Toast } from "@/composables/toast";
-import { useEventStore } from "@/stores/eventStore";
 import { useHistoryStore } from "@/stores/historyStore";
 import localize from "@/utils/localization";
 import { errorMessageAsString } from "@/utils/simple-error";
+
+import { useHistoryDragDrop } from "../../../composables/historyDragDrop";
 
 import HistoryDropZone from "../CurrentHistory/HistoryDropZone.vue";
 import MultipleViewItem from "./MultipleViewItem.vue";
@@ -65,67 +64,7 @@ async function createAndPin() {
     }
 }
 
-const showDropZone = ref(false);
-const processingDrop = ref(false);
-async function onDrop(evt: any) {
-    const eventStore = useEventStore();
-    if (processingDrop.value) {
-        showDropZone.value = false;
-        return;
-    }
-    processingDrop.value = true;
-    showDropZone.value = false;
-    const dragItems = eventStore.getDragItems();
-    // Filter out any non-history items
-    const historyItems = dragItems?.filter((item: any) => isHistoryItem(item)) as HistoryItemSummary[];
-    const multiple = historyItems.length > 1;
-    const originalHistoryId = historyItems?.[0]?.history_id;
-
-    if (historyItems && originalHistoryId) {
-        await historyStore.createNewHistory();
-        const currentHistoryId = historyStore.currentHistoryId;
-
-        let datasetCount = 0;
-        let collectionCount = 0;
-        if (currentHistoryId) {
-            // iterate over the data array and copy each item to the new history
-            for (const item of historyItems) {
-                const dataSource = item.history_content_type === "dataset" ? "hda" : "hdca";
-                await copyDataset(item.id, currentHistoryId, item.history_content_type, dataSource)
-                    .then(() => {
-                        if (item.history_content_type === "dataset") {
-                            datasetCount++;
-                            if (!multiple) {
-                                Toast.info(localize("Dataset copied to new history"));
-                            }
-                        } else {
-                            collectionCount++;
-                            if (!multiple) {
-                                Toast.info(localize("Collection copied to new history"));
-                            }
-                        }
-                    })
-                    .catch((error) => {
-                        Toast.error(errorMessageAsString(error));
-                    });
-            }
-            if (multiple && datasetCount > 0) {
-                Toast.info(`${datasetCount} dataset${datasetCount > 1 ? "s" : ""} copied to new history`);
-            }
-            if (multiple && collectionCount > 0) {
-                Toast.info(`${collectionCount} collection${collectionCount > 1 ? "s" : ""} copied to new history`);
-            }
-
-            if (historyStore.pinnedHistories.length > 0) {
-                // pin the newly created history via the drop
-                historyStore.pinHistory(currentHistoryId);
-                // also pin the original history where the item came from
-                historyStore.pinHistory(originalHistoryId);
-            }
-        }
-        processingDrop.value = false;
-    }
-}
+const { showDropZone, onDragEnter, onDragLeave, onDragOver, onDrop } = useHistoryDragDrop(undefined, true, true);
 
 async function onKeyDown(evt: KeyboardEvent) {
     if (evt.key === "Enter" || evt.key === " ") {
@@ -159,9 +98,9 @@ async function onKeyDown(evt: KeyboardEvent) {
             <div
                 class="history-picker"
                 @drop.prevent="onDrop"
-                @dragenter.prevent="showDropZone = true"
-                @dragover.prevent
-                @dragleave.prevent="showDropZone = false">
+                @dragenter.prevent="onDragEnter"
+                @dragover="onDragOver"
+                @dragleave.prevent="onDragLeave">
                 <span v-if="!showDropZone" class="d-flex flex-column h-100">
                     <div
                         class="history-picker-box top-picker text-primary"

--- a/client/src/composables/historyDragDrop.ts
+++ b/client/src/composables/historyDragDrop.ts
@@ -1,0 +1,166 @@
+import { computed, type Ref, ref, unref } from "vue";
+
+import { type DCEDataset, type DCESummary, type HistoryItemSummary, isDatasetElement, isHistoryItem } from "@/api";
+import { copyDataset, type HistoryContentSource, type HistoryContentType } from "@/api/datasets";
+import { Toast } from "@/composables/toast";
+import { useEventStore } from "@/stores/eventStore";
+import { useHistoryStore } from "@/stores/historyStore";
+
+type DraggableHistoryItem = HistoryItemSummary | DCEDataset; // TODO: DCESummary instead of DCEDataset
+
+export function useHistoryDragDrop(targetHistoryId?: Ref<string> | string, createNew = false, pinHistories = false) {
+    const destinationHistoryId = unref(targetHistoryId);
+    const eventStore = useEventStore();
+    const historyStore = useHistoryStore();
+
+    const fromHistoryId = computed(() => {
+        const dragItems = getDragItems();
+        return dragItems[0]
+            ? isHistoryItem(dragItems[0])
+                ? dragItems[0].history_id
+                : dragItems[0].object?.history_id
+            : null;
+    });
+
+    const showDropZone = ref(false);
+    const dragTarget = ref<EventTarget | null>(null);
+    const processingDrop = ref(false);
+
+    const operationDisabled = computed(
+        () =>
+            !fromHistoryId.value ||
+            (destinationHistoryId && fromHistoryId.value === destinationHistoryId) ||
+            (!createNew && !destinationHistoryId) ||
+            !getDragItems().length ||
+            processingDrop.value
+    );
+
+    function getDragItems() {
+        const storeItems = eventStore.getDragItems();
+        // Filter out any non-history or `DatasetCollectionElement` items
+        return storeItems?.filter(
+            (item) => isHistoryItem(item) || isDatasetElement(item as DCESummary)
+        ) as DraggableHistoryItem[];
+    }
+
+    function onDragEnter(e: DragEvent) {
+        if (operationDisabled.value) {
+            return;
+        }
+        dragTarget.value = e.target;
+        showDropZone.value = true;
+    }
+
+    function onDragOver(e: DragEvent) {
+        if (operationDisabled.value) {
+            return;
+        }
+        e.preventDefault();
+    }
+
+    function onDragLeave(e: DragEvent) {
+        if (operationDisabled.value) {
+            return;
+        }
+        if (dragTarget.value === e.target) {
+            showDropZone.value = false;
+        }
+    }
+
+    async function onDrop() {
+        showDropZone.value = false;
+        if (operationDisabled.value) {
+            return;
+        }
+        processingDrop.value = true;
+
+        let datasetCount = 0;
+        let collectionCount = 0;
+
+        try {
+            const dragItems = getDragItems();
+            const multiple = dragItems.length > 1;
+            const originalHistoryId = fromHistoryId.value as string;
+
+            let historyId;
+            if (destinationHistoryId) {
+                historyId = destinationHistoryId;
+            } else if (createNew) {
+                await historyStore.createNewHistory();
+                historyId = historyStore.currentHistoryId;
+            } else {
+                historyId = null;
+            }
+            if (!historyId) {
+                throw new Error("Destination history not found or created");
+            }
+
+            // iterate over the data array and copy each item to the current history
+            for (const item of dragItems) {
+                let dataSource: HistoryContentSource;
+                let type: HistoryContentType;
+                let id: string;
+                if (isHistoryItem(item)) {
+                    dataSource = item.history_content_type === "dataset" ? "hda" : "hdca";
+                    type = item.history_content_type;
+                    id = item.id;
+                }
+                // For DCEs, only `DCEDataset`s are droppable, `DCEDatasetCollection`s are not
+                else if (isDatasetElement(item) && item.object) {
+                    dataSource = "hda";
+                    type = "dataset";
+                    id = item.object.id;
+                } else {
+                    throw new Error(`Invalid item type${item.element_type ? `: ${item.element_type}` : ""}`);
+                }
+                await copyDataset(id, historyId, type, dataSource);
+
+                if (dataSource === "hda") {
+                    datasetCount++;
+                    if (!multiple) {
+                        Toast.info(`Dataset copied to ${createNew ? "new" : ""} history`);
+                    }
+                } else {
+                    collectionCount++;
+                    if (!multiple) {
+                        Toast.info(`Collection copied to ${createNew ? "new" : ""} history`);
+                    }
+                }
+            }
+
+            if (multiple && datasetCount > 0) {
+                Toast.info(
+                    `${datasetCount} dataset${datasetCount > 1 ? "s" : ""} copied to ${createNew ? "new" : ""} history`
+                );
+            }
+            if (multiple && collectionCount > 0) {
+                Toast.info(
+                    `${collectionCount} collection${collectionCount > 1 ? "s" : ""} copied to ${
+                        createNew ? "new" : ""
+                    } history`
+                );
+            }
+
+            if (pinHistories && historyStore.pinnedHistories.length > 0) {
+                // pin the target history
+                historyStore.pinHistory(historyId);
+                // also pin the original history where the item came from
+                historyStore.pinHistory(originalHistoryId);
+            } else {
+                historyStore.loadHistoryById(historyId);
+            }
+        } catch (error) {
+            Toast.error(`${error}`);
+        } finally {
+            processingDrop.value = false;
+        }
+    }
+
+    return {
+        showDropZone,
+        onDragEnter,
+        onDragOver,
+        onDragLeave,
+        onDrop,
+    };
+}

--- a/client/src/composables/historyDragDrop.ts
+++ b/client/src/composables/historyDragDrop.ts
@@ -9,7 +9,14 @@ import { useHistoryStore } from "@/stores/historyStore";
 type DraggableHistoryItem = HistoryItemSummary | DCEDataset; // TODO: DCESummary instead of DCEDataset
 
 export function useHistoryDragDrop(targetHistoryId?: Ref<string> | string, createNew = false, pinHistories = false) {
-    const destinationHistoryId = unref(targetHistoryId);
+    // convert destinationHistoryId to a ref if it's not already
+    const destinationHistoryId = computed(() => {
+        if (typeof targetHistoryId === "string") {
+            return targetHistoryId;
+        }
+        return unref(targetHistoryId);
+    });
+
     const eventStore = useEventStore();
     const historyStore = useHistoryStore();
 
@@ -29,8 +36,8 @@ export function useHistoryDragDrop(targetHistoryId?: Ref<string> | string, creat
     const operationDisabled = computed(
         () =>
             !fromHistoryId.value ||
-            (destinationHistoryId && fromHistoryId.value === destinationHistoryId) ||
-            (!createNew && !destinationHistoryId) ||
+            (destinationHistoryId.value && fromHistoryId.value === destinationHistoryId.value) ||
+            (!createNew && !destinationHistoryId.value) ||
             !getDragItems().length ||
             processingDrop.value
     );
@@ -83,8 +90,8 @@ export function useHistoryDragDrop(targetHistoryId?: Ref<string> | string, creat
             const originalHistoryId = fromHistoryId.value as string;
 
             let historyId;
-            if (destinationHistoryId) {
-                historyId = destinationHistoryId;
+            if (destinationHistoryId.value) {
+                historyId = destinationHistoryId.value;
             } else if (createNew) {
                 await historyStore.createNewHistory();
                 historyId = historyStore.currentHistoryId;

--- a/client/src/composables/historyDragDrop.ts
+++ b/client/src/composables/historyDragDrop.ts
@@ -162,13 +162,16 @@ export function useHistoryDragDrop(targetHistoryId?: Ref<string> | string, creat
                 );
             }
 
-            if (pinHistories && historyStore.pinnedHistories.length > 0) {
-                // pin the target history
-                historyStore.pinHistory(historyId);
-                // also pin the original history where the item came from
-                historyStore.pinHistory(originalHistoryId);
-            } else {
-                historyStore.loadHistoryById(historyId);
+            // if items were copied
+            if (datasetCount > 0 && collectionCount > 0) {
+                if (pinHistories && historyStore.pinnedHistories.length > 0) {
+                    // pin the target history
+                    historyStore.pinHistory(historyId);
+                    // also pin the original history where the item came from
+                    historyStore.pinHistory(originalHistoryId);
+                } else {
+                    historyStore.loadHistoryById(historyId);
+                }
             }
         } catch (error) {
             Toast.error(`${error}`);

--- a/client/src/utils/setDrag.ts
+++ b/client/src/utils/setDrag.ts
@@ -25,3 +25,21 @@ export function clearDrag() {
     const eventStore = useEventStore();
     eventStore.clearDragData();
 }
+
+export function setItemDragstart<T>(
+    item: T,
+    event: DragEvent,
+    itemIsSelected = false,
+    selectionSize = 0,
+    selectedItems?: Map<string, T>
+) {
+    if (selectedItems && itemIsSelected && selectionSize > 1) {
+        const selectedItemsObj: Record<string, T> = {};
+        for (const [key, value] of selectedItems) {
+            selectedItemsObj[key] = value;
+        }
+        setDrag(event, selectedItemsObj, true);
+    } else {
+        setDrag(event, item as any);
+    }
+}

--- a/client/src/utils/setDrag.ts
+++ b/client/src/utils/setDrag.ts
@@ -1,7 +1,10 @@
 /**
  * Helper to configure datatransfer for drag & drop operations
  */
+import { type DCESummary, isCollectionItem } from "@/api";
 import { type EventData, useEventStore } from "@/stores/eventStore";
+
+type NamedDCESummary = DCESummary & { name: string };
 
 export function setDrag(evt: DragEvent, data?: EventData, multiple = false) {
     const eventStore = useEventStore();
@@ -36,10 +39,18 @@ export function setItemDragstart<T>(
     if (selectedItems && itemIsSelected && selectionSize > 1) {
         const selectedItemsObj: Record<string, T> = {};
         for (const [key, value] of selectedItems) {
+            setCollectionElementName(value as any);
             selectedItemsObj[key] = value;
         }
         setDrag(event, selectedItemsObj, true);
     } else {
+        setCollectionElementName(item as any);
         setDrag(event, item as any);
+    }
+}
+
+function setCollectionElementName<T extends NamedDCESummary>(obj: T) {
+    if (isCollectionItem(obj as object)) {
+        obj["name"] = obj.element_identifier;
     }
 }

--- a/client/src/utils/setDrag.ts
+++ b/client/src/utils/setDrag.ts
@@ -1,7 +1,7 @@
 /**
  * Helper to configure datatransfer for drag & drop operations
  */
-import { type DCESummary, isCollectionItem } from "@/api";
+import { type DCESummary, isDCE } from "@/api";
 import { type EventData, useEventStore } from "@/stores/eventStore";
 
 type NamedDCESummary = DCESummary & { name: string };
@@ -50,7 +50,7 @@ export function setItemDragstart<T>(
 }
 
 function setCollectionElementName<T extends NamedDCESummary>(obj: T) {
-    if (isCollectionItem(obj as object)) {
+    if (isDCE(obj as object)) {
         obj["name"] = obj.element_identifier;
     }
 }


### PR DESCRIPTION
We extract the `HDAObject` from the `DCESummary` to be able to drag and drop it. For now, this works on dragging and dropping items to histories, since that process only needs the dataset's id. However, this doesn't work for `DCECollections` because they are `dataset_collection`s and not `HDCA`s.

## Drag and drop DCEs into Tool forms:
Fixes https://github.com/galaxyproject/galaxy/issues/18692

https://github.com/user-attachments/assets/993b6ecc-0e13-422e-a21d-bd0dfecbf30a

## Drag and drop DCEs to other histories:
Note that this won't work for `DatasetCollectionElement`s that are of type `dataset_collection`. `DCEDataset`s can be moved:

https://github.com/user-attachments/assets/4e34f5a2-a0fa-4b81-8fad-24a1c469f8ca



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
