### PR TITLE
[24.1] Pin ubuntu 22.04 for minikube setup action

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The `ubuntu-latest` runner label is moving to 24.04, see https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/

Fixes https://github.com/galaxyproject/galaxy/actions/runs/11260477825/job/31317049837?pr=18963:
```
No VM guests are running outdated hypervisor (qemu) binaries on this host.
/usr/bin/lsb_release --short --codename
noble
Error: Unexpected HTTP response: 404
```


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
