### PR TITLE
Add import endpoint for history contents from library

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1818,6 +1818,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/histories/{history_id}/contents/import": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Batch create new items in the given History.
+         * @description Batch create new items in the given History.
+         */
+        post: operations["import_from_library_api_histories__history_id__contents_import_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/histories/{history_id}/contents/{dataset_id}/permissions": {
         parameters: {
             query?: never;
@@ -11369,6 +11389,14 @@ export interface components {
             states: {
                 [key: string]: number;
             };
+        };
+        /** ImportHistoryContentPayload */
+        ImportHistoryContentPayload: {
+            /**
+             * library datasets or folders
+             * @description The list of library datasets or folders to import from the library.
+             */
+            items: components["schemas"]["CreateHistoryContentPayload"][];
         };
         /** ImportToolDataBundle */
         ImportToolDataBundle: {
@@ -24091,6 +24119,54 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AsyncTaskResultSummary"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    import_from_library_api_histories__history_id__contents_import_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The encoded database identifier of the History. */
+                history_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ImportHistoryContentPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HistoryContentBulkOperationResult"];
                 };
             };
             /** @description Request Error */

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -82,6 +82,7 @@ from galaxy.webapps.galaxy.services.history_contents import (
     HistoriesContentsService,
     HistoryContentsIndexJobsSummaryParams,
     HistoryContentsIndexParams,
+    ImportHistoryContentPayload,
     LegacyHistoryContentsIndexParams,
 )
 
@@ -730,9 +731,22 @@ class FastAPIHistoryContents:
         serialization_params: SerializationParams,
         payload: CreateHistoryContentPayload,
     ) -> Union[AnyHistoryContentItem, List[AnyHistoryContentItem]]:
-        """Create a new `HDA` or `HDCA` in the given History."""
+        """Create a new `HDA` orCreateHistoryContentPayload `HDCA` in the given History."""
         payload.type = type or payload.type
         return self.service.create(trans, history_id, payload, serialization_params)
+
+    @router.post(
+        "/api/histories/{history_id}/contents/import",
+        summary="Batch create new items in the given History.",
+    )
+    def import_from_library(
+        self,
+        history_id: HistoryIDPathParam,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        payload: ImportHistoryContentPayload = Body(...),
+    ) -> HistoryContentBulkOperationResult:
+        """Batch create new items in the given History."""
+        return self.service.import_from_library(trans, history_id, payload)
 
     @router.put(
         "/api/histories/{history_id}/contents/{dataset_id}/permissions",

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -1001,6 +1001,21 @@ class TestHistoryContentsApi(ApiTestCase):
         self._assert_status_code_is(update_response, 403)
         assert update_response.json()["err_msg"] == "History is immutable"
 
+    def test_import_from_library(self, history_id):
+        library_dataset_1 = self.library_populator.new_library_dataset("new_library_dataset")
+        library_dataset_2 = self.library_populator.new_library_dataset("new_library_dataset")
+        payload = {
+            "items": [
+                {"content": library_dataset_1["id"], "source": "library"},
+                {"content": library_dataset_2["id"], "source": "library"},
+            ]
+        }
+        response = self._post(f"histories/{history_id}/contents/import", data=payload, json=True)
+        self._assert_status_code_is(response, 200)
+        import_result = response.json()
+        assert import_result["success_count"] == 2, import_result
+        assert not import_result["errors"]
+
 
 class TestHistoryContentsApiBulkOperation(ApiTestCase):
     """


### PR DESCRIPTION
Implemented a new API endpoint (`/api/histories/{history_id}/contents/import`) to batch create items in a specified history from library datasets and folders. This enhances flexibility for users by allowing multiple datasets to be imported simultaneously, improving efficiency when updating their histories.
The changes include new payload definitions and refined service methods to support the import process.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
