### PR TITLE
add data source doc to the list in index

### DIFF
--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -17,6 +17,7 @@ A multi-hour long video playlist covering these slides can be found at
   build_a_job_runner
   finding_and_improving_slow_code
   data_managers
+  data_source
   data_types
   faq
   writing_tests


### PR DESCRIPTION
This PR adds data_source documentation link to the list in index file

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
