### PR TITLE
Allow deferred datasets to behave as URIs

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4686,6 +4686,13 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
         return self.dataset.state == Dataset.states.DEFERRED
 
     @property
+    def deferred_source_uri(self):
+        if self.has_deferred_data:
+            # Assuming the first source is the deferred source
+            return self.sources[0].source_uri
+        return None
+
+    @property
     def state(self):
         # self._state holds state that should only affect this particular dataset association, not the dataset state itself
         if self._state:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2737,6 +2737,7 @@ class FakeDatasetAssociation:
     def __init__(self, dataset: Optional["Dataset"] = None) -> None:
         self.dataset = dataset
         self.metadata: Dict = {}
+        self.has_deferred_data = False
 
     def get_file_name(self, sync_cache: bool = True) -> str:
         assert self.dataset

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4688,7 +4688,7 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
 
     @property
     def deferred_source_uri(self):
-        if self.has_deferred_data:
+        if self.has_deferred_data and self.sources:
             # Assuming the first source is the deferred source
             return self.sources[0].source_uri
         return None

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4326,8 +4326,8 @@ This is useful when the tool can handle the URI directly. Example:
 <param name="input" type="data" format="txt" allow_uri_if_protocol="http,https,s3" />
 ```
 
-You can specify multiple prefixes separated by comma. The URI will be passed to the tool
-as is if it starts with any of the specified prefixes.
+You can specify multiple prefixes separated by comma or use the wildcard '*' to always
+treat deferred datasets as URIs. The source URI will be passed to the tool as is.
 
 This attribute is only valid for `data` parameters.
          ]]></xs:documentation>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4317,7 +4317,7 @@ when the ``type`` attribute value is ``boolean``.</xs:documentation>
         <xs:attribute name="allow_uri_if_prefixed" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en"><![CDATA[
-When using `deferred` datasets, Galaxy will try to materialize then into files when
+When using `deferred` datasets, Galaxy will try to materialize them into files when
 running the tool. In case we don't want to download them. The `allow_uri_if_prefixed` attribute
 can be used to avoid materialization and pass the URI as is to the tool.
 This is useful when the tool can handle the URI directly. Example:

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4323,10 +4323,10 @@ can be used to avoid materialization and pass the URI as is to the tool.
 This is useful when the tool can handle the URI directly. Example:
 
 ```xml
-<param name="input" type="data" format="txt" allow_uri_if_protocol="http|https|s3" />
+<param name="input" type="data" format="txt" allow_uri_if_protocol="http,https,s3" />
 ```
 
-You can specify multiple prefixes separated by `|`. The URI will be passed to the tool
+You can specify multiple prefixes separated by comma. The URI will be passed to the tool
 as is if it starts with any of the specified prefixes.
 
 This attribute is only valid for `data` parameters.

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4330,6 +4330,28 @@ You can specify multiple prefixes separated by comma or use the wildcard '*' to 
 treat deferred datasets as URIs. The source URI will be passed to the tool as is.
 
 This attribute is only valid for `data` parameters.
+
+### Handling the input in the tool
+
+Since the input can be a regular file or a URI, the tool should be able to handle both cases.
+The tool should check if the input ``is_deferred`` and if so, treat it as a URI, otherwise
+it should treat it as a regular file. Please note that only deferred datasets with the specified
+protocol will be passed as URIs, the rest will be materialized as files.
+
+Here is an example command section that handles the above sample input:
+
+```python
+<command>
+  ## We should handle the case where the input must be treated as a URI with a specific protocol.
+  #if $input.is_deferred:
+      ## Here, the input is a deferred dataset which source URI has the protocol 'https', 'http' or 's3'.
+      echo '$input' > '$output' ## The ouput will be the source URI of the input.
+  #else:
+      ## Here, the input is a regular dataset or a materialized dataset in case of a 
+      ## deferred dataset which source URI has a protocol different than 'https', 'http' or 's3'.
+      cp '$input' '$output' ## The output will be a copy of the input content.
+</command>
+```
          ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4314,6 +4314,25 @@ template if the parameter is ``false`` or not checked by the user. Used only
 when the ``type`` attribute value is ``boolean``.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="allow_uri_if_prefixed" type="xs:string">
+          <xs:annotation>
+            <xs:documentation xml:lang="en"><![CDATA[
+When using `deferred` datasets, Galaxy will try to materialize then into files when
+running the tool. In case we don't want to download them. The `allow_uri_if_prefixed` attribute
+can be used to avoid materialization and pass the URI as is to the tool.
+This is useful when the tool can handle the URI directly. Example:
+
+```xml
+<param name="input" type="data" format="txt" allow_uri_if_prefixed="http|s3" />
+```
+
+You can specify multiple prefixes separated by `|`. The URI will be passed to the tool
+as is if it starts with any of the specified prefixes.
+
+This attribute is only valid for `data` parameters.
+         ]]></xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="size" type="xs:string" gxdocs:deprecated="true">
           <!-- TODO: can be integer or integerxinteger -->
           <xs:annotation>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4314,16 +4314,16 @@ template if the parameter is ``false`` or not checked by the user. Used only
 when the ``type`` attribute value is ``boolean``.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="allow_uri_if_prefixed" type="xs:string">
+        <xs:attribute name="allow_uri_if_protocol" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en"><![CDATA[
 When using `deferred` datasets, Galaxy will try to materialize them into files when
-running the tool. In case we don't want to download them. The `allow_uri_if_prefixed` attribute
+running the tool. In case we don't want to download them, the `allow_uri_if_protocol` attribute
 can be used to avoid materialization and pass the URI as is to the tool.
 This is useful when the tool can handle the URI directly. Example:
 
 ```xml
