### PR TITLE
[24.1] Skip metric collection if job working directory doesn't exist

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1414,7 +1414,7 @@ class MinimalJobWrapper(HasResourceParameters):
         message = str(message)
         working_directory_exists = self.working_directory_exists()
 
-        if not job.tasks:
+        if not job.tasks and working_directory_exists:
             # If job was composed of tasks, don't attempt to recollect statistics
             self._collect_metrics(job, job_metrics_directory)
 


### PR DESCRIPTION
That happens if the user stops a job before it's queued (or if we have a job rule preventing queuing).
Fixes
https://sentry.galaxyproject.org/share/issue/8b462ee0d50a4de8bb9ca2c50f049b42/:
```
Message
Could not recover job metrics
Stack Trace

Newest

JobMappingException: This tool is currently being beta-tested and your account has not been given access.

  File "galaxy/jobs/mapper.py", line 214, in __handle_rule
    job_destination = self.__invoke_expand_function(
  File "galaxy/jobs/mapper.py", line 125, in __invoke_expand_function
    return expand_function(**actual_args)
  File "tpv/rules/gateway.py", line 51, in map_tool_to_destination
    return ACTIVE_DESTINATION_MAPPER.map_to_destination(app, tool, user, job, job_wrapper, resource_params,
  File "tpv/core/mapper.py", line 168, in map_to_destination
    evaluated_entity = self.match_combine_evaluate_entities(context, tool, user)
  File "tpv/core/mapper.py", line 138, in match_combine_evaluate_entities
    evaluated_entity = combined_entity.evaluate_rules(context)
  File "tpv/core/entities.py", line 489, in evaluate_rules
    rule = rule.evaluate(context)
  File "tpv/core/entities.py", line 750, in evaluate
    raise JobMappingException(
JobMappingException: This tool is currently being beta-tested and your account has not been given access.

  File "galaxy/jobs/handler.py", line 719, in __verify_job_ready
    job_destination = job_wrapper.job_destination
  File "galaxy/jobs/__init__.py", line 2576, in job_destination
    return self.job_runner_mapper.get_job_destination(self.params)
  File "galaxy/jobs/mapper.py", line 276, in get_job_destination
    return self.__cache_job_destination(params)
  File "galaxy/jobs/mapper.py", line 257, in __cache_job_destination
    self.cached_job_destination = self.__determine_job_destination(
  File "galaxy/jobs/mapper.py", line 241, in __determine_job_destination
    job_destination = self.__handle_dynamic_job_destination(raw_job_destination)
  File "galaxy/jobs/mapper.py", line 204, in __handle_dynamic_job_destination
    return self.__handle_rule(expand_function, destination)
  File "galaxy/jobs/mapper.py", line 219, in __handle_rule
    raise e
  File "galaxy/jobs/mapper.py", line 208, in __handle_rule
    job_destination = self.__invoke_expand_function(rule_function, destination)
  File "galaxy/jobs/mapper.py", line 125, in __invoke_expand_function
    return expand_function(**actual_args)
  File "tpv/rules/gateway.py", line 51, in map_tool_to_destination
    return ACTIVE_DESTINATION_MAPPER.map_to_destination(app, tool, user, job, job_wrapper, resource_params,
  File "tpv/core/mapper.py", line 168, in map_to_destination
    evaluated_entity = self.match_combine_evaluate_entities(context, tool, user)
  File "tpv/core/mapper.py", line 138, in match_combine_evaluate_entities
    evaluated_entity = combined_entity.evaluate_rules(context)
  File "tpv/core/entities.py", line 489, in evaluate_rules
    rule = rule.evaluate(context)
  File "tpv/core/entities.py", line 750, in evaluate
    raise JobMappingException(
ObjectNotFound: objectstore, _call_method failed: _get_filename on <galaxy.model.Job(60599388) at 0x7fcaec5b6450>, kwargs: {'base_dir': 'job_work', 'dir_only': True, 'obj_dir': True}
  File "galaxy/jobs/__init__.py", line 2163, in _collect_metrics
    job_metrics_directory = self.working_directory
  File "galaxy/jobs/__init__.py", line 1317, in working_directory
    self.__working_directory = self.app.object_store.get_filename(
  File "galaxy/objectstore/__init__.py", line 475, in get_filename
    return self._invoke("get_filename", obj, **kwargs)
  File "galaxy/objectstore/__init__.py", line 451, in _invoke
    return self.__getattribute__(f"_{delegate}")(obj=obj, **kwargs)
  File "galaxy/objectstore/__init__.py", line 1009, in _get_filename
    return self._call_method("_get_filename", obj, ObjectNotFound, True, **kwargs)
  File "galaxy/objectstore/__init__.py", line 1281, in _call_method
    raise default(
```
Minor follow up to https://github.com/galaxyproject/galaxy/pull/18809

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
