### PR TITLE
[24.1] Catch and display exceptions when importing malformatted yaml workflows

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 import sqlalchemy
+import yaml
 from gxformat2 import (
     from_galaxy_native,
     ImporterGalaxyInterface,
@@ -620,9 +621,12 @@ class WorkflowContentsManager(UsesAnnotations):
             galaxy_interface = Format2ConverterGalaxyInterface()
             import_options = ImportOptions()
             import_options.deduplicate_subworkflows = True
-            as_dict = python_to_workflow(
-                as_dict, galaxy_interface, workflow_directory=workflow_directory, import_options=import_options
-            )
+            try:
+                as_dict = python_to_workflow(
+                    as_dict, galaxy_interface, workflow_directory=workflow_directory, import_options=import_options
+                )
+            except yaml.scanner.ScannerError as e:
+                raise exceptions.MalformedContents(str(e))
 
         return RawWorkflowDescription(as_dict, workflow_path)
 

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1,4 +1,5 @@
 import base64
+import io
 import json
 import os
 import shutil
@@ -7751,6 +7752,11 @@ outer_input:
         downloaded_workflow = self._download_workflow(workflow_id)
         subworkflow = downloaded_workflow["steps"]["1"]["subworkflow"]
         assert subworkflow["tags"] == []
+
+    def test_upload_malformated_yaml(self):
+        malformated_yaml = "class: GalaxyWorkflow:\n    a-1:()"
+        r = self._post("workflows", files={"archive_file": io.StringIO(malformated_yaml)})
+        assert r.status_code == 400
 
 
 class TestAdminWorkflowsApi(BaseWorkflowsApiTestCase):


### PR DESCRIPTION
@ahmedhamidawan that should give you a nice hint like
```
mapping values are not allowed here
  in "<unicode string>", line 2, column 6:
    class: GalaxyWorkflow
         ^
```

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
