### PR TITLE
[24.1] Fix resume paused jobs response handling

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -18,6 +18,7 @@ import {
     faUserLock,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import axios from "axios";
 import {
     BButton,
     BButtonGroup,
@@ -34,9 +35,12 @@ import { computed, ref } from "vue";
 
 import { canMutateHistory, type HistorySummary } from "@/api";
 import { iframeRedirect } from "@/components/plugins/legacyNavigation";
+import { useToast } from "@/composables/toast";
+import { getAppRoot } from "@/onload/loadConfig";
 import { useHistoryStore } from "@/stores/historyStore";
 import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";
+import { rethrowSimple } from "@/utils/simple-error";
 
 import CopyModal from "@/components/History/Modals/CopyModal.vue";
 import SelectorModal from "@/components/History/Modals/SelectorModal.vue";
@@ -74,6 +78,8 @@ const props = withDefaults(defineProps<Props>(), {
 const showSwitchModal = ref(false);
 const purgeHistory = ref(false);
 
+const toast = useToast();
+
 const userStore = useUserStore();
 const historyStore = useHistoryStore();
 
@@ -109,6 +115,16 @@ function userTitle(title: string) {
         return localize("Log in to") + " " + localize(title);
     } else {
         return localize(title);
+    }
+}
+
+async function resumePausedJobs() {
+    const url = `${getAppRoot()}history/resume_paused_jobs?current=True`;
+    try {
+        const response = await axios.get(url);
+        toast.success(response.data.message);
+    } catch (e) {
+        rethrowSimple(e);
     }
 }
 </script>
@@ -187,7 +203,7 @@ function userTitle(title: string) {
                     <BDropdownItem
                         :disabled="!canEditHistory"
                         :title="localize('Resume all Paused Jobs in this History')"
-                        @click="iframeRedirect('/history/resume_paused_jobs?current=True')">
+                        @click="resumePausedJobs()">
                         <FontAwesomeIcon fixed-width :icon="faPlay" class="mr-1" />
                         <span v-localize>Resume Paused Jobs</span>
                     </BDropdownItem>

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -244,7 +244,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             history = trans.get_history()
             if history:
                 history.resume_paused_jobs()
-                return trans.show_ok_message("Your jobs have been resumed.")
+                return {"message": "Your jobs have been resumed.", "status": "success"}
         raise exceptions.RequestParameterInvalidException(
             "You can currently only resume all the datasets of the current history."
         )


### PR DESCRIPTION
Fixes 
![image](https://github.com/user-attachments/assets/5462ebef-3289-4f44-b26e-ca006f0c2240)

which emerged with #18640, which changed the response type when the expose was adjusted.  We only use this in exactly one spot and it's an old a web controller method, so I kept the changes simple like the rest of the usage at that controller while still updating usage away from `trans.show_ok` and having an api-style response.

As a bonus, this is now piped into a toast, instead of potentially jarring-ly shfiting the center iframe contents.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
