### PR TITLE
Add conda hash to mulled-hash utility

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/mulled_hash.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_hash.py
@@ -33,7 +33,7 @@ def main(argv=None):
     parser.add_argument(
         "targets", metavar="TARGETS", default=None, help="Comma-separated packages for calculating the mulled hash."
     )
-    parser.add_argument("--hash", dest="hash", choices=["conda", "v1", "v2"], default="v2")
+    parser.add_argument("--hash", dest="hash", choices=IMAGE_FUNCS.keys(), default="v2")
     args = parser.parse_args()
     targets = target_str_to_targets(args.targets)
     image_name = IMAGE_FUNCS[args.hash]

--- a/lib/galaxy/tool_util/deps/mulled/mulled_hash.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_hash.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 """Produce a mulled hash for specified conda targets.
 
+Galaxy does not use the "v1" hash format for uncontainerized conda dependencies. For the mulled hash for conda
+dependencies, use `--hash conda`
+
 Examples
 
 Produce a mulled hash with:
@@ -9,11 +12,19 @@ Produce a mulled hash with:
 """
 
 from ._cli import arg_parser
+from ..conda_util import hash_conda_packages
 from .mulled_build import target_str_to_targets
 from .util import (
     v1_image_name,
     v2_image_name,
 )
+
+
+IMAGE_FUNCS = {
+    "conda": lambda x: f"mulled-v1-{hash_conda_packages(x)}",
+    "v1": v1_image_name,
+    "v2": v2_image_name,
+}
 
 
 def main(argv=None):
@@ -22,10 +33,10 @@ def main(argv=None):
     parser.add_argument(
         "targets", metavar="TARGETS", default=None, help="Comma-separated packages for calculating the mulled hash."
     )
-    parser.add_argument("--hash", dest="hash", choices=["v1", "v2"], default="v2")
+    parser.add_argument("--hash", dest="hash", choices=["conda", "v1", "v2"], default="v2")
     args = parser.parse_args()
     targets = target_str_to_targets(args.targets)
-    image_name = v2_image_name if args.hash == "v2" else v1_image_name
+    image_name = IMAGE_FUNCS[args.hash]
     print(image_name(targets))
 
 


### PR DESCRIPTION
Despite the overlap in `mulled-v1-` naming, the `v1_image_name` in mulled.util is not actually used for conda v1 mulled hashes. Perhaps it should, since as far as I know, we never used the container mulled v1 hash for anything, but that's another issue.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. ```console
      $ mulled-hash --hash conda bedtools=2.30.0,samtools=1.9
      mulled-v1-ca195b12c14e35565e393a2d07f2deac7610d8126cc3460d217504efd11d4347
      ```

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
