### PR TITLE
[24.1] Fix possible CircularDependencyError when importing collections

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6896,6 +6896,7 @@ class HistoryDatasetCollectionAssociation(
     )
     copied_to_history_dataset_collection_association = relationship(
         "HistoryDatasetCollectionAssociation",
+        viewonly=True,
         back_populates="copied_from_history_dataset_collection_association",
     )
     implicit_input_collections: Mapped[List["ImplicitlyCreatedDatasetCollectionInput"]] = relationship(


### PR DESCRIPTION
Fixes #18927

Making copied HistoryDatasetCollectionAssociation relationships view-only as an attempt to avoid potential circular dependency errors.

In practice, this gets rid of the error when importing but I'm not 100% sure this is the correct solution if `copied_from_history_dataset_collection_association` and/or `copied_to_history_dataset_collection_association` are meant to be used for persistency and not just for querying at any point.


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Try to import any exported invocation provided in #18927
  - Observe there is no CircularDependencyError during the import

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
