### PR TITLE
Disallow /tool_runner? in robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -2,3 +2,4 @@ User-agent: *
 Disallow: /display?
 Disallow: /display_as?
 Disallow: /training-material/
+Disallow: /tool_runner?


### PR DESCRIPTION
This was getting spammed on main causing lots of extraneous jobs.  Might need to follow up with updates to the tool panel to use direct tool links like: https://usegalaxy.org/root?tool_id=toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.8+galaxy0

Any other problematic spammed routes or things we otherwise don't want crawled that folks can think of?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
