### PR TITLE
Fix Masthead error when user not loaded yet

### DIFF
--- a/client/src/components/Masthead/Masthead.vue
+++ b/client/src/components/Masthead/Masthead.vue
@@ -124,7 +124,7 @@ onMounted(() => {
                 title="Login"
                 @click="openUrl('/login/start')" />
             <MastheadDropdown
-                v-if="!isAnonymous && !config.single_user"
+                v-if="currentUser && !isAnonymous && !config.single_user"
                 id="user"
                 class="loggedin-only"
                 icon="fa-user"


### PR DESCRIPTION
A user that has not been loaded yet is not anonymous, so the existing condition wasn't sufficient.

Fixes

<img width="721" alt="Screenshot 2024-09-10 at 11 30 01" src="https://github.com/user-attachments/assets/d3097ab0-0b53-4d5d-b194-07996f14357a">



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
