### PR TITLE
Allow users with 'can_modify_folder' permission to delete items in libraries

### DIFF
--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -105,7 +105,7 @@ const containsFileOrFolder = computed(() => {
     return props.folderContents.find((el) => el.type === "folder" || el.type === "file");
 });
 const canDelete = computed(() => {
-    return !!(containsFileOrFolder.value && isAdmin.value);
+    return !!(containsFileOrFolder.value && props.metadata.can_modify_folder);
 });
 const datasetManipulation = computed(() => {
     return !!(containsFileOrFolder.value && userStore.currentUser);

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -11,7 +11,6 @@ import {
     BDropdownItem,
     BFormCheckbox,
 } from "bootstrap-vue";
-import { storeToRefs } from "pinia";
 import { computed, reactive, ref } from "vue";
 
 import { GalaxyApi } from "@/api";

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -66,7 +66,6 @@ const emit = defineEmits<{
 const { config, isConfigLoaded } = useConfig();
 
 const userStore = useUserStore();
-const { isAdmin } = storeToRefs(userStore);
 
 const { datatypes } = useDetailedDatatypes();
 

--- a/client/src/components/Libraries/LibraryPermissions/LibraryPermissions.vue
+++ b/client/src/components/Libraries/LibraryPermissions/LibraryPermissions.vue
@@ -31,6 +31,15 @@
             alert="User with  <strong>any</strong> of these roles can modify this library (name, synopsis, etc.)."
             title="Roles that can modify this library"
             @input="setUserPermissionsPreferences" />
+        <PermissionsInputField
+            v-if="manage_library_role_list"
+            :id="library_id"
+            :permission_type="manage_type"
+            :initial_value="manage_library_role_list"
+            :api-root-url="apiRootUrl"
+            alert="User with <strong>any</strong> of these roles can manage this library."
+            title="Roles that can manage this library"
+            @input="setUserPermissionsPreferences" />
         <button title="Save modifications" class="toolbtn_save_permissions" @click="postPermissions">
             <FontAwesomeIcon :icon="['far', 'save']" />
             Save
@@ -71,10 +80,12 @@ export default {
             library: undefined,
             add_library_item_role_list: undefined,
             modify_library_role_list: undefined,
+            manage_library_role_list: undefined,
             access_library_role_list: undefined,
             apiRootUrl: `${getAppRoot()}api/libraries`,
             add_type: "add_library_item_role_list",
             modify_type: "modify_library_role_list",
+            manage_type: "manage_library_role_list",
             access_type: "access_library_role_list",
         };
     },
@@ -85,6 +96,7 @@ export default {
             console.log("fetched_permissions", fetched_permissions);
             this.add_library_item_role_list = extractRoles(fetched_permissions.add_library_item_role_list);
             this.modify_library_role_list = extractRoles(fetched_permissions.modify_library_role_list);
+            this.manage_library_role_list = extractRoles(fetched_permissions.manage_library_role_list);
             this.access_library_role_list = extractRoles(fetched_permissions.access_library_role_list);
         });
         this.services.getLibrary(this.library_id).then((library) => {
@@ -103,6 +115,7 @@ export default {
                 [
                     { "add_ids[]": this.add_library_item_role_list },
                     { "modify_ids[]": this.modify_library_role_list },
+                    { "manage_ids[]": this.manage_library_role_list },
                     { "access_ids[]": this.access_library_role_list },
                 ],
                 (fetched_permissions) => {


### PR DESCRIPTION
This pull request updates the permissions logic in the library folder interface to allow users with the `can_modify_folder = true` permission to delete items within a library folder. Previously, only administrators could delete items from library folders, even if a user had the permission to modify the folder. **This limitation prevented users who manage specific libraries from fully maintaining their content.** 

Specifically, it modifies the canDelete computed property so that any user who can modify a folder can also delete items inside it. In addition, I included the `manage_library_role_list` component in the library permissions interface, which was previously missing. This allows administrators to assign roles/accounts that can manage the library, which is **required** for deletion of items inside a library.

Change permission "manage" to user account via admin interface:
![grafik](https://github.com/user-attachments/assets/52ac9439-a1eb-40fb-8d88-ededfe42a3ae)

Delete button appears in users library:
![grafik](https://github.com/user-attachments/assets/f3aa4ef5-a51c-4a07-9446-b7553abc86be)

Succesful deletion of an item:
![grafik](https://github.com/user-attachments/assets/27b00595-694a-48a7-9ad0-de0811ec7442)

If the user loses the add, modify and manage permission...
![grafik](https://github.com/user-attachments/assets/00663efe-faef-41bc-a70a-046c64658e7d)

...all relevant buttons disappear:
![grafik](https://github.com/user-attachments/assets/09a072c7-9fec-4a44-8a86-bb8e4a12d01c)


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
