### PR TITLE
[24.1] Allow to change only the description of a quota

### DIFF
--- a/lib/galaxy/managers/quotas.py
+++ b/lib/galaxy/managers/quotas.py
@@ -121,7 +121,7 @@ class QuotaManager:
         stmt = select(Quota).where(and_(Quota.name == params.name, Quota.id != quota.id)).limit(1)
         if not params.name:
             raise ActionInputError("Enter a valid name.")
-        elif params.name != quota.name and self.sa_session.scalars(stmt).first():
+        elif self.sa_session.scalars(stmt).first():
             raise ActionInputError("A quota with that name already exists.")
         else:
             old_name = quota.name

--- a/lib/galaxy/managers/quotas.py
+++ b/lib/galaxy/managers/quotas.py
@@ -12,7 +12,10 @@ from typing import (
     Union,
 )
 
-from sqlalchemy import select
+from sqlalchemy import (
+    and_,
+    select,
+)
 
 from galaxy import (
     model,
@@ -115,7 +118,7 @@ class QuotaManager:
             return False
 
     def rename_quota(self, quota, params) -> str:
-        stmt = select(Quota).where(Quota.name == params.name).limit(1)
+        stmt = select(Quota).where(and_(Quota.name == params.name, Quota.id != quota.id)).limit(1)
         if not params.name:
             raise ActionInputError("Enter a valid name.")
         elif params.name != quota.name and self.sa_session.scalars(stmt).first():

--- a/test/integration/test_quota.py
+++ b/test/integration/test_quota.py
@@ -98,7 +98,6 @@ class TestQuotaIntegration(integration_util.IntegrationTestCase):
         }
         put_response = self._put(f"quotas/{quota_id}", data=update_payload, json=True)
         put_response.raise_for_status()
-        assert "has been renamed to" in put_response.text
 
         show_response = self._get(f"quotas/{quota_id}")
         show_response.raise_for_status()

--- a/test/integration/test_quota.py
+++ b/test/integration/test_quota.py
@@ -85,6 +85,27 @@ class TestQuotaIntegration(integration_util.IntegrationTestCase):
         json_response = show_response.json()
         assert json_response["name"] == new_quota_name
 
+    def test_update_description(self):
+        quota_name = "test-update-quota-description"
+        quota = self._create_quota_with_name(quota_name)
+        quota_id = quota["id"]
+
+        # update description (one needs to specify a name even if should not be changed)
+        quota_description = "description of test-updated-quota-name"
+        update_payload = {
+            "name": quota_name,
+            "description": quota_description,
+        }
+        put_response = self._put(f"quotas/{quota_id}", data=update_payload, json=True)
+        put_response.raise_for_status()
+        assert "has been renamed to" in put_response.text
+
+        show_response = self._get(f"quotas/{quota_id}")
+        show_response.raise_for_status()
+        json_response = show_response.json()
+        assert json_response["name"] == quota_name
+        assert json_response["description"] == quota_description
+
     def test_delete(self):
         quota_name = "test-delete-quota"
         quota = self._create_quota_with_name(quota_name)


### PR DESCRIPTION
A [quota update via API](https://github.com/galaxyproject/galaxy/blob/67b4a69c1b36eec4dc5871c5eeb97b6bdea8a288/lib/galaxy/webapps/galaxy/services/quotas.py#L85) requires name or quota to be set, but the [manager](https://github.com/galaxyproject/galaxy/blob/67b4a69c1b36eec4dc5871c5eeb97b6bdea8a288/lib/galaxy/managers/quotas.py#L119) requires a name to be set.

If one wants to change just the description of a quota the used select statement gets the quota itself and the elif branch hits resulting in an exception.

With the change one can change just the description, but one still needs to specify the name of the quota. We could hange this such that also in the manager the name of the quota needs to be specified.

I guess in the admin UI this has not been a problem because the name and description are prefilled with the old values.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
