### PR TITLE
Refactor ``LibraryDatasetsManager`` and fix type annotation issue

### DIFF
--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -503,18 +503,18 @@ class ModelManager(Generic[U]):
         """
         raise exceptions.NotImplemented("Abstract method")
 
-    def update(self, item, new_values, flush=True, **kwargs) -> U:
+    def update(self, item: U, new_values: Dict[str, Any], flush: bool = True, **kwargs) -> U:
         """
         Given a dictionary of new values, update `item` and return it.
 
         ..note: NO validation or deserialization occurs here.
         """
-        self.session().add(item)
         for key, value in new_values.items():
             if hasattr(item, key):
                 setattr(item, key, value)
+        session = self.session()
+        session.add(item)
         if flush:
-            session = self.session()
             with transaction(session):
                 session.commit()
         return item

--- a/lib/galaxy/managers/folders.py
+++ b/lib/galaxy/managers/folders.py
@@ -505,7 +505,7 @@ class FolderManager:
             stmt = stmt.where(
                 or_(
                     func.lower(ldda.name).contains(search_text, autoescape=True),
-                    func.lower(ldda.message).contains(search_text, autoescape=True),  # type:ignore[attr-defined]
+                    func.lower(ldda.message).contains(search_text, autoescape=True),
                 )
             )
         sort_column = LDDA_SORT_COLUMN_MAP[payload.order_by](ldda, associated_dataset)

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -35,7 +35,7 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
     def __init__(self, app: MinimalManagerApp):
         self.app = app
 
-    def get(self, trans, decoded_library_dataset_id, check_accessible=True):
+    def get(self, trans, decoded_library_dataset_id, check_accessible=True) -> LibraryDataset:
         """
         Get the library dataset from the DB.
 
@@ -129,7 +129,7 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
         for key, val in payload.items():
             if val is None:
                 continue
