### PR TITLE
Don't serialize view of item in delete/purge request

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -9924,30 +9924,6 @@ export interface components {
              */
             stop_job: boolean;
         };
-        /**
-         * DeleteHistoryContentResult
-         * @description Contains minimum information about the deletion state of a history item.
-         *
-         *     Can also contain any other properties of the item.
-         */
-        DeleteHistoryContentResult: {
-            /**
-             * Deleted
-             * @description True if the item was successfully deleted.
-             */
-            deleted: boolean;
-            /**
-             * ID
-             * @description The encoded ID of the history item.
-             * @example 0123456789ABCDEF
-             */
-            id: string;
-            /**
-             * Purged
-             * @description True if the item was successfully removed from disk.
-             */
-            purged?: boolean | null;
-        };
         /** DeleteHistoryPayload */
         DeleteHistoryPayload: {
             /**
@@ -24261,10 +24237,6 @@ export interface operations {
                  * @description Whether to stop the creating job if all outputs of the job have been deleted.
                  */
                 stop_job?: boolean | null;
-                /** @description View to be passed to the serializer */
-                view?: string | null;
-                /** @description Comma-separated list of keys to be passed to the serializer */
-                keys?: string | null;
             };
             header?: {
                 /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
@@ -24282,13 +24254,13 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Request has been executed. */
+            /** @description Successful Response */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["DeleteHistoryContentResult"];
+                    "application/json": unknown;
                 };
             };
             /** @description Request accepted, processing will finish later. */
@@ -24296,9 +24268,14 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": components["schemas"]["DeleteHistoryContentResult"];
+                content?: never;
+            };
+            /** @description Request has been executed. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
                 };
+                content?: never;
             };
             /** @description Request Error */
             "4XX": {
@@ -30217,10 +30194,6 @@ export interface operations {
                  * @description Whether to stop the creating job if all outputs of the job have been deleted.
                  */
                 stop_job?: boolean | null;
-                /** @description View to be passed to the serializer */
-                view?: string | null;
-                /** @description Comma-separated list of keys to be passed to the serializer */
-                keys?: string | null;
             };
             header?: {
                 /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
@@ -30240,13 +30213,13 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Request has been executed. */
+            /** @description Successful Response */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["DeleteHistoryContentResult"];
+                    "application/json": unknown;
                 };
             };
             /** @description Request accepted, processing will finish later. */
@@ -30254,9 +30227,14 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": components["schemas"]["DeleteHistoryContentResult"];
+                content?: never;
+            };
+            /** @description Request has been executed. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
                 };
+                content?: never;
             };
             /** @description Request Error */
             "4XX": {
@@ -30634,10 +30612,6 @@ export interface operations {
                  * @description Whether to stop the creating job if all outputs of the job have been deleted.
                  */
                 stop_job?: boolean | null;
-                /** @description View to be passed to the serializer */
-                view?: string | null;
-                /** @description Comma-separated list of keys to be passed to the serializer */
-                keys?: string | null;
             };
             header?: {
                 /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
@@ -30659,13 +30633,13 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Request has been executed. */
+            /** @description Successful Response */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["DeleteHistoryContentResult"];
+                    "application/json": unknown;
                 };
             };
             /** @description Request accepted, processing will finish later. */
@@ -30673,9 +30647,14 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": components["schemas"]["DeleteHistoryContentResult"];
+                content?: never;
+            };
+            /** @description Request has been executed. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
                 };
+                content?: never;
             };
             /** @description Request Error */
             "4XX": {

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3592,28 +3592,6 @@ class DeleteHistoryContentPayload(Model):
     )
 
 
