### PR TITLE
Fix flaky `test/integration_selenium/test_toolbox_filters.py::TestToolboxFiltersSeleniumIntegration::test_toolbox_filters`

### DIFF
--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -374,6 +374,7 @@ edit_collection_attributes:
 
 tool_panel:
   selectors:
+    tool_box: '[data-description="panel toolbox"]'
     tool_link: 'a[href$$="tool_runner?tool_id=${tool_id}"]'
     outer_tool_link: '.toolTitle a[href$$="tool_runner?tool_id=${tool_id}"]'
     data_source_tool_link: 'a[href$$="tool_runner/data_source_redirect?tool_id=${tool_id}"]'

--- a/test/integration_selenium/test_toolbox_filters.py
+++ b/test/integration_selenium/test_toolbox_filters.py
@@ -26,7 +26,6 @@ class TestToolboxFiltersSeleniumIntegration(SeleniumIntegrationTestCase):
         the specified section is no longer displayed in the browser.
         """
         self.register()
-        self.sleep_for(self.wait_types.UX_RENDER)
         self.components.tool_panel.tool_box.wait_for_visible()
         # The tool panel section should be visible and clickable at this stage
         section = self.driver.find_element(By.LINK_TEXT, "Test Section")

--- a/test/integration_selenium/test_toolbox_filters.py
+++ b/test/integration_selenium/test_toolbox_filters.py
@@ -26,6 +26,8 @@ class TestToolboxFiltersSeleniumIntegration(SeleniumIntegrationTestCase):
         the specified section is no longer displayed in the browser.
         """
         self.register()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.components.tool_panel.tool_box.wait_for_visible()
         # The tool panel section should be visible and clickable at this stage
         section = self.driver.find_element(By.LINK_TEXT, "Test Section")
         self.action_chains().move_to_element(section).click().perform()
@@ -41,6 +43,7 @@ class TestToolboxFiltersSeleniumIntegration(SeleniumIntegrationTestCase):
         self.components.toolbox_filters.submit.wait_for_and_click()
         self.sleep_for(self.wait_types.UX_RENDER)
         self.home()
+        self.components.tool_panel.tool_box.wait_for_visible()
         # But now it should raise NoSuchElementException
         with self.assertRaises(NoSuchElementException):
             self.driver.find_element(By.LINK_TEXT, "Test Section")


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/18832

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
