### PR TITLE
[24.1] Fix optional text handling in LibraryEditField

### DIFF
--- a/client/src/components/Libraries/LibraryEditField.vue
+++ b/client/src/components/Libraries/LibraryEditField.vue
@@ -6,7 +6,7 @@
                 <b-form-textarea class="form-control" :value="text" rows="3" no-resize @change="updateValue" />
             </div>
             <!-- shrink long text -->
-            <div v-else-if="text.length > maxDescriptionLength && !isExpanded">
+            <div v-else-if="text && text.length > maxDescriptionLength && !isExpanded">
                 <!-- eslint-disable vue/no-v-html -->
                 <span
                     class="shrinked-description"
@@ -20,10 +20,10 @@
             <!-- Regular -->
             <div v-else>
                 <!-- eslint-disable-next-line vue/no-v-html -->
-                <div v-html="linkify(sanitize(text))"></div>
+                <div v-html="linkify(sanitize(text ?? ''))"></div>
                 <!-- hide toggle expand if text is too short -->
                 <a
-                    v-if="text.length > maxDescriptionLength"
+                    v-if="text && text.length > maxDescriptionLength"
                     class="more-text-btn"
                     href="javascript:void(0)"
                     @click="toggleDescriptionExpand"
@@ -47,6 +47,7 @@ export default {
     props: {
         text: {
             type: String,
+            required: false,
         },
         changedValue: {
             type: String,


### PR DESCRIPTION
It is one of the more common client-side errors in Sentry (https://sentry.galaxyproject.org/share/issue/7cfa153372ab426485b0ea2d7cde8b49/), and this brings it in line with the API definition where both text and and synposis are nullable.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
