### PR TITLE
Ignore preflight options in API schema

### DIFF
--- a/lib/galaxy/webapps/base/api.py
+++ b/lib/galaxy/webapps/base/api.py
@@ -264,7 +264,7 @@ def include_all_package_routers(app: FastAPI, package_name: str):
     # handle CORS preflight requests - synchronize with wsgi behavior.
     # this needs to happen last so it doesn't clobber routes with explicit cors handling
     # it doesn't affect the CORS middleware since the middleware terminates the request handling before routing
-    @app.options("/api/{rest_of_path:path}")
+    @app.options("/api/{rest_of_path:path}", include_in_schema=False)
     async def preflight_handler(request: Request, rest_of_path: str) -> Response:
         response = Response()
         response.headers["Access-Control-Allow-Headers"] = "*"


### PR DESCRIPTION
This should fix the OpenAPI schema CI checks.

xref https://github.com/galaxyproject/galaxy/pull/18979 / https://github.com/galaxyproject/galaxy/pull/18963

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
