### PR TITLE
Fix numerous issues with tool input format "21.01"

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1836,7 +1836,9 @@ class Tool(UsesDictVisibleKeys):
         # Expand these out to individual parameters for given jobs (tool executions).
         expanded_incomings: List[ToolStateJobInstanceT]
         collection_info: Optional[MatchingCollections]
-        expanded_incomings, collection_info = expand_meta_parameters(request_context, self, incoming)
+        expanded_incomings, collection_info = expand_meta_parameters(
+            request_context, self, incoming, input_format=input_format
+        )
 
         self._ensure_expansion_is_valid(expanded_incomings, rerun_remap_job_id)
 

--- a/lib/galaxy/tools/parameters/meta.py
+++ b/lib/galaxy/tools/parameters/meta.py
@@ -19,10 +19,19 @@ from galaxy.model.dataset_collections import (
     matching,
     subcollections,
 )
-from galaxy.util import permutations
+from galaxy.util.permutations import (
+    build_combos,
+    input_classification,
+    is_in_state,
+    state_copy,
+    state_get_value,
+    state_remove_value,
+    state_set_value,
+)
 from . import visit_input_values
 from .wrapped import process_key
 from .._types import (
+    InputFormatT,
     ToolRequestT,
     ToolStateJobInstanceT,
 )
