### PR TITLE
Fixes random job failures in kubernetes 

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -775,7 +775,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             # It is possible that k8s didn't account for the status of the pods
             # and they are in the uncountedTerminatedPods status. In this
             # case we also need to wait a moment
-            if len(job.obj["status"]) == 0 or 'uncountedTerminatedPods' in job.obj["status"]:
+            if len(job.obj["status"]) == 0 or "uncountedTerminatedPods" in job.obj["status"]:
                 return job_state
             if "succeeded" in job.obj["status"]:
                 succeeded = job.obj["status"]["succeeded"]

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -775,7 +775,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             # It is possible that k8s didn't account for the status of the pods
             # and they are in the uncountedTerminatedPods status. In this
             # case we also need to wait a moment
-            if len(job.obj["status"]) == 0 or "uncountedTerminatedPods" in job.obj["status"]:
+            if len(job.obj["status"]) == 0 or in job.obj["status"].get("uncountedTerminatedPods"):
                 return job_state
             if "succeeded" in job.obj["status"]:
                 succeeded = job.obj["status"]["succeeded"]

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -775,7 +775,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             # It is possible that k8s didn't account for the status of the pods
             # and they are in the uncountedTerminatedPods status. In this
             # case we also need to wait a moment
-            if len(job.obj["status"]) == 0 or in job.obj["status"].get("uncountedTerminatedPods"):
+            if len(job.obj["status"]) == 0 or job.obj["status"].get("uncountedTerminatedPods"):
                 return job_state
             if "succeeded" in job.obj["status"]:
                 succeeded = job.obj["status"]["succeeded"]

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -772,7 +772,10 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             # as probably this means that the k8s API server hasn't
             # had time to fill in the object status since the
             # job was created only too recently.
-            if len(job.obj["status"]) == 0:
+            # It is possible that k8s didn't account for the status of the pods
+            # and they are in the uncountedTerminatedPods status. In this
+            # case we also need to wait a moment
+            if len(job.obj["status"]) == 0 or 'uncountedTerminatedPods' in job.obj["status"]:
                 return job_state
             if "succeeded" in job.obj["status"]:
                 succeeded = job.obj["status"]["succeeded"]


### PR DESCRIPTION
This fix addresses the random crashes of k8s jobs in Galaxy: https://github.com/galaxyproject/galaxy-helm/issues/490 and mentioned therein. The issue is that k8s job status may not be ready, while providing already some information: 
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobstatus-v1-batch

In the previous code `if len(job.obj["status"]) == 0:` checked whether some information is there; if yes, treat it as "final" state of the job and continue processing. In the case that the job status has the field `uncountedTerminatedPods`, k8s is not done with analyzing whether the job failed or succeeded. The code then used this information (for me 0 succeeded, 0 active and 0 failed) and went through the decision tree to decide what to do.  

My suggestion is to instead wait for k8s to determine the status of the terminated pods and only then decide what to do. This reduced the failure rate from 2-5% to 0% :)

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. The change is difficult to test. It covers an edge where a/ the job is completed, b/ k8s has yet to determine the status of the job. For me 2-5% of jobs fail without the fix. 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