-<param name="input" type="data" format="txt" allow_uri_if_prefixed="http|s3" />
+<param name="input" type="data" format="txt" allow_uri_if_protocol="http|https|s3" />
 ```
 
 You can specify multiple prefixes separated by `|`. The URI will be passed to the tool

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -341,7 +341,7 @@ class ToolEvaluator:
         if isinstance(deferred_input, DataToolParameter) and isinstance(input_value, model.DatasetInstance):
             source_uri = input_value.sources[0].source_uri or ""
             for prefix in deferred_input.allow_uri_if_protocol:
-                if source_uri.startswith(prefix):
+                if prefix == "*" or source_uri.startswith(prefix):
                     return False
         return True
 

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -333,7 +333,11 @@ class ToolEvaluator:
         We can skip materializing some deferred datasets if the input can work with URIs that are prefixed
         with a known prefix set in `allow_uri_if_protocol`.
         """
-        deferred_input = self.tool.inputs[input_name]
+        deferred_input = self.tool.inputs.get(input_name)
+        if not deferred_input:
+            # TODO: Can this ever happen? It seems like it happens in the test suite.
+            # For example, in test_metadata_validator_on_deferred_input
+            return True
         if isinstance(deferred_input, DataToolParameter) and isinstance(input_value, model.DatasetInstance):
             source_uri = input_value.sources[0].source_uri or ""
             for prefix in deferred_input.allow_uri_if_protocol:

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -331,12 +331,12 @@ class ToolEvaluator:
     def _should_materialize_deferred_input(self, input_name: str, input_value: DeferrableObjectsT) -> bool:
         """
         We can skip materializing some deferred datasets if the input can work with URIs that are prefixed
-        with a known prefix set in `allow_uri_if_prefixed`.
+        with a known prefix set in `allow_uri_if_protocol`.
         """
         deferred_input = self.tool.inputs[input_name]
         if isinstance(deferred_input, DataToolParameter) and isinstance(input_value, model.DatasetInstance):
             source_uri = input_value.sources[0].source_uri or ""
-            for prefix in deferred_input.allow_uri_if_prefixed:
+            for prefix in deferred_input.allow_uri_if_protocol:
                 if source_uri.startswith(prefix):
                     return False
         return True

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -334,10 +334,6 @@ class ToolEvaluator:
         with a known prefix set in `allow_uri_if_protocol`.
         """
         deferred_input = self.tool.inputs.get(input_name)
-        if not deferred_input:
-            # TODO: Can this ever happen? It seems like it happens in the test suite.
-            # For example, in test_metadata_validator_on_deferred_input
-            return True
         if isinstance(deferred_input, DataToolParameter) and isinstance(input_value, model.DatasetInstance):
             source_uri = input_value.sources[0].source_uri or ""
             for prefix in deferred_input.allow_uri_if_protocol:

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -335,7 +335,7 @@ class ToolEvaluator:
         """
         deferred_input = self.tool.inputs.get(input_name)
         if isinstance(deferred_input, DataToolParameter) and isinstance(input_value, model.DatasetInstance):
-            source_uri = input_value.sources[0].source_uri or ""
+            source_uri = input_value.deferred_source_uri or ""
             for prefix in deferred_input.allow_uri_if_protocol:
                 if prefix == "*" or source_uri.startswith(prefix):
                     return False

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2068,6 +2068,7 @@ class DataToolParameter(BaseDataToolParameter):
         self.tag = tag
         self.is_dynamic = True
         self._parse_options(input_source)
+        self._parse_allow_uri_if_prefixed(input_source)
         # Load conversions required for the dataset input
         self.conversions = []
         self.default_object = input_source.parse_default()
@@ -2088,6 +2089,12 @@ class DataToolParameter(BaseDataToolParameter):
                         self.name,
                     )
                 self.conversions.append((name, conv_extension, [conv_type]))
+
+    def _parse_allow_uri_if_prefixed(self, input_source):
+        # In case of deferred datasets, if the source URI is prefixed with one of the values in this list,
+        # the dataset will behave as an URI and will not be materialized into a file path.
+        allow_uri_if_prefixed = input_source.get("allow_uri_if_prefixed", None)
+        self.allow_uri_if_prefixed = allow_uri_if_prefixed.split("|") if allow_uri_if_prefixed else []
 
     def from_json(self, value, trans, other_values=None):
         session = trans.sa_session

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2068,7 +2068,7 @@ class DataToolParameter(BaseDataToolParameter):
         self.tag = tag
         self.is_dynamic = True
         self._parse_options(input_source)
-        self._parse_allow_uri_if_prefixed(input_source)
+        self._parse_allow_uri_if_protocol(input_source)
         # Load conversions required for the dataset input
         self.conversions = []
         self.default_object = input_source.parse_default()
@@ -2090,11 +2090,11 @@ class DataToolParameter(BaseDataToolParameter):
                     )
                 self.conversions.append((name, conv_extension, [conv_type]))
 
-    def _parse_allow_uri_if_prefixed(self, input_source):
+    def _parse_allow_uri_if_protocol(self, input_source):
         # In case of deferred datasets, if the source URI is prefixed with one of the values in this list,
         # the dataset will behave as an URI and will not be materialized into a file path.
-        allow_uri_if_prefixed = input_source.get("allow_uri_if_prefixed", None)
-        self.allow_uri_if_prefixed = allow_uri_if_prefixed.split("|") if allow_uri_if_prefixed else []
+        allow_uri_if_protocol = input_source.get("allow_uri_if_protocol", None)
+        self.allow_uri_if_protocol = allow_uri_if_protocol.split("|") if allow_uri_if_protocol else []
 
     def from_json(self, value, trans, other_values=None):
         session = trans.sa_session

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2094,7 +2094,7 @@ class DataToolParameter(BaseDataToolParameter):
         # In case of deferred datasets, if the source URI is prefixed with one of the values in this list,
         # the dataset will behave as an URI and will not be materialized into a file path.
         allow_uri_if_protocol = input_source.get("allow_uri_if_protocol", None)
-        self.allow_uri_if_protocol = allow_uri_if_protocol.split("|") if allow_uri_if_protocol else []
+        self.allow_uri_if_protocol = allow_uri_if_protocol.split(",") if allow_uri_if_protocol else []
 
     def from_json(self, value, trans, other_values=None):
         session = trans.sa_session

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -471,6 +471,11 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
         return self.dataset.datatype.matches_any(datatypes)
 
     def __str__(self) -> str:
+        return self._path_or_uri()
+
+    def _path_or_uri(self) -> str:
+        if self.unsanitized.has_deferred_data:
+            return self.unsanitized.deferred_source_uri or ""
         if self.false_path is not None:
             return self.false_path
         else:

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -456,6 +456,10 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
     def is_collection(self) -> bool:
         return False
 
+    @property
+    def is_deferred(self) -> bool:
+        return self.unsanitized.has_deferred_data
+
     def is_of_type(self, *exts: str) -> bool:
         datatypes = []
         if not self.datatypes_registry:
@@ -474,7 +478,7 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
         return self._path_or_uri()
 
     def _path_or_uri(self) -> str:
-        if self.unsanitized.has_deferred_data:
+        if self.is_deferred:
             return self.unsanitized.deferred_source_uri or ""
         if self.false_path is not None:
             return self.false_path

--- a/test/functional/tools/parameters/gx_allow_uri_if_protocol.xml
+++ b/test/functional/tools/parameters/gx_allow_uri_if_protocol.xml
@@ -1,0 +1,13 @@
+<tool id="gx_allow_uri_if_protocol" name="gx_allow_uri_if_protocol" version="1.0.0">
+    <command><![CDATA[
+echo '$input' > '$output'
+    ]]></command>
+    <inputs>
+        <param name="input" type="data" allow_uri_if_protocol="https"/>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt"/>
+    </outputs>
+    <tests>
+    </tests>
+</tool>

--- a/test/functional/tools/parameters/gx_allow_uri_if_protocol.xml
+++ b/test/functional/tools/parameters/gx_allow_uri_if_protocol.xml
@@ -1,6 +1,15 @@
 <tool id="gx_allow_uri_if_protocol" name="gx_allow_uri_if_protocol" version="1.0.0">
     <command><![CDATA[
-echo '$input' > '$output'
+        ## We should handle the case where the input must be treated as a URI with a specific protocol.
+        #if $input.is_deferred:
+            ## Here, the input is a deferred dataset which source URI has the protocol 'https'.
+            ## The ouput will be the source URI of the input.
+            echo '$input' > '$output'
+        #else:
+            ## Here, the input is a regular dataset or a materialized dataset in case of a 
+            ## deferred dataset which source URI has a protocol different than 'https'.
+            ## The output will be a copy of the input content.
+            cp '$input' '$output'
     ]]></command>
     <inputs>
         <param name="input" type="data" allow_uri_if_protocol="https"/>
@@ -8,6 +17,4 @@ echo '$input' > '$output'
     <outputs>
         <data name="output" format="txt"/>
     </outputs>
-    <tests>
-    </tests>
 </tool>

--- a/test/functional/tools/parameters/gx_allow_uri_if_protocol.xml
+++ b/test/functional/tools/parameters/gx_allow_uri_if_protocol.xml
@@ -1,18 +1,21 @@
 <tool id="gx_allow_uri_if_protocol" name="gx_allow_uri_if_protocol" version="1.0.0">
     <command><![CDATA[
-        ## We should handle the case where the input must be treated as a URI with a specific protocol.
-        #if $input.is_deferred:
-            ## Here, the input is a deferred dataset which source URI has the protocol 'https'.
-            ## The ouput will be the source URI of the input.
-            echo '$input' > '$output'
-        #else:
-            ## Here, the input is a regular dataset or a materialized dataset in case of a 
-            ## deferred dataset which source URI has a protocol different than 'https'.
-            ## The output will be a copy of the input content.
-            cp '$input' '$output'
+        #for $input in $input1:
+            ## We should handle the case where the input must be treated as a URI with a specific protocol.
+            #if $input.is_deferred:
+                ## Here, the input is a deferred dataset which source URI has the protocol 'https'.
+                ## We append the URI to the output file.
+                echo '$input' >> '$output'
+            #else:
+                ## Here, the input is a regular dataset or a materialized dataset in case of a 
+                ## deferred dataset which source URI has a protocol different than 'https'.
+                ## We append the content of the dataset to the output file.
+                cat '$input' >> '$output'
+            #end if
+        #end for
     ]]></command>
     <inputs>
-        <param name="input" type="data" allow_uri_if_protocol="https"/>
+        <param name="input1" type="data" allow_uri_if_protocol="https" multiple="true"/>
     </inputs>
     <outputs>
         <data name="output" format="txt"/>

--- a/test/unit/app/tools/test_parameter_parsing.py
+++ b/test/unit/app/tools/test_parameter_parsing.py
@@ -452,3 +452,12 @@ class TestParameterParsing(BaseParameterTestCase):
         )
         assert param.type == "data_collection"
         assert param.collection_types == ["list", "list:paired"]
+
+    def test_data_allow_uri_if_protocol(self):
+        param = self._parameter_for(
+            xml="""
+            <param name="deferred" type="data" allow_uri_if_protocol="https,s3">
+            </param>
+        """
+        )
+        assert param.allow_uri_if_protocol == ["https", "s3"]

--- a/test/unit/app/tools/test_wrappers.py
+++ b/test/unit/app/tools/test_wrappers.py
@@ -310,6 +310,7 @@ class MockDataset:
         self.extra_files_path = MOCK_DATASET_EXTRA_FILES_PATH
         self.ext = MOCK_DATASET_EXT
         self.tags = []
+        self.has_deferred_data = False
 
     def get_file_name(self, sync_cache=True):
         return MOCK_DATASET_PATH


### PR DESCRIPTION
Closes #19065

Some tools might accept URIs as input. In those cases there is no need to materialize deferred datasets in Galaxy, we can just pass the source URI directly to the tool.

To do that, we can now use `allow_uri_if_protocol` when declaring the input param in the tool.

```xml
<param name="input" type="data" allow_uri_if_protocol="http,https,s3" />
```

With the above example, if you provide a deferred dataset as `input` which source URI starts with one of the listed protocols (http, https or s3), when you reference your `$input` it will contain the source URI, otherwise, it will be the path to the materialized file.

You can also use `allow_uri_if_protocol="*"` to treat all deferred datasets as URIs regardless of the protocol.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Upload a deferred dataset
  - Run a tool that uses `allow_uri_if_protocol` in the input param definition with an appropriate value to filter the protocol or `*`.
  - When you reference the input param in your command line it will contain the source URI of the deferred dataset.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
