### PR TITLE
[24.1] Log `JobMappingException`s at error level rather than debug

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1402,7 +1402,7 @@ class MinimalJobWrapper(HasResourceParameters):
         try:
             self.job_destination  # noqa: B018
         except JobMappingException as exc:
-            log.debug(
+            log.error(
                 "(%s) fail(): Job destination raised JobMappingException('%s'), caching fake '__fail__' "
                 "destination for completion of fail method",
                 self.get_id_tag(),


### PR DESCRIPTION
This allows us to capture them in Sentry. Because TPV fail rules intentionally fail jobs with `JobMappingException` and we probably *don't* want those in Sentry, Marius suggested:

> I would  maybe add a `log_level` attribute to `JobMappingException` and have those fail rules be raised with `raise JobMappingException("bla", log_level="info")`. Or split the `JobMappingException` into `JobMappingUnsatisfiable` and `JobMappingException` or something like that?

Which would be good for dev (and TPV would need to change its raise).

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).