### PR TITLE
[24.1] Don't use ``async def`` where not appropriate

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/pages.py
+++ b/lib/galaxy/webapps/galaxy/api/pages.py
@@ -103,7 +103,7 @@ class FastAPIPages:
         summary="Lists all Pages viewable by the user.",
         response_description="A list with summary page information.",
     )
-    async def index(
+    def index(
         self,
         response: Response,
         trans: ProvidesUserContext = DependsOnTrans,
@@ -153,7 +153,7 @@ class FastAPIPages:
         summary="Marks the specific Page as deleted.",
         status_code=status.HTTP_204_NO_CONTENT,
     )
-    async def delete(
+    def delete(
         self,
         id: PageIdPathParam,
         trans: ProvidesUserContext = DependsOnTrans,
@@ -167,7 +167,7 @@ class FastAPIPages:
         summary="Undelete the specific Page.",
         status_code=status.HTTP_204_NO_CONTENT,
     )
-    async def undelete(
+    def undelete(
         self,
         id: PageIdPathParam,
         trans: ProvidesUserContext = DependsOnTrans,
@@ -188,7 +188,7 @@ class FastAPIPages:
             501: {"description": "PDF conversion service not available."},
         },
     )
-    async def show_pdf(
+    def show_pdf(
         self,
         id: PageIdPathParam,
         trans: ProvidesUserContext = DependsOnTrans,
@@ -210,7 +210,7 @@ class FastAPIPages:
             501: {"description": "PDF conversion service not available."},
         },
     )
-    async def prepare_pdf(
+    def prepare_pdf(
         self,
         id: PageIdPathParam,
         trans: ProvidesUserContext = DependsOnTrans,
@@ -226,7 +226,7 @@ class FastAPIPages:
         summary="Return a page summary and the content of the last revision.",
         response_description="The page summary information.",
     )
-    async def show(
+    def show(
         self,
         id: PageIdPathParam,
         trans: ProvidesUserContext = DependsOnTrans,

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -128,7 +128,7 @@ class FastAPIRemoteFiles:
         deprecated=True,
         summary="Displays remote files available to the user. Please use /api/remote_files instead.",
     )
-    async def index(
+    def index(
         self,
         response: Response,
         user_ctx: ProvidesUserContext = DependsOnTrans,
@@ -157,7 +157,7 @@ class FastAPIRemoteFiles:
         summary="Display plugin information for each of the gxfiles:// URI targets available.",
         response_description="A list with details about each plugin.",
     )
-    async def plugins(
+    def plugins(
         self,
         user_ctx: ProvidesUserContext = DependsOnTrans,
         browsable_only: Annotated[Optional[bool], BrowsableQueryParam] = True,
@@ -176,7 +176,7 @@ class FastAPIRemoteFiles:
         "/api/remote_files",
         summary="Creates a new entry (directory/record) on the remote files source.",
     )
-    async def create_entry(
+    def create_entry(
         self,
         user_ctx: ProvidesUserContext = DependsOnTrans,
         payload: CreateEntryPayload = Body(

--- a/lib/galaxy/webapps/galaxy/api/tool_data.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_data.py
@@ -67,7 +67,7 @@ class FastAPIToolData:
         summary="Import a data manager bundle",
         require_admin=True,
     )
-    async def create(
+    def create(
         self, tool_data_file_path: Optional[str] = None, import_bundle_model: ImportToolDataBundle = Body(...)
     ) -> AsyncTaskResultSummary:
         source = import_bundle_model.source
@@ -91,7 +91,7 @@ class FastAPIToolData:
         response_description="A description of the reloaded data table and its content",
         require_admin=True,
     )
-    async def reload(self, table_name: str = ToolDataTableName) -> ToolDataDetails:
+    def reload(self, table_name: str = ToolDataTableName) -> ToolDataDetails:
         """Reloads a data table and return its details."""
         return self.tool_data_manager.reload(table_name)
 
@@ -116,7 +116,7 @@ class FastAPIToolData:
         response_class=GalaxyFileResponse,
         require_admin=True,
     )
-    async def download_field_file(
+    def download_field_file(
         self,
         table_name: str = ToolDataTableName,
         field_name: str = ToolDataTableFieldName,
@@ -136,7 +136,7 @@ class FastAPIToolData:
         response_description="A description of the affected data table and its content",
         require_admin=True,
     )
-    async def delete(
+    def delete(
         self,
         payload: ToolDataItem,
         table_name: str = ToolDataTableName,

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -78,7 +78,7 @@ class FetchTools:
     service: ToolsService = depends(ToolsService)
 
     @router.post("/api/tools/fetch", summary="Upload files to Galaxy", route_class_override=JsonApiRoute)
-    async def fetch_json(self, payload: FetchDataPayload = Body(...), trans: ProvidesHistoryContext = DependsOnTrans):
+    def fetch_json(self, payload: FetchDataPayload = Body(...), trans: ProvidesHistoryContext = DependsOnTrans):
         return self.service.create_fetch(trans, payload)
 
     @router.post(
@@ -86,7 +86,7 @@ class FetchTools:
         summary="Upload files to Galaxy",
         route_class_override=FormDataApiRoute,
     )
-    async def fetch_form(
+    def fetch_form(
         self,
         request: Request,
         payload: FetchDataFormPayload = Depends(FetchDataForm.as_form),

--- a/lib/galaxy/webapps/galaxy/api/visualizations.py
+++ b/lib/galaxy/webapps/galaxy/api/visualizations.py
@@ -120,7 +120,7 @@ class FastAPIVisualizations:
         "/api/visualizations",
         summary="Returns visualizations for the current user.",
     )
-    async def index(
+    def index(
         self,
         response: Response,
         trans: ProvidesUserContext = DependsOnTrans,


### PR DESCRIPTION
Anywhere we interact with the database or the file system or we make outgoing calls using functions that are not awaitable  we shouldn't use `async def`. So basically very, very few API routes that just return in-memory data can use `async def`.

If in doubt, use a normal sync definition. async dependencies with sync routes are ok (see https://github.com/galaxyproject/galaxy/pull/18944/commits/7b54d6430f041a26a4df62ac2dea3083a6afe95c as an example for how to make it work if you do have something that needs to be awaited but you're also making blocking calls), FastAPI will run the async dependencies in the main async loop and dispatch any sync dependency to a threadpool. However async routes will run straight on the event loop, and I/O will block the event loop. If the event loop is blocked all other requests will stall, and on top of that the gunicorn liveness probe [will likely time out](https://github.com/benoitc/gunicorn/issues/1493#issuecomment-321331753), resulting in https://sentry.galaxyproject.org/share/issue/a04cd4cea5fb45dc9594fc7d1215b1c0/, which will eventually kill the worker and all requests currently in flight.

Of course other things can make the request arbiter decide to stop the worker, but what I've done here should be correct. All of these routes either query the database (directly or through lazy loading attributes) or touch files on the file system.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
