### PR TITLE
Allow using tracks and groups in visualization xml

### DIFF
--- a/client/src/components/Markdown/MarkdownVisualization.test.js
+++ b/client/src/components/Markdown/MarkdownVisualization.test.js
@@ -9,7 +9,7 @@ describe("Markdown/MarkdownVisualization", () => {
                 argumentName: "name",
                 argumentPayload: {
                     settings: [{}, {}],
-                    groups: [{}],
+                    tracks: [{}],
                 },
                 history: "history_id",
                 labels: [],

--- a/client/src/components/Markdown/MarkdownVisualization.vue
+++ b/client/src/components/Markdown/MarkdownVisualization.vue
@@ -73,14 +73,14 @@ export default {
             if (this.argumentPayload.settings && this.argumentPayload.settings.length > 0) {
                 settings = this.argumentPayload.settings.slice();
             }
-            if (this.argumentPayload.groups && this.argumentPayload.groups.length > 0) {
+            if (this.argumentPayload.tracks && this.argumentPayload.tracks.length > 0) {
                 settings = settings || [];
                 settings.push({
                     type: "repeat",
                     title: "Columns",
-                    name: "groups",
+                    name: "tracks",
                     min: 1,
-                    inputs: this.argumentPayload.groups.map((x) => {
+                    inputs: this.argumentPayload.tracks.map((x) => {
                         if (x.type == "data_column") {
                             x.is_workflow = true;
                         }

--- a/client/src/mvc/visualization/chart/components/model.js
+++ b/client/src/mvc/visualization/chart/components/model.js
@@ -2,7 +2,7 @@ import Backbone from "backbone";
 import { Visualization } from "mvc/visualization/visualization-model";
 import Utils from "utils/utils";
 
-const MATCH_GROUP = /^groups_([0-9]+)\|([\w]+)/;
+const MATCH_GROUP = /^(groups|tracks)_([0-9]+)\|([\w]+)/;
 
 export default Backbone.Model.extend({
     defaults: {

--- a/client/src/mvc/visualization/chart/views/editor.js
+++ b/client/src/mvc/visualization/chart/views/editor.js
@@ -36,7 +36,7 @@ export default Backbone.View.extend({
                 )
                 .append(new Settings(this.app).$el),
         });
-        if (this.chart.plugin.groups) {
+        if (this.chart.plugin.tracks) {
             this.tabs.add({
                 id: "groups",
                 icon: "fa-database",

--- a/client/src/mvc/visualization/chart/views/groups.js
+++ b/client/src/mvc/visualization/chart/views/groups.js
@@ -25,7 +25,7 @@ var GroupView = Backbone.View.extend({
     },
     render: function () {
         var self = this;
-        var inputs = Utils.clone(this.chart.plugin.groups) || [];
+        var inputs = Utils.clone(this.chart.plugin.tracks) || [];
         var dataset_id = this.chart.get("dataset_id");
         if (dataset_id) {
             this.chart.state("wait", "Loading metadata...");
@@ -127,7 +127,7 @@ export default Backbone.View.extend({
         });
     },
     render: function () {
-        if (_.size(this.chart.plugin.groups) > 0) {
+        if (_.size(this.chart.plugin.tracks) > 0) {
             this.repeat.$el.show();
         } else {
             this.repeat.$el.hide();

--- a/lib/galaxy/visualization/plugins/config_parser.py
+++ b/lib/galaxy/visualization/plugins/config_parser.py
@@ -151,9 +151,9 @@ class VisualizationsConfigParser:
         if (specs_section := xml_tree.find("specs")) is not None:
             returned["specs"] = DictParser(specs_section)
 
-        # load group specifiers
-        if (groups_section := xml_tree.find("groups")) is not None:
-            returned["groups"] = ListParser(groups_section)
+        # load tracks specifiers (allow 'groups' section for backward compatibility)
+        if (tracks_section := xml_tree.find("tracks") or xml_tree.find("groups")) is not None:
+            returned["tracks"] = ListParser(tracks_section)
 
         # load settings specifiers
         if (settings_section := xml_tree.find("settings")) is not None:

--- a/lib/galaxy/visualization/plugins/plugin.py
+++ b/lib/galaxy/visualization/plugins/plugin.py
@@ -125,8 +125,8 @@ class VisualizationPlugin(ServesTemplatesPluginMixin):
             "embeddable": self.config.get("embeddable"),
             "entry_point": self.config.get("entry_point"),
             "settings": self.config.get("settings"),
-            "groups": self.config.get("groups"),
             "specs": self.config.get("specs"),
+            "tracks": self.config.get("tracks"),
             "href": self._get_url(),
         }
 


### PR DESCRIPTION
While allowing for backward compatibility regarding the `groups` section use by nvd3/jqplot visualizations, this PR switches the default section name in visualization xmls to `tracks` for more clarity. This is a follow-up for #18651.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
