### PR TITLE
Fix MSA viz, new dependency specification options.

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -233,7 +233,7 @@ async function installDependenciesFromXML(xmlPath, pluginDir) {
         const installPromises = requirements.map(async (dep) => {
             const { type: reqType, package: pkgName, version } = dep.$;
 
-            if (reqType === "package" && pkgName && version) {
+            if (reqType === "npm" && pkgName && version) {
                 try {
                     const installResult = child_process.spawnSync(
                         "npm",

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -1,10 +1,11 @@
 const path = require("path");
-const fs = require("fs");
+const fs = require("fs-extra");
 const del = require("del");
 const { src, dest, series, parallel, watch } = require("gulp");
 const child_process = require("child_process");
 const { globSync } = require("glob");
 const buildIcons = require("./icons/build_icons");
+const xml2js = require("xml2js");
 
 /*
  * We'll want a flexible glob down the road, but for now there are no
@@ -24,7 +25,6 @@ const STATIC_PLUGIN_BUILD_IDS = [
     "hyphyvision",
     "jqplot/jqplot_bar",
     "media_player",
-    "msa",
     "mvpapp",
     "ngl",
     "nora",
@@ -39,8 +39,14 @@ const STATIC_PLUGIN_BUILD_IDS = [
     "ts_visjs",
     "venn",
 ];
+const INSTALL_PLUGIN_BUILD_IDS = ["msa"]; // todo: derive from XML
 const DIST_PLUGIN_BUILD_IDS = ["new_user"];
 const PLUGIN_BUILD_IDS = Array.prototype.concat(DIST_PLUGIN_BUILD_IDS, STATIC_PLUGIN_BUILD_IDS);
+
+const failOnError =
+    process.env.GALAXY_PLUGIN_BUILD_FAIL_ON_ERROR && process.env.GALAXY_PLUGIN_BUILD_FAIL_ON_ERROR !== "0"
+        ? true
+        : false;
 
 const PATHS = {
     nodeModules: "./node_modules",
@@ -56,11 +62,6 @@ const PATHS = {
         underscore: ["underscore.js", "underscore.js"],
     },
 };
-
-const failOnError =
-    process.env.GALAXY_PLUGIN_BUILD_FAIL_ON_ERROR && process.env.GALAXY_PLUGIN_BUILD_FAIL_ON_ERROR !== "0"
-        ? true
-        : false;
 
 PATHS.pluginBaseDir =
     (process.env.GALAXY_PLUGIN_PATH && process.env.GALAXY_PLUGIN_PATH !== "None"
@@ -162,6 +163,8 @@ function buildPlugins(callback, forceRebuild) {
             console.log(`No changes detected for ${pluginName}`);
         } else {
             console.log(`Installing Dependencies for ${pluginName}`);
+
+            // Else we call yarn install and yarn build
             child_process.spawnSync(
                 "yarn",
                 ["install", "--production=false", "--network-timeout=300000", "--check-files"],
@@ -205,6 +208,71 @@ function buildPlugins(callback, forceRebuild) {
     return callback();
 }
 
+function installPlugins(callback) {
+    // iterate through install_plugin_build_ids, identify xml files and install dependencies
+    for (const plugin_name of INSTALL_PLUGIN_BUILD_IDS) {
+        const pluginDir = path.join(PATHS.pluginBaseDir, `visualizations/${plugin_name}`);
+        const xmlPath = path.join(pluginDir, `config/${plugin_name}.xml`);
+        // Check if the file exists
+        if (fs.existsSync(xmlPath)) {
+            installDependenciesFromXML(xmlPath, pluginDir);
+        } else {
+            console.error(`XML file not found: ${xmlPath}`);
+        }
+    }
+
+    return callback();
+}
+
+// Function to parse the XML and install dependencies
+function installDependenciesFromXML(xmlPath, pluginDir) {
+    const parser = new xml2js.Parser();
+    fs.readFile(xmlPath, (err, data) => {
+        if (err) {
+            console.error("Error reading XML file:", err);
+            return;
+        }
+        parser.parseString(data, async (err, result) => {
+            if (err) {
+                console.error("Error parsing XML:", err);
+                return;
+            }
+            // Navigate to the dependencies
+            const requirements = result.visualization.requirements[0].requirement;
+            // Extract the details
+            requirements.forEach((dep) => {
+                const reqType = dep.$.type;
+                const pkgName = dep.$.package;
+                const version = dep.$.version;
+
+                if (reqType == "package" && pkgName && version) {
+                    // install the package.
+                    if (
+                        child_process.spawnSync("npm", ["install", "--silent", "--no-save", `${pkgName}@${version}`], {
+                            cwd: pluginDir,
+                            stdio: "inherit",
+                            shell: true,
+                        }).status === 0
+                    ) {
+                        // Copy static from the installed package to the
+                        // plugin's static directory.
+                        // This keeps separation from standard staging.
+                        fs.copy(path.join(pluginDir, "node_modules", pkgName, "static"), path.join(pluginDir, "static"))
+                            .then(() => {
+                                console.log(`Successfully staged package for ${pkgName}@${version} in ${pluginDir}`);
+                            })
+                            .catch((err) => {
+                                console.error(`Error staging package ${pkgName}@${version} in ${pluginDir}`);
+                            });
+                    } else {
+                        console.error(`Error installing package ${pkgName}@${version} in ${pluginDir}`);
+                    }
+                }
+            });
+        });
+    });
+}
+
 function forceBuildPlugins(callback) {
     return buildPlugins(callback, true);
 }
@@ -214,8 +282,8 @@ function cleanPlugins() {
 }
 
 const client = parallel(fonts, stageLibs, icons);
-const plugins = series(buildPlugins, cleanPlugins, stagePlugins);
-const pluginsRebuild = series(forceBuildPlugins, cleanPlugins, stagePlugins);
+const plugins = series(buildPlugins, installPlugins, cleanPlugins, stagePlugins);
+const pluginsRebuild = series(forceBuildPlugins, installPlugins, cleanPlugins, stagePlugins);
 
 function watchPlugins() {
     const BUILD_PLUGIN_WATCH_GLOB = [
@@ -229,3 +297,4 @@ module.exports.plugins = plugins;
 module.exports.pluginsRebuild = pluginsRebuild;
 module.exports.watchPlugins = watchPlugins;
 module.exports.default = parallel(client, plugins);
+module.exports.installPlugins = installPlugins;

--- a/client/package.json
+++ b/client/package.json
@@ -172,6 +172,7 @@
     "eslint-plugin-vuejs-accessibility": "^2.2.0",
     "expose-loader": "^4.1.0",
     "fake-indexeddb": "^6.0.0",
+    "fs-extra": "^11.2.0",
     "gulp": "^4.0.2",
     "ignore-loader": "^0.1.2",
     "imports-loader": "^4.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -204,6 +204,7 @@
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.10.0",
     "xml-js": "^1.6.11",
+    "xml2js": "^0.6.2",
     "yaml-jest": "^1.2.0",
     "yaml-loader": "^0.8.0"
   },

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6295,6 +6295,15 @@ fresh@0.5.2:
   resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
 
+fs-extra@^11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.2.0.tgz#e70e17dfad64232287d01929399e0ea7c86b0e5b"
+  integrity sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-mkdirp-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz"
@@ -6561,7 +6570,12 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.10, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
+graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
+  version "4.2.10"
+  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
+graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.11:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -8076,6 +8090,15 @@ json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jspdf@^2.5.1:
   version "2.5.1"
@@ -11601,6 +11624,11 @@ universalify@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
   integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
+universalify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
+  integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10364,6 +10364,11 @@ sass@^1.69.4:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
+sax@>=0.6.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
+  integrity sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==
+
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -12244,6 +12249,19 @@ xml-name-validator@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz"
   integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
+
+xml2js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.2.tgz#dd0b630083aa09c161e25a4d0901e2b2a929b499"
+  integrity sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlchars@^2.2.0:
   version "2.2.0"

--- a/config/plugins/visualizations/msa/config/msa.xml
+++ b/config/plugins/visualizations/msa/config/msa.xml
@@ -11,6 +11,9 @@
             <to_param param_attr="id">dataset_id</to_param>
         </data_source>
     </data_sources>
+    <requirements>
+        <requirement type="package" version="0.2.0" package="@galaxyproject/msa"/>
+    </requirements>
     <params>
         <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>
     </params>

--- a/config/plugins/visualizations/msa/config/msa.xml
+++ b/config/plugins/visualizations/msa/config/msa.xml
@@ -12,7 +12,7 @@
         </data_source>
     </data_sources>
     <requirements>
-        <requirement type="package" version="0.2.1" package="@galaxyproject/msa"/>
+        <requirement type="npm" version="0.2.1" package="@galaxyproject/msa"/>
     </requirements>
     <params>
         <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>

--- a/config/plugins/visualizations/msa/config/msa.xml
+++ b/config/plugins/visualizations/msa/config/msa.xml
@@ -12,7 +12,7 @@
         </data_source>
     </data_sources>
     <requirements>
-        <requirement type="package" version="0.2.0" package="@galaxyproject/msa"/>
+        <requirement type="package" version="0.2.1" package="@galaxyproject/msa"/>
     </requirements>
     <params>
         <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>

--- a/config/plugins/visualizations/msa/package.json
+++ b/config/plugins/visualizations/msa/package.json
@@ -11,7 +11,7 @@
         "babel-preset-env": "^1.6.1"
     },
     "scripts": {
-        "build": "parcel build src/script.js --dist-dir static"
+        "build": "parcel build src/script.js --dist-dir static --no-source-maps"
     },
     "devDependencies": {
         "parcel": "^2.12.0"

--- a/config/plugins/visualizations/msa/package.json
+++ b/config/plugins/visualizations/msa/package.json
@@ -1,15 +1,11 @@
 {
     "name": "@galaxyproject/msa",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "keywords": [
         "galaxy",
         "visualization"
     ],
     "license": "AFL-3.0",
-    "dependencies": {
-        "babel-plugin-transform-export-extensions": "^6.22.0",
-        "babel-preset-env": "^1.6.1"
-    },
     "files": [
         "static"
     ],
@@ -17,6 +13,8 @@
         "build": "parcel build src/script.js --dist-dir static --no-source-maps"
     },
     "devDependencies": {
+        "babel-plugin-transform-export-extensions": "^6.22.0",
+        "babel-preset-env": "^1.6.1",
         "parcel": "^2.12.0"
     }
 }

--- a/config/plugins/visualizations/msa/package.json
+++ b/config/plugins/visualizations/msa/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "visualization",
-    "version": "0.1.0",
+    "name": "@galaxyproject/msa",
+    "version": "0.2.0",
     "keywords": [
         "galaxy",
         "visualization"
@@ -10,6 +10,9 @@
         "babel-plugin-transform-export-extensions": "^6.22.0",
         "babel-preset-env": "^1.6.1"
     },
+    "files": [
+        "static"
+    ],
     "scripts": {
         "build": "parcel build src/script.js --dist-dir static --no-source-maps"
     },


### PR DESCRIPTION
Primary driver was fixing the deployed MSA application on main -- this has been deployed to main in the usegalaxy branch as of last week and is working well to resolve our issues w/ msa.  Specifying node package dependencies and relying on prebuilt visualization plugins (as implemented here) is going to make a huge difference in reliability moving forward.

In short, visualizations should prebuild and publish a `static` directory with whatever they need to run.

In package.json, that's this new part:

```
    "files": [
        "static"
    ],
```

Then the viz is published to npm like so:  https://www.npmjs.com/@galaxyproject/msa

And then in the viz xml, we specify a particular version (or range, as appropriate) of plugin the viz is compatible with, like so:

```
    <requirements>
        <requirement type="package" version="0.2.1" package="@galaxyproject/msa"/>
    </requirements>
```

These requirements will all get staged to the Galaxy server's static file serving *without a build process required*, avoiding all of the issues we've had with differing node versions on novel and/or archaic systems.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
