### PR TITLE
Update ruff to 0.6.1

### DIFF
--- a/lib/galaxy/dependencies/pinned-lint-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-lint-requirements.txt
@@ -4,4 +4,4 @@ flake8-bugbear==24.4.26
 mccabe==0.7.0
 pycodestyle==2.12.0
 pyflakes==3.2.0
-ruff==0.5.1
+ruff==0.6.1

--- a/lib/galaxy_test/selenium/jupyter/notebook_example_testing.ipynb
+++ b/lib/galaxy_test/selenium/jupyter/notebook_example_testing.ipynb
@@ -66,7 +66,6 @@
    "source": [
     "# optional step that shows how to access ActionChains\n",
     "\n",
-    "from selenium import webdriver\n",
     "from selenium.webdriver.common.action_chains import ActionChains\n",
     "ac = ActionChains(gx_selenium_context.driver)"
    ]

--- a/test-data/selenium-test-notebook.ipynb
+++ b/test-data/selenium-test-notebook.ipynb
@@ -44,7 +44,7 @@
     }
    ],
    "source": [
-    "get(1)"
+    "get(1)  # noqa: F821"
    ]
   },
   {
@@ -85,7 +85,7 @@
    },
    "outputs": [],
    "source": [
-    "put(\"/tmp/cow\")"
+    "put(\"/tmp/cow\")  # noqa: F821"
    ]
   },
   {
@@ -115,7 +115,7 @@
    },
    "outputs": [],
    "source": [
-    "put(\"/import/ipython_galaxy_notebook.ipynb\")"
+    "put(\"/import/ipython_galaxy_notebook.ipynb\")  # noqa: F821"
    ]
   },
   {


### PR DESCRIPTION
Since 0.6.0, ruff checks also Jupyter notebook files by default:

https://astral.sh/blog/ruff-v0.6.0

Fix test failures in https://github.com/galaxyproject/galaxy/pull/18578 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
