### PR TITLE
[24.1] quota: do not complain on no-change of default

### DIFF
--- a/lib/galaxy/managers/quotas.py
+++ b/lib/galaxy/managers/quotas.py
@@ -184,27 +184,25 @@ class QuotaManager:
             if params.default != "no":
                 self.quota_agent.set_default_quota(params.default, quota)
                 message = f"Quota '{quota.name}' is now the default for {params.default} users."
+            elif quota.default:
+                message = f"Quota '{quota.name}' is no longer the default for {quota.default[0].type} users."
+                for dqa in quota.default:
+                    self.sa_session.delete(dqa)
+                with transaction(self.sa_session):
+                    self.sa_session.commit()
             else:
-                if quota.default:
-                    message = f"Quota '{quota.name}' is no longer the default for {quota.default[0].type} users."
-                    for dqa in quota.default:
-                        self.sa_session.delete(dqa)
-                    with transaction(self.sa_session):
-                        self.sa_session.commit()
-                else:
-                    message = f"Quota '{quota.name}' is not a default."
+                message = ""
             return message
 
     def unset_quota_default(self, quota, params=None) -> str:
-        if not quota.default:
-            raise ActionInputError(f"Quota '{quota.name}' is not a default.")
-        else:
+        message = ""
+        if quota.default:
             message = f"Quota '{quota.name}' is no longer the default for {quota.default[0].type} users."
             for dqa in quota.default:
                 self.sa_session.delete(dqa)
             with transaction(self.sa_session):
                 self.sa_session.commit()
-            return message
+        return message
 
     def delete_quota(self, quota, params=None) -> str:
         quotas = util.listify(quota)


### PR DESCRIPTION
(and also no message)

Currently a quota update setting a non-default to non-default (i.e. doing nothing) raises a 400, e.g. on my instance

```
bioblend.ConnectionError: Unexpected HTTP status code: 400: {"err_msg":"Quota 'm.bernt@ufz.de' is not a default.","err_code":400008}
```


xref: https://github.com/galaxyproject/galaxy/pull/18775

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
