### PR TITLE
Better logging around tool loading

### DIFF
--- a/lib/galaxy/tool_util/toolbox/__init__.py
+++ b/lib/galaxy/tool_util/toolbox/__init__.py
@@ -3,6 +3,7 @@
 from .base import (
     AbstractToolBox,
     AbstractToolTagManager,
+    ToolLoadError,
 )
 from .panel import (
     panel_item_types,
@@ -14,6 +15,7 @@ __all__ = (
     "AbstractToolBox",
     "AbstractToolTagManager",
     "panel_item_types",
+    "ToolLoadError",
     "ToolSection",
     "ToolSectionLabel",
 )

--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -133,6 +133,10 @@ class NullToolTagManager(AbstractToolTagManager):
         return None
 
 
+class ToolLoadError(Exception):
+    pass
+
+
 class AbstractToolBox(ManagesIntegratedToolPanelMixin):
     """
     Abstract container for managing a ToolPanel - containing tools and
@@ -1073,6 +1077,10 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
                     self._load_tool_panel_views()
                     self._save_integrated_tool_panel()
                 return tool.id
+            except ToolLoadError as e:
+                # no need for full stack trace - ToolLoadError corresponds to a known load
+                # error with defined cause that is included in the message
+                log.error(f"Failed to load potential tool {tool_file} - {e}")
             except Exception:
                 log.exception("Failed to load potential tool %s.", tool_file)
                 return None

--- a/lib/galaxy/tool_util/verify/parse.py
+++ b/lib/galaxy/tool_util/verify/parse.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import traceback
 from typing import (
     Any,
     Iterable,
@@ -141,7 +142,7 @@ def _description_from_tool_source(
                 "error": False,
             }
         )
-    except Exception as e:
+    except Exception:
         processed_test_dict = InvalidToolTestDict(
             {
                 "tool_id": tool_id,
@@ -149,7 +150,7 @@ def _description_from_tool_source(
                 "test_index": test_index,
                 "inputs": {},
                 "error": True,
-                "exception": unicodify(e),
+                "exception": unicodify(traceback.format_exc()),
                 "maxseconds": maxseconds,
             }
         )


### PR DESCRIPTION
Reduce logging around certain classes of known tool loading "issues". The whole big stack trace corresponding to known configuration options acting the correct way is kind of annoying. Swapping from exception to error when we know the nature of the problem and the stack trace isn't useful. On the other hand, if there are problems generating tool test cases - include more information in the resulting API calls - these are not generally expected issues.

Just fixing some small annoyances around backend development.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
