### PR TITLE
[24.1] Allow cors in biom and q2view display applications

### DIFF
--- a/lib/galaxy/datatypes/display_applications/configs/biom/biom_simple.xml
+++ b/lib/galaxy/datatypes/display_applications/configs/biom/biom_simple.xml
@@ -2,6 +2,6 @@
 <display id="biom_simple" version="1.0.0" name="view biom at">
     <dynamic_links from_data_table="biom_simple_display" skip_startswith="#" id="value" name="name">
         <url>${ url % { 'biom_file_url_qp': $biom_file.qp } }</url>
-        <param type="data" name="biom_file" url="galaxy_${DATASET_HASH}.biom" />
+        <param type="data" name="biom_file" url="galaxy_${DATASET_HASH}.biom" allow_cors="true" />
     </dynamic_links>
 </display>

--- a/lib/galaxy/datatypes/display_applications/configs/qiime/qiime2/q2view.xml
+++ b/lib/galaxy/datatypes/display_applications/configs/qiime/qiime2/q2view.xml
@@ -2,6 +2,6 @@
 <display id="q2view" version="1.0.0" name="view at">
     <dynamic_links from_data_table="q2view_display" skip_startswith="#" id="value" name="name">
         <url>${ url % { 'q2view_file_url_qp': $q2view_file.qp } }</url>
-        <param type="data" name="q2view_file" url="galaxy_${DATASET_HASH}.${dataset.ext}" />
+        <param type="data" name="q2view_file" url="galaxy_${DATASET_HASH}.${dataset.ext}" allow_cors="true"/>
     </dynamic_links>
 </display>


### PR DESCRIPTION
Last step to get the the included display applications to actually work. This should close https://github.com/galaxyproject/galaxy/issues/18799 I think, unless we wanted to make that a built-in visualization.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
