### PR TITLE
Silence the quota manager for updates

### DIFF
--- a/lib/galaxy/managers/quotas.py
+++ b/lib/galaxy/managers/quotas.py
@@ -153,8 +153,12 @@ class QuotaManager:
                 raise ActionInputError("One or more invalid group id has been provided.")
             self.quota_agent.set_entity_quota_associations(quotas=[quota], users=in_users, groups=in_groups)
             self.sa_session.refresh(quota)
-            if len(quota.users) != len(in_users) or len(quota.groups) != len(in_groups):
+            if len(quota.users) != len(in_users) and len(quota.groups) != len(in_groups):
                 return f"Quota '{quota.name}' has been updated with {len(in_users)} associated users and {len(in_groups)} associated groups."
+            elif len(quota.users) != len(in_users):
+                return f"Quota '{quota.name}' has been updated with {len(in_users)} associated users."
+            elif len(quota.groups) != len(in_groups):
+                return f"Quota '{quota.name}' has been updated with {len(in_groups)} associated groups."
             else:
                 return None
 

--- a/lib/galaxy/managers/quotas.py
+++ b/lib/galaxy/managers/quotas.py
@@ -117,7 +117,7 @@ class QuotaManager:
         except ValueError:
             return False
 
-    def rename_quota(self, quota, params) -> str:
+    def rename_quota(self, quota, params) -> Optional[str]:
         stmt = select(Quota).where(and_(Quota.name == params.name, Quota.id != quota.id)).limit(1)
         if not params.name:
             raise ActionInputError("Enter a valid name.")
@@ -131,10 +131,12 @@ class QuotaManager:
             self.sa_session.add(quota)
             with transaction(self.sa_session):
                 self.sa_session.commit()
-            message = f"Quota '{old_name}' has been renamed to '{params.name}'."
-            return message
+            if old_name != params.name:
+                return f"Quota '{old_name}' has been renamed to '{params.name}'."
+            else:
+                return None
 
-    def manage_users_and_groups_for_quota(self, quota, params, decode_id=None) -> str:
+    def manage_users_and_groups_for_quota(self, quota, params, decode_id=None) -> Optional[str]:
         if quota.default:
             raise ActionInputError("Default quotas cannot be associated with specific users and groups.")
         else:
@@ -151,10 +153,12 @@ class QuotaManager:
                 raise ActionInputError("One or more invalid group id has been provided.")
             self.quota_agent.set_entity_quota_associations(quotas=[quota], users=in_users, groups=in_groups)
             self.sa_session.refresh(quota)
-            message = f"Quota '{quota.name}' has been updated with {len(in_users)} associated users and {len(in_groups)} associated groups."
-            return message
+            if len(quota.users) != len(in_users) or len(quota.groups) != len(in_groups):
+                return f"Quota '{quota.name}' has been updated with {len(in_users)} associated users and {len(in_groups)} associated groups."
+            else:
+                return None
 
-    def edit_quota(self, quota, params) -> str:
+    def edit_quota(self, quota, params) -> Optional[str]:
         if params.amount.lower() in ("unlimited", "none", "no limit"):
             new_amount = None
         else:
@@ -169,42 +173,43 @@ class QuotaManager:
         elif params.operation not in model.Quota.valid_operations:
             raise ActionInputError("Enter a valid operation.")
         else:
+            old_display_amount = quota.display_amount
+            old_operation = quota.operation
             quota.amount = new_amount
             quota.operation = params.operation
             self.sa_session.add(quota)
             with transaction(self.sa_session):
                 self.sa_session.commit()
-            message = f"Quota '{quota.name}' is now '{quota.operation}{quota.display_amount}'."
-            return message
+            if old_display_amount != quota.display_amount or old_operation != quota.operation:
+                return f"Quota '{quota.name}' is now '{quota.operation}{quota.display_amount}'."
+            else:
+                return None
 
-    def set_quota_default(self, quota, params) -> str:
+    def set_quota_default(self, quota, params) -> Optional[str]:
         if params.default != "no" and params.default not in model.DefaultQuotaAssociation.types.__members__.values():
             raise ActionInputError("Enter a valid default type.")
         else:
+            message = None
             if params.default != "no":
                 self.quota_agent.set_default_quota(params.default, quota)
                 message = f"Quota '{quota.name}' is now the default for {params.default} users."
-            else:
-                if quota.default:
-                    message = f"Quota '{quota.name}' is no longer the default for {quota.default[0].type} users."
-                    for dqa in quota.default:
-                        self.sa_session.delete(dqa)
-                    with transaction(self.sa_session):
-                        self.sa_session.commit()
-                else:
-                    message = f"Quota '{quota.name}' is not a default."
+            elif quota.default:
+                message = f"Quota '{quota.name}' is no longer the default for {quota.default[0].type} users."
+                for dqa in quota.default:
+                    self.sa_session.delete(dqa)
+                with transaction(self.sa_session):
+                    self.sa_session.commit()
             return message
 
-    def unset_quota_default(self, quota, params=None) -> str:
-        if not quota.default:
-            raise ActionInputError(f"Quota '{quota.name}' is not a default.")
-        else:
+    def unset_quota_default(self, quota, params=None) -> Optional[str]:
+        message = None
+        if quota.default:
             message = f"Quota '{quota.name}' is no longer the default for {quota.default[0].type} users."
             for dqa in quota.default:
                 self.sa_session.delete(dqa)
             with transaction(self.sa_session):
                 self.sa_session.commit()
-            return message
+        return message
 
     def delete_quota(self, quota, params=None) -> str:
         quotas = util.listify(quota)
@@ -248,7 +253,7 @@ class QuotaManager:
         message += ", ".join(names)
         return message
 
-    def purge_quota(self, quota, params=None):
+    def purge_quota(self, quota, params=None) -> str:
         """
         This method should only be called for a Quota that has previously been deleted.
         Purging a deleted Quota deletes all of the following from the database:

--- a/lib/galaxy/webapps/galaxy/services/quotas.py
+++ b/lib/galaxy/webapps/galaxy/services/quotas.py
@@ -96,7 +96,8 @@ class QuotasService(ServiceBase):
         messages = []
         for method in methods:
             message = method(quota, params)
-            messages.append(message)
+            if message:
+                messages.append(message)
         return "; ".join(messages)
 
     def delete(


### PR DESCRIPTION
this should make the quota manager a bit more silent when updating quotas, i.e. only message when something is changed

In https://github.com/galaxyproject/galaxy/pull/18775#issuecomment-2353115734 it was suggested to remove all messages, but I find it quite useful when using bioblend. But I'm happy to remove them all and compute a diff of the old and new quota ... ?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
