### PR TITLE
[24.1] prevent "missing refresh_token" errors by supporting <extra_scopes> also with Keycloak backend

### DIFF
--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -62,6 +62,7 @@ class CustosAuthnzConfiguration:
     pkce_support: bool
     accepted_audiences: List[str]
     extra_params: Optional[dict]
+    extra_scopes: List[str]
     authorization_endpoint: Optional[str]
     token_endpoint: Optional[str]
     end_session_endpoint: Optional[str]
@@ -98,6 +99,7 @@ class OIDCAuthnzBase(IdentityProvider):
                 )
             ),
             extra_params={},
+            extra_scopes=oidc_backend_config.get("extra_scopes",[]),
             authorization_endpoint=None,
             token_endpoint=None,
             end_session_endpoint=None,
@@ -156,6 +158,7 @@ class OIDCAuthnzBase(IdentityProvider):
     def authenticate(self, trans, idphint=None):
         base_authorize_url = self.config.authorization_endpoint
         scopes = ["openid", "email", "profile"]
+        scopes.extend(self.config.extra_scopes)
         scopes.extend(self._get_provider_specific_scopes())
         oauth2_session = self._create_oauth2_session(scope=scopes)
         nonce = generate_nonce()

--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -99,7 +99,7 @@ class OIDCAuthnzBase(IdentityProvider):
                 )
             ),
             extra_params={},
-            extra_scopes=oidc_backend_config.get("extra_scopes",[]),
+            extra_scopes=oidc_backend_config.get("extra_scopes", []),
             authorization_endpoint=None,
             token_endpoint=None,
             end_session_endpoint=None,

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -213,6 +213,8 @@ class AuthnzManager:
             rtv["ca_bundle"] = config_xml.find("ca_bundle").text
         if config_xml.find("icon") is not None:
             rtv["icon"] = config_xml.find("icon").text
+        if config_xml.find("extra_scopes") is not None:
+            rtv["extra_scopes"] = listify(config_xml.find("extra_scopes").text)
         if config_xml.find("pkce_support") is not None:
             rtv["pkce_support"] = asbool(config_xml.find("pkce_support").text)
         if config_xml.find("accepted_audiences") is not None:


### PR DESCRIPTION
The <extra_scopes> attribute of oidc_backend_config.xml is not supported in the Keycloak backend. Consequently, it was not possible to request 'offline_access' from the IdP, which is expected in the current implementation, and we kept receiving:

Sep 16 11:23:37 usegalaxy-test galaxyctl[11560]: Traceback (most recent call last):
Sep 16 11:23:37 usegalaxy-test galaxyctl[11560]:   File "/srv/galaxy/server/lib/galaxy/authnz/managers.py", line 357, in refresh_expiring_oidc_tokens_for_provider
Sep 16 11:23:37 usegalaxy-test galaxyctl[11560]:     refreshed = backend.refresh(trans, auth)
Sep 16 11:23:37 usegalaxy-test galaxyctl[11560]:   File "/srv/galaxy/server/lib/galaxy/authnz/custos_authnz.py", line 140, in refresh
Sep 16 11:23:37 usegalaxy-test galaxyctl[11560]:     token = oauth2_session.refresh_token(token_endpoint, **params)
Sep 16 11:23:37 usegalaxy-test galaxyctl[11560]:   File "/srv/galaxy/venv/lib/python3.9/site-packages/requests_oauthlib/oauth2_session.py", line 496, in refresh_token
Sep 16 11:23:37 usegalaxy-test galaxyctl[11560]:     self.token = self._client.parse_request_body_response(r.text, scope=self.scope)
Sep 16 11:23:37 usegalaxy-test galaxyctl[11560]:   File "/srv/galaxy/venv/lib/python3.9/site-packages/oauthlib/oauth2/rfc6749/clients/base.py", line 427, in parse_request_body_response
Sep 16 11:23:37 usegalaxy-test galaxyctl[11560]:     self.token = parse_token_response(body, scope=scope)
Sep 16 11:23:37 usegalaxy-test galaxyctl[11560]:   File "/srv/galaxy/venv/lib/python3.9/site-packages/oauthlib/oauth2/rfc6749/parameters.py", line 441, in parse_token_response
Sep 16 11:23:37 usegalaxy-test galaxyctl[11560]:     validate_token_parameters(params)
Sep 16 11:23:37 usegalaxy-test galaxyctl[11560]:   File "/srv/galaxy/venv/lib/python3.9/site-packages/oauthlib/oauth2/rfc6749/parameters.py", line 448, in validate_token_parameters
Sep 16 11:23:37 usegalaxy-test galaxyctl[11560]:     raise_from_error(params.get('error'), params)
Sep 16 11:23:37 usegalaxy-test galaxyctl[11560]:   File "/srv/galaxy/venv/lib/python3.9/site-packages/oauthlib/oauth2/rfc6749/errors.py", line 399, in raise_from_error
Sep 16 11:23:37 usegalaxy-test galaxyctl[11560]:     raise cls(**kwargs)
Sep 16 11:23:37 usegalaxy-test galaxyctl[11560]: oauthlib.oauth2.rfc6749.errors.InvalidClientIdError: (invalid_request) refresh_token parameter not provided

The patch is conservative, unless <extra_scopes> appears in the config, it does nothing.

