### PR TITLE
[24.1] Fix possible CircularDependencyError when importing collections

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7179,7 +7179,7 @@ class HistoryDatasetCollectionAssociation(
             visible=self.visible,
             deleted=self.deleted,
             name=self.name,
-            copied_from_history_dataset_collection_association=self,
+            copied_from_history_dataset_collection_association_id=self.id,
         )
         if self.implicit_collection_jobs_id:
             hdca.implicit_collection_jobs_id = self.implicit_collection_jobs_id

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6892,10 +6892,12 @@ class HistoryDatasetCollectionAssociation(
         primaryjoin=copied_from_history_dataset_collection_association_id == id,
         remote_side=[id],
         uselist=False,
+        viewonly=True,
         back_populates="copied_to_history_dataset_collection_association",
     )
     copied_to_history_dataset_collection_association = relationship(
         "HistoryDatasetCollectionAssociation",
+        viewonly=True,
         back_populates="copied_from_history_dataset_collection_association",
     )
     implicit_input_collections: Mapped[List["ImplicitlyCreatedDatasetCollectionInput"]] = relationship(

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -412,6 +412,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
         self._import_libraries(object_import_tracker)
         self._import_collection_instances(object_import_tracker, collections_attrs, history, new_history)
         self._import_collection_implicit_input_associations(object_import_tracker, collections_attrs)
+        self._flush()
         self._import_collection_copied_associations(object_import_tracker, collections_attrs)
         self._import_implicit_dataset_conversions(object_import_tracker)
         self._reassign_hids(object_import_tracker, history)
@@ -999,14 +1000,12 @@ class ModelImportStore(metaclass=abc.ABCMeta):
             # sense.
             hdca_copied_from_sinks = object_import_tracker.hdca_copied_from_sinks
             if copied_from_object_key in object_import_tracker.hdcas_by_key:
-                hdca.copied_from_history_dataset_collection_association = object_import_tracker.hdcas_by_key[
-                    copied_from_object_key
-                ]
+                copied_hdca = object_import_tracker.hdcas_by_key[copied_from_object_key]
+                hdca.copied_from_history_dataset_collection_association_id = copied_hdca.id
             else:
                 if copied_from_object_key in hdca_copied_from_sinks:
-                    hdca.copied_from_history_dataset_collection_association = object_import_tracker.hdcas_by_key[
-                        hdca_copied_from_sinks[copied_from_object_key]
-                    ]
+                    copied_hdca = object_import_tracker.hdcas_by_key[hdca_copied_from_sinks[copied_from_object_key]]
+                    hdca.copied_from_history_dataset_collection_association_id = copied_hdca.id
                 else:
                     hdca_copied_from_sinks[copied_from_object_key] = dataset_collection_key
 


### PR DESCRIPTION
Fixes #18927
xref #19005

Making copied HistoryDatasetCollectionAssociation relationships view-only as an attempt to avoid potential circular dependency errors.

In practice, this gets rid of the error when importing but I'm not 100% sure this is the correct solution if `copied_from_history_dataset_collection_association` and/or `copied_to_history_dataset_collection_association` are meant to be used for persistency and not just for querying at any point.


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Try to import any exported invocation provided in #18927
  - Observe there is no CircularDependencyError during the import

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
