### PR TITLE
Add author and tools details in RO-Crate

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7866,7 +7866,7 @@ class Workflow(Base, Dictifiable, RepresentById):
     has_cycles: Mapped[Optional[bool]]
     has_errors: Mapped[Optional[bool]]
     reports_config: Mapped[Optional[bytes]] = mapped_column(JSONType)
-    creator_metadata: Mapped[Optional[bytes]] = mapped_column(JSONType)
+    creator_metadata: Mapped[Optional[List[Dict[str, Any]]]] = mapped_column(JSONType)
     license: Mapped[Optional[str]] = mapped_column(TEXT)
     source_metadata: Mapped[Optional[Dict[str, str]]] = mapped_column(JSONType)
     uuid: Mapped[Optional[Union[UUID, str]]] = mapped_column(UUIDType)

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -239,7 +239,7 @@ class WorkflowRunCrateProfileBuilder:
                                 properties={
                                     "@type": "Person",
                                     "name": creator_data.get("name", ""),  # Default to empty string if name is missing
-                                    "orcid": creator_data.get(
+                                    "identifier": creator_data.get(
                                         "identifier", ""
                                     ),  # Assuming identifier is ORCID, or adjust as needed
                                     "url": creator_data.get("url", ""),  # Add URL if available, otherwise empty string

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -311,7 +311,7 @@ class WorkflowRunCrateProfileBuilder:
                             "position": position[0],
                             "name": step.tool_id,
                             "description": step_description,
-                            "workExample": f"#{step.tool_id}"
+                            "workExample": f"#{step.tool_id}",
                         },
                     )
                 )

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -311,6 +311,7 @@ class WorkflowRunCrateProfileBuilder:
                             "position": position[0],
                             "name": step.tool_id,
                             "description": step_description,
+                            "workExample": f"#{step.tool_id}"
                         },
                     )
                 )
@@ -359,13 +360,12 @@ class WorkflowRunCrateProfileBuilder:
                     tool_entity = crate.add(
                         ContextEntity(
                             crate,
-                            tool_id,
+                            f"#{tool_id}",  # Prepend # to tool_id
                             properties={
                                 "@type": "SoftwareApplication",
                                 "name": tool_name,
                                 "version": tool_version,
                                 "description": tool_description,
-                                "url": "https://toolshed.g2.bx.psu.edu",  # URL if relevant
                             },
                         )
                     )
@@ -375,7 +375,7 @@ class WorkflowRunCrateProfileBuilder:
 
                 # Append the tool entity to the workflow (instrument) and store it in the list
                 tool_entities.append(tool_entity)
-                crate.mainEntity.append_to("instrument", tool_entity)
+                crate.mainEntity.append_to("hasPart", tool_entity)
 
             # Handle subworkflows recursively
             elif step.type == "subworkflow":

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -3,6 +3,7 @@ import os
 from typing import (
     Any,
     Dict,
+    List,
     Optional,
 )
 

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -45,6 +45,7 @@ ATTRS_FILENAME_INVOCATIONS = "invocation_attrs.txt"
 class WorkflowRunCrateProfileBuilder:
     def __init__(self, model_store: Any):
         self.model_store = model_store
