### PR TITLE
[24.1] Disable storage dashboard button for anon users

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -57,6 +57,9 @@ const showPreferredObjectStoreModal = ref(false);
 const historyPreferredObjectStoreId = ref(props.history.preferred_object_store_id);
 
 const niceHistorySize = computed(() => prettyBytes(historySize.value));
+const canManageStorage = computed(
+    () => userOwnsHistory(currentUser.value, props.history) && !currentUser.value?.isAnonymous
+);
 
 const storageLocationTitle = computed(() => {
     if (isOnlyPreference.value) {
@@ -137,7 +140,7 @@ onMounted(() => {
             variant="link"
             size="sm"
             class="rounded-0 text-decoration-none history-storage-overview-button"
-            :disabled="!userOwnsHistory(currentUser, props.history)"
+            :disabled="!canManageStorage"
             data-description="storage dashboard button"
             @click="onDashboard">
             <FontAwesomeIcon :icon="faDatabase" />


### PR DESCRIPTION
Should largely avoid
https://sentry.galaxyproject.org/share/issue/79354f243bd44cbf833255e27d6dd8fa/:
```
Error: API authentication required for this request
  at rethrowSimple(webpack://@galaxyproject/galaxy-client/./src/utils/simple-error.ts:24:11)
  at <anonymous>(webpack://@galaxyproject/galaxy-client/./src/api/schema/fetcher.ts:19:9)
  at Generator.throw(<anonymous>)
  at rejected(webpack://@galaxyproject/galaxy-client/./src/api/schema/fetcher.ts:5:64)
```
Note that the stack trace isn't as informative as the url ( https://usegalaxy.org/storage/history/<history_id>) and referrer.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
