### PR TITLE
[24.0] Fetch invocation id only once on the job info page

### DIFF
--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -41,7 +41,7 @@ const metadataDetail = ref({
 
 function updateJob(newJob) {
     job.value = newJob;
-    if (newJob) {
+    if (newJob && !invocationId.value) {
         fetchInvocation(newJob.id);
     }
 }
@@ -57,6 +57,7 @@ function filterMetadata(jobMessages) {
     });
 }
 
+/** Fetches the invocation for the given job id to get the associated invocation id */
 async function fetchInvocation(jobId) {
     if (jobId) {
         const invocation = await invocationForJob({ jobId: jobId });


### PR DESCRIPTION
... instead of polling while the job is non terminal; we only need the id once.

Fixes https://github.com/galaxyproject/galaxy/issues/18921

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