+        self.toolbox = self.model_store.app.toolbox
         self.invocation: WorkflowInvocation = model_store.included_invocations[0]
         self.workflow: Workflow = self.invocation.workflow
         self.param_type_mapping = {
@@ -85,6 +86,8 @@ class WorkflowRunCrateProfileBuilder:
         self.file_entities: Dict[int, Any] = {}
         self.param_entities: Dict[int, Any] = {}
         self.pv_entities: Dict[str, Any] = {}
+        # Cache for tools to avoid duplicating entities for the same tool
+        self.tool_cache: Dict[str, ContextEntity] = {}
 
     def build_crate(self):
         crate = ROCrate()

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -328,7 +328,7 @@ class WorkflowRunCrateProfileBuilder:
                     self._add_steps_recursive(subworkflow.steps, crate, step_entities, position)
 
     def _add_tools(self, crate: ROCrate):
-        tool_entities = []
+        tool_entities: List[ContextEntity] = []
         self._add_tools_recursive(self.workflow.steps, crate, tool_entities)
 
     def _add_tools_recursive(self, steps, crate: ROCrate, tool_entities):

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -280,7 +280,7 @@ class WorkflowRunCrateProfileBuilder:
         """
         Add workflow steps (HowToStep) to the RO-Crate. These are unique for each tool occurrence.
         """
-        step_entities = []
+        step_entities: List[ContextEntity] = []
         # Initialize the position as a list with a single element to keep it mutable
         position = [1]
         self._add_steps_recursive(self.workflow.steps, crate, step_entities, position)

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -516,7 +516,7 @@ def validate_tools(ro_crate: ROCrate):
     """
     Validate that tools (SoftwareApplication) are correctly added.
     """
-    tools = ro_crate.mainEntity.get("instrument")
+    tools = ro_crate.mainEntity.get("hasPart")
     assert tools, "No tools found in the RO-Crate"
 
     tool_ids = set()
@@ -524,7 +524,6 @@ def validate_tools(ro_crate: ROCrate):
         assert tool["@type"] == "SoftwareApplication"
         assert "name" in tool
         assert "version" in tool
-        assert "url" in tool
         assert "description" in tool or tool["description"] is None
         assert tool.id not in tool_ids, "Duplicate tool found"
         tool_ids.add(tool.id)

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -19,6 +19,7 @@ import pytest
 from rocrate.rocrate import ROCrate
 from sqlalchemy import select
 from sqlalchemy.orm.scoping import scoped_session
+from unittest.mock import Mock
 
 from galaxy import model
 from galaxy.model import store
@@ -1186,11 +1187,33 @@ class TestApp(GalaxyDataTestApp):
         )
 
 
+class MockTool:
+    """Mock class to simulate Galaxy tools with essential metadata for testing."""
+
+    def __init__(self, tool_id):
+        self.tool_id = tool_id
+        self.citations = [{"type": "doi", "value": "10.1234/example.doi"}]
+        self.xrefs = [{"type": "registry", "value": "tool_registry_id"}]
+        self.edam_operations = ["operation_1234"]
+
+
+class MockToolbox:
+    """Mock class for the Galaxy toolbox, which returns tools based on their IDs."""
+
+    def get_tool(self, tool_id):
+        # Returns a MockTool object with basic metadata for testing
+        return MockTool(tool_id)
+
+
 def _mock_app(store_by=DEFAULT_OBJECT_STORE_BY):
     app = TestApp()
     test_object_store_config = TestConfig(store_by=store_by)
     app.object_store = test_object_store_config.object_store
     app.model.Dataset.object_store = app.object_store
+
+    # Add a mocked toolbox attribute for tests requiring tool metadata
+    app.toolbox = MockToolbox()
+
     return app
 
 

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -23,7 +23,6 @@ from sqlalchemy.orm.scoping import scoped_session
 from galaxy import model
 from galaxy.model import store
 from galaxy.model.metadata import MetadataTempFile
-from galaxy.model.orm.now import now
 from galaxy.model.unittest_utils import GalaxyDataTestApp
 from galaxy.model.unittest_utils.store_fixtures import (
     deferred_hda_model_store_dict,

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -19,7 +19,6 @@ import pytest
 from rocrate.rocrate import ROCrate
 from sqlalchemy import select
 from sqlalchemy.orm.scoping import scoped_session
-from unittest.mock import Mock
 
 from galaxy import model
 from galaxy.model import store

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -439,7 +439,6 @@ def test_import_export_library(tmp_path):
 def test_import_export_invocation():
     app = _mock_app()
     workflow_invocation = _setup_invocation(app)
-    print(workflow_invocation)
     temp_directory = mkdtemp()
     with store.DirectoryModelExportStore(temp_directory, app=app) as export_store:
         export_store.export_workflow_invocation(workflow_invocation)

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -1168,7 +1168,6 @@ def _setup_simple_invocation(app):
     workflow_step_1 = model.WorkflowStep()
     workflow_step_1.order_index = 0
     workflow_step_1.type = "data_input"
-    workflow_step_1.label = "Input Step"
     workflow_step_1.tool_inputs = {}
     sa_session.add(workflow_step_1)
     workflow = _workflow_from_steps(u, [workflow_step_1])

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -1186,32 +1186,11 @@ class TestApp(GalaxyDataTestApp):
         )
 
 
