### PR TITLE
[24.0] Fix ``TypeError`` from Pydantic 2.9.0

### DIFF
--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -11,6 +11,7 @@ from pydantic import (
     Field,
     field_validator,
 )
+from typing_extensions import Annotated
 
 from galaxy.schema.schema import (
     AnnotationField,
@@ -189,19 +190,21 @@ class StoredWorkflowDetailed(StoredWorkflowSummary):
     )
     steps: Dict[
         int,
-        Union[
-            InputDataStep,
-            InputDataCollectionStep,
-            InputParameterStep,
-            PauseStep,
-            ToolStep,
-            SubworkflowStep,
+        Annotated[
+            Union[
+                InputDataStep,
+                InputDataCollectionStep,
+                InputParameterStep,
+                PauseStep,
+                ToolStep,
+                SubworkflowStep,
+            ],
+            Field(discriminator="type"),
         ],
     ] = Field(
         {},
         title="Steps",
         description="A dictionary with information about all the steps of the workflow.",
-        discriminator="type",
     )
     importable: Optional[bool] = Field(
         ...,


### PR DESCRIPTION
Introduced in commit 5133abd79af570fe654c09539ca8c5a2064178b2 .

Fix the following traceback:

```
Traceback (most recent call last):
  File "scripts/dump_openapi_schema.py", line 50, in <module>
    write_open_api_schema()
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "scripts/dump_openapi_schema.py", line 37, in write_open_api_schema
    openapi_schema = get_openapi_schema()
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/webapps/galaxy/fast_app.py", line 166, in get_openapi_schema
    include_all_package_routers(app, "galaxy.webapps.galaxy.api")
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/webapps/base/api.py", line 250, in include_all_package_routers
    for _, module in walk_controller_modules(package_name):
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/web/framework/base.py", line 617, in walk_controller_modules
    module = import_module(module_name)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/webapps/galaxy/api/workflows.py", line 79, in <module>
    from galaxy.schema.workflows import (
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/schema/workflows.py", line 179, in <module>
    class StoredWorkflowDetailed(StoredWorkflowSummary):
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_model_construction.py", line 223, in __new__
    complete_model_class(
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_model_construction.py", line 568, in complete_model_class
    schema = cls.__get_pydantic_core_schema__(cls, handler)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/main.py", line 670, in __get_pydantic_core_schema__
    return handler(source)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_schema_generation_shared.py", line 83, in __call__
    schema = self._handler(source_type)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 655, in generate_schema
    schema = self._generate_schema_inner(obj)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 924, in _generate_schema_inner
    return self._model_schema(obj)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 739, in _model_schema
    {k: self._generate_md_field_schema(k, v, decorators) for k, v in fields.items()},
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 739, in <dictcomp>
    {k: self._generate_md_field_schema(k, v, decorators) for k, v in fields.items()},
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 1115, in _generate_md_field_schema
    common_field = self._common_field_schema(name, field_info, decorators)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 1304, in _common_field_schema
    schema = self._apply_annotations(
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 2104, in _apply_annotations
    schema = get_inner_schema(source_type)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_schema_generation_shared.py", line 83, in __call__
    schema = self._handler(source_type)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 2093, in inner_handler
    return transform_inner_schema(schema)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 1294, in set_discriminator
    schema = self._apply_discriminator_to_union(schema, field_info.discriminator)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_generate_schema.py", line 574, in _apply_discriminator_to_union
    return _discriminated_union.apply_discriminator(
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_discriminated_union.py", line 97, in apply_discriminator
    return _ApplyInferredDiscriminator(discriminator, definitions or {}).apply(schema)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_discriminated_union.py", line 191, in apply
    schema = self._apply_to_root(schema)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_discriminated_union.py", line 227, in _apply_to_root
    self._handle_choice(choice)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.8/site-packages/pydantic/_internal/_discriminated_union.py", line 289, in _handle_choice
    raise TypeError(
TypeError: 'dict' is not a valid discriminated union variant; should be a `BaseModel` or `dataclass`
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
