### PR TITLE
Remove some unused dynamic drill down options.

### DIFF
--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -443,18 +443,11 @@ class DynamicOptions(metaclass=ABCMeta):
         """If dynamic options are loaded from an index file, return the name."""
 
 
-DrillDownDynamicFilters = Dict[str, Dict[str, dict]]  # {input key: {metadata_key: metadata values}}
-
-
 class DrillDownDynamicOptions(metaclass=ABCMeta):
 
     @abstractmethod
     def from_code_block(self) -> Optional[str]:
         """Get a code block to do an eval on."""
-
-    @abstractmethod
-    def from_filters(self) -> Optional[DrillDownDynamicFilters]:
-        """Get filters to apply to target datasets."""
 
 
 class InputSource(metaclass=ABCMeta):

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -37,7 +37,6 @@ from galaxy.util import (
 from .interface import (
     AssertionList,
     Citation,
-    DrillDownDynamicFilters,
     DrillDownDynamicOptions,
     DrillDownOptionsDict,
     DynamicOptions,
@@ -1371,50 +1370,13 @@ class XmlInputSource(InputSource):
     def parse_drill_down_dynamic_options(
         self, tool_data_path: Optional[str] = None
     ) -> Optional[DrillDownDynamicOptions]:
-        from_file = self.input_elem.get("from_file", None)
-        if from_file:
-            if not os.path.isabs(from_file):
-                assert tool_data_path, "This tool cannot be parsed outside of a Galaxy context"
-                from_file = os.path.join(tool_data_path, from_file)
-            elem = XML(f"<root>{open(from_file).read()}</root>")
-        else:
-            elem = self.input_elem
-
+        elem = self.input_elem
         dynamic_options_raw = elem.get("dynamic_options", None)
         dynamic_options: Optional[str] = str(dynamic_options_raw) if dynamic_options_raw else None
-        filters: Optional[DrillDownDynamicFilters] = None
-        if elem.find("filter"):
-            _filters: DrillDownDynamicFilters = {}
-            for filter in elem.findall("filter"):
-                # currently only filtering by metadata key matching input file is allowed
-                filter_type = filter.get("type")
-                if filter_type == "data_meta":
-                    data_ref = filter.get("data_ref")
-                    assert data_ref
-                    if data_ref not in _filters:
-                        _filters[data_ref] = {}
-                    meta_key = filter.get("meta_key")
-                    assert meta_key
-                    if meta_key not in _filters[data_ref]:
-                        _filters[data_ref][meta_key] = {}
-                    meta_value = filter.get("value")
-                    if meta_value not in _filters[data_ref][meta_key]:
-                        _filters[data_ref][meta_key][meta_value] = []
-                    assert meta_value
-                    options_elem = filter.find("options")
-                    assert options_elem
-                    _recurse_drill_down_elems(
-                        _filters[data_ref][meta_key][meta_value],
-                        options_elem.findall("option"),
-                    )
-            filters = _filters
-        if filters is None and dynamic_options is None:
+        if dynamic_options is None:
             return None
         else:
-            return XmlDrillDownDynamicOptions(
-                code_block=dynamic_options,
-                filters=filters,
-            )
+            return XmlDrillDownDynamicOptions(code_block=dynamic_options)
 
     def parse_drill_down_static_options(
         self, tool_data_path: Optional[str] = None
@@ -1572,16 +1534,12 @@ def parse_citation_elem(citation_elem: Element) -> Optional[Citation]:
 
 class XmlDrillDownDynamicOptions(DrillDownDynamicOptions):
 
-    def __init__(self, code_block: Optional[str], filters: Optional[DrillDownDynamicFilters]):
+    def __init__(self, code_block: Optional[str]):
         self._code_block = code_block
-        self._filters = filters
 
     def from_code_block(self) -> Optional[str]:
         """Get a code block to do an eval on."""
         return self._code_block
-
-    def from_filters(self) -> Optional[DrillDownDynamicFilters]:
-        return self._filters
 
 
 def _element_to_dict(elem: Element) -> Dict[str, Any]:

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1647,7 +1647,7 @@ class DrillDownSelectToolParameter(SelectToolParameter):
         drill_down_dynamic_options = input_source.parse_drill_down_dynamic_options(tool_data_path)
         if drill_down_dynamic_options is not None:
             self.is_dynamic = True
-            self.dynamic_options = drill_down_dynamic_options.code_block
+            self.dynamic_options = drill_down_dynamic_options.from_code_block()
             self.options = []
         else:
             self.is_dynamic = False

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1814,6 +1814,9 @@ class DrillDownSelectToolParameter(SelectToolParameter):
             return "\n".join(map(str, rval))
         return "Nothing selected."
 
+    def get_dependencies(self):
+        return []
+
     def to_dict(self, trans, other_values=None):
         other_values = other_values or {}
         # skip SelectToolParameter (the immediate parent) bc we need to get options in a different way here

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1648,12 +1648,10 @@ class DrillDownSelectToolParameter(SelectToolParameter):
         if drill_down_dynamic_options is not None:
             self.is_dynamic = True
             self.dynamic_options = drill_down_dynamic_options.code_block
-            self.filtered = drill_down_dynamic_options.filters
             self.options = []
         else:
             self.is_dynamic = False
             self.dynamic_options = None
-            self.filtered = {}
             self.options = input_source.parse_drill_down_static_options(tool_data_path)
 
     def _get_options_from_code(self, trans=None, other_values=None):
@@ -1674,20 +1672,6 @@ class DrillDownSelectToolParameter(SelectToolParameter):
                 options = self._get_options_from_code(trans=trans, other_values=other_values)
             else:
                 options = []
-            for filter_key, filter_value in self.filtered.items():
-                dataset = other_values.get(filter_key)
-                if dataset.__class__.__name__.endswith(
-                    "DatasetFilenameWrapper"
-                ):  # this is a bad way to check for this, but problems importing class (due to circular imports?)
-                    dataset = dataset.dataset
-                if dataset:
-                    for meta_key, meta_dict in filter_value.items():
-                        if hasattr(dataset, "metadata") and hasattr(dataset.metadata, "spec"):
-                            check_meta_val = dataset.metadata.spec[meta_key].param.to_string(
-                                dataset.metadata.get(meta_key)
-                            )
-                            if check_meta_val in meta_dict:
-                                options.extend(meta_dict[check_meta_val])
             return options
         return self.options
 
@@ -1829,12 +1813,6 @@ class DrillDownSelectToolParameter(SelectToolParameter):
         if rval:
             return "\n".join(map(str, rval))
         return "Nothing selected."
-
-    def get_dependencies(self):
-        """
-        Get the *names* of the other params this param depends on.
-        """
-        return list(self.filtered.keys())
 
     def to_dict(self, trans, other_values=None):
         other_values = other_values or {}


### PR DESCRIPTION
No tools in tools-devteam or tools-iuc developed in the last 15 years seem to use these features. This would be really nice complexity to get rid of without any real loss I believe. There is a tool that used to use this feature that is available on usegalaxy.org and usegalaxy.eu but the tool does not work on either server. The tool is @ https://usegalaxy.org/?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Fannotation_profiler%2FAnnotation_Profiler_0%2F1.0.0&version=latest and https://usegalaxy.eu/?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Fannotation_profiler%2FAnnotation_Profiler_0%2F1.0.0&version=latest. The tool only ever had data for hg18 and it does not work on either server.

The usegalaxy.eu error is:

```
Traceback (most recent call last):
  File "/opt/galaxy/shed_tools/toolshed.g2.bx.psu.edu/repos/devteam/annotation_profiler/3b33da018e74/annotation_profiler/annotation_profiler_for_interval.py", line 358, in <module>
    if __name__ == "__main__": __main__()
  File "/opt/galaxy/shed_tools/toolshed.g2.bx.psu.edu/repos/devteam/annotation_profiler/3b33da018e74/annotation_profiler/annotation_profiler_for_interval.py", line 341, in __main__
    assert os.path.isdir( options.path ), IOError( "Configuration error: Table directory is missing (%s)" % options.path )
AssertionError: Configuration error: Table directory is missing (/opt/galaxy/tool-data/annotation_profiler/hg18)
```

The usegalaxy.org error is:

```
Traceback (most recent call last):
  File "/cvmfs/main.galaxyproject.org/migrated_tools/toolshed.g2.bx.psu.edu/repos/devteam/annotation_profiler/3b33da018e74/annotation_profiler/annotation_profiler_for_interval.py", line 358, in <module>
    if __name__ == "__main__": __main__()
  File "/cvmfs/main.galaxyproject.org/migrated_tools/toolshed.g2.bx.psu.edu/repos/devteam/annotation_profiler/3b33da018e74/annotation_profiler/annotation_profiler_for_interval.py", line 341, in __main__
    assert os.path.isdir( options.path ), IOError( "Configuration error: Table directory is missing (%s)" % options.path )
AssertionError: Configuration error: Table directory is missing (/corral4/main/tool_data/annotation_profiler/hg18)
```


## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Try out the broken tools and notice they are broken.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
