### PR TITLE
[23.2] Pin Ubuntu to 22.04 for Python 3.7 workflow

### DIFF
--- a/.github/workflows/test_galaxy_packages_for_pulsar.yaml
+++ b/.github/workflows/test_galaxy_packages_for_pulsar.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04  # Python 3.7 is not available via setup-python on ubuntu >=24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The `ubuntu-latest` runner label is moving to 24.04, see https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/

Fix the following error at the setup-python step:

```
Version 3.7 was not found in the local cache
Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

See e.g. https://github.com/galaxyproject/galaxy/actions/runs/11252595341/job/31294713655

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
