### PR TITLE
[24.1] Retry container monitor POST if it fails (don't assume it succeeded)

### DIFF
--- a/lib/galaxy/job_execution/container_monitor.py
+++ b/lib/galaxy/job_execution/container_monitor.py
@@ -75,7 +75,8 @@ def main():
                         if ports[key]["host"] == "0.0.0.0":
                             ports[key]["host"] = host_ip
                 if callback_url:
-                    requests.post(callback_url, json={"container_runtime": ports}, timeout=DEFAULT_SOCKET_TIMEOUT)
+                    r = requests.post(callback_url, json={"container_runtime": ports}, timeout=DEFAULT_SOCKET_TIMEOUT)
+                    r.raise_for_status()
                 else:
                     with open("container_runtime.json", "w") as f:
                         json.dump(ports, f)


### PR DESCRIPTION
I am seeing this initially return 403 sometimes on Test, not sure why since there is nothing logged by the endpoint or to Sentry. I assume it's some kind of timing issue, but the retry fixes it.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
