### PR TITLE
Reduce tool form building frequency

### DIFF
--- a/client/src/components/Form/FormDisplay.vue
+++ b/client/src/components/Form/FormDisplay.vue
@@ -139,10 +139,7 @@ export default {
     },
     created() {
         this.onCloneInputs();
-        // build flat formData that is ready to be submitted
-        this.formData = this.buildFormData();
-        // emit back to parent, so that parent has submittable data
-        this.$emit("onChange", this.formData);
+        this.onChange();
         // highlight initial warnings
         this.onWarnings();
         // highlight initial errors

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -120,6 +120,7 @@ import ToolEntryPoints from "components/ToolEntryPoints/ToolEntryPoints";
 import { mapActions, mapState, storeToRefs } from "pinia";
 import { useHistoryItemsStore } from "stores/historyItemsStore";
 import { useJobStore } from "stores/jobStore";
+import { debounce } from "underscore";
 import { refreshContentsWrapper } from "utils/data";
 
 import { canMutateHistory } from "@/api";
@@ -287,7 +288,7 @@ export default {
                 this.onUpdate();
             }
         },
-        onUpdate() {
+        onUpdate: debounce(function (e) {
             this.disabled = true;
             console.debug("ToolForm - Updating input parameters.", this.formData);
             updateToolFormData(this.formConfig.id, this.currentVersion, this.history_id, this.formData)
@@ -297,7 +298,7 @@ export default {
                 .finally(() => {
                     this.disabled = false;
                 });
-        },
+        }, 500),
         onChangeVersion(newVersion) {
             this.requestTool(newVersion);
         },

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -120,7 +120,6 @@ import ToolEntryPoints from "components/ToolEntryPoints/ToolEntryPoints";
 import { mapActions, mapState, storeToRefs } from "pinia";
 import { useHistoryItemsStore } from "stores/historyItemsStore";
 import { useJobStore } from "stores/jobStore";
-import { debounce } from "underscore";
 import { refreshContentsWrapper } from "utils/data";
 
 import { canMutateHistory } from "@/api";
@@ -288,7 +287,7 @@ export default {
                 this.onUpdate();
             }
         },
-        onUpdate: debounce(function (e) {
+        onUpdate() {
             this.disabled = true;
             console.debug("ToolForm - Updating input parameters.", this.formData);
             updateToolFormData(this.formConfig.id, this.currentVersion, this.history_id, this.formData)
@@ -298,7 +297,7 @@ export default {
                 .finally(() => {
                     this.disabled = false;
                 });
-        }, 500),
+        },
         onChangeVersion(newVersion) {
             this.requestTool(newVersion);
         },


### PR DESCRIPTION
Mitigates #18848

When we have multiple data inputs in a tool, the ToolForm will request a tool rebuild for each data input in rapid succession (see https://github.com/galaxyproject/galaxy/issues/18848#issuecomment-2399667355).

This will ensure that only the last request with all the updated data is sent.

## Before

![image](https://github.com/user-attachments/assets/da15efb1-7ee2-44e2-aa75-1b37ba4c9a1b)

## After

![image](https://github.com/user-attachments/assets/9233244a-a1e4-4493-9618-7df3398b9772)



## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
