### PR TITLE
Add docs on indexing for filter column

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -5619,7 +5619,7 @@ Currently the filters in the ``filter_types`` dictionary in the module
     </xs:attribute>
     <xs:attribute name="column" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Column targeted by this filter given as column index or a column name. Invalid if ``type`` is ``add_value`` or ``remove_value``.
+        <xs:documentation xml:lang="en">Column targeted by this filter given as 0-based column index or a column name. Invalid if ``type`` is ``add_value`` or ``remove_value``.
 </xs:documentation>
       </xs:annotation>
     </xs:attribute>


### PR DESCRIPTION
Wondering if it would be a good idea to push name based adressing of columns more by rewriting the examples a bit, but most of them (or all) seem to be rather abstract, i.e. there are no real datatables that they refer to (so I do not know the names of the columns).

xref https://github.com/galaxyproject/tools-iuc/pull/6337

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
