### PR TITLE
add h5ad assert test

### DIFF
--- a/lib/galaxy/tool_util/verify/asserts/hdf5.py
+++ b/lib/galaxy/tool_util/verify/asserts/hdf5.py
@@ -21,7 +21,7 @@ def assert_has_h5_attribute(output_bytes: bytes, key: str, value: str) -> None:
     local_attrs = h5py.File(output_temp, "r").attrs
     assert (
         key in local_attrs and str(local_attrs[key]) == value
-    ), f"Not a HDF5 file or H5 attributes do not match:\n\t{[(key, str(value)) for key, value in local_attrs.items()]}\n\n\t({key} : {value})"
+    ), f"Not a HDF5 file or H5 attributes do not match:\n\t{list(local_attrs.items())}\n\n\t({key} : {value})"
 
 
 # TODO the function actually queries groups. so the function and argument name are misleading
@@ -42,3 +42,24 @@ def assert_has_h5_keys(output_bytes: bytes, keys: str) -> None:
         if key not in local_keys:
             missing += 1
     assert missing == 0, f"Not a HDF5 file or H5 keys missing:\n\t{local_keys}\n\t{h5_keys}"
+
+def assert_has_h5ad_group_entry(output_bytes: bytes, group: str, entry: str) -> None:
+    """Asserts the specified HDF5 group has a given entry-value pair."""
+    _assert_h5py()
+    h5_entries = sorted([e.strip() for e in entry.strip().split(",")])
+    output_temp = io.BytesIO(output_bytes)
+    
+    with h5py.File(output_temp, "r") as h5file:
+        if group not in list(h5file.keys()):
+            raise KeyError(f"group '{group}' not found in HDF5 file.")
+        
+        group = list(h5file[group].keys())
+        
+    missing=0
+    for entry in h5_entries:
+        if entry not in group:
+            missing+=1
+    
+    assert (
+        missing == 0
+    ), f"Expected entries '{h5_entries}' for group '{group}' in h5ad file does not match.\n\n\Found: {h5_entries}"

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2292,6 +2292,7 @@ module.
     <xs:choice>
       <xs:element name="has_h5_keys" type="AssertHasH5Keys"/>
       <xs:element name="has_h5_attribute" type="AssertHasH5Attribute"/>
+      <xs:element name="has_h5ad_group_entry" type="AssertHasH5ADGroupEntry"/>
     </xs:choice>
   </xs:group>
   <xs:complexType name="AssertHasSize">
@@ -3121,6 +3122,30 @@ $attribute_list::5
     <xs:attribute name="value" type="xs:string">
       <xs:annotation>
         <xs:documentation xml:lang="en">Expected value of HDF5 attribute to check.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="AssertHasH5ADGroupEntry">
+    <xs:annotation>
+      <xs:documentation xml:lang="en"><![CDATA[
+Asserts HFAD output contains the specified ``entry`` for a group (``group``), e.g.
+
+```xml
+<has_h5ad_group_entry group="obs" entry="index" />
+```
+
+$attribute_list::5
+]]>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="group" type="xs:string">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">HDF5 attribute group to check entry of.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="entry" type="xs:string">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Expected entry of HDF5 attribute group to check.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>

--- a/test/unit/tool_util/verify/test_asserts.py
+++ b/test/unit/tool_util/verify/test_asserts.py
@@ -1294,6 +1294,16 @@ if h5py is not None:
             <has_h5_attribute key="myfileattrint" value="also_wrong" />
         </assert_contents>
     """
+    H5AD_HAS_GROUP_ENTRY = """
+        <assert_contents>
+            <has_h5ad_group_entry group="myfilegroup" entry="myfileentry" />
+        </assert_contents>
+    """
+    H5AD_HAS_GROUP_ENTRY_NEGATIVE = """
+        <assert_contents>
+            <has_h5ad_group_entry group="myfilegroup" entry="wrong" />
+        </assert_contents>
+    """
 
     def test_has_h5_keys():
         """test has_h5_keys"""
@@ -1320,6 +1330,19 @@ if h5py is not None:
         )
         assert len(a) == 1
 
+    def test_has_h5ad_group_entry():
+        """test has_h5ad_group_entry"""
+        a = run_assertions(H5AD_HAS_GROUP_ENTRY, H5BYTES)
+        assert len(a) == 0
+
+    def test_has_h5ad_group_entry_failure():
+        """test has_h5ad_group_entry .. negative"""
+        a = run_assertions(H5AD_HAS_GROUP_ENTRY_NEGATIVE, H5BYTES)
+        assert (
+            "Not a HDF5 file or H5 entries do not match:\n\t[('myfilegroup', 'myfileentry')]\n\n\t(myfilegroup : wrong)"
+            in a
+        )
+        assert len(a) == 1
 
 def run_assertions(assertion_xml: str, data, decompress=False) -> Tuple:
     assertion = parse_xml_string(assertion_xml)


### PR DESCRIPTION
Current h5 assertions (`has_h5_keys` and `has_h5_attribute`) are not enough for an h5ad object. Because the tool developer needs to check the content of each group (like if "cell_type" is in "obs") not the main attribute (which is "{'encoding-type': 'anndata', 'encoding-version': '0.1.0'}" for all h5ad files), for more info please see the [anndata documentation.](https://anndata.readthedocs.io/en/latest/fileformat-prose.html#) 

I had this problem when I wanted to assert those when [updating scanpy](https://github.com/galaxyproject/tools-iuc/pull/6162). 

I also wrote an [issue](https://github.com/galaxyproject/galaxy/issues/18767).

I wrote a new assert for this and tested that locally and it worked (I added the test to my local planemo ".../planemo/lib64/python3.12/site-packages/galaxy/tool_util/verify/asserts/hdf5.py"

I hope I put it correctly here :)

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
