### PR TITLE
Do not skip CI tests on missing tools.

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -18,6 +18,7 @@ env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
   GALAXY_CONFIG_SQLALCHEMY_WARN_20: '1'
+  GALAXY_TEST_REQUIRE_ALL_NEEDED_TOOLS: '1'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -29,7 +29,6 @@ from galaxy_test.base.populators import (
     BaseDatasetCollectionPopulator,
     DatasetCollectionPopulator,
     DatasetPopulator,
-    LibraryPopulator,
     skip_without_tool,
     stage_rules_example,
 )
@@ -1026,18 +1025,6 @@ class TestToolsApi(ApiTestCase, TestsTools):
                 output = response["outputs"]
                 content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output[0])
                 assert "parameter: 1,2" in content
-
-    @skip_without_tool("library_data")
-    def test_library_data_param(self):
-        with self.dataset_populator.test_history(require_new=False) as history_id:
-            ld = LibraryPopulator(self.galaxy_interactor).new_library_dataset("lda_test_library")
-            inputs = {"library_dataset": ld["ldda_id"], "library_dataset_multiple": [ld["ldda_id"], ld["ldda_id"]]}
-            response = self._run("library_data", history_id, inputs, assert_ok=True)
-            output = response["outputs"]
-            output_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output[0])
-            assert output_content == "TestData\n", output_content
-            output_multiple_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output[1])
-            assert output_multiple_content == "TestData\nTestData\n", output_multiple_content
 
     @skip_without_tool("cat1")
     def test_run_cat1(self):


### PR DESCRIPTION
I don't think you should have to send special flags to filter the API tests down for a particular version of Galaxy but I do think in CI we expect all of these tool to be available to it is appropriate to not skip when tools are missing. This also drops a test for a tool we seem to no longer have. I guess we removed library data parameters at some point - I vaguely recall that.

Uses the flat that was introduced in #18977.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