@@ -169,7 +178,7 @@ def expand_flat_parameters_to_nested(incoming_copy: ToolRequestT) -> Dict[str, A
     return nested_dict
 
 
-def expand_meta_parameters(trans, tool, incoming: ToolRequestT) -> ExpandedT:
+def expand_meta_parameters(trans, tool, incoming: ToolRequestT, input_format: InputFormatT) -> ExpandedT:
     """
     Take in a dictionary of raw incoming parameters and expand to a list
     of expanded incoming parameters (one set of parameters per tool
@@ -184,29 +193,24 @@ def expand_meta_parameters(trans, tool, incoming: ToolRequestT) -> ExpandedT:
     # order matters, so the following reorders incoming
     # according to tool.inputs (which is ordered).
     incoming_copy = incoming.copy()
-    nested_dict = expand_flat_parameters_to_nested(incoming_copy)
-    reordered_incoming = {}
+    if input_format == "legacy":
+        nested_dict = expand_flat_parameters_to_nested(incoming_copy)
+    else:
+        nested_dict = incoming_copy
 
-    def visitor(input, value, prefix, prefixed_name, prefixed_label, error, **kwargs):
-        if prefixed_name in incoming_copy:
-            reordered_incoming[prefixed_name] = incoming_copy[prefixed_name]
-            del incoming_copy[prefixed_name]
+    collections_to_match = matching.CollectionsToMatch()
 
-    visit_input_values(inputs=tool.inputs, input_values=nested_dict, callback=visitor)
-    reordered_incoming.update(incoming_copy)
-
-    def classifier(input_key):
-        value = incoming[input_key]
+    def classifier_from_value(value, input_key):
         if isinstance(value, dict) and "values" in value:
             # Explicit meta wrapper for inputs...
             is_batch = value.get("batch", False)
             is_linked = value.get("linked", True)
             if is_batch and is_linked:
-                classification = permutations.input_classification.MATCHED
+                classification = input_classification.MATCHED
             elif is_batch:
-                classification = permutations.input_classification.MULTIPLIED
+                classification = input_classification.MULTIPLIED
             else:
-                classification = permutations.input_classification.SINGLE
+                classification = input_classification.SINGLE
             if __collection_multirun_parameter(value):
                 collection_value = value["values"][0]
                 values = __expand_collection_parameter(
@@ -215,22 +219,112 @@ def expand_meta_parameters(trans, tool, incoming: ToolRequestT) -> ExpandedT:
             else:
                 values = value["values"]
         else:
-            classification = permutations.input_classification.SINGLE
+            classification = input_classification.SINGLE
             values = value
         return classification, values
 
-    collections_to_match = matching.CollectionsToMatch()
+    nested = input_format != "legacy"
+    if not nested:
+        reordered_incoming = reorder_parameters(tool, incoming_copy, nested_dict, nested)
+        incoming_template = reordered_incoming
 
-    # Stick an unexpanded version of multirun keys so they can be replaced,
-    # by expand_mult_inputs.
-    incoming_template = reordered_incoming
+        def classifier_flat(input_key):
+            return classifier_from_value(incoming[input_key], input_key)
 
-    expanded_incomings = permutations.expand_multi_inputs(incoming_template, classifier)
+        single_inputs, matched_multi_inputs, multiplied_multi_inputs = split_inputs_flat(
+            incoming_template, classifier_flat
+        )
+    else:
+        reordered_incoming = reorder_parameters(tool, incoming_copy, nested_dict, nested)
+        incoming_template = reordered_incoming
+        single_inputs, matched_multi_inputs, multiplied_multi_inputs = split_inputs_nested(
+            tool.inputs, incoming_template, classifier_from_value
+        )
+
+    expanded_incomings = build_combos(single_inputs, matched_multi_inputs, multiplied_multi_inputs, nested=nested)
     if collections_to_match.has_collections():
         collection_info = trans.app.dataset_collection_manager.match_collections(collections_to_match)
     else:
         collection_info = None
     return expanded_incomings, collection_info
+
+
+def reorder_parameters(tool, incoming, nested_dict, nested):
+    # If we're going to multiply input dataset combinations
+    # order matters, so the following reorders incoming
+    # according to tool.inputs (which is ordered).
+    incoming_copy = state_copy(incoming, nested)
+
+    reordered_incoming = {}
+
+    def visitor(input, value, prefix, prefixed_name, prefixed_label, error, **kwargs):
+        if is_in_state(incoming_copy, prefixed_name, nested):
+            value_to_copy_over = state_get_value(incoming_copy, prefixed_name, nested)
+            state_set_value(reordered_incoming, prefixed_name, value_to_copy_over, nested)
+            state_remove_value(incoming_copy, prefixed_name, nested)
+
+    visit_input_values(inputs=tool.inputs, input_values=nested_dict, callback=visitor)
+
+    def merge_into(from_object, into_object):
+        if isinstance(from_object, dict):
+            for key, value in from_object.items():
+                if key not in into_object:
+                    into_object[key] = value
+                else:
+                    into_target = into_object[key]
+                    merge_into(value, into_target)
+        elif isinstance(from_object, list):
+            for index in from_object:
+                if len(into_object) <= index:
+                    into_object.append(from_object[index])
+                else:
+                    merge_into(from_object[index], into_object[index])
+
+    merge_into(incoming_copy, reordered_incoming)
+    return reordered_incoming
+
+
+def split_inputs_flat(inputs: Dict[str, Any], classifier):
+    single_inputs: Dict[str, Any] = {}
+    matched_multi_inputs: Dict[str, Any] = {}
+    multiplied_multi_inputs: Dict[str, Any] = {}
+
+    for input_key in inputs:
+        input_type, expanded_val = classifier(input_key)
+        if input_type == input_classification.SINGLE:
+            single_inputs[input_key] = expanded_val
+        elif input_type == input_classification.MATCHED:
+            matched_multi_inputs[input_key] = expanded_val
+        elif input_type == input_classification.MULTIPLIED:
+            multiplied_multi_inputs[input_key] = expanded_val
+
+    return (single_inputs, matched_multi_inputs, multiplied_multi_inputs)
+
+
+def split_inputs_nested(inputs, nested_dict, classifier):
+    single_inputs: Dict[str, Any] = {}
+    matched_multi_inputs: Dict[str, Any] = {}
+    multiplied_multi_inputs: Dict[str, Any] = {}
+    unset_value = object()
+
+    def visitor(input, value, prefix, prefixed_name, prefixed_label, error, **kwargs):
+        if value is unset_value:
+            # don't want to inject extra nulls into state
+            return
+
+        input_type, expanded_val = classifier(value, prefixed_name)
+        if input_type == input_classification.SINGLE:
+            single_inputs[prefixed_name] = expanded_val
+        elif input_type == input_classification.MATCHED:
+            matched_multi_inputs[prefixed_name] = expanded_val
+        elif input_type == input_classification.MULTIPLIED:
+            multiplied_multi_inputs[prefixed_name] = expanded_val
+
+    visit_input_values(
+        inputs=inputs, input_values=nested_dict, callback=visitor, allow_case_inference=True, unset_value=unset_value
+    )
+    single_inputs_nested = expand_flat_parameters_to_nested(single_inputs)
+    return (single_inputs_nested, matched_multi_inputs, multiplied_multi_inputs)
 
 
 def __expand_collection_parameter(trans, input_key, incoming_val, collections_to_match, linked=False):

--- a/lib/galaxy/tools/parameters/meta.py
+++ b/lib/galaxy/tools/parameters/meta.py
@@ -161,6 +161,14 @@ def expand_workflow_inputs(param_inputs, inputs=None):
 ExpandedT = Tuple[List[ToolStateJobInstanceT], Optional[matching.MatchingCollections]]
 
 
+def expand_flat_parameters_to_nested(incoming_copy: ToolRequestT) -> Dict[str, Any]:
+    nested_dict: Dict[str, Any] = {}
+    for incoming_key, incoming_value in incoming_copy.items():
+        if not incoming_key.startswith("__"):
+            process_key(incoming_key, incoming_value=incoming_value, d=nested_dict)
+    return nested_dict
+
+
 def expand_meta_parameters(trans, tool, incoming: ToolRequestT) -> ExpandedT:
     """
     Take in a dictionary of raw incoming parameters and expand to a list
@@ -176,11 +184,7 @@ def expand_meta_parameters(trans, tool, incoming: ToolRequestT) -> ExpandedT:
     # order matters, so the following reorders incoming
     # according to tool.inputs (which is ordered).
     incoming_copy = incoming.copy()
-    nested_dict: Dict[str, Any] = {}
-    for incoming_key, incoming_value in incoming_copy.items():
-        if not incoming_key.startswith("__"):
-            process_key(incoming_key, incoming_value=incoming_value, d=nested_dict)
-
+    nested_dict = expand_flat_parameters_to_nested(incoming_copy)
     reordered_incoming = {}
 
     def visitor(input, value, prefix, prefixed_name, prefixed_label, error, **kwargs):

--- a/lib/galaxy/tools/parameters/wrapped.py
+++ b/lib/galaxy/tools/parameters/wrapped.py
@@ -25,6 +25,10 @@ from galaxy.tools.wrappers import (
     InputValueWrapper,
     SelectToolParameterWrapper,
 )
+from galaxy.util.permutations import (
+    looks_like_flattened_repeat_key,
+    split_flattened_repeat_key,
+)
 
 PARAMS_UNWRAPPED = object()
 
@@ -172,10 +176,9 @@ def process_key(incoming_key: str, incoming_value: Any, d: Dict[str, Any]):
             # In case we get an empty repeat after we already filled in a repeat element
             return
         d[incoming_key] = incoming_value
-    elif key_parts[0].rsplit("_", 1)[-1].isdigit():
+    elif looks_like_flattened_repeat_key(key_parts[0]):
         # Repeat
-        input_name, _index = key_parts[0].rsplit("_", 1)
-        index = int(_index)
+        input_name, index = split_flattened_repeat_key(key_parts[0])
         d.setdefault(input_name, [])
         newlist: List[Dict[Any, Any]] = [{} for _ in range(index + 1)]
         d[input_name].extend(newlist[len(d[input_name]) :])

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -802,6 +802,8 @@ class ElementIdentifierMapper:
             self.identifier_key_dict = {}
 
     def identifier(self, dataset_value: str, input_values: Dict[str, str]) -> Optional[str]:
+        if isinstance(dataset_value, list):
+            raise TypeError(f"Expected {dataset_value} to be hashable")
         element_identifier = None
         if identifier_key := self.identifier_key_dict.get(dataset_value, None):
             element_identifier = input_values.get(identifier_key, None)

--- a/lib/galaxy/util/permutations.py
+++ b/lib/galaxy/util/permutations.py
@@ -7,10 +7,8 @@ Maybe this doesn't make sense and maybe much of this stuff could be replaced
 with itertools product and permutations. These are open questions.
 """
 
-from typing import (
-    Dict,
-    TypeVar,
-)
+import copy
+from typing import Tuple
 
 from galaxy.exceptions import MessageException
 from galaxy.util.bunch import Bunch
@@ -21,47 +19,20 @@ input_classification = Bunch(
     MULTIPLIED="multiplied",
 )
 
-# generic type of splitting input dictionary
-T = TypeVar("T")
-
 
 class InputMatchedException(MessageException):
     """Indicates problem matching inputs while building up inputs
     permutations."""
 
 
-def expand_multi_inputs(inputs: Dict[str, T], classifier, key_filter=None):
-    key_filter = key_filter or (lambda x: True)
-
-    single_inputs, matched_multi_inputs, multiplied_multi_inputs = __split_inputs(inputs, classifier, key_filter)
-
+def build_combos(single_inputs, matched_multi_inputs, multiplied_multi_inputs, nested):
     # Build up every combination of inputs to be run together.
-    input_combos = __extend_with_matched_combos(single_inputs, matched_multi_inputs)
-    input_combos = __extend_with_multiplied_combos(input_combos, multiplied_multi_inputs)
-
+    input_combos = __extend_with_matched_combos(single_inputs, matched_multi_inputs, nested)
+    input_combos = __extend_with_multiplied_combos(input_combos, multiplied_multi_inputs, nested)
     return input_combos
 
 
-def __split_inputs(inputs: Dict[str, T], classifier, key_filter):
-    key_filter = key_filter or (lambda x: True)
-
-    single_inputs: Dict[str, T] = {}
-    matched_multi_inputs: Dict[str, T] = {}
-    multiplied_multi_inputs: Dict[str, T] = {}
-
-    for input_key in filter(key_filter, inputs):
-        input_type, expanded_val = classifier(input_key)
-        if input_type == input_classification.SINGLE:
-            single_inputs[input_key] = expanded_val
-        elif input_type == input_classification.MATCHED:
-            matched_multi_inputs[input_key] = expanded_val
-        elif input_type == input_classification.MULTIPLIED:
-            multiplied_multi_inputs[input_key] = expanded_val
-
-    return (single_inputs, matched_multi_inputs, multiplied_multi_inputs)
-
-
-def __extend_with_matched_combos(single_inputs, multi_inputs):
+def __extend_with_matched_combos(single_inputs, multi_inputs, nested):
     """
 
     {a => 1, b => 2} and {c => {3, 4}, d => {5, 6}}
@@ -81,7 +52,7 @@ def __extend_with_matched_combos(single_inputs, multi_inputs):
     first_multi_value = multi_inputs.get(first_multi_input_key)
 
     for value in first_multi_value:
-        new_inputs = __copy_and_extend_inputs(single_inputs, first_multi_input_key, value)
+        new_inputs = __copy_and_extend_inputs(single_inputs, first_multi_input_key, value, nested=nested)
         matched_multi_inputs.append(new_inputs)
 
     for multi_input_key, multi_input_values in multi_inputs.items():
@@ -94,12 +65,12 @@ def __extend_with_matched_combos(single_inputs, multi_inputs):
             )
 
         for index, value in enumerate(multi_input_values):
