### PR TITLE
Refactor migration testing setup code

### DIFF
--- a/test/unit/data/model/migration_fixes/conftest.py
+++ b/test/unit/data/model/migration_fixes/conftest.py
@@ -1,26 +1,32 @@
-from typing import (
-    Generator,
-    TYPE_CHECKING,
-)
+import tempfile
+from typing import TYPE_CHECKING
 
 import pytest
-from sqlalchemy import (
-    create_engine,
-    text,
-)
+from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
-
-from galaxy import model as m
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Engine
 
-from galaxy.model.unittest_utils.model_testing_utils import (  # noqa: F401 - url_factory is a fixture we have to import explicitly
-    sqlite_url_factory,
+from galaxy.model.unittest_utils.model_testing_utils import (
+    _generate_unique_database_name,
+    _make_sqlite_db_url,
 )
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
+def sqlite_url_factory():
+    """Return a function that generates a sqlite url"""
+
+    def url():
+        database = _generate_unique_database_name()
+        return _make_sqlite_db_url(tmp_dir, database)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        yield url
+
+
+@pytest.fixture(scope="module")
 def db_url(sqlite_url_factory):  # noqa: F811
     return sqlite_url_factory()
 
@@ -33,15 +39,3 @@ def engine(db_url: str) -> "Engine":
 @pytest.fixture
 def session(engine: "Engine") -> Session:
     return Session(engine)
-
-
-@pytest.fixture(autouse=True)
-def clear_database(engine: "Engine") -> "Generator":
-    """Delete all rows from all tables. Called after each test."""
-    yield
-    with engine.begin() as conn:
-        for table in m.mapper_registry.metadata.tables:
-            # Unless db is sqlite, disable foreign key constraints to delete out of order
-            if engine.name != "sqlite":
-                conn.execute(text(f"ALTER TABLE {table} DISABLE TRIGGER ALL"))
-            conn.execute(text(f"DELETE FROM {table}"))


### PR DESCRIPTION
Ref: https://github.com/galaxyproject/galaxy/pull/18493#discussion_r1773807209

As an alternative, move the fixture into the test module: that will prevent accidental usage from other modules in that directory or its subdirectories. The fixture is not available to test functions that are outside the `migration_fixes` directory.

Also:
- Do not explicitly import fixtures (a little duplication is safer/cleaner)
- Ensure only one database is used for all tests in module

Alternatives:
1. Do not set autouse. In this case, the fixture will have to be explicitly passed to every test function. The downside is that it's easy to forget to do that; and when there are many tests, it'll be hard to find that missing argument when left over data is causing some test to fail. 
1. Enable for sqlite only, as per comment. The downside is that we won't be able to test this on postgres, and we should. The current version doesn't have postgres automated (the db_url fixture does not handle it yet), but it's possible to simply override the return value - which I did locally when testing the latest migrations.




## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
