### PR TITLE
Fix the bioblend test failures

### DIFF
--- a/lib/galaxy/actions/library.py
+++ b/lib/galaxy/actions/library.py
@@ -125,8 +125,9 @@ class LibraryActions:
             raise exceptions.InvalidFileFormatError("Invalid folder specified")
         # Proceed with (mostly) regular upload processing if we're still errorless
         if payload.upload_option == "upload_file":
-            for i, upload_dataset in enumerate(tool_params["files"]):
-                upload_dataset["file_data"] = payload.upload_files[i]
+            if payload.upload_files:
+                for i, upload_dataset in enumerate(tool_params["files"]):
+                    upload_dataset["file_data"] = payload.upload_files[i]
             tool_params = upload_common.persist_uploads(tool_params, trans)
             uploaded_datasets = upload_common.get_uploaded_datasets(
                 trans, cntrller, tool_params, dataset_upload_inputs, library_bunch=library_bunch


### PR DESCRIPTION
This PR fixes Bioblend test failures by refactoring the `library_content` API logic. It now checks for files before assigning them to `tool_params` for uploading.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
