### PR TITLE
[24.1] Make all fields optional for HelpForumPost

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -7031,17 +7031,17 @@ export interface components {
              * Avatar Template
              * @description The avatar template of the user.
              */
-            avatar_template: string;
+            avatar_template: string | null;
             /**
              * Blurb
              * @description The blurb of the post.
              */
-            blurb: string;
+            blurb: string | null;
             /**
              * Created At
              * @description The creation date of the post.
              */
-            created_at: string;
+            created_at: string | null;
             /**
              * Id
              * @description The ID of the post.
@@ -7051,27 +7051,27 @@ export interface components {
              * Like Count
              * @description The number of likes of the post.
              */
-            like_count: number;
+            like_count: number | null;
             /**
              * Name
              * @description The name of the post.
              */
-            name: string;
+            name: string | null;
             /**
              * Post Number
              * @description The post number of the post.
              */
-            post_number: number;
+            post_number: number | null;
             /**
              * Topic Id
              * @description The ID of the topic of the post.
              */
-            topic_id: number;
+            topic_id: number | null;
             /**
              * Username
              * @description The username of the post author.
              */
-            username: string;
+            username: string | null;
             [key: string]: unknown | undefined;
         };
         /**

--- a/lib/galaxy/schema/help.py
+++ b/lib/galaxy/schema/help.py
@@ -27,14 +27,14 @@ class HelpForumPost(HelpTempBaseModel):
     """Model for a post in the help forum."""
 
     id: Annotated[int, Field(description="The ID of the post.")]
-    name: Annotated[str, Field(description="The name of the post.")]
-    username: Annotated[str, Field(description="The username of the post author.")]
-    avatar_template: Annotated[str, Field(description="The avatar template of the user.")]
-    created_at: Annotated[str, Field(description="The creation date of the post.")]
-    like_count: Annotated[int, Field(description="The number of likes of the post.")]
-    blurb: Annotated[str, Field(description="The blurb of the post.")]
-    post_number: Annotated[int, Field(description="The post number of the post.")]
-    topic_id: Annotated[int, Field(description="The ID of the topic of the post.")]
+    name: Annotated[Optional[str], Field(description="The name of the post.")]
+    username: Annotated[Optional[str], Field(description="The username of the post author.")]
+    avatar_template: Annotated[Optional[str], Field(description="The avatar template of the user.")]
+    created_at: Annotated[Optional[str], Field(description="The creation date of the post.")]
+    like_count: Annotated[Optional[int], Field(description="The number of likes of the post.")]
+    blurb: Annotated[Optional[str], Field(description="The blurb of the post.")]
+    post_number: Annotated[Optional[int], Field(description="The post number of the post.")]
+    topic_id: Annotated[Optional[int], Field(description="The ID of the topic of the post.")]
 
 
 class HelpForumTopic(Model):


### PR DESCRIPTION
Fixes #18827

Unfortunately, the OpenAPI schema for the `/search.json` route in Discourse (https://docs.discourse.org/openapi.json) does not specify the proper type for the posts array in the response. 

```
...
"properties": {
    "posts": {
        "type": "array",
        "items": {}
    },
    "users": {
        "type": "array",
        "items": {}
    },
    "categories": {
        "type": "array",
        "items": {}
    },
    "tags": {
        "type": "array",
        "items": {}
    },
    "groups": {
        "type": "array",
        "items": {}
    }
...
```

We can try to infer it from `/posts.json` but there, seem to be no required properties at all, which is also strange.

I made all the properties except for the `id` optional in case more cases like these exist.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
