### PR TITLE
Workflow license and creator edit keyboard access

### DIFF
--- a/client/src/components/License/LicenseSelector.vue
+++ b/client/src/components/License/LicenseSelector.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
+import { watchImmediate } from "@vueuse/core";
 import { BAlert } from "bootstrap-vue";
-import { computed, ref, watch } from "vue";
+import { computed, ref } from "vue";
 import Multiselect from "vue-multiselect";
 
 import { GalaxyApi } from "@/api";
@@ -31,7 +32,7 @@ const emit = defineEmits<{
     (e: "onLicense", license: string | null): void;
 }>();
 
-const licensesLoading = ref(true);
+const licensesLoading = ref(false);
 const errorMessage = ref<string>("");
 const currentLicense = ref<LicenseType>();
 const licenses = ref<LicenseMetadataModel[] | undefined>([]);
@@ -70,7 +71,9 @@ async function fetchLicenses() {
 }
 
 async function setCurrentLicense() {
-    if (!licenses.value?.length) {
+    if (!licenses.value?.length && !licensesLoading.value) {
+        licensesLoading.value = true;
+
         await fetchLicenses();
     }
 
@@ -79,14 +82,12 @@ async function setCurrentLicense() {
     currentLicense.value = (licenses.value || []).find((l) => l.licenseId == inputLicense) || defaultLicense;
 }
 
-watch(
+watchImmediate(
     () => props.inputLicense,
     () => {
         setCurrentLicense();
     }
 );
-
-setCurrentLicense();
 </script>
 
 <template>

--- a/client/src/components/License/LicenseSelector.vue
+++ b/client/src/components/License/LicenseSelector.vue
@@ -1,17 +1,25 @@
 <script setup lang="ts">
-import { faEdit, faSave, faTimes } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BButton, BFormSelect } from "bootstrap-vue";
+import { BAlert } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
+import Multiselect from "vue-multiselect";
 
 import { GalaxyApi } from "@/api";
 import { type components } from "@/api/schema";
 import { errorMessageAsString } from "@/utils/simple-error";
 
-import License from "./License.vue";
+import License from "@/components/License/License.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
+const defaultLicense: LicenseType = {
+    licenseId: null,
+    name: "*Do not specify a license.*",
+};
+
 type LicenseMetadataModel = components["schemas"]["LicenseMetadataModel"];
+type LicenseType = {
+    licenseId: string | null;
+    name: string;
+};
 
 interface Props {
     inputLicense: string;
@@ -20,37 +28,24 @@ interface Props {
 const props = defineProps<Props>();
 
 const emit = defineEmits<{
-    (e: "onLicense", license: string): void;
+    (e: "onLicense", license: string | null): void;
 }>();
 
-const editLicense = ref(false);
 const licensesLoading = ref(true);
 const errorMessage = ref<string>("");
-const currentLicense = ref<string>(props.inputLicense);
+const currentLicense = ref<LicenseType>();
 const licenses = ref<LicenseMetadataModel[] | undefined>([]);
 
-const currentLicenseInfo = computed(() => {
-    for (const l of licenses.value || []) {
-        if (l.licenseId == currentLicense.value) {
-            return l;
-        }
-    }
-
-    return null;
-});
 const licenseOptions = computed(() => {
-    const options = [];
+    const options: LicenseType[] = [];
 
-    options.push({
-        value: null,
-        text: "*Do not specify a license.*",
-    });
+    options.push(defaultLicense);
 
-    for (const l of licenses.value || []) {
-        if (l.licenseId == currentLicense.value || l.recommended) {
+    for (const license of licenses.value || []) {
+        if (license.licenseId == currentLicense.value?.licenseId || license.recommended) {
             options.push({
-                value: l.licenseId,
-                text: l.name,
+                licenseId: license.licenseId,
+                name: license.name,
             });
         }
     }
@@ -58,18 +53,8 @@ const licenseOptions = computed(() => {
     return options;
 });
 
-function onSave() {
-    onLicense(currentLicense.value);
-    disableEdit();
-}
-
-function disableEdit() {
-    editLicense.value = false;
-    errorMessage.value = "";
-}
-
-function onLicense(l: string) {
-    emit("onLicense", l);
+function onLicense(license: LicenseType) {
+    emit("onLicense", license.licenseId);
 }
 
 async function fetchLicenses() {
@@ -84,78 +69,43 @@ async function fetchLicenses() {
     licensesLoading.value = false;
 }
 
+async function setCurrentLicense() {
+    if (!licenses.value?.length) {
+        await fetchLicenses();
+    }
+
+    const inputLicense = props.inputLicense;
+
+    currentLicense.value = (licenses.value || []).find((l) => l.licenseId == inputLicense) || defaultLicense;
+}
+
 watch(
     () => props.inputLicense,
-    (newLicense) => {
-        currentLicense.value = newLicense;
+    () => {
+        setCurrentLicense();
     }
 );
 
-fetchLicenses();
+setCurrentLicense();
 </script>
 
 <template>
-    <div v-if="editLicense" class="license-selector">
-        <LoadingSpan v-if="licensesLoading" message="Loading licenses" />
+    <div>
+        <BAlert v-if="licensesLoading" variant="info" class="m-0" show>
+            <LoadingSpan message="Loading licenses" />
+        </BAlert>
         <BAlert v-else-if="errorMessage" variant="danger" class="m-0" show>
             {{ errorMessage }}
         </BAlert>
-        <BFormSelect v-else v-model="currentLicense" data-description="license select" :options="licenseOptions" />
-
-        <License v-if="currentLicenseInfo" :license-id="currentLicense" :input-license-info="currentLicenseInfo">
-            <template v-slot:buttons>
-                <BButton v-b-tooltip.hover variant="outline-danger" title="Cancel Edit" @click="disableEdit">
-                    <FontAwesomeIcon :icon="faTimes" data-description="license cancel" />
-                    Cancel
-                </BButton>
-                <BButton v-b-tooltip.hover variant="primary" title="Save License" @click="onSave">
-                    <FontAwesomeIcon :icon="faSave" data-description="license save" />
-                    Save License
-                </BButton>
-            </template>
-        </License>
-        <div v-else>
-            <BButton variant="outline-danger" @click="editLicense = false">
-                <FontAwesomeIcon :icon="faTimes" data-description="license cancel" />
-                Cancel
-            </BButton>
-            <BButton variant="primary" @click="onSave">
-                <FontAwesomeIcon :icon="faSave" data-description="license save" />
-                Save without license
-            </BButton>
-        </div>
-    </div>
-    <div
-        v-else-if="currentLicense"
-        data-description="license selector"
-        :data-license="currentLicense"
-        class="license-selector-edit">
-        <License :license-id="currentLicense">
-            <template v-slot:inline-buttons>
-                <BButton
-                    v-b-tooltip.hover
-                    class="inline-icon-button"
-                    variant="link"
-                    size="sm"
-                    title="Edit License"
-                    @click="editLicense = true">
-                    <FontAwesomeIcon :icon="faEdit" data-description="edit license link" fixed-width />
-                </BButton>
-            </template>
-        </License>
-    </div>
-    <div v-else data-description="license selector" data-license="null">
-        <i>
-            <a href="#" data-description="edit license link" @click.prevent="editLicense = true">
-                Specify a license for this workflow.
-            </a>
-        </i>
+        <Multiselect
+            v-else
+            v-model="currentLicense"
+            data-description="license select"
+            track-by="licenseId"
+            :options="licenseOptions"
+            label="name"
+            placeholder="Select a license"
+            @select="onLicense" />
+        <License v-if="currentLicense?.licenseId" :license-id="currentLicense.licenseId" />
     </div>
 </template>
-
-<style scoped lang="scss">
-.license-selector {
-    display: grid;
-    gap: 0.5em;
-}
-</style>

--- a/client/src/components/License/LicenseSelector.vue
+++ b/client/src/components/License/LicenseSelector.vue
@@ -2,7 +2,7 @@
 import { faEdit, faSave, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BButton, BFormSelect } from "bootstrap-vue";
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 
 import { GalaxyApi } from "@/api";
 import { type components } from "@/api/schema";
@@ -24,7 +24,7 @@ const emit = defineEmits<{
 }>();
 
 const editLicense = ref(false);
-const licensesLoading = ref(false);
+const licensesLoading = ref(true);
 const errorMessage = ref<string>("");
 const currentLicense = ref<string>(props.inputLicense);
 const licenses = ref<LicenseMetadataModel[] | undefined>([]);
@@ -72,16 +72,7 @@ function onLicense(l: string) {
     emit("onLicense", l);
 }
 
-watch(
-    () => props.inputLicense,
-    (newLicense) => {
-        currentLicense.value = newLicense;
-    }
-);
-
-onMounted(async () => {
-    licensesLoading.value = true;
-
+async function fetchLicenses() {
     const { error, data } = await GalaxyApi().GET("/api/licenses");
 
     if (error) {
@@ -91,7 +82,16 @@ onMounted(async () => {
     licenses.value = data;
 
     licensesLoading.value = false;
-});
+}
+
+watch(
+    () => props.inputLicense,
+    (newLicense) => {
+        currentLicense.value = newLicense;
+    }
+);
+
+fetchLicenses();
 </script>
 
 <template>

--- a/client/src/components/SchemaOrg/CreatorEditor.vue
+++ b/client/src/components/SchemaOrg/CreatorEditor.vue
@@ -10,12 +10,24 @@
             <div v-for="(creator, index) in creatorsCurrent" :key="index">
                 <CreatorViewer :creator="creator">
                     <template v-slot:buttons>
-                        <span v-b-tooltip.hover title="Edit Creator"
-                            ><FontAwesomeIcon icon="edit" @click="onEdit(index)"
-                        /></span>
-                        <span v-b-tooltip.hover title="Remove Creator">
-                            <FontAwesomeIcon icon="times" @click="onRemove(index)" />
-                        </span>
+                        <BButton
+                            v-b-tooltip.hover
+                            class="inline-icon-button"
+                            variant="link"
+                            size="sm"
+                            title="Edit Creator"
+                            @click="onEdit(index)">
+                            <FontAwesomeIcon icon="edit" />
+                        </BButton>
+                        <BButton
+                            v-b-tooltip.hover
+                            class="inline-icon-button"
+                            variant="link"
+                            size="sm"
+                            title="Remove Creator"
+                            @click="onRemove(index)">
+                            <FontAwesomeIcon icon="times" />
+                        </BButton>
                     </template>
                 </CreatorViewer>
             </div>

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -747,15 +747,10 @@ workflow_editor:
     canvas_body: '#workflow-canvas'
     edit_annotation: '#workflow-annotation'
     edit_name: '#workflow-name'
-    license_selector:
-      selector: 'license selector'
-      type: data-description
-    edit_license_link:
-      selector: 'edit license link'
-      type: data-description
-    license_select:
-      selector: 'license select'
-      type: data-description
+    license_selector: '[data-description="license select"]'
+    license_current_value: '[data-description="license select"] .multiselect__single'
+    license_selector_input: '[data-description="license select"] input.multiselect__input'
+    license_selector_option: '[data-description="license select"] .multiselect__element'
     license_save:
       selector: 'license save'
       type: data-description

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1204,11 +1204,12 @@ class NavigatesGalaxy(HasDriver):
         text_area_elem.send_keys(json)
 
     def workflow_editor_set_license(self, license: str) -> None:
-        editor = self.components.workflow_editor
-        editor.edit_license_link.wait_for_and_click()
-        select = editor.license_select.wait_for_select()
-        select.select_by_value(license)
-        editor.license_save.wait_for_and_click()
+        license_selector = self.components.workflow_editor.license_selector
+        license_selector.wait_for_and_click()
+        license_selector.wait_for_and_send_keys(license)
+
+        license_selector_option = self.components.workflow_editor.license_selector_option
+        license_selector_option.wait_for_and_click()
 
     def workflow_editor_click_option(self, option_label):
         self.workflow_editor_click_options()

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -100,15 +100,14 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows):
         name = self.workflow_create_new()
         editor.canvas_body.wait_for_visible()
         editor.license_selector.wait_for_visible()
-        editor.license_selector.assert_no_axe_violations_with_impact_of_at_least("serious")
-        editor.license_selector.assert_data_value("license", "null")
+        assert "Do not specify" in editor.license_current_value.wait_for_text()
 
         self.workflow_editor_set_license("MIT")
         self.workflow_editor_click_save()
 
         self.workflow_index_open_with_name(name)
         editor.license_selector.wait_for_visible()
-        editor.license_selector.assert_data_value("license", "MIT")
+        assert "MIT" in editor.license_current_value.wait_for_text()
 
     @selenium_test
     def test_optional_select_data_field(self):


### PR DESCRIPTION
Closes #18915. This PR improves the `LicenseSelector` and `CreatorEditor` ui and makes them keyboard accessible. It migrates `LicenseSelector` to composition API and typescript, uses GalaxyAPI to fetch license options, and uses the `MultiSelect` component, simplifying the license handling steps.

https://github.com/user-attachments/assets/6efa07a2-ae2d-4056-b640-2deac21b968e

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. In the workflow editor, access and edit license and creator via keyboard

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