-            matched_multi_inputs[index][multi_input_key] = value
+            state_set_value(matched_multi_inputs[index], multi_input_key, value, nested)
 
     return matched_multi_inputs
 
 
-def __extend_with_multiplied_combos(input_combos, multi_inputs):
+def __extend_with_multiplied_combos(input_combos, multi_inputs, nested):
     combos = input_combos
 
     for multi_input_key, multi_input_value in multi_inputs.items():
@@ -107,7 +78,7 @@ def __extend_with_multiplied_combos(input_combos, multi_inputs):
 
         for combo in combos:
             for input_value in multi_input_value:
-                iter_combo = __copy_and_extend_inputs(combo, multi_input_key, input_value)
+                iter_combo = __copy_and_extend_inputs(combo, multi_input_key, input_value, nested)
                 iter_combos.append(iter_combo)
 
         combos = iter_combos
@@ -115,7 +86,84 @@ def __extend_with_multiplied_combos(input_combos, multi_inputs):
     return combos
 
 
-def __copy_and_extend_inputs(inputs, key, value):
-    new_inputs = dict(inputs)
-    new_inputs[key] = value
+def __copy_and_extend_inputs(inputs, key, value, nested):
+    # can't deepcopy dicts with our models for reason I don't understand,
+    # test_map_over_two_collections_unlinked breaks if I try to combine these two branches of the if
+    new_inputs = state_copy(inputs, nested)
+    state_set_value(new_inputs, key, value, nested)
     return new_inputs
