### PR TITLE
Handle compressed content in dataset preview for all sequence classes

### DIFF
--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -318,30 +318,6 @@ class Sequence(data.Text):
 
         return [cmd]
 
-
-class Alignment(data.Text):
-    """Class describing an alignment"""
-
-    edam_data = "data_0863"
-
-    MetadataElement(
-        name="species", desc="Species", default=[], param=metadata.SelectParameter, multiple=True, readonly=True
-    )
-
-    @classmethod
-    def split(cls, input_datasets: List, subdir_generator_function: Callable, split_params: Optional[Dict]) -> None:
-        """Split a generic alignment file (not sensible or possible, see subclasses)."""
-        if split_params is None:
-            return None
-        raise NotImplementedError("Can't split generic alignment files")
-
-
-class BaseSequence(Sequence):
-    """
-    Common base class provides common methods used by FASTQ and FASTA sequence format classes.
-    It includes functionality for displaying data shared among FASTQ and FASTA formats.
-    """
-
     def display_data(
         self,
         trans,
@@ -368,11 +344,28 @@ class BaseSequence(Sequence):
                     headers,
                 )
         else:
-            return Sequence.display_data(self, trans, dataset, preview, filename, to_ext, **kwd)
+            return super().display_data(self, trans, dataset, preview, filename, to_ext, **kwd)
+
+
+class Alignment(data.Text):
+    """Class describing an alignment"""
+
+    edam_data = "data_0863"
+
+    MetadataElement(
+        name="species", desc="Species", default=[], param=metadata.SelectParameter, multiple=True, readonly=True
+    )
+
+    @classmethod
+    def split(cls, input_datasets: List, subdir_generator_function: Callable, split_params: Optional[Dict]) -> None:
+        """Split a generic alignment file (not sensible or possible, see subclasses)."""
+        if split_params is None:
+            return None
+        raise NotImplementedError("Can't split generic alignment files")
 
 
 @build_sniff_from_prefix
-class Fasta(BaseSequence):
+class Fasta(Sequence):
     """Class representing a FASTA sequence"""
 
     edam_format = "format_1929"
@@ -727,7 +720,7 @@ class Fastg(Sequence):
 
 
 @build_sniff_from_prefix
-class BaseFastq(BaseSequence):
+class BaseFastq(Sequence):
     """Base class for FastQ sequences"""
 
     edam_format = "format_1930"

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -344,7 +344,7 @@ class Sequence(data.Text):
                     headers,
                 )
         else:
-            return super().display_data(self, trans, dataset, preview, filename, to_ext, **kwd)
+            return super().display_data(trans, dataset, preview, filename, to_ext, **kwd)
 
 
 class Alignment(data.Text):

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -799,7 +799,6 @@ class BaseFastq(BaseSequence):
             return False
         return self.check_first_block(file_prefix)
 
-
     @classmethod
     def split(cls, input_datasets: List, subdir_generator_function: Callable, split_params: Optional[Dict]) -> None:
         """


### PR DESCRIPTION
This PR fixes https://github.com/galaxyproject/galaxy/issues/15653
Method display_data moved to common class for fasta and fastq instead being used only in fasq class.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
