### PR TITLE
Optimize to_history_dataset_association in create_datasets_from_library_folder

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6049,7 +6049,7 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, Serializable):
         self.user = user
 
     def to_history_dataset_association(
-        self, target_history, parent_id=None, add_to_history=False, visible=None, flush=True
+        self, target_history, parent_id=None, add_to_history=False, visible=None, commit=True
     ):
         sa_session = object_session(self)
         hda = HistoryDatasetAssociation(
@@ -6075,9 +6075,9 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, Serializable):
         hda.metadata = self.metadata
         if add_to_history and target_history:
             target_history.stage_addition(hda)
-            if flush:
+            if commit:
                 target_history.add_pending_items()
-        if flush:
+        if commit:
             with transaction(sa_session):
                 sa_session.commit()
         return hda

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6048,7 +6048,7 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, Serializable):
         self.library_dataset = library_dataset
         self.user = user
 
-    def to_history_dataset_association(self, target_history, parent_id=None, add_to_history=False, visible=None):
+    def to_history_dataset_association(self, target_history, parent_id=None, add_to_history=False, visible=None, flush=True):
         sa_session = object_session(self)
         hda = HistoryDatasetAssociation(
             name=self.name,
@@ -6073,8 +6073,9 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, Serializable):
         hda.metadata = self.metadata
         if add_to_history and target_history:
             target_history.add_dataset(hda)
-        with transaction(sa_session):
-            sa_session.commit()
+        if flush:
+            with transaction(sa_session):
+                sa_session.commit()
         return hda
 
     def copy(self, parent_id=None, target_folder=None, flush=True):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6048,7 +6048,9 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, Serializable):
         self.library_dataset = library_dataset
         self.user = user
 
-    def to_history_dataset_association(self, target_history, parent_id=None, add_to_history=False, visible=None, flush=True):
+    def to_history_dataset_association(
+        self, target_history, parent_id=None, add_to_history=False, visible=None, flush=True
+    ):
         sa_session = object_session(self)
         hda = HistoryDatasetAssociation(
             name=self.name,
@@ -6072,7 +6074,9 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, Serializable):
         sa_session.add(hda)
         hda.metadata = self.metadata
         if add_to_history and target_history:
-            target_history.add_dataset(hda)
+            target_history.stage_addition(hda)
+            if flush:
+                target_history.add_pending_items()
         if flush:
             with transaction(sa_session):
                 sa_session.commit()

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1180,6 +1180,8 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
                     hda, user=trans.user, trans=trans, encode_id=False, **serialization_params.model_dump()
                 )
                 rval.append(hda_dict)
+            history.add_pending_items()
+
         else:
             message = f"Invalid 'source' parameter in request: {source}"
             raise exceptions.RequestParameterInvalidException(message)

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1174,7 +1174,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
 
             hdas = [
                 ld.library_dataset_dataset_association.to_history_dataset_association(
-                    history, add_to_history=True, flush=False
+                    history, add_to_history=True, commit=False
                 )
                 for ld in traverse(folder)
             ]

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1174,7 +1174,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
 
             for ld in traverse(folder):
                 hda = ld.library_dataset_dataset_association.to_history_dataset_association(
-                    history, add_to_history=True
+                    history, add_to_history=True, flush=False
                 )
                 hda_dict = self.hda_serializer.serialize_to_view(
                     hda, user=trans.user, trans=trans, encode_id=False, **serialization_params.model_dump()

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1172,23 +1172,27 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
                         rval.append(ld)
                 return rval
 
-            for ld in traverse(folder):
-                hda = ld.library_dataset_dataset_association.to_history_dataset_association(
+            hdas = [
+                ld.library_dataset_dataset_association.to_history_dataset_association(
                     history, add_to_history=True, flush=False
                 )
+                for ld in traverse(folder)
+            ]
+            history.add_pending_items()
+
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
+
+            for hda in hdas:
                 hda_dict = self.hda_serializer.serialize_to_view(
                     hda, user=trans.user, trans=trans, encode_id=False, **serialization_params.model_dump()
                 )
                 rval.append(hda_dict)
-            history.add_pending_items()
+            return rval
 
         else:
             message = f"Invalid 'source' parameter in request: {source}"
             raise exceptions.RequestParameterInvalidException(message)
-
-        with transaction(trans.sa_session):
-            trans.sa_session.commit()
-        return rval
 
     def __create_dataset(
         self,


### PR DESCRIPTION
This pull request optimizes the `to_history_dataset_association` method in the `__create_datasets_from_library_folder` function. The method now includes an additional parameter `flush` which allows for more efficient handling of the transaction. This optimization improves the performance of creating datasets from a library folder.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
