### PR TITLE
[24.1] Ctrl/Cmd-click on `SwitchHistoryLink` opens in new tab

### DIFF
--- a/client/src/components/History/SwitchToHistoryLink.vue
+++ b/client/src/components/History/SwitchToHistoryLink.vue
@@ -8,6 +8,7 @@ import { useRouter } from "vue-router/composables";
 
 import { type HistorySummary, userOwnsHistory } from "@/api";
 import { Toast } from "@/composables/toast";
+import { useEventStore } from "@/stores/eventStore";
 import { useHistoryStore } from "@/stores/historyStore";
 import { useUserStore } from "@/stores/userStore";
 import { errorMessageAsString } from "@/utils/simple-error";
@@ -47,8 +48,10 @@ const actionText = computed(() => {
     return "View in new tab";
 });
 
-async function onClick(history: HistorySummary) {
-    if (canSwitch.value) {
+async function onClick(event: MouseEvent, history: HistorySummary) {
+    const eventStore = useEventStore();
+    const ctrlKey = eventStore.isMac ? event.metaKey : event.ctrlKey;
+    if (!ctrlKey && canSwitch.value) {
         if (props.filters) {
             historyStore.applyFilters(history.id, props.filters);
         } else {
@@ -78,7 +81,7 @@ function viewHistoryInNewTab(history: HistorySummary) {
                 class="truncate"
                 href="#"
                 :title="`<b>${actionText}</b><br>${history.name}`"
-                @click.stop="onClick(history)">
+                @click.stop="onClick($event, history)">
                 {{ history.name }}
             </BLink>
 


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/18897

### Note: We can target dev instead if we want?

https://github.com/user-attachments/assets/8b22bfb4-5ed1-40d7-955a-4928ccde894e

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. There are multiple places to find the `SwitchToHistoryLink` component. For e.g.: Go to an invocation (open any invocation from the panel)
  2. On the top left, where it says the history name, click on it, and see that it changes your current history (if that history can be switched to)
  3. Try again, but this time Ctrl (if on Windows) or Cmd (if on Mac) + Click on the history name to see the history open in a new tab.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
