### PR TITLE
[23.2] Don't check availability of shellescape

### DIFF
--- a/lib/galaxy/tool_util/cwl/__init__.py
+++ b/lib/galaxy/tool_util/cwl/__init__.py
@@ -1,7 +1,4 @@
-from .cwltool_deps import (
-    needs_shell_quoting,
-    shellescape,
-)
+from .cwltool_deps import needs_shell_quoting
 from .parser import (
     tool_proxy,
     tool_proxy_from_persistent_representation,
@@ -21,5 +18,4 @@ __all__ = (
     "to_cwl_job",
     "to_galaxy_parameters",
     "needs_shell_quoting",
-    "shellescape",
 )

--- a/lib/galaxy/tool_util/cwl/cwltool_deps.py
+++ b/lib/galaxy/tool_util/cwl/cwltool_deps.py
@@ -4,6 +4,7 @@ Use this as the import interface for cwltool and just call
 :func:`ensure_cwltool_available` before using any of the imported
 functionality at runtime.
 """
+
 import re
 import warnings
 
@@ -71,11 +72,6 @@ except ImportError:
     normalizeFilesDirs = None  # type: ignore[assignment]
 
 try:
-    import shellescape
-except ImportError:
-    shellescape = None
-
-try:
     import schema_salad
     from schema_salad import (
         ref_resolver,
@@ -104,7 +100,7 @@ def ensure_cwltool_available():
 
     Throw an ImportError with a description of the problem if they do not exist.
     """
-    if main is None or workflow is None or shellescape is None:
+    if main is None or workflow is None:
         message = "This feature requires cwltool and dependencies to be available, they are not."
         if main is None:
             message += " cwltool is not unavailable."
@@ -112,8 +108,6 @@ def ensure_cwltool_available():
             message += " cwltool.load_tool.resolve_and_validate_document is unavailable - cwltool version is too old."
         if requests is None:
             message += " Library 'requests' unavailable."
-        if shellescape is None:
-            message += " Library 'shellescape' unavailable."
         if schema_salad is None:
             message += " Library 'schema_salad' unavailable."
         raise ImportError(message)
@@ -136,7 +130,6 @@ __all__ = (
     "resolve_and_validate_document",
     "RuntimeContext",
     "schema_salad",
-    "shellescape",
     "sourceline",
     "StdFsAccess",
     "visit_class",


### PR DESCRIPTION
It is not used in the CWL branch any more.

cwltool removed shellescape as dependency in 3.1.20241007082533 , which causes errors like the following in test_galaxy_packages tests:

```
_______________________________ test_tool_proxy ________________________________

    def test_tool_proxy():
        """Test that tool proxies load some valid tools correctly."""
>       tool_proxy(_cwl_tool_path("v1.0/v1.0/cat1-testcli.cwl"))

tests/tool_util/test_cwl.py:35:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
galaxy/tool_util/cwl/parser.py:726: in tool_proxy
    ensure_cwltool_available()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    def ensure_cwltool_available():
        """Assert optional dependencies proxied via this module are available at runtime.

        Throw an ImportError with a description of the problem if they do not exist.
        """
        if main is None or workflow is None or shellescape is None:
            message = "This feature requires cwltool and dependencies to be available, they are not."
            if main is None:
                message += " cwltool is not unavailable."
            elif resolve_and_validate_document is None:
                message += " cwltool.load_tool.resolve_and_validate_document is unavailable - cwltool version is too old."
            if requests is None:
                message += " Library 'requests' unavailable."
            if shellescape is None:
                message += " Library 'shellescape' unavailable."
            if schema_salad is None:
                message += " Library 'schema_salad' unavailable."
>           raise ImportError(message)
E           ImportError: This feature requires cwltool and dependencies to be available, they are not. Library 'shellescape' unavailable.
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
