### PR TITLE
[24.1] Fix ``named cursor is not valid anymore``

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -1119,7 +1119,7 @@ def get_jobs_to_check_at_startup(session: galaxy_scoped_session, track_jobs_in_d
         # Filter out the jobs of inactive users.
         stmt = stmt.outerjoin(User).filter(or_((Job.user_id == null()), (User.active == true())))
 
-    return session.scalars(stmt)
+    return session.scalars(stmt).all()
 
 
 def get_job(session, *where_clauses):


### PR DESCRIPTION
Fixes
https://github.com/galaxyproject/galaxy/issues/18782 / https://sentry.galaxyproject.org/share/issue/dca23c8d10e743509648cf6092a1dc15/:
```
Message
Error closing cursor
Stack Trace

Newest

ProgrammingError: named cursor isn't valid anymore
  File "sqlalchemy/engine/cursor.py", line 1255, in fetchmany
    new = dbapi_cursor.fetchmany(size - lb)
ProgrammingError: named cursor isn't valid anymore
  File "sqlalchemy/engine/base.py", line 2213, in _safe_close_cursor
    cursor.close()
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
