### PR TITLE
[24.1] Make pylibmagic import optional

### DIFF
--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -37,7 +37,11 @@ from galaxy.util.checkers import (
 )
 from galaxy.util.path import StrPath
 
-import pylibmagic  # noqa: F401  # isort:skip
+try:
+    import pylibmagic  # noqa: F401  # isort:skip
+except ImportError:
+    # Not available in conda, but docker image contains libmagic
+    pass
 import magic  # isort:skip
 
 


### PR DESCRIPTION
I was trying to use the galaxy-data container for data source tools, but it fails with:
```
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/test/functional/tools/data_source.py", line 13, in <module>
    from galaxy.datatypes import sniff
  File "/usr/local/lib/python3.12/site-packages/galaxy/datatypes/sniff.py", line 40, in <module>
    import pylibmagic  # noqa: F401  # isort:skip
    ^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'pylibmagic'
```
pylibmagic is just shipping the magic library and adds it to path, but that's not needed for the conda-package which installs libmagic (https://github.com/conda-forge/python-magic-feedstock/blob/main/recipe/meta.yaml)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
