### PR TITLE
Fix `WorkflowInvocationHeader` import type and current user errors

### DIFF
--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationHeader.test.ts
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationHeader.test.ts
@@ -1,4 +1,5 @@
 import { createTestingPinia } from "@pinia/testing";
+import { getFakeRegisteredUser } from "@tests/test-data";
 import { shallowMount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { getLocalVue } from "tests/jest/helpers";
@@ -81,14 +82,9 @@ async function mountWorkflowInvocationHeader(ownsWorkflow = true, hasReturnBtn =
     });
 
     const userStore = useUserStore();
-    userStore.currentUser = {
-        id: "1",
-        email: "test@mail.test",
-        tags_used: [],
-        isAnonymous: false,
-        total_disk_usage: 0,
+    userStore.currentUser = getFakeRegisteredUser({
         username: ownsWorkflow ? WORKFLOW_OWNER : OTHER_USER,
-    };
+    });
 
     return { wrapper };
 }

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationHeader.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationHeader.vue
@@ -3,13 +3,15 @@ import { faClock } from "@fortawesome/free-regular-svg-icons";
 import { faArrowLeft, faEdit, faHdd, faSitemap, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BButton, BButtonGroup } from "bootstrap-vue";
+import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 import { RouterLink } from "vue-router";
 
+import { isRegisteredUser } from "@/api";
 import type { WorkflowInvocationElementView } from "@/api/invocations";
 import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
 import { useUserStore } from "@/stores/userStore";
-import { Workflow } from "@/stores/workflowStore";
+import type { Workflow } from "@/stores/workflowStore";
 import localize from "@/utils/localization";
 import { errorMessageAsString } from "@/utils/simple-error";
 
@@ -31,10 +33,10 @@ const props = defineProps<Props>();
 
 const { workflow } = useWorkflowInstance(props.invocation.workflow_id);
 
-const userStore = useUserStore();
+const { currentUser, isAnonymous } = storeToRefs(useUserStore());
 const owned = computed(() => {
-    if (userStore.currentUser && workflow.value) {
-        return userStore.currentUser.username === workflow.value.owner;
+    if (isRegisteredUser(currentUser.value) && workflow.value) {
+        return currentUser.value.username === workflow.value.owner;
     } else {
         return false;
     }
@@ -129,7 +131,7 @@ function getWorkflowName(): string {
                         v-else
                         v-b-tooltip.hover.noninteractive
                         size="sm"
-                        :disabled="userStore.isAnonymous"
+                        :disabled="isAnonymous"
                         :title="localize('Import this workflow')"
                         :icon="faUpload"
                         variant="outline-primary"


### PR DESCRIPTION
This PR fixes the below breaking errors in `WorkflowInvocationHeader` after merging release_24.1 to dev on 01512cb159f7aca841d566a7aa0d832af08bf8af. The changes have merged in #18930

![image](https://github.com/user-attachments/assets/ef4accac-ddb3-402a-a561-33a434e21816)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
