### PR TITLE
[24.1] Add error handling in `WorkflowInvocationState`

### DIFF
--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -73,7 +73,7 @@ useAnimationFrameResizeObserver(scrollableDiv, ({ clientSize, scrollSize }) => {
 });
 
 const invocation = computed(() =>
-    !initialLoading.value
+    !initialLoading.value && !errorMessage.value
         ? (invocationStore.getInvocationById(props.invocationId) as WorkflowInvocationElementView)
         : null
 );
@@ -120,6 +120,8 @@ onMounted(async () => {
         }
     } catch (e) {
         errorMessage.value = errorMessageAsString(e);
+    } finally {
+        initialLoading.value = false;
     }
 });
 
@@ -274,10 +276,13 @@ function getWorkflowName() {
             </BTab>
         </BTabs>
     </div>
+    <BAlert v-else-if="initialLoading" variant="info" show>
+        <LoadingSpan message="Loading invocation" />
+    </BAlert>
     <BAlert v-else-if="errorMessage" variant="danger" show>
         {{ errorMessage }}
     </BAlert>
     <BAlert v-else variant="info" show>
-        <LoadingSpan message="Loading invocation" />
+        <span v-localize>Invocation not found.</span>
     </BAlert>
 </template>


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/18723

Without this fix, if you get to the `WorkflowInvocationState` route for another user's invocation, there is a 403 error which is unhandled since there is a computed `invocation` ref that we constantly poll. Adding a `initialLoading` ref that ensures the first fetch for the invocation was valid (or the error is caught) fixes this.

![invocation_state_unhandled_error](https://github.com/user-attachments/assets/bde2f18f-386b-4a26-8f85-990c70af0f90)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