-class DeleteHistoryContentResult(Model):
-    """Contains minimum information about the deletion state of a history item.
-
-    Can also contain any other properties of the item."""
-
-    id: DecodedDatabaseIdField = Field(
-        ...,
-        title="ID",
-        description="The encoded ID of the history item.",
-    )
-    deleted: bool = Field(
-        ...,
-        title="Deleted",
-        description="True if the item was successfully deleted.",
-    )
-    purged: Optional[bool] = Field(
-        default=None,
-        title="Purged",
-        description="True if the item was successfully removed from disk.",
-    )
-
-
 class HistoryContentsArchiveDryRunResult(RootModel):
     """
     Contains a collection of filepath/filename entries that represent

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -672,7 +672,7 @@ class TestDatasetsApi(ApiTestCase):
             history_id, output_hda_id, stop_job=True, use_query_params=use_query_params
         )
         self._assert_status_code_is_ok(delete_response)
-        deleted_hda = delete_response.json()
+        deleted_hda = self.dataset_populator.get_history_dataset_details(history_id, content_id=output_hda_id)
         assert deleted_hda["deleted"], deleted_hda
 
         # The job should be cancelled

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -692,7 +692,7 @@ class TestHistoryContentsApi(ApiTestCase):
         assert not dataset_collection["deleted"]
 
         delete_response = self._delete(collection_url)
-        self._assert_status_code_is(delete_response, 200)
+        self._assert_status_code_is_ok(delete_response)
 
         show_response = self._get(collection_url)
         dataset_collection = show_response.json()

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -736,7 +736,7 @@ steps:
         output = run_response["outputs"][0]
         # Delete second jobs input while second job is waiting for first job
         delete_response = self._delete(f"histories/{history_id}/contents/{hda1['id']}")
-        self._assert_status_code_is(delete_response, 200)
+        self._assert_status_code_is_ok(delete_response)
         self.dataset_populator.wait_for_history_jobs(history_id, assert_ok=False)
         dataset_details = self._get(f"histories/{history_id}/contents/{output['id']}").json()
         assert dataset_details["state"] == "paused"
@@ -773,11 +773,11 @@ steps:
         self._search(search_payload, expected_search_count=1)
         # Now we delete the original input HDA that was used -- we should still be able to find the job
         delete_respone = self._delete(f"histories/{history_id}/contents/{dataset_id}")
-        self._assert_status_code_is(delete_respone, 200)
+        self._assert_status_code_is_ok(delete_respone)
         self._search(search_payload, expected_search_count=1)
         # Now we also delete the copy -- we shouldn't find a job
         delete_respone = self._delete(f"histories/{new_history_id}/contents/{new_dataset_id}")
-        self._assert_status_code_is(delete_respone, 200)
+        self._assert_status_code_is_ok(delete_respone)
         self._search(search_payload, expected_search_count=0)
 
     @pytest.mark.require_new_history
@@ -803,7 +803,7 @@ steps:
         tool_response = self._job_search(tool_id="cat1", history_id=history_id, inputs=inputs)
         output_id = tool_response.json()["outputs"][0]["id"]
         delete_respone = self._delete(f"histories/{history_id}/contents/{output_id}")
-        self._assert_status_code_is(delete_respone, 200)
+        self._assert_status_code_is_ok(delete_respone)
         search_payload = self._search_payload(history_id=history_id, tool_id="cat1", inputs=inputs)
         self._search(search_payload, expected_search_count=0)
 
@@ -847,7 +847,7 @@ steps:
         # and use the correct input job definition, the job should not be found
         output_id = tool_response.json()["outputs"][0]["id"]
         delete_respone = self._delete(f"histories/{history_id}/contents/{output_id}")
-        self._assert_status_code_is(delete_respone, 200)
+        self._assert_status_code_is_ok(delete_respone)
         search_payload = self._search_payload(history_id=history_id, tool_id="multi_data_param", inputs=inputs)
         self._search(search_payload, expected_search_count=0)
 
@@ -863,14 +863,14 @@ steps:
         output_id = tool_response.json()["outputs"][0]["id"]
         # We delete a single tool output, no job should be returned
         delete_respone = self._delete(f"histories/{history_id}/contents/{output_id}")
-        self._assert_status_code_is(delete_respone, 200)
+        self._assert_status_code_is_ok(delete_respone)
         search_payload = self._search_payload(history_id=history_id, tool_id="collection_creates_list", inputs=inputs)
         self._search(search_payload, expected_search_count=0)
         tool_response = self._job_search(tool_id="collection_creates_list", history_id=history_id, inputs=inputs)
         output_collection_id = tool_response.json()["output_collections"][0]["id"]
         # We delete a collection output, no job should be returned
         delete_respone = self._delete(f"histories/{history_id}/contents/dataset_collections/{output_collection_id}")
-        self._assert_status_code_is(delete_respone, 200)
+        self._assert_status_code_is_ok(delete_respone)
         search_payload = self._search_payload(history_id=history_id, tool_id="collection_creates_list", inputs=inputs)
         self._search(search_payload, expected_search_count=0)
 
@@ -902,11 +902,11 @@ steps:
         self._search(search_payload, expected_search_count=1)
         # Now we delete the original input HDCA that was used -- we should still be able to find the job
         delete_respone = self._delete(f"histories/{history_id}/contents/dataset_collections/{list_id_a}")
-        self._assert_status_code_is(delete_respone, 200)
+        self._assert_status_code_is_ok(delete_respone)
         self._search(search_payload, expected_search_count=1)
         # Now we also delete the copy -- we shouldn't find a job
         delete_respone = self._delete(f"histories/{history_id}/contents/dataset_collections/{new_list_a}")
-        self._assert_status_code_is(delete_respone, 200)
+        self._assert_status_code_is_ok(delete_respone)
         self._search(search_payload, expected_search_count=0)
 
     @pytest.mark.require_new_history

--- a/lib/galaxy_test/api/test_pages.py
+++ b/lib/galaxy_test/api/test_pages.py
@@ -338,7 +338,7 @@ steps:
     def test_delete(self):
         response_json = self._create_valid_page_with_slug("testdelete")
         delete_response = delete(self._api_url(f"pages/{response_json['id']}", use_key=True))
-        self._assert_status_code_is(delete_response, 204)
+        self._assert_status_code_is_ok(delete_response)
 
     def test_400_on_delete_invalid_page_id(self):
         delete_response = delete(self._api_url(f"pages/{self._random_key()}", use_key=True))

--- a/lib/galaxy_test/api/test_tags.py
+++ b/lib/galaxy_test/api/test_tags.py
@@ -30,7 +30,7 @@ class TagsApiTests(ApiTestCase):
 
         new_tags = ["APITag"]
         update_history_tags_response = self._update_tags_using_tags_api(item_id, new_tags)
-        self._assert_status_code_is(update_history_tags_response, 204)
+        self._assert_status_code_is_ok(update_history_tags_response)
         self._assert_tags_in_item(item_id, new_tags)
 
         # other users can't create or update tags

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -216,10 +216,10 @@ class TestUsersApi(ApiTestCase):
             assert api_key["key"] == user_api_key
             # Delete user API key
             response = self._delete(f"users/{user_id}/api_key")
-            self._assert_status_code_is(response, 204)
+            self._assert_status_code_is_ok(response)
             # No API key anymore, so the detailed request returns no content 204 with admin key
             response = self._get(f"users/{user_id}/api_key/detailed", admin=True)
-            self._assert_status_code_is(response, 204)
+            self._assert_status_code_is_ok(response)
             # No API key anymore, so the detailed request returns unauthorized 401 with user key
             response = self._get(f"users/{user_id}/api_key/detailed")
             self._assert_status_code_is(response, 401)

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -392,7 +392,7 @@ class TestWorkflowsApi(BaseWorkflowsApiTestCase, ChangeDatatypeTests):
         self._assert_user_has_workflow_with_name(workflow_name)
         workflow_url = self._api_url(f"workflows/{workflow_id}", use_key=True)
         delete_response = delete(workflow_url)
-        self._assert_status_code_is(delete_response, 204)
+        self._assert_status_code_is_ok(delete_response)
         # Make sure workflow is no longer in index by default.
         assert workflow_name not in self._workflow_names()
 
@@ -411,7 +411,7 @@ class TestWorkflowsApi(BaseWorkflowsApiTestCase, ChangeDatatypeTests):
         delete(workflow_delete_url)
         workflow_undelete_url = self._api_url(f"workflows/{workflow_id}/undelete", use_key=True)
         undelete_response = post(workflow_undelete_url)
-        self._assert_status_code_is(undelete_response, 204)
+        self._assert_status_code_is_ok(undelete_response)
         assert workflow_name in self._workflow_names()
 
     def test_other_cannot_undelete(self):
@@ -434,7 +434,7 @@ class TestWorkflowsApi(BaseWorkflowsApiTestCase, ChangeDatatypeTests):
         assert [w for w in workflow_index if w["id"] == workflow_id]
         workflow_url = self._api_url(f"workflows/{workflow_id}", use_key=True)
         delete_response = delete(workflow_url)
-        self._assert_status_code_is(delete_response, 204)
+        self._assert_status_code_is_ok(delete_response)
         workflow_index = self._get("workflows").json()
         assert not [w for w in workflow_index if w["id"] == workflow_id]
         workflow_index = self._get("workflows?show_deleted=true").json()

--- a/test/integration/test_notifications.py
+++ b/test/integration/test_notifications.py
@@ -417,7 +417,7 @@ class NotificationsIntegrationBase(IntegrationTestCase):
 
     def _update_notification(self, notification_id: str, update_state: dict[str, Any]):
         update_response = self._put(f"notifications/{notification_id}", data=update_state, json=True)
-        self._assert_status_code_is(update_response, 204)
+        self._assert_status_code_is_ok(update_response)
 
     def _assert_notifications_sent(self, response, expected_count: int = 0):
         if self.task_based:


### PR DESCRIPTION
This is a breaking change for the API, it is motivated by https://sentry.galaxyproject.org/share/issue/3970e49a695f4600bcaeae55021555a9/:
```
Message
Unexpected error
Stack Trace

Newest

FileNotFoundError: [Errno 2] No such file or directory: ''
  File "galaxy/datatypes/interval.py", line 1326, in get_estimated_display_viewport
    with open(dataset.get_file_name()) as fh:
```
This is a purge request, which does return the entire detailed response, including available display applications. We already check that the dataset isn't purged, but the celery task often executes between the check and the deletion.

I don't think it makes sense to return any data at all here, and there are other endpoints where we simply return 202 or 204, like purging user file source instances.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
