### PR TITLE
Backend handling of setting user-role, user-group, and group-role associations

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -655,7 +655,7 @@ class GalaxyManagerApplication(MinimalManagerApp, MinimalGalaxyApplication, Inst
         # Load security policy.
         self.security_agent = self.model.security_agent
         self.host_security_agent = galaxy.model.security.HostAgent(
-            model=self.security_agent.model, permitted_actions=self.security_agent.permitted_actions
+            self.security_agent.sa_session, permitted_actions=self.security_agent.permitted_actions
         )
 
         # We need the datatype registry for running certain tasks that modify HDAs, and to build the registry we need

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2967,10 +2967,11 @@ class Group(Base, Dictifiable, RepresentById):
 
 class UserGroupAssociation(Base, RepresentById):
     __tablename__ = "user_group_association"
+    __table_args__ = (UniqueConstraint("user_id", "group_id"),)
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[int] = mapped_column(ForeignKey("galaxy_user.id"), index=True, nullable=True)
-    group_id: Mapped[int] = mapped_column(ForeignKey("galaxy_group.id"), index=True, nullable=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
+    group_id: Mapped[int] = mapped_column(ForeignKey("galaxy_group.id"), index=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
     user: Mapped["User"] = relationship(back_populates="groups")

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3685,10 +3685,11 @@ class HistoryUserShareAssociation(Base, UserShareAssociation):
 
 class UserRoleAssociation(Base, RepresentById):
     __tablename__ = "user_role_association"
+    __table_args__ = (UniqueConstraint("user_id", "role_id"),)
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[int] = mapped_column(ForeignKey("galaxy_user.id"), index=True, nullable=True)
-    role_id: Mapped[int] = mapped_column(ForeignKey("role.id"), index=True, nullable=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
+    role_id: Mapped[int] = mapped_column(ForeignKey("role.id"), index=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3705,10 +3705,11 @@ class UserRoleAssociation(Base, RepresentById):
 
 class GroupRoleAssociation(Base, RepresentById):
     __tablename__ = "group_role_association"
+    __table_args__ = (UniqueConstraint("group_id", "role_id"),)
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    group_id: Mapped[int] = mapped_column(ForeignKey("galaxy_group.id"), index=True, nullable=True)
-    role_id: Mapped[int] = mapped_column(ForeignKey("role.id"), index=True, nullable=True)
+    group_id: Mapped[int] = mapped_column(ForeignKey("galaxy_group.id"), index=True)
+    role_id: Mapped[int] = mapped_column(ForeignKey("role.id"), index=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
     group: Mapped["Group"] = relationship(back_populates="roles")

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -849,14 +849,6 @@ class User(Base, Dictifiable, RepresentById):
     all_notifications: Mapped[List["UserNotificationAssociation"]] = relationship(
         back_populates="user", cascade_backrefs=False
     )
-    non_private_roles: Mapped[List["UserRoleAssociation"]] = relationship(
-        viewonly=True,
-        primaryjoin=(
-            lambda: (User.id == UserRoleAssociation.user_id)
-            & (UserRoleAssociation.role_id == Role.id)
-            & not_(Role.name == User.email)
-        ),
-    )
 
     preferences: AssociationProxy[Any]
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -780,7 +780,7 @@ class User(Base, Dictifiable, RepresentById):
     id: Mapped[int] = mapped_column(primary_key=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
-    email: Mapped[str] = mapped_column(TrimmedString(255), index=True)
+    email: Mapped[str] = mapped_column(TrimmedString(255), index=True, unique=True)
     username: Mapped[Optional[str]] = mapped_column(TrimmedString(255), index=True, unique=True)
     password: Mapped[str] = mapped_column(TrimmedString(255))
     last_password_change: Mapped[Optional[datetime]] = mapped_column(default=now)

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -97,7 +97,7 @@ def _build_model_mapping(engine, map_install_models, thread_local_log) -> Galaxy
         model_modules.append(tool_shed_install)
 
     model_mapping = GalaxyModelMapping(model_modules, engine)
-    model_mapping.security_agent = GalaxyRBACAgent(model_mapping)
+    model_mapping.security_agent = GalaxyRBACAgent(model_mapping.session)
     model_mapping.thread_local_log = thread_local_log
     return model_mapping
 

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/13fe10b8e35b_add_not_null_constraints_to_user_group_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/13fe10b8e35b_add_not_null_constraints_to_user_group_.py
@@ -1,0 +1,42 @@
+"""Add not-null constraints to user_group_association
+
+Revision ID: 13fe10b8e35b
+Revises: 56ddf316dbd0
+Create Date: 2024-09-09 21:26:26.032842
+
+"""
+
+from alembic import op
+
+from galaxy.model.migrations.data_fixes.association_table_fixer import UserGroupAssociationNullFix
+from galaxy.model.migrations.util import (
+    alter_column,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "13fe10b8e35b"
+down_revision = "56ddf316dbd0"
+branch_labels = None
+depends_on = None
+
+table_name = "user_group_association"
+
+
+def upgrade():
+    with transaction():
+        _remove_records_with_nulls()
+        alter_column(table_name, "user_id", nullable=False)
+        alter_column(table_name, "group_id", nullable=False)
+
+
+def downgrade():
+    with transaction():
+        alter_column(table_name, "user_id", nullable=True)
+        alter_column(table_name, "group_id", nullable=True)
+
+
+def _remove_records_with_nulls():
+    """Remove associations having null as user_id or group_id"""
+    connection = op.get_bind()
+    UserGroupAssociationNullFix(connection).run()

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/1cf595475b58_email_column_unique_constraint.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/1cf595475b58_email_column_unique_constraint.py
@@ -1,0 +1,52 @@
+"""Email column unique constraint
+
+Revision ID: 1cf595475b58
+Revises: d619fdfa6168
+Create Date: 2024-07-03 19:53:22.443016
+"""
+
+from alembic import op
+
+from galaxy.model.database_object_names import build_index_name
+from galaxy.model.migrations.data_fixes.user_table_fixer import EmailDeduplicator
+from galaxy.model.migrations.util import (
+    create_index,
+    drop_index,
+    index_exists,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "1cf595475b58"
+down_revision = "d619fdfa6168"
+branch_labels = None
+depends_on = None
+
+
+table_name = "galaxy_user"
+column_name = "email"
+index_name = build_index_name(table_name, [column_name])
+
+
+def upgrade():
+    with transaction():
+        _fix_duplicate_emails()
+        # Existing databases may have an existing index we no longer need
+        # New databases will not have that index, so we must check.
+        if index_exists(index_name, table_name, False):
+            drop_index(index_name, table_name)
+        # Create a UNIQUE index
+        create_index(index_name, table_name, [column_name], unique=True)
+
+
+def downgrade():
+    with transaction():
+        drop_index(index_name, table_name)
+        # Restore a non-unique index
+        create_index(index_name, table_name, [column_name])
+
+
+def _fix_duplicate_emails():
+    """Fix records with duplicate usernames"""
+    connection = op.get_bind()
+    EmailDeduplicator(connection).run()

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/1fdd615f2cdb_add_not_null_constraints_to_user_role_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/1fdd615f2cdb_add_not_null_constraints_to_user_role_.py
@@ -1,0 +1,42 @@
+"""Add not-null constraints to user_role_association
+
+Revision ID: 1fdd615f2cdb
+Revises: 349dd9d9aac9
+Create Date: 2024-09-09 21:28:11.987054
+
+"""
+
+from alembic import op
+
+from galaxy.model.migrations.data_fixes.association_table_fixer import UserRoleAssociationNullFix
+from galaxy.model.migrations.util import (
+    alter_column,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "1fdd615f2cdb"
+down_revision = "349dd9d9aac9"
+branch_labels = None
+depends_on = None
+
+table_name = "user_role_association"
+
+
+def upgrade():
+    with transaction():
+        _remove_records_with_nulls()
+        alter_column(table_name, "user_id", nullable=False)
+        alter_column(table_name, "role_id", nullable=False)
+
+
+def downgrade():
+    with transaction():
+        alter_column(table_name, "user_id", nullable=True)
+        alter_column(table_name, "role_id", nullable=True)
+
+
+def _remove_records_with_nulls():
+    """Remove associations having null as user_id or role_id"""
+    connection = op.get_bind()
+    UserRoleAssociationNullFix(connection).run()

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/25b092f7938b_add_not_null_constraints_to_group_role_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/25b092f7938b_add_not_null_constraints_to_group_role_.py
@@ -1,0 +1,42 @@
+"""Add not-null constraints to group_role_association
+
+Revision ID: 25b092f7938b
+Revises: 9ef6431f3a4e
+Create Date: 2024-09-09 16:17:26.652865
+
+"""
+
+from alembic import op
+
+from galaxy.model.migrations.data_fixes.association_table_fixer import GroupRoleAssociationNullFix
+from galaxy.model.migrations.util import (
+    alter_column,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "25b092f7938b"
+down_revision = "9ef6431f3a4e"
+branch_labels = None
+depends_on = None
+
+table_name = "group_role_association"
+
+
+def upgrade():
+    with transaction():
+        _remove_records_with_nulls()
+        alter_column(table_name, "group_id", nullable=True)
+        alter_column(table_name, "role_id", nullable=False)
+
+
+def downgrade():
+    with transaction():
+        alter_column(table_name, "group_id", nullable=True)
+        alter_column(table_name, "role_id", nullable=True)
+
+
+def _remove_records_with_nulls():
+    """Remove associations having null as group_id or role_id"""
+    connection = op.get_bind()
+    GroupRoleAssociationNullFix(connection).run()

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/349dd9d9aac9_add_unique_constraint_to_user_role_assoc.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/349dd9d9aac9_add_unique_constraint_to_user_role_assoc.py
@@ -1,0 +1,45 @@
+"""Add unique constraint to user_role_association
+
+Revision ID: 349dd9d9aac9
+Revises: 1cf595475b58
+Create Date: 2024-09-09 16:14:58.278850
+
+"""
+
+from alembic import op
+
+from galaxy.model.migrations.data_fixes.association_table_fixer import UserRoleAssociationDuplicateFix
+from galaxy.model.migrations.util import (
+    create_unique_constraint,
+    drop_constraint,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "349dd9d9aac9"
+down_revision = "1cf595475b58"
+branch_labels = None
+depends_on = None
+
+table_name = "user_role_association"
+constraint_column_names = ["user_id", "role_id"]
+unique_constraint_name = (
+    "user_role_association_user_id_key"  # This is what the model's naming convention will generate.
+)
+
+
+def upgrade():
+    with transaction():
+        _remove_duplicate_records()
+        create_unique_constraint(unique_constraint_name, table_name, constraint_column_names)
+
+
+def downgrade():
+    with transaction():
+        drop_constraint(unique_constraint_name, table_name)
+
+
+def _remove_duplicate_records():
+    """Remove duplicate associations"""
+    connection = op.get_bind()
+    UserRoleAssociationDuplicateFix(connection).run()

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/56ddf316dbd0_add_unique_constraint_to_user_group_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/56ddf316dbd0_add_unique_constraint_to_user_group_.py
@@ -1,0 +1,45 @@
+"""Add unique constraint to user_group_association
+
+Revision ID: 56ddf316dbd0
+Revises: 1fdd615f2cdb
+Create Date: 2024-09-09 16:10:37.081834
+
+"""
+
+from alembic import op
+
+from galaxy.model.migrations.data_fixes.association_table_fixer import UserGroupAssociationDuplicateFix
+from galaxy.model.migrations.util import (
+    create_unique_constraint,
+    drop_constraint,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "56ddf316dbd0"
+down_revision = "1fdd615f2cdb"
+branch_labels = None
+depends_on = None
+
+table_name = "user_group_association"
+constraint_column_names = ["user_id", "group_id"]
+unique_constraint_name = (
+    "user_group_association_user_id_key"  # This is what the model's naming convention will generate.
+)
+
+
+def upgrade():
+    with transaction():
+        _remove_duplicate_records()
+        create_unique_constraint(unique_constraint_name, table_name, constraint_column_names)
+
+
+def downgrade():
+    with transaction():
+        drop_constraint(unique_constraint_name, table_name)
+
+
+def _remove_duplicate_records():
+    """Remove duplicate associations"""
+    connection = op.get_bind()
+    UserGroupAssociationDuplicateFix(connection).run()

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/9ef6431f3a4e_add_unique_constraint_to_group_role_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/9ef6431f3a4e_add_unique_constraint_to_group_role_.py
@@ -1,0 +1,45 @@
+"""Add unique constraint to group_role_association
+
+Revision ID: 9ef6431f3a4e
+Revises: 13fe10b8e35b
+Create Date: 2024-09-09 15:01:20.426534
+
+"""
+
+from alembic import op
+
+from galaxy.model.migrations.data_fixes.association_table_fixer import GroupRoleAssociationDuplicateFix
+from galaxy.model.migrations.util import (
+    create_unique_constraint,
+    drop_constraint,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "9ef6431f3a4e"
+down_revision = "13fe10b8e35b"
+branch_labels = None
+depends_on = None
+
+table_name = "group_role_association"
+constraint_column_names = ["group_id", "role_id"]
+unique_constraint_name = (
+    "group_role_association_group_id_key"  # This is what the model's naming convention will generate.
+)
+
+
+def upgrade():
+    with transaction():
+        _remove_duplicate_records()
+        create_unique_constraint(unique_constraint_name, table_name, constraint_column_names)
+
+
+def downgrade():
+    with transaction():
+        drop_constraint(unique_constraint_name, table_name)
+
+
+def _remove_duplicate_records():
+    """Remove duplicate associations"""
+    connection = op.get_bind()
+    GroupRoleAssociationDuplicateFix(connection).run()

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/d619fdfa6168_username_column_unique_constraint.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/d619fdfa6168_username_column_unique_constraint.py
@@ -1,0 +1,51 @@
+"""Username column unique constraint
+
+Revision ID: d619fdfa6168
+Revises: d2d8f51ebb7e
+Create Date: 2024-07-02 13:13:10.325586
+"""
+
+from alembic import op
+
+from galaxy.model.database_object_names import build_index_name
+from galaxy.model.migrations.data_fixes.user_table_fixer import UsernameDeduplicator
+from galaxy.model.migrations.util import (
+    create_index,
+    drop_index,
+    index_exists,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "d619fdfa6168"
+down_revision = "d2d8f51ebb7e"
+branch_labels = None
+depends_on = None
+
+table_name = "galaxy_user"
+column_name = "username"
+index_name = build_index_name(table_name, [column_name])
+
+
+def upgrade():
+    with transaction():
+        _fix_duplicate_usernames()
+        # Existing databases may have an existing index we no longer need
+        # New databases will not have that index, so we must check.
+        if index_exists(index_name, table_name, False):
+            drop_index(index_name, table_name)
+        # Create a UNIQUE index
+        create_index(index_name, table_name, [column_name], unique=True)
+
+
+def downgrade():
+    with transaction():
+        drop_index(index_name, table_name)
+        # Restore a non-unique index
+        create_index(index_name, table_name, [column_name])
+
+
+def _fix_duplicate_usernames():
+    """Fix records with duplicate usernames"""
+    connection = op.get_bind()
+    UsernameDeduplicator(connection).run()

--- a/lib/galaxy/model/migrations/data_fixes/__init__.py
+++ b/lib/galaxy/model/migrations/data_fixes/__init__.py
@@ -1,0 +1,4 @@
+"""
+Package contains code for fixing inconsistent data in the database that must be
+run together with a migration script.
+"""

--- a/lib/galaxy/model/migrations/data_fixes/association_table_fixer.py
+++ b/lib/galaxy/model/migrations/data_fixes/association_table_fixer.py
@@ -1,0 +1,200 @@
+from abc import (
+    ABC,
+    abstractmethod,
+)
+
+from sqlalchemy import (
+    delete,
+    func,
+    null,
+    or_,
+    select,
+)
+
+from galaxy.model import (
+    GroupRoleAssociation,
+    UserGroupAssociation,
+    UserRoleAssociation,
+)
+
+
+class AssociationNullFix(ABC):
+
+    def __init__(self, connection):
+        self.connection = connection
+        self.assoc_model = self.association_model()
+        self.assoc_name = self.assoc_model.__tablename__
+        self.where_clause = self.build_where_clause()
+
+    def run(self):
+        invalid_assocs = self.count_associations_with_nulls()
+        if invalid_assocs:
+            self.delete_associations_with_nulls()
+
+    def count_associations_with_nulls(
+        self,
+    ):
+        """
+        Retrieve association records where one or both associated item ids are null.
+        """
+        select_stmt = select(func.count()).where(self.where_clause)
+        return self.connection.scalar(select_stmt)
+
+    def delete_associations_with_nulls(self):
+        """
+        Delete association records where one or both associated item ids are null.
+        """
+        delete_stmt = delete(self.assoc_model).where(self.where_clause)
+        self.connection.execute(delete_stmt)
+
+    @abstractmethod
+    def association_model(self):
+        """Return model class"""
+
+    @abstractmethod
+    def build_where_clause(self):
+        """Build where clause for filtering records containing nulls instead of associated item ids"""
+
+
+class UserGroupAssociationNullFix(AssociationNullFix):
+
+    def association_model(self):
+        return UserGroupAssociation
+
+    def build_where_clause(self):
+        return or_(UserGroupAssociation.user_id == null(), UserGroupAssociation.group_id == null())
+
+
+class UserRoleAssociationNullFix(AssociationNullFix):
+
+    def association_model(self):
+        return UserRoleAssociation
+
+    def build_where_clause(self):
+        return or_(UserRoleAssociation.user_id == null(), UserRoleAssociation.role_id == null())
+
+
+class GroupRoleAssociationNullFix(AssociationNullFix):
+
+    def association_model(self):
+        return GroupRoleAssociation
+
+    def build_where_clause(self):
+        return or_(GroupRoleAssociation.group_id == null(), GroupRoleAssociation.role_id == null())
+
+
+class AssociationDuplicateFix(ABC):
+
+    def __init__(self, connection):
+        self.connection = connection
+        self.assoc_model = self.association_model()
+        self.assoc_name = self.assoc_model.__tablename__
+
+    def run(self):
+        duplicate_assocs = self.select_duplicate_associations()
+        if duplicate_assocs:
+            self.delete_duplicate_associations(duplicate_assocs)
+
+    def select_duplicate_associations(self):
+        """Retrieve duplicate association records."""
+        select_stmt = self.build_duplicate_tuples_statement()
+        return self.connection.execute(select_stmt).all()
+
+    @abstractmethod
+    def association_model(self):
+        """Return model class"""
+
+    @abstractmethod
+    def build_duplicate_tuples_statement(self):
+        """
+        Build select statement returning a list of tuples (item1_id, item2_id) that have counts > 1
+        """
+
+    @abstractmethod
+    def build_duplicate_ids_statement(self, user_id, group_id):
+        """
+        Build select statement returning a list of ids for duplicate records retrieved via build_duplicate_tuples_statement().
+        """
+
+    def delete_duplicate_associations(self, records):
+        """
+        Delete duplicate association records retaining oldest record in each group of duplicates.
+        """
+        to_delete = []
+        for item1_id, item2_id in records:
+            to_delete += self._get_duplicates_to_delete(item1_id, item2_id)
+        for id in to_delete:
+            delete_stmt = delete(self.assoc_model).where(self.assoc_model.id == id)
+            self.connection.execute(delete_stmt)
+
+    def _get_duplicates_to_delete(self, item1_id, item2_id):
+        stmt = self.build_duplicate_ids_statement(item1_id, item2_id)
+        duplicates = self.connection.scalars(stmt).all()
+        # IMPORTANT: we slice to skip the first item ([1:]), which is the oldest record and SHOULD NOT BE DELETED.
+        return duplicates[1:]
+
+
+class UserGroupAssociationDuplicateFix(AssociationDuplicateFix):
+
+    def association_model(self):
+        return UserGroupAssociation
+
+    def build_duplicate_tuples_statement(self):
+        stmt = (
+            select(UserGroupAssociation.user_id, UserGroupAssociation.group_id)
+            .group_by(UserGroupAssociation.user_id, UserGroupAssociation.group_id)
+            .having(func.count() > 1)
+        )
+        return stmt
+
+    def build_duplicate_ids_statement(self, user_id, group_id):
+        stmt = (
+            select(UserGroupAssociation.id)
+            .where(UserGroupAssociation.user_id == user_id, UserGroupAssociation.group_id == group_id)
+            .order_by(UserGroupAssociation.update_time)
+        )
+        return stmt
+
+
+class UserRoleAssociationDuplicateFix(AssociationDuplicateFix):
+
+    def association_model(self):
+        return UserRoleAssociation
+
+    def build_duplicate_tuples_statement(self):
+        stmt = (
+            select(UserRoleAssociation.user_id, UserRoleAssociation.role_id)
+            .group_by(UserRoleAssociation.user_id, UserRoleAssociation.role_id)
+            .having(func.count() > 1)
+        )
+        return stmt
+
+    def build_duplicate_ids_statement(self, user_id, role_id):
+        stmt = (
+            select(UserRoleAssociation.id)
+            .where(UserRoleAssociation.user_id == user_id, UserRoleAssociation.role_id == role_id)
+            .order_by(UserRoleAssociation.update_time)
+        )
+        return stmt
+
+
+class GroupRoleAssociationDuplicateFix(AssociationDuplicateFix):
+
+    def association_model(self):
+        return GroupRoleAssociation
+
+    def build_duplicate_tuples_statement(self):
+        stmt = (
+            select(GroupRoleAssociation.group_id, GroupRoleAssociation.role_id)
+            .group_by(GroupRoleAssociation.group_id, GroupRoleAssociation.role_id)
+            .having(func.count() > 1)
+        )
+        return stmt
+
+    def build_duplicate_ids_statement(self, group_id, role_id):
+        stmt = (
+            select(GroupRoleAssociation.id)
+            .where(GroupRoleAssociation.group_id == group_id, GroupRoleAssociation.role_id == role_id)
+            .order_by(GroupRoleAssociation.update_time)
+        )
+        return stmt

--- a/lib/galaxy/model/migrations/data_fixes/association_table_fixer.py
+++ b/lib/galaxy/model/migrations/data_fixes/association_table_fixer.py
@@ -111,7 +111,7 @@ class AssociationDuplicateFix(ABC):
         """
 
     @abstractmethod
-    def build_duplicate_ids_statement(self, user_id, group_id):
+    def build_duplicate_ids_statement(self, item1_id, item2_id):
         """
         Build select statement returning a list of ids for duplicate records retrieved via build_duplicate_tuples_statement().
         """

--- a/lib/galaxy/model/migrations/data_fixes/user_table_fixer.py
+++ b/lib/galaxy/model/migrations/data_fixes/user_table_fixer.py
@@ -1,0 +1,47 @@
+from sqlalchemy import (
+    func,
+    Result,
+    select,
+    update,
+)
+
+from galaxy.model import User
+
+
+class UsernameDeduplicator:
+
+    def __init__(self, connection):
+        self.connection = connection
+
+    def run(self):
+        """
+        Deduplicate usernames by generating a unique value for all duplicates, keeping
+        the username of the most recently created user unchanged.
+        """
+        duplicates = self._get_duplicate_username_data()
+        prev_username = None
+        for id, username, _ in duplicates:
+            if username == prev_username:
+                new_username = self._generate_next_available_username(username)
+                stmt = update(User).where(User.id == id).values(username=new_username)
+                self.connection.execute(stmt)
+            else:
+                prev_username = username
+
+    def _get_duplicate_username_data(self) -> Result:
+        # Duplicate usernames
+        counts = select(User.username, func.count()).group_by(User.username).having(func.count() > 1)
+        sq = select(User.username).select_from(counts.cte())
+        # User data for records with duplicate usernames (ordering: newest to oldest)
+        stmt = (
+            select(User.id, User.username, User.create_time)
+            .where(User.username.in_(sq))
+            .order_by(User.username, User.create_time.desc())
+        )
+        return self.connection.execute(stmt)
+
+    def _generate_next_available_username(self, username):
+        i = 1
+        while self.connection.execute(select(User).where(User.username == f"{username}-{i}")).first():
+            i += 1
+        return f"{username}-{i}"

--- a/lib/galaxy/model/migrations/data_fixes/user_table_fixer.py
+++ b/lib/galaxy/model/migrations/data_fixes/user_table_fixer.py
@@ -1,7 +1,10 @@
+import uuid
+
 from sqlalchemy import (
     func,
     Result,
     select,
+    text,
     update,
 )
 
@@ -17,25 +20,25 @@ class UsernameDeduplicator:
         """
         Deduplicate usernames by generating a unique value for all duplicates, keeping
         the username of the most recently created user unchanged.
+        Records updated with the generated value are marked as deleted.
         """
         duplicates = self._get_duplicate_username_data()
         prev_username = None
         for id, username, _ in duplicates:
             if username == prev_username:
                 new_username = self._generate_next_available_username(username)
-                stmt = update(User).where(User.id == id).values(username=new_username)
+                stmt = update(User).where(User.id == id).values(username=new_username, deleted=True)
                 self.connection.execute(stmt)
             else:
                 prev_username = username
 
     def _get_duplicate_username_data(self) -> Result:
         # Duplicate usernames
-        counts = select(User.username, func.count()).group_by(User.username).having(func.count() > 1)
-        sq = select(User.username).select_from(counts.cte())
+        duplicates_stmt = select(User.username).group_by(User.username).having(func.count() > 1)
         # User data for records with duplicate usernames (ordering: newest to oldest)
         stmt = (
             select(User.id, User.username, User.create_time)
-            .where(User.username.in_(sq))
+            .where(User.username.in_(duplicates_stmt))
             .order_by(User.username, User.create_time.desc())
         )
         return self.connection.execute(stmt)
@@ -45,3 +48,65 @@ class UsernameDeduplicator:
         while self.connection.execute(select(User).where(User.username == f"{username}-{i}")).first():
             i += 1
         return f"{username}-{i}"
+
+
+class EmailDeduplicator:
+
+    def __init__(self, connection):
+        self.connection = connection
+
+    def run(self):
+        """
+        Deduplicate user emails by generating a unique value for all duplicates, keeping
+        the email of the most recently created user that has one or more history unchanged.
+        If such a user does not exist, keep the oldest user.
+        Records updated with the generated value are marked as deleted (we presume them
+        to be invalid, and the user should not be able to login).
+        """
+        stmt = select(User.email).group_by(User.email).having(func.count() > 1)
+        duplicate_emails = self.connection.scalars(stmt)
+        for email in duplicate_emails:
+            users = self._get_users_with_same_email(email)
+            user_with_history = self._find_oldest_user_with_history(users)
+            duplicates = self._get_users_to_deduplicate(users, user_with_history)
+            self._deduplicate_users(email, duplicates)
+
+    def _get_users_with_same_email(self, email: str):
+        sql = text(
+            """
+            SELECT u.id, EXISTS(SELECT h.id FROM history h WHERE h.user_id = u.id)
+            FROM galaxy_user u
+            WHERE u.email = :email
+            ORDER BY u.create_time
+            """
+        )
+        params = {"email": email}
+        return self.connection.execute(sql, params).all()
+
+    def _find_oldest_user_with_history(self, users):
+        for user_id, exists in users:
+            if exists:
+                return user_id
+        return None
+
+    def _get_users_to_deduplicate(self, users, user_with_history):
+        if user_with_history:
+            # Preserve the oldest user with a history
+            return [user_id for user_id, _ in users if user_id != user_with_history]
+        else:
+            # Preserve the oldest user
+            return [user_id for user_id, _ in users[1:]]
+
+    def _deduplicate_users(self, email, to_deduplicate):
+        for id in to_deduplicate:
+            new_email = self._generate_replacement_for_duplicate_email(email)
+            stmt = update(User).where(User.id == id).values(email=new_email, deleted=True)
+            self.connection.execute(stmt)
+
+    def _generate_replacement_for_duplicate_email(self, email: str) -> str:
+        """
+        Generate a replacement for a duplicate email value. The new value consists of the original
+        email and a unique suffix. Since the original email is part of the new value, it will be
+        possible to retrieve the user record based on this value, if needed.
+        """
+        return f"{email}-{uuid.uuid4()}"

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -1455,7 +1455,7 @@ WHERE history.user_id != :user_id and history_dataset_association.dataset_id = :
         """
         self._ensure_model_instance_has_id(user)
         if group_ids is not None:
-            self._set_user_groups(user, group_ids or [])
+            self._set_user_groups(user, group_ids)
         if role_ids is not None:
             self._set_user_roles(user, role_ids or [])
         # Commit only if both user groups and user roles have been set.

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -1499,9 +1499,9 @@ WHERE history.user_id != :user_id and history_dataset_association.dataset_id = :
         """
         self._ensure_model_instance_has_id(role)
         if user_ids is not None:
-            self._set_role_users(role, user_ids or [])
+            self._set_role_users(role, user_ids)
         if group_ids is not None:
-            self._set_role_groups(role, group_ids or [])
+            self._set_role_groups(role, group_ids)
         # Commit only if both role users and role groups have been set.
         self.sa_session.commit()
 

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -1457,7 +1457,7 @@ WHERE history.user_id != :user_id and history_dataset_association.dataset_id = :
         if group_ids is not None:
             self._set_user_groups(user, group_ids)
         if role_ids is not None:
-            self._set_user_roles(user, role_ids or [])
+            self._set_user_roles(user, role_ids)
         # Commit only if both user groups and user roles have been set.
         self.sa_session.commit()
 

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -1453,7 +1453,7 @@ WHERE history.user_id != :user_id and history_dataset_association.dataset_id = :
         If the provided list is empty, existing associations will be removed.
         If the provided value is None, existing associations will not be updated.
         """
-        self._ensure_model_instance_has_id(user)
+        self._persist_new_model(user)
         if group_ids is not None:
             self._set_user_groups(user, group_ids)
         if role_ids is not None:
@@ -1475,7 +1475,7 @@ WHERE history.user_id != :user_id and history_dataset_association.dataset_id = :
         If the provided list is empty, existing associations will be removed.
         If the provided value is None, existing associations will not be updated.
         """
-        self._ensure_model_instance_has_id(group)
+        self._persist_new_model(group)
         if user_ids is not None:
             self._set_group_users(group, user_ids)
         if role_ids is not None:
@@ -1497,7 +1497,7 @@ WHERE history.user_id != :user_id and history_dataset_association.dataset_id = :
         If the provided list is empty, existing associations will be removed.
         If the provided value is None, existing associations will not be updated.
         """
-        self._ensure_model_instance_has_id(role)
+        self._persist_new_model(role)
         if user_ids is not None:
             self._set_role_users(role, user_ids)
         if group_ids is not None:
@@ -1574,7 +1574,7 @@ WHERE history.user_id != :user_id and history_dataset_association.dataset_id = :
         insert_values = [{"role_id": role.id, "group_id": group_id} for group_id in group_ids]
         self._set_associations(role, GroupRoleAssociation, delete_stmt, insert_values)
 
-    def _ensure_model_instance_has_id(self, model_instance):
+    def _persist_new_model(self, model_instance):
         # If model_instance is new, it may have not been assigned a database id yet, which is required
         # for creating association records. Flush if that's the case.
         if model_instance.id is None:

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -710,20 +710,6 @@ WHERE history.user_id != :user_id and history_dataset_association.dataset_id = :
                     perms[action].extend([_ for _ in role_ids if _ not in perms[action]])
         return perms
 
-    def associate_components(self, **kwd):
-        if "user" in kwd:
-            if "group" in kwd:
-                return self.associate_user_group(kwd["user"], kwd["group"])
-            elif "role" in kwd:
-                return self.associate_user_role(kwd["user"], kwd["role"])
-        elif "role" in kwd:
-            if "group" in kwd:
-                return self.associate_group_role(kwd["group"], kwd["role"])
-        if "action" in kwd:
-            if "dataset" in kwd and "role" in kwd:
-                return self.associate_action_dataset_role(kwd["action"], kwd["dataset"], kwd["role"])
-        raise Exception(f"No valid method of associating provided components: {kwd}")
-
     def associate_user_group(self, user, group):
         assoc = UserGroupAssociation(user, group)
         self.sa_session.add(assoc)
@@ -1036,7 +1022,7 @@ WHERE history.user_id != :user_id and history_dataset_association.dataset_id = :
             with transaction(self.sa_session):
                 self.sa_session.commit()
             for user in users:
-                self.associate_components(user=user, role=sharing_role)
+                self.associate_user_role(user, sharing_role)
         self.set_dataset_permission(dataset, {self.permitted_actions.DATASET_ACCESS: [sharing_role]})
 
     def set_all_library_permissions(self, trans, library_item, permissions=None):

--- a/lib/galaxy/model/unittest_utils/utils.py
+++ b/lib/galaxy/model/unittest_utils/utils.py
@@ -1,0 +1,13 @@
+import random
+import string
+
+
+def random_str() -> str:
+    alphabet = string.ascii_lowercase + string.digits
+    size = random.randint(5, 10)
+    return "".join(random.choices(alphabet, k=size))
+
+
+def random_email() -> str:
+    text = random_str()
+    return f"{text}@galaxy.testing"

--- a/lib/galaxy/schema/groups.py
+++ b/lib/galaxy/schema/groups.py
@@ -73,5 +73,18 @@ class GroupCreatePayload(Model):
 
 
 @partial_model()
-class GroupUpdatePayload(GroupCreatePayload):
-    pass
+class GroupUpdatePayload(Model):
+    """Payload schema for updating a group."""
+
+    name: str = Field(
+        ...,
+        title="name of the group",
+    )
+    user_ids: Optional[List[DecodedDatabaseIdField]] = Field(
+        None,
+        title="user IDs",
+    )
+    role_ids: Optional[List[DecodedDatabaseIdField]] = Field(
+        None,
+        title="role IDs",
+    )

--- a/lib/galaxy/security/__init__.py
+++ b/lib/galaxy/security/__init__.py
@@ -95,9 +95,6 @@ class RBACAgent:
     def can_manage_library_item(self, roles, item):
         raise Exception("Unimplemented Method")
 
-    def associate_components(self, **kwd):
-        raise Exception(f"No valid method of associating provided components: {kwd}")
-
     def create_private_user_role(self, user):
         raise Exception("Unimplemented Method")
 

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -13,7 +13,10 @@ from galaxy import (
     util,
     web,
 )
-from galaxy.exceptions import ActionInputError
+from galaxy.exceptions import (
+    ActionInputError,
+    RequestParameterInvalidException,
+)
 from galaxy.managers.quotas import QuotaManager
 from galaxy.model.base import transaction
 from galaxy.model.index_filter_util import (
@@ -807,35 +810,17 @@ class AdminGalaxy(controller.JSAppLauncher):
                 ],
             }
         else:
-            in_users = [
-                trans.sa_session.query(trans.app.model.User).get(trans.security.decode_id(x))
-                for x in util.listify(payload.get("in_users"))
-            ]
-            in_groups = [
-                trans.sa_session.query(trans.app.model.Group).get(trans.security.decode_id(x))
-                for x in util.listify(payload.get("in_groups"))
-            ]
-            if None in in_users or None in in_groups:
+            user_ids = [trans.security.decode_id(id) for id in util.listify(payload.get("in_users"))]
+            group_ids = [trans.security.decode_id(id) for id in util.listify(payload.get("in_groups"))]
+            try:
+                trans.app.security_agent.set_role_user_and_group_associations(
+                    role, user_ids=user_ids, group_ids=group_ids
+                )
+                return {
+                    "message": f"Role '{role.name}' has been updated with {len(user_ids)} associated users and {len(group_ids)} associated groups."
+                }
+            except RequestParameterInvalidException:
                 return self.message_exception(trans, "One or more invalid user/group id has been provided.")
-            for ura in role.users:
-                user = trans.sa_session.query(trans.app.model.User).get(ura.user_id)
-                if user not in in_users:
-                    # Delete DefaultUserPermissions for previously associated users that have been removed from the role
-                    for dup in user.default_permissions:
-                        if role == dup.role:
-                            trans.sa_session.delete(dup)
-                    # Delete DefaultHistoryPermissions for previously associated users that have been removed from the role
-                    for history in user.histories:
-                        for dhp in history.default_permissions:
-                            if role == dhp.role:
-                                trans.sa_session.delete(dhp)
-                    with transaction(trans.sa_session):
-                        trans.sa_session.commit()
-            trans.app.security_agent.set_entity_role_associations(roles=[role], users=in_users, groups=in_groups)
-            trans.sa_session.refresh(role)
-            return {
-                "message": f"Role '{role.name}' has been updated with {len(in_users)} associated users and {len(in_groups)} associated groups."
-            }
 
     @web.legacy_expose_api
     @web.require_admin
@@ -912,21 +897,17 @@ class AdminGalaxy(controller.JSAppLauncher):
                 ],
             }
         else:
-            in_users = [
-                trans.sa_session.query(trans.app.model.User).get(trans.security.decode_id(x))
-                for x in util.listify(payload.get("in_users"))
-            ]
-            in_roles = [
-                trans.sa_session.query(trans.app.model.Role).get(trans.security.decode_id(x))
-                for x in util.listify(payload.get("in_roles"))
-            ]
-            if None in in_users or None in in_roles:
+            user_ids = [trans.security.decode_id(id) for id in util.listify(payload.get("in_users"))]
+            role_ids = [trans.security.decode_id(id) for id in util.listify(payload.get("in_roles"))]
+            try:
+                trans.app.security_agent.set_group_user_and_role_associations(
+                    group, user_ids=user_ids, role_ids=role_ids
+                )
+                return {
+                    "message": f"Group '{group.name}' has been updated with {len(user_ids)} associated users and {len(role_ids)} associated roles."
+                }
+            except RequestParameterInvalidException:
                 return self.message_exception(trans, "One or more invalid user/role id has been provided.")
-            trans.app.security_agent.set_entity_group_associations(groups=[group], users=in_users, roles=in_roles)
-            trans.sa_session.refresh(group)
-            return {
-                "message": f"Group '{group.name}' has been updated with {len(in_users)} associated users and {len(in_roles)} associated roles."
-            }
 
     @web.legacy_expose_api
     @web.require_admin
@@ -1099,27 +1080,17 @@ class AdminGalaxy(controller.JSAppLauncher):
                 ],
             }
         else:
-            in_roles = [
-                trans.sa_session.query(trans.app.model.Role).get(trans.security.decode_id(x))
-                for x in util.listify(payload.get("in_roles"))
-            ]
-            in_groups = [
-                trans.sa_session.query(trans.app.model.Group).get(trans.security.decode_id(x))
-                for x in util.listify(payload.get("in_groups"))
-            ]
-            if None in in_groups or None in in_roles:
+            role_ids = [trans.security.decode_id(id) for id in util.listify(payload.get("in_roles"))]
+            group_ids = [trans.security.decode_id(id) for id in util.listify(payload.get("in_groups"))]
+            try:
+                trans.app.security_agent.set_user_group_and_role_associations(
+                    user, group_ids=group_ids, role_ids=role_ids
+                )
+                return {
+                    "message": f"User '{user.email}' has been updated with {len(role_ids)} associated roles and {len(group_ids)} associated groups (private roles are not displayed)."
+                }
+            except RequestParameterInvalidException:
                 return self.message_exception(trans, "One or more invalid role/group id has been provided.")
-
-            # make sure the user is not dis-associating himself from his private role
-            private_role = trans.app.security_agent.get_private_user_role(user)
-            if private_role not in in_roles:
-                in_roles.append(private_role)
-
-            trans.app.security_agent.set_entity_user_associations(users=[user], roles=in_roles, groups=in_groups)
-            trans.sa_session.refresh(user)
-            return {
-                "message": f"User '{user.email}' has been updated with {len(in_roles) - 1} associated roles and {len(in_groups)} associated groups (private roles are not displayed)."
-            }
 
 
 # ---- Utility methods -------------------------------------------------------

--- a/lib/galaxy_test/api/test_groups.py
+++ b/lib/galaxy_test/api/test_groups.py
@@ -107,7 +107,9 @@ class TestGroupsApi(ApiTestCase):
             another_user_id = self.dataset_populator.user_id()
             another_role_id = self.dataset_populator.user_private_role_id()
         assert another_user_id is not None
-        update_response = self._put(f"groups/{group_id}", data={"user_ids": [another_user_id]}, admin=True, json=True)
+        update_response = self._put(
+            f"groups/{group_id}", data={"user_ids": [user_id, another_user_id]}, admin=True, json=True
+        )
         self._assert_status_code_is_ok(update_response)
 
         # Check if the user was added
@@ -119,7 +121,9 @@ class TestGroupsApi(ApiTestCase):
         )
 
         # Add another role to the group
-        update_response = self._put(f"groups/{group_id}", data={"role_ids": [another_role_id]}, admin=True, json=True)
+        update_response = self._put(
+            f"groups/{group_id}", data={"role_ids": [user_private_role_id, another_role_id]}, admin=True, json=True
+        )
         self._assert_status_code_is_ok(update_response)
 
         # Check if the role was added

--- a/test/integration/test_celery_user_rate_limit.py
+++ b/test/integration/test_celery_user_rate_limit.py
@@ -50,7 +50,7 @@ def setup_users(dburl: str, num_users: int = 2):
                 for user_id in user_ids_to_add:
                     conn.execute(
                         text("insert into galaxy_user(id, active, email, password) values (:id, :active, :email, :pw)"),
-                        [{"id": user_id, "active": True, "email": "e", "pw": "p"}],
+                        [{"id": user_id, "active": True, "email": f"e{user_id}", "pw": "p"}],
                     )
 
 

--- a/test/unit/app/jobs/test_rule_helper.py
+++ b/test/unit/app/jobs/test_rule_helper.py
@@ -66,7 +66,7 @@ def __setup_fixtures(app):
     # user3 has no jobs.
     user1 = model.User(email=USER_EMAIL_1, password="pass1")
     user2 = model.User(email=USER_EMAIL_2, password="pass2")
-    user3 = model.User(email=USER_EMAIL_2, password="pass2")
+    user3 = model.User(email=USER_EMAIL_3, password="pass3")
 
     app.add(user1, user2, user3)
 

--- a/test/unit/app/managers/test_NotificationManager.py
+++ b/test/unit/app/managers/test_NotificationManager.py
@@ -524,8 +524,9 @@ class TestNotificationRecipientResolver(NotificationsBaseTestCase):
         sa_session = self.trans.sa_session
         group = Group(name=name)
         sa_session.add(group)
-        self.trans.app.security_agent.set_entity_group_associations(groups=[group], roles=roles, users=users)
-        sa_session.flush()
+        user_ids = [user.id for user in users]
+        role_ids = [role.id for role in roles]
+        self.trans.app.security_agent.set_group_user_and_role_associations(group, user_ids=user_ids, role_ids=role_ids)
         return group
 
     def _create_test_role(self, name: str, users: List[User], groups: List[Group]):

--- a/test/unit/data/model/__init__.py
+++ b/test/unit/data/model/__init__.py
@@ -1,0 +1,10 @@
+PRIVATE_OBJECT_STORE_ID = "my_private_data"
+
+
+class MockObjectStore:
+
+    def is_private(self, object):
+        if object.object_store_id == PRIVATE_OBJECT_STORE_ID:
+            return True
+        else:
+            return False

--- a/test/unit/data/model/conftest.py
+++ b/test/unit/data/model/conftest.py
@@ -120,6 +120,19 @@ def make_default_history_permissions(session, make_history, make_role):
 
 
 @pytest.fixture
+def make_default_user_permissions(session, make_user, make_role):
+    def f(**kwd):
+        kwd["user"] = kwd.get("user") or make_user()
+        kwd["action"] = kwd.get("action") or random_str()
+        kwd["role"] = kwd.get("role") or make_role()
+        model = m.DefaultUserPermissions(**kwd)
+        write_to_db(session, model)
+        return model
+
+    return f
+
+
+@pytest.fixture
 def make_event(session):
     def f(**kwd):
         model = m.Event(**kwd)

--- a/test/unit/data/model/conftest.py
+++ b/test/unit/data/model/conftest.py
@@ -152,6 +152,26 @@ def make_galaxy_session_to_history_association(session, make_history, make_galax
 
 
 @pytest.fixture
+def make_group(session):
+    def f(**kwd):
+        model = m.Group(**kwd)
+        write_to_db(session, model)
+        return model
+
+    return f
+
+
+@pytest.fixture
+def make_group_role_association(session):
+    def f(group, role):
+        model = m.GroupRoleAssociation(group, role)
+        write_to_db(session, model)
+        return model
+
+    return f
+
+
+@pytest.fixture
 def make_hda(session, make_history):
     def f(**kwd):
         kwd["history"] = kwd.get("history") or make_history()
@@ -391,6 +411,16 @@ def make_user(session):
 def make_user_item_rating_association(session):
     def f(assoc_class, user, item, rating):
         model = assoc_class(user, item, rating)
+        write_to_db(session, model)
+        return model
+
+    return f
+
+
+@pytest.fixture
+def make_user_group_association(session):
+    def f(user, group):
+        model = m.UserGroupAssociation(user, group)
         write_to_db(session, model)
         return model
 

--- a/test/unit/data/model/conftest.py
+++ b/test/unit/data/model/conftest.py
@@ -1,7 +1,5 @@
 import contextlib
 import os
-import random
-import string
 import tempfile
 import uuid
 
@@ -10,6 +8,10 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
 from galaxy import model as m
+from galaxy.model.unittest_utils.utils import (
+    random_email,
+    random_str,
+)
 
 
 @pytest.fixture
@@ -447,17 +449,6 @@ def transaction(session):
             yield
     else:
         yield
-
-
-def random_str() -> str:
-    alphabet = string.ascii_lowercase + string.digits
-    size = random.randint(5, 10)
-    return "".join(random.choices(alphabet, k=size))
-
-
-def random_email() -> str:
-    text = random_str()
-    return f"{text}@galaxy.testing"
 
 
 def write_to_db(session, model) -> None:

--- a/test/unit/data/model/db/__init__.py
+++ b/test/unit/data/model/db/__init__.py
@@ -3,18 +3,7 @@ from collections import (
     namedtuple,
 )
 
-PRIVATE_OBJECT_STORE_ID = "my_private_data"
-
 MockTransaction = namedtuple("MockTransaction", "user")
-
-
-class MockObjectStore:
-
-    def is_private(self, object):
-        if object.object_store_id == PRIVATE_OBJECT_STORE_ID:
-            return True
-        else:
-            return False
 
 
 def verify_items(items, expected_items):

--- a/test/unit/data/model/db/__init__.py
+++ b/test/unit/data/model/db/__init__.py
@@ -6,8 +6,8 @@ from collections import (
 MockTransaction = namedtuple("MockTransaction", "user")
 
 
-def verify_items(items, expected_items):
+def have_same_elements(items, expected_items):
     """
     Assert that items and expected_items contain the same elements.
     """
-    assert Counter(items) == Counter(expected_items)
+    return Counter(items) == Counter(expected_items)

--- a/test/unit/data/model/db/conftest.py
+++ b/test/unit/data/model/db/conftest.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     create_engine,
     text,
 )
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from galaxy import model as m
@@ -35,7 +36,11 @@ def engine(db_url: str) -> "Engine":
 
 @pytest.fixture
 def session(engine: "Engine") -> Session:
-    return Session(engine)
+    session = Session(engine)
+    # For sqlite, we need to explicitly enale foreign key constraints.
+    if engine.name == "sqlite":
+        session.execute(text("PRAGMA foreign_keys = ON;"))
+    return session
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -58,12 +63,35 @@ def init_datatypes() -> None:
 
 
 @pytest.fixture(autouse=True)
-def clear_database(engine: "Engine") -> "Generator":
+def clear_database(engine: "Engine", session) -> "Generator":
     """Delete all rows from all tables. Called after each test."""
     yield
-    with engine.begin() as conn:
-        for table in m.mapper_registry.metadata.tables:
-            # Unless db is sqlite, disable foreign key constraints to delete out of order
-            if engine.name != "sqlite":
-                conn.execute(text(f"ALTER TABLE {table} DISABLE TRIGGER ALL"))
-            conn.execute(text(f"DELETE FROM {table}"))
+
+    # If a test left an open transaction, rollback to prevent database locking.
+    if session.in_transaction():
+        session.rollback()
+
+    with engine.connect() as conn:
+        if engine.name == "sqlite":
+            conn.execute(text("PRAGMA foreign_keys = OFF;"))
+            for table in m.mapper_registry.metadata.tables:
+                conn.execute(text(f"DELETE FROM {table}"))
+        else:
+            # For postgres, we can disable foreign key constraints with this statement:
+            #   conn.execute(text(f"ALTER TABLE {table} DISABLE TRIGGER ALL"))
+            # However, unless running as superuser, this will raise an error when trying
+            #   to disable a system trigger. Disabling USER triggers instead of ALL
+            #   won't work because the USER option excludes foreign key constraints.
+            # The following is an alternative: we do multiple passes until all tables have been cleared:
+            to_delete = list(m.mapper_registry.metadata.tables)
+            failed = []
+            while to_delete:
+                for table in to_delete:
+                    try:
+                        conn.execute(text(f"DELETE FROM {table}"))
+                    except IntegrityError:
+                        failed.append(table)
+                        conn.rollback()
+                to_delete, failed = failed, []
+
+        conn.commit()

--- a/test/unit/data/model/db/conftest.py
+++ b/test/unit/data/model/db/conftest.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 from galaxy import model as m
 from galaxy.datatypes.registry import Registry as DatatypesRegistry
 from galaxy.model.triggers.update_audit_table import install as install_timestamp_triggers
-from . import MockObjectStore
+from .. import MockObjectStore
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Engine

--- a/test/unit/data/model/db/test_libraries.py
+++ b/test/unit/data/model/db/test_libraries.py
@@ -5,7 +5,7 @@ from galaxy.model.db.library import (
     get_library_ids,
     get_library_permissions_by_role,
 )
-from . import verify_items
+from . import have_same_elements
 
 
 def test_get_library_ids(session, make_library, make_library_permissions):
@@ -18,7 +18,7 @@ def test_get_library_ids(session, make_library, make_library_permissions):
 
     ids = get_library_ids(session, "b").all()
     expected = [l2.id, l3.id]
-    verify_items(ids, expected)
+    have_same_elements(ids, expected)
 
 
 def test_get_library_permissions_by_role(session, make_role, make_library_permissions):
@@ -31,7 +31,7 @@ def test_get_library_permissions_by_role(session, make_role, make_library_permis
 
     lp_roles = [lp.role for lp in lps]
     expected = [r1, r2]
-    verify_items(lp_roles, expected)
+    have_same_elements(lp_roles, expected)
 
 
 def test_get_libraries_for_admins(session, make_library):
@@ -44,14 +44,14 @@ def test_get_libraries_for_admins(session, make_library):
 
     libs_deleted = get_libraries_for_admins(session, True).all()
     expected = [libs[0], libs[1]]
-    verify_items(libs_deleted, expected)
+    have_same_elements(libs_deleted, expected)
 
     libs_not_deleted = get_libraries_for_admins(session, False).all()
     expected = [libs[2], libs[3], libs[4]]
-    verify_items(libs_not_deleted, expected)
+    have_same_elements(libs_not_deleted, expected)
 
     libs_all = get_libraries_for_admins(session, None).all()
-    verify_items(libs_all, libs)
+    have_same_elements(libs_all, libs)
 
 
 def test_get_libraries_for_admins__ordering(session, make_library):
@@ -75,7 +75,7 @@ def test_get_libraries_for_non_admins(session, make_library):
     # Expected:  l1 (not deleted, not restricted), l2 (not deleted, restricted but accessible)
     # Not returned: l3 (not deleted but restricted), l4 (deleted)
     expected = [l1, l2]
-    verify_items(allowed, expected)
+    have_same_elements(allowed, expected)
 
 
 def test_get_libraries_for_admins_non_admins__ordering(session, make_library):

--- a/test/unit/data/model/db/test_misc.py
+++ b/test/unit/data/model/db/test_misc.py
@@ -5,10 +5,8 @@ from sqlalchemy import inspect
 
 from galaxy import model as m
 from galaxy.model.unittest_utils.db_helpers import get_hdca_by_name
-from . import (
-    MockTransaction,
-    PRIVATE_OBJECT_STORE_ID,
-)
+from . import MockTransaction
+from .. import PRIVATE_OBJECT_STORE_ID
 
 
 def test_history_update(make_history, make_hda, session):

--- a/test/unit/data/model/db/test_role.py
+++ b/test/unit/data/model/db/test_role.py
@@ -4,7 +4,7 @@ from galaxy.model.db.role import (
     get_private_user_role,
     get_roles_by_ids,
 )
-from . import verify_items
+from . import have_same_elements
 
 
 def test_get_npns_roles(session, make_role):
@@ -18,7 +18,7 @@ def test_get_npns_roles(session, make_role):
     # Expected: r4, r5
     # Not returned: r1: deleted, r2: private, r3: sharing
     expected = [r4, r5]
-    verify_items(roles, expected)
+    have_same_elements(roles, expected)
 
 
 def test_get_private_user_role(session, make_user, make_role, make_user_role_association):
@@ -41,4 +41,4 @@ def test_get_roles_by_ids(session, make_role):
 
     roles2 = get_roles_by_ids(session, ids)
     expected = [r1, r2, r3]
-    verify_items(roles2, expected)
+    have_same_elements(roles2, expected)

--- a/test/unit/data/model/db/test_security.py
+++ b/test/unit/data/model/db/test_security.py
@@ -64,6 +64,20 @@ def test_private_user_role_assoc_not_affected_by_setting_role_users(session, mak
     verify_role_associations(private_role, [user], [])
 
 
+def test_cannot_assign_private_roles(session, make_user_and_role, make_role):
+    user, private_role1 = make_user_and_role()
+    _, private_role2 = make_user_and_role()
+    new_role = make_role()
+    verify_user_associations(user, [], [private_role1])  # the only existing association is with the private role
+
+    # Try to assign 2 more roles: regular role + another private role
+    GalaxyRBACAgent(session).set_user_group_and_role_associations(
+        user, group_ids=[], role_ids=[new_role.id, private_role2.id]
+    )
+    # Only regular role has been added: other private role ignored; original private role still assigned
+    verify_user_associations(user, [], [private_role1, new_role])
+
+
 class TestSetGroupUserAndRoleAssociations:
 
     def test_add_associations_to_existing_group(self, session, make_user_and_role, make_role, make_group):

--- a/test/unit/data/model/db/test_security.py
+++ b/test/unit/data/model/db/test_security.py
@@ -1,0 +1,868 @@
+import pytest
+
+from galaxy.exceptions import RequestParameterInvalidException
+from galaxy.model import (
+    Group,
+    Role,
+    User,
+)
+from galaxy.model.security import GalaxyRBACAgent
+from . import have_same_elements
+
+
+@pytest.fixture
+def make_user_and_role(session, make_user, make_role, make_user_role_association):
+    """
+    Each user created in Galaxy is assumed to have a private role, such that role.name == user.email.
+    Since we are testing user/group/role associations here, to ensure the correct state of the test database,
+    we need to ensure that a user is never created without a corresponding private role.
+    Therefore, we use this fixture instead of make_user (which only creates a user).
+    """
+
+    def f(**kwd):
+        user = make_user()
+        private_role = make_role(name=user.email, type=Role.types.PRIVATE)
+        make_user_role_association(user, private_role)
+        return user, private_role
+
+    return f
+
+
+def test_private_user_role_assoc_not_affected_by_setting_user_roles(session, make_user_and_role):
+    # Create user with a private role
+    user, private_role = make_user_and_role()
+    assert user.email == private_role.name
+    verify_user_associations(user, [], [private_role])  # the only existing association is with the private role
+
+    # Update users's email so it's no longer the same as the private role's name.
+    user.email = user.email + "updated"
+    session.add(user)
+    session.commit()
+    assert user.email != private_role.name
+
+    # Delete user roles
+    GalaxyRBACAgent(session).set_user_group_and_role_associations(user, group_ids=[], role_ids=[])
+    # association with private role is preserved
+    verify_user_associations(user, [], [private_role])
+
+
+def test_private_user_role_assoc_not_affected_by_setting_role_users(session, make_user_and_role):
+    # Create user with a private role
+    user, private_role = make_user_and_role()
+    assert user.email == private_role.name
+    verify_user_associations(user, [], [private_role])  # the only existing association is with the private role
+
+    # Update users's email
+    user.email = user.email + "updated"
+    session.add(user)
+    session.commit()
+    assert user.email != private_role.name
+
+    # Update role users
+    GalaxyRBACAgent(session).set_role_user_and_group_associations(private_role, user_ids=[], group_ids=[])
+    # association of private role with user is preserved
+    verify_role_associations(private_role, [user], [])
+
+
+class TestSetGroupUserAndRoleAssociations:
+
+    def test_add_associations_to_existing_group(self, session, make_user_and_role, make_role, make_group):
+        """
+        State: group exists in database, has no user and role associations.
+        Action: add new associations.
+        """
+        group = make_group()
+        users = [make_user_and_role()[0] for _ in range(5)]
+        roles = [make_role() for _ in range(5)]
+
+        # users and roles for creating associations
+        users_to_add = [users[0], users[2], users[4]]
+        user_ids = [u.id for u in users_to_add]
+        roles_to_add = [roles[1], roles[3]]
+        role_ids = [r.id for r in roles_to_add]
+
+        # verify no preexisting associations
+        verify_group_associations(group, [], [])
+
+        # set associations
+        GalaxyRBACAgent(session).set_group_user_and_role_associations(group, user_ids=user_ids, role_ids=role_ids)
+
+        # verify new associations
+        verify_group_associations(group, users_to_add, roles_to_add)
+
+    def test_add_associations_to_new_group(self, session, make_user_and_role, make_role):
+        """
+        State: group does NOT exist in database, has no user and role associations.
+        Action: add new associations.
+        """
+        group = Group()
+        session.add(group)
+        assert group.id is None  # group does not exist in database
+        users = [make_user_and_role()[0] for _ in range(5)]
+        roles = [make_role() for _ in range(5)]
+
+        # users and roles for creating associations
+        users_to_add = [users[0], users[2], users[4]]
+        user_ids = [u.id for u in users_to_add]
+        roles_to_add = [roles[1], roles[3]]
+        role_ids = [r.id for r in roles_to_add]
+
+        # set associations
+        GalaxyRBACAgent(session).set_group_user_and_role_associations(group, user_ids=user_ids, role_ids=role_ids)
+
+        # verify new associations
+        verify_group_associations(group, users_to_add, roles_to_add)
+
+    def test_update_associations(
+        self,
+        session,
+        make_user_and_role,
+        make_role,
+        make_group,
+        make_user_group_association,
+        make_group_role_association,
+    ):
+        """
+        State: group exists in database AND has user and role associations.
+        Action: update associations (add some/drop some).
+        Expect: old associations are REPLACED by new associations.
+        """
+        group = make_group()
+        users = [make_user_and_role()[0] for _ in range(5)]
+        roles = [make_role() for _ in range(5)]
+
+        # load and verify existing associations
+        users_to_load = [users[0], users[2]]
+        roles_to_load = [roles[1], roles[3]]
+        for user in users_to_load:
+            make_user_group_association(user, group)
+        for role in roles_to_load:
+            make_group_role_association(group, role)
+        verify_group_associations(group, users_to_load, roles_to_load)
+
+        # users and roles for creating new associations
+        new_users_to_add = [users[0], users[1], users[3]]
+        user_ids = [u.id for u in new_users_to_add]
+        new_roles_to_add = [roles[2]]
+        role_ids = [r.id for r in new_roles_to_add]
+
+        # sanity check: ensure we are trying to change existing associations
+        assert not have_same_elements(users_to_load, new_users_to_add)
+        assert not have_same_elements(roles_to_load, new_roles_to_add)
+
+        # set associations
+        GalaxyRBACAgent(session).set_group_user_and_role_associations(group, user_ids=user_ids, role_ids=role_ids)
+
+        # verify new associations
+        verify_group_associations(group, new_users_to_add, new_roles_to_add)
+
+    def test_drop_associations(
+        self,
+        session,
+        make_user_and_role,
+        make_role,
+        make_group,
+        make_user_group_association,
+        make_group_role_association,
+    ):
+        """
+        State: group exists in database AND has user and role associations.
+        Action: drop all associations.
+        """
+        group = make_group()
+        users = [make_user_and_role()[0] for _ in range(5)]
+        roles = [make_role() for _ in range(5)]
+
+        # load and verify existing associations
+        users_to_load = [users[0], users[2]]
+        roles_to_load = [roles[1], roles[3]]
+        for user in users_to_load:
+            make_user_group_association(user, group)
+        for role in roles_to_load:
+            make_group_role_association(group, role)
+        verify_group_associations(group, users_to_load, roles_to_load)
+
+        # drop associations
+        GalaxyRBACAgent(session).set_group_user_and_role_associations(group, user_ids=[], role_ids=[])
+
+        # verify associations dropped
+        verify_group_associations(group, [], [])
+
+    def test_invalid_user(self, session, make_user_and_role, make_role, make_group):
+        """
+        State: group exists in database, has no user and role associations.
+        Action: try to add several associations, last one having an invalid user id.
+        Expect: no associations are added, appropriate error is raised.
+        """
+        group = make_group()
+        users = [make_user_and_role()[0] for _ in range(5)]
+
+        # users for creating associations
+        user_ids = [users[0].id, -1]  # first is valid, second is invalid
+
+        # verify no preexisting associations
+        assert len(group.users) == 0
+
+        # try to set associations
+        with pytest.raises(RequestParameterInvalidException):
+            GalaxyRBACAgent(session).set_group_user_and_role_associations(group, user_ids=user_ids, role_ids=[])
+
+        # verify no change
+        assert len(group.users) == 0
+
+    def test_invalid_role(self, session, make_role, make_group):
+        """
+        state: group exists in database, has no user and role associations.
+        action: try to add several associations, last one having an invalid role id.
+        expect: no associations are added, appropriate error is raised.
+        """
+        group = make_group()
+        roles = [make_role() for _ in range(5)]
+
+        # roles for creating associations
+        role_ids = [roles[0].id, -1]  # first is valid, second is invalid
+
+        # verify no preexisting associations
+        assert len(group.roles) == 0
+
+        # try to set associations
+        with pytest.raises(RequestParameterInvalidException):
+            GalaxyRBACAgent(session).set_group_user_and_role_associations(group, user_ids=[], role_ids=role_ids)
+
+        # verify no change
+        assert len(group.roles) == 0
+
+    def test_duplicate_user(
+        self,
+        session,
+        make_user_and_role,
+        make_role,
+        make_group,
+        make_user_group_association,
+        make_group_role_association,
+    ):
+        """
+        State: group exists in database and has user and role associations.
+        Action: try update user and role associations including a duplicate user
+        Expect: error raised, no change is made to group users and group roles.
+        """
+        group = make_group()
+        users = [make_user_and_role()[0] for _ in range(5)]
+        roles = [make_role() for _ in range(5)]
+
+        # load and verify existing associations
+        users_to_load = [users[0], users[2]]
+        roles_to_load = [roles[1], roles[3]]
+        for user in users_to_load:
+            make_user_group_association(user, group)
+        for role in roles_to_load:
+            make_group_role_association(group, role)
+        verify_group_associations(group, users_to_load, roles_to_load)
+
+        # users and roles for creating new associations
+        new_users_to_add = users + [users[0]]  # include a duplicate user
+        user_ids = [u.id for u in new_users_to_add]
+
+        new_roles_to_add = roles  # NO duplice roles
+        role_ids = [r.id for r in new_roles_to_add]
+
+        # sanity check: ensure we are trying to change existing associations
+        assert not have_same_elements(users_to_load, new_users_to_add)
+        assert not have_same_elements(roles_to_load, new_roles_to_add)
+
+        with pytest.raises(RequestParameterInvalidException):
+            GalaxyRBACAgent(session).set_group_user_and_role_associations(group, user_ids=user_ids, role_ids=role_ids)
+
+        # verify associations not updated
+        verify_group_associations(group, users_to_load, roles_to_load)
+
+    def test_duplicate_role(
+        self,
+        session,
+        make_user_and_role,
+        make_role,
+        make_group,
+        make_user_group_association,
+        make_group_role_association,
+    ):
+        """
+        State: group exists in database and has user and role associations.
+        Action: try update user and role associations including a duplicate role
+        Expect: error raised, no change is made to group users and group roles.
+        """
+        group = make_group()
+        users = [make_user_and_role()[0] for _ in range(5)]
+        roles = [make_role() for _ in range(5)]
+
+        # load and verify existing associations
+        users_to_load = [users[0], users[2]]
+        roles_to_load = [roles[1], roles[3]]
+        for user in users_to_load:
+            make_user_group_association(user, group)
+        for role in roles_to_load:
+            make_group_role_association(group, role)
+        verify_group_associations(group, users_to_load, roles_to_load)
+
+        # users and roles for creating new associations
+        new_users_to_add = users  # NO duplicate users
+        user_ids = [u.id for u in new_users_to_add]
+
+        new_roles_to_add = roles + [roles[0]]  # include a duplicate role
+        role_ids = [r.id for r in new_roles_to_add]
+
+        # sanity check: ensure we are trying to change existing associations
+        assert not have_same_elements(users_to_load, new_users_to_add)
+        assert not have_same_elements(roles_to_load, new_roles_to_add)
+
+        with pytest.raises(RequestParameterInvalidException):
+            GalaxyRBACAgent(session).set_group_user_and_role_associations(group, user_ids=user_ids, role_ids=role_ids)
+
+        # verify associations not updated
+        verify_group_associations(group, users_to_load, roles_to_load)
+
+
+class TestSetUserGroupAndRoleAssociations:
+    """
+    Note: a user should always have a private role which is not affected
+    by modifying a user's group associations or role associations.
+    """
+
+    def test_add_associations_to_existing_user(self, session, make_user_and_role, make_role, make_group):
+        """
+        State: user exists in database, has no group and only one private role association.
+        Action: add new associations.
+        """
+        user, private_role = make_user_and_role()
+        groups = [make_group() for _ in range(5)]
+        roles = [make_role() for _ in range(5)]
+
+        # groups and roles for creating associations
+        groups_to_add = [groups[0], groups[2], groups[4]]
+        group_ids = [g.id for g in groups_to_add]
+        roles_to_add = [roles[1], roles[3]]
+        role_ids = [r.id for r in roles_to_add]
+
+        # verify preexisting associations
+        verify_user_associations(user, [], [private_role])
+
+        # set associations
+        GalaxyRBACAgent(session).set_user_group_and_role_associations(user, group_ids=group_ids, role_ids=role_ids)
+
+        # verify new associations
+        verify_user_associations(user, groups_to_add, roles_to_add + [private_role])
+
+    def test_add_associations_to_new_user(self, session, make_role, make_group):
+        """
+        State: user does NOT exist in database, has no group and role associations.
+        Action: add new associations.
+        """
+        user = User(email="foo@foo.com", password="password")
+        # We are not creating a private role and a user-role association with that role because that would result in
+        # adding the user to the database before calling the method under test, whereas the test is intended to verify
+        # correct processing of a user that has NOT been saved to the database.
+
+        session.add(user)
+        assert user.id is None  # user does not exist in database
+        groups = [make_group() for _ in range(5)]
+        roles = [make_role() for _ in range(5)]
+
+        # groups and roles for creating associations
+        groups_to_add = [groups[0], groups[2], groups[4]]
+        group_ids = [g.id for g in groups_to_add]
+        roles_to_add = [roles[1], roles[3]]
+        role_ids = [r.id for r in roles_to_add]
+
+        # set associations
+        GalaxyRBACAgent(session).set_user_group_and_role_associations(user, group_ids=group_ids, role_ids=role_ids)
+
+        # verify new associations
+        verify_user_associations(user, groups_to_add, roles_to_add)
+
+    def test_update_associations(
+        self,
+        session,
+        make_user_and_role,
+        make_role,
+        make_group,
+        make_user_group_association,
+        make_user_role_association,
+    ):
+        """
+        State: user exists in database AND has group and role associations.
+        Action: update associations (add some/drop some).
+        Expect: old associations are REPLACED by new associations.
+        """
+        user, private_role = make_user_and_role()
+        groups = [make_group() for _ in range(5)]
+        roles = [make_role() for _ in range(5)]
+
+        # load and verify existing associations
+        groups_to_load = [groups[0], groups[2]]
+        roles_to_load = [roles[1], roles[3]]
+        for group in groups_to_load:
+            make_user_group_association(user, group)
+        for role in roles_to_load:
+            make_user_role_association(user, role)
+        verify_user_associations(user, groups_to_load, roles_to_load + [private_role])
+
+        # groups and roles for creating new associations
+        new_groups_to_add = [groups[0], groups[1], groups[3]]
+        group_ids = [g.id for g in new_groups_to_add]
+        new_roles_to_add = [roles[2]]
+        role_ids = [r.id for r in new_roles_to_add]
+
+        # sanity check: ensure we are trying to change existing associations
+        assert not have_same_elements(groups_to_load, new_groups_to_add)
+        assert not have_same_elements(roles_to_load, new_roles_to_add)
+
+        # set associations
+        GalaxyRBACAgent(session).set_user_group_and_role_associations(user, group_ids=group_ids, role_ids=role_ids)
+        # verify new associations
+        verify_user_associations(user, new_groups_to_add, new_roles_to_add + [private_role])
+
+    def test_drop_associations(
+        self,
+        session,
+        make_user_and_role,
+        make_role,
+        make_group,
+        make_user_group_association,
+        make_user_role_association,
+    ):
+        """
+        State: user exists in database AND has group and role associations.
+        Action: drop all associations.
+        """
+        user, private_role = make_user_and_role()
+        groups = [make_group() for _ in range(5)]
+        roles = [make_role() for _ in range(5)]
+
+        # load and verify existing associations
+        groups_to_load = [groups[0], groups[2]]
+        roles_to_load = [roles[1], roles[3]]
+        for group in groups_to_load:
+            make_user_group_association(user, group)
+        for role in roles_to_load:
+            make_user_role_association(user, role)
+        verify_user_associations(user, groups_to_load, roles_to_load + [private_role])
+
+        # drop associations
+        GalaxyRBACAgent(session).set_user_group_and_role_associations(user, group_ids=[], role_ids=[])
+
+        # verify associations dropped
+        verify_user_associations(user, [], [private_role])
+
+    def test_invalid_group(self, session, make_user_and_role, make_group):
+        """
+        State: user exists in database, has no group and only one private role association.
+        Action: try to add several associations, last one having an invalid group id.
+        Expect: no associations are added, appropriate error is raised.
+        """
+        user, private_role = make_user_and_role()
+        groups = [make_group() for _ in range(5)]
+
+        # groups for creating associations
+        group_ids = [groups[0].id, -1]  # first is valid, second is invalid
+
+        # verify no preexisting associations
+        assert len(user.groups) == 0
+
+        # try to set associations
+        with pytest.raises(RequestParameterInvalidException):
+            GalaxyRBACAgent(session).set_user_group_and_role_associations(user, group_ids=group_ids, role_ids=[])
+
+        # verify no change
+        assert len(user.groups) == 0
+
+    def test_invalid_role(self, session, make_user_and_role, make_role):
+        """
+        State: user exists in database, has no group and only one private role association.
+        action: try to add several associations, last one having an invalid role id.
+        expect: no associations are added, appropriate error is raised.
+        """
+        user, private_role = make_user_and_role()
+        roles = [make_role() for _ in range(5)]
+
+        # roles for creating associations
+        role_ids = [roles[0].id, -1]  # first is valid, second is invalid
+
+        # verify no preexisting associations
+        assert len(user.roles) == 1  # one is the private role association
+
+        # try to set associations
+        with pytest.raises(RequestParameterInvalidException):
+            GalaxyRBACAgent(session).set_user_group_and_role_associations(user, group_ids=[], role_ids=role_ids)
+
+        # verify no change
+        assert len(user.roles) == 1  # one is the private role association
+
+    def test_duplicate_group(
+        self,
+        session,
+        make_user_and_role,
+        make_role,
+        make_group,
+        make_user_group_association,
+        make_user_role_association,
+    ):
+        """
+        State: user exists in database and has group and role associations.
+        Action: try update group and role associations including a duplicate group
+        Expect: error raised, no change is made to user groups and user roles.
+        """
+        user, private_role = make_user_and_role()
+        groups = [make_group() for _ in range(5)]
+        roles = [make_role() for _ in range(5)]
+
+        # load and verify existing associations
+        groups_to_load = [groups[0], groups[2]]
+        roles_to_load = [roles[1], roles[3]]
+        for group in groups_to_load:
+            make_user_group_association(user, group)
+        for role in roles_to_load:
+            make_user_role_association(user, role)
+        verify_user_associations(user, groups_to_load, roles_to_load + [private_role])
+
+        # groups and roles for creating new associations
+        new_groups_to_add = groups + [groups[0]]  # include a duplicate group
+        group_ids = [g.id for g in new_groups_to_add]
+
+        new_roles_to_add = roles  # NO duplicate roles
+        role_ids = [r.id for r in new_roles_to_add]
+
+        # sanity check: ensure we are trying to change existing associations
+        assert not have_same_elements(groups_to_load, new_groups_to_add)
+        assert not have_same_elements(roles_to_load, new_roles_to_add)
+
+        with pytest.raises(RequestParameterInvalidException):
+            GalaxyRBACAgent(session).set_user_group_and_role_associations(user, group_ids=group_ids, role_ids=role_ids)
+
+        # verify associations not updated
+        verify_user_associations(user, groups_to_load, roles_to_load + [private_role])
+
+    def test_duplicate_role(
+        self,
+        session,
+        make_user_and_role,
+        make_role,
+        make_group,
+        make_user_group_association,
+        make_user_role_association,
+    ):
+        """
+        State: user exists in database and has group and role associations.
+        Action: try update group and role associations including a duplicate role
+        Expect: error raised, no change is made to user groups and user roles.
+        """
+        user, private_role = make_user_and_role()
+        groups = [make_group() for _ in range(5)]
+        roles = [make_role() for _ in range(5)]
+
+        # load and verify existing associations
+        groups_to_load = [groups[0], groups[2]]
+        roles_to_load = [roles[1], roles[3]]
+        for group in groups_to_load:
+            make_user_group_association(user, group)
+        for role in roles_to_load:
+            make_user_role_association(user, role)
+        verify_user_associations(user, groups_to_load, roles_to_load + [private_role])
+
+        # groups and roles for creating new associations
+        new_groups_to_add = groups  # NO duplicate groups
+        group_ids = [g.id for g in new_groups_to_add]
+
+        new_roles_to_add = roles + [roles[0]]  # include a duplicate role
+        role_ids = [r.id for r in new_roles_to_add]
+
+        # sanity check: ensure we are trying to change existing associations
+        assert not have_same_elements(groups_to_load, new_groups_to_add)
+        assert not have_same_elements(roles_to_load, new_roles_to_add)
+
+        with pytest.raises(RequestParameterInvalidException):
+            GalaxyRBACAgent(session).set_user_group_and_role_associations(user, group_ids=group_ids, role_ids=role_ids)
+
+        # verify associations not updated
+        verify_user_associations(user, groups_to_load, roles_to_load + [private_role])
+
+
+class TestSetRoleUserAndGroupAssociations:
+    """
+    Note: a user should always have a private role which is not affected
+    by modifying a user's group associations or role associations.
+    """
+
+    def test_add_associations_to_existing_role(self, session, make_user_and_role, make_role, make_group):
+        """
+        State: role exists in database, has no group and no user associations.
+        Action: add new associations.
+        """
+        role = make_role()
+        users = [make_user_and_role()[0] for _ in range(5)]
+        groups = [make_group() for _ in range(5)]
+
+        # users and groups for creating associations
+        users_to_add = [users[0], users[2], users[4]]
+        user_ids = [u.id for u in users_to_add]
+        groups_to_add = [groups[0], groups[2], groups[4]]
+        group_ids = [g.id for g in groups_to_add]
+
+        # verify preexisting associations
+        verify_role_associations(role, [], [])
+
+        # set associations
+        GalaxyRBACAgent(session).set_role_user_and_group_associations(role, user_ids=user_ids, group_ids=group_ids)
+
+        # verify new associations
+        verify_role_associations(role, users_to_add, groups_to_add)
+
+    def test_add_associations_to_new_role(self, session, make_user_and_role, make_group):
+        """
+        State: user does NOT exist in database, has no group and role associations.
+        Action: add new associations.
+        """
+        role = Role()
+        session.add(role)
+        assert role.id is None  # role does not exist in database
+        users = [make_user_and_role()[0] for _ in range(5)]
+        groups = [make_group() for _ in range(5)]
+
+        # users and groups for creating associations
+        users_to_add = [users[0], users[2], users[4]]
+        user_ids = [u.id for u in users_to_add]
+        groups_to_add = [groups[0], groups[2], groups[4]]
+        group_ids = [g.id for g in groups_to_add]
+
+        # set associations
+        GalaxyRBACAgent(session).set_role_user_and_group_associations(role, user_ids=user_ids, group_ids=group_ids)
+
+        # verify new associations
+        verify_role_associations(role, users_to_add, groups_to_add)
+
+    def test_update_associations(
+        self,
+        session,
+        make_user_and_role,
+        make_role,
+        make_group,
+        make_user_role_association,
+        make_group_role_association,
+    ):
+        """
+        State: role exists in database AND has user and group associations.
+        Action: update associations (add some/drop some).
+        Expect: old associations are REPLACED by new associations.
+        """
+        role = make_role()
+        users = [make_user_and_role()[0] for _ in range(5)]
+        groups = [make_group() for _ in range(5)]
+
+        # load and verify existing associations
+        users_to_load = [users[1], users[3]]
+        groups_to_load = [groups[0], groups[2]]
+        for user in users_to_load:
+            make_user_role_association(user, role)
+        for group in groups_to_load:
+            make_group_role_association(group, role)
+        verify_role_associations(role, users_to_load, groups_to_load)
+
+        # users and groups for creating new associations
+        new_users_to_add = [users[0], users[2], users[4]]
+        user_ids = [u.id for u in new_users_to_add]
+        new_groups_to_add = [groups[0], groups[2], groups[4]]
+        group_ids = [g.id for g in new_groups_to_add]
+
+        # sanity check: ensure we are trying to change existing associations
+        assert not have_same_elements(users_to_load, new_users_to_add)
+        assert not have_same_elements(groups_to_load, new_groups_to_add)
+
+        # set associations
+        GalaxyRBACAgent(session).set_role_user_and_group_associations(role, user_ids=user_ids, group_ids=group_ids)
+        # verify new associations
+        verify_role_associations(role, new_users_to_add, new_groups_to_add)
+
+    def test_drop_associations(
+        self,
+        session,
+        make_user_and_role,
+        make_role,
+        make_group,
+        make_group_role_association,
+        make_user_role_association,
+    ):
+        """
+        State: role exists in database AND has user and group associations.
+        Action: drop all associations.
+        """
+        role = make_role()
+        users = [make_user_and_role()[0] for _ in range(5)]
+        groups = [make_group() for _ in range(5)]
+
+        # load and verify existing associations
+        users_to_load = [users[1], users[3]]
+        groups_to_load = [groups[0], groups[2]]
+        for user in users_to_load:
+            make_user_role_association(user, role)
+        for group in groups_to_load:
+            make_group_role_association(group, role)
+        verify_role_associations(role, users_to_load, groups_to_load)
+
+        # drop associations
+        GalaxyRBACAgent(session).set_role_user_and_group_associations(role, user_ids=[], group_ids=[])
+
+        # verify associations dropped
+        verify_role_associations(role, [], [])
+
+    def test_invalid_user(self, session, make_role, make_user_and_role):
+        """
+        State: role exists in database, has no user and group eassociations.
+        action: try to add several associations, last one having an invalid user id.
+        expect: no associations are added, appropriate error is raised.
+        """
+        role = make_role()
+        users = [make_user_and_role()[0] for _ in range(5)]
+
+        # users for creating associations
+        user_ids = [users[0].id, -1]  # first is valid, second is invalid
+
+        # verify no preexisting associations
+        assert len(role.users) == 0
+
+        # try to set associations
+        with pytest.raises(RequestParameterInvalidException):
+            GalaxyRBACAgent(session).set_role_user_and_group_associations(role, user_ids=user_ids, group_ids=[])
+
+        # verify no change
+        assert len(role.users) == 0
+
+    def test_invalid_group(self, session, make_role, make_group):
+        """
+        State: role exists in database, has no user and group eassociations.
+        Action: try to add several associations, last one having an invalid group id.
+        Expect: no associations are added, appropriate error is raised.
+        """
+        role = make_role()
+        groups = [make_group() for _ in range(5)]
+
+        # groups for creating associations
+        group_ids = [groups[0].id, -1]  # first is valid, second is invalid
+
+        # verify no preexisting associations
+        assert len(role.groups) == 0
+
+        # try to set associations
+        with pytest.raises(RequestParameterInvalidException):
+            GalaxyRBACAgent(session).set_role_user_and_group_associations(role, user_ids=[], group_ids=group_ids)
+
+        # verify no change
+        assert len(role.groups) == 0
+
+    def test_duplicate_user(
+        self,
+        session,
+        make_user_and_role,
+        make_role,
+        make_group,
+        make_group_role_association,
+        make_user_role_association,
+    ):
+        """
+        State: role exists in database and has group and user associations.
+        Action: try update group and user associations including a duplicate user
+        Expect: error raised, no change is made to role groups and role users.
+        """
+        role = make_role()
+        users = [make_user_and_role()[0] for _ in range(5)]
+        groups = [make_group() for _ in range(5)]
+
+        # load and verify existing associations
+        users_to_load = [users[1], users[3]]
+        groups_to_load = [groups[0], groups[2]]
+        for user in users_to_load:
+            make_user_role_association(user, role)
+        for group in groups_to_load:
+            make_group_role_association(group, role)
+
+        verify_role_associations(role, users_to_load, groups_to_load)
+
+        # users and groups for creating new associations
+        new_users_to_add = users + [users[0]]  # include a duplicate user
+        user_ids = [u.id for u in new_users_to_add]
+
+        new_groups_to_add = groups  # NO duplicate groups
+        group_ids = [g.id for g in new_groups_to_add]
+
+        # sanity check: ensure we are trying to change existing associations
+        assert not have_same_elements(users_to_load, new_users_to_add)
+        assert not have_same_elements(groups_to_load, new_groups_to_add)
+
+        with pytest.raises(RequestParameterInvalidException):
+            GalaxyRBACAgent(session).set_role_user_and_group_associations(role, user_ids=user_ids, group_ids=group_ids)
+
+        # verify associations not updated
+        verify_role_associations(role, users_to_load, groups_to_load)
+
+    def test_duplicate_group(
+        self,
+        session,
+        make_user_and_role,
+        make_role,
+        make_group,
+        make_group_role_association,
+        make_user_role_association,
+    ):
+        """
+        State: role exists in database and has group and user associations.
+        Action: try update group and user associations including a duplicate group
+        Expect: error raised, no change is made to role groups and role users.
+        """
+        role = make_role()
+        users = [make_user_and_role()[0] for _ in range(5)]
+        groups = [make_group() for _ in range(5)]
+
+        # load and verify existing associations
+        users_to_load = [users[1], users[3]]
+        groups_to_load = [groups[0], groups[2]]
+        for user in users_to_load:
+            make_user_role_association(user, role)
+        for group in groups_to_load:
+            make_group_role_association(group, role)
+
+        verify_role_associations(role, users_to_load, groups_to_load)
+
+        # users and groups for creating new associations
+        new_users_to_add = users  # NO duplicate users
+        user_ids = [u.id for u in new_users_to_add]
+
+        new_groups_to_add = groups + [groups[0]]  # include a duplicate group
+        group_ids = [g.id for g in new_groups_to_add]
+
+        # sanity check: ensure we are trying to change existing associations
+        assert not have_same_elements(users_to_load, new_users_to_add)
+        assert not have_same_elements(groups_to_load, new_groups_to_add)
+
+        with pytest.raises(RequestParameterInvalidException):
+            GalaxyRBACAgent(session).set_role_user_and_group_associations(role, user_ids=user_ids, group_ids=group_ids)
+
+        # verify associations not updated
+        verify_role_associations(role, users_to_load, groups_to_load)
+
+
+def verify_group_associations(group, expected_users, expected_roles):
+    new_group_users = [assoc.user for assoc in group.users]
+    new_group_roles = [assoc.role for assoc in group.roles]
+    assert have_same_elements(new_group_users, expected_users)
+    assert have_same_elements(new_group_roles, expected_roles)
+
+
+def verify_user_associations(user, expected_groups, expected_roles):
+    new_user_groups = [assoc.group for assoc in user.groups]
+    new_user_roles = [assoc.role for assoc in user.roles]
+    assert have_same_elements(new_user_groups, expected_groups)
+    assert have_same_elements(new_user_roles, expected_roles)
+
+
+def verify_role_associations(role, expected_users, expected_groups):
+    new_role_users = [assoc.user for assoc in role.users]
+    new_role_groups = [assoc.group for assoc in role.groups]
+    assert have_same_elements(new_role_users, expected_users)
+    assert have_same_elements(new_role_groups, expected_groups)

--- a/test/unit/data/model/db/test_security.py
+++ b/test/unit/data/model/db/test_security.py
@@ -98,7 +98,7 @@ class TestSetGroupUserAndRoleAssociations:
         group = Group()
         session.add(group)
         assert group.id is None  # group does not exist in database
-        users = [make_user_and_role()[0] for _ in range(5)]
+        users = [make_user_and_role()[0] for _ in range(5)]  # type: ignore[unreachable]
         roles = [make_role() for _ in range(5)]
 
         # users and roles for creating associations
@@ -363,7 +363,7 @@ class TestSetUserGroupAndRoleAssociations:
 
         session.add(user)
         assert user.id is None  # user does not exist in database
-        groups = [make_group() for _ in range(5)]
+        groups = [make_group() for _ in range(5)]  # type: ignore[unreachable]
         roles = [make_role() for _ in range(5)]
 
         # groups and roles for creating associations
@@ -623,7 +623,7 @@ class TestSetRoleUserAndGroupAssociations:
         role = Role()
         session.add(role)
         assert role.id is None  # role does not exist in database
-        users = [make_user_and_role()[0] for _ in range(5)]
+        users = [make_user_and_role()[0] for _ in range(5)]  # type: ignore[unreachable]
         groups = [make_group() for _ in range(5)]
 
         # users and groups for creating associations

--- a/test/unit/data/model/db/test_security.py
+++ b/test/unit/data/model/db/test_security.py
@@ -41,7 +41,7 @@ def test_private_user_role_assoc_not_affected_by_setting_user_roles(session, mak
     assert user.email != private_role.name
 
     # Delete user roles
-    GalaxyRBACAgent(session).set_user_group_and_role_associations(user, group_ids=[], role_ids=[])
+    GalaxyRBACAgent(session).set_user_group_and_role_associations(user, role_ids=[])
     # association with private role is preserved
     verify_user_associations(user, [], [private_role])
 
@@ -59,7 +59,7 @@ def test_private_user_role_assoc_not_affected_by_setting_role_users(session, mak
     assert user.email != private_role.name
 
     # Update role users
-    GalaxyRBACAgent(session).set_role_user_and_group_associations(private_role, user_ids=[], group_ids=[])
+    GalaxyRBACAgent(session).set_role_user_and_group_associations(private_role, user_ids=[])
     # association of private role with user is preserved
     verify_role_associations(private_role, [user], [])
 
@@ -71,9 +71,7 @@ def test_cannot_assign_private_roles(session, make_user_and_role, make_role):
     verify_user_associations(user, [], [private_role1])  # the only existing association is with the private role
 
     # Try to assign 2 more roles: regular role + another private role
-    GalaxyRBACAgent(session).set_user_group_and_role_associations(
-        user, group_ids=[], role_ids=[new_role.id, private_role2.id]
-    )
+    GalaxyRBACAgent(session).set_user_group_and_role_associations(user, role_ids=[new_role.id, private_role2.id])
     # Only regular role has been added: other private role ignored; original private role still assigned
     verify_user_associations(user, [], [private_role1, new_role])
 
@@ -219,7 +217,7 @@ class TestSetGroupUserAndRoleAssociations:
 
         # try to set associations
         with pytest.raises(RequestParameterInvalidException):
-            GalaxyRBACAgent(session).set_group_user_and_role_associations(group, user_ids=user_ids, role_ids=[])
+            GalaxyRBACAgent(session).set_group_user_and_role_associations(group, user_ids=user_ids)
 
         # verify no change
         assert len(group.users) == 0
@@ -241,7 +239,7 @@ class TestSetGroupUserAndRoleAssociations:
 
         # try to set associations
         with pytest.raises(RequestParameterInvalidException):
-            GalaxyRBACAgent(session).set_group_user_and_role_associations(group, user_ids=[], role_ids=role_ids)
+            GalaxyRBACAgent(session).set_group_user_and_role_associations(group, role_ids=role_ids)
 
         # verify no change
         assert len(group.roles) == 0
@@ -483,7 +481,7 @@ class TestSetUserGroupAndRoleAssociations:
 
         # try to set associations
         with pytest.raises(RequestParameterInvalidException):
-            GalaxyRBACAgent(session).set_user_group_and_role_associations(user, group_ids=group_ids, role_ids=[])
+            GalaxyRBACAgent(session).set_user_group_and_role_associations(user, group_ids=group_ids)
 
         # verify no change
         assert len(user.groups) == 0
@@ -505,7 +503,7 @@ class TestSetUserGroupAndRoleAssociations:
 
         # try to set associations
         with pytest.raises(RequestParameterInvalidException):
-            GalaxyRBACAgent(session).set_user_group_and_role_associations(user, group_ids=[], role_ids=role_ids)
+            GalaxyRBACAgent(session).set_user_group_and_role_associations(user, role_ids=role_ids)
 
         # verify no change
         assert len(user.roles) == 1  # one is the private role association
@@ -743,7 +741,7 @@ class TestSetRoleUserAndGroupAssociations:
 
         # try to set associations
         with pytest.raises(RequestParameterInvalidException):
-            GalaxyRBACAgent(session).set_role_user_and_group_associations(role, user_ids=user_ids, group_ids=[])
+            GalaxyRBACAgent(session).set_role_user_and_group_associations(role, user_ids=user_ids)
 
         # verify no change
         assert len(role.users) == 0
@@ -765,7 +763,7 @@ class TestSetRoleUserAndGroupAssociations:
 
         # try to set associations
         with pytest.raises(RequestParameterInvalidException):
-            GalaxyRBACAgent(session).set_role_user_and_group_associations(role, user_ids=[], group_ids=group_ids)
+            GalaxyRBACAgent(session).set_role_user_and_group_associations(role, group_ids=group_ids)
 
         # verify no change
         assert len(role.groups) == 0
@@ -907,7 +905,7 @@ class TestSetRoleUserAndGroupAssociations:
         assert have_same_elements(history3.default_permissions, [dhp3])
 
         # now update role users
-        GalaxyRBACAgent(session).set_role_user_and_group_associations(role, user_ids=user_ids, group_ids=[])
+        GalaxyRBACAgent(session).set_role_user_and_group_associations(role, user_ids=user_ids)
 
         # verify user role associations
         verify_role_associations(role, new_users_to_add, [])

--- a/test/unit/data/model/db/test_user.py
+++ b/test/unit/data/model/db/test_user.py
@@ -7,7 +7,7 @@ from galaxy.model.db.user import (
     get_users_by_ids,
     get_users_for_index,
 )
-from . import verify_items
+from . import have_same_elements
 
 
 @pytest.fixture
@@ -42,7 +42,7 @@ def test_get_users_by_ids(session, make_random_users):
 
     users2 = get_users_by_ids(session, ids)
     expected = [u1, u2, u3]
-    verify_items(users2, expected)
+    have_same_elements(users2, expected)
 
 
 def test_get_users_for_index(session, make_user):
@@ -54,25 +54,25 @@ def test_get_users_for_index(session, make_user):
     u6 = make_user(email="z", username="i")
 
     users = get_users_for_index(session, False, f_email="a", expose_user_email=True)
-    verify_items(users, [u1])
+    have_same_elements(users, [u1])
     users = get_users_for_index(session, False, f_email="c", is_admin=True)
-    verify_items(users, [u2])
+    have_same_elements(users, [u2])
     users = get_users_for_index(session, False, f_name="f", expose_user_name=True)
-    verify_items(users, [u3])
+    have_same_elements(users, [u3])
     users = get_users_for_index(session, False, f_name="h", is_admin=True)
-    verify_items(users, [u4])
+    have_same_elements(users, [u4])
     users = get_users_for_index(session, False, f_any="i", is_admin=True)
-    verify_items(users, [u5, u6])
+    have_same_elements(users, [u5, u6])
     users = get_users_for_index(session, False, f_any="i", expose_user_email=True, expose_user_name=True)
-    verify_items(users, [u5, u6])
+    have_same_elements(users, [u5, u6])
     users = get_users_for_index(session, False, f_any="i", expose_user_email=True)
-    verify_items(users, [u5])
+    have_same_elements(users, [u5])
     users = get_users_for_index(session, False, f_any="i", expose_user_name=True)
-    verify_items(users, [u6])
+    have_same_elements(users, [u6])
 
     u1.deleted = True
     users = get_users_for_index(session, True)
-    verify_items(users, [u1])
+    have_same_elements(users, [u1])
 
 
 def test_username_is_unique(make_user):

--- a/test/unit/data/model/migration_fixes/conftest.py
+++ b/test/unit/data/model/migration_fixes/conftest.py
@@ -1,0 +1,47 @@
+from typing import (
+    Generator,
+    TYPE_CHECKING,
+)
+
+import pytest
+from sqlalchemy import (
+    create_engine,
+    text,
+)
+from sqlalchemy.orm import Session
+
+from galaxy import model as m
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
+
+from galaxy.model.unittest_utils.model_testing_utils import (  # noqa: F401 - url_factory is a fixture we have to import explicitly
+    sqlite_url_factory,
+)
+
+
+@pytest.fixture()
+def db_url(sqlite_url_factory):  # noqa: F811
+    return sqlite_url_factory()
+
+
+@pytest.fixture()
+def engine(db_url: str) -> "Engine":
+    return create_engine(db_url)
+
+
+@pytest.fixture
+def session(engine: "Engine") -> Session:
+    return Session(engine)
+
+
+@pytest.fixture(autouse=True)
+def clear_database(engine: "Engine") -> "Generator":
+    """Delete all rows from all tables. Called after each test."""
+    yield
+    with engine.begin() as conn:
+        for table in m.mapper_registry.metadata.tables:
+            # Unless db is sqlite, disable foreign key constraints to delete out of order
+            if engine.name != "sqlite":
+                conn.execute(text(f"ALTER TABLE {table} DISABLE TRIGGER ALL"))
+            conn.execute(text(f"DELETE FROM {table}"))

--- a/test/unit/data/model/migration_fixes/test_migrations.py
+++ b/test/unit/data/model/migration_fixes/test_migrations.py
@@ -1,6 +1,12 @@
 import pytest
+from sqlalchemy import select
 
-from galaxy.model import User
+from galaxy.model import (
+    GroupRoleAssociation,
+    User,
+    UserGroupAssociation,
+    UserRoleAssociation,
+)
 from galaxy.model.unittest_utils.migration_scripts_testing_utils import (  # noqa: F401 - contains fixtures we have to import explicitly
     run_command,
     tmp_directory,
@@ -152,3 +158,222 @@ def test_d619fdfa6168(monkeypatch, session, make_user):
     assert u1_fixed.deleted is True
     assert u2_fixed.deleted is True
     assert u3_fixed.deleted is False
+
+
+def test_349dd9d9aac9(monkeypatch, session, make_user, make_role, make_user_role_association):
+    # Initialize db and migration environment
+    dburl = str(session.bind.url)
+    monkeypatch.setenv("GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION", dburl)
+    monkeypatch.setenv("GALAXY_INSTALL_CONFIG_OVERRIDE_INSTALL_DATABASE_CONNECTION", dburl)
+    run_command(f"{COMMAND} init")
+
+    # Load pre-migration state
+    run_command(f"{COMMAND} downgrade 1cf595475b58")
+
+    # Load duplicate records
+    u1, u2 = make_user(), make_user()
+    r1, r2 = make_role(), make_role()
+    make_user_role_association(user=u1, role=r1)
+    make_user_role_association(user=u1, role=r2)
+    make_user_role_association(user=u1, role=r2)  # duplicate
+    make_user_role_association(user=u2, role=r1)
+    make_user_role_association(user=u2, role=r1)  # duplicate
+
+    # Verify duplicates
+    assert len(u1.roles) == 3
+    assert len(u2.roles) == 2
+    all_associations = session.execute(select(UserRoleAssociation)).all()
+    assert len(all_associations) == 5
+
+    # Run migration
+    run_command(f"{COMMAND} upgrade 349dd9d9aac9")
+    session.expire_all()
+
+    # Verify clean data
+    assert len(u1.roles) == 2
+    assert len(u2.roles) == 1
+    all_associations = session.execute(select(UserRoleAssociation)).all()
+    assert len(all_associations) == 3
+
+
+def test_56ddf316dbd0(monkeypatch, session, make_user, make_group, make_user_group_association):
+    # Initialize db and migration environment
+    dburl = str(session.bind.url)
+    monkeypatch.setenv("GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION", dburl)
+    monkeypatch.setenv("GALAXY_INSTALL_CONFIG_OVERRIDE_INSTALL_DATABASE_CONNECTION", dburl)
+    run_command(f"{COMMAND} init")
+
+    # Load pre-migration state
+    run_command(f"{COMMAND} downgrade 1fdd615f2cdb")
+
+    # Load duplicate records
+    u1, u2 = make_user(), make_user()
+    g1, g2 = make_group(), make_group()
+    make_user_group_association(user=u1, group=g1)
+    make_user_group_association(user=u1, group=g2)
+    make_user_group_association(user=u1, group=g2)  # duplicate
+    make_user_group_association(user=u2, group=g1)
+    make_user_group_association(user=u2, group=g1)  # duplicate
+
+    # Verify duplicates
+    assert len(u1.groups) == 3
+    assert len(u2.groups) == 2
+    all_associations = session.execute(select(UserGroupAssociation)).all()
+    assert len(all_associations) == 5
+
+    # Run migration
+    run_command(f"{COMMAND} upgrade 56ddf316dbd0")
+    session.expire_all()
+
+    # Verify clean data
+    assert len(u1.groups) == 2
+    assert len(u2.groups) == 1
+    all_associations = session.execute(select(UserGroupAssociation)).all()
+    assert len(all_associations) == 3
+
+
+def test_9ef6431f3a4e(monkeypatch, session, make_group, make_role, make_group_role_association):
+    # Initialize db and migration environment
+    dburl = str(session.bind.url)
+    monkeypatch.setenv("GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION", dburl)
+    monkeypatch.setenv("GALAXY_INSTALL_CONFIG_OVERRIDE_INSTALL_DATABASE_CONNECTION", dburl)
+    run_command(f"{COMMAND} init")
+
+    # Load pre-migration state
+    run_command(f"{COMMAND} downgrade 13fe10b8e35b")
+
+    # Load duplicate records
+    g1, g2 = make_group(), make_group()
+    r1, r2 = make_role(), make_role()
+    make_group_role_association(group=g1, role=r1)
+    make_group_role_association(group=g1, role=r2)
+    make_group_role_association(group=g1, role=r2)  # duplicate
+    make_group_role_association(group=g2, role=r1)
+    make_group_role_association(group=g2, role=r1)  # duplicate
+
+    # Verify duplicates
+    assert len(g1.roles) == 3
+    assert len(g2.roles) == 2
+    all_associations = session.execute(select(GroupRoleAssociation)).all()
+    assert len(all_associations) == 5
+
+    # Run migration
+    run_command(f"{COMMAND} upgrade 9ef6431f3a4e")
+    session.expire_all()
+
+    # Verify clean data
+    assert len(g1.roles) == 2
+    assert len(g2.roles) == 1
+    all_associations = session.execute(select(GroupRoleAssociation)).all()
+    assert len(all_associations) == 3
+
+
+def test_1fdd615f2cdb(monkeypatch, session, make_user, make_role, make_user_role_association):
+    # Initialize db and migration environment
+    dburl = str(session.bind.url)
+    monkeypatch.setenv("GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION", dburl)
+    monkeypatch.setenv("GALAXY_INSTALL_CONFIG_OVERRIDE_INSTALL_DATABASE_CONNECTION", dburl)
+    run_command(f"{COMMAND} init")
+
+    # Load pre-migration state
+    run_command(f"{COMMAND} downgrade 349dd9d9aac9")
+
+    # Load records w/nulls
+    ura1 = make_user_role_association(user=make_user(), role=make_role())
+    ura2 = make_user_role_association(user=make_user(), role=make_role())
+    ura3 = make_user_role_association(user=make_user(), role=make_role())
+    ura1.user_id = None
+    ura2.role_id = None
+    ura3.user_id = None
+    ura3.role_id = None
+    session.add_all([ura1, ura2, ura3])
+    session.commit()
+
+    # Load record w/o nulls
+    make_user_role_association(user=make_user(), role=make_role())
+
+    # Verify data
+    all_associations = session.execute(select(UserRoleAssociation)).all()
+    assert len(all_associations) == 4
+
+    # Run migration
+    run_command(f"{COMMAND} upgrade 1fdd615f2cdb")
+    session.expire_all()
+
+    # Verify clean data
+    all_associations = session.execute(select(UserRoleAssociation)).all()
+    assert len(all_associations) == 1
+
+
+def test_13fe10b8e35b(monkeypatch, session, make_user, make_group, make_user_group_association):
+    # Initialize db and migration environment
+    dburl = str(session.bind.url)
+    monkeypatch.setenv("GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION", dburl)
+    monkeypatch.setenv("GALAXY_INSTALL_CONFIG_OVERRIDE_INSTALL_DATABASE_CONNECTION", dburl)
+    run_command(f"{COMMAND} init")
+
+    # Load pre-migration state
+    run_command(f"{COMMAND} downgrade 56ddf316dbd0")
+
+    # Load records w/nulls
+    uga1 = make_user_group_association(user=make_user(), group=make_group())
+    uga2 = make_user_group_association(user=make_user(), group=make_group())
+    uga3 = make_user_group_association(user=make_user(), group=make_group())
+    uga1.user_id = None
+    uga2.group_id = None
+    uga3.user_id = None
+    uga3.group_id = None
+    session.add_all([uga1, uga2, uga3])
+    session.commit()
+
+    # Load record w/o nulls
+    make_user_group_association(user=make_user(), group=make_group())
+
+    # Verify data
+    all_associations = session.execute(select(UserGroupAssociation)).all()
+    assert len(all_associations) == 4
+
+    # Run migration
+    run_command(f"{COMMAND} upgrade 13fe10b8e35b")
+    session.expire_all()
+
+    # Verify clean data
+    all_associations = session.execute(select(UserGroupAssociation)).all()
+    assert len(all_associations) == 1
+
+
+def test_25b092f7938b(monkeypatch, session, make_group, make_role, make_group_role_association):
+    # Initialize db and migration environment
+    dburl = str(session.bind.url)
+    monkeypatch.setenv("GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION", dburl)
+    monkeypatch.setenv("GALAXY_INSTALL_CONFIG_OVERRIDE_INSTALL_DATABASE_CONNECTION", dburl)
+    run_command(f"{COMMAND} init")
+
+    # Load pre-migration state
+    run_command(f"{COMMAND} downgrade 9ef6431f3a4e")
+
+    # Load records w/nulls
+    gra1 = make_group_role_association(group=make_group(), role=make_role())
+    gra2 = make_group_role_association(group=make_group(), role=make_role())
+    gra3 = make_group_role_association(group=make_group(), role=make_role())
+    gra1.group_id = None
+    gra2.role_id = None
+    gra3.group_id = None
+    gra3.role_id = None
+    session.add_all([gra1, gra2, gra3])
+    session.commit()
+
+    # Load record w/o nulls
+    make_group_role_association(group=make_group(), role=make_role())
+
+    # Verify data
+    all_associations = session.execute(select(GroupRoleAssociation)).all()
+    assert len(all_associations) == 4
+
+    # Run migration
+    run_command(f"{COMMAND} upgrade 25b092f7938b")
+    session.expire_all()
+
+    # Verify clean data
+    all_associations = session.execute(select(GroupRoleAssociation)).all()
+    assert len(all_associations) == 1

--- a/test/unit/data/model/migration_fixes/test_migrations.py
+++ b/test/unit/data/model/migration_fixes/test_migrations.py
@@ -1,0 +1,154 @@
+import pytest
+
+from galaxy.model import User
+from galaxy.model.unittest_utils.migration_scripts_testing_utils import (  # noqa: F401 - contains fixtures we have to import explicitly
+    run_command,
+    tmp_directory,
+)
+
+COMMAND = "manage_db.sh"
+
+
+@pytest.fixture(autouse=True)
+def upgrade_database_after_test():
+    """Run after each test for proper cleanup"""
+    yield
+    run_command(f"{COMMAND} upgrade")
+
+
+def test_1cf595475b58(monkeypatch, session, make_user, make_history):
+    # Initialize db and migration environment
+    dburl = str(session.bind.url)
+    monkeypatch.setenv("GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION", dburl)
+    monkeypatch.setenv("GALAXY_INSTALL_CONFIG_OVERRIDE_INSTALL_DATABASE_CONNECTION", dburl)
+    run_command(f"{COMMAND} init")
+
+    # STEP 0: Load pre-migration state
+    run_command(f"{COMMAND} downgrade d619fdfa6168")
+
+    # STEP 1: Load users with duplicate emails
+
+    # Duplicate group 1: users have no histories
+    # Expect: oldest user preserved
+    u1_1 = make_user(email="a")
+    u1_2 = make_user(email="a")
+    u1_3 = make_user(email="a")
+    original_email1 = u1_1.email
+    assert u1_1.email == u1_2.email == u1_3.email
+    assert u1_1.create_time < u1_2.create_time < u1_3.create_time  # u1_1 is oldest user
+
+    # Duplicate group 2: oldest user does NOT have a history, another user has a history
+    # Expect: user with history preserved
+    u2_1 = make_user(email="b")
+    u2_2 = make_user(email="b")
+    u2_3 = make_user(email="b")
+    original_email2 = u2_1.email
+    assert u2_1.email == u2_2.email == u2_3.email
+    assert u2_1.create_time < u2_2.create_time < u2_3.create_time  # u2_1 is oldest user
+
+    make_history(user=u2_2)  # u2_2 has a history
+
+    # Duplicate group 3: oldest user does NOT have a history, 2 users have a history
+    # Expect: oldest user with history preserved
+    u3_1 = make_user(email="c")
+    u3_2 = make_user(email="c")
+    u3_3 = make_user(email="c")
+    original_email3 = u3_1.email
+    assert u3_1.email == u3_2.email == u3_3.email
+    assert u3_1.create_time < u3_2.create_time < u3_3.create_time  # u2_1 is oldest user
+
+    make_history(user=u3_2)  # u3_2 has a history
+    make_history(user=u3_3)  # u3_3 has a history
+
+    # User w/o duplicate email
+    u4 = make_user()
+    original_email4 = u4.email
+
+    # STEP 2: Run migration
+
+    run_command(f"{COMMAND} upgrade 1cf595475b58")
+    session.expire_all()
+
+    # STEP 3: Verify deduplicated results
+
+    # Duplicate group 1:
+    u1_1_fixed = session.get(User, u1_1.id)
+    u1_2_fixed = session.get(User, u1_2.id)
+    u1_3_fixed = session.get(User, u1_3.id)
+
+    # oldest user's email is preserved; the rest are deduplicated
+    assert u1_1.email == original_email1
+    assert u1_1.email != u1_2.email != u1_3.email
+    # deduplicated users are marked as deleted
+    assert u1_1_fixed.deleted is False
+    assert u1_2_fixed.deleted is True
+    assert u1_3_fixed.deleted is True
+
+    # Duplicate group 2:
+    u2_1_fixed = session.get(User, u2_1.id)
+    u2_2_fixed = session.get(User, u2_2.id)
+    u2_3_fixed = session.get(User, u2_3.id)
+
+    # the email of the user with a history is preserved; the rest are deduplicated
+    assert u2_2.email == original_email2
+    assert u2_1.email != u1_2.email != u1_3.email
+    # deduplicated users are marked as deleted
+    assert u2_1_fixed.deleted is True
+    assert u2_2_fixed.deleted is False
+    assert u2_3_fixed.deleted is True
+
+    # Duplicate group 3:
+    u3_1_fixed = session.get(User, u3_1.id)
+    u3_2_fixed = session.get(User, u3_2.id)
+    u3_3_fixed = session.get(User, u3_3.id)
+
+    # the email of the oldest user with a history is preserved; the rest are deduplicated
+    assert u3_2.email == original_email3
+    assert u3_1.email != u3_2.email != u3_3.email
+    # deduplicated users are marked as deleted
+    assert u3_1_fixed.deleted is True
+    assert u3_2_fixed.deleted is False
+    assert u3_3_fixed.deleted is True
+
+    # User w/o duplicate email
+    u4_no_change = session.get(User, u4.id)
+    assert u4_no_change.email == original_email4
+    assert u4_no_change.deleted is False
+
+
+def test_d619fdfa6168(monkeypatch, session, make_user):
+    # Initialize db and migration environment
+    dburl = str(session.bind.url)
+    monkeypatch.setenv("GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION", dburl)
+    monkeypatch.setenv("GALAXY_INSTALL_CONFIG_OVERRIDE_INSTALL_DATABASE_CONNECTION", dburl)
+    run_command(f"{COMMAND} init")
+
+    # STEP 0: Load pre-migration state
+    run_command(f"{COMMAND} downgrade d2d8f51ebb7e")
+
+    # STEP 1: Load users with duplicate usernames
+
+    # Expect: oldest user preserved
+    u1 = make_user(username="a")
+    u2 = make_user(username="a")
+    u3 = make_user(username="a")
+    original_username = u3.username
+    assert u1.username == u2.username == u3.username
+    assert u1.create_time < u2.create_time < u3.create_time  # u3 is newest user
+
+    # STEP 2: Run migration
+    run_command(f"{COMMAND} upgrade d619fdfa6168")
+    session.expire_all()
+
+    # STEP 3: Verify deduplicated results
+    u1_fixed = session.get(User, u1.id)
+    u2_fixed = session.get(User, u2.id)
+    u3_fixed = session.get(User, u3.id)
+
+    # oldest user's username is preserved; the rest are deduplicated
+    assert u3_fixed.username == original_username
+    assert u1.username != u2.username != u3.username
+    # deduplicated users are marked as deleted
+    assert u1_fixed.deleted is True
+    assert u2_fixed.deleted is True
+    assert u3_fixed.deleted is False

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -456,7 +456,7 @@ class TestMappings(BaseModelTestCase):
         assert counts.root["scheduled"] == 1
 
     def test_role_creation(self):
-        security_agent = GalaxyRBACAgent(self.model)
+        security_agent = GalaxyRBACAgent(self.model.session)
 
         def check_private_role(private_role, email):
             assert private_role.type == model.Role.types.PRIVATE
@@ -489,7 +489,7 @@ class TestMappings(BaseModelTestCase):
         check_private_role(role, email)
 
     def test_private_share_role(self):
-        security_agent = GalaxyRBACAgent(self.model)
+        security_agent = GalaxyRBACAgent(self.model.session)
 
         u_from, u_to, u_other = self._three_users("private_share_role")
 
@@ -504,7 +504,7 @@ class TestMappings(BaseModelTestCase):
         assert not security_agent.can_access_dataset(u_other.all_roles(), d1.dataset)
 
     def test_make_dataset_public(self):
-        security_agent = GalaxyRBACAgent(self.model)
+        security_agent = GalaxyRBACAgent(self.model.session)
         u_from, u_to, u_other = self._three_users("make_dataset_public")
 
         h = model.History(name="History for Annotation", user=u_from)
@@ -520,7 +520,7 @@ class TestMappings(BaseModelTestCase):
         assert security_agent.can_access_dataset(u_other.all_roles(), d1.dataset)
 
     def test_set_all_dataset_permissions(self):
-        security_agent = GalaxyRBACAgent(self.model)
+        security_agent = GalaxyRBACAgent(self.model.session)
         u_from, _, u_other = self._three_users("set_all_perms")
 
         h = model.History(name="History for Annotation", user=u_from)
@@ -541,7 +541,7 @@ class TestMappings(BaseModelTestCase):
         assert not security_agent.can_access_dataset(u_other.all_roles(), d1.dataset)
 
     def test_can_manage_privately_shared_dataset(self):
-        security_agent = GalaxyRBACAgent(self.model)
+        security_agent = GalaxyRBACAgent(self.model.session)
         u_from, u_to, u_other = self._three_users("can_manage_dataset")
 
         h = model.History(name="History for Prevent Sharing", user=u_from)
@@ -556,7 +556,7 @@ class TestMappings(BaseModelTestCase):
         assert not security_agent.can_manage_dataset(u_to.all_roles(), d1.dataset)
 
     def test_can_manage_private_dataset(self):
-        security_agent = GalaxyRBACAgent(self.model)
+        security_agent = GalaxyRBACAgent(self.model.session)
         u_from, _, u_other = self._three_users("can_manage_dataset_ps")
 
         h = model.History(name="History for Prevent Sharing", user=u_from)
@@ -570,7 +570,7 @@ class TestMappings(BaseModelTestCase):
         assert not security_agent.can_manage_dataset(u_other.all_roles(), d1.dataset)
 
     def test_cannot_make_private_objectstore_dataset_public(self):
-        security_agent = GalaxyRBACAgent(self.model)
+        security_agent = GalaxyRBACAgent(self.model.session)
         u_from, u_to, _ = self._three_users("cannot_make_private_public")
 
         h = self.model.History(name="History for Prevent Sharing", user=u_from)
@@ -587,7 +587,7 @@ class TestMappings(BaseModelTestCase):
         assert galaxy.model.CANNOT_SHARE_PRIVATE_DATASET_MESSAGE in str(exec_info.value)
 
     def test_cannot_make_private_objectstore_dataset_shared(self):
-        security_agent = GalaxyRBACAgent(self.model)
+        security_agent = GalaxyRBACAgent(self.model.session)
         u_from, u_to, _ = self._three_users("cannot_make_private_shared")
 
         h = self.model.History(name="History for Prevent Sharing", user=u_from)
@@ -604,7 +604,7 @@ class TestMappings(BaseModelTestCase):
         assert galaxy.model.CANNOT_SHARE_PRIVATE_DATASET_MESSAGE in str(exec_info.value)
 
     def test_cannot_set_dataset_permisson_on_private(self):
-        security_agent = GalaxyRBACAgent(self.model)
+        security_agent = GalaxyRBACAgent(self.model.session)
         u_from, u_to, _ = self._three_users("cannot_set_permissions_on_private")
 
         h = self.model.History(name="History for Prevent Sharing", user=u_from)
@@ -624,7 +624,7 @@ class TestMappings(BaseModelTestCase):
         assert galaxy.model.CANNOT_SHARE_PRIVATE_DATASET_MESSAGE in str(exec_info.value)
 
     def test_cannot_make_private_dataset_public(self):
-        security_agent = GalaxyRBACAgent(self.model)
+        security_agent = GalaxyRBACAgent(self.model.session)
         u_from, u_to, u_other = self._three_users("cannot_make_private_dataset_public")
 
         h = self.model.History(name="History for Annotation", user=u_from)

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -22,6 +22,7 @@ from galaxy.model.orm.util import (
     get_object_session,
 )
 from galaxy.model.security import GalaxyRBACAgent
+from galaxy.model.unittest_utils.utils import random_email
 from galaxy.objectstore import QuotaSourceMap
 from galaxy.util.unittest import TestCase
 
@@ -78,7 +79,7 @@ class BaseModelTestCase(TestCase):
 class TestMappings(BaseModelTestCase):
 
     def test_dataset_instance_order(self) -> None:
-        u = model.User(email="mary@example.com", password="password")
+        u = model.User(email=random_email(), password="password")
         h1 = model.History(name="History 1", user=u)
         elements = []
         list_pair = model.DatasetCollection(collection_type="list:paired")
@@ -213,7 +214,7 @@ class TestMappings(BaseModelTestCase):
         assert c4.dataset_elements == [dce1, dce2]
 
     def test_history_audit(self):
-        u = model.User(email="contents@foo.bar.baz", password="password")
+        u = model.User(email=random_email(), password="password")
         h1 = model.History(name="HistoryAuditHistory", user=u)
         h2 = model.History(name="HistoryAuditHistory", user=u)
 
@@ -272,7 +273,7 @@ class TestMappings(BaseModelTestCase):
         # states and flushing in SQL Alchemy is very subtle and it is good to have a executable
         # reference for how it behaves in the context of Galaxy objects.
         model = self.model
-        user = model.User(email="testworkflows@bx.psu.edu", password="password")
+        user = model.User(email=random_email(), password="password")
         galaxy_session = model.GalaxySession()
         galaxy_session_other = model.GalaxySession()
         galaxy_session.user = user
@@ -345,7 +346,7 @@ class TestMappings(BaseModelTestCase):
         assert "id" not in inspect(galaxy_model_object_new).unloaded
 
     def test_workflows(self):
-        user = model.User(email="testworkflows@bx.psu.edu", password="password")
+        user = model.User(email=random_email(), password="password")
 
         child_workflow = _workflow_from_steps(user, [])
         self.persist(child_workflow)

--- a/test/unit/data/test_quota.py
+++ b/test/unit/data/test_quota.py
@@ -1,6 +1,7 @@
 import uuid
 
 from galaxy import model
+from galaxy.model.unittest_utils.utils import random_email
 from galaxy.objectstore import (
     QuotaSourceInfo,
     QuotaSourceMap,
@@ -16,7 +17,7 @@ class TestPurgeUsage(BaseModelTestCase):
     def setUp(self):
         super().setUp()
         model = self.model
-        u = model.User(email="purge_usage@example.com", password="password")
+        u = model.User(email=random_email(), password="password")
         u.disk_usage = 25
         self.persist(u)
 

--- a/test/unit/workflows/test_run_parameters.py
+++ b/test/unit/workflows/test_run_parameters.py
@@ -1,5 +1,6 @@
 from galaxy import model
 from galaxy.model.base import transaction
+from galaxy.model.unittest_utils.utils import random_email
 from galaxy.workflow.run_request import (
     _normalize_inputs,
     _normalize_step_parameters,
@@ -89,7 +90,7 @@ def __new_input():
 
 
 def __workflow_fixure(trans):
-    user = model.User(email="testworkflow_params@bx.psu.edu", password="pass")
+    user = model.User(email=random_email(), password="pass")
     stored_workflow = model.StoredWorkflow()
     stored_workflow.user = user
     workflow = model.Workflow()


### PR DESCRIPTION
Fixes #18636

REQUIRES #18493

To do prior to merging:

- [x] Fill in bodies of scripts to automatically fix inconsistent data in database for violated not null constraints and unique constraints.
(I think these scripts should be optional, as opposed to triggered automatically from the migration script. Instead, the script will display a helpful error message with the name of the script the admin can run.)
- [x] Rebase on top of @jmchilton's PR(s) that contain db migrations; update migration scripts.

### Harden database schema of user_role_association, user_group_association, group_role_association tables:
1. Add not null constraint for user_id, group_id, role_id fields
(A null value for any of these fields makes the record meaningless + it could only result from a bug, which  now will be detected on first occurrence.)

2. Add unique constraint for combinations of values: user_id/group_id, user_id/role_id, group_id/role_id.
(Helps fix linked issue; duplicate associations are meaningless and may cause bugs.)

### Rewrite the backend handling of setting user-role, user-group, and group-role associations.

The bug described in the issue is largely due to the inefficient handling of these associations (see discussion in issue). Here's a step-by-step pseudo-code description of what the code did when assigning users to a group (the example from the linked issue):

```
- for each selected user:
  - retrieve user from database
- for each selected role:
  - retrieve role from database
- retrieve current group role associations for group
- retrieve current user group associations for group
- for each retrieved group/role and user/group association:
  - delete association  (implicitly starts new transaction)
  - commit transaction
- for each role in retrieved roles:
  - create new group role association and add to session
  - (implicitly start new transaction)
  - commit transaction
- for each user in retrieved users:
  - create new user group association and add to session  (implicitly starts new transaction)
  - commit transaction
  ```
The above has ***linear complexity***. If we apply the numbers from the example in the issue (add 1000 users to a group) + use some modest assumptions (there are currently 10 group role associations and 100 user group associations for this group), we end up with *approximately* the following database accesses:
```
- 1000 select user statement executions
- 10 select role statement executions
- 1 select group-role-association statement execution
- 1 select user-group-association statement execution
- 10 transactions: delete group-role-association
- 100 transactions: delete user-group-association
- 10 transactions: insert group-role-association
- 1000 transactions: insert user-group-association
```
**TOTAL: 1110 transactions (inserts and deletes) including 1022 selects (as part of first transaction)**

In the new version we bypass the ORM and use SQLAlchemy Core instead. This results in ***constant complexity***. Running the same update operation looks like this:
```
- 1 flush if group is a new record and needs an id
- 1 delete group-role-associations by group
- 1 delete user-group-associations by group
- 1 insert group-role-associations w/multiple values
- 1 insert user-group-association w/multiple values
- 1 commit
```
**TOTAL: 1 transaction with 2 delete and 2 insert statements.** (setting user roles is an exception since we do select each role from the database to verify it's not a private role; there's still only 1 transaction though).

Unlike the previous version, the new version wraps everything in one transaction, so there can be no errors from interrupted partial updates (e.g. old associations deleted, new associations not added).

User private roles are handled with care: they can be neither assigned, nor deleted (see unit tests). 

Old unused code, as well as redundant logic has been removed (refreshing the session, flushing conditionally, checking if a transaction is started, etc.). I've also tried to simplify the logic (nested loops where the outer loop was guaranteed to have only 1 element removed, etc.)

### Database unit tests:
For each association class, we test the following:
- add associations to new and to existing item
- update item associations (add some, drop some)
- drop all item associations
- verify error when adding an invalid id for an associated item
- verify error when adding a duplicate association

In addition:
- test setting default user permissions and default history permissions when updating role users
- verify private roles cannot be assigned
- verify user associations with private roles are not affected by updating user roles
- verify user associations with private roles are not affected by updating role users

### For follow-up PRs:
- [ ] Add same constraints + apply same refactoring to similar models (DatasetPermission, UserQuotaAssociation, etc.)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Login as admin, use the admin UI to add/drop user/role/group associations via the "edit permissions" link.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
