### PR TITLE
[24.1] Put cached jobs back into queue on handler restart

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -309,6 +309,8 @@ class JobHandlerQueue(BaseJobHandlerQueue):
             self.job_wrapper(job).fail(
                 "This tool was disabled before the job completed.  Please contact your Galaxy administrator."
             )
+        elif job.copied_from_job_id:
+            self.queue.put((job.id, job.tool_id))
         elif job.job_runner_name is not None and job.job_runner_external_id is None:
             # This could happen during certain revisions of Galaxy where a runner URL was persisted before the job was dispatched to a runner.
             log.debug(f"({job.id}) Job runner assigned but no external ID recorded, adding to the job handler queue")


### PR DESCRIPTION
and don't recover job wrapper, which will fail since we don't actually create a job working directory for cached jobs.

Should fix https://sentry.galaxyproject.org/share/issue/92e693581896411f8e59cf1167420b3e/

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
