### PR TITLE
Fix tag processing in library upload

### DIFF
--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -195,8 +195,9 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, tag_h
         tag_handler.apply_item_tag(item=ldda, user=trans.user, name="name", value=tag_from_filename, flush=False)
 
     if tags_list := uploaded_dataset.get("tags", False):
-        for tag in tags_list:
-            tag_handler.apply_item_tag(item=ldda, user=trans.user, name="name", value=tag, flush=False)
+        new_tags = tag_handler.parse_tags_list(tags_list)
+        for tag in new_tags:
+            tag_handler.apply_item_tag(item=ldda, user=trans.user, name=tag[0], value=tag[1], flush=False)
 
     trans.sa_session.add(ldda)
     if state:

--- a/lib/galaxy_test/api/test_tags.py
+++ b/lib/galaxy_test/api/test_tags.py
@@ -112,6 +112,11 @@ class TestLibraryDatasetTags(TagsApiTests):
         item = item_response.json()
         return item
 
+    def test_upload_file_contents_with_tags(self):
+        initial_tags = ["name:foobar", "barfoo"]
+        ld = self.library_populator.new_library_dataset(name=f"test-library-dataset-{uuid4()}", tags=initial_tags)
+        assert ld["tags"] == initial_tags
+
 
 class TestPageTags(TagsApiTests):
     api_name = "pages"

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -2687,6 +2687,7 @@ class LibraryPopulator:
             "upload_option": upload_option,
             "file_type": kwds.get("file_type", "auto"),
             "db_key": kwds.get("db_key", "?"),
+            "tags": kwds.get("tags", []),
         }
         if kwds.get("link_data"):
             create_data["link_data_only"] = "link_to_files"


### PR DESCRIPTION
Fixes #18700

It seems recent changes make `uploaded_dataset` contain the tags passed in the tool inputs. So before the recent changes, the place where the tags were processed was:

https://github.com/galaxyproject/galaxy/blob/64bd95dd349dec0ac44a71dd616736551341eb0e/lib/galaxy/tools/actions/upload_common.py#L274

Because after the recent changes `uploaded_dataset` now has a `tags` attribute, the actual tag processing was done here:

https://github.com/galaxyproject/galaxy/blob/64bd95dd349dec0ac44a71dd616736551341eb0e/lib/galaxy/tools/actions/upload_common.py#L199

And this code path was assuming the tags were already parsed.

I think this is the correct fix. This code is old, but the bug was probably uncovered now while the first condition checking the  `library_bunch` looked like a workaround. Let me know if that is not the case.



## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
