### PR TITLE
Fix CILogon redirect

### DIFF
--- a/client/src/utils/redirect.test.ts
+++ b/client/src/utils/redirect.test.ts
@@ -10,6 +10,10 @@ test("route prefix changes", async () => {
     expect(withPrefix("http://")).toEqual("http://");
     expect(withPrefix("/")).toEqual("/prefix/");
     expect(withPrefix("/home")).toEqual("/prefix/home");
+    // keep protocols in query parameters intact
+    expect(withPrefix("/authz/cilogon/login?idphint=https://test.com")).toEqual(
+        "/prefix/authz/cilogon/login?idphint=https://test.com"
+    );
     // ensure that it can only be called once
     expect(withPrefix(withPrefix("/home"))).toEqual("/prefix/prefix/home");
     // This doesn't do what it looks like it should do?

--- a/client/src/utils/redirect.ts
+++ b/client/src/utils/redirect.ts
@@ -10,7 +10,7 @@ export function reloadPage() {
     window.location.reload();
 }
 
-const slashCleanup = /(\/)+/g;
+const slashCleanup = /(?<!:)(\/)+/g;
 /**
  * Prepends the configured app root to given url
  * @param path


### PR DESCRIPTION
When galaxy redirects to CILogon, it passes a query parameter called idphint which is usually a url starting with https://.

Starting at 24.1 the axios calls in the ExternalLogin.vue were changed to use withPrefix from utils/redirect.ts. The problem is that this strips all double slashes, invalidating any protocol passed as parameters (`https://` becomes `http:/`)

I added a test to ensure that CILogon redirects are done correctly and changed the regex to only match duplicate slashes that are not preceded by a colon.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
