### PR TITLE
Improvements to help terms & tool help.

### DIFF
--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -17,6 +17,7 @@ import { BATCH, SOURCE, VARIANTS } from "./variants";
 
 import FormSelection from "../FormSelection.vue";
 import FormSelect from "@/components/Form/Elements/FormSelect.vue";
+import HelpText from "@/components/Help/HelpText.vue";
 
 library.add(faCopy, faFile, faFolder, faCaretDown, faCaretUp, faExclamation, faLink, faUnlink);
 
@@ -650,7 +651,11 @@ const noOptionsWarningMessage = computed(() => {
             </BFormCheckbox>
             <div class="info text-info">
                 <FontAwesomeIcon icon="fa-exclamation" />
-                <span v-localize class="ml-1">
+                <span v-if="props.type == 'data' && currentVariant.src == SOURCE.COLLECTION" class="ml-1">
+                    The supplied input will be <HelpText text="mapped over" uri="galaxy.collections.mapOver" /> this
+                    tool.
+                </span>
+                <span v-else v-localize class="ml-1">
                     This is a batch mode input field. Individual jobs will be triggered for each dataset.
                 </span>
             </div>

--- a/client/src/components/Help/HelpPopover.vue
+++ b/client/src/components/Help/HelpPopover.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { BPopover } from "bootstrap-vue";
+
+import HelpTerm from "./HelpTerm.vue";
+
+interface Props {
+    target: any;
+    term: string;
+}
+
+defineProps<Props>();
+</script>
+
+<template>
+    <BPopover :target="target" triggers="hover" placement="bottom">
+        <HelpTerm :term="term" />
+    </BPopover>
+</template>

--- a/client/src/components/Help/HelpTerm.vue
+++ b/client/src/components/Help/HelpTerm.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { BAlert } from "bootstrap-vue";
+import { toRef } from "vue";
+
+import { useHelpForTerm } from "@/stores/helpTermsStore";
+
+import LoadingSpan from "@/components/LoadingSpan.vue";
+import ConfigurationMarkdown from "@/components/ObjectStore/ConfigurationMarkdown.vue";
+
+interface Props {
+    term: string;
+}
+
+const props = defineProps<Props>();
+
+const { loading, hasHelp, help } = useHelpForTerm(toRef(props, "term"));
+</script>
+
+<template>
+    <div>
+        <div v-if="loading">
+            <LoadingSpan message="Loading Galaxy help terms" />
+        </div>
+        <div v-else-if="hasHelp">
+            <ConfigurationMarkdown :markdown="help" :admin="true" />
+        </div>
+        <div v-else>
+            <BAlert variant="error"> Something went wrong, no Galaxy help found for term or URI {{ term }}. </BAlert>
+        </div>
+    </div>
+</template>

--- a/client/src/components/Help/HelpText.vue
+++ b/client/src/components/Help/HelpText.vue
@@ -1,41 +1,24 @@
 <script setup lang="ts">
-import { computed } from "vue";
-
-import { hasHelp as hasHelpText, help as helpText } from "./terms";
-
-import ConfigurationMarkdown from "@/components/ObjectStore/ConfigurationMarkdown.vue";
+import HelpPopover from "./HelpPopover.vue";
 
 interface Props {
     uri: string;
     text: string;
 }
 
-const props = defineProps<Props>();
-
-const hasHelp = computed<boolean>(() => {
-    return hasHelpText(props.uri);
-});
-
-const help = computed<string>(() => {
-    return helpText(props.uri) as string;
-});
+defineProps<Props>();
 </script>
 
 <template>
     <span>
-        <b-popover
-            v-if="hasHelp"
+        <HelpPopover
             :target="
                 () => {
                     return $refs.helpTarget;
                 }
             "
-            triggers="hover"
-            placement="bottom">
-            <ConfigurationMarkdown :markdown="help" :admin="true" />
-        </b-popover>
-        <span v-if="hasHelp" ref="helpTarget" class="help-text">{{ text }}</span>
-        <span v-else>{{ text }}</span>
+            :term="uri" />
+        <span ref="helpTarget" class="help-text">{{ text }}</span>
     </span>
 </template>
 

--- a/client/src/components/Help/terms.yml
+++ b/client/src/components/Help/terms.yml
@@ -29,6 +29,31 @@ unix:
     More information on stack traces can be found on [Wikipedia](https://en.wikipedia.org/wiki/Stack_trace).
 
 galaxy:
+  collections:
+    flatList: |
+      A flat list is just a simple dataset collection of type ``list`` that contains only datasets and not
+      other collections.
+    mapOver: |
+      When a tool consumes a dataset but is run with a collection, the collection *maps over* the collection.
+      This means instead of just running the tool once - the tool will be run once for each element of the
+      provided collection. Additionally, the outputs of the tool will be collected into a collection that
+      matches the structure of the provided collection. This matching structure means the output collections
+      will have the same element identifiers as the provided collection and they will appear in the same order.
+
+      It is easiest to visualize "mapping over" a collection is in the context of a tool that consumes a dataset
+      and produces a dataset, but the semantics apply rather naturally to tools that consume collections or
+      produce collections as well.
+      
+      For instance, consider a tool that consumes a ``paired`` collection and produces an output dataset.
+      If a list of paired collections (collection type ``list:paired``) is passed to the tool - it will
+      will produce a flat list (collection type ``list``) of output datasets with the same number of elements
+      in the same order as the provided list of ``paired`` collections.
+
+      In the case of outputs, consider a tool that takes in a dataset and produces a flat list. If this tool
+      is run over a flat list of datasets - that list will be "mapped over" and each element will produce a list.
+      These lists will be gathered together in a nested list structured (collection type ``list:list``) where
+      the outer element count and structure matches that of the input and the inner list for each of those
+      is just the outputs of the tool for the corresponding element of the input.
   jobs:
     states:
       # upload, waiting, failed, paused, deleting, deleted, stop, stopped, skipped.

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -186,7 +186,7 @@ const showHelpForum = computed(() => isConfigLoaded.value && config.value.enable
         <div>
             <div v-if="props.options.help" class="mt-2 mb-4">
                 <Heading h2 separator bold size="sm"> Help </Heading>
-                <ToolHelp :content="props.options.help" />
+                <ToolHelp :content="props.options.help" :format="props.options.help_format" />
             </div>
 
             <ToolTutorialRecommendations

--- a/client/src/components/Tool/ToolHelp.vue
+++ b/client/src/components/Tool/ToolHelp.vue
@@ -1,42 +1,18 @@
-<script setup>
-import { useFormattedToolHelp } from "composables/formattedToolHelp";
+<script setup lang="ts">
+import ToolHelpMarkdown from "./ToolHelpMarkdown.vue";
+import ToolHelpRst from "./ToolHelpRst.vue";
 
-const props = defineProps({
-    content: {
-        type: String,
-        required: true,
-    },
-});
-
-const { formattedContent } = useFormattedToolHelp(props.content);
+defineProps<{
+    format: string;
+    content: string;
+}>();
 </script>
-
 <template>
-    <div class="form-help form-text" v-html="formattedContent" />
+    <span>
+        <ToolHelpMarkdown v-if="format == 'markdown'" :content="content" />
+        <ToolHelpRst v-else-if="format == 'restructuredtext'" :content="content" />
+        <div v-else class="form-help form-text">
+            {{ content }}
+        </div>
+    </span>
 </template>
-
-<style lang="scss" scoped>
-@import "scss/theme/blue.scss";
-
-.form-help {
-    &:deep(h3) {
-        font-size: $h4-font-size;
-        font-weight: bold;
-    }
-
-    &:deep(h4) {
-        font-size: $h5-font-size;
-        font-weight: bold;
-    }
-
-    &:deep(h5) {
-        font-size: $h6-font-size;
-        font-weight: bold;
-    }
-
-    &:deep(h6) {
-        font-size: $h6-font-size;
-        text-decoration: underline;
-    }
-}
-</style>

--- a/client/src/components/Tool/ToolHelpMarkdown.vue
+++ b/client/src/components/Tool/ToolHelpMarkdown.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+
+import { markup } from "@/components/ObjectStore/configurationMarkdown";
+import { useFormattedToolHelp } from "@/composables/formattedToolHelp";
+import { getAppRoot } from "@/onload/loadConfig";
+
+import HelpPopover from "@/components/Help/HelpPopover.vue";
+
+const props = defineProps<{
+    content: string;
+}>();
+
+const markdownHtml = computed(() => markup(props.content ?? "", false));
+// correct links and header information... this should work the same between rst and
+// markdown entirely I think.
+const { formattedContent } = useFormattedToolHelp(markdownHtml);
+
+const helpHtml = ref<HTMLDivElement>();
+
+interface InternalTypeReference {
+    element: HTMLElement;
+    term: string;
+}
+
+const internalHelpReferences = ref<InternalTypeReference[]>([]);
+
+function setupPopovers() {
+    internalHelpReferences.value.length = 0;
+    if (helpHtml.value) {
+        const links = helpHtml.value.getElementsByTagName("a");
+        Array.from(links).forEach((link) => {
+            if (link.href.startsWith("gxhelp://")) {
+                const uri = link.href.substr("gxhelp://".length);
+                internalHelpReferences.value.push({ element: link, term: uri });
+                link.href = `${getAppRoot()}help/terms/${uri}`;
+                link.style.color = "inherit";
+                link.style.textDecorationLine = "underline";
+                link.style.textDecorationStyle = "dashed";
+            }
+        });
+        const imgs = helpHtml.value.getElementsByTagName("img");
+        Array.from(imgs).forEach((img) => {
+            if (img.src.startsWith("gxstatic://")) {
+                const rest = img.src.substr("gxstatic://".length);
+                img.src = `${getAppRoot()}static/${rest}`;
+            }
+        });
+    }
+}
+
+onMounted(setupPopovers);
+</script>
+
+<template>
+    <span>
+        <!-- Disable v-html warning because we allow markdown generated HTML
+            in various places in the Galaxy interface. Raw HTML is not allowed
+            here because admin = false in the call to markup.
+        -->
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <div ref="helpHtml" v-html="formattedContent" />
+        <span v-for="(value, i) in internalHelpReferences" v-bind:key="i">
+            <HelpPopover :target="value.element" :term="value.term" />
+        </span>
+    </span>
+</template>

--- a/client/src/components/Tool/ToolHelpRst.test.js
+++ b/client/src/components/Tool/ToolHelpRst.test.js
@@ -1,7 +1,7 @@
 import { mount } from "@vue/test-utils";
 import { getLocalVue } from "tests/jest/helpers";
 
-import ToolHelp from "./ToolHelp";
+import ToolHelpRst from "./ToolHelpRst";
 
 const localVue = getLocalVue();
 
@@ -25,9 +25,9 @@ const expectedHelpText = `
 <h6>h4 Heading</h6>
 <a target="_blank">empty link</a>`;
 
-describe("ToolHelp", () => {
+describe("ToolHelp RST", () => {
     it("modifies help text", () => {
-        const wrapper = mount(ToolHelp, {
+        const wrapper = mount(ToolHelpRst, {
             propsData: {
                 content: inputHelpText,
             },

--- a/client/src/components/Tool/ToolHelpRst.vue
+++ b/client/src/components/Tool/ToolHelpRst.vue
@@ -1,0 +1,42 @@
+<script setup>
+import { useFormattedToolHelp } from "composables/formattedToolHelp";
+
+const props = defineProps({
+    content: {
+        type: String,
+        required: true,
+    },
+});
+
+const { formattedContent } = useFormattedToolHelp(props.content);
+</script>
+
+<template>
+    <div class="form-help form-text" v-html="formattedContent" />
+</template>
+
+<style lang="scss" scoped>
+@import "scss/theme/blue.scss";
+
+.form-help {
+    &:deep(h3) {
+        font-size: $h4-font-size;
+        font-weight: bold;
+    }
+
+    &:deep(h4) {
+        font-size: $h5-font-size;
+        font-weight: bold;
+    }
+
+    &:deep(h5) {
+        font-size: $h6-font-size;
+        font-weight: bold;
+    }
+
+    &:deep(h6) {
+        font-size: $h6-font-size;
+        text-decoration: underline;
+    }
+}
+</style>

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -7,6 +7,7 @@ import DatasetAttributes from "components/DatasetInformation/DatasetAttributes";
 import DatasetDetails from "components/DatasetInformation/DatasetDetails";
 import DatasetError from "components/DatasetInformation/DatasetError";
 import FormGeneric from "components/Form/FormGeneric";
+import HelpTerm from "components/Help/HelpTerm";
 import HistoryExportTasks from "components/History/Export/HistoryExport";
 import HistoryPublished from "components/History/HistoryPublished";
 import HistoryView from "components/History/HistoryView";
@@ -194,6 +195,11 @@ export function getRouter(Galaxy) {
                     {
                         path: "about",
                         component: AboutGalaxy,
+                    },
+                    {
+                        path: "help/terms/:term",
+                        component: HelpTerm,
+                        props: true,
                     },
                     {
                         path: "carbon_emissions_calculations",

--- a/client/src/stores/helpTermsStore.ts
+++ b/client/src/stores/helpTermsStore.ts
@@ -1,0 +1,129 @@
+import { defineStore } from "pinia";
+import { computed, type Ref, ref } from "vue";
+
+import { hasHelp as hasHelpTextFromYaml, help as helpTextFromYaml } from "@/components/Help/terms";
+
+import { useDatatypeStore } from "./datatypeStore";
+
+interface DatatypeDescription {
+    ext: string;
+    description: string | null;
+    descriptionUrl: string | null;
+}
+
+interface RawDatatypeDescription {
+    id: string;
+    text: string;
+    description: string | unknown | null;
+    description_url: string | unknown | null;
+    upload_warning: string | unknown | null;
+}
+
+export const useHelpTermsStore = defineStore("helpTermsStore", () => {
+    const initialized = ref(false);
+    const datatypeDescriptions = ref<DatatypeDescription[] | null>(null as DatatypeDescription[] | null);
+    const datatypeStore = useDatatypeStore();
+
+    function datatypeDescriptionForExtension(extension: string): DatatypeDescription | null {
+        if (!datatypeDescriptions.value) {
+            return null;
+        }
+        for (const description of datatypeDescriptions.value) {
+            if (description.ext == extension) {
+                return description;
+            }
+        }
+        return null;
+    }
+
+    function moreInformationFromUrlMarkdown(ext: string, url: string) {
+        return `More information on the datatype ${ext} can be found at [${url}](${url}).`;
+    }
+
+    function datatypeDescriptionToMarkdown(datatypeDescription: DatatypeDescription): string {
+        const ext = datatypeDescription.ext;
+        let description = datatypeDescription.description?.trimEnd();
+        const url = datatypeDescription.descriptionUrl;
+        if (!description && !url) {
+            return `${ext} is a registered Galaxy datatype.`;
+        } else if (!description) {
+            return moreInformationFromUrlMarkdown(ext, url as string);
+        } else if (!url) {
+            return description;
+        } else {
+            if (description.charAt(description.length - 1) != ".") {
+                description += ".";
+            }
+            return `${description}\n\n${moreInformationFromUrlMarkdown(ext, url)}`;
+        }
+    }
+
+    async function ensureInitialized() {
+        if (!initialized.value) {
+            await datatypeStore.fetchUploadDatatypes();
+            const rawDatatypes = datatypeStore.getUploadDatatypes as RawDatatypeDescription[];
+            datatypeDescriptions.value = rawDatatypes.map((datatype: RawDatatypeDescription) => {
+                return {
+                    ext: datatype.id,
+                    description: datatype.description || null,
+                    descriptionUrl: datatype.description_url || null,
+                } as DatatypeDescription;
+            });
+            initialized.value = true;
+        }
+    }
+
+    const loading = computed(() => {
+        return !initialized.value;
+    });
+
+    function hasHelpText(term: string): boolean {
+        if (term.startsWith("galaxy.datatypes.extensions.")) {
+            const extension = term.substring("galaxy.datatypes.extensions.".length);
+            return datatypeDescriptionForExtension(extension) != null;
+        } else {
+            return hasHelpTextFromYaml(term);
+        }
+    }
+
+    function helpText(term: string): string | null {
+        if (term.startsWith("galaxy.datatypes.extensions.")) {
+            const extension = term.substring("galaxy.datatypes.extensions.".length);
+            const description = datatypeDescriptionForExtension(extension);
+            if (!description) {
+                return null;
+            }
+            return datatypeDescriptionToMarkdown(description);
+        } else {
+            return helpTextFromYaml(term);
+        }
+    }
+
+    return {
+        ensureInitialized,
+        hasHelpText,
+        helpText,
+        loading,
+    };
+});
+
+export function useHelpForTerm(uri: Ref<string>) {
+    const termsStore = useHelpTermsStore();
+    termsStore.ensureInitialized();
+
+    const loading = computed(() => {
+        return termsStore.loading;
+    });
+    const hasHelp = computed(() => {
+        return termsStore.hasHelpText(uri.value);
+    });
+    const help = computed(() => {
+        return termsStore.helpText(uri.value);
+    });
+
+    return {
+        loading,
+        hasHelp,
+        help,
+    };
+}

--- a/lib/galaxy/tool_util/linters/cwl.py
+++ b/lib/galaxy/tool_util/linters/cwl.py
@@ -89,5 +89,5 @@ class CWLHelpTODO(Linter):
     @classmethod
     def lint(cls, tool_source: "ToolSource", lint_ctx: "LintContext"):
         help = tool_source.parse_help()
-        if help and "TODO" in help:
+        if help and "TODO" in help.content:
             lint_ctx.warn("Help contains TODO text.")

--- a/lib/galaxy/tool_util/models.py
+++ b/lib/galaxy/tool_util/models.py
@@ -17,6 +17,7 @@ from .parameters import (
 )
 from .parser.interface import (
     Citation,
+    HelpContent,
     ToolSource,
     XrefDict,
 )
@@ -39,7 +40,7 @@ class ParsedTool(BaseModel):
     edam_operations: List[str]
     edam_topics: List[str]
     xrefs: List[XrefDict]
-    help: Optional[str]
+    help: Optional[HelpContent]
 
 
 def parse_tool(tool_source: ToolSource) -> ParsedTool:

--- a/lib/galaxy/tool_util/parser/cwl.py
+++ b/lib/galaxy/tool_util/parser/cwl.py
@@ -11,6 +11,7 @@ from galaxy.tool_util.cwl.parser import (
 )
 from galaxy.tool_util.deps import requirements
 from .interface import (
+    HelpContent,
     PageSource,
     PagesSource,
     ToolSource,
@@ -80,7 +81,11 @@ class CwlToolSource(ToolSource):
         return []
 
     def parse_help(self):
-        return self.tool_proxy.doc()
+        doc = self.tool_proxy.doc()
+        if doc:
+            return HelpContent(format="plain_text", content=doc)
+        else:
+            return None
 
     def parse_sanitize(self):
         return False

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -121,6 +121,11 @@ class Citation(BaseModel):
     content: str
 
 
+class HelpContent(BaseModel):
+    format: Literal["restructuredtext", "plain_text", "markdown"]
+    content: str
+
+
 class ToolSource(metaclass=ABCMeta):
     """This interface represents an abstract source to parse tool
     information from.
@@ -333,9 +338,11 @@ class ToolSource(metaclass=ABCMeta):
         return [], []
 
     @abstractmethod
-    def parse_help(self) -> Optional[str]:
-        """Return RST definition of help text for tool or None if the tool
-        doesn't define help text.
+    def parse_help(self) -> Optional[HelpContent]:
+        """Return help text for tool or None if the tool doesn't define help text.
+
+        The returned object contains the help text and an indication if it is reStructuredText
+        (``restructuredtext``), Markdown (``markdown``), or plain text (``plain_text``).
         """
 
     @abstractmethod

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -41,6 +41,7 @@ from .interface import (
     DrillDownDynamicOptions,
     DrillDownOptionsDict,
     DynamicOptions,
+    HelpContent,
     InputSource,
     PageSource,
     PagesSource,
@@ -649,9 +650,14 @@ class XmlToolSource(ToolSource):
         else:
             return string_as_bool(default)
 
-    def parse_help(self):
+    def parse_help(self) -> Optional[HelpContent]:
         help_elem = self.root.find("help")
-        return help_elem.text if help_elem is not None else None
+        if help_elem is None:
+            return None
+
+        help_format = help_elem.get("format", "restructuredtext")
+        content = help_elem.text or ""
+        return HelpContent(format=help_format, content=content)
 
     @property
     def macro_paths(self):

--- a/lib/galaxy/tool_util/parser/yaml.py
+++ b/lib/galaxy/tool_util/parser/yaml.py
@@ -19,6 +19,7 @@ from galaxy.tool_util.parser.util import (
 from .interface import (
     AssertionDict,
     AssertionList,
+    HelpContent,
     InputSource,
     PageSource,
     PagesSource,
@@ -124,8 +125,12 @@ class YamlToolSource(ToolSource):
     def parse_stdio(self):
         return error_on_exit_code()
 
-    def parse_help(self):
-        return self.root_dict.get("help", None)
+    def parse_help(self) -> Optional[HelpContent]:
+        content = self.root_dict.get("help", None)
+        if content:
+            return HelpContent(format="markdown", content=content)
+        else:
+            return None
 
     def parse_outputs(self, tool):
         outputs = self.root_dict.get("outputs", {})

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -132,51 +132,7 @@ the tool menu immediately following the hyperlink for the tool (based on the
         <xs:element name="inputs" type="Inputs" minOccurs="0"/>
         <xs:element name="tests" type="Tests" minOccurs="0"/>
         <xs:element name="stdio" type="Stdio" minOccurs="0"/>
-        <xs:element name="help" type="xs:string" minOccurs="0">
-          <xs:annotation gxdocs:best_practices="help-tag">
-            <xs:documentation xml:lang="en"><![CDATA[This tag set includes all of the necessary details of how to use the tool. This tag set should be included as the next to the last tag set, before citations, in the tool config. Tool help is written in reStructuredText. Included here is only an overview of a subset of features. For more information see [here](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html).
-
-tag | details
---- | -------
-``.. class:: warningmark`` | a yellow warning symbol
-``.. class:: infomark`` | a blue information symbol
-``.. image:: path-of-the-file.png :height: 500 :width: 600`` | insert a png file of height 500 and width 600 at this position |
-``**bold**`` | bold
-``*italic*`` | italic
-``*`` | list
-``-`` | list
-``::`` | paragraph
-``-----`` | a horizontal line
-
-### Examples
-
-Show a warning sign to remind users that this tool accept fasta format files only, followed by an example of the query sequence and a figure.
-
-```xml
-<help>
-
-.. class:: warningmark
-
-'''TIP''' This tool requires *fasta* format.
-
-----
-
-'''Example'''
-
-Query sequence::
-    >seq1
-    ATCG...
-
-.. image:: my_figure.png
-    :height: 500
-    :width: 600
-
-</help>
-```
-
-]]></xs:documentation>
-          </xs:annotation>
-        </xs:element>
+        <xs:element name="help" type="Help" minOccurs="0" maxOccurs="1" />
         <xs:element name="code" type="Code" minOccurs="0"/>
         <xs:element name="uihints" type="UIhints" minOccurs="0"/>
         <xs:element name="options" type="Options" minOccurs="0"/>
@@ -778,6 +734,69 @@ Read more about configuring Galaxy to run Docker jobs
         <xs:attribute name="type" type="ContainerType" use="required">
           <xs:annotation>
             <xs:documentation xml:lang="en">This value describes the type of container that the tool may be executed in and currently may be ``docker`` or ``singularity``.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="HelpFormatType">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">Document type of tool help</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="restructuredtext"/>
+      <xs:enumeration value="markdown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Help">
+    <xs:annotation gxdocs:best_practices="help-tag">
+      <xs:documentation xml:lang="en"><![CDATA[This tag set includes all of the necessary details of how to use the tool. This tag set should be included as the next to the last tag set, before citations, in the tool config. Tool help is written in reStructuredText. Included here is only an overview of a subset of features. For more information see [here](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html).
+
+tag | details
+--- | -------
+``.. class:: warningmark`` | a yellow warning symbol
+``.. class:: infomark`` | a blue information symbol
+``.. image:: path-of-the-file.png :height: 500 :width: 600`` | insert a png file of height 500 and width 600 at this position |
+``**bold**`` | bold
+``*italic*`` | italic
+``*`` | list
+``-`` | list
+``::`` | paragraph
+``-----`` | a horizontal line
+
+### Examples
+
+Show a warning sign to remind users that this tool accept fasta format files only, followed by an example of the query sequence and a figure.
+
+```xml
+<help>
+
+.. class:: warningmark
+
+'''TIP''' This tool requires *fasta* format.
+
+----
+
+'''Example'''
+
+Query sequence::
+    >seq1
+    ATCG...
+
+.. image:: my_figure.png
+    :height: 500
+    :width: 600
+
+</help>
+```
+
+]]></xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="format" type="HelpFormatType">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">Valid values are ``restructuredtext`` and ``markdown``</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -222,6 +222,7 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
     webapp.add_client_route("/admin/form/{form_id}")
     webapp.add_client_route("/admin/api_keys")
     webapp.add_client_route("/carbon_emissions_calculations")
+    webapp.add_client_route("/help/terms/{term_id}")
     webapp.add_client_route("/datatypes")
     webapp.add_client_route("/login/start")
     webapp.add_client_route("/tools/list")

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1854,7 +1854,7 @@ class ToolModule(WorkflowModule):
         return self.tool.version if self.tool else self.tool_version
 
     def get_tooltip(self, static_path=None):
-        if self.tool and self.tool.help:
+        if self.tool and self.tool.raw_help and self.tool.raw_help.format == "restructuredtext":
             host_url = self.trans.url_builder("/")
             static_path = self.trans.url_builder(static_path) if static_path else ""
             return self.tool.help.render(host_url=host_url, static_path=static_path)

--- a/lib/tool_shed/webapp/frontend/src/schema/schema.ts
+++ b/lib/tool_shed/webapp/frontend/src/schema/schema.ts
@@ -1585,6 +1585,16 @@ export interface components {
              */
             parameter_type: "gx_group_tag"
         }
+        /** HelpContent */
+        HelpContent: {
+            /** Content */
+            content: string
+            /**
+             * Format
+             * @enum {string}
+             */
+            format: "restructuredtext" | "plain_text" | "markdown"
+        }
         /** HiddenParameterModel */
         HiddenParameterModel: {
             /** Argument */
@@ -1735,8 +1745,7 @@ export interface components {
             edam_operations: string[]
             /** Edam Topics */
             edam_topics: string[]
-            /** Help */
-            help: string | null
+            help: components["schemas"]["HelpContent"] | null
             /** Id */
             id: string
             /** Inputs */

--- a/test/functional/tools/help_features_markdown.xml
+++ b/test/functional/tools/help_features_markdown.xml
@@ -1,0 +1,75 @@
+<tool id="help_features_markdown" name="help_features_markdown" version="1.0.0">
+    <command>
+        cp '$input.file_name' '$output'
+    </command>
+    <inputs>
+        <param name="input" type="data" format="txt" />
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <help format="markdown"><![CDATA[
+----
+
+Static path images
+
+![Zipping operation](gxstatic://images/tools/collection_ops/zip.svg)
+
+----
+
+Markdown can also reference help terms like [map over](gxhelp://galaxy.collections.mapOver),
+[command line](gxhelp://unix.commandLine), [standard error](gxhelp://unix.stderr), and
+[the FASTA file format](gxhelp://galaxy.datatypes.extensions.fasta).
+
+-----
+
+Markdown extensions for tables should work...
+
+
+| this | is | a | table |
+|------|----|---|-------|
+| 1 | 2 | 3 | 4 |
+
+Some more examples from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables
+
+| Command | Description |
+| --- | --- |
+| `git status` | List all *new or modified* files |
+| `git diff` | Show file differences that **haven't been** staged |
+
+
+| Left-aligned | Center-aligned | Right-aligned |
+| :---         |     :---:      |          ---: |
+| git status   | git status     | git status    |
+| git diff     | git diff       | git diff      |
+
+-----
+
+
+Text styles 
+
+**This is bold text**
+
+_This text is italicized_
+
+~~This was mistaken text~~
+
+**This text is _extremely_ important**
+
+***All this text is important***
+
+----
+
+It would be easy to turn on sub script but we haven't yet.
+
+This is a <sub>subscript</sub> text
+
+----
+
+Text that is not a quote
+
+> Text that is a quote
+
+Well... that does render with a block quote tag in Galaxy 24.2 but it isn't formatted at all.
+]]></help>
+</tool>

--- a/test/functional/tools/help_features_rst.xml
+++ b/test/functional/tools/help_features_rst.xml
@@ -1,0 +1,80 @@
+<tool id="help_features_rst" name="help_features_rst" version="1.0.0">
+    <command>
+        cp '$input.file_name' '$output'
+    </command>
+    <inputs>
+        <param name="input" type="data" format="txt" />
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <help><![CDATA[
+Header
+-------
+
+SubHeader
+---------
+
+SubSubHeader
+~~~~~~~~~~
+
+Some text here....
+
+----
+
+.. class:: warningmark
+
+'''TIP''' This tool requires *txt* format.
+
+----
+
+.. class:: infomark
+
+Here is some extra info....
+
+----
+
+Example Table from RST Docs....
+
+
+.. list-table:: Title of the table.
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Heading row 1, column 1
+     - Heading row 1, column 2
+     - Heading row 1, column 3
+   * - Row 1, column 1
+     -
+     - Row 1, column 3
+   * - Row 2, column 1
+     - Row 2, column 2
+     - Row 2, column 3
+
+----
+
+**negative example**
+
+.. code-block::
+   :caption: Doesn't work in Galaxy
+
+       Code with captions doesn't seem to work.
+
+
+----
+
+.. code-block::
+
+       The output of this line has no spaces at the beginning.
+
+----
+
+Static path images...
+
+.. image:: ${static_path}/images/tools/collection_ops/zip.svg
+  :width: 500
+  :alt: Zipping operation
+
+
+    ]]></help>
+</tool>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -24,6 +24,8 @@
   <tool file="multi_repeats.xml" />
   <tool file="remove_value.xml" />
   <tool file="bibtex.xml" />
+  <tool file="help_features_rst.xml" />
+  <tool file="help_features_markdown.xml" />
   <tool file="select_from_url.xml" />
   <tool file="multi_select.xml" />
   <tool file="multi_output.xml" />

--- a/test/unit/tool_util/test_parsing.py
+++ b/test/unit/tool_util/test_parsing.py
@@ -372,7 +372,7 @@ class TestXmlLoader(BaseLoaderTestCase):
         assert isinf(exit[0].range_end)
 
     def test_help(self):
-        help_text = self._tool_source.parse_help()
+        help_text = self._tool_source.parse_help().content
         assert help_text.strip() == "This is HELP TEXT1!!!"
 
     def test_tests(self):
@@ -579,7 +579,7 @@ class TestYamlLoader(BaseLoaderTestCase):
         assert isinf(exit[1].range_end)
 
     def test_help(self):
-        help_text = self._tool_source.parse_help()
+        help_text = self._tool_source.parse_help().content
         assert help_text.strip() == "This is HELP TEXT2!!!"
 
     def test_inputs(self):


### PR DESCRIPTION
## What is in the PR

- Allow tools to declare markdown help.
- Allow tools to reference help terms from their Markdown tools.
- Auto generate help terms for each datatype from values in datatypes_conf.xml
- Add permanent links for each help term - both the auto generated ones and the YAML specified
ones.
- Add some initial help terms for collection operations.
- Use new help term for "map over" from tool form.

## Motivation

I had the request to define "map over" in #18698. I don't want to do that in the context of a narrow tool - I'd rather make some progress on some longer term goals in dev. This is some infrastructure for embedding help terms (added as part of #17569) into tools - along with the option to allow Markdown help in tools (a long requested feature - xref https://github.com/galaxyproject/galaxy/issues/6230).

## Screenshots

### Map Over Terminology

One thing I did was to restore the term "map over" back into the tool form. It was removed a while ago but I think it is important to distinguish running a tool on a bunch of datasets vs. running a tool on collections. The different is important in terms of sample tracking and workflow construction. 

24.1:
<img width="577" alt="Screenshot 2024-08-19 at 2 04 47 PM" src="https://github.com/user-attachments/assets/73af2518-1d76-4a31-a410-28337b444dca">

After:

<img width="936" alt="Screenshot 2024-08-19 at 2 04 59 PM" src="https://github.com/user-attachments/assets/9f6a4d9d-bd1b-430e-aa1a-6ecdc3ce91fd">

### Embedding Help Links into Tool Help:

<img width="935" alt="Screenshot 2024-08-19 at 2 07 51 PM" src="https://github.com/user-attachments/assets/b374cd15-06cc-4894-9462-26ab588261b7">

<img width="951" alt="Screenshot 2024-08-19 at 2 07 59 PM" src="https://github.com/user-attachments/assets/0dbbf2c3-b55d-4681-ba7a-b4b0fd1c8a5e">

### Help Terms for Datatypes ( per request from @bgruening )

<img width="1425" alt="Screenshot 2024-08-20 at 11 24 33 AM" src="https://github.com/user-attachments/assets/d4472c83-bae1-4222-ba39-43ff2b8d4122">

### Perm Links for Galaxy Terms

<img width="1289" alt="Screenshot 2024-08-20 at 11 26 30 AM" src="https://github.com/user-attachments/assets/2477e85a-68d0-4de2-b1a1-ff5c943f4a07">
<img width="1476" alt="Screenshot 2024-08-20 at 11 26 19 AM" src="https://github.com/user-attachments/assets/427fbb59-59b3-4614-8212-6b50866e06da">


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
