### PR TITLE
[24.0] Backporting PR title update workflow

### DIFF
--- a/.github/workflows/pr-title-update.yml
+++ b/.github/workflows/pr-title-update.yml
@@ -1,0 +1,27 @@
+name: Update PR title
+
+on:
+  pull_request_target:
+    types: [opened, edited]
+    branches:
+      - "release_**"
+
+jobs:
+  update-title:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update PR title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TARGET_BRANCH: "${{ github.base_ref }}"
+          PR_TITLE: "${{ github.event.pull_request.title }}"
+        run: |
+          VERSION=$(echo $TARGET_BRANCH | grep -oP '\d+\.\d+')
+          if [[ -n "$VERSION" && ! "$PR_TITLE" =~ ^\[$VERSION\] ]]; then
+            NEW_TITLE="[$VERSION] $PR_TITLE"
+            gh pr edit $PR_NUMBER --title "$NEW_TITLE"
+          fi


### PR DESCRIPTION
Backporting the PR title update workflow to the release_24.0 branch ensures it runs on PRs where it's useful.
Thanks @nsoranzo for mentioning this https://github.com/galaxyproject/galaxy/pull/18835#issuecomment-2417174560

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