-class MockTool:
-    """Mock class to simulate Galaxy tools with essential metadata for testing."""
-
-    def __init__(self, tool_id):
-        self.tool_id = tool_id
-        self.citations = [{"type": "doi", "value": "10.1234/example.doi"}]
-        self.xrefs = [{"type": "registry", "value": "tool_registry_id"}]
-        self.edam_operations = ["operation_1234"]
-
-
-class MockToolbox:
-    """Mock class for the Galaxy toolbox, which returns tools based on their IDs."""
-
-    def get_tool(self, tool_id):
-        # Returns a MockTool object with basic metadata for testing
-        return MockTool(tool_id)
-
-
 def _mock_app(store_by=DEFAULT_OBJECT_STORE_BY):
     app = TestApp()
     test_object_store_config = TestConfig(store_by=store_by)
     app.object_store = test_object_store_config.object_store
     app.model.Dataset.object_store = app.object_store
-
-    # Add a mocked toolbox attribute for tests requiring tool metadata
-    app.toolbox = MockToolbox()
 
     return app
 

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -1165,19 +1165,18 @@ def _setup_simple_invocation(app):
     j.parameters = [model.JobParameter(name="index_path", value='"/old/path/human"')]
 
     # Create a workflow
-    workflow = model.Workflow()
+    workflow_step_1 = model.WorkflowStep()
+    workflow_step_1.order_index = 0
+    workflow_step_1.type = "data_input"
+    workflow_step_1.label = "Input Step"
+    workflow_step_1.tool_inputs = {}
+    sa_session.add(workflow_step_1)
+    workflow = _workflow_from_steps(u, [workflow_step_1])
     workflow.license = "MIT"
     workflow.name = "Test Workflow"
     workflow.creator_metadata = [
         {"class": "Person", "name": "Bob", "identifier": "0000-0002-3456-7890", "email": "bob@example.com"},
     ]
-
-    # Create and associate a data_input step
-    workflow_step_input = model.WorkflowStep()
-    workflow_step_input.order_index = 0
-    workflow_step_input.type = "data_input"
-    workflow_step_input.label = "Input Step"
-    workflow.steps.append(workflow_step_input)
 
     # Create and associate a tool step
     workflow_step_tool = model.WorkflowStep()
@@ -1192,7 +1191,7 @@ def _setup_simple_invocation(app):
 
     # Create a workflow invocation
     invocation = _invocation_for_workflow(u, workflow)
-    invocation.add_input(d1, step=workflow_step_input)  # Associate input dataset
+    invocation.add_input(d1, step=workflow_step_1)  # Associate input dataset
     wf_output = model.WorkflowOutput(workflow_step_tool, label="output_label")
     invocation.add_output(wf_output, workflow_step_tool, d2)  # Associate output dataset
 


### PR DESCRIPTION
Here we go again !
I am launching this PR on a bit of work I did to ameliorate the RO-Crate plugin.

I updated the `_add_worfklow` function. I added the information on the author of the workflow:
- Name
- Orcid
The update checks if the workflow attribute 'creator_metadata' exist. If it exists, it writes into the ro-crate the name of the creator (if there is no name it leaves a "") same for the idenifier (by default i put the ORCID maybe it's not a good Idea and if there is no Orcid it leaves a ""). If there is no  'creator_metadata' nothing is written on the creator.

I created a function `_add_tools` that checks the different info in `workflow.steps` to add some tools details:
- Id of the tool
- tool's name (label if there is one or id if there is no label)
- tools' version
- tool's description: the update checks if the tool has an annotations attribute if it exist it is written as the description if it does not the description remains "")
- url to the the toolshed (not sure this part is relevant as I did not yet solve how to have the exact url to the tool in the toolshed and I just let the global url to the toolshed)

I am not sure if I wrote that the correct way corresponding to the run crate profile (this is a bit obscure to me)

@pauldg What do you think of this ?
Thanks !!
