### PR TITLE
[24.1] Fix datatype validation of newly built collection

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6581,6 +6581,11 @@ export interface components {
              */
             element_count?: number | null;
             /**
+             * Elements Datatypes
+             * @description A set containing all the different element datatypes in the collection.
+             */
+            elements_datatypes: string[];
+            /**
              * HID
              * @description The index position of this item in the History.
              */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6399,6 +6399,142 @@ export interface components {
              */
             visible: boolean;
         };
+        /** HDCACustom */
+        HDCACustom: {
+            /**
+             * Dataset Collection ID
+             * @example 0123456789ABCDEF
+             */
+            collection_id?: string;
+            /**
+             * Collection Type
+             * @description The type of the collection, can be `list`, `paired`, or define subcollections using `:` as separator like `list:paired` or `list:list`.
+             */
+            collection_type?: string | null;
+            /**
+             * Contents URL
+             * @description The relative URL to access the contents of this History.
+             */
+            contents_url?: string | null;
+            /**
+             * Create Time
+             * @description The time and date this item was created.
+             */
+            create_time?: string | null;
+            /**
+             * Deleted
+             * @description Whether this item is marked as deleted.
+             */
+            deleted?: boolean | null;
+            /**
+             * Element Count
+             * @description The number of elements contained in the dataset collection. It may be None or undefined if the collection could not be populated.
+             */
+            element_count?: number | null;
+            /**
+             * Elements
+             * @description The summary information of each of the elements inside the dataset collection.
+             */
+            elements?: components["schemas"]["DCESummary"][] | null;
+            /**
+             * Elements Datatypes
+             * @description A set containing all the different element datatypes in the collection.
+             */
+            elements_datatypes?: string[] | null;
+            /**
+             * HID
+             * @description The index position of this item in the History.
+             */
+            hid?: number | null;
+            /**
+             * History Content Type
+             * @description This is always `dataset_collection` for dataset collections.
+             */
+            history_content_type?: "dataset_collection" | null;
+            /**
+             * History ID
+             * @example 0123456789ABCDEF
+             */
+            history_id?: string;
+            /**
+             * Id
+             * @example 0123456789ABCDEF
+             */
+            id?: string;
+            /**
+             * Implicit Collection Jobs Id
+             * @description Encoded ID for the ICJ object describing the collection of jobs corresponding to this collection
+             */
+            implicit_collection_jobs_id?: string | null;
+            /**
+             * Job Source ID
+             * @description The encoded ID of the Job that produced this dataset collection. Used to track the state of the job.
+             */
+            job_source_id?: string | null;
+            /**
+             * Job Source Type
+             * @description The type of job (model class) that produced this dataset collection. Used to track the state of the job.
+             */
+            job_source_type?: components["schemas"]["JobSourceType"] | null;
+            /**
+             * Job State Summary
+             * @description Overview of the job states working inside the dataset collection.
+             */
+            job_state_summary?: components["schemas"]["HDCJobStateSummary"] | null;
+            /**
+             * Model class
+             * @description The name of the database model class.
+             * @constant
+             */
+            model_class?: "HistoryDatasetCollectionAssociation";
+            /**
+             * Name
+             * @description The name of the item.
+             */
+            name?: string | null;
+            /**
+             * Populated
+             * @description Whether the dataset collection elements (and any subcollections elements) were successfully populated.
+             */
+            populated?: boolean | null;
+            /**
+             * Populated State
+             * @description Indicates the general state of the elements in the dataset collection:- 'new': new dataset collection, unpopulated elements.- 'ok': collection elements populated (HDAs may or may not have errors).- 'failed': some problem populating, won't be populated.
+             */
+            populated_state?: components["schemas"]["DatasetCollectionPopulatedState"] | null;
+            /**
+             * Populated State Message
+             * @description Optional message with further information in case the population of the dataset collection failed.
+             */
+            populated_state_message?: string | null;
+            tags?: components["schemas"]["TagCollection"] | null;
+            /**
+             * Type
+             * @description This is always `collection` for dataset collections.
+             */
+            type?: "collection" | null;
+            /**
+             * Type - ID
+             * @description The type and the encoded ID of this item. Used for caching.
+             */
+            type_id?: string | null;
+            /**
+             * Update Time
+             * @description The last time and date this item was updated.
+             */
+            update_time?: string | null;
+            /**
+             * URL
+             * @deprecated
+             * @description The relative URL to access this item.
+             */
+            url?: string | null;
+            /**
+             * Visible
+             * @description Whether this item is visible or hidden to the user by default.
+             */
+            visible?: boolean | null;
+        };
         /**
          * HDCADetailed
          * @description History Dataset Collection Association detailed information.
@@ -7204,6 +7340,7 @@ export interface components {
             | components["schemas"]["HDADetailed"]
             | components["schemas"]["HDASummary"]
             | components["schemas"]["HDAInaccessible"]
+            | components["schemas"]["HDCACustom"]
             | components["schemas"]["HDCADetailed"]
             | components["schemas"]["HDCASummary"]
         )[];
@@ -7221,6 +7358,7 @@ export interface components {
                 | components["schemas"]["HDADetailed"]
                 | components["schemas"]["HDASummary"]
                 | components["schemas"]["HDAInaccessible"]
+                | components["schemas"]["HDCACustom"]
                 | components["schemas"]["HDCADetailed"]
                 | components["schemas"]["HDCASummary"]
             )[];
@@ -13964,7 +14102,10 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["HDCADetailed"] | components["schemas"]["HDCASummary"];
+                    "application/json":
+                        | components["schemas"]["HDCACustom"]
+                        | components["schemas"]["HDCADetailed"]
+                        | components["schemas"]["HDCASummary"];
                 };
             };
             /** @description Validation Error */
@@ -14165,6 +14306,7 @@ export interface operations {
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDAInaccessible"]
+                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
                     )[];
@@ -14288,6 +14430,7 @@ export interface operations {
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDAInaccessible"]
+                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"];
                 };
@@ -17407,6 +17550,7 @@ export interface operations {
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDAInaccessible"]
+                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
                         | (
@@ -17414,6 +17558,7 @@ export interface operations {
                               | components["schemas"]["HDADetailed"]
                               | components["schemas"]["HDASummary"]
                               | components["schemas"]["HDAInaccessible"]
+                              | components["schemas"]["HDCACustom"]
                               | components["schemas"]["HDCADetailed"]
                               | components["schemas"]["HDCASummary"]
                           )[];
@@ -17998,6 +18143,7 @@ export interface operations {
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDAInaccessible"]
+                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"];
                 };
@@ -18050,6 +18196,7 @@ export interface operations {
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDAInaccessible"]
+                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"];
                 };
@@ -18283,6 +18430,7 @@ export interface operations {
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDAInaccessible"]
+                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
                         | (
@@ -18290,6 +18438,7 @@ export interface operations {
                               | components["schemas"]["HDADetailed"]
                               | components["schemas"]["HDASummary"]
                               | components["schemas"]["HDAInaccessible"]
+                              | components["schemas"]["HDCACustom"]
                               | components["schemas"]["HDCADetailed"]
                               | components["schemas"]["HDCASummary"]
                           )[];
@@ -18341,6 +18490,7 @@ export interface operations {
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDAInaccessible"]
+                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"];
                 };
@@ -18392,6 +18542,7 @@ export interface operations {
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDAInaccessible"]
+                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"];
                 };
@@ -18624,6 +18775,7 @@ export interface operations {
                         | components["schemas"]["HDADetailed"]
                         | components["schemas"]["HDASummary"]
                         | components["schemas"]["HDAInaccessible"]
+                        | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"]
                     )[];

--- a/client/src/stores/collectionElementsStore.test.ts
+++ b/client/src/stores/collectionElementsStore.test.ts
@@ -115,6 +115,7 @@ function mockCollection(id: string, numElements = 10): HDCASummary {
     return {
         id: id,
         element_count: numElements,
+        elements_datatypes: ["txt"],
         collection_type: "list",
         populated_state: "ok",
         populated_state_message: "",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3283,8 +3283,17 @@ class HDACustom(HDADetailed):
     model_config = ConfigDict(extra="allow")
 
 
+@partial_model()
+class HDCACustom(HDCADetailed):
+    """Can contain any serializable property of an HDCA.
+
+    Allows arbitrary custom keys to be specified in the serialization
+    parameters without a particular view (predefined set of keys).
+    """
+
+
 AnyHDA = Union[HDACustom, HDADetailed, HDASummary, HDAInaccessible]
-AnyHDCA = Union[HDCADetailed, HDCASummary]
+AnyHDCA = Union[HDCACustom, HDCADetailed, HDCASummary]
 AnyHistoryContentItem = Annotated[
     Union[
         AnyHDA,

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1104,6 +1104,9 @@ class HDCASummary(HDCACommon, WithModelClass):
     populated_state: DatasetCollectionPopulatedState = PopulatedStateField
     populated_state_message: Optional[str] = PopulatedStateMessageField
     element_count: ElementCountField
+    elements_datatypes: Set[str] = Field(
+        ..., description="A set containing all the different element datatypes in the collection."
+    )
     job_source_id: Optional[EncodedDatabaseIdField] = Field(
         None,
         title="Job Source ID",
@@ -1128,9 +1131,6 @@ class HDCADetailed(HDCASummary):
 
     populated: PopulatedField
     elements: List[DCESummary] = ElementsField
-    elements_datatypes: Set[str] = Field(
-        ..., description="A set containing all the different element datatypes in the collection."
-    )
     implicit_collection_jobs_id: Optional[EncodedDatabaseIdField] = Field(
         None,
         description="Encoded ID for the ICJ object describing the collection of jobs corresponding to this collection",


### PR DESCRIPTION
We only request the summary view when polling the history for updates, so we don't serialize elements_datatypes, which is used to make sure that the dragged element is of the correct datatype.

This probably fixes https://sentry.galaxyproject.org/share/issue/790be09602694a638d66257004325163/:
```
Message
(60007760) Failure preparing job
Stack Trace

Newest

NotFound: cannot find 'ext'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1724455756_31925_91921.py", line 102, in respond
```

where a user provided a collection of HTML elements into a fasta/fastq input. This is the only way I can think of where the validation would fail.

Has the nice side-effect that once you build a collection in the history the datatypes for the collection are shown (which currently requires reloading the history).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
