### PR TITLE
Fix auto-detect metadata from Edit Dataset Attributes panel

### DIFF
--- a/client/src/components/DatasetInformation/DatasetAttributes.vue
+++ b/client/src/components/DatasetInformation/DatasetAttributes.vue
@@ -138,7 +138,8 @@ onMounted(async () => {
                     v-if="
                         (!datasetAttributes['conversion_disable'] || !datasetAttributes['datatype_disable']) &&
                         !datasetAttributes['metadata_disable']
-                    ">
+                    "
+                    title-link-class="dataset-edit-datatype-tab">
                     <template v-slot:title>
                         <FontAwesomeIcon :icon="faDatabase" class="mr-1" />
                         {{ localize("Datatypes") }}
@@ -168,7 +169,9 @@ onMounted(async () => {
                                     {{ localize("Save") }}
                                 </BButton>
 
-                                <BButton @click="submit('datatype', 'datatype_detect')">
+                                <BButton
+                                    id="dataset-attributes-autodetect-datatype"
+                                    @click="submit('datatype', 'datatype_detect')">
                                     <FontAwesomeIcon :icon="faRedo" class="mr-1" />
                                     {{ localize("Auto-detect") }}
                                 </BButton>

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -349,7 +349,10 @@ edit_dataset_attributes:
     name_input: '[aria-labelledby="dataset-attributes-heading"] input#name'
     info_input: '[aria-labelledby="dataset-attributes-heading"] textarea#info'
     annotation_input: '[aria-labelledby="dataset-attributes-heading"] textarea#annotation'
+    datatypes_tab: '.dataset-edit-datatype-tab'
+    datatype_dropdown: ' #datatype .multiselect'
     save_button: '#dataset-attributes-default-save'
+    auto_detect_datatype_button: '#dataset-attributes-autodetect-datatype'
     alert: '.dataset-attributes-alert'
 
   dbkey_dropdown_results:

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -372,8 +372,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                         trans.app.datatypes_registry.set_external_metadata_tool,
                         trans,
                         incoming={"input1": data},
-                        overwrite=False,
-                    )  # overwrite is False as per existing behavior
+                    )
                     trans.app.job_manager.enqueue(job, tool=trans.app.datatypes_registry.set_external_metadata_tool)
                     message = f"Detection was finished and changed the datatype to {datatype}."
             else:

--- a/lib/galaxy_test/selenium/test_dataset_edit.py
+++ b/lib/galaxy_test/selenium/test_dataset_edit.py
@@ -65,3 +65,33 @@ class TestHistoryPanel(SeleniumTestCase):
 
         assert annotation_component.wait_for_value() == TEST_ANNOTATION
         assert info_component.wait_for_value() == TEST_INFO
+
+    @selenium_test
+    @managed_history
+    def test_history_dataset_auto_detect_datatype(self):
+        expected_datatype = "txt"
+        provided_datatype = "tabular"
+        history_entry = self.perform_single_upload(self.get_filename("1.txt"), ext=provided_datatype)
+        hid = history_entry.hid
+        self.wait_for_history()
+        self.history_panel_wait_for_hid_ok(hid)
+        self.history_panel_item_edit(hid=hid)
+        edit_dataset_attributes = self.components.edit_dataset_attributes
+        datatypes_tab = edit_dataset_attributes.datatypes_tab
+        datatype_component = edit_dataset_attributes.datatype_dropdown
+        datatypes_tab.wait_for_and_click()
+        assert datatype_component.wait_for_text() == provided_datatype
+
+        # click auto detect datatype button
+        edit_dataset_attributes.auto_detect_datatype_button.wait_for_and_click()
+        edit_dataset_attributes.alert.wait_for_visible()
+
+        assert edit_dataset_attributes.alert.has_class("alert-success")
+
+        # reopen and check that datatype is updated
+        self.home()
+        self.history_panel_wait_for_hid_ok(hid)
+        self.history_panel_item_edit(hid=hid)
+        datatypes_tab.wait_for_and_click()
+
+        assert datatype_component.wait_for_text() == expected_datatype


### PR DESCRIPTION
I assume this was a leftover from #18626 since the overwrite parameter is now forced to `True`:

https://github.com/galaxyproject/galaxy/blob/e9f7316cfd3f260218aba887cc337ca43548c35e/lib/galaxy/tools/actions/metadata.py#L63

Fixes:

```
ERROR    galaxy.web.framework.decorators:decorators.py:361 Uncaught exception in exposed API method:
Traceback (most recent call last):
  File "/home/dlopez/dev/galaxy/lib/galaxy/web/framework/decorators.py", line 346, in decorator
    rval = func(self, trans, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dlopez/dev/galaxy/lib/galaxy/webapps/galaxy/controllers/dataset.py", line 371, in set_edit
    job, *_ = trans.app.datatypes_registry.set_external_metadata_tool.tool_action.execute(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: SetMetadataToolAction.execute() got an unexpected keyword argument 'overwrite'
```

Includes a selenium test.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Click on Edit attributes on any dataset
  - Go to Datatypes tab
  - Click Auto-detect button
  - Observe there is no error

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
