### PR TITLE
Assert that `data_column` parameters have a valid `data_ref`

### DIFF
--- a/lib/galaxy/tool_shed/tools/tool_validator.py
+++ b/lib/galaxy/tool_shed/tools/tool_validator.py
@@ -97,7 +97,7 @@ class ToolValidator:
             tool = None
             valid = False
             error_message = (
-                f'This file requires an entry for "{str(e)}" in the tool_data_table_conf.xml file.  Upload a file '
+                f'This file requires an entry for "{str(e)}" in the tool_data_table_conf.xml file. Upload a file '
             )
             error_message += (
                 "named tool_data_table_conf.xml.sample to the repository that includes the required entry to correct "

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -68,6 +68,10 @@ List of behavior changes associated with profile versions:
 - Do not use Galaxy python environment for `data_source_async` tools.
 - Drop request parameters received by data source tools that are not declared in `<request_param_translation>` section.
 
+### 24.2
+
+- require a valid `data_ref` attribute for `data_column` parameters
+
 ### Examples
 
 A normal tool:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1665,7 +1665,9 @@ class Tool(UsesDictVisibleKeys):
         # form when it changes
         for name in param.get_dependencies():
             # Let it throw exception, but give some hint what the problem might be
-            assert name in context, f"Tool with id '{self.id}': Could not find dependency '{name}' of parameter '{param.name}'"
+            assert (
+                name in context
+            ), f"Tool with id '{self.id}': Could not find dependency '{name}' of parameter '{param.name}'"
             context[name].refresh_on_change = True
         return param
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1665,8 +1665,7 @@ class Tool(UsesDictVisibleKeys):
         # form when it changes
         for name in param.get_dependencies():
             # Let it throw exception, but give some hint what the problem might be
-            if name not in context:
-                log.error(f"Tool with id '{self.id}': Could not find dependency '{name}' of parameter '{param.name}'")
+            assert name in context, f"Tool with id '{self.id}': Could not find dependency '{name}' of parameter '{param.name}'"
             context[name].refresh_on_change = True
         return param
 

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1403,7 +1403,7 @@ class ColumnListParameter(SelectToolParameter):
         if self.accept_default:
             self.optional = True
         self.data_ref = input_source.get("data_ref", None)
-        assert self.data_ref is not None, f'data_column parameter {self.name} requires a valid data_ref attribute'
+        assert self.data_ref is not None, f"data_column parameter {self.name} requires a valid data_ref attribute"
         self.ref_input = None
         # Legacy style default value specification...
         self.default_value = input_source.get("default_value", None)

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1403,6 +1403,7 @@ class ColumnListParameter(SelectToolParameter):
         if self.accept_default:
             self.optional = True
         self.data_ref = input_source.get("data_ref", None)
+        assert self.data_ref is not None, f'data_column parameter {self.name} requires a valid data_ref attribute'
         self.ref_input = None
         # Legacy style default value specification...
         self.default_value = input_source.get("default_value", None)

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1403,7 +1403,10 @@ class ColumnListParameter(SelectToolParameter):
         if self.accept_default:
             self.optional = True
         self.data_ref = input_source.get("data_ref", None)
-        assert self.data_ref is not None, f"data_column parameter {self.name} requires a valid data_ref attribute"
+        profile = tool.profile if tool else None
+        assert (
+            profile is None or Version(str(profile)) < Version("24.2") or self.data_ref is not None
+        ), f"data_column parameter {self.name} requires a valid data_ref attribute"
         self.ref_input = None
         # Legacy style default value specification...
         self.default_value = input_source.get("default_value", None)

--- a/lib/tool_shed/test/test_data/repos/missing_data_ref/missing_data_ref.xml
+++ b/lib/tool_shed/test/test_data/repos/missing_data_ref/missing_data_ref.xml
@@ -1,0 +1,19 @@
+<tool id="missing_data_ref" name="missing_data_ref" version="1.0" profile="23.0">
+    <requirements>
+    </requirements>
+    <command detect_errors="aggressive">
+        <![CDATA[
+        echo $column
+        ]]>
+    </command>
+    <inputs>
+        <param name="input" type="data" format="tabular"/>
+        <param name="column" type="data_column" />
+    </inputs>
+    <outputs>
+        <data name="output" format="text"/>
+    </outputs>
+    <tests>
+    </tests>
+    <help/>
+</tool>

--- a/lib/tool_shed/test/test_data/repos/wrong_data_ref/wrong_data_ref.xml
+++ b/lib/tool_shed/test/test_data/repos/wrong_data_ref/wrong_data_ref.xml
@@ -1,0 +1,19 @@
+<tool id="wrong_data_ref" name="wrong_data_ref" version="1.0" profile="23.0">
+    <requirements>
+    </requirements>
+    <command detect_errors="aggressive">
+        <![CDATA[
+        echo $column
+        ]]>
+    </command>
+    <inputs>
+        <param name="input" type="data" format="tabular"/>
+        <param name="column" type="data_column" data_ref="nonsense" />
+    </inputs>
+    <outputs>
+        <data name="output" format="text"/>
+    </outputs>
+    <tests>
+    </tests>
+    <help/>
+</tool>

--- a/test/unit/tool_shed/test_tool_validation.py
+++ b/test/unit/tool_shed/test_tool_validation.py
@@ -11,6 +11,8 @@ BISMARK_DIR = os.path.join(galaxy_directory(), "lib/tool_shed/test/test_data/rep
 BOWTIE2_INDICES = os.path.join(
     galaxy_directory(), "lib/tool_shed/test/test_data/bowtie2_loc_sample/bowtie2_indices.loc.sample"
 )
+MISSING_DATA_REF_DIR = os.path.join(galaxy_directory(), "lib/tool_shed/test/test_data/repos/missing_data_ref")
+WRONG_DATA_REF_DIR = os.path.join(galaxy_directory(), "lib/tool_shed/test/test_data/repos/wrong_data_ref")
 
 
 def test_validate_valid_tool():
@@ -62,6 +64,22 @@ def test_validate_tool_without_index():
         assert len(invalid_files_and_errors_tups) == 0
         assert not tool.params_with_missing_data_table_entry
         assert not tool.params_with_missing_index_file
+
+
+def test_validate_missing_data_ref():
+    repo_dir = MISSING_DATA_REF_DIR
+    with get_tool_validator() as tv:
+        full_path = os.path.join(repo_dir, "missing_data_ref.xml")
+        tool, valid, message = tv.load_tool_from_config(repository_id=None, full_path=full_path)
+        assert valid is False
+
+
+def test_validate_wrong_data_ref():
+    repo_dir = WRONG_DATA_REF_DIR
+    with get_tool_validator() as tv:
+        full_path = os.path.join(repo_dir, "wrong_data_ref.xml")
+        tool, valid, message = tv.load_tool_from_config(repository_id=None, full_path=full_path)
+        assert valid is False
 
 
 @contextmanager


### PR DESCRIPTION
- `data_ref` needs to be specified in the XML
- `data_ref` needs to refer to an existing parameter

Fixes https://github.com/galaxyproject/galaxy/issues/18359 (i.e. the misleading error message, since now the `KeyError` caused by missing/wrong `data_ref` are replaced by `AssertionErrors` which will be reported properly, but still as tool loading error)

Questions:

- Do we need a profile version for this?
- I could add linter rule(s) for this,  but I guess this should be done in a larger project analogous to [this](https://github.com/galaxyproject/galaxy/pull/18787), which should cover all allowed/required attribute combinations for `<param>`?


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
