### PR TITLE
[24.1] Fix Workflow index bookmark filter

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -24368,8 +24368,17 @@ export interface operations {
              * `is:published`
              * : Include only published workflows in the final result. Be sure the query parameter `show_published` is set to `true` if to include all published workflows and not just the requesting user's.
              *
+             * `is:importable`
+             * : Include only importable workflows in the final result.
+             *
+             * `is:deleted`
+             * : Include only deleted workflows in the final result.
+             *
              * `is:share_with_me`
              * : Include only workflows shared with the requesting user.  Be sure the query parameter `show_shared` is set to `true` if to include shared workflows.
+             *
+             * `is:bookmarked`
+             * : Include only workflows bookmarked by the requesting user.
              *
              * ## Free Text
              *

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -24374,7 +24374,7 @@ export interface operations {
              * `is:deleted`
              * : Include only deleted workflows in the final result.
              *
-             * `is:share_with_me`
+             * `is:shared_with_me`
              * : Include only workflows shared with the requesting user.  Be sure the query parameter `show_shared` is set to `true` if to include shared workflows.
              *
              * `is:bookmarked`

--- a/client/src/components/Workflow/WorkflowFilters.js
+++ b/client/src/components/Workflow/WorkflowFilters.js
@@ -116,6 +116,13 @@ export function WorkflowFilters(activeList = "my") {
                     handler: equals("deleted", "deleted", toBool),
                     menuItem: true,
                 },
+                bookmarked: {
+                    placeholder: "Bookmarked",
+                    type: Boolean,
+                    boolType: "is",
+                    handler: equals("bookmarked", "bookmarked", toBool),
+                    menuItem: true,
+                },
             },
             undefined,
             false,

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -241,7 +241,7 @@ class WorkflowsManager(sharable.SharableModelManager, deletable.DeletableManager
                             stmt = stmt.where(StoredWorkflowUserShareAssociation.user == user)
                         elif q == "bookmarked":
                             stmt = (
-                                stmt.outerjoin(model.StoredWorkflowMenuEntry)
+                                stmt.join(model.StoredWorkflowMenuEntry)
                                 .where(model.StoredWorkflowMenuEntry.stored_workflow_id == StoredWorkflow.id)
                                 .where(model.StoredWorkflowMenuEntry.user_id == user.id)
                             )

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -239,6 +239,12 @@ class WorkflowsManager(sharable.SharableModelManager, deletable.DeletableManager
                                 message = "Can only use tag is:shared_with_me if show_shared parameter also true."
                                 raise exceptions.RequestParameterInvalidException(message)
                             stmt = stmt.where(StoredWorkflowUserShareAssociation.user == user)
+                        elif q == "bookmarked":
+                            stmt = (
+                                stmt.outerjoin(model.StoredWorkflowMenuEntry)
+                                .where(model.StoredWorkflowMenuEntry.stored_workflow_id == StoredWorkflow.id)
+                                .where(model.StoredWorkflowMenuEntry.user_id == user.id)
+                            )
                 elif isinstance(term, RawTextTerm):
                     tf = w_tag_filter(term.text, False)
                     alias = aliased(User)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -863,7 +863,7 @@ query_tags = [
         "Include only deleted workflows in the final result.",
     ),
     IndexQueryTag(
-        "is:share_with_me",
+        "is:shared_with_me",
         "Include only workflows shared with the requesting user.  Be sure the query parameter `show_shared` is set to `true` if to include shared workflows.",
     ),
     IndexQueryTag(

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -855,8 +855,20 @@ query_tags = [
         "Include only published workflows in the final result. Be sure the query parameter `show_published` is set to `true` if to include all published workflows and not just the requesting user's.",
     ),
     IndexQueryTag(
+        "is:importable",
+        "Include only importable workflows in the final result.",
+    ),
+    IndexQueryTag(
+        "is:deleted",
+        "Include only deleted workflows in the final result.",
+    ),
+    IndexQueryTag(
         "is:share_with_me",
         "Include only workflows shared with the requesting user.  Be sure the query parameter `show_shared` is set to `true` if to include shared workflows.",
+    ),
+    IndexQueryTag(
+        "is:bookmarked",
+        "Include only workflows bookmarked by the requesting user.",
     ),
 ]
 


### PR DESCRIPTION
Fixes #18718. It adds the `is:bookmarked` filter to the workflows index API `"/api/workflows"` to filter bookmarked workflows on the server. Previously, they were filtered on the client side.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
