### PR TITLE
Implement regex validators for text workflow parameter

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -11556,6 +11556,21 @@ export interface components {
              */
             workflow_step_id: number;
         };
+        /** InvocationFailureWorkflowParameterInvalidResponse */
+        InvocationFailureWorkflowParameterInvalidResponse: {
+            /**
+             * Details
+             * @description Message raised by validator
+             */
+            details: string;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            reason: "workflow_parameter_invalid";
+            /** Workflow parameter step that failed validation */
+            workflow_step_id: number;
+        };
         /** InvocationInput */
         InvocationInput: {
             /**
@@ -11637,7 +11652,8 @@ export interface components {
             | components["schemas"]["InvocationFailureExpressionEvaluationFailedResponse"]
             | components["schemas"]["InvocationFailureWhenNotBooleanResponse"]
             | components["schemas"]["InvocationUnexpectedFailureResponse"]
-            | components["schemas"]["InvocationEvaluationWarningWorkflowOutputNotFoundResponse"];
+            | components["schemas"]["InvocationEvaluationWarningWorkflowOutputNotFoundResponse"]
+            | components["schemas"]["InvocationFailureWorkflowParameterInvalidResponse"];
         /** InvocationOutput */
         InvocationOutput: {
             /**

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -195,7 +195,7 @@ defineExpose({
                         Workflow submission failed: {{ submissionError }}
                     </BAlert>
                     <WorkflowRunFormSimple
-                        v-else-if="fromVariant === 'simple'"
+                        v-if="fromVariant === 'simple'"
                         :model="workflowModel"
                         :target-history="simpleFormTargetHistory"
                         :use-job-cache="simpleFormUseJobCache"

--- a/client/src/components/WorkflowInvocationState/InvocationMessage.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationMessage.vue
@@ -20,6 +20,7 @@ type ReasonToLevel = {
     when_not_boolean: "error";
     unexpected_failure: "error";
     workflow_output_not_found: "warning";
+    workflow_parameter_invalid: "error";
 };
 
 const level: ReasonToLevel = {
@@ -34,6 +35,7 @@ const level: ReasonToLevel = {
     when_not_boolean: "error",
     unexpected_failure: "error",
     workflow_output_not_found: "warning",
+    workflow_parameter_invalid: "error",
 };
 
 const levelClasses = {
@@ -165,6 +167,10 @@ const infoString = computed(() => {
         return `Defined workflow output '${invocationMessage.output_name}' was not found in step ${
             invocationMessage.workflow_step_id + 1
         }.`;
+    } else if (reason === "workflow_parameter_invalid") {
+        return `Workflow parameter on step ${invocationMessage.workflow_step_id + 1} failed validation: ${
+            invocationMessage.details
+        }`;
     } else {
         return reason;
     }

--- a/lib/galaxy/schema/invocation.py
+++ b/lib/galaxy/schema/invocation.py
@@ -77,6 +77,7 @@ class FailureReason(str, Enum):
     expression_evaluation_failed = "expression_evaluation_failed"
     when_not_boolean = "when_not_boolean"
     unexpected_failure = "unexpected_failure"
+    workflow_parameter_invalid = "workflow_parameter_invalid"
 
 
 # The reasons below are attached to the invocation and user-actionable.
@@ -212,6 +213,14 @@ class GenericInvocationEvaluationWarningWorkflowOutputNotFound(
     )
 
 
+class GenericInvocationFailureWorkflowParameterInvalid(InvocationFailureMessageBase[DatabaseIdT], Generic[DatabaseIdT]):
+    reason: Literal[FailureReason.workflow_parameter_invalid]
+    workflow_step_id: int = Field(
+        ..., title="Workflow parameter step that failed validation", validation_alias="workflow_step_index"
+    )
+    details: str = Field(..., description="Message raised by validator")
+
+
 InvocationCancellationReviewFailed = GenericInvocationCancellationReviewFailed[int]
 InvocationCancellationHistoryDeleted = GenericInvocationCancellationHistoryDeleted[int]
 InvocationCancellationUserRequest = GenericInvocationCancellationUserRequest[int]
@@ -223,6 +232,7 @@ InvocationFailureExpressionEvaluationFailed = GenericInvocationFailureExpression
 InvocationFailureWhenNotBoolean = GenericInvocationFailureWhenNotBoolean[int]
 InvocationUnexpectedFailure = GenericInvocationUnexpectedFailure[int]
 InvocationWarningWorkflowOutputNotFound = GenericInvocationEvaluationWarningWorkflowOutputNotFound[int]
+InvocationFailureWorkflowParameterInvalid = GenericInvocationFailureWorkflowParameterInvalid[int]
 
 InvocationMessageUnion = Union[
     InvocationCancellationReviewFailed,
@@ -236,6 +246,7 @@ InvocationMessageUnion = Union[
     InvocationFailureWhenNotBoolean,
     InvocationUnexpectedFailure,
     InvocationWarningWorkflowOutputNotFound,
+    InvocationFailureWorkflowParameterInvalid,
 ]
 
 InvocationCancellationReviewFailedResponseModel = GenericInvocationCancellationReviewFailed[EncodedDatabaseIdField]
@@ -253,6 +264,9 @@ InvocationUnexpectedFailureResponseModel = GenericInvocationUnexpectedFailure[En
 InvocationWarningWorkflowOutputNotFoundResponseModel = GenericInvocationEvaluationWarningWorkflowOutputNotFound[
     EncodedDatabaseIdField
 ]
+InvocationFailureWorkflowParameterInvalidResponseModel = GenericInvocationFailureWorkflowParameterInvalid[
+    EncodedDatabaseIdField
+]
 
 _InvocationMessageResponseUnion = Annotated[
     Union[
@@ -267,6 +281,7 @@ _InvocationMessageResponseUnion = Annotated[
         InvocationFailureWhenNotBooleanResponseModel,
         InvocationUnexpectedFailureResponseModel,
         InvocationWarningWorkflowOutputNotFoundResponseModel,
+        InvocationFailureWorkflowParameterInvalidResponseModel,
     ],
     Field(discriminator="reason"),
 ]

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -1360,7 +1360,8 @@ class XmlInputSource(InputSource):
         for elem in self.input_elem.findall("validator"):
             elem_dict = {"content": elem.text}
             for attribute, type_cast in attributes.items():
-                if val := elem.get(attribute):
+                val = elem.get(attribute)
+                if val:
                     elem_dict[attribute] = type_cast(val)
             elements.append(elem_dict)
         return elements

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -1337,7 +1337,33 @@ class XmlInputSource(InputSource):
         return self.input_elem.find("sanitizer")
 
     def parse_validator_elems(self):
-        return self.input_elem.findall("validator")
+        elements = []
+        attributes = {
+            "type": str,
+            "message": str,
+            "negate": string_as_bool,
+            "check": str,
+            "table_name": str,
+            "filename": str,
+            "metadata_name": str,
+            "metadata_column": str,
+            "min": float,
+            "max": float,
+            "exclude_min": string_as_bool,
+            "exclude_max": string_as_bool,
+            "split": str,
+            "skip": str,
+            "value": str,
+            "value_json": lambda v: json.loads(v) if v else None,
+            "line_startswith": str,
+        }
+        for elem in self.input_elem.findall("validator"):
+            elem_dict = {"content": elem.text}
+            for attribute, type_cast in attributes.items():
+                if val := elem.get(attribute):
+                    elem_dict[attribute] = type_cast(val)
+            elements.append(elem_dict)
+        return elements
 
     def parse_dynamic_options(self) -> Optional[XmlDynamicOptions]:
         """Return a XmlDynamicOptions to describe dynamic options if options elem is available."""

--- a/lib/galaxy/tool_util/parser/yaml.py
+++ b/lib/galaxy/tool_util/parser/yaml.py
@@ -375,6 +375,21 @@ class YamlInputSource(InputSource):
             sources.append((value, case_page_source))
         return sources
 
+    def parse_validator_elems(self):
+        elements = []
+        if "validators" in self.input_dict:
+            for elem in self.input_dict["validators"]:
+                if "regex_match" in elem:
+                    elements.append(
+                        {
+                            "message": elem.get("regex_doc"),
+                            "content": elem["regex_match"],
+                            "negate": elem.get("negate", False),
+                            "type": "regex",
+                        }
+                    )
+        return elements
+
     def parse_static_options(self) -> List[Tuple[str, str, bool]]:
         static_options = []
         input_dict = self.input_dict

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2679,7 +2679,6 @@ class Tool(UsesDictVisibleKeys):
         Populates the tool model consumed by the client form builder.
         """
         populate_model(
-            self.app,
             request_context=request_context,
             inputs=inputs,
             state_inputs=state_inputs,

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -315,7 +315,7 @@ class ToolParameter(UsesDictVisibleKeys):
             try:
                 validator.validate(value, trans)
             except ValueError as e:
-                raise ValueError(f"Parameter {self.name}: {e}") from None
+                raise ParameterValueError(str(e), self.name, value) from None
 
     def to_dict(self, trans, other_values=None):
         """to_dict tool parameter. This can be overridden by subclasses."""
@@ -1982,7 +1982,7 @@ class BaseDataToolParameter(ToolParameter):
                     try:
                         validator.validate(v, trans)
                     except ValueError as e:
-                        raise ValueError(f"Parameter {self.name}: {e}") from None
+                        raise ParameterValueError(str(e), self.name, v) from None
 
         dataset_count = 0
         if value:

--- a/lib/galaxy/tools/parameters/populate_model.py
+++ b/lib/galaxy/tools/parameters/populate_model.py
@@ -1,0 +1,70 @@
+import logging
+from typing import List
+
+from galaxy.util.expressions import ExpressionContext
+from .basic import ImplicitConversionRequired
+
+log = logging.getLogger(__name__)
+
+
+def populate_model(app, request_context, inputs, state_inputs, group_inputs, other_values=None):
+    """
+    Populates the tool model consumed by the client form builder.
+    """
+    other_values = ExpressionContext(state_inputs, other_values)
+    for input_index, input in enumerate(inputs.values()):
+        tool_dict = None
+        group_state = state_inputs.get(input.name, {})
+        if input.type == "repeat":
+            tool_dict = input.to_dict(request_context)
+            group_size = len(group_state)
+            tool_dict["cache"] = [None] * group_size
+            group_cache: List[List[str]] = tool_dict["cache"]
+            for i in range(group_size):
+                group_cache[i] = []
+                populate_model(request_context, input.inputs, group_state[i], group_cache[i], other_values)
+        elif input.type == "conditional":
+            tool_dict = input.to_dict(request_context)
+            if "test_param" in tool_dict:
+                test_param = tool_dict["test_param"]
+                test_param["value"] = input.test_param.value_to_basic(
+                    group_state.get(
+                        test_param["name"], input.test_param.get_initial_value(request_context, other_values)
+                    ),
+                    app,
+                )
+                test_param["text_value"] = input.test_param.value_to_display_text(test_param["value"])
+                for i in range(len(tool_dict["cases"])):
+                    current_state = {}
+                    if i == group_state.get("__current_case__"):
+                        current_state = group_state
+                    populate_model(
+                        request_context,
+                        input.cases[i].inputs,
+                        current_state,
+                        tool_dict["cases"][i]["inputs"],
+                        other_values,
+                    )
+        elif input.type == "section":
+            tool_dict = input.to_dict(request_context)
+            populate_model(request_context, input.inputs, group_state, tool_dict["inputs"], other_values)
+        else:
+            try:
+                initial_value = input.get_initial_value(request_context, other_values)
+                tool_dict = input.to_dict(request_context, other_values=other_values)
+                tool_dict["value"] = input.value_to_basic(
+                    state_inputs.get(input.name, initial_value), app, use_security=True
+                )
+                tool_dict["default_value"] = input.value_to_basic(initial_value, app, use_security=True)
+                tool_dict["text_value"] = input.value_to_display_text(tool_dict["value"])
+            except ImplicitConversionRequired:
+                tool_dict = input.to_dict(request_context)
+                # This hack leads client to display a text field
+                tool_dict["textable"] = True
+            except Exception:
+                tool_dict = input.to_dict(request_context)
+                log.exception("tools::to_json() - Skipping parameter expansion '%s'", input.name)
+        if input_index >= len(group_inputs):
+            group_inputs.append(tool_dict)
+        else:
+            group_inputs[input_index] = tool_dict

--- a/lib/galaxy/tools/parameters/populate_model.py
+++ b/lib/galaxy/tools/parameters/populate_model.py
@@ -23,7 +23,7 @@ def populate_model(request_context, inputs, state_inputs, group_inputs: List[Dic
             tool_dict = input.to_dict(request_context)
             group_size = len(group_state)
             tool_dict["cache"] = [None] * group_size
-            group_cache: List[List[str]] = tool_dict["cache"]
+            group_cache: List[List[Dict[str, Any]]] = tool_dict["cache"]
             for i in range(group_size):
                 group_cache[i] = []
                 populate_model(request_context, input.inputs, group_state[i], group_cache[i], other_values)

--- a/lib/galaxy/tools/parameters/populate_model.py
+++ b/lib/galaxy/tools/parameters/populate_model.py
@@ -7,7 +7,7 @@ from .basic import ImplicitConversionRequired
 log = logging.getLogger(__name__)
 
 
-def populate_model(app, request_context, inputs, state_inputs, group_inputs, other_values=None):
+def populate_model(request_context, inputs, state_inputs, group_inputs, other_values=None):
     """
     Populates the tool model consumed by the client form builder.
     """
@@ -31,7 +31,7 @@ def populate_model(app, request_context, inputs, state_inputs, group_inputs, oth
                     group_state.get(
                         test_param["name"], input.test_param.get_initial_value(request_context, other_values)
                     ),
-                    app,
+                    request_context.app,
                 )
                 test_param["text_value"] = input.test_param.value_to_display_text(test_param["value"])
                 for i in range(len(tool_dict["cases"])):
@@ -53,9 +53,9 @@ def populate_model(app, request_context, inputs, state_inputs, group_inputs, oth
                 initial_value = input.get_initial_value(request_context, other_values)
                 tool_dict = input.to_dict(request_context, other_values=other_values)
                 tool_dict["value"] = input.value_to_basic(
-                    state_inputs.get(input.name, initial_value), app, use_security=True
+                    state_inputs.get(input.name, initial_value), request_context.app, use_security=True
                 )
-                tool_dict["default_value"] = input.value_to_basic(initial_value, app, use_security=True)
+                tool_dict["default_value"] = input.value_to_basic(initial_value, request_context.app, use_security=True)
                 tool_dict["text_value"] = input.value_to_display_text(tool_dict["value"])
             except ImplicitConversionRequired:
                 tool_dict = input.to_dict(request_context)

--- a/lib/galaxy/tools/parameters/populate_model.py
+++ b/lib/galaxy/tools/parameters/populate_model.py
@@ -1,5 +1,9 @@
 import logging
-from typing import List
+from typing import (
+    Any,
+    Dict,
+    List,
+)
 
 from galaxy.util.expressions import ExpressionContext
 from .basic import ImplicitConversionRequired
@@ -7,7 +11,7 @@ from .basic import ImplicitConversionRequired
 log = logging.getLogger(__name__)
 
 
-def populate_model(request_context, inputs, state_inputs, group_inputs, other_values=None):
+def populate_model(request_context, inputs, state_inputs, group_inputs: List[Dict[str, Any]], other_values=None):
     """
     Populates the tool model consumed by the client form builder.
     """

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1286,14 +1286,20 @@ class InputParameterModule(WorkflowModule):
                 add_validators_repeat.inputs = {
                     "regex_match": TextToolParameter(
                         None,
-                        {"optional": False, "name": "regex_match", "label": "Specify a regex that must match input"},
+                        {
+                            "optional": False,
+                            "name": "regex_match",
+                            "label": "Specify regex",
+                            "help": "Provided regex must match input value for input to be valid",
+                        },
                     ),
                     "regex_doc": TextToolParameter(
                         None,
                         {
                             "optional": False,
                             "name": "regex_doc",
-                            "label": "Specify a message that should be shown as a hint",
+                            "label": "Specify a message",
+                            "help": "This message will be shown if the regex does not match the input",
                         },
                     ),
                 }

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1256,12 +1256,15 @@ class InputParameterModule(WorkflowModule):
 
             when_true = ConditionalWhen()
             when_true.value = "true"
-            when_true.inputs = {}
-            when_true.inputs["default"] = specify_default_cond
+            when_true.inputs = {"default": specify_default_cond}
 
             when_false = ConditionalWhen()
             when_false.value = "false"
-            when_false.inputs = {}
+            # This is only present for backwards compatibility,
+            # We don't need this conditional since you can set
+            # a default value for optional and required parameters.
+            # TODO: version the state and upgrade it to a simpler version
+            when_false.inputs = {"default": specify_default_cond}
 
             optional_cases = [when_true, when_false]
             optional_cond.cases = optional_cases
@@ -1585,7 +1588,6 @@ class InputParameterModule(WorkflowModule):
         if "default" in state:
             default_set = True
             default_value = state["default"]
-            state["optional"] = True
         multiple = state.get("multiple")
         validators = state.get("validators")
         restrictions = state.get("restrictions")

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -16,8 +16,8 @@ from typing import (
     List,
     Literal,
     Optional,
-    Type,
     Tuple,
+    Type,
     TYPE_CHECKING,
     Union,
 )

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -89,6 +89,7 @@ from galaxy.tools.parameters.grouping import (
     Repeat,
 )
 from galaxy.tools.parameters.history_query import HistoryQuery
+from galaxy.tools.parameters.populate_model import populate_model
 from galaxy.tools.parameters.workflow_utils import (
     ConnectedValue,
     is_runtime_value,
@@ -1396,6 +1397,12 @@ class InputParameterModule(WorkflowModule):
 
         parameter_type_cond.cases = cases
         return {"parameter_definition": parameter_type_cond}
+
+    def get_config_form(self, step=None):
+        """Serializes input parameters of a module into input dictionaries."""
+        group_inputs = []
+        populate_model(self.trans, self.get_inputs(), self.state.inputs, group_inputs)
+        return {"title": self.name, "inputs": group_inputs}
 
     def restrict_options(self, step, connections: Iterable[WorkflowStepConnection], default_value):
         try:

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1280,9 +1280,8 @@ class InputParameterModule(WorkflowModule):
 
                 specify_multiple = BooleanToolParameter(None, specify_multiple_source)
 
-                add_validators_repeat = Repeat()
+                add_validators_repeat = Repeat("validators")
                 add_validators_repeat._title = "Add validator to restrict valid input"
-                add_validators_repeat.name = "validators"
                 add_validators_repeat.min = 0
                 add_validators_repeat.max = math.inf
                 add_validators_repeat.inputs = {
@@ -1569,7 +1568,6 @@ class InputParameterModule(WorkflowModule):
             input_value = default_value.get("value", NO_REPLACEMENT)
         input_param = self.get_runtime_inputs(self)["input"]
         # TODO: raise DelayedWorkflowEvaluation if replacement not ready ? Need test
-        # TODO: move (at least regex) to frontend. failing here is kind of stupid
         try:
             input_param.validate(input_value)
         except ValueError as e:

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -570,7 +570,7 @@ class WorkflowProgress:
             step_id = step.id
             if step_id not in self.inputs_by_step_id and "output" not in outputs:
                 default_value = step.input_default_value
-                if default_value or step.input_optional:
+                if step.default_value_set:
                     outputs["output"] = default_value
                 else:
                     log.error(f"{step.log_str()} not found in inputs_step_id {self.inputs_by_step_id}")

--- a/lib/galaxy/workflow/workflow_parameter_input_definitions.py
+++ b/lib/galaxy/workflow/workflow_parameter_input_definitions.py
@@ -1,0 +1,76 @@
+from typing import (
+    Any,
+    Dict,
+    Literal,
+    Union,
+)
+
+from galaxy.tools.parameters.basic import (
+    BooleanToolParameter,
+    ColorToolParameter,
+    FloatToolParameter,
+    IntegerToolParameter,
+    TextToolParameter,
+)
+
+param_types = Literal["text", "integer", "float", "color", "boolean"]
+default_source_type = Dict[str, Union[int, float, bool, str]]
+tool_param_type = Union[
+    TextToolParameter,
+    IntegerToolParameter,
+    FloatToolParameter,
+    BooleanToolParameter,
+    ColorToolParameter,
+]
+
+
+def get_default_source(param_type: param_types, parameter_def: Dict[str, Any]) -> tool_param_type:
+    """
+    param_type is the type of parameter we want to build up, stored_parameter_type is the parameter_type
+    as stored in the tool state
+    """
+    stored_parameter_type = parameter_def["parameter_type"]
+    default_source: default_source_type = dict(name="default", label="Default Value", type=param_type)
+    if param_type == "text":
+        if stored_parameter_type == "text":
+            text_default = parameter_def.get("default") or ""
+        else:
+            text_default = ""
+        default_source["value"] = text_default
+        input_default_value: Union[
+            TextToolParameter,
+            IntegerToolParameter,
+            FloatToolParameter,
+            BooleanToolParameter,
+            ColorToolParameter,
+        ] = TextToolParameter(None, default_source)
+    elif param_type == "integer":
+        if stored_parameter_type == "integer":
+            integer_default = parameter_def.get("default") or 0
+        else:
+            integer_default = 0
+        default_source["value"] = integer_default
+        input_default_value = IntegerToolParameter(None, default_source)
+    elif param_type == "float":
+        if stored_parameter_type == "float":
+            float_default = parameter_def.get("default") or 0.0
+        else:
+            float_default = 0.0
+        default_source["value"] = float_default
+        input_default_value = FloatToolParameter(None, default_source)
+    elif param_type == "boolean":
+        if stored_parameter_type == "boolean":
+            boolean_default = parameter_def.get("default") or False
+        else:
+            boolean_default = False
+        default_source["value"] = boolean_default
+        default_source["checked"] = boolean_default
+        input_default_value = BooleanToolParameter(None, default_source)
+    elif param_type == "color":
+        if stored_parameter_type == "color":
+            color_default = parameter_def.get("default") or "#000000"
+        else:
+            color_default = "#000000"
+        default_source["value"] = color_default
+        input_default_value = ColorToolParameter(None, default_source)
+    return input_default_value

--- a/lib/galaxy/workflow/workflow_parameter_input_definitions.py
+++ b/lib/galaxy/workflow/workflow_parameter_input_definitions.py
@@ -1,5 +1,4 @@
 from typing import (
-    Any,
     Dict,
     Literal,
     Union,
@@ -24,19 +23,13 @@ tool_param_type = Union[
 ]
 
 
-def get_default_source(param_type: param_types, parameter_def: Dict[str, Any]) -> tool_param_type:
+def get_default_parameter(param_type: param_types) -> tool_param_type:
     """
     param_type is the type of parameter we want to build up, stored_parameter_type is the parameter_type
     as stored in the tool state
     """
-    stored_parameter_type = parameter_def["parameter_type"]
-    default_source: default_source_type = dict(name="default", label="Default Value", type=param_type)
+    default_source: default_source_type = dict(name="default", label="Default Value", type=param_type, optional=False)
     if param_type == "text":
-        if stored_parameter_type == "text":
-            text_default = parameter_def.get("default") or ""
-        else:
-            text_default = ""
-        default_source["value"] = text_default
         input_default_value: Union[
             TextToolParameter,
             IntegerToolParameter,
@@ -45,32 +38,11 @@ def get_default_source(param_type: param_types, parameter_def: Dict[str, Any]) -
             ColorToolParameter,
         ] = TextToolParameter(None, default_source)
     elif param_type == "integer":
-        if stored_parameter_type == "integer":
-            integer_default = parameter_def.get("default") or 0
-        else:
-            integer_default = 0
-        default_source["value"] = integer_default
         input_default_value = IntegerToolParameter(None, default_source)
     elif param_type == "float":
-        if stored_parameter_type == "float":
-            float_default = parameter_def.get("default") or 0.0
-        else:
-            float_default = 0.0
-        default_source["value"] = float_default
         input_default_value = FloatToolParameter(None, default_source)
     elif param_type == "boolean":
-        if stored_parameter_type == "boolean":
-            boolean_default = parameter_def.get("default") or False
-        else:
-            boolean_default = False
-        default_source["value"] = boolean_default
-        default_source["checked"] = boolean_default
         input_default_value = BooleanToolParameter(None, default_source)
     elif param_type == "color":
-        if stored_parameter_type == "color":
-            color_default = parameter_def.get("default") or "#000000"
-        else:
-            color_default = "#000000"
-        default_source["value"] = color_default
         input_default_value = ColorToolParameter(None, default_source)
     return input_default_value

--- a/lib/galaxy_test/base/workflow_fixtures.py
+++ b/lib/galaxy_test/base/workflow_fixtures.py
@@ -617,6 +617,7 @@ inputs:
   int_input:
     type: integer
     default: 3
+    optional: true
 steps:
   random:
     tool_id: random_lines1

--- a/test/unit/app/tools/test_parameter_validation.py
+++ b/test/unit/app/tools/test_parameter_validation.py
@@ -107,7 +107,7 @@ class TestParameterValidation(BaseParameterTestCase):
 </param>"""
         )
         p.validate("foo")
-        with self.assertRaisesRegex(ValueError, "Parameter blah: Field requires a value"):
+        with self.assertRaisesRegex(ValueError, "Parameter 'blah': Field requires a value"):
             p.validate("")
 
         p = self._parameter_for(
@@ -116,7 +116,7 @@ class TestParameterValidation(BaseParameterTestCase):
     <validator type="empty_field" negate="true"/>
 </param>"""
         )
-        with self.assertRaisesRegex(ValueError, "Parameter blah: Field must not set a value"):
+        with self.assertRaisesRegex(ValueError, "Parameter 'blah': Field must not set a value"):
             p.validate("foo")
         p.validate("")
 
@@ -130,14 +130,14 @@ class TestParameterValidation(BaseParameterTestCase):
         p.validate("Foo")
         p.validate("foo")
         with self.assertRaisesRegex(
-            ValueError, r"Parameter blah: Value 'Fop' does not match regular expression '\[Ff\]oo'"
+            ValueError, r"Parameter 'blah': Value 'Fop' does not match regular expression '\[Ff\]oo'"
         ):
             p.validate("Fop")
 
         # test also valitation of lists (for select parameters)
         p.validate(["Foo", "foo"])
         with self.assertRaisesRegex(
-            ValueError, r"Parameter blah: Value 'Fop' does not match regular expression '\[Ff\]oo'"
+            ValueError, r"Parameter 'blah': Value 'Fop' does not match regular expression '\[Ff\]oo'"
         ):
             p.validate(["Foo", "Fop"])
 
@@ -148,16 +148,16 @@ class TestParameterValidation(BaseParameterTestCase):
 </param>"""
         )
         with self.assertRaisesRegex(
-            ValueError, r"Parameter blah: Value 'Foo' does match regular expression '\[Ff\]oo'"
+            ValueError, r"Parameter 'blah': Value 'Foo' does match regular expression '\[Ff\]oo'"
         ):
             p.validate("Foo")
         with self.assertRaisesRegex(
-            ValueError, r"Parameter blah: Value 'foo' does match regular expression '\[Ff\]oo'"
+            ValueError, r"Parameter 'blah': Value 'foo' does match regular expression '\[Ff\]oo'"
         ):
             p.validate("foo")
         p.validate("Fop")
         with self.assertRaisesRegex(
-            ValueError, r"Parameter blah: Value 'foo' does match regular expression '\[Ff\]oo'"
+            ValueError, r"Parameter 'blah': Value 'foo' does match regular expression '\[Ff\]oo'"
         ):
             p.validate(["Fop", "foo"])
         p.validate(["Fop", "fop"])
@@ -171,9 +171,9 @@ class TestParameterValidation(BaseParameterTestCase):
         )
         p.validate("foo")
         p.validate("bar")
-        with self.assertRaisesRegex(ValueError, "Parameter blah: Must have length of at least 2 and at most 8"):
+        with self.assertRaisesRegex(ValueError, "Parameter 'blah': Must have length of at least 2 and at most 8"):
             p.validate("f")
-        with self.assertRaisesRegex(ValueError, "Parameter blah: Must have length of at least 2 and at most 8"):
+        with self.assertRaisesRegex(ValueError, "Parameter 'blah': Must have length of at least 2 and at most 8"):
             p.validate("foobarbaz")
 
         p = self._parameter_for(
@@ -182,9 +182,9 @@ class TestParameterValidation(BaseParameterTestCase):
     <validator type="length" min="2" max="8" negate="true"/>
 </param>"""
         )
-        with self.assertRaisesRegex(ValueError, "Parameter blah: Must not have length of at least 2 and at most 8"):
+        with self.assertRaisesRegex(ValueError, "Parameter 'blah': Must not have length of at least 2 and at most 8"):
             p.validate("foo")
-        with self.assertRaisesRegex(ValueError, "Parameter blah: Must not have length of at least 2 and at most 8"):
+        with self.assertRaisesRegex(ValueError, "Parameter 'blah': Must not have length of at least 2 and at most 8"):
             p.validate("bar")
         p.validate("f")
         p.validate("foobarbaz")
@@ -204,11 +204,11 @@ class TestParameterValidation(BaseParameterTestCase):
     <validator type="in_range" message="Doh!! %s not in range" min="10" exclude_min="true" max="20"/>
 </param>"""
         )
-        with self.assertRaisesRegex(ValueError, "Parameter blah: Doh!! 10 not in range"):
+        with self.assertRaisesRegex(ValueError, "Parameter 'blah': Doh!! 10 not in range"):
             p.validate(10)
         p.validate(15)
         p.validate(20)
-        with self.assertRaisesRegex(ValueError, "Parameter blah: Doh!! 21 not in range"):
+        with self.assertRaisesRegex(ValueError, "Parameter 'blah': Doh!! 21 not in range"):
             p.validate(21)
 
         p = self._parameter_for(
@@ -220,12 +220,12 @@ class TestParameterValidation(BaseParameterTestCase):
         p.validate(10)
         with self.assertRaisesRegex(
             ValueError,
-            r"Parameter blah: Value \('15'\) must not fulfill float\('10'\) < float\(value\) <= float\('20'\)",
+            r"Parameter 'blah': Value \('15'\) must not fulfill float\('10'\) < float\(value\) <= float\('20'\)",
         ):
             p.validate(15)
         with self.assertRaisesRegex(
             ValueError,
-            r"Parameter blah: Value \('20'\) must not fulfill float\('10'\) < float\(value\) <= float\('20'\)",
+            r"Parameter 'blah': Value \('20'\) must not fulfill float\('10'\) < float\(value\) <= float\('20'\)",
         ):
             p.validate(20)
         p.validate(21)
@@ -253,7 +253,7 @@ class TestParameterValidation(BaseParameterTestCase):
         p.validate(ok_hda)
         with self.assertRaisesRegex(
             ValueError,
-            "Parameter blah: The selected dataset is still being generated, select another dataset or wait until it is completed",
+            "Parameter 'blah': The selected dataset is still being generated, select another dataset or wait until it is completed",
         ):
             p.validate(notok_hda)
         p = self._parameter_for(
@@ -262,7 +262,7 @@ class TestParameterValidation(BaseParameterTestCase):
     <validator type="dataset_ok_validator" negate="true"/>
 </param>"""
         )
-        with self.assertRaisesRegex(ValueError, "Parameter blah: The selected dataset must not be in state OK"):
+        with self.assertRaisesRegex(ValueError, "Parameter 'blah': The selected dataset must not be in state OK"):
             p.validate(ok_hda)
         p.validate(notok_hda)
 
@@ -288,7 +288,7 @@ class TestParameterValidation(BaseParameterTestCase):
         )
         p.validate(full_hda)
         with self.assertRaisesRegex(
-            ValueError, "Parameter blah: The selected dataset is empty, this tool expects non-empty files."
+            ValueError, "Parameter 'blah': The selected dataset is empty, this tool expects non-empty files."
         ):
             p.validate(empty_hda)
 
@@ -299,7 +299,7 @@ class TestParameterValidation(BaseParameterTestCase):
 </param>"""
         )
         with self.assertRaisesRegex(
-            ValueError, "Parameter blah: The selected dataset is non-empty, this tool expects empty files."
+            ValueError, "Parameter 'blah': The selected dataset is non-empty, this tool expects empty files."
         ):
             p.validate(full_hda)
         p.validate(empty_hda)
@@ -329,7 +329,7 @@ class TestParameterValidation(BaseParameterTestCase):
         p.validate(has_extra_hda)
         with self.assertRaisesRegex(
             ValueError,
-            "Parameter blah: The selected dataset's extra_files_path directory is empty or does not exist, this tool expects non-empty extra_files_path directories associated with the selected input.",
+            "Parameter 'blah': The selected dataset's extra_files_path directory is empty or does not exist, this tool expects non-empty extra_files_path directories associated with the selected input.",
         ):
             p.validate(has_no_extra_hda)
 
@@ -342,7 +342,7 @@ class TestParameterValidation(BaseParameterTestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "Parameter blah: The selected dataset's extra_files_path directory is non-empty or does exist, this tool expects empty extra_files_path directories associated with the selected input.",
+            "Parameter 'blah': The selected dataset's extra_files_path directory is non-empty or does exist, this tool expects empty extra_files_path directories associated with the selected input.",
         ):
             p.validate(has_extra_hda)
         p.validate(has_no_extra_hda)
@@ -376,7 +376,7 @@ class TestParameterValidation(BaseParameterTestCase):
         p = self._parameter_for(xml=param_xml.format(check="strandCol", skip=""))
         with self.assertRaisesRegex(
             ValueError,
-            "Parameter blah: Metadata 'strandCol' missing, click the pencil icon in the history item to edit / save the metadata attributes",
+            "Parameter 'blah': Metadata 'strandCol' missing, click the pencil icon in the history item to edit / save the metadata attributes",
         ):
             p.validate(hda)
 
@@ -385,7 +385,7 @@ class TestParameterValidation(BaseParameterTestCase):
         p = self._parameter_for(xml=param_xml.format(check="", skip="dbkey,comment_lines,column_names,nameCol"))
         with self.assertRaisesRegex(
             ValueError,
-            "Parameter blah: Metadata 'strandCol' missing, click the pencil icon in the history item to edit / save the metadata attributes",
+            "Parameter 'blah': Metadata 'strandCol' missing, click the pencil icon in the history item to edit / save the metadata attributes",
         ):
             p.validate(hda)
 
@@ -398,7 +398,7 @@ class TestParameterValidation(BaseParameterTestCase):
         p = self._parameter_for(xml=param_xml_negate.format(check="nameCol", skip=""))
         with self.assertRaisesRegex(
             ValueError,
-            "Parameter blah: At least one of the checked metadata 'nameCol' is set, click the pencil icon in the history item to edit / save the metadata attributes",
+            "Parameter 'blah': At least one of the checked metadata 'nameCol' is set, click the pencil icon in the history item to edit / save the metadata attributes",
         ):
             p.validate(hda)
 
@@ -409,7 +409,7 @@ class TestParameterValidation(BaseParameterTestCase):
         )
         with self.assertRaisesRegex(
             ValueError,
-            "Parameter blah: At least one of the non skipped metadata 'dbkey,comment_lines,column_names,strandCol' is set, click the pencil icon in the history item to edit / save the metadata attributes",
+            "Parameter 'blah': At least one of the non skipped metadata 'dbkey,comment_lines,column_names,strandCol' is set, click the pencil icon in the history item to edit / save the metadata attributes",
         ):
             p.validate(hda)
 
@@ -437,7 +437,7 @@ class TestParameterValidation(BaseParameterTestCase):
         p.validate(has_dbkey_hda)
         with self.assertRaisesRegex(
             ValueError,
-            "Parameter blah: Unspecified genome build, click the pencil icon in the history item to set the genome build",
+            "Parameter 'blah': Unspecified genome build, click the pencil icon in the history item to set the genome build",
         ):
             p.validate(has_no_dbkey_hda)
 
@@ -449,7 +449,7 @@ class TestParameterValidation(BaseParameterTestCase):
         )
         with self.assertRaisesRegex(
             ValueError,
-            "Parameter blah: Specified genome build, click the pencil icon in the history item to remove the genome build",
+            "Parameter 'blah': Specified genome build, click the pencil icon in the history item to remove the genome build",
         ):
             p.validate(has_dbkey_hda)
         p.validate(has_no_dbkey_hda)


### PR DESCRIPTION
<img width="1205" alt="Screenshot 2024-09-05 at 17 14 24" src="https://github.com/user-attachments/assets/d2c4c5f1-e3d9-4e4a-aea8-f34d7a5810b9">

<img width="514" alt="Screenshot 2024-09-05 at 17 16 49" src="https://github.com/user-attachments/assets/3d4c460d-12a5-4c2d-a477-81f8f31db0e8">


Can't quite get the repeat to render in the editor when loading the persisted state ... but other than that I think this is functional. Will also need https://github.com/galaxyproject/gxformat2/pull/105 for tests

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
