### PR TITLE
Fix test_stock.py unit test

### DIFF
--- a/lib/galaxy/tools/stock.py
+++ b/lib/galaxy/tools/stock.py
@@ -7,6 +7,7 @@ from lxml.etree import XMLSyntaxError
 # Set GALAXY_INCLUDES_ROOT from tool shed to point this at a Galaxy root
 # (once we are running the tool shed from packages not rooted with Galaxy).
 import galaxy.tools
+from galaxy.tool_util.loader_directory import looks_like_a_tool_xml
 from galaxy.tool_util.parser import get_tool_source
 from galaxy.util import galaxy_directory
 from galaxy.util.resources import files
@@ -26,7 +27,7 @@ def stock_tool_sources():
 
 
 def _walk_directory_for_tools(path):
-    if path.is_file() and path.name.endswith(".xml"):
+    if path.is_file() and not path.name.endswith("tool_conf.xml") and looks_like_a_tool_xml(path):
         yield path
     elif path.is_dir():
         for directory in path.iterdir():


### PR DESCRIPTION
We'd treat macros.xml and sample_tool_conf.xml as potential tools and fail `assert tool_source.parse_id()`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
