### PR TITLE
Remove Build Dataset Pair option from history actions

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
@@ -211,23 +211,18 @@ describe("History Selection Operations", () => {
 
             it("should display collection building options only on active (non-deleted) items", async () => {
                 const buildListOption = '[data-description="build list"]';
-                const buildPairOption = '[data-description="build pair"]';
                 const buildListOfPairsOption = '[data-description="build list of pairs"]';
                 await wrapper.setProps({ filterText: "visible:true deleted:false" });
                 expect(wrapper.find(buildListOption).exists()).toBe(true);
-                expect(wrapper.find(buildPairOption).exists()).toBe(true);
                 expect(wrapper.find(buildListOfPairsOption).exists()).toBe(true);
                 await wrapper.setProps({ filterText: "deleted:true" });
                 expect(wrapper.find(buildListOption).exists()).toBe(false);
-                expect(wrapper.find(buildPairOption).exists()).toBe(false);
                 expect(wrapper.find(buildListOfPairsOption).exists()).toBe(false);
                 await wrapper.setProps({ filterText: "visible:any deleted:false" });
                 expect(wrapper.find(buildListOption).exists()).toBe(true);
-                expect(wrapper.find(buildPairOption).exists()).toBe(true);
                 expect(wrapper.find(buildListOfPairsOption).exists()).toBe(true);
                 await wrapper.setProps({ filterText: "deleted:any" });
                 expect(wrapper.find(buildListOption).exists()).toBe(false);
-                expect(wrapper.find(buildPairOption).exists()).toBe(false);
                 expect(wrapper.find(buildListOfPairsOption).exists()).toBe(false);
             });
 

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -37,9 +37,6 @@
             <b-dropdown-item v-if="showBuildOptions" data-description="build list" @click="buildDatasetList">
                 <span v-localize>Build Dataset List</span>
             </b-dropdown-item>
-            <b-dropdown-item v-if="showBuildOptions" data-description="build pair" @click="buildDatasetPair">
-                <span v-localize>Build Dataset Pair</span>
-            </b-dropdown-item>
             <b-dropdown-item v-if="showBuildOptions" data-description="build list of pairs" @click="buildListOfPairs">
                 <span v-localize>Build List of Dataset Pairs</span>
             </b-dropdown-item>
@@ -384,9 +381,6 @@ export default {
             allContents = data;
 
             this.buildNewCollection("list", allContents);
-        },
-        async buildDatasetPair() {
-            await this.buildNewCollection("paired");
         },
         async buildListOfPairs() {
             await this.buildNewCollection("list:paired");

--- a/lib/galaxy_test/selenium/test_collection_builders.py
+++ b/lib/galaxy_test/selenium/test_collection_builders.py
@@ -34,18 +34,6 @@ class TestCollectionBuilders(SeleniumTestCase):
 
     @selenium_test
     @managed_history
-    def test_build_pair_simple_hidden(self):
-        self.perform_upload(self.get_filename("1.tabular"))
-        self.perform_upload(self.get_filename("2.tabular"))
-        self._wait_for_and_select([1, 2])
-        self._collection_dropdown("build pair")
-        self.collection_builder_set_name("my awesome pair")
-        self.screenshot("collection_builder_pair")
-        self.collection_builder_create()
-        self._wait_for_hid_visible(5)
-
-    @selenium_test
-    @managed_history
     def test_build_paired_list_simple(self):
         self.perform_upload(self.get_filename("1.tabular"))
         self.perform_upload(self.get_filename("2.tabular"))


### PR DESCRIPTION
As discussed during our team meeting, the Build Dataset Pair option is redundant and should be removed.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
