### PR TITLE
Fix extra files path type hint

### DIFF
--- a/lib/galaxy/datatypes/genetics.py
+++ b/lib/galaxy/datatypes/genetics.py
@@ -869,8 +869,7 @@ class RexpBase(Html):
             pf = None
         if pf:
             header = pf[0].strip()
-            columns = header.split("\t")  # hope is header
-            columns = [escape(x) for x in columns]
+            columns = [escape(x) for x in header.split("\t")]  # hope is header
             dataset.metadata.column_names = columns
             dataset.metadata.columns = len(columns)
             dataset.peek = "".join(pf[:5])

--- a/lib/galaxy/datatypes/genetics.py
+++ b/lib/galaxy/datatypes/genetics.py
@@ -863,16 +863,16 @@ class RexpBase(Html):
         pp = os.path.join(dataset.extra_files_path, pn)
         dataset.metadata.pheno_path = pp
         try:
-            with open(pp) as f:
-                pf = f.readlines()  # read the basename.phenodata in the extra_files_path
+            with open(pp) as file:
+                pf = file.readlines()  # read the basename.phenodata in the extra_files_path
         except Exception:
             pf = None
         if pf:
-            h = pf[0].strip()
-            h = h.split("\t")  # hope is header
-            h = [escape(x) for x in h]
-            dataset.metadata.column_names = h
-            dataset.metadata.columns = len(h)
+            header = pf[0].strip()
+            columns = header.split("\t")  # hope is header
+            columns = [escape(x) for x in columns]
+            dataset.metadata.column_names = columns
+            dataset.metadata.columns = len(columns)
             dataset.peek = "".join(pf[:5])
         else:
             dataset.metadata.column_names = []

--- a/lib/galaxy/datatypes/protocols.py
+++ b/lib/galaxy/datatypes/protocols.py
@@ -27,7 +27,7 @@ class HasExt(Protocol):
 
 class HasExtraFilesPath(Protocol):
     @property
-    def extra_files_path(self): ...
+    def extra_files_path(self) -> str: ...
 
 
 class HasFileName(Protocol):


### PR DESCRIPTION
Detected by pylance while working on https://github.com/galaxyproject/galaxy/pull/17614

![image](https://github.com/user-attachments/assets/35aea95b-ab71-44c3-9fa5-e90d2f4ba3ba)

The type of `extra_files_path` will resolve to Any/None otherwise. Fixing this revealed other typing issues downstream.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
