### PR TITLE
Workflow landing improvements

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -7103,6 +7103,12 @@ export interface components {
         CreateWorkflowLandingRequestPayload: {
             /** Client Secret */
             client_secret?: string | null;
+            /**
+             * Public
+             * @description If workflow landing request is public anyone with the uuid can use the landing request. If not public the request must be claimed before use and additional verification might occur.
+             * @default false
+             */
+            public: boolean;
             /** Request State */
             request_state?: Record<string, never> | null;
             /** Workflow Id */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -7111,7 +7111,7 @@ export interface components {
              * Workflow Target Type
              * @enum {string}
              */
-            workflow_target_type: "stored_workflow" | "workflow";
+            workflow_target_type: "stored_workflow" | "workflow" | "trs_url";
         };
         /** CreatedEntryResponse */
         CreatedEntryResponse: {
@@ -18137,7 +18137,7 @@ export interface components {
              * Workflow Target Type
              * @enum {string}
              */
-            workflow_target_type: "stored_workflow" | "workflow";
+            workflow_target_type: "stored_workflow" | "workflow" | "trs_url";
         };
         /** WriteInvocationStoreToPayload */
         WriteInvocationStoreToPayload: {

--- a/client/src/components/Landing/WorkflowLanding.vue
+++ b/client/src/components/Landing/WorkflowLanding.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { BAlert } from "bootstrap-vue";
-import { onBeforeMount, ref } from "vue";
+import { storeToRefs } from "pinia";
+import { ref, watch } from "vue";
+import { useRouter } from "vue-router/composables";
 
 import { GalaxyApi } from "@/api";
+import { useUserStore } from "@/stores/userStore";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import LoadingSpan from "@/components/LoadingSpan.vue";
@@ -21,33 +24,45 @@ const workflowId = ref<string | null>(null);
 const errorMessage = ref<string | null>(null);
 const requestState = ref<Record<string, never> | null>(null);
 const instance = ref<boolean>(false);
+const userStore = useUserStore();
+const router = useRouter();
 
-onBeforeMount(async () => {
-    const { data, error } = await GalaxyApi().GET("/api/workflow_landings/{uuid}", {
-        params: {
-            path: { uuid: props.uuid },
-        },
-    });
-    if (data) {
-        workflowId.value = data.workflow_id;
-        instance.value = data.workflow_target_type === "workflow";
-        requestState.value = data.request_state;
-    } else {
-        errorMessage.value = errorMessageAsString(error);
-    }
-    console.log(data);
-});
+userStore.loadUser(false);
+const { isAnonymous, currentUser } = storeToRefs(userStore);
+
+watch(
+    currentUser,
+    async () => {
+        if (isAnonymous.value) {
+            router.push(`/login/start?redirect=/workflow_landings/${props.uuid}`);
+        } else if (currentUser.value) {
+            const { data, error } = await GalaxyApi().GET("/api/workflow_landings/{uuid}", {
+                params: {
+                    path: { uuid: props.uuid },
+                },
+            });
+            if (data) {
+                workflowId.value = data.workflow_id;
+                instance.value = data.workflow_target_type === "workflow";
+                requestState.value = data.request_state;
+            } else {
+                errorMessage.value = errorMessageAsString(error);
+            }
+        }
+    },
+    { immediate: true }
+);
 </script>
 
 <template>
     <div>
-        <div v-if="!workflowId">
-            <LoadingSpan message="Loading workflow parameters" />
-        </div>
-        <div v-else-if="errorMessage">
+        <div v-if="errorMessage">
             <BAlert variant="danger" show>
                 {{ errorMessage }}
             </BAlert>
+        </div>
+        <div v-else-if="!workflowId">
+            <LoadingSpan message="Loading workflow parameters" />
         </div>
         <div v-else>
             <WorkflowRun

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -31,6 +31,7 @@ interface Props {
     simpleFormTargetHistory?: string;
     simpleFormUseJobCache?: boolean;
     requestState?: Record<string, never>;
+    instance?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -39,6 +40,7 @@ const props = withDefaults(defineProps<Props>(), {
     simpleFormTargetHistory: "current",
     simpleFormUseJobCache: false,
     requestState: undefined,
+    instance: false,
 });
 
 const loading = ref(true);
@@ -80,7 +82,7 @@ function handleSubmissionError(error: string) {
 
 async function loadRun() {
     try {
-        const runData = await getRunData(props.workflowId, props.version || undefined);
+        const runData = await getRunData(props.workflowId, props.version || undefined, props.instance);
         const incomingModel = new WorkflowRunModel(runData);
 
         simpleForm.value = props.preferSimpleForm;

--- a/client/src/components/Workflow/Run/services.js
+++ b/client/src/components/Workflow/Run/services.js
@@ -12,8 +12,8 @@ import { rethrowSimple } from "utils/simple-error";
  * @param {String} workflowId - (Stored?) Workflow ID to fetch data for.
  * @param {String} version - Version of the workflow to fetch.
  */
-export async function getRunData(workflowId, version = null) {
-    let url = `${getAppRoot()}api/workflows/${workflowId}/download?style=run`;
+export async function getRunData(workflowId, version = null, instance = false) {
+    let url = `${getAppRoot()}api/workflows/${workflowId}/download?style=run&instance=${instance}`;
     if (version) {
         url += `&version=${version}`;
     }

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -506,7 +506,7 @@ export function getRouter(Galaxy) {
                         component: WorkflowLanding,
                         props: (route) => ({
                             uuid: route.params.uuid,
-                            public: !!route.query.public,
+                            public: route.query.public.toLowerCase() === "true",
                             secret: route.query.client_secret,
                         }),
                     },

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -504,7 +504,11 @@ export function getRouter(Galaxy) {
                     {
                         path: "workflow_landings/:uuid",
                         component: WorkflowLanding,
-                        props: true,
+                        props: (route) => ({
+                            uuid: route.params.uuid,
+                            public: !!route.query.public,
+                            secret: route.query.client_secret,
+                        }),
                     },
                     {
                         path: "user",

--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -241,6 +241,10 @@ class Conflict(MessageException):
     err_code = error_codes_by_name["CONFLICT"]
 
 
+class ItemMustBeClaimed(Conflict):
+    err_code = error_codes_by_name["MUST_CLAIM"]
+
+
 class DeprecatedMethod(MessageException):
     """
     Method (or a particular form/arg signature) has been removed and won't be available later

--- a/lib/galaxy/exceptions/error_codes.json
+++ b/lib/galaxy/exceptions/error_codes.json
@@ -165,6 +165,11 @@
         "message": "Database conflict prevented fulfilling the request."
     },
     {
+        "name": "MUST_CLAIM",
+        "code": 409010,
+        "message": "Private request must be claimed before use"
+    },
+    {
         "name": "DEPRECATED_API_CALL",
         "code": 410001,
         "message": "This API method or call signature has been deprecated and is no longer available"

--- a/lib/galaxy/managers/landing.py
+++ b/lib/galaxy/managers/landing.py
@@ -4,15 +4,19 @@ from typing import (
 )
 from uuid import uuid4
 
+import yaml
 from pydantic import UUID4
 from sqlalchemy import select
 
 from galaxy.exceptions import (
-    InconsistentDatabase,
     InsufficientPermissionsException,
     ItemAlreadyClaimedException,
     ObjectNotFound,
     RequestParameterMissingException,
+)
+from galaxy.managers.workflows import (
+    WorkflowContentsManager,
+    WorkflowCreateOptions,
 )
 from galaxy.model import (
     ToolLandingRequest as ToolLandingRequestModel,
@@ -29,6 +33,7 @@ from galaxy.schema.schema import (
     WorkflowLandingRequest,
 )
 from galaxy.security.idencoding import IdEncodingHelper
+from galaxy.structured_app import StructuredApp
 from galaxy.util import safe_str_cmp
 from .context import ProvidesUserContext
 
@@ -37,17 +42,25 @@ LandingRequestModel = Union[ToolLandingRequestModel, WorkflowLandingRequestModel
 
 class LandingRequestManager:
 
-    def __init__(self, sa_session: galaxy_scoped_session, security: IdEncodingHelper):
+    def __init__(
+        self,
+        sa_session: galaxy_scoped_session,
+        security: IdEncodingHelper,
+        workflow_contents_manager: WorkflowContentsManager,
+    ):
         self.sa_session = sa_session
         self.security = security
+        self.workflow_contents_manager = workflow_contents_manager
 
-    def create_tool_landing_request(self, payload: CreateToolLandingRequestPayload) -> ToolLandingRequest:
+    def create_tool_landing_request(self, payload: CreateToolLandingRequestPayload, user_id=None) -> ToolLandingRequest:
         model = ToolLandingRequestModel()
         model.tool_id = payload.tool_id
         model.tool_version = payload.tool_version
         model.request_state = payload.request_state
         model.uuid = uuid4()
         model.client_secret = payload.client_secret
+        if user_id:
+            model.user_id = user_id
         self._save(model)
         return self._tool_response(model)
 
@@ -55,11 +68,15 @@ class LandingRequestManager:
         model = WorkflowLandingRequestModel()
         if payload.workflow_target_type == "stored_workflow":
             model.stored_workflow_id = self.security.decode_id(payload.workflow_id)
-        else:
+        elif payload.workflow_target_type == "workflow":
             model.workflow_id = self.security.decode_id(payload.workflow_id)
-        model.request_state = payload.request_state
+        elif payload.workflow_target_type == "trs_url":
+            model.workflow_source_type = "trs_url"
+            # validate this ?
+            model.workflow_source = payload.workflow_id
         model.uuid = uuid4()
         model.client_secret = payload.client_secret
+        model.request_state = payload.request_state
         self._save(model)
         return self._workflow_response(model)
 
@@ -77,9 +94,31 @@ class LandingRequestManager:
     ) -> WorkflowLandingRequest:
         request = self._get_workflow_landing_request(uuid)
         self._check_can_claim(trans, request, claim)
+        self._ensure_workflow(trans, request)
         request.user_id = trans.user.id
         self._save(request)
         return self._workflow_response(request)
+
+    def _ensure_workflow(self, trans: ProvidesUserContext, request: WorkflowLandingRequestModel):
+        if request.workflow_source_type == "trs_url" and isinstance(trans.app, StructuredApp):
+            # trans is always structured app except for unit test
+            assert request.workflow_source
+            trs_id, trs_version = request.workflow_source.rsplit("/", 1)
+            _, trs_id, trs_version = trans.app.trs_proxy.get_trs_id_and_version_from_trs_url(request.workflow_source)
+            workflow = self.workflow_contents_manager.get_workflow_by_trs_id_and_version(
+                self.sa_session, trs_id=trs_id, trs_version=trs_version, user_id=trans.user and trans.user.id
+            )
+            if not workflow:
+                data = trans.app.trs_proxy.get_version_from_trs_url(request.workflow_source)
+                as_dict = yaml.safe_load(data)
+                raw_workflow_description = self.workflow_contents_manager.normalize_workflow_format(trans, as_dict)
+                created_workflow = self.workflow_contents_manager.build_workflow_from_raw_description(
+                    trans,
+                    raw_workflow_description,
+                    WorkflowCreateOptions(),
+                )
+                workflow = created_workflow.workflow
+            request.workflow_id = workflow.id
 
     def get_tool_landing_request(self, trans: ProvidesUserContext, uuid: UUID4) -> ToolLandingRequest:
         request = self._get_claimed_tool_landing_request(trans, uuid)
@@ -87,6 +126,7 @@ class LandingRequestManager:
 
     def get_workflow_landing_request(self, trans: ProvidesUserContext, uuid: UUID4) -> WorkflowLandingRequest:
         request = self._get_claimed_workflow_landing_request(trans, uuid)
+        self._ensure_workflow(trans, request)
         return self._workflow_response(request)
 
     def _check_can_claim(
@@ -139,18 +179,20 @@ class LandingRequestManager:
         return response_model
 
     def _workflow_response(self, model: WorkflowLandingRequestModel) -> WorkflowLandingRequest:
-        workflow_id: Optional[int]
+
+        workflow_id: Optional[Union[int, str]] = None
         if model.stored_workflow_id is not None:
             workflow_id = model.stored_workflow_id
             target_type = "stored_workflow"
-        else:
+        elif model.workflow_id is not None:
             workflow_id = model.workflow_id
             target_type = "workflow"
-        if workflow_id is None:
-            raise InconsistentDatabase()
+        elif model.workflow_source_type == "trs_url":
+            target_type = model.workflow_source_type
+            workflow_id = model.workflow_source
         assert workflow_id
         response_model = WorkflowLandingRequest(
-            workflow_id=self.security.encode_id(workflow_id),
+            workflow_id=self.security.encode_id(workflow_id) if isinstance(workflow_id, int) else workflow_id,
             workflow_target_type=target_type,
             request_state=model.request_state,
             uuid=model.uuid,
@@ -159,7 +201,7 @@ class LandingRequestManager:
         return response_model
 
     def _check_ownership(self, trans: ProvidesUserContext, model: LandingRequestModel):
-        if model.user_id != trans.user.id:
+        if model.user_id and model.user_id != trans.user.id:
             raise InsufficientPermissionsException()
 
     def _state(self, model: LandingRequestModel) -> LandingRequestState:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -11264,6 +11264,7 @@ class ToolLandingRequest(Base):
     tool_version: Mapped[Optional[str]] = mapped_column(String(255), default=None)
     request_state: Mapped[Optional[Dict]] = mapped_column(JSONType)
     client_secret: Mapped[Optional[str]] = mapped_column(String(255), default=None)
+    public: Mapped[bool] = mapped_column(Boolean)
 
     user: Mapped[Optional["User"]] = relationship()
 
@@ -11284,6 +11285,7 @@ class WorkflowLandingRequest(Base):
     client_secret: Mapped[Optional[str]] = mapped_column(String(255), default=None)
     workflow_source: Mapped[Optional[str]] = mapped_column(String(255), default=None)
     workflow_source_type: Mapped[Optional[str]] = mapped_column(String(255), default=None)
+    public: Mapped[bool] = mapped_column(Boolean)
 
     user: Mapped[Optional["User"]] = relationship()
     stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship()

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -11282,6 +11282,8 @@ class WorkflowLandingRequest(Base):
     uuid: Mapped[Union[UUID, str]] = mapped_column(UUIDType(), index=True)
     request_state: Mapped[Optional[Dict]] = mapped_column(JSONType)
     client_secret: Mapped[Optional[str]] = mapped_column(String(255), default=None)
+    workflow_source: Mapped[Optional[str]] = mapped_column(String(255), default=None)
+    workflow_source_type: Mapped[Optional[str]] = mapped_column(String(255), default=None)
 
     user: Mapped[Optional["User"]] = relationship()
     stored_workflow: Mapped[Optional["StoredWorkflow"]] = relationship()

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/a99a5b52ccb8_add_workflow_source_and_workflow_source_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/a99a5b52ccb8_add_workflow_source_and_workflow_source_.py
@@ -1,0 +1,36 @@
+"""Add workflow_source and workflow_source_type column
+
+Revision ID: a99a5b52ccb8
+Revises: 7ffd33d5d144
+Create Date: 2024-10-10 14:23:29.485113
+
+"""
+
+import sqlalchemy as sa
+
+from galaxy.model.migrations.util import (
+    add_column,
+    drop_column,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "a99a5b52ccb8"
+down_revision = "7ffd33d5d144"
+branch_labels = None
+depends_on = None
+
+table_name = "workflow_landing_request"
+column_names = ["workflow_source", "workflow_source_type"]
+
+
+def upgrade():
+    with transaction():
+        for column_name in column_names:
+            add_column(table_name, sa.Column(column_name, sa.String(255), nullable=True))
+
+
+def downgrade():
+    with transaction():
+        for column_name in column_names:
+            drop_column(table_name, column_name)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/a99a5b52ccb8_add_workflow_source_and_workflow_source_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/a99a5b52ccb8_add_workflow_source_and_workflow_source_.py
@@ -34,8 +34,8 @@ def upgrade():
     with transaction():
         add_column(workflow_table_name, sa.Column("workflow_source", sa.String(255), nullable=True))
         add_column(workflow_table_name, sa.Column("workflow_source_type", sa.String(255), nullable=True))
-        add_column(workflow_table_name, sa.Column("public", sa.Boolean, nullable=False))
-        add_column(tool_table_name, sa.Column("public", sa.Boolean, nullable=False))
+        add_column(workflow_table_name, sa.Column("public", sa.Boolean, nullable=False, server_default=sa.false()))
+        add_column(tool_table_name, sa.Column("public", sa.Boolean, nullable=False, server_default=sa.false()))
 
 
 def downgrade():

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3854,6 +3854,7 @@ class CreateToolLandingRequestPayload(Model):
     tool_version: Optional[str] = None
     request_state: Optional[Dict[str, Any]] = None
     client_secret: Optional[str] = None
+    public: bool = False
 
 
 class CreateWorkflowLandingRequestPayload(Model):
@@ -3861,6 +3862,10 @@ class CreateWorkflowLandingRequestPayload(Model):
     workflow_target_type: Literal["stored_workflow", "workflow", "trs_url"]
     request_state: Optional[Dict[str, Any]] = None
     client_secret: Optional[str] = None
+    public: bool = Field(
+        False,
+        description="If workflow landing request is public anyone with the uuid can use the landing request. If not public the request must be claimed before use and additional verification might occur.",
+    )
 
 
 class ClaimLandingPayload(Model):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3858,7 +3858,7 @@ class CreateToolLandingRequestPayload(Model):
 
 class CreateWorkflowLandingRequestPayload(Model):
     workflow_id: str
-    workflow_target_type: Literal["stored_workflow", "workflow"]
+    workflow_target_type: Literal["stored_workflow", "workflow", "trs_url"]
     request_state: Optional[Dict[str, Any]] = None
     client_secret: Optional[str] = None
 
@@ -3878,7 +3878,7 @@ class ToolLandingRequest(Model):
 class WorkflowLandingRequest(Model):
     uuid: UuidField
     workflow_id: str
-    workflow_target_type: Literal["stored_workflow", "workflow"]
+    workflow_target_type: Literal["stored_workflow", "workflow", "trs_url"]
     request_state: Dict[str, Any]
     state: LandingRequestState
 

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -299,6 +299,13 @@ class NavigatesGalaxy(HasDriver):
         except SeleniumTimeoutException as e:
             raise ClientBuildException(e)
 
+    def go_to_workflow_landing(self, uuid: str, public: Literal["false", "true"], client_secret: Optional[str]):
+        path = f"workflow_landings/{uuid}?public={public}"
+        if client_secret:
+            path = f"{path}&client_secret={client_secret}"
+        self.driver.get(self.build_url(path))
+        self.components.workflow_run.run_workflow.wait_for_visible()
+
     def go_to_trs_search(self) -> None:
         self.driver.get(self.build_url("workflows/trs_search"))
         self.components.masthead._.wait_for_visible()

--- a/lib/galaxy/tool_util/client/landing.py
+++ b/lib/galaxy/tool_util/client/landing.py
@@ -65,7 +65,10 @@ def generate_claim_url(request: Request) -> Response:
         landing_request_url,
         json=template,
     )
-    raw_response.raise_for_status()
+    try:
+        raw_response.raise_for_status()
+    except Exception:
+        raise Exception("Request failed: %s", raw_response.text)
     response = raw_response.json()
     url = f"{galaxy_url}/{template_type}_landings/{response['uuid']}"
     if client_secret:

--- a/lib/galaxy/tools/stock.py
+++ b/lib/galaxy/tools/stock.py
@@ -7,6 +7,7 @@ from lxml.etree import XMLSyntaxError
 # Set GALAXY_INCLUDES_ROOT from tool shed to point this at a Galaxy root
 # (once we are running the tool shed from packages not rooted with Galaxy).
 import galaxy.tools
+from galaxy.tool_util.loader_directory import looks_like_a_tool_xml
 from galaxy.tool_util.parser import get_tool_source
 from galaxy.util import galaxy_directory
 from galaxy.util.resources import files
@@ -26,7 +27,7 @@ def stock_tool_sources():
 
 
 def _walk_directory_for_tools(path):
-    if path.is_file() and path.name.endswith(".xml"):
+    if path.is_file() and not path.name.endswith("tool_conf.xml") and looks_like_a_tool_xml(path):
         yield path
     elif path.is_dir():
         for directory in path.iterdir():

--- a/lib/galaxy/webapps/base/api.py
+++ b/lib/galaxy/webapps/base/api.py
@@ -264,7 +264,7 @@ def include_all_package_routers(app: FastAPI, package_name: str):
     # handle CORS preflight requests - synchronize with wsgi behavior.
     # this needs to happen last so it doesn't clobber routes with explicit cors handling
     # it doesn't affect the CORS middleware since the middleware terminates the request handling before routing
-    @app.options("/api/{rest_of_path:path}")
+    @app.options("/api/{rest_of_path:path}", include_in_schema=False)
     async def preflight_handler(request: Request, rest_of_path: str) -> Response:
         response = Response()
         response.headers["Access-Control-Allow-Headers"] = "*"

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1171,11 +1171,7 @@ class FastAPIWorkflows:
         trans: ProvidesUserContext = DependsOnTrans,
         workflow_landing_request: CreateWorkflowLandingRequestPayload = Body(...),
     ) -> WorkflowLandingRequest:
-        try:
-            return self.landing_manager.create_workflow_landing_request(workflow_landing_request)
-        except Exception:
-            log.exception("Problem...")
-            raise
+        return self.landing_manager.create_workflow_landing_request(workflow_landing_request)
 
     @router.post("/api/workflow_landings/{uuid}/claim")
     def claim_landing(
@@ -1184,11 +1180,7 @@ class FastAPIWorkflows:
         uuid: UUID4 = LandingUuidPathParam,
         payload: Optional[ClaimLandingPayload] = Body(...),
     ) -> WorkflowLandingRequest:
-        try:
-            return self.landing_manager.claim_workflow_landing_request(trans, uuid, payload)
-        except Exception:
-            log.exception("claiim problem...")
-            raise
+        return self.landing_manager.claim_workflow_landing_request(trans, uuid, payload)
 
     @router.get("/api/workflow_landings/{uuid}")
     def get_landing(

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -105,6 +105,7 @@ from galaxy.webapps.galaxy.api import (
     BaseGalaxyAPIController,
     depends,
     DependsOnTrans,
+    DependsOnUser,
     IndexQueryTag,
     LandingUuidPathParam,
     Router,
@@ -1179,6 +1180,7 @@ class FastAPIWorkflows:
         trans: ProvidesUserContext = DependsOnTrans,
         uuid: UUID4 = LandingUuidPathParam,
         payload: Optional[ClaimLandingPayload] = Body(...),
+        user: model.User = DependsOnUser,
     ) -> WorkflowLandingRequest:
         return self.landing_manager.claim_workflow_landing_request(trans, uuid, payload)
 
@@ -1187,6 +1189,7 @@ class FastAPIWorkflows:
         self,
         trans: ProvidesUserContext = DependsOnTrans,
         uuid: UUID4 = LandingUuidPathParam,
+        user: model.User = DependsOnUser,
     ) -> WorkflowLandingRequest:
         return self.landing_manager.get_workflow_landing_request(trans, uuid)
 

--- a/lib/galaxy_test/api/test_landing.py
+++ b/lib/galaxy_test/api/test_landing.py
@@ -4,7 +4,10 @@ from typing import (
     Dict,
 )
 
-from galaxy.schema.schema import CreateWorkflowLandingRequestPayload
+from galaxy.schema.schema import (
+    CreateWorkflowLandingRequestPayload,
+    WorkflowLandingRequest,
+)
 from galaxy_test.base.populators import (
     DatasetPopulator,
     skip_without_tool,
@@ -23,22 +26,85 @@ class TestLandingApi(ApiTestCase):
         self.workflow_populator = WorkflowPopulator(self.galaxy_interactor)
 
     @skip_without_tool("cat1")
-    def test_workflow_landing(self):
-        workflow_id = self.workflow_populator.simple_workflow("test_landing")
-        workflow_target_type = "stored_workflow"
-        request_state = _workflow_request_state()
-        request = CreateWorkflowLandingRequestPayload(
-            workflow_id=workflow_id,
-            workflow_target_type=workflow_target_type,
-            request_state=request_state,
-        )
+    def test_create_public_workflow_landing_authenticated_user(self):
+        request = _get_simple_landing_payload(self.workflow_populator, public=True)
         response = self.dataset_populator.create_workflow_landing(request)
-        assert response.workflow_id == workflow_id
-        assert response.workflow_target_type == workflow_target_type
+        assert response.workflow_id == request.workflow_id
+        assert response.workflow_target_type == request.workflow_target_type
 
-        response = self.dataset_populator.claim_workflow_landing(response.uuid)
-        assert response.workflow_id == workflow_id
-        assert response.workflow_target_type == workflow_target_type
+        with self._different_user():
+            # Can use without claim
+            _can_use_request(self.dataset_populator, response)
+
+        with self._different_user(anon=True):
+            # Cannot claim since can't run workflows
+            _cannot_use_request(self.dataset_populator, response)
+
+        # Should claim of public landing request be denied ?
+        # Yes, so other user cannot own workflow in between use and invocation submission
+        # No, since there's no way to delete a landing request. If you accidentally make something
+        # with a private reference public you can't delete the landing page request.
+        # TODO: allow deleting landing request, deny claiming public requests ?
+
+        with self._different_user():
+            _can_claim_request(self.dataset_populator, response)
+            _can_use_request(self.dataset_populator, response)
+
+        # Cannot use if other user claimed
+        _cannot_claim_request(self.dataset_populator, response)
+
+    @skip_without_tool("cat1")
+    def test_create_public_workflow_landing_anonymous_user(self):
+        # Anonymous user can create public landing request
+        request = _get_simple_landing_payload(self.workflow_populator, public=True)
+        with self._different_user(anon=True):
+            response = self.dataset_populator.create_workflow_landing(request)
+
+        with self._different_user():
+            # Can use without claim
+            _can_use_request(self.dataset_populator, response)
+
+        with self._different_user(anon=True):
+            # Cannot claim since can't run workflows
+            _cannot_use_request(self.dataset_populator, response)
+
+        with self._different_user():
+            _can_claim_request(self.dataset_populator, response)
+            _can_use_request(self.dataset_populator, response)
+
+        # Cannot use if other user claimed
+        _cannot_claim_request(self.dataset_populator, response)
+
+    @skip_without_tool("cat1")
+    def test_create_private_workflow_landing_authenticated_user(self):
+        request = _get_simple_landing_payload(self.workflow_populator, public=False)
+        response = self.dataset_populator.create_workflow_landing(request)
+        with self._different_user():
+            # Must be claimed first
+            _cannot_use_request(self.dataset_populator, response, expect_status_code=409)
+            _can_claim_request(self.dataset_populator, response)
+            # Can be used after claim by same user
+            _can_use_request(self.dataset_populator, response)
+
+        # other user claimed, so we can't use
+        _cannot_claim_request(self.dataset_populator, response)
+        _cannot_use_request(self.dataset_populator, response)
+
+    @skip_without_tool("cat1")
+    def test_create_private_workflow_landing_anonymous_user(self):
+        request = _get_simple_landing_payload(self.workflow_populator, public=False)
+        with self._different_user(anon=True):
+            response = self.dataset_populator.create_workflow_landing(request)
+        with self._different_user():
+            # Must be claimed first
+            _cannot_use_request(self.dataset_populator, response, expect_status_code=409)
+            _can_claim_request(self.dataset_populator, response)
+            # Can be used after claim by same user
+            _can_use_request(self.dataset_populator, response)
+
+        # other user claimed, so we can't use
+        _cannot_claim_request(self.dataset_populator, response)
+        _cannot_use_request(self.dataset_populator, response)
 
 
 def _workflow_request_state() -> Dict[str, Any]:
@@ -50,3 +116,51 @@ def _workflow_request_state() -> Dict[str, Any]:
         "WorkflowInput2": {"src": "url", "url": f"base64://{input_b64_2}", "ext": "txt", "deferred": deferred},
     }
     return inputs
+
+
+def _get_simple_landing_payload(workflow_populator: WorkflowPopulator, public: bool = False):
+    workflow_id = workflow_populator.simple_workflow("test_landing")
+    if public:
+        workflow_populator.make_public(workflow_id)
+    workflow_target_type = "stored_workflow"
+    request_state = _workflow_request_state()
+    return CreateWorkflowLandingRequestPayload(
+        workflow_id=workflow_id,
+        workflow_target_type=workflow_target_type,
+        request_state=request_state,
+        public=public,
+    )
+
+
+def _can_claim_request(dataset_populator: DatasetPopulator, request: WorkflowLandingRequest):
+    response = dataset_populator.claim_workflow_landing(request.uuid)
+    assert response.workflow_id == request.workflow_id
+    assert response.workflow_target_type == request.workflow_target_type
+
+
+def _cannot_claim_request(dataset_populator: DatasetPopulator, request: WorkflowLandingRequest):
+    exception_encountered = False
+    try:
+        _can_claim_request(dataset_populator, request)
+    except Exception as e:
+        assert "Request status code (403)" in str(e)
+        exception_encountered = True
+    assert exception_encountered, "Expected claim to fail"
+
+
+def _can_use_request(dataset_populator: DatasetPopulator, request: WorkflowLandingRequest):
+    response = dataset_populator.use_workflow_landing(request.uuid)
+    assert response.workflow_id == request.workflow_id
+    assert response.workflow_target_type == request.workflow_target_type
+
+
+def _cannot_use_request(
+    dataset_populator: DatasetPopulator, request: WorkflowLandingRequest, expect_status_code: int = 403
+):
+    exception_encountered = False
+    try:
+        _can_use_request(dataset_populator, request)
+    except Exception as e:
+        assert f"Request status code ({expect_status_code})" in str(e)
+        exception_encountered = True
+    assert exception_encountered, "Expected landing page usage to fail"

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -797,6 +797,12 @@ class BaseDatasetPopulator(BasePopulator):
         api_asserts.assert_status_code_is(claim_response, 200)
         return WorkflowLandingRequest.model_validate(claim_response.json())
 
+    def use_workflow_landing(self, uuid: UUID4) -> WorkflowLandingRequest:
+        url = f"workflow_landings/{uuid}"
+        landing_reponse = self._get(url, {"client_secret": "foobar"})
+        api_asserts.assert_status_code_is(landing_reponse, 200)
+        return WorkflowLandingRequest.model_validate(landing_reponse.json())
+
     def create_tool_from_path(self, tool_path: str) -> Dict[str, Any]:
         tool_directory = os.path.dirname(os.path.abspath(tool_path))
         payload = dict(

--- a/lib/galaxy_test/selenium/test_workflow_landing.py
+++ b/lib/galaxy_test/selenium/test_workflow_landing.py
@@ -1,0 +1,63 @@
+from typing import Literal
+
+from galaxy.schema.schema import CreateWorkflowLandingRequestPayload
+from .framework import (
+    managed_history,
+    RunsWorkflows,
+    selenium_test,
+    SeleniumTestCase,
+)
+
+
+class TestWorkflowLanding(SeleniumTestCase, RunsWorkflows):
+    ensure_registered = True
+
+    @selenium_test
+    @managed_history
+    def test_private_request(self):
+        self._create_landing_and_run(public="false")
+
+    @selenium_test
+    @managed_history
+    def test_pubblic_request(self):
+        self._create_landing_and_run(public="true")
+
+    def _create_landing_and_run(self, public: Literal["false", "true"]):
+        self.perform_upload(self.get_filename("1.txt"))
+        self.wait_for_history()
+        workflow_id = self.workflow_populator.upload_yaml_workflow(
+            """
+class: GalaxyWorkflow
+inputs:
+  input_int: integer
+  input_data: data
+steps:
+  simple_constructs:
+    tool_id: simple_constructs
+    label: tool_exec
+    in:
+      inttest: input_int
+      files_0|file: input_data
+""",
+            name=self._get_random_name("landing_wf"),
+        )
+        if public == "true":
+            client_secret = None
+        else:
+            client_secret = "abcdefg"
+        landing_request_payload = CreateWorkflowLandingRequestPayload(
+            workflow_id=workflow_id,
+            workflow_target_type="stored_workflow",
+            request_state={"input_int": 321123},
+            public=public,
+            client_secret=client_secret,
+        )
+        landing_request = self.dataset_populator.create_workflow_landing(landing_request_payload)
+        self.go_to_workflow_landing(str(landing_request.uuid), public="false", client_secret=client_secret)
+        self.screenshot("workflow_run_private_landing")
+        self.workflow_run_submit()
+        output_hid = 2
+        self.workflow_run_wait_for_ok(hid=output_hid)
+        history_id = self.current_history_id()
+        content = self.dataset_populator.get_history_dataset_content(history_id, hid=output_hid)
+        assert "321123" in content, content

--- a/test/unit/workflows/test_trs_proxy.py
+++ b/test/unit/workflows/test_trs_proxy.py
@@ -4,6 +4,7 @@ from os import environ
 import pytest
 import yaml
 
+from galaxy.config import GalaxyAppConfiguration
 from galaxy.exceptions import ConfigDoesNotAllowException
 from galaxy.workflow.trs_proxy import (
     GA4GH_GALAXY_DESCRIPTOR,
@@ -18,8 +19,12 @@ search_test = pytest.mark.skipif(
 )
 
 
+def get_trs_proxy():
+    return TrsProxy(GalaxyAppConfiguration(trs_servers_config_file=None, fetch_url_allowlist_ips=[]))
+
+
 def test_proxy():
-    proxy = TrsProxy()
+    proxy = get_trs_proxy()
     server = proxy.get_server("dockstore")
 
     assert "dockstore" == proxy.get_servers()[0]["id"]
@@ -49,7 +54,7 @@ def test_proxy():
 
 
 def test_match_url():
-    proxy = TrsProxy()
+    proxy = get_trs_proxy()
     valid_dockstore = proxy._match_url(
         "https://dockstore.org/api/ga4gh/trs/v2/tools/"
         "quay.io%2Fcollaboratory%2Fdockstore-tool-bedtools-genomecov/versions/0.3",
@@ -115,7 +120,7 @@ def test_match_url():
 
 
 def test_server_from_url():
-    proxy = TrsProxy()
+    proxy = get_trs_proxy()
     server = proxy.server_from_url("https://workflowhub.eu")
 
     assert "https://workflowhub.eu" == server._trs_url
@@ -144,7 +149,7 @@ def test_server_from_url():
 
 @search_test
 def test_search():
-    proxy = TrsProxy()
+    proxy = get_trs_proxy()
     server = proxy.get_server("dockstore")
 
     search_kwd = parse_search_kwds("documentation")

--- a/test/unit/workflows/test_trs_proxy.py
+++ b/test/unit/workflows/test_trs_proxy.py
@@ -20,7 +20,7 @@ search_test = pytest.mark.skipif(
 
 
 def get_trs_proxy():
-    return TrsProxy(GalaxyAppConfiguration(trs_servers_config_file=None, fetch_url_allowlist_ips=[]))
+    return TrsProxy(GalaxyAppConfiguration(fetch_url_allowlist_ips=[], override_tempdir=False))
 
 
 def test_proxy():


### PR DESCRIPTION
Optimizing the BRC / IWC case first here:
- Separate creation of public and private landing requests
- Don't claim the landing page if public=true is passed in request
- Allow passing in a TRS url so we don't need to hardcode instance-specific workflow ids
- Don't reimport TRS workflow if the user already has it
- Redirect user to login / registration form if not logged in, then send them back to landing page

Also adds a selenium test that exercises public and private landing requests.  

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
