### PR TITLE
Allow CORS requests to /api/workflow_landings

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/lib/galaxy/webapps/base/api.py
+++ b/lib/galaxy/webapps/base/api.py
@@ -260,3 +260,13 @@ def include_all_package_routers(app: FastAPI, package_name: str):
         router = getattr(module, "router", None)
         if router:
             app.include_router(router, responses=responses)
+
+    # handle CORS preflight requests - synchronize with wsgi behavior.
+    # this needs to happen last so it doesn't clobber routes with explicit cors handling
+    # it doesn't affect the CORS middleware since the middleware terminates the request handling before routing
+    @app.options("/api/{rest_of_path:path}")
+    async def preflight_handler(request: Request, rest_of_path: str) -> Response:
+        response = Response()
+        response.headers["Access-Control-Allow-Headers"] = "*"
+        response.headers["Access-Control-Max-Age"] = "600"
+        return response

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1165,7 +1165,7 @@ class FastAPIWorkflows:
     ) -> StoredWorkflowDetailed:
         return self.service.show_workflow(trans, workflow_id, instance, legacy, version)
 
-    @router.post("/api/workflow_landings", public=True)
+    @router.post("/api/workflow_landings", public=True, allow_cors=True)
     def create_landing(
         self,
         trans: ProvidesUserContext = DependsOnTrans,

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -10,7 +10,6 @@ from fastapi import (
 )
 from fastapi.openapi.constants import REF_TEMPLATE
 from starlette.middleware.cors import CORSMiddleware
-from starlette.responses import Response
 
 from galaxy.schema.generics import CustomJsonSchema
 from galaxy.version import VERSION
@@ -121,14 +120,6 @@ def add_galaxy_middleware(app: FastAPI, gx_app):
             allow_methods=["*"],
             max_age=600,
         )
-    else:
-        # handle CORS preflight requests - synchronize with wsgi behavior.
-        @app.options("/api/{rest_of_path:path}")
-        async def preflight_handler(request: Request, rest_of_path: str) -> Response:
-            response = Response()
-            response.headers["Access-Control-Allow-Headers"] = "*"
-            response.headers["Access-Control-Max-Age"] = "600"
-            return response
 
 
 def include_legacy_openapi(app, gx_app):

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -781,6 +781,7 @@ class BaseDatasetPopulator(BasePopulator):
         json = payload.model_dump(mode="json")
         create_response = self._post(create_url, json, json=True, anon=True)
         api_asserts.assert_status_code_is(create_response, 200)
+        assert create_response.headers["access-control-allow-origin"]
         create_response.raise_for_status()
         return WorkflowLandingRequest.model_validate(create_response.json())
 

--- a/test/integration/test_web_framework_config.py
+++ b/test/integration/test_web_framework_config.py
@@ -4,10 +4,14 @@ from requests import options
 
 from galaxy_test.driver import integration_util
 
+ENDPOINT_WITH_CORS = "workflow_landings"
+ENDPOINT_WITHOUT_EXPLICIT_CORS = "licenses"
+WSGI_ENDPOINT = "tools"
+
 
 class BaseWebFrameworkTestCase(integration_util.IntegrationTestCase):
-    def _options(self, headers=None):
-        url = self._api_url("licenses")
+    def _options(self, headers=None, endpoint=ENDPOINT_WITH_CORS):
+        url = self._api_url(endpoint)
         options_response = options(url, headers=headers or {})
         return options_response
 
@@ -18,8 +22,18 @@ class TestCorsDefaultIntegration(BaseWebFrameworkTestCase):
             "Access-Control-Request-Method": "GET",
             "origin": "http://192.168.0.101:8083",
         }
-        options_response = self._options(headers)
-        assert options_response.status_code == 200
+        options_response = self._options(headers, ENDPOINT_WITHOUT_EXPLICIT_CORS)
+        options_response.raise_for_status()
+        assert "access-control-allow-origin" not in options_response.headers
+
+    def test_options_wsgi(self):
+        # Tests legacy handling
+        headers = {
+            "Access-Control-Request-Method": "GET",
+            "origin": "http://192.168.0.101:8083",
+        }
+        options_response = self._options(headers, WSGI_ENDPOINT)
+        options_response.raise_for_status()
         assert "access-control-allow-origin" not in options_response.headers
 
     def test_origin_not_allowed_default(self):
@@ -28,9 +42,19 @@ class TestCorsDefaultIntegration(BaseWebFrameworkTestCase):
             "Access-Control-Request-Headers": "Authorization",
             "origin": "http://192.168.0.101:8083",
         }
-        options_response = self._options(headers)
-        assert options_response.status_code == 200
+        options_response = self._options(headers, ENDPOINT_WITHOUT_EXPLICIT_CORS)
+        options_response.raise_for_status()
         assert "access-control-allow-origin" not in options_response.headers
+
+    def test_origin_explicitly_allowed(self):
+        headers = {
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "Authorization",
+            "Origin": "http://192.168.0.101:8083",
+        }
+        options_response = self._options(headers, ENDPOINT_WITH_CORS)
+        options_response.raise_for_status()
+        assert options_response.headers["access-control-allow-origin"] == "http://192.168.0.101:8083"
 
 
 class TestAllowOriginIntegration(BaseWebFrameworkTestCase):
@@ -45,7 +69,7 @@ class TestAllowOriginIntegration(BaseWebFrameworkTestCase):
             "origin": "http://192.168.0.101:8083",
             "Access-Control-Request-Headers": "Authorization",
         }
-        options_response = self._options(headers)
+        options_response = self._options(headers, ENDPOINT_WITHOUT_EXPLICIT_CORS)
         options_response.raise_for_status()
         assert "access-control-allow-origin" in options_response.headers
         assert options_response.headers["access-control-allow-origin"] == "http://192.168.0.101:8083"
@@ -57,7 +81,7 @@ class TestAllowOriginIntegration(BaseWebFrameworkTestCase):
             "origin": "http://rna.galaxyproject.org",
             "Access-Control-Request-Headers": "Authorization",
         }
-        options_response = self._options(headers)
+        options_response = self._options(headers, ENDPOINT_WITHOUT_EXPLICIT_CORS)
         options_response.raise_for_status()
         assert "access-control-allow-origin" in options_response.headers
         assert options_response.headers["access-control-allow-origin"] == "http://rna.galaxyproject.org"
@@ -69,5 +93,5 @@ class TestAllowOriginIntegration(BaseWebFrameworkTestCase):
             "origin": "http://192.168.0.102:8083",  # swapped ip by one
             "Access-Control-Request-Headers": "Authorization",
         }
-        options_response = self._options(headers)
+        options_response = self._options(headers, ENDPOINT_WITHOUT_EXPLICIT_CORS)
         assert options_response.status_code == 400


### PR DESCRIPTION
We'll need CORS response headers for the intended purpose of creating landing requests on external sites. While we could push that into the nginx config I think it's better if this works out of the box. We'll use this in the IWC static site to allow users to run workflows with example data, and ideally they should be able to use any Galaxy instance.

For simple, non-authenticated requests you can now just do `allow_cors=True` in the route decorator.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
