### PR TITLE
[24.1] Fix extra call to test_data_path that requires an admin key

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -560,7 +560,7 @@ class GalaxyInteractorApi:
             file_name = None
             file_name_exists = False
             location = self._ensure_valid_location_in(test_data)
-            if fname:
+            if fname and force_path_paste:
                 file_name = self.test_data_path(tool_id, fname, tool_version=tool_version)
                 file_name_exists = os.path.exists(f"{file_name}")
             upload_from_location = not file_name_exists and location is not None
@@ -575,7 +575,8 @@ class GalaxyInteractorApi:
             if upload_from_location:
                 tool_input.update({"files_0|url_paste": location})
             elif force_path_paste:
-                file_name = self.test_data_path(tool_id, fname, tool_version=tool_version)
+                if file_name is None:
+                    file_name = self.test_data_path(tool_id, fname, tool_version=tool_version)
                 tool_input.update({"files_0|url_paste": f"file://{file_name}"})
             else:
                 file_content = self.test_data_download(tool_id, fname, is_output=False, tool_version=tool_version)


### PR DESCRIPTION
Regression introduced by @natefoo when he let https://github.com/galaxyproject/galaxy/commit/4a47efa23ceba7863c5b1e4be634589dc1589d6b get merged in without even reviewing it and catching this. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
 - Run a tool test as a non-admin user against test.galaxyproject.org with and without this change.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
