### PR TITLE
[24.1] Fix collectionElementsStore's hasLoadingCollectionElementsError computed.

### DIFF
--- a/client/src/stores/collectionElementsStore.ts
+++ b/client/src/stores/collectionElementsStore.ts
@@ -66,7 +66,7 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
 
     const hasLoadingCollectionElementsError = computed(() => {
         return (collection: CollectionEntry) => {
-            return loadingCollectionElementsErrors.value[getCollectionKey(collection) ?? false];
+            return loadingCollectionElementsErrors.value[getCollectionKey(collection)] ?? false;
         };
     });
 


### PR DESCRIPTION
As it was, false was being used as an index instead of the fallback return value -- just a minor typo from https://github.com/galaxyproject/galaxy/pull/18756.

No idea if this manifested as anything wonky in the app -- just something I noticed working on the `vue3` branch.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
