### PR TITLE
[24.1] Unpin social-auth-core in galaxy-data package

### DIFF
--- a/packages/data/setup.cfg
+++ b/packages/data/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     python-magic
     pysam>=0.21
     rocrate
-    social-auth-core[openidconnect]==4.0.3
+    social-auth-core[openidconnect]>=4.0.3
     SQLAlchemy>=2.0,<2.1
     tifffile
     typing-extensions

--- a/packages/data/setup.cfg
+++ b/packages/data/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     python-magic
     pysam>=0.21
     rocrate
-    social-auth-core[openidconnect]>=4.0.3
+    social-auth-core>=4.5.0
     SQLAlchemy>=2.0,<2.1
     tifffile
     typing-extensions


### PR DESCRIPTION
I am not sure why this is pinned but it conflicts with the version in `pinned-requirements.txt` and prevents the creation of the `galaxy` metapackage in #19051.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
