### PR TITLE
[WIP] Implement Tool Request API

### DIFF
--- a/.github/workflows/framework_tools.yaml
+++ b/.github/workflows/framework_tools.yaml
@@ -26,6 +26,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8']
+        use-legacy-api: ['if_needed', 'always']
     services:
       postgres:
         image: postgres:13
@@ -66,7 +67,7 @@ jobs:
           path: 'galaxy root/.venv'
           key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-framework-tools
       - name: Run tests
-        run: ./run_tests.sh --coverage --framework-tools
+        run: GALAXY_TEST_USE_LEGACY_TOOL_API="${{ matrix.use-legacy-api }}" ./run_tests.sh --coverage --framework-tools
         working-directory: 'galaxy root'
       - uses: codecov/codecov-action@v3
         with:

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -2427,6 +2427,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/histories/{history_id}/tool_requests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Return all the tool requests for the tools submitted to this history. */
+        get: operations["tool_requests_api_histories__history_id__tool_requests_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/histories/{history_id}/unpublish": {
         parameters: {
             query?: never;
@@ -2705,7 +2722,8 @@ export interface paths {
         /** Index */
         get: operations["index_api_jobs_get"];
         put?: never;
-        post?: never;
+        /** Create */
+        post: operations["create_api_jobs_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4175,6 +4193,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/tool_requests/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get tool request state. */
+        get: operations["get_tool_request_api_tool_requests__id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/tool_requests/{id}/state": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get tool request state. */
+        get: operations["tool_request_state_api_tool_requests__id__state_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/tool_shed_repositories": {
         parameters: {
             query?: never;
@@ -4237,6 +4289,23 @@ export interface paths {
         put?: never;
         /** Upload files to Galaxy */
         post: operations["fetch_form_api_tools_fetch_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/tools/{tool_id}/inputs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get tool inputs. */
+        get: operations["tool_inputs_api_tools__tool_id__inputs_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -5956,6 +6025,39 @@ export interface components {
                   )
                 | ("cloud" | "quota" | "no_quota" | "restricted" | "user_defined");
         };
+        /** BaseUrlParameterModel */
+        BaseUrlParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default gx_baseurl
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_baseurl";
+        };
         /** BasicRoleModel */
         BasicRoleModel: {
             /**
@@ -6004,6 +6106,48 @@ export interface components {
             history_id: unknown;
             /** Targets */
             targets: unknown;
+        };
+        /** BooleanParameterModel */
+        BooleanParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Falsevalue */
+            falsevalue?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default gx_boolean
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_boolean";
+            /** Truevalue */
+            truevalue?: string | null;
+            /**
+             * Value
+             * @default false
+             */
+            value: boolean | null;
         };
         /** BroadcastNotificationContent */
         BroadcastNotificationContent: {
@@ -6300,6 +6444,41 @@ export interface components {
          * @enum {string}
          */
         ColletionSourceType: "hda" | "ldda" | "hdca" | "new_collection";
+        /** ColorParameterModel */
+        ColorParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default gx_color
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_color";
+            /** Value */
+            value?: string | null;
+        };
         /** CompositeDataElement */
         CompositeDataElement: {
             /** Md5 */
@@ -6440,6 +6619,82 @@ export interface components {
              * @description The quota source label corresponding to the object store the dataset is stored in (or would be stored in)
              */
             source: string | null;
+        };
+        /** ConditionalParameterModel */
+        ConditionalParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default gx_conditional
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_conditional";
+            /** Test Parameter */
+            test_parameter:
+                | components["schemas"]["BooleanParameterModel"]
+                | components["schemas"]["SelectParameterModel"];
+            /** Whens */
+            whens: components["schemas"]["ConditionalWhen"][];
+        };
+        /** ConditionalWhen */
+        ConditionalWhen: {
+            /** Discriminator */
+            discriminator: boolean | string;
+            /** Is Default When */
+            is_default_when: boolean;
+            /** Parameters */
+            parameters: (
+                | components["schemas"]["CwlIntegerParameterModel"]
+                | components["schemas"]["CwlFloatParameterModel"]
+                | components["schemas"]["CwlStringParameterModel"]
+                | components["schemas"]["CwlBooleanParameterModel"]
+                | components["schemas"]["CwlNullParameterModel"]
+                | components["schemas"]["CwlFileParameterModel"]
+                | components["schemas"]["CwlDirectoryParameterModel"]
+                | components["schemas"]["CwlUnionParameterModel"]
+                | components["schemas"]["TextParameterModel"]
+                | components["schemas"]["IntegerParameterModel"]
+                | components["schemas"]["FloatParameterModel"]
+                | components["schemas"]["BooleanParameterModel"]
+                | components["schemas"]["HiddenParameterModel"]
+                | components["schemas"]["SelectParameterModel"]
+                | components["schemas"]["DataParameterModel"]
+                | components["schemas"]["DataCollectionParameterModel"]
+                | components["schemas"]["DataColumnParameterModel"]
+                | components["schemas"]["DirectoryUriParameterModel"]
+                | components["schemas"]["RulesParameterModel"]
+                | components["schemas"]["DrillDownParameterModel"]
+                | components["schemas"]["GroupTagParameterModel"]
+                | components["schemas"]["BaseUrlParameterModel"]
+                | components["schemas"]["GenomeBuildParameterModel"]
+                | components["schemas"]["ColorParameterModel"]
+                | components["schemas"]["ConditionalParameterModel"]
+                | components["schemas"]["RepeatParameterModel"]
+                | components["schemas"]["SectionParameterModel"]
+            )[];
         };
         /** ConnectAction */
         ConnectAction: {
@@ -7329,6 +7584,155 @@ export interface components {
              */
             username_and_slug?: string | null;
         };
+        /** CwlBooleanParameterModel */
+        CwlBooleanParameterModel: {
+            /** Name */
+            name: string;
+            /**
+             * Parameter Type
+             * @default cwl_boolean
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "cwl_boolean";
+        };
+        /** CwlDirectoryParameterModel */
+        CwlDirectoryParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default cwl_directory
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "cwl_directory";
+        };
+        /** CwlFileParameterModel */
+        CwlFileParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default cwl_file
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "cwl_file";
+        };
+        /** CwlFloatParameterModel */
+        CwlFloatParameterModel: {
+            /** Name */
+            name: string;
+            /**
+             * Parameter Type
+             * @default cwl_float
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "cwl_float";
+        };
+        /** CwlIntegerParameterModel */
+        CwlIntegerParameterModel: {
+            /** Name */
+            name: string;
+            /**
+             * Parameter Type
+             * @default cwl_integer
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "cwl_integer";
+        };
+        /** CwlNullParameterModel */
+        CwlNullParameterModel: {
+            /** Name */
+            name: string;
+            /**
+             * Parameter Type
+             * @default cwl_null
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "cwl_null";
+        };
+        /** CwlStringParameterModel */
+        CwlStringParameterModel: {
+            /** Name */
+            name: string;
+            /**
+             * Parameter Type
+             * @default cwl_string
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "cwl_string";
+        };
+        /** CwlUnionParameterModel */
+        CwlUnionParameterModel: {
+            /** Name */
+            name: string;
+            /**
+             * Parameter Type
+             * @default cwl_union
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "cwl_union";
+            /** Parameters */
+            parameters: (
+                | components["schemas"]["CwlIntegerParameterModel"]
+                | components["schemas"]["CwlFloatParameterModel"]
+                | components["schemas"]["CwlStringParameterModel"]
+                | components["schemas"]["CwlBooleanParameterModel"]
+                | components["schemas"]["CwlNullParameterModel"]
+                | components["schemas"]["CwlFileParameterModel"]
+                | components["schemas"]["CwlDirectoryParameterModel"]
+                | components["schemas"]["CwlUnionParameterModel"]
+            )[];
+        };
         /**
          * DCESummary
          * @description Dataset Collection Element summary information.
@@ -7418,6 +7822,85 @@ export interface components {
              */
             populated?: boolean;
         };
+        /** DataCollectionParameterModel */
+        DataCollectionParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Collection Type */
+            collection_type?: string | null;
+            /**
+             * Extensions
+             * @default [
+             *       "data"
+             *     ]
+             */
+            extensions: string[];
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default gx_data_collection
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_data_collection";
+            /** Value */
+            value: Record<string, never> | null;
+        };
+        /** DataColumnParameterModel */
+        DataColumnParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Multiple */
+            multiple: boolean;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default gx_data_column
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_data_column";
+        };
         /** DataElementsFromTarget */
         DataElementsFromTarget: {
             /**
@@ -7474,6 +7957,55 @@ export interface components {
          * @enum {string}
          */
         DataItemSourceType: "hda" | "ldda" | "hdca" | "dce" | "dc";
+        /** DataParameterModel */
+        DataParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /**
+             * Extensions
+             * @default [
+             *       "data"
+             *     ]
+             */
+            extensions: string[];
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Max */
+            max?: number | null;
+            /** Min */
+            min?: number | null;
+            /**
+             * Multiple
+             * @default false
+             */
+            multiple: boolean;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default gx_data
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_data";
+        };
         /** DatasetAssociationRoles */
         DatasetAssociationRoles: {
             /**
@@ -8104,6 +8636,39 @@ export interface components {
              */
             username: string;
         };
+        /** DirectoryUriParameterModel */
+        DirectoryUriParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default gx_directory_uri
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_directory_uri";
+        };
         /** DisconnectAction */
         DisconnectAction: {
             /**
@@ -8146,6 +8711,59 @@ export interface components {
             name: string;
             /** Version */
             version: string;
+        };
+        /** DrillDownOptionsDict */
+        DrillDownOptionsDict: {
+            /** Name */
+            name: string | null;
+            /** Options */
+            options: components["schemas"]["DrillDownOptionsDict"][];
+            /** Selected */
+            selected: boolean;
+            /** Value */
+            value: string;
+        };
+        /** DrillDownParameterModel */
+        DrillDownParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Hierarchy
+             * @enum {string}
+             */
+            hierarchy: "recurse" | "exact";
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Multiple */
+            multiple: boolean;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /** Options */
+            options?: components["schemas"]["DrillDownOptionsDict"][] | null;
+            /**
+             * Parameter Type
+             * @default gx_drill_down
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_drill_down";
         };
         /** DrsObject */
         DrsObject: {
@@ -8897,6 +9515,45 @@ export interface components {
             /** Step */
             step: components["schemas"]["StepReferenceByOrderIndex"] | components["schemas"]["StepReferenceByLabel"];
         };
+        /** FloatParameterModel */
+        FloatParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Max */
+            max?: number | null;
+            /** Min */
+            min?: number | null;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default gx_float
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_float";
+            /** Value */
+            value?: number | null;
+        };
         /** FolderLibraryFolderItem */
         FolderLibraryFolderItem: {
             /** Can Manage */
@@ -9018,6 +9675,41 @@ export interface components {
             /** Tags */
             tags?: string[] | null;
         };
+        /** GenomeBuildParameterModel */
+        GenomeBuildParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Multiple */
+            multiple: boolean;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default gx_genomebuild
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_genomebuild";
+        };
         /**
          * GroupCreatePayload
          * @description Payload schema for creating a group.
@@ -9127,6 +9819,41 @@ export interface components {
              * @description The relative URL to access this item.
              */
             url: string;
+        };
+        /** GroupTagParameterModel */
+        GroupTagParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Multiple */
+            multiple: boolean;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default gx_group_tag
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_group_tag";
         };
         /** GroupUpdatePayload */
         GroupUpdatePayload: {
@@ -10723,6 +11450,41 @@ export interface components {
         HelpForumUser: {
             [key: string]: unknown;
         };
+        /** HiddenParameterModel */
+        HiddenParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default gx_hidden
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_hidden";
+            /** Value */
+            value: string | null;
+        };
         /**
          * HistoryActiveContentCounts
          * @description Contains the number of active, deleted or hidden items in a History.
@@ -11377,6 +12139,42 @@ export interface components {
             tool_shed_status: components["schemas"]["InstalledRepositoryToolShedStatus"] | null;
             /** Uninstalled */
             uninstalled: boolean;
+        };
+        /** IntegerParameterModel */
+        IntegerParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Max */
+            max?: number | null;
+            /** Min */
+            min?: number | null;
+            /** Name */
+            name: string;
+            /** Optional */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default gx_integer
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_integer";
+            /** Value */
+            value?: number | null;
         };
         /** InvocationCancellationHistoryDeletedResponse */
         InvocationCancellationHistoryDeletedResponse: {
@@ -12266,6 +13064,15 @@ export interface components {
              */
             update_time: string;
         };
+        /** JobCreateResponse */
+        JobCreateResponse: {
+            task_result: components["schemas"]["AsyncTaskResultSummary"];
+            /**
+             * Tool Request Id
+             * @example 0123456789ABCDEF
+             */
+            tool_request_id: string;
+        };
         /** JobDestinationParams */
         JobDestinationParams: {
             /**
@@ -12544,6 +13351,19 @@ export interface components {
              */
             name: string;
         };
+        /** JobOutputCollectionAssociation */
+        JobOutputCollectionAssociation: {
+            /**
+             * dataset_collection_instance
+             * @description Reference to the associated item.
+             */
+            dataset_collection_instance: components["schemas"]["EncodedDataItemSourceId"];
+            /**
+             * name
+             * @description Name of the job parameter.
+             */
+            name: string;
+        };
         /** JobParameter */
         JobParameter: {
             /**
@@ -12571,6 +13391,47 @@ export interface components {
                 | boolean
                 | string
                 | null;
+        };
+        /** JobRequest */
+        JobRequest: {
+            /**
+             * history_id
+             * @description TODO
+             */
+            history_id?: string | null;
+            /**
+             * Inputs
+             * @description TODO
+             */
+            inputs?: Record<string, never> | null;
+            /**
+             * rerun_remap_job_id
+             * @description TODO
+             */
+            rerun_remap_job_id?: string | null;
+            /**
+             * Send Email Notification
+             * @description TODO
+             * @default false
+             */
+            send_email_notification: boolean;
+            /**
+             * tool_id
+             * @description TODO
+             */
+            tool_id?: string | null;
+            /**
+             * tool_uuid
+             * @description TODO
+             */
+            tool_uuid?: string | null;
+            /**
+             * tool_version
+             * @description TODO
+             */
+            tool_version?: string | null;
+            /** use_cached_jobs */
+            use_cached_jobs?: boolean | null;
         };
         /**
          * JobSourceType
@@ -12703,6 +13564,15 @@ export interface components {
              * @description The email of the user that owns this job. Only the owner of the job and administrators can see this value.
              */
             user_email?: string | null;
+        };
+        /** LabelValue */
+        LabelValue: {
+            /** Label */
+            label: string;
+            /** Selected */
+            selected: boolean;
+            /** Value */
+            value: string;
         };
         /**
          * LabelValuePair
@@ -14632,6 +15502,73 @@ export interface components {
              */
             action_type: "remove_unlabeled_workflow_outputs";
         };
+        /** RepeatParameterModel */
+        RepeatParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Max */
+            max?: number | null;
+            /** Min */
+            min?: number | null;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default gx_repeat
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_repeat";
+            /** Parameters */
+            parameters: (
+                | components["schemas"]["CwlIntegerParameterModel"]
+                | components["schemas"]["CwlFloatParameterModel"]
+                | components["schemas"]["CwlStringParameterModel"]
+                | components["schemas"]["CwlBooleanParameterModel"]
+                | components["schemas"]["CwlNullParameterModel"]
+                | components["schemas"]["CwlFileParameterModel"]
+                | components["schemas"]["CwlDirectoryParameterModel"]
+                | components["schemas"]["CwlUnionParameterModel"]
+                | components["schemas"]["TextParameterModel"]
+                | components["schemas"]["IntegerParameterModel"]
+                | components["schemas"]["FloatParameterModel"]
+                | components["schemas"]["BooleanParameterModel"]
+                | components["schemas"]["HiddenParameterModel"]
+                | components["schemas"]["SelectParameterModel"]
+                | components["schemas"]["DataParameterModel"]
+                | components["schemas"]["DataCollectionParameterModel"]
+                | components["schemas"]["DataColumnParameterModel"]
+                | components["schemas"]["DirectoryUriParameterModel"]
+                | components["schemas"]["RulesParameterModel"]
+                | components["schemas"]["DrillDownParameterModel"]
+                | components["schemas"]["GroupTagParameterModel"]
+                | components["schemas"]["BaseUrlParameterModel"]
+                | components["schemas"]["GenomeBuildParameterModel"]
+                | components["schemas"]["ColorParameterModel"]
+                | components["schemas"]["ConditionalParameterModel"]
+                | components["schemas"]["RepeatParameterModel"]
+                | components["schemas"]["SectionParameterModel"]
+            )[];
+        };
         /** Report */
         Report: {
             /** Markdown */
@@ -14739,6 +15676,39 @@ export interface components {
         RootModel_Dict_str__int__: {
             [key: string]: number;
         };
+        /** RulesParameterModel */
+        RulesParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default gx_rules
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_rules";
+        };
         /** SearchJobsPayload */
         SearchJobsPayload: {
             /**
@@ -14758,6 +15728,106 @@ export interface components {
             tool_id: string;
         } & {
             [key: string]: unknown;
+        };
+        /** SectionParameterModel */
+        SectionParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default gx_section
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_section";
+            /** Parameters */
+            parameters: (
+                | components["schemas"]["CwlIntegerParameterModel"]
+                | components["schemas"]["CwlFloatParameterModel"]
+                | components["schemas"]["CwlStringParameterModel"]
+                | components["schemas"]["CwlBooleanParameterModel"]
+                | components["schemas"]["CwlNullParameterModel"]
+                | components["schemas"]["CwlFileParameterModel"]
+                | components["schemas"]["CwlDirectoryParameterModel"]
+                | components["schemas"]["CwlUnionParameterModel"]
+                | components["schemas"]["TextParameterModel"]
+                | components["schemas"]["IntegerParameterModel"]
+                | components["schemas"]["FloatParameterModel"]
+                | components["schemas"]["BooleanParameterModel"]
+                | components["schemas"]["HiddenParameterModel"]
+                | components["schemas"]["SelectParameterModel"]
+                | components["schemas"]["DataParameterModel"]
+                | components["schemas"]["DataCollectionParameterModel"]
+                | components["schemas"]["DataColumnParameterModel"]
+                | components["schemas"]["DirectoryUriParameterModel"]
+                | components["schemas"]["RulesParameterModel"]
+                | components["schemas"]["DrillDownParameterModel"]
+                | components["schemas"]["GroupTagParameterModel"]
+                | components["schemas"]["BaseUrlParameterModel"]
+                | components["schemas"]["GenomeBuildParameterModel"]
+                | components["schemas"]["ColorParameterModel"]
+                | components["schemas"]["ConditionalParameterModel"]
+                | components["schemas"]["RepeatParameterModel"]
+                | components["schemas"]["SectionParameterModel"]
+            )[];
+        };
+        /** SelectParameterModel */
+        SelectParameterModel: {
+            /** Argument */
+            argument?: string | null;
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Multiple */
+            multiple: boolean;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /** Options */
+            options?: components["schemas"]["LabelValue"][] | null;
+            /**
+             * Parameter Type
+             * @default gx_select
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_select";
         };
         /** ServerDirElement */
         ServerDirElement: {
@@ -15739,6 +16809,51 @@ export interface components {
              */
             type: "string";
         };
+        /** TextParameterModel */
+        TextParameterModel: {
+            /**
+             * Area
+             * @default false
+             */
+            area: boolean;
+            /** Argument */
+            argument?: string | null;
+            /**
+             * Default Options
+             * @default []
+             */
+            default_options: components["schemas"]["LabelValue"][];
+            /** Help */
+            help?: string | null;
+            /**
+             * Hidden
+             * @default false
+             */
+            hidden: boolean;
+            /**
+             * Is Dynamic
+             * @default false
+             */
+            is_dynamic: boolean;
+            /** Label */
+            label?: string | null;
+            /** Name */
+            name: string;
+            /**
+             * Optional
+             * @default false
+             */
+            optional: boolean;
+            /**
+             * Parameter Type
+             * @default gx_text
+             * @constant
+             * @enum {string}
+             */
+            parameter_type: "gx_text";
+            /** Value */
+            value?: string | null;
+        };
         /** ToolDataDetails */
         ToolDataDetails: {
             /**
@@ -15819,6 +16934,25 @@ export interface components {
              */
             values: string;
         };
+        /** ToolRequestModel */
+        ToolRequestModel: {
+            /**
+             * ID
+             * @description Encoded ID of the role
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /** Request */
+            request: Record<string, never>;
+            state: components["schemas"]["ToolRequestState"];
+            /** State Message */
+            state_message: string | null;
+        };
+        /**
+         * ToolRequestState
+         * @enum {string}
+         */
+        ToolRequestState: "new" | "submitted" | "failed";
         /** ToolStep */
         ToolStep: {
             /**
@@ -25206,6 +26340,50 @@ export interface operations {
             };
         };
     };
+    tool_requests_api_histories__history_id__tool_requests_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The encoded database identifier of the History. */
+                history_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ToolRequestModel"][];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
     unpublish_api_histories__history_id__unpublish_put: {
         parameters: {
             query?: never;
@@ -26035,6 +27213,8 @@ export interface operations {
                 invocation_id?: string | null;
                 /** @description Limit listing of jobs to those that match the specified implicit collection job ID. If none, jobs from any implicit collection execution (or from no implicit collection execution) may be returned. */
                 implicit_collection_jobs_id?: string | null;
+                /** @description Limit listing of jobs to those that were created from the supplied tool request ID. If none, jobs from any tool request (or from no workflows) may be returned. */
+                tool_request_id?: string | null;
                 /** @description Sort results by specified field. */
                 order_by?: components["schemas"]["JobIndexSortByEnum"];
                 /** @description A mix of free text and GitHub-style tags used to filter the index operation.
@@ -26105,6 +27285,51 @@ export interface operations {
                         | components["schemas"]["EncodedJobDetails"]
                         | components["schemas"]["JobSummary"]
                     )[];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    create_api_jobs_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["JobRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobCreateResponse"];
                 };
             };
             /** @description Request Error */
@@ -26568,7 +27793,10 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["JobOutputAssociation"][];
+                    "application/json": (
+                        | components["schemas"]["JobOutputAssociation"]
+                        | components["schemas"]["JobOutputCollectionAssociation"]
+                    )[];
                 };
             };
             /** @description Request Error */
@@ -30587,6 +31815,92 @@ export interface operations {
             };
         };
     };
+    get_tool_request_api_tool_requests__id__get: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ToolRequestModel"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    tool_request_state_api_tool_requests__id__state_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
     index_api_tool_shed_repositories_get: {
         parameters: {
             query?: {
@@ -30743,6 +32057,80 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    tool_inputs_api_tools__tool_id__inputs_get: {
+        parameters: {
+            query?: {
+                tool_version?: string | null;
+            };
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The tool ID for the lineage stored in Galaxy's toolbox. */
+                tool_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": (
+                        | components["schemas"]["CwlIntegerParameterModel"]
+                        | components["schemas"]["CwlFloatParameterModel"]
+                        | components["schemas"]["CwlStringParameterModel"]
+                        | components["schemas"]["CwlBooleanParameterModel"]
+                        | components["schemas"]["CwlNullParameterModel"]
+                        | components["schemas"]["CwlFileParameterModel"]
+                        | components["schemas"]["CwlDirectoryParameterModel"]
+                        | components["schemas"]["CwlUnionParameterModel"]
+                        | components["schemas"]["TextParameterModel"]
+                        | components["schemas"]["IntegerParameterModel"]
+                        | components["schemas"]["FloatParameterModel"]
+                        | components["schemas"]["BooleanParameterModel"]
+                        | components["schemas"]["HiddenParameterModel"]
+                        | components["schemas"]["SelectParameterModel"]
+                        | components["schemas"]["DataParameterModel"]
+                        | components["schemas"]["DataCollectionParameterModel"]
+                        | components["schemas"]["DataColumnParameterModel"]
+                        | components["schemas"]["DirectoryUriParameterModel"]
+                        | components["schemas"]["RulesParameterModel"]
+                        | components["schemas"]["DrillDownParameterModel"]
+                        | components["schemas"]["GroupTagParameterModel"]
+                        | components["schemas"]["BaseUrlParameterModel"]
+                        | components["schemas"]["GenomeBuildParameterModel"]
+                        | components["schemas"]["ColorParameterModel"]
+                        | components["schemas"]["ConditionalParameterModel"]
+                        | components["schemas"]["RepeatParameterModel"]
+                        | components["schemas"]["SectionParameterModel"]
+                    )[];
                 };
             };
             /** @description Request Error */

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -672,6 +672,10 @@ class GalaxyManagerApplication(MinimalManagerApp, MinimalGalaxyApplication, Inst
         self._register_singleton(Registry, self.datatypes_registry)
         galaxy.model.set_datatypes_registry(self.datatypes_registry)
         self.configure_sentry_client()
+        # Load dbkey / genome build manager
+        self._configure_genome_builds(data_table_name="__dbkeys__", load_old_style=True)
+        # Tool Data Tables
+        self._configure_tool_data_tables(from_shed_config=False)
 
         self._configure_tool_shed_registry()
         self._register_singleton(tool_shed_registry.Registry, self.tool_shed_registry)
@@ -749,11 +753,6 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
             TestDataResolver, TestDataResolver(file_dirs=self.config.tool_test_data_directories)
         )
         self.api_keys_manager = self._register_singleton(ApiKeyManager)
-
-        # Tool Data Tables
-        self._configure_tool_data_tables(from_shed_config=False)
-        # Load dbkey / genome build manager
-        self._configure_genome_builds(data_table_name="__dbkeys__", load_old_style=True)
 
         # Genomes
         self.genomes = self._register_singleton(Genomes)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/7ffd33d5d144_implement_structured_tool_state.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/7ffd33d5d144_implement_structured_tool_state.py
@@ -1,0 +1,96 @@
+"""implement structured tool state
+
+Revision ID: 7ffd33d5d144
+Revises: eee9229a9765
+Create Date: 2022-11-09 15:53:11.451185
+
+"""
+
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+)
+
+from galaxy.model.custom_types import JSONType
+from galaxy.model.database_object_names import build_index_name
+from galaxy.model.migrations.util import (
+    add_column,
+    create_foreign_key,
+    create_index,
+    create_table,
+    drop_column,
+    drop_index,
+    drop_table,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "7ffd33d5d144"
+down_revision = "eee9229a9765"
+branch_labels = None
+depends_on = None
+
+job_table_name = "job"
+tool_source_table_name = "tool_source"
+tool_request_table_name = "tool_request"
+request_column_name = "tool_request_id"
+job_request_index_name = build_index_name(job_table_name, request_column_name)
+
+
+def upgrade():
+    with transaction():
+        create_table(
+            tool_source_table_name,
+            Column("id", Integer, primary_key=True),
+            Column("hash", String(255), index=True),
+            Column("source", JSONType),
+        )
+        create_table(
+            tool_request_table_name,
+            Column("id", Integer, primary_key=True),
+            Column("request", JSONType),
+            Column("state", String(32)),
+            Column("state_message", JSONType),
+            Column("tool_source_id", Integer, index=True),
+            Column("history_id", Integer, index=True),
+        )
+
+        create_foreign_key(
+            "foreign_key_tool_source_id",
+            tool_request_table_name,
+            tool_source_table_name,
+            ["tool_source_id"],
+            ["id"],
+        )
+
+        create_foreign_key(
+            "foreign_key_history_id",
+            tool_request_table_name,
+            "history",
+            ["history_id"],
+            ["id"],
+        )
+
+        add_column(
+            job_table_name,
+            Column(request_column_name, Integer, default=None),
+        )
+
+        create_foreign_key(
+            "foreign_key_tool_request_id",
+            job_table_name,
+            tool_request_table_name,
+            ["tool_request_id"],
+            ["id"],
+        )
+
+        create_index(job_request_index_name, job_table_name, [request_column_name])
+
+
+def downgrade():
+    with transaction():
+        drop_index(job_request_index_name, job_table_name)
+        drop_column(job_table_name, request_column_name)
+        drop_table(tool_request_table_name)
+        drop_table(tool_source_table_name)

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -82,6 +82,19 @@ class JobOutputAssociation(JobAssociation):
     )
 
 
+class JobOutputCollectionAssociation(Model):
+    name: str = Field(
+        default=...,
+        title="name",
+        description="Name of the job parameter.",
+    )
+    dataset_collection_instance: EncodedDataItemSourceId = Field(
+        default=...,
+        title="dataset_collection_instance",
+        description="Reference to the associated item.",
+    )
+
+
 class ReportJobErrorPayload(Model):
     dataset_id: DecodedDatabaseIdField = Field(
         default=...,

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1533,6 +1533,7 @@ class JobIndexQueryPayload(Model):
     workflow_id: Optional[DecodedDatabaseIdField] = None
     invocation_id: Optional[DecodedDatabaseIdField] = None
     implicit_collection_jobs_id: Optional[DecodedDatabaseIdField] = None
+    tool_request_id: Optional[DecodedDatabaseIdField] = None
     order_by: JobIndexSortByEnum = JobIndexSortByEnum.update_time
     search: Optional[str] = None
     limit: int = 500
@@ -3730,6 +3731,22 @@ class AsyncTaskResultSummary(Model):
         None,
         title="Queue of task being done derived from Celery AsyncResult",
     )
+
+
+ToolRequestIdField = Field(title="ID", description="Encoded ID of the role")
+
+
+class ToolRequestState(str, Enum):
+    NEW = "new"
+    SUBMITTED = "submitted"
+    FAILED = "failed"
+
+
+class ToolRequestModel(Model):
+    id: EncodedDatabaseIdField = ToolRequestIdField
+    request: Dict[str, Any]
+    state: ToolRequestState
+    state_message: Optional[str]
 
 
 class AsyncFile(Model):

--- a/lib/galaxy/schema/tasks.py
+++ b/lib/galaxy/schema/tasks.py
@@ -119,3 +119,16 @@ class ComputeDatasetHashTaskRequest(Model):
 
 class PurgeDatasetsTaskRequest(Model):
     dataset_ids: List[int]
+
+
+class ToolSource(Model):
+    raw_tool_source: str
+    tool_dir: str
+
+
+class QueueJobs(Model):
+    tool_source: ToolSource
+    tool_request_id: int  # links to request ("incoming") and history
+    user: RequestUser  # TODO: test anonymous users through this submission path
+    use_cached_jobs: bool
+    rerun_remap_job_id: Optional[int]  # link to a job to rerun & remap

--- a/lib/galaxy/tool_util/parameters/__init__.py
+++ b/lib/galaxy/tool_util/parameters/__init__.py
@@ -62,6 +62,7 @@ from .visitor import (
     repeat_inputs_to_array,
     validate_explicit_conditional_test_value,
     visit_input_values,
+    VISITOR_NO_REPLACEMENT,
 )
 
 __all__ = (
@@ -116,6 +117,7 @@ __all__ = (
     "keys_starting_with",
     "visit_input_values",
     "repeat_inputs_to_array",
+    "VISITOR_NO_REPLACEMENT",
     "decode",
     "encode",
     "WorkflowStepToolState",

--- a/lib/galaxy/tool_util/parameters/__init__.py
+++ b/lib/galaxy/tool_util/parameters/__init__.py
@@ -2,6 +2,7 @@ from .case import test_case_state
 from .convert import (
     decode,
     encode,
+    encode_test,
 )
 from .factory import (
     from_input_source,
@@ -26,7 +27,9 @@ from .models import (
     CwlStringParameterModel,
     CwlUnionParameterModel,
     DataCollectionParameterModel,
+    DataCollectionRequest,
     DataParameterModel,
+    DataRequest,
     FloatParameterModel,
     HiddenParameterModel,
     IntegerParameterModel,
@@ -75,6 +78,8 @@ __all__ = (
     "JobInternalToolState",
     "ToolParameterBundle",
     "ToolParameterBundleModel",
+    "DataRequest",
+    "DataCollectionRequest",
     "ToolParameterModel",
     "IntegerParameterModel",
     "BooleanParameterModel",
@@ -120,6 +125,7 @@ __all__ = (
     "VISITOR_NO_REPLACEMENT",
     "decode",
     "encode",
+    "encode_test",
     "WorkflowStepToolState",
     "WorkflowStepLinkedToolState",
 )

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -286,11 +286,14 @@ def _select_which_when(
     conditional: ConditionalParameterModel, state: dict, inputs: ToolSourceTestInputs, prefix: str
 ) -> ConditionalWhen:
     test_parameter = conditional.test_parameter
+    is_boolean = test_parameter.parameter_type == "gx_boolean"
     test_parameter_name = test_parameter.name
     test_parameter_flat_path = flat_state_path(test_parameter_name, prefix)
 
     test_input = _input_for(test_parameter_flat_path, inputs)
     explicit_test_value = test_input["value"] if test_input else None
+    if is_boolean and isinstance(explicit_test_value, str):
+        explicit_test_value = asbool(explicit_test_value)
     test_value = validate_explicit_conditional_test_value(test_parameter_name, explicit_test_value)
     for when in conditional.whens:
         if test_value is None and when.is_default_when:

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -12,10 +12,13 @@ from typing import (
 from packaging.version import Version
 
 from galaxy.tool_util.parser.interface import (
+    TestCollectionDef,
     ToolSource,
     ToolSourceTest,
     ToolSourceTestInput,
     ToolSourceTestInputs,
+    xml_data_input_to_json,
+    XmlTestCollectionDefDict,
 )
 from galaxy.util import asbool
 from .factory import input_models_for_tool_source
@@ -25,6 +28,7 @@ from .models import (
     ConditionalWhen,
     DataCollectionParameterModel,
     DataColumnParameterModel,
+    DataParameterModel,
     FloatParameterModel,
     IntegerParameterModel,
     RepeatParameterModel,
@@ -249,8 +253,26 @@ def _merge_into_state(
     else:
         test_input = _input_for(state_path, inputs)
         if test_input is not None:
+            input_value: Any
             if isinstance(tool_input, (DataCollectionParameterModel,)):
-                input_value = test_input.get("attributes", {}).get("collection")
+                input_value = TestCollectionDef.from_dict(
+                    cast(XmlTestCollectionDefDict, test_input.get("attributes", {}).get("collection"))
+                ).test_format_to_dict()
+            elif isinstance(tool_input, (DataParameterModel,)):
+                data_tool_input = cast(DataParameterModel, tool_input)
+                if data_tool_input.multiple:
+                    value = test_input["value"]
+                    input_value_list = []
+                    if value:
+                        test_input_values = cast(str, value).split(",")
+                        for test_input_value in test_input_values:
+                            instance_test_input = test_input.copy()
+                            instance_test_input["value"] = test_input_value
+                            input_value = xml_data_input_to_json(test_input)
+                            input_value_list.append(input_value)
+                    input_value = input_value_list
+                else:
+                    input_value = xml_data_input_to_json(test_input)
             else:
                 input_value = test_input["value"]
                 input_value = legacy_from_string(tool_input, input_value, warnings, profile)

--- a/lib/galaxy/tool_util/parameters/convert.py
+++ b/lib/galaxy/tool_util/parameters/convert.py
@@ -1,23 +1,37 @@
 """Utilities for converting between request states.
 """
 
+import logging
 from typing import (
     Any,
     Callable,
+    cast,
+    List,
 )
 
+from galaxy.tool_util.parser.interface import (
+    JsonTestCollectionDefDict,
+    JsonTestDatasetDefDict,
+)
 from .models import (
+    DataCollectionRequest,
+    DataParameterModel,
+    DataRequest,
+    SelectParameterModel,
     ToolParameterBundle,
     ToolParameterT,
 )
 from .state import (
     RequestInternalToolState,
     RequestToolState,
+    TestCaseToolState,
 )
 from .visitor import (
     visit_input_values,
     VISITOR_NO_REPLACEMENT,
 )
+
+log = logging.getLogger(__name__)
 
 
 def decode(
@@ -27,13 +41,24 @@ def decode(
 
     external_state.validate(input_models)
 
+    def decode_src_dict(src_dict: dict):
+        assert "id" in src_dict
+        decoded_dict = src_dict.copy()
+        decoded_dict["id"] = decode_id(src_dict["id"])
+        return decoded_dict
+
     def decode_callback(parameter: ToolParameterT, value: Any):
         if parameter.parameter_type == "gx_data":
+            data_parameter = cast(DataParameterModel, parameter)
+            if data_parameter.multiple:
+                assert isinstance(value, list), str(value)
+                return list(map(decode_src_dict, value))
+            else:
+                assert isinstance(value, dict), str(value)
+                return decode_src_dict(value)
+        elif parameter.parameter_type == "gx_data_collection":
             assert isinstance(value, dict), str(value)
-            assert "id" in value
-            decoded_dict = value.copy()
-            decoded_dict["id"] = decode_id(value["id"])
-            return decoded_dict
+            return decode_src_dict(value)
         else:
             return VISITOR_NO_REPLACEMENT
 
@@ -53,19 +78,80 @@ def encode(
 ) -> RequestToolState:
     """Prepare an external representation of tool state (request) for storing in the database (request_internal)."""
 
+    def encode_src_dict(src_dict: dict):
+        assert "id" in src_dict
+        encoded_dict = src_dict.copy()
+        encoded_dict["id"] = encode_id(src_dict["id"])
+        return encoded_dict
+
     def encode_callback(parameter: ToolParameterT, value: Any):
         if parameter.parameter_type == "gx_data":
+            data_parameter = cast(DataParameterModel, parameter)
+            if data_parameter.multiple:
+                assert isinstance(value, list), str(value)
+                return list(map(encode_src_dict, value))
+            else:
+                assert isinstance(value, dict), str(value)
+                return encode_src_dict(value)
+        elif parameter.parameter_type == "gx_data_collection":
             assert isinstance(value, dict), str(value)
-            assert "id" in value
-            encoded_dict = value.copy()
-            encoded_dict["id"] = encode_id(value["id"])
-            return encoded_dict
+            return encode_src_dict(value)
         else:
             return VISITOR_NO_REPLACEMENT
 
     request_state_dict = visit_input_values(
         input_models,
         external_state,
+        encode_callback,
+    )
+    request_state = RequestToolState(request_state_dict)
+    request_state.validate(input_models)
+    return request_state
+
+
+# interfaces for adapting test data dictionaries to tool request dictionaries
+# e.g. {class: File, path: foo.bed} => {src: hda, id: ab1235cdfea3}
+AdaptDatasets = Callable[[JsonTestDatasetDefDict], DataRequest]
+AdaptCollections = Callable[[JsonTestCollectionDefDict], DataCollectionRequest]
+
+
+def encode_test(
+    test_case_state: TestCaseToolState,
+    input_models: ToolParameterBundle,
+    adapt_datasets: AdaptDatasets,
+    adapt_collections: AdaptCollections,
+):
+
+    def encode_callback(parameter: ToolParameterT, value: Any):
+        if parameter.parameter_type == "gx_data":
+            data_parameter = cast(DataParameterModel, parameter)
+            if value is not None:
+                if data_parameter.multiple:
+                    assert isinstance(value, list), str(value)
+                    test_datasets = cast(List[JsonTestDatasetDefDict], value)
+                    return [d.model_dump() for d in map(adapt_datasets, test_datasets)]
+                else:
+                    assert isinstance(value, dict), str(value)
+                    test_dataset = cast(JsonTestDatasetDefDict, value)
+                    return adapt_datasets(test_dataset).model_dump()
+        elif parameter.parameter_type == "gx_data_collection":
+            # data_collection_parameter = cast(DataCollectionParameterModel, parameter)
+            if value is not None:
+                assert isinstance(value, dict), str(value)
+                test_collection = cast(JsonTestCollectionDefDict, value)
+                return adapt_collections(test_collection).model_dump()
+        elif parameter.parameter_type == "gx_select":
+            select_parameter = cast(SelectParameterModel, parameter)
+            if select_parameter.multiple and value is not None:
+                return [v.strip() for v in value.split(",")]
+            else:
+                return VISITOR_NO_REPLACEMENT
+
+        return VISITOR_NO_REPLACEMENT
+
+    request_state_dict = visit_input_values(
+        input_models,
+        test_case_state,
         encode_callback,
     )
     request_state = RequestToolState(request_state_dict)

--- a/lib/galaxy/tool_util/parameters/factory.py
+++ b/lib/galaxy/tool_util/parameters/factory.py
@@ -229,7 +229,9 @@ def _from_input_source_galaxy(input_source: InputSource) -> ToolParameterT:
             if typed_value == default_test_value:
                 is_default_when = True
             whens.append(
-                ConditionalWhen(discriminator=value, parameters=tool_parameter_models, is_default_when=is_default_when)
+                ConditionalWhen(
+                    discriminator=typed_value, parameters=tool_parameter_models, is_default_when=is_default_when
+                )
             )
         return ConditionalParameterModel(
             name=input_source.parse_name(),

--- a/lib/galaxy/tool_util/parameters/models.py
+++ b/lib/galaxy/tool_util/parameters/models.py
@@ -41,7 +41,8 @@ from typing_extensions import (
 from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.tool_util.parser.interface import (
     DrillDownOptionsDict,
-    TestCollectionDefDict,
+    JsonTestCollectionDefDict,
+    JsonTestDatasetDefDict,
 )
 from ._types import (
     cast_as_type,
@@ -312,9 +313,9 @@ class DataParameterModel(BaseGalaxyToolParameterModelDefinition):
     def py_type_test_case(self) -> Type:
         base_model: Type
         if self.multiple:
-            base_model = str
+            base_model = list_type(JsonTestDatasetDefDict)
         else:
-            base_model = str
+            base_model = JsonTestDatasetDefDict
         return optional_if_needed(base_model, self.optional)
 
     def pydantic_template(self, state_representation: StateRepresentationT) -> DynamicModelInformation:
@@ -372,7 +373,7 @@ class DataCollectionParameterModel(BaseGalaxyToolParameterModelDefinition):
         elif state_representation == "workflow_step_linked":
             return dynamic_model_information_from_py_type(self, ConnectedValue)
         elif state_representation == "test_case_xml":
-            return dynamic_model_information_from_py_type(self, TestCollectionDefDict)
+            return dynamic_model_information_from_py_type(self, JsonTestCollectionDefDict)
         else:
             raise NotImplementedError(
                 f"Have not implemented data collection parameter models for state representation {state_representation}"
@@ -1183,7 +1184,7 @@ def to_simple_model(input_parameter: Union[ToolParameterModel, ToolParameterT]) 
 def simple_input_models(
     input_models: Union[List[ToolParameterModel], List[ToolParameterT]]
 ) -> Iterable[ToolParameterT]:
-    return [to_simple_model(m) for m in input_models]
+    return [to_simple_model(m) for m in parameters]
 
 
 def create_model_strict(*args, **kwd) -> Type[BaseModel]:

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -8,6 +8,7 @@ from abc import (
 from os.path import join
 from typing import (
     Any,
+    cast,
     Dict,
     List,
     Optional,
@@ -557,7 +558,8 @@ class PageSource(metaclass=ABCMeta):
         """Return a list of InputSource objects."""
 
 
-TestCollectionDefElementObject = Union["TestCollectionDefDict", "ToolSourceTestInput"]
+AnyTestCollectionDefDict = Union["JsonTestCollectionDefDict", "XmlTestCollectionDefDict"]
+TestCollectionDefElementObject = Union[AnyTestCollectionDefDict, "ToolSourceTestInput"]
 TestCollectionAttributeDict = Dict[str, Any]
 CollectionType = str
 
@@ -567,7 +569,16 @@ class TestCollectionDefElementDict(TypedDict):
     element_definition: TestCollectionDefElementObject
 
 
-class TestCollectionDefDict(TypedDict):
+class TestCollectionDefElementInternal(TypedDict):
+    element_identifier: str
+    element_definition: Union["TestCollectionDef", "ToolSourceTestInput"]
+
+
+# two versions of collection inputs can be parsed out, XmlTestCollectionDefDict is historically
+# used by tools and Galaxy internals and exposed in the API via the test definition endpoints for
+# tool execution. JsonTestCollectionDefDict is the format consumed by Planemo that mirrors a CWL
+# way of defining inputs.
+class XmlTestCollectionDefDict(TypedDict):
     model_class: Literal["TestCollectionDef"]
     attributes: TestCollectionAttributeDict
     collection_type: CollectionType
@@ -575,8 +586,96 @@ class TestCollectionDefDict(TypedDict):
     name: str
 
 
+JsonTestDatasetDefDict = TypedDict(
+    "JsonTestDatasetDefDict",
+    {
+        "class": Literal["File"],
+        "path": NotRequired[Optional[str]],
+        "location": NotRequired[Optional[str]],
+        "name": NotRequired[Optional[str]],
+        "dbkey": NotRequired[Optional[str]],
+        "filetype": NotRequired[Optional[str]],
+        "composite_data": NotRequired[Optional[List[str]]],
+        "tags": NotRequired[Optional[List[str]]],
+    },
+)
+
+JsonTestCollectionDefElementDict = Union[
+    "JsonTestCollectionDefDatasetElementDict", "JsonTestCollectionDefCollectionElementDict"
+]
+JsonTestCollectionDefDatasetElementDict = TypedDict(
+    "JsonTestCollectionDefDatasetElementDict",
+    {
+        "identifier": str,
+        "class": Literal["File"],
+        "path": NotRequired[Optional[str]],
+        "location": NotRequired[Optional[str]],
+        "name": NotRequired[Optional[str]],
+        "dbkey": NotRequired[Optional[str]],
+        "filetype": NotRequired[Optional[str]],
+        "composite_data": NotRequired[Optional[List[str]]],
+        "tags": NotRequired[Optional[List[str]]],
+    },
+)
+BaseJsonTestCollectionDefCollectionElementDict = TypedDict(
+    "BaseJsonTestCollectionDefCollectionElementDict",
+    {
+        "class": Literal["Collection"],
+        "collection_type": str,
+        "elements": NotRequired[Optional[List[JsonTestCollectionDefElementDict]]],
+    },
+)
+JsonTestCollectionDefCollectionElementDict = TypedDict(
+    "JsonTestCollectionDefCollectionElementDict",
+    {
+        "identifier": str,
+        "class": Literal["Collection"],
+        "collection_type": str,
+        "elements": NotRequired[Optional[List[JsonTestCollectionDefElementDict]]],
+    },
+)
+JsonTestCollectionDefDict = TypedDict(
+    "JsonTestCollectionDefDict",
+    {
+        "class": Literal["Collection"],
+        "collection_type": str,
+        "elements": NotRequired[Optional[List[JsonTestCollectionDefElementDict]]],
+        "name": NotRequired[Optional[str]],
+    },
+)
+
+
+def xml_data_input_to_json(xml_input: ToolSourceTestInput) -> "JsonTestDatasetDefDict":
+    attributes = xml_input["attributes"]
+    as_dict: JsonTestDatasetDefDict = {
+        "class": "File",
+    }
+    value = xml_input["value"]
+    if value:
+        as_dict["path"] = value
+    _copy_if_exists(attributes, as_dict, "location")
+    _copy_if_exists(attributes, as_dict, "dbkey")
+    _copy_if_exists(attributes, as_dict, "ftype", "filetype")
+    _copy_if_exists(attributes, as_dict, "composite_data", only_if_value=True)
+    tags = attributes.get("tags")
+    if tags:
+        as_dict["tags"] = [t.strip() for t in tags.split(",")]
+    return as_dict
+
+
+def _copy_if_exists(attributes, as_dict, name: str, as_name: Optional[str] = None, only_if_value: bool = False):
+    if name in attributes:
+        value = attributes[name]
+        if not value and only_if_value:
+            return
+        if as_name is None:
+            as_name = name
+        as_dict[as_name] = value
+
+
 class TestCollectionDef:
     __test__ = False  # Prevent pytest from discovering this class (issue #12071)
+    elements: List[TestCollectionDefElementInternal]
 
     def __init__(self, attrib, name, collection_type, elements):
         self.attrib = attrib
@@ -584,7 +683,40 @@ class TestCollectionDef:
         self.elements = elements
         self.name = name
 
-    def to_dict(self) -> TestCollectionDefDict:
+    def _test_format_to_dict(self) -> "BaseJsonTestCollectionDefCollectionElementDict":
+
+        def to_element(xml_element_dict: "TestCollectionDefElementInternal") -> "JsonTestCollectionDefElementDict":
+            identifier = xml_element_dict["element_identifier"]
+            element_object = xml_element_dict["element_definition"]
+            as_dict: JsonTestCollectionDefElementDict
+
+            if isinstance(element_object, TestCollectionDef):
+                as_dict = JsonTestCollectionDefCollectionElementDict(
+                    identifier=identifier, **element_object._test_format_to_dict()
+                )
+            else:
+                as_dict = JsonTestCollectionDefDatasetElementDict(
+                    identifier=identifier,
+                    **xml_data_input_to_json(cast(ToolSourceTestInput, element_object)),
+                )
+            return as_dict
+
+        test_format_dict = BaseJsonTestCollectionDefCollectionElementDict(
+            {
+                "class": "Collection",
+                "elements": list(map(to_element, self.elements)),
+                "collection_type": self.collection_type,
+            }
+        )
+        return test_format_dict
+
+    def test_format_to_dict(self) -> JsonTestCollectionDefDict:
+        test_format_dict = JsonTestCollectionDefDict(**self._test_format_to_dict())
+        if self.name:
+            test_format_dict["name"] = self.name
+        return test_format_dict
+
+    def to_dict(self) -> XmlTestCollectionDefDict:
         def element_to_dict(element_dict):
             element_identifier, element_def = element_dict["element_identifier"], element_dict["element_definition"]
             if isinstance(element_def, TestCollectionDef):
@@ -603,23 +735,53 @@ class TestCollectionDef:
         }
 
     @staticmethod
-    def from_dict(as_dict: TestCollectionDefDict):
-        assert as_dict["model_class"] == "TestCollectionDef"
+    def from_dict(
+        as_dict: Union[AnyTestCollectionDefDict, JsonTestCollectionDefCollectionElementDict]
+    ) -> "TestCollectionDef":
+        if "model_class" in as_dict:
+            xml_as_dict = cast(XmlTestCollectionDefDict, as_dict)
+            assert xml_as_dict["model_class"] == "TestCollectionDef"
 
-        def element_from_dict(element_dict):
-            if "element_definition" not in element_dict:
-                raise Exception(f"Invalid element_dict {element_dict}")
-            element_def = element_dict["element_definition"]
-            if element_def.get("model_class", None) == "TestCollectionDef":
-                element_def = TestCollectionDef.from_dict(element_def)
-            return {"element_identifier": element_dict["element_identifier"], "element_definition": element_def}
+            def element_from_dict(element_dict) -> TestCollectionDefElementInternal:
+                if "element_definition" not in element_dict:
+                    raise Exception(f"Invalid element_dict {element_dict}")
+                element_def = element_dict["element_definition"]
+                if element_def.get("model_class", None) == "TestCollectionDef":
+                    element_def = TestCollectionDef.from_dict(element_def)
+                return {"element_identifier": element_dict["element_identifier"], "element_definition": element_def}
 
-        return TestCollectionDef(
-            attrib=as_dict["attributes"],
-            name=as_dict["name"],
-            elements=list(map(element_from_dict, as_dict["elements"] or [])),
-            collection_type=as_dict["collection_type"],
-        )
+            return TestCollectionDef(
+                attrib=xml_as_dict["attributes"],
+                name=xml_as_dict.get("name", "Unnamed Collection"),
+                elements=list(map(element_from_dict, xml_as_dict["elements"] or [])),
+                collection_type=xml_as_dict["collection_type"],
+            )
+        else:
+            json_as_dict = cast(JsonTestCollectionDefDict, as_dict)
+
+            def element_from_dict_json(
+                element_dict: JsonTestCollectionDefElementDict,
+            ) -> TestCollectionDefElementInternal:
+                element_class = element_dict.get("class")
+                identifier = element_dict["identifier"]
+                element_def: Union[TestCollectionDef, ToolSourceTestInput]
+                if element_class == "Collection":
+                    collection_element_dict = cast(JsonTestCollectionDefCollectionElementDict, element_dict)
+                    element_def = TestCollectionDef.from_dict(collection_element_dict)
+                else:
+                    dataset_element_dict = cast(JsonTestCollectionDefDatasetElementDict, element_dict)
+                    value = dataset_element_dict["path"]  # todo handle location
+                    name = dataset_element_dict.get("name") or "Unnamed Collection"
+                    element_def = {"name": name, "value": value, "attributes": {}}
+                return TestCollectionDefElementInternal(element_identifier=identifier, element_definition=element_def)
+
+            elements = list(map(element_from_dict_json, json_as_dict.get("elements") or []))
+            return TestCollectionDef(
+                attrib={},
+                name=json_as_dict.get("name") or "Unnamed Collection",
+                elements=elements,
+                collection_type=json_as_dict["collection_type"],
+            )
 
     def collect_inputs(self):
         inputs = []

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -46,7 +46,6 @@ from .interface import (
     PageSource,
     PagesSource,
     RequiredFiles,
-    TestCollectionDefDict,
     TestCollectionDefElementDict,
     TestCollectionDefElementObject,
     TestCollectionOutputDef,
@@ -59,6 +58,7 @@ from .interface import (
     ToolSourceTestOutputAttributes,
     ToolSourceTestOutputs,
     ToolSourceTests,
+    XmlTestCollectionDefDict,
     XrefDict,
 )
 from .output_actions import ToolOutputActionGroup
@@ -1011,7 +1011,7 @@ def __parse_inputs_elems(test_elem, i) -> ToolSourceTestInputs:
     return raw_inputs
 
 
-def _test_collection_def_dict(elem: Element) -> TestCollectionDefDict:
+def _test_collection_def_dict(elem: Element) -> XmlTestCollectionDefDict:
     elements: List[TestCollectionDefElementDict] = []
     attrib: Dict[str, Any] = _element_to_dict(elem)
     collection_type = attrib["type"]
@@ -1027,7 +1027,7 @@ def _test_collection_def_dict(elem: Element) -> TestCollectionDefDict:
             element_definition = __parse_param_elem(element)
         elements.append({"element_identifier": element_identifier, "element_definition": element_definition})
 
-    return TestCollectionDefDict(
+    return XmlTestCollectionDefDict(
         model_class="TestCollectionDef",
         attributes=attrib,
         collection_type=collection_type,

--- a/lib/galaxy/tool_util/verify/_types.py
+++ b/lib/galaxy/tool_util/verify/_types.py
@@ -19,10 +19,15 @@ from galaxy.tool_util.parser.interface import (
     ToolSourceTestOutputs,
 )
 
-# inputs that have been processed with parse.py and expanded out
+# legacy inputs for working with POST /api/tools
+# + inputs that have been processed with parse.py and expanded out
 ExpandedToolInputs = Dict[str, Any]
-# ExpandedToolInputs where any model objects have been json-ified with to_dict()
+# + ExpandedToolInputs where any model objects have been json-ified with to_dict()
 ExpandedToolInputsJsonified = Dict[str, Any]
+
+# modern inputs for working with POST /api/jobs*
+RawTestToolRequest = Dict[str, Any]
+
 ExtraFileInfoDictT = Dict[str, Any]
 RequiredFileTuple = Tuple[str, ExtraFileInfoDictT]
 RequiredFilesT = List[RequiredFileTuple]
@@ -36,6 +41,8 @@ class ToolTestDescriptionDict(TypedDict):
     name: str
     test_index: int
     inputs: ExpandedToolInputsJsonified
+    request: NotRequired[Optional[Dict[str, Any]]]
+    request_schema: NotRequired[Optional[Dict[str, Any]]]
     outputs: ToolSourceTestOutputs
     output_collections: List[TestSourceTestOutputColllection]
     stdout: Optional[AssertionList]

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -588,7 +588,7 @@ class GalaxyInteractorApi:
             raise ValueError(f"Invalid `location` URL: `{location}`")
         return location
 
-    def run_tool(self, testdef, history_id, resource_parameters=None) -> RunToolResponse:
+    def run_tool(self, testdef: "ToolTestDescription", history_id: str, resource_parameters: Optional[Dict[str, Any]] = None) -> RunToolResponse:
         # We need to handle the case where we've uploaded a valid compressed file since the upload
         # tool will have uncompressed it on the fly.
         resource_parameters = resource_parameters or {}

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -38,10 +38,10 @@ from galaxy import util
 from galaxy.tool_util.parser.interface import (
     AssertionList,
     TestCollectionDef,
-    TestCollectionDefDict,
     TestCollectionOutputDef,
     TestSourceTestOutputColllection,
     ToolSourceTestOutputs,
+    XmlTestCollectionDefDict,
 )
 from galaxy.util import requests
 from galaxy.util.bunch import Bunch
@@ -588,7 +588,9 @@ class GalaxyInteractorApi:
             raise ValueError(f"Invalid `location` URL: `{location}`")
         return location
 
-    def run_tool(self, testdef: "ToolTestDescription", history_id: str, resource_parameters: Optional[Dict[str, Any]] = None) -> RunToolResponse:
+    def run_tool(
+        self, testdef: "ToolTestDescription", history_id: str, resource_parameters: Optional[Dict[str, Any]] = None
+    ) -> RunToolResponse:
         # We need to handle the case where we've uploaded a valid compressed file since the upload
         # tool will have uncompressed it on the fly.
         resource_parameters = resource_parameters or {}
@@ -1754,7 +1756,7 @@ def expanded_inputs_from_json(expanded_inputs_json: ExpandedToolInputsJsonified)
     loaded_inputs: ExpandedToolInputs = {}
     for key, value in expanded_inputs_json.items():
         if isinstance(value, dict) and value.get("model_class"):
-            collection_def_dict = cast(TestCollectionDefDict, value)
+            collection_def_dict = cast(XmlTestCollectionDefDict, value)
             loaded_inputs[key] = TestCollectionDef.from_dict(collection_def_dict)
         else:
             loaded_inputs[key] = value

--- a/lib/galaxy/tool_util/verify/parse.py
+++ b/lib/galaxy/tool_util/verify/parse.py
@@ -1,7 +1,9 @@
 import logging
 import os
+from dataclasses import dataclass
 from typing import (
     Any,
+    Dict,
     Iterable,
     List,
     Optional,
@@ -14,6 +16,8 @@ from packaging.version import Version
 from galaxy.tool_util.parameters import (
     input_models_for_tool_source,
     test_case_state as case_state,
+    TestCaseToolState,
+    ToolParameterBundleModel,
 )
 from galaxy.tool_util.parser.interface import (
     InputSource,
@@ -64,15 +68,19 @@ def parse_tool_test_descriptions(
     profile = tool_source.parse_profile()
     for i, raw_test_dict in enumerate(raw_tests_dict.get("tests", [])):
         validation_exception: Optional[Exception] = None
-        if validate_on_load:
+        request_and_schema: Optional[TestRequestAndSchema] = None
+        try:
             tool_parameter_bundle = input_models_for_tool_source(tool_source)
             try:
-                case_state(raw_test_dict, tool_parameter_bundle.input_models, profile, validate=True)
-            except Exception as e:
-                # TOOD: restrict types of validation exceptions a bit probably?
-                validation_exception = e
+                validated_test_case = case_state(raw_test_dict, tool_parameter_bundle.parameters, profile, validate=True)
+                request_and_schema = TestRequestAndSchema(
+                    validated_test_case.tool_state,
+                    tool_parameter_bundle,
+                )
+        except Exception as e:
+            validation_exception = e
 
-        if validation_exception:
+        if validation_exception and validate_on_load:
             tool_id, tool_version = _tool_id_and_version(tool_source, tool_guid)
             test = ToolTestDescription.from_tool_source_dict(
                 InvalidToolTestDict(
@@ -88,13 +96,23 @@ def parse_tool_test_descriptions(
                 )
             )
         else:
-            test = _description_from_tool_source(tool_source, raw_test_dict, i, tool_guid)
+            test = _description_from_tool_source(tool_source, raw_test_dict, i, tool_guid, request_and_schema)
         tests.append(test)
     return tests
 
 
+@dataclass
+class TestRequestAndSchema:
+    request: TestCaseToolState
+    request_schema: ToolParameterBundleModel
+
+
 def _description_from_tool_source(
-    tool_source: ToolSource, raw_test_dict: ToolSourceTest, test_index: int, tool_guid: Optional[str]
+    tool_source: ToolSource,
+    raw_test_dict: ToolSourceTest,
+    test_index: int,
+    tool_guid: Optional[str],
+    request_and_schema: Optional[TestRequestAndSchema],
 ) -> ToolTestDescription:
     required_files: RequiredFilesT = []
     required_data_tables: RequiredDataTablesT = []
@@ -106,6 +124,12 @@ def _description_from_tool_source(
     maxseconds = raw_test_dict.get("maxseconds", None)
     if maxseconds is not None:
         maxseconds = int(maxseconds)
+
+    request: Optional[Dict[str, Any]] = None
+    request_schema: Optional[Dict[str, Any]] = None
+    if request_and_schema:
+        request = request_and_schema.request.input_state
+        request_schema = request_and_schema.request_schema.dict()
 
     tool_id, tool_version = _tool_id_and_version(tool_source, tool_guid)
     processed_test_dict: Union[ValidToolTestDict, InvalidToolTestDict]
@@ -121,6 +145,8 @@ def _description_from_tool_source(
         processed_test_dict = ValidToolTestDict(
             {
                 "inputs": processed_inputs,
+                "request": request,
+                "request_schema": request_schema,
                 "outputs": raw_test_dict["outputs"],
                 "output_collections": raw_test_dict["output_collections"],
                 "num_outputs": num_outputs,

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1447,10 +1447,9 @@ class ColumnListParameter(SelectToolParameter):
 
     @staticmethod
     def _strip_c(column):
-        if isinstance(column, str):
-            column = column.strip()
-            if column.startswith("c") and len(column) > 1 and all(c.isdigit() for c in column[1:]):
-                column = column.lower()[1:]
+        column = str(column).strip()
+        if column.startswith("c") and len(column) > 1 and all(c.isdigit() for c in column[1:]):
+            column = column.lower()[1:]
         return column
 
     def get_column_list(self, trans, other_values):

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -61,6 +61,7 @@ from galaxy.schema.schema import (
     ShareWithPayload,
     SharingStatus,
     StoreExportPayload,
+    ToolRequestModel,
     UpdateHistoryPayload,
     WriteStoreToPayload,
 )
@@ -373,6 +374,17 @@ class FastAPIHistories:
         trans: ProvidesHistoryContext = DependsOnTrans,
     ) -> List[Any]:
         return self.service.citations(trans, history_id)
+
+    @router.get(
+        "/api/histories/{history_id}/tool_requests",
+        summary="Return all the tool requests for the tools submitted to this history.",
+    )
+    def tool_requests(
+        self,
+        history_id: HistoryIDPathParam,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+    ) -> List[ToolRequestModel]:
+        return self.service.tool_requests(trans, history_id)
 
     @router.post(
         "/api/histories",

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -44,6 +44,7 @@ from galaxy.schema.jobs import (
     JobInputAssociation,
     JobInputSummary,
     JobOutputAssociation,
+    JobOutputCollectionAssociation,
     ReportJobErrorPayload,
     SearchJobsPayload,
     ShowFullJobResponse,
@@ -67,11 +68,14 @@ from galaxy.webapps.galaxy.api import (
 )
 from galaxy.webapps.galaxy.api.common import query_parameter_as_list
 from galaxy.webapps.galaxy.services.jobs import (
+    JobCreateResponse,
     JobIndexPayload,
     JobIndexViewEnum,
+    JobRequest,
     JobsService,
 )
 from galaxy.work.context import proxy_work_context_for_history
+from .tools import validate_not_protected
 
 log = logging.getLogger(__name__)
 
@@ -155,6 +159,12 @@ ImplicitCollectionJobsIdQueryParam: Optional[DecodedDatabaseIdField] = Query(
     description="Limit listing of jobs to those that match the specified implicit collection job ID. If none, jobs from any implicit collection execution (or from no implicit collection execution) may be returned.",
 )
 
+ToolRequestIdQueryParam: Optional[DecodedDatabaseIdField] = Query(
+    default=None,
+    title="Tool Request ID",
+    description="Limit listing of jobs to those that were created from the supplied tool request ID. If none, jobs from any tool request (or from no workflows) may be returned.",
+)
+
 SortByQueryParam: JobIndexSortByEnum = Query(
     default=JobIndexSortByEnum.update_time,
     title="Sort By",
@@ -207,6 +217,13 @@ DeleteJobBody = Body(title="Delete/cancel job", description="The values to delet
 class FastAPIJobs:
     service: JobsService = depends(JobsService)
 
+    @router.post("/api/jobs")
+    def create(
+        self, trans: ProvidesHistoryContext = DependsOnTrans, job_request: JobRequest = Body(...)
+    ) -> JobCreateResponse:
+        validate_not_protected(job_request.tool_id)
+        return self.service.create(trans, job_request)
+
     @router.get("/api/jobs")
     def index(
         self,
@@ -223,6 +240,7 @@ class FastAPIJobs:
         workflow_id: Optional[DecodedDatabaseIdField] = WorkflowIdQueryParam,
         invocation_id: Optional[DecodedDatabaseIdField] = InvocationIdQueryParam,
         implicit_collection_jobs_id: Optional[DecodedDatabaseIdField] = ImplicitCollectionJobsIdQueryParam,
+        tool_request_id: Optional[DecodedDatabaseIdField] = ToolRequestIdQueryParam,
         order_by: JobIndexSortByEnum = SortByQueryParam,
         search: Optional[str] = SearchQueryParam,
         limit: int = LimitQueryParam,
@@ -241,6 +259,7 @@ class FastAPIJobs:
             workflow_id=workflow_id,
             invocation_id=invocation_id,
             implicit_collection_jobs_id=implicit_collection_jobs_id,
+            tool_request_id=tool_request_id,
             order_by=order_by,
             search=search,
             limit=limit,
@@ -361,12 +380,14 @@ class FastAPIJobs:
         self,
         job_id: JobIdPathParam,
         trans: ProvidesUserContext = DependsOnTrans,
-    ) -> List[JobOutputAssociation]:
+    ) -> List[Union[JobOutputAssociation, JobOutputCollectionAssociation]]:
         job = self.service.get_job(trans=trans, job_id=job_id)
         associations = self.service.dictify_associations(trans, job.output_datasets, job.output_library_datasets)
-        output_associations = []
+        output_associations: List[Union[JobOutputAssociation, JobOutputCollectionAssociation]] = []
         for association in associations:
             output_associations.append(JobOutputAssociation(name=association.name, dataset=association.dataset))
+
+        output_associations.extend(self.service.dictify_output_collection_associations(trans, job))
         return output_associations
 
     @router.get(

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -12,6 +12,8 @@ from typing import (
 from fastapi import (
     Body,
     Depends,
+    Path,
+    Query,
     Request,
     UploadFile,
 )
@@ -27,10 +29,14 @@ from galaxy.managers.collections import DatasetCollectionManager
 from galaxy.managers.context import ProvidesHistoryContext
 from galaxy.managers.hdas import HDAManager
 from galaxy.managers.histories import HistoryManager
+from galaxy.model import ToolRequest
 from galaxy.schema.fetch_data import (
     FetchDataFormPayload,
     FetchDataPayload,
 )
+from galaxy.schema.fields import DecodedDatabaseIdField
+from galaxy.schema.schema import ToolRequestModel
+from galaxy.tool_util.parameters import ToolParameterT
 from galaxy.tool_util.verify import ToolTestDescriptionDict
 from galaxy.tools.evaluation import global_tool_errors
 from galaxy.util.zipstream import ZipstreamWrapper
@@ -42,7 +48,11 @@ from galaxy.web import (
 )
 from galaxy.webapps.base.controller import UsesVisualizationMixin
 from galaxy.webapps.base.webapp import GalaxyWebTransaction
-from galaxy.webapps.galaxy.services.tools import ToolsService
+from galaxy.webapps.galaxy.services.base import tool_request_to_model
+from galaxy.webapps.galaxy.services.tools import (
+    ToolRunReference,
+    ToolsService,
+)
 from . import (
     APIContentTypeRoute,
     as_form,
@@ -74,6 +84,14 @@ router = Router(tags=["tools"])
 FetchDataForm = as_form(FetchDataFormPayload)
 
 
+ToolIDPathParam: str = Path(
+    ...,
+    title="Tool ID",
+    description="The tool ID for the lineage stored in Galaxy's toolbox.",
+)
+ToolVersionQueryParam: Optional[str] = Query(default=None, title="Tool Version", description="")
+
+
 @router.cbv
 class FetchTools:
     service: ToolsService = depends(ToolsService)
@@ -103,6 +121,57 @@ class FetchTools:
                 if isinstance(value, StarletteUploadFile):
                     files2.append(value)
         return self.service.create_fetch(trans, payload, files2)
+
+    @router.get(
+        "/api/tool_requests/{id}",
+        summary="Get tool request state.",
+    )
+    def get_tool_request(
+        self,
+        id: DecodedDatabaseIdField,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+    ) -> ToolRequestModel:
+        tool_request = self._get_tool_request_or_raise_not_found(trans, id)
+        return tool_request_to_model(tool_request)
+
+    @router.get(
+        "/api/tool_requests/{id}/state",
+        summary="Get tool request state.",
+    )
+    def tool_request_state(
+        self,
+        id: DecodedDatabaseIdField,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+    ) -> str:
+        tool_request = self._get_tool_request_or_raise_not_found(trans, id)
+        state = tool_request.state
+        if not state:
+            raise exceptions.InconsistentDatabase()
+        return cast(str, state)
+
+    def _get_tool_request_or_raise_not_found(
+        self, trans: ProvidesHistoryContext, id: DecodedDatabaseIdField
+    ) -> ToolRequest:
+        tool_request: Optional[ToolRequest] = cast(
+            Optional[ToolRequest], trans.app.model.context.query(ToolRequest).get(id)
+        )
+        if tool_request is None:
+            raise exceptions.ObjectNotFound()
+        assert tool_request
+        return tool_request
+
+    @router.get(
+        "/api/tools/{tool_id}/inputs",
+        summary="Get tool inputs.",
+    )
+    def tool_inputs(
+        self,
+        tool_id: str = ToolIDPathParam,
+        tool_version: Optional[str] = ToolVersionQueryParam,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+    ) -> List[ToolParameterT]:
+        tool_run_ref = ToolRunReference(tool_id=tool_id, tool_version=tool_version, tool_uuid=None)
+        return self.service.inputs(trans, tool_run_ref)
 
 
 class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
@@ -584,14 +653,15 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
         :type input_format: str
         """
         tool_id = payload.get("tool_id")
-        tool_uuid = payload.get("tool_uuid")
-        if tool_id in PROTECTED_TOOLS:
-            raise exceptions.RequestParameterInvalidException(
-                f"Cannot execute tool [{tool_id}] directly, must use alternative endpoint."
-            )
-        if tool_id is None and tool_uuid is None:
-            raise exceptions.RequestParameterInvalidException("Must specify a valid tool_id to use this endpoint.")
+        validate_not_protected(tool_id)
         return self.service._create(trans, payload, **kwd)
+
+
+def validate_not_protected(tool_id: Optional[str]):
+    if tool_id in PROTECTED_TOOLS:
+        raise exceptions.RequestParameterInvalidException(
+            f"Cannot execute tool [{tool_id}] directly, must use alternative endpoint."
+        )
 
 
 def _kwd_or_payload(kwd: Dict[str, Any]) -> Dict[str, Any]:

--- a/lib/galaxy/webapps/galaxy/services/base.py
+++ b/lib/galaxy/webapps/galaxy/services/base.py
@@ -23,13 +23,19 @@ from galaxy.managers.base import (
 )
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.model_stores import create_objects_from_store
-from galaxy.model import User
+from galaxy.model import (
+    ToolRequest,
+    User,
+)
 from galaxy.model.store import (
     get_export_store_factory,
     ModelExportStore,
 )
 from galaxy.schema.fields import EncodedDatabaseIdField
-from galaxy.schema.schema import AsyncTaskResultSummary
+from galaxy.schema.schema import (
+    AsyncTaskResultSummary,
+    ToolRequestModel,
+)
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.short_term_storage import (
     ShortTermStorageAllocator,
@@ -193,3 +199,13 @@ def async_task_summary(async_result: AsyncResult) -> AsyncTaskResultSummary:
         name=name,
         queue=queue,
     )
+
+
+def tool_request_to_model(tool_request: ToolRequest) -> ToolRequestModel:
+    as_dict = {
+        "id": tool_request.id,
+        "request": tool_request.request,
+        "state": tool_request.state,
+        "state_message": tool_request.state_message,
+    }
+    return ToolRequestModel.model_validate(as_dict)

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -70,6 +70,7 @@ from galaxy.schema.schema import (
     ShareHistoryWithStatus,
     ShareWithPayload,
     StoreExportPayload,
+    ToolRequestModel,
     WriteStoreToPayload,
 )
 from galaxy.schema.tasks import (
@@ -87,6 +88,7 @@ from galaxy.webapps.galaxy.services.base import (
     model_store_storage_target,
     ServesExportStores,
     ServiceBase,
+    tool_request_to_model,
 )
 from galaxy.webapps.galaxy.services.notifications import NotificationService
 from galaxy.webapps.galaxy.services.sharable import ShareableService
@@ -532,6 +534,13 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
             for history in histories
         ]
         return rval
+
+    def tool_requests(
+        self, trans: ProvidesHistoryContext, history_id: DecodedDatabaseIdField
+    ) -> List[ToolRequestModel]:
+        history = self.manager.get_accessible(history_id, trans.user, current_history=trans.history)
+        tool_requests = history.tool_requests
+        return [tool_request_to_model(tr) for tr in tool_requests]
 
     def citations(self, trans: ProvidesHistoryContext, history_id: DecodedDatabaseIdField):
         """

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -1,3 +1,4 @@
+import logging
 from enum import Enum
 from typing import (
     Any,
@@ -6,24 +7,83 @@ from typing import (
     Optional,
 )
 
+from pydantic import (
+    BaseModel,
+    Field,
+)
+
 from galaxy import (
     exceptions,
     model,
 )
+from galaxy.celery.tasks import queue_jobs
 from galaxy.managers import hdas
 from galaxy.managers.base import security_check
-from galaxy.managers.context import ProvidesUserContext
+from galaxy.managers.context import (
+    ProvidesHistoryContext,
+    ProvidesUserContext,
+)
+from galaxy.managers.histories import HistoryManager
 from galaxy.managers.jobs import (
     JobManager,
     JobSearch,
     view_show_job,
 )
-from galaxy.model import Job
-from galaxy.schema.fields import DecodedDatabaseIdField
-from galaxy.schema.jobs import JobAssociation
-from galaxy.schema.schema import JobIndexQueryPayload
+from galaxy.model import (
+    Job,
+    ToolRequest,
+    ToolSource as ToolSourceModel,
+)
+from galaxy.model.base import transaction
+from galaxy.schema.fields import (
+    DecodedDatabaseIdField,
+    EncodedDatabaseIdField,
+)
+from galaxy.schema.jobs import (
+    JobAssociation,
+    JobOutputCollectionAssociation,
+)
+from galaxy.schema.schema import (
+    AsyncTaskResultSummary,
+    JobIndexQueryPayload,
+)
+from galaxy.schema.tasks import (
+    QueueJobs,
+    ToolSource,
+)
 from galaxy.security.idencoding import IdEncodingHelper
-from galaxy.webapps.galaxy.services.base import ServiceBase
+from galaxy.tool_util.parameters import (
+    decode,
+    RequestToolState,
+)
+from galaxy.webapps.galaxy.services.base import (
+    async_task_summary,
+    ServiceBase,
+)
+from .tools import (
+    ToolRunReference,
+    validate_tool_for_running,
+)
+
+log = logging.getLogger(__name__)
+
+
+class JobRequest(BaseModel):
+    tool_id: Optional[str] = Field(default=None, title="tool_id", description="TODO")
+    tool_uuid: Optional[str] = Field(default=None, title="tool_uuid", description="TODO")
+    tool_version: Optional[str] = Field(default=None, title="tool_version", description="TODO")
+    history_id: Optional[DecodedDatabaseIdField] = Field(default=None, title="history_id", description="TODO")
+    inputs: Optional[Dict[str, Any]] = Field(default_factory=lambda: {}, title="Inputs", description="TODO")
+    use_cached_jobs: Optional[bool] = Field(default=None, title="use_cached_jobs")
+    rerun_remap_job_id: Optional[DecodedDatabaseIdField] = Field(
+        default=None, title="rerun_remap_job_id", description="TODO"
+    )
+    send_email_notification: bool = Field(default=False, title="Send Email Notification", description="TODO")
+
+
+class JobCreateResponse(BaseModel):
+    tool_request_id: EncodedDatabaseIdField
+    task_result: AsyncTaskResultSummary
 
 
 class JobIndexViewEnum(str, Enum):
@@ -39,6 +99,7 @@ class JobsService(ServiceBase):
     job_manager: JobManager
     job_search: JobSearch
     hda_manager: hdas.HDAManager
+    history_manager: HistoryManager
 
     def __init__(
         self,
@@ -46,11 +107,13 @@ class JobsService(ServiceBase):
         job_manager: JobManager,
         job_search: JobSearch,
         hda_manager: hdas.HDAManager,
+        history_manager: HistoryManager,
     ):
         super().__init__(security=security)
         self.job_manager = job_manager
         self.job_search = job_search
         self.hda_manager = hda_manager
+        self.history_manager = history_manager
 
     def show(
         self,
@@ -146,3 +209,62 @@ class JobsService(ServiceBase):
             else:
                 dataset_dict = {"src": "ldda", "id": dataset.id}
         return JobAssociation(name=job_dataset_association.name, dataset=dataset_dict)
+
+    def dictify_output_collection_associations(self, trans, job: model.Job) -> List[JobOutputCollectionAssociation]:
+        output_associations: List[JobOutputCollectionAssociation] = []
+        for job_output_collection_association in job.output_dataset_collection_instances:
+            ref_dict = {"src": "hdca", "id": job_output_collection_association.dataset_collection_id}
+            output_associations.append(
+                JobOutputCollectionAssociation(
+                    name=job_output_collection_association.name,
+                    dataset_collection_instance=ref_dict,
+                )
+            )
+        return output_associations
+
+    def create(self, trans: ProvidesHistoryContext, job_request: JobRequest) -> JobCreateResponse:
+        tool_run_reference = ToolRunReference(job_request.tool_id, job_request.tool_uuid, job_request.tool_version)
+        tool = validate_tool_for_running(trans, tool_run_reference)
+        history_id = job_request.history_id
+        target_history = None
+        if history_id is not None:
+            target_history = self.history_manager.get_owned(history_id, trans.user, current_history=trans.history)
+        inputs = job_request.inputs
+        request_state = RequestToolState(inputs or {})
+        request_state.validate(tool)
+        request_internal_state = decode(request_state, tool, trans.security.decode_id)
+        tool_request = ToolRequest()
+        # TODO: hash and such...
+        tool_source_model = ToolSourceModel(
+            source=[p.model_dump() for p in tool.parameters],
+            hash="TODO",
+        )
+        tool_request.request = request_internal_state.input_state
+        tool_request.tool_source = tool_source_model
+        tool_request.state = ToolRequest.states.NEW
+        tool_request.history = target_history
+        sa_session = trans.sa_session
+        sa_session.add(tool_source_model)
+        sa_session.add(tool_request)
+        with transaction(sa_session):
+            sa_session.commit()
+        tool_request_id = tool_request.id
+        tool_source = ToolSource(
+            raw_tool_source=tool.tool_source.to_string(),
+            tool_dir=tool.tool_dir,
+        )
+        task_request = QueueJobs(
+            user=trans.async_request_user,
+            history_id=target_history and target_history.id,
+            tool_source=tool_source,
+            tool_request_id=tool_request_id,
+            use_cached_jobs=job_request.use_cached_jobs or False,
+            rerun_remap_job_id=job_request.rerun_remap_job_id,
+        )
+        result = queue_jobs.delay(request=task_request)
+        return JobCreateResponse(
+            **{
+                "tool_request_id": tool_request_id,
+                "task_result": async_task_summary(result),
+            }
+        )

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -4,8 +4,10 @@ import tempfile
 from json import dumps
 from typing import (
     Any,
+    cast,
     Dict,
     List,
+    NamedTuple,
     Optional,
     Union,
 )
@@ -34,12 +36,47 @@ from galaxy.schema.fetch_data import (
     FilesPayload,
 )
 from galaxy.security.idencoding import IdEncodingHelper
+from galaxy.tool_util.parameters import ToolParameterT
 from galaxy.tools import Tool
+from galaxy.tools._types import InputFormatT
 from galaxy.tools.search import ToolBoxSearch
 from galaxy.webapps.galaxy.services._fetch_util import validate_and_normalize_targets
 from galaxy.webapps.galaxy.services.base import ServiceBase
 
 log = logging.getLogger(__name__)
+
+
+class ToolRunReference(NamedTuple):
+    tool_id: Optional[str]
+    tool_uuid: Optional[str]
+    tool_version: Optional[str]
+
+
+def get_tool(trans: ProvidesHistoryContext, tool_ref: ToolRunReference) -> Tool:
+    get_kwds = dict(
+        tool_id=tool_ref.tool_id,
+        tool_uuid=tool_ref.tool_uuid,
+        tool_version=tool_ref.tool_version,
+    )
+
+    tool = trans.app.toolbox.get_tool(**get_kwds)
+    if not tool:
+        log.debug(f"Not found tool with kwds [{tool_ref}]")
+        raise exceptions.ToolMissingException("Tool not found.")
+    return tool
+
+
+def validate_tool_for_running(trans: ProvidesHistoryContext, tool_ref: ToolRunReference) -> Tool:
+    if trans.user_is_bootstrap_admin:
+        raise exceptions.RealUserRequiredException("Only real users can execute tools or run jobs.")
+
+    if tool_ref.tool_id is None and tool_ref.tool_uuid is None:
+        raise exceptions.RequestParameterMissingException("Must specify a valid tool_id to use this endpoint.")
+
+    tool = get_tool(trans, tool_ref)
+    if not tool.allow_user_access(trans.user):
+        raise exceptions.ItemAccessibilityException("Tool not accessible.")
+    return tool
 
 
 class ToolsService(ServiceBase):
@@ -54,6 +91,14 @@ class ToolsService(ServiceBase):
         self.config = config
         self.toolbox_search = toolbox_search
         self.history_manager = history_manager
+
+    def inputs(
+        self,
+        trans: ProvidesHistoryContext,
+        tool_ref: ToolRunReference,
+    ) -> List[ToolParameterT]:
+        tool = get_tool(trans, tool_ref)
+        return tool.parameters
 
     def create_fetch(
         self,
@@ -100,37 +145,14 @@ class ToolsService(ServiceBase):
         return self._create(trans, create_payload)
 
     def _create(self, trans: ProvidesHistoryContext, payload, **kwd):
-        if trans.user_is_bootstrap_admin:
-            raise exceptions.RealUserRequiredException("Only real users can execute tools or run jobs.")
         action = payload.get("action")
         if action == "rerun":
             raise Exception("'rerun' action has been deprecated")
 
-        # Get tool.
-        tool_version = payload.get("tool_version")
-        tool_id = payload.get("tool_id")
-        tool_uuid = payload.get("tool_uuid")
-        get_kwds = dict(
-            tool_id=tool_id,
-            tool_uuid=tool_uuid,
-            tool_version=tool_version,
+        tool_run_reference = ToolRunReference(
+            payload.get("tool_id"), payload.get("tool_uuid"), payload.get("tool_version")
         )
-        if tool_id is None and tool_uuid is None:
-            raise exceptions.RequestParameterMissingException("Must specify either a tool_id or a tool_uuid.")
-
-        tool = trans.app.toolbox.get_tool(**get_kwds)
-        if not tool:
-            log.debug(f"Not found tool with kwds [{get_kwds}]")
-            raise exceptions.ToolMissingException("Tool not found.")
-        if not tool.allow_user_access(trans.user):
-            raise exceptions.ItemAccessibilityException("Tool not accessible.")
-        if self.config.user_activation_on:
-            if not trans.user:
-                log.warning("Anonymous user attempts to execute tool, but account activation is turned on.")
-            elif not trans.user.active:
-                log.warning(
-                    f'User "{trans.user.email}" attempts to execute tool, but account activation is turned on and user account is not active.'
-                )
+        tool = validate_tool_for_running(trans, tool_run_reference)
 
         # Set running history from payload parameters.
         # History not set correctly as part of this API call for
@@ -166,7 +188,10 @@ class ToolsService(ServiceBase):
             inputs.get("use_cached_job", "false")
         )
         preferred_object_store_id = payload.get("preferred_object_store_id")
-        input_format = str(payload.get("input_format", "legacy"))
+        input_format_raw = str(payload.get("input_format", "legacy"))
+        if input_format_raw not in ["legacy", "21.01"]:
+            raise exceptions.RequestParameterInvalidException(f"invalid input format {input_format_raw}")
+        input_format = cast(InputFormatT, input_format_raw)
         if "data_manager_mode" in payload:
             incoming["__data_manager_mode"] = payload["data_manager_mode"]
         vars = tool.handle_input(

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1435,8 +1435,28 @@ class BaseDatasetPopulator(BasePopulator):
         wait_on(is_ready, "waiting for download to become ready")
         assert is_ready()
 
+    def wait_on_tool_request(self, tool_request_id: str):
+        # should this to defer to interactor's copy of this method?
+
+        def state():
+            state_response = self._get(f"tool_requests/{tool_request_id}/state")
+            state_response.raise_for_status()
+            return state_response.json()
+
+        def is_ready():
+            is_complete = state() in ["submitted", "failed"]
+            return True if is_complete else None
+
+        wait_on(is_ready, "waiting for tool request to submit")
+        return state() == "submitted"
+
     def wait_on_task(self, async_task_response: Response):
-        task_id = async_task_response.json()["id"]
+        response_json = async_task_response.json()
+        self.wait_on_task_object(response_json)
+
+    def wait_on_task_object(self, async_task_json: Dict[str, Any]):
+        assert "id" in async_task_json, f"Task response {async_task_json} does not contain expected 'id' field."
+        task_id = async_task_json["id"]
         return self.wait_on_task_id(task_id)
 
     def wait_on_task_id(self, task_id: str):

--- a/scripts/gen_typescript_artifacts.py
+++ b/scripts/gen_typescript_artifacts.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+try:
+    from pydantic2ts import generate_typescript_defs
+except ImportError:
+    generate_typescript_defs = None
+
+
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "lib")))
+
+
+def main():
+    if generate_typescript_defs is None:
+        raise Exception("Please install pydantic-to-typescript into Galaxy's environment")
+    generate_typescript_defs("galaxy.tool_util.parser.parameters", "client/src/components/Tool/parameterModels.ts")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/functional/test_toolbox_pytest.py
+++ b/test/functional/test_toolbox_pytest.py
@@ -1,11 +1,16 @@
 import os
 from typing import (
+    cast,
     List,
     NamedTuple,
 )
 
 import pytest
 
+from galaxy.tool_util.verify.interactor import (
+    DEFAULT_USE_LEGACY_API,
+    UseLegacyApiT,
+)
 from galaxy_test.api._framework import ApiTestCase
 from galaxy_test.driver.driver_util import GalaxyTestDriver
 
@@ -61,4 +66,7 @@ class TestFrameworkTools(ApiTestCase):
 
     @pytest.mark.parametrize("testcase", cases(), ids=idfn)
     def test_tool(self, testcase: ToolTest):
-        self._test_driver.run_tool_test(testcase.tool_id, testcase.test_index, tool_version=testcase.tool_version)
+        use_legacy_api = cast(UseLegacyApiT, os.environ.get("GALAXY_TEST_USE_LEGACY_TOOL_API", DEFAULT_USE_LEGACY_API))
+        self._test_driver.run_tool_test(
+            testcase.tool_id, testcase.test_index, tool_version=testcase.tool_version, use_legacy_api=use_legacy_api
+        )

--- a/test/functional/tools/options_from_metadata_file.xml
+++ b/test/functional/tools/options_from_metadata_file.xml
@@ -22,7 +22,7 @@ echo '${species_2}' >> '${output}'
         </options>
     </param>
     <!-- test meta_file_key referring a collection to define options-->
-    <param name="input_2" type="data_collection" collection_type="list" format="maf" label="MAF Collection" multiple="true"/>
+    <param name="input_2" type="data_collection" collection_type="list" format="maf" label="MAF Collection" />
     <param name="species_2" type="select" optional="false" label="Select species for the input dataset" multiple="true">
         <options from_dataset="input_2" meta_file_key="species_chromosomes">
             <column name="name" index="0"/>

--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -1017,9 +1017,9 @@ gx_drill_down_exact:
   - parameter: aa
   - parameter: bbb
   - parameter: ba
-  request_invalid:
-  # not multiple so cannot choose a non-leaf
+  # non-leaf nodes seem to be selectable in exact mode
   - parameter: a
+  request_invalid:
   - parameter: c
   - parameter: {}
   # no implicit default currently - see test_drill_down_first_by_default in API test test_tools.py.
@@ -1032,12 +1032,26 @@ gx_drill_down_exact_with_selection:
   - parameter: bbb
   - parameter: ba
   # - {}
-  request_invalid:
-  # not multiple so cannot choose a non-leaf
+  # non-leaf nodes seem to be selectable in exact mode
   - parameter: a
+  request_invalid:
   - parameter: c
   - parameter: {}
   - parameter: null
+
+gx_drill_down_recurse:
+  request_valid:
+  - parameter: bba
+  request_invalid:
+  - parameter: a
+  - parameter: c
+
+gx_drill_down_recurse_multiple:
+  request_valid:
+  - parameter: [bba]
+  - parameter: [a]
+  request_invalid:
+  - parameter: c
 
 gx_data_column:
   request_valid:

--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -533,6 +533,13 @@ gx_data:
    # expanded out.
    - parameter: {__class__: "Batch", values: [{src: hdca, id: 5}]}
    - parameter: {src: hda, id: abcdabcd}
+  test_case_xml_valid:
+   - parameter: {class: File, path: foo.bed}
+   - parameter: {class: File, location: "https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt"}
+  test_case_xml_invalid:
+   - parameter: foo.bed
+   - parameter: null
+   - {}
   workflow_step_valid:
    - {}
   workflow_step_invalid:
@@ -592,6 +599,11 @@ gx_data_optional:
    - {src: hda, id: 7}
    - parameter: {__class__: "Batch", values: [{src: hdca, id: 5}]}
    - parameter: {__class__: 'ConnectedValueX'}
+  test_case_xml_valid:
+  - {}
+  - parameter: {class: "File", path: "1.bed"}
+  test_case_xml_invalid:
+  - parameter: {class: "NotAFile", path: "1.bed"}
 
 gx_data_multiple:
   request_valid:
@@ -690,6 +702,49 @@ gx_data_collection:
   - parameter: {__class__: 'ConnectedValue'}
   workflow_step_linked_invalid:
   - {}
+  test_case_xml_valid:
+  - parameter: {class: Collection, collection_type: list, elements: []}
+  - parameter:
+     class: Collection
+     collection_type: list
+     elements:
+     - {identifier: "first", path: "1.bed", class: File}
+     - {identifier: "second", path: "2.bed", class: File}
+  - parameter:
+     name: "A nested listed with a name"
+     class: Collection
+     collection_type: "list:paired"
+     elements:
+     - class: Collection
+       collection_type: paired
+       identifier: first_el
+       elements:
+       - {identifier: "forward", path: "1_f.bed", class: File}
+       - {identifier: "reverse", path: "1_r.bed", class: File}
+  test_case_xml_invalid:
+  # collection type is required
+  - parameter: {class: Collection, elements: []}
+  - parameter:
+     class: Collection
+     collection_type: list
+     elements:
+     - {identifier: "first", path: "1.bed", class: NotAFile}
+  - parameter:
+     class: Collection
+     collection_type: list
+     elements:
+     - {identifier: "first", pathmisspelled: "1.bed", class: File}
+  - parameter:
+     name: "A nested listed with a name"
+     class: Collection
+     collection_type: "list:paired"
+     elements:
+     - class: Collection
+       collection_type: paired
+       identifier: first_el
+       elements:
+       - {identifier: "forward", path: "1_f.bed", class: File}
+       - {identifier: "reverse", path: "1_r.bed", class: FileX}
 
 gx_data_collection_optional:
   request_valid:
@@ -995,11 +1050,11 @@ gx_data_column:
   request_internal_invalid:
   - { ref_parameter: {src: hda, id: 123}, parameter: "0" }
   test_case_xml_valid:
-  - { ref_parameter: "1.bed", parameter: 3 }
+  - { ref_parameter: {class: "File", path: "1.bed"}, parameter: 3 }
   test_case_xml_invalid:
-  - { ref_parameter: "1.bed", parameter: "3" }
+  - { ref_parameter: {class: "File", path: "1.bed"}, parameter: "3" }
   test_case_xml_invalid:
-  - { ref_parameter: "1.bed", parameter: "c2: With name" }
+  - { ref_parameter: {class: "File", path: "1.bed"}, parameter: "c2: With name" }
 
 gx_data_column_optional:
   request_valid:

--- a/test/unit/tool_util/test_parameter_covert.py
+++ b/test/unit/tool_util/test_parameter_covert.py
@@ -1,0 +1,99 @@
+from typing import Dict
+
+from galaxy.tool_util.parameters import (
+    decode,
+    encode,
+    input_models_for_tool_source,
+    RequestToolState,
+)
+from .test_parameter_test_cases import tool_source_for
+
+EXAMPLE_ID_1_ENCODED = "123456789abcde"
+EXAMPLE_ID_1 = 13
+EXAMPLE_ID_2_ENCODED = "123456789abcd2"
+EXAMPLE_ID_2 = 14
+
+ID_MAP: Dict[int, str] = {
+    EXAMPLE_ID_1: EXAMPLE_ID_1_ENCODED,
+    EXAMPLE_ID_2: EXAMPLE_ID_2_ENCODED,
+}
+
+
+def test_encode_data():
+    tool_source = tool_source_for("parameters/gx_data")
+    bundle = input_models_for_tool_source(tool_source)
+    request_state = RequestToolState({"parameter": {"src": "hda", "id": EXAMPLE_ID_1_ENCODED}})
+    request_state.validate(bundle)
+    decoded_state = decode(request_state, bundle, _fake_decode)
+    assert decoded_state.input_state["parameter"]["src"] == "hda"
+    assert decoded_state.input_state["parameter"]["id"] == EXAMPLE_ID_1
+
+
+def test_encode_collection():
+    tool_source = tool_source_for("parameters/gx_data_collection")
+    bundle = input_models_for_tool_source(tool_source)
+    request_state = RequestToolState({"parameter": {"src": "hdca", "id": EXAMPLE_ID_1_ENCODED}})
+    request_state.validate(bundle)
+    decoded_state = decode(request_state, bundle, _fake_decode)
+    assert decoded_state.input_state["parameter"]["src"] == "hdca"
+    assert decoded_state.input_state["parameter"]["id"] == EXAMPLE_ID_1
+
+
+def test_encode_repeat():
+    tool_source = tool_source_for("parameters/gx_repeat_data")
+    bundle = input_models_for_tool_source(tool_source)
+    request_state = RequestToolState({"parameter": [{"data_parameter": {"src": "hda", "id": EXAMPLE_ID_1_ENCODED}}]})
+    request_state.validate(bundle)
+    decoded_state = decode(request_state, bundle, _fake_decode)
+    assert decoded_state.input_state["parameter"][0]["data_parameter"]["src"] == "hda"
+    assert decoded_state.input_state["parameter"][0]["data_parameter"]["id"] == EXAMPLE_ID_1
+
+
+def test_encode_section():
+    tool_source = tool_source_for("parameters/gx_section_data")
+    bundle = input_models_for_tool_source(tool_source)
+    request_state = RequestToolState({"parameter": {"data_parameter": {"src": "hda", "id": EXAMPLE_ID_1_ENCODED}}})
+    request_state.validate(bundle)
+    decoded_state = decode(request_state, bundle, _fake_decode)
+    assert decoded_state.input_state["parameter"]["data_parameter"]["src"] == "hda"
+    assert decoded_state.input_state["parameter"]["data_parameter"]["id"] == EXAMPLE_ID_1
+
+
+def test_encode_conditional():
+    tool_source = tool_source_for("identifier_in_conditional")
+    bundle = input_models_for_tool_source(tool_source)
+    request_state = RequestToolState(
+        {"outer_cond": {"multi_input": False, "input1": {"src": "hda", "id": EXAMPLE_ID_1_ENCODED}}}
+    )
+    request_state.validate(bundle)
+    decoded_state = decode(request_state, bundle, _fake_decode)
+    assert decoded_state.input_state["outer_cond"]["input1"]["src"] == "hda"
+    assert decoded_state.input_state["outer_cond"]["input1"]["id"] == EXAMPLE_ID_1
+
+
+def test_multi_data():
+    tool_source = tool_source_for("parameters/gx_data_multiple")
+    bundle = input_models_for_tool_source(tool_source)
+    request_state = RequestToolState(
+        {"parameter": [{"src": "hda", "id": EXAMPLE_ID_1_ENCODED}, {"src": "hda", "id": EXAMPLE_ID_2_ENCODED}]}
+    )
+    request_state.validate(bundle)
+    decoded_state = decode(request_state, bundle, _fake_decode)
+    assert decoded_state.input_state["parameter"][0]["src"] == "hda"
+    assert decoded_state.input_state["parameter"][0]["id"] == EXAMPLE_ID_1
+    assert decoded_state.input_state["parameter"][1]["src"] == "hda"
+    assert decoded_state.input_state["parameter"][1]["id"] == EXAMPLE_ID_2
+
+    encoded_state = encode(decoded_state, bundle, _fake_encode)
+    assert encoded_state.input_state["parameter"][0]["src"] == "hda"
+    assert encoded_state.input_state["parameter"][0]["id"] == EXAMPLE_ID_1_ENCODED
+    assert encoded_state.input_state["parameter"][1]["src"] == "hda"
+    assert encoded_state.input_state["parameter"][1]["id"] == EXAMPLE_ID_2_ENCODED
+
+
+def _fake_decode(input: str) -> int:
+    return next(key for key, value in ID_MAP.items() if value == input)
+
+
+def _fake_encode(input: int) -> str:
+    return ID_MAP[input]

--- a/test/unit/tool_util/test_test_definition_parsing.py
+++ b/test/unit/tool_util/test_test_definition_parsing.py
@@ -1,6 +1,5 @@
 """Tool test parsing to dicts logic."""
 
-import json
 import os
 from typing import (
     Any,
@@ -17,6 +16,7 @@ from galaxy.util import (
     in_packages,
 )
 from galaxy.util.unittest import TestCase
+from .util import dict_verify_each
 
 # Not the whole response, just some keys and such to test...
 SIMPLE_CONSTRUCTS_EXPECTATIONS_0 = [
@@ -117,18 +117,6 @@ class TestTestParsing(TestCase):
         self._verify_each(test_dicts[1].to_dict(), BIGWIG_TO_WIG_EXPECTATIONS)
 
     def _verify_each(self, target_dict: dict, expectations: List[Any]):
-        assert_json_encodable(target_dict)
-        for path, expectation in expectations:
-            exception = target_dict.get("exception")
-            assert not exception, f"Test failed to generate with exception {exception}"
-            self._verify(target_dict, path, expectation)
-
-    def _verify(self, target_dict: dict, expectation_path: List[str], expectation: Any):
-        rest = target_dict
-        for path_part in expectation_path:
-            rest = rest[path_part]
-        assert rest == expectation, f"{rest} != {expectation} for {expectation_path}"
-
-
-def assert_json_encodable(as_dict: dict):
-    json.dumps(as_dict)
+        exception = target_dict.get("exception")
+        assert not exception, f"Test failed to generate with exception {exception}"
+        dict_verify_each(target_dict, expectations)

--- a/test/unit/tool_util/util.py
+++ b/test/unit/tool_util/util.py
@@ -1,9 +1,33 @@
+import json
 from contextlib import contextmanager
 from os import environ
+from typing import (
+    Any,
+    List,
+)
 
 import pytest
 
 external_dependency_management = pytest.mark.external_dependency_management
+
+
+def dict_verify_each(target_dict: dict, expectations: List[Any]):
+    assert_json_encodable(target_dict)
+    for path, expectation in expectations:
+        exception = target_dict.get("exception")
+        assert not exception, f"Test failed to generate with exception {exception}"
+        dict_verify(target_dict, path, expectation)
+
+
+def dict_verify(target_dict: dict, expectation_path: List[str], expectation: Any):
+    rest = target_dict
+    for path_part in expectation_path:
+        rest = rest[path_part]
+    assert rest == expectation, f"{rest} != {expectation} for {expectation_path}"
+
+
+def assert_json_encodable(as_dict: dict):
+    json.dumps(as_dict)
 
 
 @contextmanager


### PR DESCRIPTION
I've extracted the client pieces out of the structured state work (https://github.com/galaxyproject/galaxy/pull/17393). I think I would want to extract the workflow validation stuff out also before pulling this PR out of WIP. Some of this work is getting old - so I also need to update some of the SA idioms and break the migration out into its own commit. 

Once polished, the immediate gain here is that sometimes the tool form submission can take several minutes to process. Think large collection map over jobs and such. We're creating 1000s of job objects in a web request and this is untenable. This API will allow us to just register a validated tool request in the database and let the job creation process happen within a Celery task. That will be a user experience improvement in the short term but in the long term these validated tool states will allow us to correct many technical issues with workflow extraction, job rerunning, etc.. We will always be able to recover what the user requested and how we processed the parameters - two things we just make guesses about right now (something something reproducibility).

See https://docs.google.com/document/d/1HQOLpLN54CjrB-wbD463XqzvUm-dNB8vTXUFBExh_2o/edit?usp=sharing.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
