### PR TITLE
Allow recovering a normalized version of workflow request state from API

### DIFF
--- a/.github/workflows/framework_workflows.yaml
+++ b/.github/workflows/framework_workflows.yaml
@@ -16,6 +16,7 @@ on:
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
+  GALAXY_TEST_WORKFLOW_AFTER_RERUN: '1'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -2645,6 +2645,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/invocations/{invocation_id}/request": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a description modeling an API request to invoke this workflow - this is recreated and will be more specific in some ways than the initial creation request. */
+        get: operations["invocation_as_request_api_invocations__invocation_id__request_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/invocations/{invocation_id}/step_jobs_summary": {
         parameters: {
             query?: never;
@@ -12385,8 +12402,9 @@ export interface components {
              */
             batch: boolean | null;
             /**
-             * Dataset Map
-             * @description TODO
+             * Legacy Dataset Map
+             * @deprecated
+             * @description An older alternative to specifying inputs using database IDs, do not use this and use inputs instead
              * @default {}
              */
             ds_map: {
@@ -12409,12 +12427,12 @@ export interface components {
             history_id?: string | null;
             /**
              * Inputs
-             * @description TODO
+             * @description Specify values for formal inputs to the workflow
              */
             inputs?: Record<string, never> | null;
             /**
              * Inputs By
-             * @description How inputs maps to inputs (datasets/collections) to workflows steps.
+             * @description How the 'inputs' field maps its inputs (datasets/collections/step parameters) to workflows steps.
              */
             inputs_by?: string | null;
             /**
@@ -12441,35 +12459,35 @@ export interface components {
              */
             no_add_to_history: boolean | null;
             /**
-             * Parameters
-             * @description The raw parameters for the workflow invocation.
+             * Legacy Step Parameters
+             * @description Parameters specified per-step for the workflow invocation, this is legacy and you should generally use inputs and only specify the formal parameters of a workflow instead.
              * @default {}
              */
             parameters: Record<string, never> | null;
             /**
-             * Parameters Normalized
-             * @description Indicates if parameters are already normalized for workflow invocation.
+             * Legacy Step Parameters Normalized
+             * @description Indicates if legacy parameters are already normalized to be indexed by the order_index and are specified as a dictionary per step. Legacy-style parameters could previously be specified as one parameter per step or by tool ID.
              * @default false
              */
             parameters_normalized: boolean | null;
             /**
              * Preferred Intermediate Object Store ID
-             * @description The ID of the ? object store that should be used to store ? datasets in this history.
+             * @description The ID of the object store that should be used to store the intermediate datasets of this workflow -  - Galaxy's job configuration may override this in some cases but this workflow preference will override tool and user preferences
              */
             preferred_intermediate_object_store_id?: string | null;
             /**
              * Preferred Object Store ID
-             * @description The ID of the object store that should be used to store new datasets in this history.
+             * @description The ID of the object store that should be used to store all datasets (can instead specify object store IDs for intermediate and outputs datasts separately) -  - Galaxy's job configuration may override this in some cases but this workflow preference will override tool and user preferences
              */
             preferred_object_store_id?: string | null;
             /**
              * Preferred Outputs Object Store ID
-             * @description The ID of the object store that should be used to store ? datasets in this history.
+             * @description The ID of the object store that should be used to store the marked output datasets of this workflow - Galaxy's job configuration may override this in some cases but this workflow preference will override tool and user preferences.
              */
             preferred_outputs_object_store_id?: string | null;
             /**
              * Replacement Parameters
-             * @description TODO
+             * @description Class of parameters mostly used for string replacement in PJAs. In best practice workflows, these should be replaced with input parameters
              * @default {}
              */
             replacement_params: Record<string, never> | null;
@@ -12481,7 +12499,7 @@ export interface components {
             require_exact_tool_versions: boolean | null;
             /**
              * Resource Parameters
-             * @description TODO
+             * @description If a workflow_resource_params_file file is defined and the target workflow is configured to consumer resource parameters, they can be specified with this parameter. See https://github.com/galaxyproject/galaxy/pull/4830 for more information.
              * @default {}
              */
             resource_params: Record<string, never> | null;
@@ -12490,11 +12508,6 @@ export interface components {
              * @description Scheduler to use for workflow invocation.
              */
             scheduler?: string | null;
-            /**
-             * Step Parameters
-             * @description TODO
-             */
-            step_parameters?: Record<string, never> | null;
             /**
              * Use cached job
              * @description Indicated whether to use a cached job for workflow invocation.
@@ -18185,6 +18198,86 @@ export interface components {
              * Workflow ID
              * @description The encoded Workflow ID associated with the invocation.
              * @example 0123456789ABCDEF
+             */
+            workflow_id: string;
+        };
+        /**
+         * WorkflowInvocationRequestModel
+         * @description Model a workflow invocation request (InvokeWorkflowPayload) for an existing invocation.
+         */
+        WorkflowInvocationRequestModel: {
+            /**
+             * History ID
+             * @description The encoded history id the workflow was run in.
+             */
+            history_id: string;
+            /**
+             * Inputs
+             * @description Values for inputs
+             */
+            inputs: Record<string, never>;
+            /**
+             * Inputs by
+             * @description How the 'inputs' field maps its inputs (datasets/collections/step parameters) to workflows steps.
+             */
+            inputs_by: string;
+            /**
+             * Is instance
+             * @description This API yields a particular workflow instance, newer workflows belonging to the same storedworkflow may have different state.
+             * @default true
+             * @constant
+             * @enum {boolean}
+             */
+            instance: true;
+            /**
+             * Legacy Step Parameters
+             * @description Parameters specified per-step for the workflow invocation, this is legacy and you should generally use inputs and only specify the formal parameters of a workflow instead. If these are set, the workflow was not executed in a best-practice fashion and we the resulting invocation request may not fully reflect the executed workflow state.
+             */
+            parameters?: Record<string, never> | null;
+            /**
+             * Legacy Step Parameters Normalized
+             * @description Indicates if legacy parameters are already normalized to be indexed by the order_index and are specified as a dictionary per step. Legacy-style parameters could previously be specified as one parameter per step or by tool ID.
+             * @default true
+             * @constant
+             * @enum {boolean}
+             */
+            parameters_normalized: true;
+            /**
+             * Preferred Intermediate Object Store ID
+             * @description The ID of the object store that should be used to store the intermediate datasets of this workflow -  - Galaxy's job configuration may override this in some cases but this workflow preference will override tool and user preferences
+             */
+            preferred_intermediate_object_store_id?: string | null;
+            /**
+             * Preferred Object Store ID
+             * @description The ID of the object store that should be used to store all datasets (can instead specify object store IDs for intermediate and outputs datasts separately) -  - Galaxy's job configuration may override this in some cases but this workflow preference will override tool and user preferences
+             */
+            preferred_object_store_id?: string | null;
+            /**
+             * Preferred Outputs Object Store ID
+             * @description The ID of the object store that should be used to store the marked output datasets of this workflow - Galaxy's job configuration may override this in some cases but this workflow preference will override tool and user preferences.
+             */
+            preferred_outputs_object_store_id?: string | null;
+            /**
+             * Replacement Parameters
+             * @description Class of parameters mostly used for string replacement in PJAs. In best practice workflows, these should be replaced with input parameters
+             * @default {}
+             */
+            replacement_params: Record<string, never> | null;
+            /**
+             * Resource Parameters
+             * @description If a workflow_resource_params_file file is defined and the target workflow is configured to consumer resource parameters, they can be specified with this parameter. See https://github.com/galaxyproject/galaxy/pull/4830 for more information.
+             * @default {}
+             */
+            resource_params: Record<string, never> | null;
+            /**
+             * Use cached job
+             * @description Indicated whether to use a cached job for workflow invocation.
+             * @default false
+             */
+            use_cached_job: boolean;
+            /**
+             * Workflow ID
+             * @description The encoded Workflow ID associated with the invocation.
              */
             workflow_id: string;
         };
@@ -27035,6 +27128,50 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    invocation_as_request_api_invocations__invocation_id__request_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The encoded database identifier of the Invocation. */
+                invocation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkflowInvocationRequestModel"];
+                };
             };
             /** @description Request Error */
             "4XX": {

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7749,6 +7749,16 @@ class StoredWorkflow(Base, HasTags, Dictifiable, RepresentById, UsesCreateAndUpd
             raise galaxy.exceptions.RequestParameterInvalidException("Version does not exist")
         return list(reversed(self.workflows))[version]
 
+    def get_internal_version_by_id(self, workflow_instance_id: int):
+        sa_session = object_session(self)
+        assert sa_session
+        workflow = sa_session.get(Workflow, workflow_instance_id)
+        if not workflow:
+            raise galaxy.exceptions.ObjectNotFound()
+        elif workflow.stored_workflow != self:
+            raise galaxy.exceptions.RequestParameterInvalidException()
+        return workflow
+
     def version_of(self, workflow):
         for version, workflow_instance in enumerate(reversed(self.workflows)):
             if workflow_instance.id == workflow.id:

--- a/lib/galaxy/schema/invocation.py
+++ b/lib/galaxy/schema/invocation.py
@@ -47,6 +47,19 @@ from galaxy.schema.schema import (
     UpdateTimeField,
     WithModelClass,
 )
+from .workflows import (
+    INPUTS_BY_DESCRIPTION,
+    PreferredIntermediateObjectStoreIdField,
+    PreferredObjectStoreIdField,
+    PreferredOutputsObjectStoreIdField,
+    ReplacementParametersField,
+    ResourceParametersField,
+    STEP_PARAMETERS_DESCRIPTION,
+    STEP_PARAMETERS_NORMALIZED_DESCRIPTION,
+    STEP_PARAMETERS_NORMALIZED_TITLE,
+    STEP_PARAMETERS_TITLE,
+    UseCachedJobField,
+)
 
 INVOCATION_STEP_OUTPUT_SRC = Literal["hda"]
 INVOCATION_STEP_COLLECTION_OUTPUT_SRC = Literal["hdca"]
@@ -531,13 +544,16 @@ class InvocationOutputCollection(InvocationIOBase):
     )
 
 
+InvocationWorkflowIdField = Field(
+    title="Workflow ID", description="The encoded Workflow ID associated with the invocation."
+)
+
+
 class WorkflowInvocationCollectionView(Model, WithModelClass):
     id: EncodedDatabaseIdField = InvocationIdField
     create_time: datetime = CreateTimeField
     update_time: datetime = UpdateTimeField
-    workflow_id: EncodedDatabaseIdField = Field(
-        title="Workflow ID", description="The encoded Workflow ID associated with the invocation."
-    )
+    workflow_id: EncodedDatabaseIdField = InvocationWorkflowIdField
     history_id: EncodedDatabaseIdField = Field(
         default=...,
         title="History ID",
@@ -581,6 +597,48 @@ class WorkflowInvocationResponse(RootModel):
     root: Annotated[
         Union[WorkflowInvocationElementView, WorkflowInvocationCollectionView], Field(union_mode="left_to_right")
     ]
+
+
+class WorkflowInvocationRequestModel(Model):
+    """Model a workflow invocation request (InvokeWorkflowPayload) for an existing invocation."""
+
+    history_id: str = Field(
+        ...,
+        title="History ID",
+        description="The encoded history id the workflow was run in.",
+    )
+    workflow_id: str = Field(title="Workflow ID", description="The encoded Workflow ID associated with the invocation.")
+    inputs: Dict[str, Any] = Field(
+        ...,
+        title="Inputs",
+        description="Values for inputs",
+    )
+    inputs_by: str = Field(
+        ...,
+        title="Inputs by",
+        description=INPUTS_BY_DESCRIPTION,
+    )
+    replacement_params: Optional[Dict[str, Any]] = ReplacementParametersField
+    resource_params: Optional[Dict[str, Any]] = ResourceParametersField
+    use_cached_job: bool = UseCachedJobField
+    preferred_object_store_id: Optional[str] = PreferredObjectStoreIdField
+    preferred_intermediate_object_store_id: Optional[str] = PreferredIntermediateObjectStoreIdField
+    preferred_outputs_object_store_id: Optional[str] = PreferredOutputsObjectStoreIdField
+    parameters_normalized: Literal[True] = Field(
+        True,
+        title=STEP_PARAMETERS_NORMALIZED_TITLE,
+        description=STEP_PARAMETERS_NORMALIZED_DESCRIPTION,
+    )
+    parameters: Optional[Dict[str, Any]] = Field(
+        None,
+        title=STEP_PARAMETERS_TITLE,
+        description=f"{STEP_PARAMETERS_DESCRIPTION} If these are set, the workflow was not executed in a best-practice fashion and we the resulting invocation request may not fully reflect the executed workflow state.",
+    )
+    instance: Literal[True] = Field(
+        True,
+        title="Is instance",
+        description="This API yields a particular workflow instance, newer workflows belonging to the same storedworkflow may have different state.",
+    )
 
 
 class InvocationJobsSummaryBaseModel(Model):

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -64,6 +64,7 @@ from galaxy.schema.invocation import (
     InvocationStepJobsResponseJobModel,
     InvocationStepJobsResponseStepModel,
     InvocationUpdatePayload,
+    WorkflowInvocationRequestModel,
     WorkflowInvocationResponse,
 )
 from galaxy.schema.schema import (
@@ -1468,6 +1469,17 @@ class FastAPIInvocations:
             step_details=step_details, legacy_job_state=legacy_job_state
         )
         return self.invocations_service.show(trans, invocation_id, serialization_params, eager=True)
+
+    @router.get(
+        "/api/invocations/{invocation_id}/request",
+        summary="Get a description modeling an API request to invoke this workflow - this is recreated and will be more specific in some ways than the initial creation request.",
+    )
+    def invocation_as_request(
+        self,
+        invocation_id: InvocationIDPathParam,
+        trans: ProvidesUserContext = DependsOnTrans,
+    ) -> WorkflowInvocationRequestModel:
+        return self.invocations_service.as_request(trans, invocation_id)
 
     @router.get(
         "/api/workflows/{workflow_id}/invocations/{invocation_id}",

--- a/lib/galaxy/webapps/galaxy/services/invocations.py
+++ b/lib/galaxy/webapps/galaxy/services/invocations.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import (
     Any,
@@ -14,9 +15,13 @@ from galaxy.celery.tasks import (
 )
 from galaxy.exceptions import (
     AdminRequiredException,
+    InconsistentDatabase,
     ObjectNotFound,
 )
-from galaxy.managers.context import ProvidesHistoryContext
+from galaxy.managers.context import (
+    ProvidesHistoryContext,
+    ProvidesUserContext,
+)
 from galaxy.managers.histories import HistoryManager
 from galaxy.managers.jobs import (
     fetch_job_states,
@@ -24,8 +29,11 @@ from galaxy.managers.jobs import (
 )
 from galaxy.managers.workflows import WorkflowsManager
 from galaxy.model import (
+    HistoryDatasetAssociation,
+    HistoryDatasetCollectionAssociation,
     WorkflowInvocation,
     WorkflowInvocationStep,
+    WorkflowRequestInputParameter,
 )
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.invocation import (
@@ -33,6 +41,7 @@ from galaxy.schema.invocation import (
     InvocationSerializationParams,
     InvocationSerializationView,
     InvocationStep,
+    WorkflowInvocationRequestModel,
     WorkflowInvocationResponse,
 )
 from galaxy.schema.schema import (
@@ -132,6 +141,12 @@ class InvocationsService(ServiceBase, ConsumesModelStores):
             trans, invocation_id, eager, check_ownership=False, check_accessible=True
         )
         return self.serialize_workflow_invocation(wfi, serialization_params)
+
+    def as_request(self, trans: ProvidesUserContext, invocation_id) -> WorkflowInvocationRequestModel:
+        wfi = self._workflows_manager.get_invocation(
+            trans, invocation_id, True, check_ownership=True, check_accessible=True
+        )
+        return self.serialize_workflow_invocation_to_request(trans, wfi)
 
     def cancel(self, trans, invocation_id, serialization_params):
         wfi = self._workflows_manager.request_invocation_cancellation(trans, invocation_id)
@@ -252,3 +267,71 @@ class InvocationsService(ServiceBase, ConsumesModelStores):
             history=history,
         )
         return self.serialize_workflow_invocations(object_tracker.invocations_by_key.values(), serialization_params)
+
+    def serialize_workflow_invocation_to_request(
+        self, trans: ProvidesUserContext, invocation: WorkflowInvocation
+    ) -> WorkflowInvocationRequestModel:
+        history_id = trans.security.encode_id(invocation.history.id)
+        workflow_id = trans.security.encode_id(invocation.workflow.id)
+        inputs, inputs_by = invocation.recover_inputs()
+        export_inputs = {}
+        for key, value in inputs.items():
+            if isinstance(value, HistoryDatasetAssociation):
+                export_inputs[key] = {"src": "hda", "id": trans.security.encode_id(value.id)}
+            elif isinstance(value, HistoryDatasetCollectionAssociation):
+                export_inputs[key] = {"src": "hdca", "id": trans.security.encode_id(value.id)}
+            else:
+                export_inputs[key] = value
+
+        param_types = WorkflowRequestInputParameter.types
+        steps_by_id = invocation.workflow.steps_by_id
+
+        replacement_dict = {}
+        resource_params = {}
+        use_cached_job = False
+        preferred_object_store_id = None
+        preferred_intermediate_object_store_id = None
+        preferred_outputs_object_store_id = None
+        step_param_map: Dict[str, Dict] = {}
+        for parameter in invocation.input_parameters:
+            parameter_type = parameter.type
+
+            if parameter_type == param_types.REPLACEMENT_PARAMETERS:
+                replacement_dict[parameter.name] = parameter.value
+            elif parameter_type == param_types.META_PARAMETERS:
+                # copy_inputs_to_history is being skipped here sort of intentionally,
+                # we wouldn't want to include this on re-run.
+                if parameter.name == "use_cached_job":
+                    use_cached_job = parameter.value == "true"
+                if parameter.name == "preferred_object_store_id":
+                    preferred_object_store_id = parameter.value
+                if parameter.name == "preferred_intermediate_object_store_id":
+                    preferred_intermediate_object_store_id = parameter.value
+                if parameter.name == "preferred_outputs_object_store_id":
+                    preferred_outputs_object_store_id = parameter.value
+            elif parameter_type == param_types.RESOURCE_PARAMETERS:
+                resource_params[parameter.name] = parameter.value
+            elif parameter_type == param_types.STEP_PARAMETERS:
+                # TODO: test subworkflows and ensure this works
+                step_id: int
+                try:
+                    step_id = int(parameter.name)
+                except TypeError:
+                    raise InconsistentDatabase("saved workflow step parameters not in the format expected")
+                step_param_map[str(steps_by_id[step_id].order_index)] = json.loads(parameter.value)
+
+        return WorkflowInvocationRequestModel(
+            history_id=history_id,
+            workflow_id=workflow_id,
+            instance=True,  # this is a workflow ID and not a stored workflow ID
+            inputs=export_inputs,
+            inputs_by=inputs_by,
+            replacement_params=None if not replacement_dict else replacement_dict,
+            resource_params=None if not resource_params else resource_params,
+            use_cached_job=use_cached_job,
+            preferred_object_store_id=preferred_object_store_id,
+            preferred_intermediate_object_store_id=preferred_intermediate_object_store_id,
+            preferred_outputs_object_store_id=preferred_outputs_object_store_id,
+            parameters_normalized=True,
+            parameters=None if not step_param_map else step_param_map,
+        )

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -131,7 +131,10 @@ class WorkflowsService(ServiceBase):
         by_stored_id = not payload.instance
         stored_workflow = self._workflows_manager.get_stored_accessible_workflow(trans, workflow_id, by_stored_id)
         version = payload.version
-        workflow = stored_workflow.get_internal_version(version)
+        if version is None and payload.instance:
+            workflow = stored_workflow.get_internal_version_by_id(workflow_id)
+        else:
+            workflow = stored_workflow.get_internal_version(version)
         run_configs = build_workflow_run_configs(trans, workflow, payload.model_dump(exclude_unset=True))
         is_batch = payload.batch
         if not is_batch and len(run_configs) != 1:

--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -116,7 +116,7 @@ def extract_steps(
         if name not in step_labels:
             step.label = name
             step_labels.add(name)
-        step.tool_inputs = dict(name=name)  # type:ignore[assignment]
+        step.tool_inputs = dict(name=name)
         hid_to_output_pair[hid] = (step, "output")
         steps.append(step)
     for i, hid in enumerate(dataset_collection_ids):
@@ -132,7 +132,7 @@ def extract_steps(
         if name not in step_labels:
             step.label = name
             step_labels.add(name)
-        step.tool_inputs = dict(name=name, collection_type=collection_type)  # type:ignore[assignment]
+        step.tool_inputs = dict(name=name, collection_type=collection_type)
         hid_to_output_pair[hid] = (step, "output")
         steps.append(step)
     # Tool steps

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -121,7 +121,9 @@ def _normalize_inputs(
             elif inputs_by_el == "step_uuid":
                 possible_input_keys.append(str(step.uuid))
             elif inputs_by_el == "name":
-                possible_input_keys.append(step.label or step.tool_inputs.get("name"))  # type:ignore[union-attr]
+                label = step.effective_label
+                if label:
+                    possible_input_keys.append(label)
             else:
                 raise exceptions.MessageException(
                     "Workflow cannot be run because unexpected inputs_by value specified."
@@ -317,7 +319,7 @@ def build_workflow_run_configs(
     add_to_history = "no_add_to_history" not in payload
     legacy = payload.get("legacy", False)
     already_normalized = payload.get("parameters_normalized", False)
-    raw_parameters = payload.get("parameters", {})
+    raw_parameters = payload.get("parameters") or {}
     requires_materialization: bool = False
     run_configs = []
     unexpanded_param_map = _normalize_step_parameters(

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1953,7 +1953,7 @@ class BaseWorkflowPopulator(BasePopulator):
         url = f"workflows/{workflow_id}/invocations"
         invocation_response = self._post(url, data=request, json=True)
         if assert_ok:
-            invocation_response.raise_for_status()
+            api_asserts.assert_status_code_is_ok(invocation_response)
         return invocation_response
 
     def invoke_workflow(
@@ -2041,6 +2041,11 @@ class BaseWorkflowPopulator(BasePopulator):
             return response.json()
         else:
             return ordered_load(response.text)
+
+    def invocation_to_request(self, invocation_id: str):
+        request_response = self._get(f"invocations/{invocation_id}/request")
+        api_asserts.assert_status_code_is_ok(request_response)
+        return request_response.json()
 
     def set_tags(self, workflow_id: str, tags: List[str]) -> None:
         update_payload = {"tags": tags}
@@ -2140,7 +2145,51 @@ class BaseWorkflowPopulator(BasePopulator):
             workflow_request.update(extra_invocation_kwds)
         if has_uploads:
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+
+        return self._request_to_summary(
+            history_id,
+            workflow_id,
+            workflow_request,
+            inputs=inputs,
+            wait=wait,
+            assert_ok=assert_ok,
+            invocations=invocations,
+            expected_response=expected_response,
+        )
+
+    def rerun(self, run_jobs_summary: "RunJobsSummary", wait: bool = True, assert_ok: bool = True) -> "RunJobsSummary":
+        history_id = run_jobs_summary.history_id
+        invocation_id = run_jobs_summary.invocation_id
+        inputs = run_jobs_summary.inputs
+        workflow_request = self.invocation_to_request(invocation_id)
+        workflow_id = workflow_request["workflow_id"]
+        assert workflow_request["history_id"] == history_id
+        assert workflow_request["instance"] is True
+        return self._request_to_summary(
+            history_id,
+            workflow_id,
+            workflow_request,
+            inputs=inputs,
+            wait=wait,
+            assert_ok=assert_ok,
+            invocations=1,
+            expected_response=200,
+        )
+
+    def _request_to_summary(
+        self,
+        history_id: str,
+        workflow_id: str,
+        workflow_request: Dict[str, Any],
+        inputs,
+        wait: bool,
+        assert_ok: bool,
+        invocations: int,
+        expected_response: int,
+    ):
+        workflow_populator = self
         assert invocations > 0
+
         jobs = []
         for _ in range(invocations):
             invocation_response = workflow_populator.invoke_workflow_raw(workflow_id, workflow_request)
@@ -2156,6 +2205,7 @@ class BaseWorkflowPopulator(BasePopulator):
                 if wait:
                     workflow_populator.wait_for_workflow(workflow_id, invocation_id, history_id, assert_ok=assert_ok)
                 jobs.extend(self.dataset_populator.invocation_jobs(invocation_id))
+
         return RunJobsSummary(
             history_id=history_id,
             workflow_id=workflow_id,

--- a/lib/galaxy_test/workflow/test_framework_workflows.py
+++ b/lib/galaxy_test/workflow/test_framework_workflows.py
@@ -21,6 +21,7 @@ from galaxy.tool_util.verify.interactor import (
     get_metadata_to_test,
     verify_collection,
 )
+from galaxy.util import asbool
 from galaxy_test.api._framework import ApiTestCase
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
@@ -30,6 +31,7 @@ from galaxy_test.base.populators import (
 )
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
+TEST_WORKFLOW_AFTER_RERUN = asbool(os.environ.get("GALAXY_TEST_WORKFLOW_AFTER_RERUN", "0"))
 
 
 def find_workflows():
@@ -67,6 +69,8 @@ class TestWorkflow(ApiTestCase):
                 test_data=test_job["job"],
                 history_id=history_id,
             )
+            if TEST_WORKFLOW_AFTER_RERUN:
+                run_summary = self.workflow_populator.rerun(run_summary)
             self._verify(run_summary, test_job["outputs"])
 
     def _verify(self, run_summary: RunJobsSummary, output_definitions: OutputsDict):

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -1066,7 +1066,7 @@ def _setup_collection_invocation(app):
     workflow_step_1 = model.WorkflowStep()
     workflow_step_1.order_index = 0
     workflow_step_1.type = "data_collection_input"
-    workflow_step_1.tool_inputs = {}  # type:ignore[assignment]
+    workflow_step_1.tool_inputs = {}
     sa_session.add(workflow_step_1)
     workflow_1 = _workflow_from_steps(u, [workflow_step_1])
     workflow_1.license = "MIT"
@@ -1092,7 +1092,7 @@ def _setup_simple_invocation(app):
     workflow_step_1 = model.WorkflowStep()
     workflow_step_1.order_index = 0
     workflow_step_1.type = "data_input"
-    workflow_step_1.tool_inputs = {}  # type:ignore[assignment]
+    workflow_step_1.tool_inputs = {}
     sa_session.add(workflow_step_1)
     workflow = _workflow_from_steps(u, [workflow_step_1])
     workflow.license = "MIT"


### PR DESCRIPTION
Implements https://github.com/galaxyproject/galaxy/issues/18981

Also made small improvements to the schema for running workflows. Filled in a bunch of stub descriptions, dropped ``step_parameters`` which never existed in the API. There is a random check that it isn't in the request because it a field that is included in the test format - but it shouldn't have been part of the schema.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
