### PR TITLE
Update Visualization FastAPI

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -16848,12 +16848,6 @@ export interface components {
              */
             dbkey?: string | null;
             /**
-             * Save
-             * @description Whether to save the visualization.
-             * @default true
-             */
-            save: boolean | null;
-            /**
              * Slug
              * @description The slug of the visualization.
              */
@@ -16875,8 +16869,9 @@ export interface components {
             /**
              * ID
              * @description Encoded ID of the Visualization.
+             * @example 0123456789ABCDEF
              */
-            id?: string | null;
+            id: string;
         };
         /** VisualizationPluginResponse */
         VisualizationPluginResponse: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -16857,7 +16857,7 @@ export interface components {
              * @description The name of the visualization.
              * @default Untitled Visualization
              */
-            title: string;
+            title: string | null;
             /**
              * Type
              * @description The type of the visualization.

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -4689,11 +4689,8 @@ export interface paths {
         put?: never;
         /**
          * Create a new visualization.
-         * @description POST /api/visualizations
-         *     creates a new visualization using the given payload and does not require the import_id field
-         *
-         *     POST /api/visualizations?import_id={encoded_visualization_id}
-         *     imports a copy of an existing visualization into the user's workspace and does not require the rest of the payload
+         * @description Creates a new visualization using the given payload and does not require the import_id field.
+         *     If import_id given, it imports a copy of an existing visualization into the user's workspace and does not require the rest of the payload.
          */
         post: operations["create_api_visualizations_post"];
         delete?: never;
@@ -16866,21 +16863,20 @@ export interface components {
              * @description The name of the visualization.
              * @default Untitled Visualization
              */
-            title: string | null;
+            title: string;
             /**
              * Type
              * @description The type of the visualization.
              */
-            type?: string | null;
+            type: string;
         };
         /** VisualizationCreateResponse */
         VisualizationCreateResponse: {
             /**
              * ID
              * @description Encoded ID of the Visualization.
-             * @example 0123456789ABCDEF
              */
-            id: string;
+            id?: string | null;
         };
         /** VisualizationPluginResponse */
         VisualizationPluginResponse: {

--- a/lib/galaxy/schema/visualization.py
+++ b/lib/galaxy/schema/visualization.py
@@ -303,7 +303,7 @@ class VisualizationCreatePayload(Model):
         title="Type",
         description="The type of the visualization.",
     )
-    title: SanitizedString = Field(
+    title: Optional[SanitizedString] = Field(
         SanitizedString("Untitled Visualization"),
         title="Title",
         description="The name of the visualization.",

--- a/lib/galaxy/schema/visualization.py
+++ b/lib/galaxy/schema/visualization.py
@@ -277,8 +277,8 @@ class VisualizationShowResponse(Model, WithModelClass):
 
 
 class VisualizationCreateResponse(Model):
-    id: Optional[EncodedDatabaseIdField] = Field(
-        None,
+    id: EncodedDatabaseIdField = Field(
+        ...,
         title="ID",
         description="Encoded ID of the Visualization.",
     )
@@ -327,11 +327,6 @@ class VisualizationCreatePayload(Model):
         {},
         title="Config",
         description="The config of the visualization.",
-    )
-    save: Optional[bool] = Field(
-        True,
-        title="Save",
-        description="Whether to save the visualization.",
     )
 
 

--- a/lib/galaxy/schema/visualization.py
+++ b/lib/galaxy/schema/visualization.py
@@ -307,6 +307,7 @@ class VisualizationCreatePayload(Model):
         SanitizedString("Untitled Visualization"),
         title="Title",
         description="The name of the visualization.",
+        min_length=3,
     )
     dbkey: Optional[SanitizedString] = Field(
         None,

--- a/lib/galaxy/schema/visualization.py
+++ b/lib/galaxy/schema/visualization.py
@@ -277,8 +277,8 @@ class VisualizationShowResponse(Model, WithModelClass):
 
 
 class VisualizationCreateResponse(Model):
-    id: EncodedDatabaseIdField = Field(
-        ...,
+    id: Optional[EncodedDatabaseIdField] = Field(
+        None,
         title="ID",
         description="Encoded ID of the Visualization.",
     )
@@ -298,12 +298,12 @@ class VisualizationUpdateResponse(Model):
 
 
 class VisualizationCreatePayload(Model):
-    type: Optional[SanitizedString] = Field(
-        None,
+    type: SanitizedString = Field(
+        ...,
         title="Type",
         description="The type of the visualization.",
     )
-    title: Optional[SanitizedString] = Field(
+    title: SanitizedString = Field(
         SanitizedString("Untitled Visualization"),
         title="Title",
         description="The name of the visualization.",

--- a/lib/galaxy/schema/visualization.py
+++ b/lib/galaxy/schema/visualization.py
@@ -298,7 +298,7 @@ class VisualizationUpdateResponse(Model):
 
 
 class VisualizationCreatePayload(Model):
-    type: SanitizedString = Field(
+    type: str = Field(
         ...,
         title="Type",
         description="The type of the visualization.",

--- a/lib/galaxy/webapps/galaxy/api/visualizations.py
+++ b/lib/galaxy/webapps/galaxy/api/visualizations.py
@@ -256,11 +256,8 @@ class FastAPIVisualizations:
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> VisualizationCreateResponse:
         """
-        POST /api/visualizations
-        creates a new visualization using the given payload and does not require the import_id field
-
-        POST /api/visualizations?import_id={encoded_visualization_id}
-        imports a copy of an existing visualization into the user's workspace and does not require the rest of the payload
+        Creates a new visualization using the given payload and does not require the import_id field.
+        If import_id given, it imports a copy of an existing visualization into the user's workspace and does not require the rest of the payload.
         """
         return self.service.create(trans, import_id, payload)
 

--- a/lib/galaxy/webapps/galaxy/services/visualizations.py
+++ b/lib/galaxy/webapps/galaxy/services/visualizations.py
@@ -292,7 +292,7 @@ class VisualizationsService(ServiceBase):
         self,
         trans: ProvidesUserContext,
         type: SanitizedString,
-        title: SanitizedString,
+        title: Optional[SanitizedString] = SanitizedString("Untitled Visualization"),
         dbkey: Optional[SanitizedString] = None,
         slug: Optional[SanitizedString] = None,
         annotation: Optional[SanitizedString] = None,

--- a/lib/galaxy/webapps/galaxy/services/visualizations.py
+++ b/lib/galaxy/webapps/galaxy/services/visualizations.py
@@ -31,7 +31,6 @@ from galaxy.model.item_attrs import (
     get_item_annotation_str,
 )
 from galaxy.schema.fields import DecodedDatabaseIdField
-from galaxy.schema.schema import SanitizedString
 from galaxy.schema.visualization import (
     VisualizationCreatePayload,
     VisualizationCreateResponse,
@@ -291,11 +290,11 @@ class VisualizationsService(ServiceBase):
     def _create_visualization(
         self,
         trans: ProvidesUserContext,
-        type: SanitizedString,
-        title: Optional[SanitizedString] = SanitizedString("Untitled Visualization"),
-        dbkey: Optional[SanitizedString] = None,
-        slug: Optional[SanitizedString] = None,
-        annotation: Optional[SanitizedString] = None,
+        type: str,
+        title: Optional[str] = "Untitled Visualization",
+        dbkey: Optional[str] = None,
+        slug: Optional[str] = None,
+        annotation: Optional[str] = None,
     ) -> Visualization:
         """Create visualization but not first revision. Returns Visualization object."""
         user = trans.get_user()

--- a/lib/galaxy/webapps/galaxy/services/visualizations.py
+++ b/lib/galaxy/webapps/galaxy/services/visualizations.py
@@ -169,20 +169,18 @@ class VisualizationsService(ServiceBase):
             dbkey = payload.dbkey
             annotation = payload.annotation
             config = payload.config
-            save = payload.save
 
             # generate defaults - this will err if given a weird key?
-            visualization = self._create_visualization(trans, type, title, dbkey, slug, annotation, save)
+            visualization = self._create_visualization(trans, type, title, dbkey, slug, annotation)
 
             # Create and save first visualization revision
             revision = VisualizationRevision(visualization=visualization, title=title, config=config, dbkey=dbkey)
             visualization.latest_revision = revision
 
-            if save:
-                session = trans.sa_session
-                session.add(revision)
-                with transaction(session):
-                    session.commit()
+            session = trans.sa_session
+            session.add(revision)
+            with transaction(session):
+                session.commit()
 
         return VisualizationCreateResponse(id=str(visualization.id))
 
@@ -298,7 +296,6 @@ class VisualizationsService(ServiceBase):
         dbkey: Optional[SanitizedString] = None,
         slug: Optional[SanitizedString] = None,
         annotation: Optional[SanitizedString] = None,
-        save: Optional[bool] = True,
     ) -> Visualization:
         """Create visualization but not first revision. Returns Visualization object."""
         user = trans.get_user()
@@ -328,11 +325,10 @@ class VisualizationsService(ServiceBase):
             #   right now this is depending on the classes that include this mixin to have UsesAnnotations
             add_item_annotation(trans.sa_session, trans.user, visualization, annotation)
 
-        if save:
-            session = trans.sa_session
-            session.add(visualization)
-            with transaction(session):
-                session.commit()
+        session = trans.sa_session
+        session.add(visualization)
+        with transaction(session):
+            session.commit()
 
         return visualization
 


### PR DESCRIPTION
- Updated the VisualizationCreatePayload model to make the 'type' and 'title' fields required.
- Updated the create_visualization method in visualizations.py to use the SanitizedString type and make it required for the 'type' and 'title' parameters.
- Removed the sanitize_html function from visualizations.py.
- Removed Unnecessary checking for variable exists

Related to #18721 and #10889

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
