### PR TITLE
[24.1] Fix infinite rapid polling in useKeyedCache

### DIFF
--- a/client/src/components/History/CurrentCollection/CollectionPanel.vue
+++ b/client/src/components/History/CurrentCollection/CollectionPanel.vue
@@ -8,10 +8,12 @@ import { canMutateHistory, isCollectionElement, isHDCA } from "@/api";
 import ExpandedItems from "@/components/History/Content/ExpandedItems";
 import { updateContentFields } from "@/components/History/model/queries";
 import { useCollectionElementsStore } from "@/stores/collectionElementsStore";
+import { errorMessageAsString } from "@/utils/simple-error";
 
 import CollectionDetails from "./CollectionDetails.vue";
 import CollectionNavigation from "./CollectionNavigation.vue";
 import CollectionOperations from "./CollectionOperations.vue";
+import Alert from "@/components/Alert.vue";
 import ContentItem from "@/components/History/Content/ContentItem.vue";
 import ListingLayout from "@/components/History/Layout/ListingLayout.vue";
 
@@ -54,6 +56,7 @@ watch(
 
 const collectionElements = computed(() => collectionElementsStore.getCollectionElements(dsc.value) ?? []);
 const loading = computed(() => collectionElementsStore.isLoadingCollectionElements(dsc.value));
+const error = computed(() => collectionElementsStore.hasLoadingCollectionElementsError(dsc.value));
 const jobState = computed(() => ("job_state_summary" in dsc.value ? dsc.value.job_state_summary : undefined));
 const populatedStateMsg = computed(() =>
     "populated_state_message" in dsc.value ? dsc.value.populated_state_message : undefined
@@ -118,7 +121,10 @@ watch(
 </script>
 
 <template>
-    <ExpandedItems v-slot="{ isExpanded, setExpanded }" :scope-key="dsc.id" :get-item-key="getItemKey">
+    <Alert v-if="error" variant="error">
+        {{ errorMessageAsString(error) }}
+    </Alert>
+    <ExpandedItems v-else v-slot="{ isExpanded, setExpanded }" :scope-key="dsc.id" :get-item-key="getItemKey">
         <section class="dataset-collection-panel w-100 d-flex flex-column">
             <section>
                 <CollectionNavigation

--- a/client/src/stores/collectionAttributesStore.ts
+++ b/client/src/stores/collectionAttributesStore.ts
@@ -5,13 +5,14 @@ import { fetchCollectionAttributes } from "@/api/datasetCollections";
 import { useKeyedCache } from "@/composables/keyedCache";
 
 export const useCollectionAttributesStore = defineStore("collectionAttributesStore", () => {
-    const { storedItems, getItemById, isLoadingItem } = useKeyedCache<DatasetCollectionAttributes>((params) =>
-        fetchCollectionAttributes({ id: params.id, instance_type: "history" })
+    const { storedItems, getItemById, isLoadingItem, hasItemLoadError } = useKeyedCache<DatasetCollectionAttributes>(
+        (params) => fetchCollectionAttributes({ id: params.id, instance_type: "history" })
     );
 
     return {
         storedAttributes: storedItems,
         getAttributes: getItemById,
         isLoadingAttributes: isLoadingItem,
+        hasItemLoadError: hasItemLoadError,
     };
 });

--- a/client/src/stores/collectionElementsStore.ts
+++ b/client/src/stores/collectionElementsStore.ts
@@ -37,6 +37,7 @@ const FETCH_LIMIT = 50;
 export const useCollectionElementsStore = defineStore("collectionElementsStore", () => {
     const storedCollections = ref<{ [key: string]: HDCASummary }>({});
     const loadingCollectionElements = ref<{ [key: string]: boolean }>({});
+    const loadingCollectionElementsErrors = ref<{ [key: string]: Error }>({});
     const storedCollectionElements = ref<{ [key: string]: DCEEntry[] }>({});
 
     /**
@@ -60,6 +61,12 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
     const isLoadingCollectionElements = computed(() => {
         return (collection: CollectionEntry) => {
             return loadingCollectionElements.value[getCollectionKey(collection)] ?? false;
+        };
+    });
+
+    const hasLoadingCollectionElementsError = computed(() => {
+        return (collection: CollectionEntry) => {
+            return loadingCollectionElementsErrors.value[getCollectionKey(collection) ?? false];
         };
     });
 
@@ -106,6 +113,8 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
             });
 
             return { fetchedElements, elementOffset: offset };
+        } catch (error) {
+            set(loadingCollectionElementsErrors.value, collectionKey, error);
         } finally {
             del(loadingCollectionElements.value, collectionKey);
         }
@@ -162,7 +171,7 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
     /** Returns collection from storedCollections, will load collection if not in store */
     const getCollectionById = computed(() => {
         return (collectionId: string) => {
-            if (!storedCollections.value[collectionId]) {
+            if (!storedCollections.value[collectionId] && !loadingCollectionElementsErrors.value[collectionId]) {
                 // TODO: Try to remove this as it can cause computed side effects (use keyedCache in this store instead?)
                 fetchCollection({ id: collectionId });
             }
@@ -176,6 +185,8 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
             const collection = await fetchCollectionDetails({ id: params.id });
             set(storedCollections.value, collection.id, collection);
             return collection;
+        } catch (error) {
+            set(loadingCollectionElementsErrors.value, params.id, error);
         } finally {
             del(loadingCollectionElements.value, params.id);
         }
@@ -203,6 +214,8 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
         storedCollectionElements,
         getCollectionElements,
         isLoadingCollectionElements,
+        hasLoadingCollectionElementsError,
+        loadingCollectionElementsErrors,
         getCollectionById,
         fetchCollection,
         invalidateCollectionElements,


### PR DESCRIPTION
Fixes https://sentry.galaxyproject.org/share/issue/e68b539766464e76a627c80333430c82/, which caused 250K events in less than 2 days.

To reproduce try editing a collection you don't own via `<galaxy_url>/collection/<hdca_id>/edit`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