-            if key in ("name"):
+            if key in ("name",):
                 if len(val) < MINIMUM_STRING_LENGTH:
                     raise RequestParameterInvalidException(
                         f"{key} must have at least length of {MINIMUM_STRING_LENGTH}"
@@ -139,19 +139,19 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
             if key in ("misc_info", "message"):
                 val = validation.validate_and_sanitize_basestring(key, val)
                 validated_payload[key] = val
-            if key in ("file_ext"):
+            if key in ("file_ext",):
                 datatype = self.app.datatypes_registry.get_datatype_by_extension(val)
                 if datatype is None and val not in ("auto",):
                     raise RequestParameterInvalidException(f"This Galaxy does not recognize the datatype of: {val}")
                 validated_payload[key] = val
-            if key in ("genome_build"):
+            if key in ("genome_build",):
                 if len(val) < MINIMUM_STRING_LENGTH:
                     raise RequestParameterInvalidException(
                         f"{key} must have at least length of {MINIMUM_STRING_LENGTH}"
                     )
                 val = validation.validate_and_sanitize_basestring(key, val)
                 validated_payload[key] = val
-            if key in ("tags"):
+            if key in ("tags",):
                 val = validation.validate_and_sanitize_basestring_list(key, util.listify(val))
                 validated_payload[key] = val
         return validated_payload
@@ -187,7 +187,7 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
 
         :raises:    ObjectNotFound
         """
-        if not trans.app.security_agent.can_access_library_item(trans.get_current_user_roles(), ld, trans.user):
+        if not self.app.security_agent.can_access_library_item(trans.get_current_user_roles(), ld, trans.user):
             raise ObjectNotFound("Library dataset with the id provided was not found.")
         elif ld.deleted:
             raise ObjectNotFound("Library dataset with the id provided is deleted.")
@@ -210,27 +210,27 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
             raise ObjectNotFound("Library dataset with the id provided is deleted.")
         elif trans.user_is_admin:
             return ld
-        if not trans.app.security_agent.can_modify_library_item(trans.get_current_user_roles(), ld):
+        if not self.app.security_agent.can_modify_library_item(trans.get_current_user_roles(), ld):
             raise InsufficientPermissionsException("You do not have proper permission to modify this library dataset.")
         else:
             return ld
 
-    def serialize(self, trans, ld):
+    def serialize(self, trans, ld: LibraryDataset) -> Dict[str, Any]:
         """Serialize the library dataset into a dictionary."""
         current_user_roles = trans.get_current_user_roles()
 
         # Build the full path for breadcrumb purposes.
         full_path = self._build_path(trans, ld.folder)
-        dataset_item = (trans.security.encode_id(ld.id), ld.name)
+        dataset_item = (self.app.security.encode_id(ld.id), ld.name)
         full_path.insert(0, dataset_item)
         full_path = full_path[::-1]
 
         # Find expired versions of the library dataset
         expired_ldda_versions = []
         for expired_ldda in ld.expired_datasets:
-            expired_ldda_versions.append((trans.security.encode_id(expired_ldda.id), expired_ldda.name))
+            expired_ldda_versions.append((self.app.security.encode_id(expired_ldda.id), expired_ldda.name))
 
-        rval = trans.security.encode_all_ids(ld.to_dict())
+        rval = self.app.security.encode_all_ids(ld.to_dict())
         if len(expired_ldda_versions) > 0:
             rval["has_versions"] = True
             rval["expired_versions"] = expired_ldda_versions
@@ -249,14 +249,14 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
         rval["file_size"] = util.nice_size(int(ldda.get_size(calculate_size=False)))
         rval["date_uploaded"] = ldda.create_time.isoformat()
         rval["update_time"] = ldda.update_time.isoformat()
-        rval["can_user_modify"] = trans.user_is_admin or trans.app.security_agent.can_modify_library_item(
+        rval["can_user_modify"] = trans.user_is_admin or self.app.security_agent.can_modify_library_item(
             current_user_roles, ld
         )
-        rval["is_unrestricted"] = trans.app.security_agent.dataset_is_public(ldda.dataset)
+        rval["is_unrestricted"] = self.app.security_agent.dataset_is_public(ldda.dataset)
         rval["tags"] = trans.tag_handler.get_tags_list(ldda.tags)
 
         #  Manage dataset permission is always attached to the dataset itself, not the ld or ldda to maintain consistency
-        rval["can_user_manage"] = trans.user_is_admin or trans.app.security_agent.can_manage_dataset(
+        rval["can_user_manage"] = trans.user_is_admin or self.app.security_agent.can_manage_dataset(
             current_user_roles, ldda.dataset
         )
         return rval
@@ -275,15 +275,15 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
         path_to_root = []
         if folder.parent_id is None:
             # We are almost in root
-            path_to_root.append((f"F{trans.security.encode_id(folder.id)}", folder.name))
+            path_to_root.append((f"F{self.app.security.encode_id(folder.id)}", folder.name))
         else:
             # We add the current folder and traverse up one folder.
-            path_to_root.append((f"F{trans.security.encode_id(folder.id)}", folder.name))
+            path_to_root.append((f"F{self.app.security.encode_id(folder.id)}", folder.name))
             upper_folder = trans.sa_session.get(LibraryFolder, folder.parent_id)
             path_to_root.extend(self._build_path(trans, upper_folder))
         return path_to_root
 
 
-def get_library_dataset(session, library_dataset_id):
+def get_library_dataset(session, library_dataset_id) -> LibraryDataset:
     stmt = select(LibraryDataset).where(LibraryDataset.id == library_dataset_id)
     return session.scalars(stmt).one()

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -171,7 +171,7 @@ class LibraryDatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin,
         :rtype:     dictionary
         :returns:   dict of current roles for all available permission types
         """
-        return self.ldda_manager.serialize_dataset_association_roles(trans, library_dataset)
+        return self.ldda_manager.serialize_dataset_association_roles(library_dataset)
 
     @expose_api
     def update(self, trans, encoded_dataset_id, payload=None, **kwd):

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -199,7 +199,8 @@ class LibraryDatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin,
         :rtype:     dictionary
         """
         library_dataset = self.ld_manager.get(trans, managers_base.decode_id(self.app, encoded_dataset_id))
-        updated = self.ld_manager.update(trans, library_dataset, payload)
+        self.ld_manager.check_modifiable(trans, library_dataset)
+        updated = self.ld_manager.update(library_dataset, payload, trans=trans)
         serialized = self.ld_manager.serialize(trans, updated)
         return serialized
 

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -569,7 +569,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         dataset_manager = self.dataset_manager_by_type[hda_ldda]
         dataset = dataset_manager.get_accessible(dataset_id, trans.user)
         dataset_manager.update_permissions(trans, dataset, **payload_dict)
-        return dataset_manager.serialize_dataset_association_roles(trans, dataset)
+        return dataset_manager.serialize_dataset_association_roles(dataset)
 
     def extra_files(
         self,

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -604,7 +604,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         assert hda is not None
         self.history_manager.error_unless_mutable(hda.history)
         self.hda_manager.update_permissions(trans, hda, **payload_dict)
-        roles = self.hda_manager.serialize_dataset_association_roles(trans, hda)
+        roles = self.hda_manager.serialize_dataset_association_roles(hda)
         return DatasetAssociationRoles(**roles)
 
     def update(

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -447,10 +447,11 @@ class TestLibrariesApi(ApiTestCase):
             "name": "updated_name",
             "file_ext": "fasta",
             "misc_info": "updated_info",
-            "genome_build": "updated_genome_build",
+            "message": "update message",
         }
         ld_updated = self._patch_library_dataset(ld["id"], data)
-        self._assert_has_keys(ld_updated, "name", "file_ext", "misc_info", "genome_build")
+        for key, value in data.items():
+            assert ld_updated[key] == value
 
     @requires_new_library
     def test_update_dataset_tags(self):


### PR DESCRIPTION
- Refactor and type annotate `LibraryDatasetsManager`, including changing its `model_class` to the more appropriate `LibraryDataset`.
- Make `LibraryDatasetsManager.update()` method compatible with supertype, fixing one error reported by mypy 1.11 (see https://github.com/galaxyproject/galaxy/pull/18578 ).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
