### PR TITLE
[24.1] Fix upload when current history changes

### DIFF
--- a/client/src/components/Upload/DefaultBox.vue
+++ b/client/src/components/Upload/DefaultBox.vue
@@ -58,7 +58,7 @@ const props = defineProps({
     },
     lazyLoad: {
         type: Number,
-        default: 50,
+        default: 150,
     },
     listDbKeys: {
         type: Array,

--- a/client/src/components/Upload/DefaultBox.vue
+++ b/client/src/components/Upload/DefaultBox.vue
@@ -2,9 +2,10 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCopy, faEdit, faFolderOpen, faLaptop } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { watchImmediate } from "@vueuse/core";
 import { BButton } from "bootstrap-vue";
 import { filesDialog } from "utils/data";
-import Vue, { computed, onMounted, ref, watch } from "vue";
+import Vue, { computed, ref } from "vue";
 
 import { UploadQueue } from "@/utils/upload-queue.js";
 
@@ -100,11 +101,7 @@ const listExtensions = computed(() => props.effectiveExtensions.filter((ext) => 
 const showHelper = computed(() => Object.keys(uploadItems.value).length === 0);
 const uploadValues = computed(() => Object.values(uploadItems.value));
 
-onMounted(() => {
-    queue.value = initUploadQueue();
-});
-
-watch(
+watchImmediate(
     () => props.historyId,
     () => {
         queue.value = initUploadQueue();

--- a/client/src/components/Upload/DefaultBox.vue
+++ b/client/src/components/Upload/DefaultBox.vue
@@ -2,7 +2,6 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCopy, faEdit, faFolderOpen, faLaptop } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { watchImmediate } from "@vueuse/core";
 import { BButton } from "bootstrap-vue";
 import { filesDialog } from "utils/data";
 import Vue, { computed, ref } from "vue";
@@ -85,7 +84,7 @@ const uploadCompleted = ref(0);
 const uploadFile = ref(null);
 const uploadItems = ref({});
 const uploadSize = ref(0);
-const queue = ref();
+const queue = ref(createUploadQueue());
 
 const counterNonRunning = computed(() => counterAnnounce.value + counterSuccess.value + counterError.value);
 const enableBuild = computed(
@@ -101,13 +100,6 @@ const listExtensions = computed(() => props.effectiveExtensions.filter((ext) => 
 const showHelper = computed(() => Object.keys(uploadItems.value).length === 0);
 const uploadValues = computed(() => Object.values(uploadItems.value));
 
-watchImmediate(
-    () => props.historyId,
-    () => {
-        queue.value = initUploadQueue();
-    }
-);
-
 function createUploadQueue() {
     return new UploadQueue({
         announce: eventAnnounce,
@@ -115,32 +107,11 @@ function createUploadQueue() {
         complete: eventComplete,
         error: eventError,
         get: (index) => uploadItems.value[index],
-        historyId: historyId.value,
         multiple: props.multiple,
         progress: eventProgress,
         success: eventSuccess,
         warning: eventWarning,
     });
-}
-
-function initUploadQueue() {
-    if (!queue.value) {
-        return createUploadQueue();
-    }
-
-    if (queue.value.historyId !== historyId.value) {
-        // The history has changed since the queue was created
-        if (isRunning.value) {
-            // The queue is running on the old history, so we need to create a new queue
-            // that will target the new history
-            return createUploadQueue();
-        }
-        // The queue is not running, so we can just update the target historyId and reuse the queue
-        queue.value.historyId = historyId.value;
-        return queue.value;
-    }
-    // Nothing has changed, so we can just return the existing queue
-    return queue.value;
 }
 
 /** Add files to queue */
@@ -295,6 +266,11 @@ function eventStart() {
         uploadValues.value.forEach((model) => {
             if (model.status === "init") {
                 model.status = "queued";
+                if (!model.targetHistoryId) {
+                    // Associate with current history once upload starts
+                    // This will not change if the current history is changed during upload
+                    model.targetHistoryId = historyId.value;
+                }
                 uploadSize.value += model.fileSize;
             }
         });

--- a/client/src/components/Upload/UploadModal.vue
+++ b/client/src/components/Upload/UploadModal.vue
@@ -1,17 +1,17 @@
 <script setup>
-import { setIframeEvents } from "components/Upload/utils";
-import { useConfig } from "composables/config";
-import { useUserHistories } from "composables/userHistories";
 import { storeToRefs } from "pinia";
 import { ref, watch } from "vue";
 
+import { setIframeEvents } from "@/components/Upload/utils";
+import { useConfig } from "@/composables/config";
+import { useUserHistories } from "@/composables/userHistories";
 import { useUserStore } from "@/stores/userStore";
 import { wait } from "@/utils/utils";
 
 import UploadContainer from "./UploadContainer.vue";
 
 const { currentUser } = storeToRefs(useUserStore());
-const { currentHistoryId } = useUserHistories(currentUser);
+const { currentHistoryId, currentHistory } = useUserHistories(currentUser);
 
 const { config, isConfigLoaded } = useConfig();
 
@@ -81,7 +81,12 @@ defineExpose({
         no-enforce-focus
         hide-footer>
         <template v-slot:modal-header>
-            <h2 class="title h-sm" tabindex="0">{{ options.title }}</h2>
+            <h2 class="title h-sm" tabindex="0">
+                {{ options.title }}
+                <span v-if="currentHistory">
+                    to <b>{{ currentHistory.name }}</b>
+                </span>
+            </h2>
         </template>
         <UploadContainer
             v-if="currentHistoryId"

--- a/client/src/composables/userHistories.js
+++ b/client/src/composables/userHistories.js
@@ -15,6 +15,10 @@ export function useUserHistories(user) {
     );
 
     const currentHistoryId = computed(() => historyStore.currentHistoryId);
+    const currentHistory = computed(() => historyStore.currentHistory);
 
-    return { currentHistoryId };
+    return {
+        currentHistoryId,
+        currentHistory,
+    };
 }

--- a/client/src/utils/upload-queue.js
+++ b/client/src/utils/upload-queue.js
@@ -66,14 +66,6 @@ export class UploadQueue {
         return this.queue.size;
     }
 
-    get historyId() {
-        return this.opts.historyId;
-    }
-
-    set historyId(historyId) {
-        this.opts.historyId = historyId;
-    }
-
     // Initiate upload process
     start() {
         if (!this.isRunning) {
@@ -104,7 +96,11 @@ export class UploadQueue {
             // Remove item from queue
             this.remove(index);
             // Collect upload request data
-            const data = uploadPayload([this.opts.get(index)], this.opts.historyId);
+            const item = this.opts.get(index);
+            if (!item.targetHistoryId) {
+                throw new Error(`Missing target history for upload item [${index}] ${item.fileName}`);
+            }
+            const data = uploadPayload([item], item.targetHistoryId);
             // Initiate upload request
             this._processSubmit(index, data);
         } catch (e) {

--- a/client/src/utils/upload-queue.js
+++ b/client/src/utils/upload-queue.js
@@ -66,6 +66,14 @@ export class UploadQueue {
         return this.queue.size;
     }
 
+    get historyId() {
+        return this.opts.historyId;
+    }
+
+    set historyId(historyId) {
+        this.opts.historyId = historyId;
+    }
+
     // Initiate upload process
     start() {
         if (!this.isRunning) {

--- a/client/src/utils/upload-queue.test.js
+++ b/client/src/utils/upload-queue.test.js
@@ -177,6 +177,7 @@ describe("UploadQueue", () => {
                     spaceToTab: true,
                     status: "queued",
                     toPosixLines: false,
+                    targetHistoryId: "historyId",
                 };
             },
             get: (index) => fileEntries[index],


### PR DESCRIPTION
Fixes #18662

<del>The upload queue will now be reused if it was not started/running before when you change the target history.</del>

This will ensure that when we change the current history in the middle of the upload each dataset goes to the history where it was scheduled for the first time.

As a bonus, the name of the current history is shown at the top of the upload modal to be more clear about the target history (thanks @ahmedhamidawan for the idea). If this is too much for a fix we can move those commits to dev or drop them if people think is not necessary.

![image](https://github.com/user-attachments/assets/b14eb297-92f5-4275-91a5-1f2bef725d90)


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Follow the steps in #18662

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
