### PR TITLE
Remove `defaults` channel for conda usage

### DIFF
--- a/.github/workflows/osx_startup.yaml
+++ b/.github/workflows/osx_startup.yaml
@@ -49,9 +49,10 @@ jobs:
         with:
           path: .tox
           key: tox-cache-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-osx
-      - name: Install miniconda  # use this job to test using Python from a conda environment
+      - name: Install miniforge  # use this job to test using Python from a conda environment
         uses: conda-incubator/setup-miniconda@v3
         with:
+          miniforge-version: latest
           activate-environment: ''
       - name: Restore client cache
         uses: actions/cache@v4

--- a/doc/source/admin/dependency_resolvers.rst
+++ b/doc/source/admin/dependency_resolvers.rst
@@ -207,7 +207,7 @@ debug
 ensure_channels
     Conda channels to enable by default. See https://conda.io/docs/user-guide/tasks/manage-channels.html for more
     information about channels. This defaults to the value of the global ``conda_ensure_channels`` option or
-    ``iuc,conda-forge,bioconda,defaults`` otherwise.  This order should be consistent with the `Bioconda prescribed
+    ``conda-forge,bioconda`` otherwise.  This order should be consistent with the `Bioconda prescribed
     order <https://github.com/bioconda/bioconda-recipes/blob/master/config.yml>`__ if it includes ``bioconda``.
 
 auto_install

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -477,7 +477,7 @@
 :Description:
     conda channels to enable by default
     (https://conda.io/docs/user-guide/tasks/manage-channels.html)
-:Default: ``conda-forge,bioconda,defaults``
+:Default: ``conda-forge,bioconda``
 :Type: str
 
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -578,7 +578,7 @@ galaxy:
 
   # conda channels to enable by default
   # (https://conda.io/docs/user-guide/tasks/manage-channels.html)
-  #conda_ensure_channels: conda-forge,bioconda,defaults
+  #conda_ensure_channels: conda-forge,bioconda
 
   # Use locally-built conda packages.
   #conda_use_local: false

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -359,7 +359,7 @@ mapping:
 
       conda_ensure_channels:
         type: str
-        default: conda-forge,bioconda,defaults
+        default: conda-forge,bioconda
         required: false
         desc: |
           conda channels to enable by default

--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -77,7 +77,7 @@ def find_conda_prefix() -> str:
         destination = os.path.join(home, destination)
         if os.path.exists(destination):
             return destination
-    return "miniforge3"
+    return os.path.join(home, "miniforge3")
 
 
 class CondaContext(installable.InstallableContext):

--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -60,13 +60,10 @@ def conda_link() -> str:
         else:
             url = "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh"
     else:
-        if sys.maxsize > 2**32:
-            if "arm64" in platform.platform():
-                url = "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh"
-            else:
-                url = "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh"
+        if "arm64" in platform.platform():
+            url = "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh"
         else:
-            url = "https://repo.anaconda.com/miniconda/Miniconda3-4.5.12-Linux-x86.sh"
+            url = "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh"
     return url
 
 

--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -72,21 +72,12 @@ def find_conda_prefix() -> str:
     for Miniconda installs.
     """
     home = os.path.expanduser("~")
-    miniconda_2_dest = os.path.join(home, "miniconda2")
-    miniconda_3_dest = os.path.join(home, "miniconda3")
-    anaconda_2_dest = os.path.join(home, "anaconda2")
-    anaconda_3_dest = os.path.join(home, "anaconda3")
-    # Prefer miniconda3 install if both available
-    if os.path.exists(miniconda_3_dest):
-        return miniconda_3_dest
-    elif os.path.exists(miniconda_2_dest):
-        return miniconda_2_dest
-    elif os.path.exists(anaconda_3_dest):
-        return anaconda_3_dest
-    elif os.path.exists(anaconda_2_dest):
-        return anaconda_2_dest
-    else:
-        return miniconda_3_dest
+    destinations = ["miniforge3", "miniconda3", "miniconda2", "anaconda3", "anaconda2"]
+    for destination in destinations:
+        destination = os.path.join(home, destination)
+        if os.path.exists(destination):
+            return destination
+    return "miniforge3"
 
 
 class CondaContext(installable.InstallableContext):

--- a/lib/galaxy/tool_util/deps/resolvers/conda.py
+++ b/lib/galaxy/tool_util/deps/resolvers/conda.py
@@ -45,7 +45,7 @@ DEFAULT_BASE_PATH_DIRECTORY = "_conda"
 DEFAULT_CONDARC_OVERRIDE = "_condarc"
 # Conda channel order from highest to lowest, following the one used in
 # https://github.com/bioconda/bioconda-recipes/blob/master/config.yml
-DEFAULT_ENSURE_CHANNELS = "conda-forge,bioconda,defaults"
+DEFAULT_ENSURE_CHANNELS = "conda-forge,bioconda"
 CONDA_SOURCE_CMD = """[ "$(basename "$CONDA_DEFAULT_ENV")" = "$(basename '{environment_path}')" ] || {{
 MAX_TRIES=3
 COUNT=0


### PR DESCRIPTION
See https://www.theregister.com/2024/08/08/anaconda_puts_the_squeeze_on/

According to the [FAQs](https://repo.anaconda.com/pkgs/) this includes `pkgs/main`, `pkgs/r`, and `pkgs/msys2`.
Seems also to be a good idea because for `mulled_channels` we apparently never used it (consistency).

Probably we also need to replace any use of miniconda (because it uses the default channel in the base env) by miniforge (?). Found so far:

- https://github.com/galaxyproject/galaxy/blob/9f3ed273a045119a9a20d2aff65bebb66c9ae11e/lib/galaxy/tool_util/deps/conda_util.py#L69
- https://github.com/galaxyproject/galaxy/blob/9f3ed273a045119a9a20d2aff65bebb66c9ae11e/.github/workflows/osx_startup.yaml#L53
- https://github.com/galaxyproject/galaxy/blob/9f3ed273a045119a9a20d2aff65bebb66c9ae11e/lib/galaxy/tool_util/deps/mulled/mulled_build.py#L377

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