+
+
+def state_copy(inputs, nested):
+    # can't deepcopy dicts with our models for reason I don't understand,
+    # test_map_over_two_collections_unlinked breaks if I try to combine these two branches of the if
+    if nested:
+        state_dict_copy = copy.deepcopy(inputs)
+    else:
+        state_dict_copy = dict(inputs)
+    return state_dict_copy
+
+
+def state_set_value(state_dict, key, value, nested):
+    if "|" not in key or not nested:
+        state_dict[key] = value
+    else:
+        first, rest = key.split("|", 1)
+        if first not in state_dict and looks_like_flattened_repeat_key(first):
+            repeat_name, index = split_flattened_repeat_key(first)
+            if repeat_name not in state_dict:
+                state_dict[repeat_name] = []
+            repeat_state = state_dict[repeat_name]
+            while len(repeat_state) <= index:
+                repeat_state.append({})
+            state_set_value(repeat_state[index], rest, value, nested)
+        else:
+            state_set_value(state_dict[first], rest, value, nested)
+
+
+def state_remove_value(state_dict, key, nested):
+    if "|" not in key or not nested:
+        del state_dict[key]
+    else:
+        first, rest = key.split("|", 1)
+        child_dict = state_dict[first]
+        # repeats?
+        if "|" in rest:
+            state_remove_value(child_dict, rest, nested)
+        else:
+            del child_dict[rest]
+            if len(child_dict) == 0:
+                del state_dict[first]
+
+
+def state_get_value(state_dict, key, nested):
+    if "|" not in key or not nested:
+        return state_dict[key]
+    else:
+        first, rest = key.split("|", 1)
+        if first not in state_dict and looks_like_flattened_repeat_key(first):
+            repeat_name, index = split_flattened_repeat_key(first)
+            return state_get_value(state_dict[repeat_name][index], rest, nested)
+        else:
+            return state_get_value(state_dict[first], rest, nested)
+
+
+def is_in_state(state_dict, key, nested):
+    if not state_dict:
+        return False
+    if "|" not in key or not nested:
+        return key in state_dict
+    else:
+        first, rest = key.split("|", 1)
+        # repeats?
+        is_in_state(state_dict.get(first), rest, nested)
+
+
+def looks_like_flattened_repeat_key(key: str) -> bool:
+    return key.rsplit("_", 1)[-1].isdigit()
+
+
+def split_flattened_repeat_key(key: str) -> Tuple[str, int]:
+    input_name, _index = key.rsplit("_", 1)
+    index = int(_index)
+    return input_name, index

