### PR TITLE
[24.1] Fix extension not showing in DataDialog for collection elements

### DIFF
--- a/client/src/components/DataDialog/services.js
+++ b/client/src/components/DataDialog/services.js
@@ -48,6 +48,7 @@ export class Services {
     /** Populate record data from raw record source **/
     getRecord(record) {
         const host = `${window.location.protocol}//${window.location.hostname}:${window.location.port}`;
+        record.extension = record.extension ?? record.file_ext;
         record.details = record.extension || record.description;
         record.time = record.update_time || record.create_time;
         record.isLeaf = this.isDataset(record);


### PR DESCRIPTION
Fixes #18693

![FixDataDialogColElemExt](https://github.com/user-attachments/assets/ace39475-b297-4d86-84e9-42c9890b4050)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Have some collections in your history
  2. Open the DataDialog from any tool
  3. Browse one of the collections and check the extension is now displayed for the elements

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
