### PR TITLE
Enable extra user preferences for remotely authorized users

### DIFF
--- a/client/src/components/User/UserPreferencesModel.js
+++ b/client/src/components/User/UserPreferencesModel.js
@@ -9,9 +9,10 @@ export const getUserPreferencesModel = (user_id) => {
         information: {
             title: _l("Manage Information"),
             id: "edit-preferences-information",
-            description: config.enable_account_interface && !config.use_remote_user
-                ? _l("Edit your email, addresses and custom parameters or change your public name.")
-                : _l("Edit your custom parameters."),
+            description:
+                config.enable_account_interface && !config.use_remote_user
+                    ? _l("Edit your email, addresses and custom parameters or change your public name.")
+                    : _l("Edit your custom parameters."),
             url: `/api/users/${user_id}/information/inputs`,
             icon: "fa-user",
             redirect: "/user",

--- a/client/src/components/User/UserPreferencesModel.js
+++ b/client/src/components/User/UserPreferencesModel.js
@@ -9,13 +9,12 @@ export const getUserPreferencesModel = (user_id) => {
         information: {
             title: _l("Manage Information"),
             id: "edit-preferences-information",
-            description: config.enable_account_interface
+            description: config.enable_account_interface && !config.use_remote_user
                 ? _l("Edit your email, addresses and custom parameters or change your public name.")
                 : _l("Edit your custom parameters."),
             url: `/api/users/${user_id}/information/inputs`,
             icon: "fa-user",
             redirect: "/user",
-            disabled: config.use_remote_user,
         },
         password: {
             title: _l("Change Password"),

--- a/lib/galaxy/web/framework/middleware/remoteuser.py
+++ b/lib/galaxy/web/framework/middleware/remoteuser.py
@@ -165,6 +165,7 @@ class RemoteUser:
                 "/user/api_key",
                 "/user/edit_username",
                 "/user/dbkeys",
+                "/user/information",
                 "/user/logout",
                 "/user/toolbox_filters",
                 "/user/set_default_permissions",

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -814,6 +814,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
             "username": username,
         }
         is_galaxy_app = trans.webapp.name == "galaxy"
+        
         if (trans.app.config.enable_account_interface and not trans.app.config.use_remote_user) or not is_galaxy_app:
             inputs.append(
                 {

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -814,7 +814,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
             "username": username,
         }
         is_galaxy_app = trans.webapp.name == "galaxy"
-        if trans.app.config.enable_account_interface or not is_galaxy_app:
+        if (trans.app.config.enable_account_interface and not trans.app.config.use_remote_user) or not is_galaxy_app:
             inputs.append(
                 {
                     "id": "email_input",
@@ -826,7 +826,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
                 }
             )
         if is_galaxy_app:
-            if trans.app.config.enable_account_interface:
+            if trans.app.config.enable_account_interface and not trans.app.config.use_remote_user:
                 inputs.append(
                     {
                         "id": "name_input",

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -814,7 +814,6 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
             "username": username,
         }
         is_galaxy_app = trans.webapp.name == "galaxy"
-        
         if (trans.app.config.enable_account_interface and not trans.app.config.use_remote_user) or not is_galaxy_app:
             inputs.append(
                 {


### PR DESCRIPTION
These changes enable editing of extra user preferences (if enabled in Galaxy conf) for users that are authorized remotely (use_remote_user: true). In the current version, when authorized remotely, the extra user preferences interface in the webapp is automatically disabled together with the editing of email address and username. This PR enables the editing of the extra user preferences, while still disabling editing email  and username.

Fixes #18823  

Files changed:
- front-end: UserPreferencesModel.js (to make the 'Manage information' link appear when authorized remotely)
- middleware: remoteuser.py (added the user/information URL to allowed paths)
- API: users.py (to disable email/username when authorized remotely)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Set `use_remote_user: true` in Galaxy conf and implement remote auth (for instance by injecting REMOTE_USER in your request headers)
  2. Enable extra user preferences via `config/user_preferences_extra_conf.yml` and add some preference input for testing.
  3. Restart Galaxy, and test via User > Preferences > Manage information

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
