### PR TITLE
Explicitly display dataset preview in pages and workflow reports

### DIFF
--- a/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
@@ -152,7 +152,7 @@ export default {
             return `${getAppRoot()}dataset/display?dataset_id=${this.args.history_dataset_id}`;
         },
         displayUrl() {
-            return `${getAppRoot()}datasets/${this.args.history_dataset_id}/display`;
+            return `${getAppRoot()}datasets/${this.args.history_dataset_id}/display/?preview=True`;
         },
         importUrl() {
             return `${getAppRoot()}dataset/imp?dataset_id=${this.args.history_dataset_id}`;


### PR DESCRIPTION
When embedding certain datasets into pages and workflow reports, the dataset might not be properly displayed since the `preview=True` option is not specified.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