--- a/test/integration/test_extended_metadata_mapping.py
+++ b/test/integration/test_extended_metadata_mapping.py
@@ -29,3 +29,18 @@ class TestExtendedMetadataMappingIntegration(integration_util.IntegrationTestCas
             "input1": {"batch": True, "values": [{"src": "hdca", "id": hdca_id}]},
         }
         self._run_and_check_simple_collection_mapping(history_id, inputs)
+
+    def _run_and_check_simple_collection_mapping(self, history_id, inputs):
+        create = self._run_cat(history_id, inputs=inputs, assert_ok=True)
+        outputs = create["outputs"]
+        jobs = create["jobs"]
+        implicit_collections = create["implicit_collections"]
+        assert len(jobs) == 2
+        assert len(outputs) == 2
+        assert len(implicit_collections) == 1
+        output1 = outputs[0]
+        output2 = outputs[1]
+        output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
+        output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
+        assert output1_content.strip() == "123"
+        assert output2_content.strip() == "456"


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/18984 and many related issues - builds on work in https://github.com/galaxyproject/galaxy/pull/19027. Part of this work is migrating tool execution tests around these things into the new format introduced in #18977 which now has a compact syntax and fixture support for testing both input formats with the same test method. I will hopefully be able to just add another fixture param element for the tool request API (#17393) in order to make sure all these tests work with the new API.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
