### PR TITLE
Install npm-package viz to the package prefix explicitly.

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -237,7 +237,7 @@ async function installDependenciesFromXML(xmlPath, pluginDir) {
                 try {
                     const installResult = child_process.spawnSync(
                         "npm",
-                        ["install", "--silent", "--no-save", `${pkgName}@${version}`],
+                        ["install", "--silent", "--no-save", "--prefix .", `${pkgName}@${version}`],
                         {
                             cwd: pluginDir,
                             stdio: "inherit",


### PR DESCRIPTION
Simply makes it explicit that the package will be installed in the plugin directory, regardless of package.json existence or contents.

I had originally done this in https://github.com/galaxyproject/galaxy/pull/18760/ but I dropped it as a yagni -- this (functionality of the prefix flag) is actually the whole reason that linkage is using `npm` instead of `yarn`.

That said, looks like we're going to need it, xref https://github.com/galaxyproject/galaxy/pull/18946#discussion_r1791171879.  

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
