### PR TITLE
Jupyter Interactive Tool 1.0.1/24.07

### DIFF
--- a/lib/galaxy/config/sample/tool_conf.xml.sample
+++ b/lib/galaxy/config/sample/tool_conf.xml.sample
@@ -140,6 +140,7 @@
     <tool file="interactive/interactivetool_ethercalc.xml" />
     <tool file="interactive/interactivetool_guacamole_desktop.xml" />
     <tool file="interactive/interactivetool_hicbrowser.xml" />
+    <tool file="interactive/interactivetool_jupyter_notebook_1.0.1.xml" />
     <tool file="interactive/interactivetool_jupyter_notebook_1.0.0.xml" />
     <tool file="interactive/interactivetool_jupyter_notebook.xml" />
     <tool file="interactive/interactivetool_neo4j.xml" />

--- a/tools/interactive/interactivetool_jupyter_notebook_1.0.0.xml
+++ b/tools/interactive/interactivetool_jupyter_notebook_1.0.0.xml
@@ -1,7 +1,10 @@
-<tool id="interactive_tool_jupyter_notebook" tool_type="interactive" name="Interactive JupyterLab Notebook" version="1.0.0" profile="22.01">
+<tool id="interactive_tool_jupyter_notebook" tool_type="interactive" name="Interactive JupyterLab Notebook" version="1.0.1" profile="23.0">
     <requirements>
-        <container type="docker">quay.io/bgruening/docker-jupyter-notebook:2021-03-05</container>
+        <container type="docker">quay.io/bgruening/docker-jupyter-notebook:24.07</container>
     </requirements>
+    <required_files>
+        <include path="default_notebook.ipynb"/>
+    </required_files>
     <entry_points>
         <entry_point name="JupyTool interactive tool" label="jupytool" requires_domain="False" requires_path_in_url="True">
             <port>8888</port>

--- a/tools/interactive/interactivetool_jupyter_notebook_1.0.1.xml
+++ b/tools/interactive/interactivetool_jupyter_notebook_1.0.1.xml
@@ -1,6 +1,6 @@
-<tool id="interactive_tool_jupyter_notebook" tool_type="interactive" name="Interactive JupyterLab Notebook" version="1.0.0" profile="22.01">
+<tool id="interactive_tool_jupyter_notebook" tool_type="interactive" name="Interactive JupyterLab Notebook" version="1.0.1" profile="23.0">
     <requirements>
-        <container type="docker">quay.io/bgruening/docker-jupyter-notebook:2021-03-05</container>
+        <container type="docker">quay.io/bgruening/docker-jupyter-notebook:24.07</container>
     </requirements>
     <required_files>
         <include path="default_notebook.ipynb"/>


### PR DESCRIPTION
Note: You need to set `$NB_UID` in your job conf environment (destination) for this tool.

```yaml
docker_run_extra_arguments: "-e NB_UID=$(id -u)"
```

I added `<required_files>` for running via Pulsar but this is otherwise just a version update from `tools/interactive/interactivetool_jupyter_notebook_1.0.0.xml`.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
