### PR TITLE
[24.0] Fix discovered outputs with directory metadata and distributed object

### DIFF
--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -132,11 +132,6 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
                 )
                 self.persist_object(primary_data)
 
-                if init_from:
-                    self.permission_provider.copy_dataset_permissions(init_from, primary_data)
-                    primary_data.state = init_from.state
-                else:
-                    self.permission_provider.set_default_hda_permissions(primary_data)
             else:
                 ld = galaxy.model.LibraryDataset(folder=library_folder, name=name)
                 ldda = galaxy.model.LibraryDatasetDatasetAssociation(
@@ -208,6 +203,7 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
                     filename=filename,
                     link_data=link_data,
                     output_name=output_name,
+                    init_from=init_from,
                 )
             else:
                 storage_callbacks.append(
@@ -218,11 +214,14 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
                         filename=filename,
                         link_data=link_data,
                         output_name=output_name,
+                        init_from=init_from,
                     )
                 )
         return primary_data
 
-    def finalize_storage(self, primary_data, dataset_attributes, extra_files, filename, link_data, output_name):
+    def finalize_storage(
+        self, primary_data, dataset_attributes, extra_files, filename, link_data, output_name, init_from
+    ):
         if primary_data.dataset.purged:
             # metadata won't be set, maybe we should do that, then purge ?
             primary_data.dataset.file_size = 0
@@ -243,6 +242,13 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
         else:
             # We are sure there are no extra files, so optimize things that follow by settting total size also.
             primary_data.set_size(no_extra_files=True)
+
+        if init_from:
+            self.permission_provider.copy_dataset_permissions(init_from, primary_data)
+            primary_data.state = init_from.state
+        else:
+            self.permission_provider.set_default_hda_permissions(primary_data)
+
         # TODO: this might run set_meta after copying the file to the object store, which could be inefficient if job working directory is closer to the node.
         self.set_datasets_metadata(datasets=[primary_data], datasets_attributes=[dataset_attributes])
 

--- a/test/integration/test_extended_metadata.py
+++ b/test/integration/test_extended_metadata.py
@@ -43,6 +43,7 @@ TEST_TOOL_IDS = [
     "collection_creates_dynamic_nested_from_json_elements",
     "implicit_conversion",
     "environment_variables",
+    "all_output_types",
 ]
 
 


### PR DESCRIPTION
stores

The problem is that `object_store.is_private` would check in which object store the dataset is stored, and that fails if we haven't written to the object store yet (which is why extended metadata is a workaround).

Fixes https://github.com/galaxyproject/galaxy/issues/17208


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
