### PR TITLE
Fix backend role sharing bug

### DIFF
--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -1017,13 +1017,17 @@ WHERE history.user_id != :user_id and history_dataset_association.dataset_id = :
                     sharing_role = role
                     break
         if sharing_role is None:
-            sharing_role = Role(name=f"Sharing role for: {', '.join(u.email for u in users)}", type=Role.types.SHARING)
-            self.sa_session.add(sharing_role)
-            with transaction(self.sa_session):
-                self.sa_session.commit()
-            for user in users:
-                self.associate_user_role(user, sharing_role)
+            sharing_role = self._create_sharing_role(users)
         self.set_dataset_permission(dataset, {self.permitted_actions.DATASET_ACCESS: [sharing_role]})
+
+    def _create_sharing_role(self, users):
+        sharing_role = Role(name=f"Sharing role for: {', '.join(u.email for u in users)}", type=Role.types.SHARING)
+        self.sa_session.add(sharing_role)
+        with transaction(self.sa_session):
+            self.sa_session.commit()
+        for user in users:
+            self.associate_user_role(user, sharing_role)
+        return sharing_role
 
     def set_all_library_permissions(self, trans, library_item, permissions=None):
         # Set new permissions on library_item, eliminating all current permissions

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -792,10 +792,13 @@ WHERE history.user_id != :user_id and history_dataset_association.dataset_id = :
         return role, num_in_groups
 
     def get_sharing_roles(self, user):
-        stmt = select(Role).where(
-            and_((Role.name).like(f"Sharing role for: %{user.email}%"), Role.type == Role.types.SHARING)
+        stmt = (
+            select(Role)
+            .join(Role.users)
+            .where(UserRoleAssociation.user_id == user.id)
+            .where(Role.type == Role.types.SHARING)
         )
-        return self.sa_session.scalars(stmt)
+        return self.sa_session.scalars(stmt).all()
 
     def user_set_default_permissions(
         self,

--- a/test/unit/data/model/db/test_security.py
+++ b/test/unit/data/model/db/test_security.py
@@ -76,6 +76,33 @@ def test_cannot_assign_private_roles(session, make_user_and_role, make_role):
     verify_user_associations(user, [], [private_role1, new_role])
 
 
+def test_get_sharing_roles(session, make_user):
+    security_agent = GalaxyRBACAgent(session)
+    user1 = make_user()
+    user2 = make_user()
+
+    # verify: no sharing roles yet
+    roles1 = security_agent.get_sharing_roles(user1)
+    assert len(roles1) == 0
+    roles2 = security_agent.get_sharing_roles(user2)
+    assert len(roles2) == 0
+
+    # create sharing role for both users, verify
+    sharing_role = security_agent._create_sharing_role([user1, user2])
+    roles1 = security_agent.get_sharing_roles(user1)
+    assert len(roles1) == 1
+    roles2 = security_agent.get_sharing_roles(user2)
+    assert len(roles2) == 1
+
+    # update user's email, retrieve sharing roles for that user again, verify
+    user1.email = f"{user1.email}-updated"
+    roles3 = security_agent.get_sharing_roles(user1)
+    assert len(roles3) == 1
+
+    # verify we've been retrieving the correct role
+    assert roles1[0] is roles2[0] is roles3[0] is sharing_role
+
+
 class TestSetGroupUserAndRoleAssociations:
 
     def test_add_associations_to_existing_group(self, session, make_user_and_role, make_role, make_group):


### PR DESCRIPTION
This is part of decoupling role names from user email addresses. 

Bug: after a user's email is modified, sharing roles cannot be retrieved for that user:

- role is initially created with `name=f"Sharing role for: {', '.join(u.email for u in users)}"`
- ...and retrieved based on `(Role.name).like(f"Sharing role for: %{user.email}%")`

The solution here is to retrieve based on the association defined via the `UserRoleAssociation` model.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run the new unit test without the commit with the fix
  2. Apply commit with the fix and rerun the test.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
