### PR TITLE
[24.0] Fix wrong final state when init_from is used

### DIFF
--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -245,7 +245,6 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
 
         if init_from:
             self.permission_provider.copy_dataset_permissions(init_from, primary_data)
-            primary_data.state = init_from.state
         else:
             self.permission_provider.set_default_hda_permissions(primary_data)
 


### PR DESCRIPTION
Fixes
https://github.com/galaxyproject/galaxy/pull/18855#issuecomment-2366883313. I don't think this had any effect in the previous version since we'd always set the state to final_job_state anyway.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
