### PR TITLE
[24.1] Fix copying workflow with subworkflow step for step that you own

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8215,6 +8215,7 @@ class WorkflowStep(Base, RepresentById, UsesCreateAndUpdateTime):
             if stored_subworkflow and stored_subworkflow.user == user:
                 # This should be fine and reduces the number of stored subworkflows
                 copied_step.subworkflow = subworkflow
+                copied_subworkflow = subworkflow
             else:
                 # Can this even happen, building a workflow with a subworkflow you don't own ?
                 copied_subworkflow = subworkflow.copy()
@@ -8223,8 +8224,8 @@ class WorkflowStep(Base, RepresentById, UsesCreateAndUpdateTime):
                 )
                 copied_subworkflow.stored_workflow = stored_workflow
                 copied_step.subworkflow = copied_subworkflow
-                for subworkflow_step, copied_subworkflow_step in zip(subworkflow.steps, copied_subworkflow.steps):
-                    subworkflow_step_mapping[subworkflow_step.id] = copied_subworkflow_step
+            for subworkflow_step, copied_subworkflow_step in zip(subworkflow.steps, copied_subworkflow.steps):
+                subworkflow_step_mapping[subworkflow_step.id] = copied_subworkflow_step
 
         for old_conn, new_conn in zip(self.input_connections, copied_step.input_connections):
             new_conn.input_step_input = copied_step.get_or_add_input(old_conn.input_name)


### PR DESCRIPTION
Fixes https://sentry.galaxyproject.org/share/issue/b115ec00f2e3469c83c8793c0a7d50bb/ which fixes the currently blocked IWC workflow deployment script

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
