### PR TITLE
[24.1] Persist uploaded data between Regular and Collection upload tabs

### DIFF
--- a/client/src/components/Upload/UploadContainer.vue
+++ b/client/src/components/Upload/UploadContainer.vue
@@ -177,12 +177,7 @@ defineExpose({
         </span>
     </BAlert>
     <BTabs v-else-if="ready">
-        <BTab
-            v-if="showRegular"
-            id="regular"
-            title="Regular"
-            button-id="tab-title-link-regular"
-            :active.sync="regularTabActive">
+        <BTab v-if="showRegular" title="Regular" button-id="tab-title-link-regular" :active.sync="regularTabActive">
         </BTab>
         <BTab v-if="showComposite" id="composite" title="Composite" button-id="tab-title-link-composite">
             <CompositeBox
@@ -197,7 +192,6 @@ defineExpose({
         </BTab>
         <BTab
             v-if="showCollection"
-            id="collection"
             title="Collection"
             button-id="tab-title-link-collection"
             :active.sync="collectionTabActive">
@@ -213,6 +207,7 @@ defineExpose({
         <DefaultBox
             v-if="showRegular || showCollection"
             v-show="regularTabActive || collectionTabActive"
+            :id="collectionTabActive ? 'collection' : 'regular'"
             ref="regular"
             :chunk-upload-size="chunkUploadSize"
             :default-db-key="defaultDbKey"

--- a/client/src/components/Upload/UploadContainer.vue
+++ b/client/src/components/Upload/UploadContainer.vue
@@ -74,6 +74,7 @@ const props = defineProps({
     },
 });
 
+const collectionTabActive = ref(null);
 const extensionsSet = ref(false);
 const datatypesMapper = ref(null);
 const datatypesMapperReady = ref(false);
@@ -81,6 +82,7 @@ const dbKeysSet = ref(false);
 const listExtensions = ref([]);
 const listDbKeys = ref([]);
 const regular = ref(null);
+const regularTabActive = ref(null);
 
 const { percentage, status } = storeToRefs(useUploadStore());
 
@@ -112,12 +114,15 @@ const ready = computed(
 );
 const canUploadToHistory = computed(() => currentHistory.value && canMutateHistory(currentHistory.value));
 const showCollection = computed(() => !props.formats && props.multiple);
-const showComposite = computed(() => !props.formats || hasCompositeExtension);
-const showRegular = computed(() => !props.formats || hasRegularExtension);
+const showComposite = computed(() => !props.formats || hasCompositeExtension.value);
+const showRegular = computed(() => !props.formats || hasRegularExtension.value);
 const showRules = computed(() => !props.formats || props.multiple);
 
 function immediateUpload(files) {
-    regular.value?.addFiles(files, true);
+    if (showRegular.value) {
+        regularTabActive.value = true;
+        regular.value?.addFiles(files, true);
+    }
 }
 
 function toData(items, history_id, composite = false) {
@@ -172,21 +177,12 @@ defineExpose({
         </span>
     </BAlert>
     <BTabs v-else-if="ready">
-        <BTab v-if="showRegular" id="regular" title="Regular" button-id="tab-title-link-regular">
-            <DefaultBox
-                ref="regular"
-                :chunk-upload-size="chunkUploadSize"
-                :default-db-key="defaultDbKey"
-                :default-extension="defaultExtension"
-                :effective-extensions="effectiveExtensions"
-                :file-sources-configured="fileSourcesConfigured"
-                :ftp-upload-site="currentUserId && ftpUploadSite"
-                :has-callback="hasCallback"
-                :history-id="currentHistoryId"
-                :list-db-keys="listDbKeys"
-                :multiple="multiple"
-                @progress="progress"
-                v-on="$listeners" />
+        <BTab
+            v-if="showRegular"
+            id="regular"
+            title="Regular"
+            button-id="tab-title-link-regular"
+            :active.sync="regularTabActive">
         </BTab>
         <BTab v-if="showComposite" id="composite" title="Composite" button-id="tab-title-link-composite">
             <CompositeBox
@@ -199,19 +195,12 @@ defineExpose({
                 :list-db-keys="listDbKeys"
                 v-on="$listeners" />
         </BTab>
-        <BTab v-if="showCollection" id="collection" title="Collection" button-id="tab-title-link-collection">
-            <DefaultBox
-                :chunk-upload-size="chunkUploadSize"
-                :default-db-key="defaultDbKey"
-                :default-extension="defaultExtension"
-                :effective-extensions="effectiveExtensions"
-                :file-sources-configured="fileSourcesConfigured"
-                :ftp-upload-site="currentUserId && ftpUploadSite"
-                :has-callback="hasCallback"
-                :history-id="currentHistoryId"
-                :is-collection="true"
-                :list-db-keys="listDbKeys"
-                v-on="$listeners" />
+        <BTab
+            v-if="showCollection"
+            id="collection"
+            title="Collection"
+            button-id="tab-title-link-collection"
+            :active.sync="collectionTabActive">
         </BTab>
         <BTab v-if="showRules" id="rule-based" title="Rule-based" button-id="tab-title-link-rule-based">
             <RulesInput
@@ -221,6 +210,23 @@ defineExpose({
                 :history-id="currentHistoryId"
                 v-on="$listeners" />
         </BTab>
+        <DefaultBox
+            v-if="showRegular || showCollection"
+            v-show="regularTabActive || collectionTabActive"
+            ref="regular"
+            :chunk-upload-size="chunkUploadSize"
+            :default-db-key="defaultDbKey"
+            :default-extension="defaultExtension"
+            :effective-extensions="effectiveExtensions"
+            :file-sources-configured="fileSourcesConfigured"
+            :ftp-upload-site="currentUserId && ftpUploadSite"
+            :has-callback="hasCallback"
+            :history-id="currentHistoryId"
+            :list-db-keys="listDbKeys"
+            :multiple="regularTabActive ? multiple : undefined"
+            :is-collection="collectionTabActive"
+            @progress="progress"
+            v-on="$listeners" />
     </BTabs>
     <div v-else>
         <LoadingSpan message="Loading required information from Galaxy server." />

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -1127,7 +1127,7 @@ upload:
     setting_space_to_tab: '.upload-space-to-tab'
     source_button: '#upload-row-${n} .upload-source'
     start: '#activity-upload'
-    start_button: '#btn-start'
+    start_button: '#regular #btn-start'
 
 new_user_welcome:
   selectors:

--- a/config/plugins/tours/core.history.yaml
+++ b/config/plugins/tours/core.history.yaml
@@ -28,11 +28,11 @@ steps:
         https://raw.githubusercontent.com/bgruening/galaxytools/adf077b912ddebd97b07b947b855cdd2862ed8ef/tools/statistics/test-data/anderson.tabular
 
     - title: "Start the upload"
-      element: "#btn-start"
+      element: "#regular #btn-start"
       intro: "Upload the data into your Galaxy <b>History</b>."
       postclick:
-        - "#btn-start"
-        - "#btn-close"
+        - "#regular #btn-start"
+        - "#regular #btn-close"
 
     - title: "History"
       element: "#current-history-panel"

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -894,7 +894,7 @@ class NavigatesGalaxy(HasDriver):
 
         self.upload_start()
 
-        self.wait_for_and_click_selector("button#btn-close")
+        self.components.upload.close_button.wait_for_and_click()
 
     def perform_upload_of_composite_dataset_pasted_data(self, ext, paste_content):
         self.home()

--- a/lib/galaxy_test/selenium/test_uploads.py
+++ b/lib/galaxy_test/selenium/test_uploads.py
@@ -182,7 +182,7 @@ class TestUploads(SeleniumTestCase, UsesHistoryItemAssertions):
         self.upload_start_click()
         self.upload_queue_local_file(self.get_filename("1.sam"))
         self.upload_paste_data("some pasted data")
-        self.wait_for_and_click_selector("button#btn-close")
+        self.components.upload.close_button.wait_for_and_click()
 
         # reopen modal and check that the files are still there
         self.upload_start_click()
@@ -191,12 +191,12 @@ class TestUploads(SeleniumTestCase, UsesHistoryItemAssertions):
 
         # perform upload and close modal
         self.upload_start()
-        self.wait_for_and_click_selector("button#btn-close")
+        self.components.upload.close_button.wait_for_and_click()
 
         # add another pasted file, but don't upload it
         self.upload_start_click()
         self.upload_paste_data("some more pasted data")
-        self.wait_for_and_click_selector("button#btn-close")
+        self.components.upload.close_button.wait_for_and_click()
 
         # reopen modal and see 2 uploaded, 1 yet to upload
         self.upload_start_click()


### PR DESCRIPTION
Uses a singular `DefaultBox` component so that both the Regular and Collection tabs in the `UploadContainer` (modal) have the same files.

Fixes https://github.com/galaxyproject/galaxy/issues/19081

https://github.com/user-attachments/assets/146335b4-8451-4e14-83d3-7056a6ffdf9c

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
