### PR TITLE
[24.1] Fixing RegisterForm.vue not appending prefix when set.

### DIFF
--- a/client/src/components/Login/RegisterForm.vue
+++ b/client/src/components/Login/RegisterForm.vue
@@ -79,7 +79,7 @@ async function submit() {
             Toast.info(response.data.message);
         }
 
-        window.location.href = props.redirect || withPrefix("/");
+        window.location.href = props.redirect ? withPrefix(props.redirect) : withPrefix("/");
     } catch (error: any) {
         disableCreate.value = false;
         messageText.value = errorMessageAsString(error, "Registration failed for an unknown reason.");


### PR DESCRIPTION
Hello,

I've been working on configuring a Galaxy instance (Galaxy 24.1) for work. For our purposes, Galaxy is served under a prefix specified in the galaxy.yml config file; however, I noticed that when trying to create a user through the admin panel, I would be redirected back to /admin/users without my specified prefix. The user is still created successfully, just that I have to attach the prefix myself to return it successfully.

https://github.com/user-attachments/assets/a84db9a9-18d6-4c2e-8cf5-801e9f7be5d1


At first I thought this might have been a misconfiguration in our nginx setup; however, I've been able to recreate the issue on a virtual machine running Debian 12 and on my personal machine running Ubuntu 23.10, neither of which has nginx configured. My co-worker and I dug through the source code and narrowed down the issue to RegisterForm.vue and noticed there doesn't seem to be anything in place to redirect with a prefix.

The proposed change fixes this issue, and after rebuilding Galaxy and testing on different machines by specifying a prefix in the galaxy.yml config file, the admin panel redirects with the specified prefix.

## How to test the changes?
Run galaxy with change applied.

(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
