### PR TITLE
Allow several Galaxy Markdown directives to be embedded.

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -8041,7 +8041,7 @@ export interface components {
             annotation?: string | null;
             /**
              * Content
-             * @description Raw text contents of the last page revision (type dependent on content_format).
+             * @description Text contents of the last page revision with embedded directives expanded (type dependent on content_format).
              * @default
              */
             content: string | null;
@@ -17065,10 +17065,16 @@ export interface components {
             author_deleted: boolean;
             /**
              * Content
-             * @description Raw text contents of the last page revision (type dependent on content_format).
+             * @description Text contents of the last page revision with embedded directives expanded (type dependent on content_format).
              * @default
              */
             content: string | null;
+            /**
+             * Content for Editor
+             * @description Raw text contents of the last page revision (type dependent on content_format).
+             * @default
+             */
+            content_editor: string | null;
             /**
              * Content format
              * @description Either `markdown` or `html`.
@@ -20130,7 +20136,7 @@ export interface components {
         ToolReportForDataset: {
             /**
              * Content
-             * @description Raw text contents of the last page revision (type dependent on content_format).
+             * @description Text contents of the last page revision with embedded directives expanded (type dependent on content_format).
              * @default
              */
             content: string | null;

--- a/client/src/components/Markdown/MarkdownHelpPopovers.vue
+++ b/client/src/components/Markdown/MarkdownHelpPopovers.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import type { HelpElementReference } from "@/components/Markdown/gxuris-types";
+
+import HelpPopover from "@/components/Help/HelpPopover.vue";
+
+interface Props {
+    elements: HelpElementReference[];
+}
+
+defineProps<Props>();
+</script>
+
+<template>
+    <span>
+        <span v-for="(value, i) in elements" :key="i">
+            <HelpPopover :target="value.element" :term="value.term" />
+        </span>
+    </span>
+</template>

--- a/client/src/components/Markdown/Sections/MarkdownDefault.vue
+++ b/client/src/components/Markdown/Sections/MarkdownDefault.vue
@@ -2,7 +2,9 @@
 import MarkdownIt from "markdown-it";
 //@ts-ignore
 import markdownItRegexp from "markdown-it-regexp";
-import { computed } from "vue";
+import { computed, ref } from "vue";
+
+import { useGxUris } from "@/components/Markdown/gxuris";
 
 //@ts-ignore
 import markdownItKatex from "./Plugins/markdown-it-katex";
@@ -20,8 +22,14 @@ const props = defineProps<{
 }>();
 
 const renderedContent = computed(() => md.render(props.content));
+
+const renderedMarkdownDiv = ref<HTMLDivElement>();
+const { internalHelpReferences, MarkdownHelpPopovers } = useGxUris(renderedMarkdownDiv);
 </script>
 
 <template>
-    <div class="text-justify" v-html="renderedContent" />
+    <span>
+        <div ref="renderedMarkdownDiv" class="text-justify" v-html="renderedContent" />
+        <MarkdownHelpPopovers :elements="internalHelpReferences" />
+    </span>
 </template>

--- a/client/src/components/Markdown/gxuris-types.ts
+++ b/client/src/components/Markdown/gxuris-types.ts
@@ -1,0 +1,4 @@
+export interface HelpElementReference {
+    element: HTMLElement;
+    term: string;
+}

--- a/client/src/components/Markdown/gxuris.ts
+++ b/client/src/components/Markdown/gxuris.ts
@@ -1,0 +1,46 @@
+import { type Ref, ref, watch } from "vue";
+
+import { getAppRoot } from "@/onload/loadConfig";
+
+import type { HelpElementReference } from "./gxuris-types";
+
+import MarkdownHelpPopovers from "./MarkdownHelpPopovers.vue";
+
+function rewriteGxUris(ref: Ref<HTMLDivElement | undefined>, internalHelpReferences: Ref<HelpElementReference[]>) {
+    internalHelpReferences.value.length = 0;
+    if (ref.value) {
+        const links = ref.value.getElementsByTagName("a");
+        Array.from(links).forEach((link: HTMLAnchorElement) => {
+            if (link.href.startsWith("gxhelp://")) {
+                const uri = link.href.substr("gxhelp://".length);
+                internalHelpReferences.value.push({ element: link, term: uri });
+                link.href = `${getAppRoot()}help/terms/${uri}`;
+                link.style.color = "inherit";
+                link.style.textDecorationLine = "underline";
+                link.style.textDecorationStyle = "dashed";
+            }
+        });
+        const imgs = ref.value.getElementsByTagName("img");
+        Array.from(imgs).forEach((img) => {
+            if (img.src.startsWith("gxstatic://")) {
+                const rest = img.src.substr("gxstatic://".length);
+                img.src = `${getAppRoot()}static/${rest}`;
+            }
+        });
+    }
+}
+
+export function useGxUris(divRef: Ref<HTMLDivElement | undefined>) {
+    const internalHelpReferences = ref<HelpElementReference[]>([]);
+
+    function refresh() {
+        rewriteGxUris(divRef, internalHelpReferences);
+    }
+
+    watch(divRef, refresh, { immediate: true });
+
+    return {
+        internalHelpReferences,
+        MarkdownHelpPopovers,
+    };
+}

--- a/client/src/components/Markdown/gxuris.ts
+++ b/client/src/components/Markdown/gxuris.ts
@@ -26,6 +26,11 @@ function rewriteGxUris(ref: Ref<HTMLDivElement | undefined>, internalHelpReferen
                 const rest = img.src.substr("gxstatic://".length);
                 img.src = `${getAppRoot()}static/${rest}`;
             }
+            if (img.src.startsWith("gxdatasetasimage://")) {
+                const historyDatasetId = img.src.substr("gxdatasetasimage://".length);
+                const imageUrl = `${getAppRoot()}dataset/display?dataset_id=${historyDatasetId}`;
+                img.src = imageUrl;
+            }
         });
     }
 }

--- a/client/src/components/PageEditor/PageEditor.vue
+++ b/client/src/components/PageEditor/PageEditor.vue
@@ -5,7 +5,7 @@
         :title="title"
         :page-id="pageId"
         :public-url="publicUrl"
-        :content="content"
+        :content="contentEditor"
         :content-data="contentData" />
 </template>
 
@@ -24,6 +24,7 @@ interface PageData {
     title: string;
     content: string;
     content_format: string;
+    content_editor: string;
     username: string;
     slug: string;
 }
@@ -34,6 +35,7 @@ const props = defineProps<{
 
 const title = ref("");
 const content = ref<string>("");
+const contentEditor = ref<string>("");
 const contentFormat = ref<string>("");
 const contentData = ref<PageData>();
 const publicUrl = ref<string>("");
@@ -60,6 +62,7 @@ const loadPage = async () => {
         if (data) {
             publicUrl.value = `${getAppRoot()}u/${data.username}/p/${data.slug}`;
             content.value = data.content;
+            contentEditor.value = data.content_editor;
             contentFormat.value = data.content_format;
             contentData.value = data || {};
             title.value = data.title;

--- a/client/src/components/Tool/ToolHelpMarkdown.vue
+++ b/client/src/components/Tool/ToolHelpMarkdown.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from "vue";
+import { computed, ref } from "vue";
 
+import { useGxUris } from "@/components/Markdown/gxuris";
 import { markup } from "@/components/ObjectStore/configurationMarkdown";
 import { useFormattedToolHelp } from "@/composables/formattedToolHelp";
-import { getAppRoot } from "@/onload/loadConfig";
-
-import HelpPopover from "@/components/Help/HelpPopover.vue";
 
 const props = defineProps<{
     content: string;
@@ -18,38 +16,7 @@ const { formattedContent } = useFormattedToolHelp(markdownHtml);
 
 const helpHtml = ref<HTMLDivElement>();
 
-interface InternalTypeReference {
-    element: HTMLElement;
-    term: string;
-}
-
-const internalHelpReferences = ref<InternalTypeReference[]>([]);
-
-function setupPopovers() {
-    internalHelpReferences.value.length = 0;
-    if (helpHtml.value) {
-        const links = helpHtml.value.getElementsByTagName("a");
-        Array.from(links).forEach((link) => {
-            if (link.href.startsWith("gxhelp://")) {
-                const uri = link.href.substr("gxhelp://".length);
-                internalHelpReferences.value.push({ element: link, term: uri });
-                link.href = `${getAppRoot()}help/terms/${uri}`;
-                link.style.color = "inherit";
-                link.style.textDecorationLine = "underline";
-                link.style.textDecorationStyle = "dashed";
-            }
-        });
-        const imgs = helpHtml.value.getElementsByTagName("img");
-        Array.from(imgs).forEach((img) => {
-            if (img.src.startsWith("gxstatic://")) {
-                const rest = img.src.substr("gxstatic://".length);
-                img.src = `${getAppRoot()}static/${rest}`;
-            }
-        });
-    }
-}
-
-onMounted(setupPopovers);
+const { internalHelpReferences, MarkdownHelpPopovers } = useGxUris(helpHtml);
 </script>
 
 <template>
@@ -60,8 +27,6 @@ onMounted(setupPopovers);
         -->
         <!-- eslint-disable-next-line vue/no-v-html -->
         <div ref="helpHtml" v-html="formattedContent" />
-        <span v-for="(value, i) in internalHelpReferences" :key="i">
-            <HelpPopover :target="value.element" :term="value.term" />
-        </span>
+        <MarkdownHelpPopovers :elements="internalHelpReferences" />
     </span>
 </template>

--- a/lib/galaxy/managers/markdown_parse.py
+++ b/lib/galaxy/managers/markdown_parse.py
@@ -68,6 +68,7 @@ VALID_ARGUMENTS: dict[str, Union[list[str], DynamicArguments]] = {
     "workflow_license": ["invocation_id", "workflow_id"],
 }
 EMBED_CAPABLE_DIRECTIVES = [
+    "history_dataset_as_image",
     "history_dataset_name",
     "history_dataset_type",
     "workflow_license",

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -343,6 +343,10 @@ class GalaxyInternalMarkdownDirectiveHandler(metaclass=abc.ABCMeta):
                 title = trans.app.config.organization_name
                 url = trans.app.config.organization_url
                 return _link_to_markdown(url, title)
+            elif container == "history_dataset_as_image":
+                _check_object(object_id, match.group(0))
+                hda = hda_manager.get_accessible(object_id, trans.user)
+                return f"![{hda.name}](gxdatasetasimage://{encoded_id})"
             else:
                 raise MalformedContents(f"Unknown embedded Galaxy Markdown directive encountered [{container}].")
 

--- a/lib/galaxy/managers/pages.py
+++ b/lib/galaxy/managers/pages.py
@@ -374,8 +374,9 @@ class PageManager(sharable.SharableModelManager[model.Page], UsesAnnotations):
             content = unicodify(processor.output(), "utf-8")
             as_dict["content"] = content
         elif content_format == PageContentFormat.markdown.value:
-            content, extra_attributes = ready_galaxy_markdown_for_export(trans, content)
-            as_dict["content"] = content
+            content, content_embed_expanded, extra_attributes = ready_galaxy_markdown_for_export(trans, content)
+            as_dict["content"] = content_embed_expanded
+            as_dict["content_editor"] = content
             as_dict.update(extra_attributes)
         else:
             raise exceptions.RequestParameterInvalidException(

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3815,6 +3815,12 @@ ContentFormatField: PageContentFormat = Field(
 ContentField: Optional[str] = Field(
     default="",
     title="Content",
+    description="Text contents of the last page revision with embedded directives expanded (type dependent on content_format).",
+)
+
+ContentEditorField: Optional[str] = Field(
+    default="",
+    title="Content for Editor",
     description="Raw text contents of the last page revision (type dependent on content_format).",
 )
 
@@ -4030,6 +4036,7 @@ class PageDetails(PageSummary):
     annotation: Optional[str] = AnnotationField
     content_format: PageContentFormat = ContentFormatField
     content: Optional[str] = ContentField
+    content_editor: Optional[str] = ContentEditorField
     generate_version: Optional[str] = GenerateVersionField
     generate_time: Optional[str] = GenerateTimeField
     model_config = ConfigDict(extra="allow")

--- a/lib/galaxy/workflow/reports/generators/__init__.py
+++ b/lib/galaxy/workflow/reports/generators/__init__.py
@@ -43,12 +43,14 @@ class WorkflowMarkdownGeneratorPlugin(WorkflowReportGeneratorPlugin, metaclass=A
         internal_markdown = self._generate_internal_markdown(
             trans, invocation, runtime_report_config_json=runtime_report_config_json
         )
-        export_markdown, extra_rendering_data = ready_galaxy_markdown_for_export(trans, internal_markdown)
+        export_markdown, export_markdown_embed_expanded, extra_rendering_data = ready_galaxy_markdown_for_export(
+            trans, internal_markdown
+        )
         # Invocations can only be run on history, and user must exist, so this should always work
         username = invocation.history and invocation.history.user and invocation.history.user.username
         rval = {
             "render_format": "markdown",  # Presumably the frontend could render things other ways.
-            "markdown": export_markdown,
+            "markdown": export_markdown_embed_expanded,
             "invocation_markdown": export_markdown,
             "model_class": "Report",
             "id": trans.app.security.encode_id(invocation.workflow_id),

--- a/test/unit/app/managers/test_markdown_export.py
+++ b/test/unit/app/managers/test_markdown_export.py
@@ -339,7 +339,7 @@ history_dataset_display(history_dataset_id=1)
 ```
 """
         with self._expect_get_hda(hda):
-            export_markdown, extra_data = self._ready_export(example)
+            _, export_markdown, extra_data = self._ready_export(example)
         assert "history_datasets" in extra_data
         assert len(extra_data["history_datasets"]) == 1
 
@@ -357,7 +357,7 @@ history_dataset_display(history_dataset_id=2)
 ```
 """
         self.app.hda_manager.get_accessible.side_effect = [hda, hda2]
-        export_markdown, extra_data = self._ready_export(example)
+        _, export_markdown, extra_data = self._ready_export(example)
         assert "history_datasets" in extra_data
         assert len(extra_data["history_datasets"]) == 2
 
@@ -384,7 +384,7 @@ history_dataset_collection_display(history_dataset_collection_id=1)
             mock.patch.object(HDCASerializer, "url_for", return_value="http://google.com"),
             mock.patch.object(HDCASerializer, "serialize_to_view", return_value=mock_hdca_view),
         ):
-            export, extra_data = self._ready_export(example)
+            _, export, extra_data = self._ready_export(example)
         assert "history_dataset_collections" in extra_data
         assert len(extra_data.get("history_dataset_collections")) == 1
 
@@ -394,7 +394,7 @@ history_dataset_collection_display(history_dataset_collection_id=1)
 generate_galaxy_version()
 ```
 """
-        result, extra_data = self._ready_export(example)
+        _, result, extra_data = self._ready_export(example)
         assert "generate_version" in extra_data
         assert extra_data["generate_version"] == "19.09"
 
@@ -404,7 +404,7 @@ generate_galaxy_version()
 generate_time()
 ```
 """
-        result, extra_data = self._ready_export(example)
+        _, result, extra_data = self._ready_export(example)
         assert "generate_time" in extra_data
 
     def test_get_invocation_time(self):
@@ -415,12 +415,95 @@ generate_time()
 invocation_time(invocation_id=1)
 ```
 """
-        result, extra_data = self._ready_export(example)
+        _, result, extra_data = self._ready_export(example)
         assert "invocations" in extra_data
         assert "create_time" in extra_data["invocations"]["be8be0fd2ce547f6"]
         assert extra_data["invocations"]["be8be0fd2ce547f6"]["create_time"] == invocation.create_time.strftime(
             "%Y-%m-%d, %H:%M:%S"
         )
 
-    def _ready_export(self, example):
+    def test_export_replaces_embedded_history_dataset_type(self):
+        hda = self._new_hda()
+        hda.extension = "fasta"
+        hda2 = self._new_hda()
+        hda2.extension = "fastqsanger"
+        hda2.id = 2
+        example = """
+I ran a cool analysis with two inputs of types ${galaxy history_dataset_type(history_dataset_id=1)} and ${galaxy history_dataset_type(history_dataset_id=2)}.
+"""
+        self.app.hda_manager.get_accessible.side_effect = [hda, hda2]
+        _, export_markdown, _ = self._ready_export(example)
+        assert (
+            export_markdown
+            == """
+I ran a cool analysis with two inputs of types fasta and fastqsanger.
+"""
+        )
+
+    def test_export_replaces_embedded_history_dataset_name(self):
+        hda = self._new_hda()
+        hda.name = "foo bar"
+        hda2 = self._new_hda()
+        hda2.name = "cow dog"
+        hda2.id = 2
+        example = """
+I ran a cool analysis with two inputs of types ${galaxy history_dataset_name(history_dataset_id=1)} and ${galaxy history_dataset_name(history_dataset_id=2)}.
+"""
+        self.app.hda_manager.get_accessible.side_effect = [hda, hda2]
+        _, export_markdown, _ = self._ready_export(example)
+        assert (
+            export_markdown
+            == """
+I ran a cool analysis with two inputs of types foo bar and cow dog.
+"""
+        )
+
+    def test_export_replaces_embedded_generate_time(self):
+        example = """
+I ran a cool analysis at ${galaxy generate_time()}.
+"""
+        _, export_markdown, _ = self._ready_export(example)
+        assert export_markdown.startswith(
+            """
+I ran a cool analysis at 2"""
+        )
+
+    def test_export_replaces_embedded_invocation_time(self):
+        invocation = self._new_invocation()
+        self.app.workflow_manager.get_invocation.side_effect = [invocation]
+        example = """
+I ran a cool analysis at ${galaxy invocation_time(invocation_id=1)}.
+"""
+        _, export_markdown, _ = self._ready_export(example)
+        assert export_markdown.startswith(
+            """
+I ran a cool analysis at 2"""
+        )
+
+    def test_export_replaces_embedded_galaxy_version(self):
+        example = """
+I ran a cool analysis with Galaxy ${galaxy generate_galaxy_version()}.
+"""
+        _, export_markdown, _ = self._ready_export(example)
+        assert (
+            export_markdown
+            == """
+I ran a cool analysis with Galaxy 19.09.
+"""
+        )
+
+    def test_export_replaces_embedded_access_link(self):
+        self.trans.app.config.instance_access_url = "http://mycoolgalaxy.org"
+        example = """
+I ran a cool analysis at ${galaxy instance_access_link()}.
+"""
+        _, export_markdown, _ = self._ready_export(example)
+        assert (
+            export_markdown
+            == """
+I ran a cool analysis at [http://mycoolgalaxy.org](http://mycoolgalaxy.org).
+"""
+        )
+
+    def _ready_export(self, example: str):
         return ready_galaxy_markdown_for_export(self.trans, example)

--- a/test/unit/app/test_markdown_validate.py
+++ b/test/unit/app/test_markdown_validate.py
@@ -304,3 +304,45 @@ visualization(foo|bar=hello)
 ```
 """
     )
+
+
+def test_markdown_validation_embed():
+    assert_markdown_valid(
+        """
+| moo | cow |
+| 1 | 2 |
+"""
+    )
+    assert_markdown_valid(
+        """
+| moo | cow |
+| 1 | ${galaxy generate_galaxy_version()} |
+"""
+    )
+    assert_markdown_valid(
+        """
+| moo | cow |
+| 1 | ${galaxy history_dataset_name(input=foobar)} |
+"""
+    )
+    assert_markdown_invalid(
+        """
+| moo | cow |
+| 1 | ${galaxy history_dataset_name(foo=bar)} |
+""",
+        at_line=2,
+    )
+    assert_markdown_invalid(
+        """
+| moo | cow |
+| 1 | ${galaxy generate_galaxy_version(moo=cow)} |
+""",
+        at_line=2,
+    )
+    assert_markdown_invalid(
+        """
+| moo | cow |
+| 1 | ${galaxy invalid()} |
+""",
+        at_line=2,
+    )


### PR DESCRIPTION
First step toward implementing https://github.com/galaxyproject/galaxy/issues/17522.

Reserving a whole block of HTML makes sense for the display of an image or table but for some of the directives it is a bulky thing that really breaks up reports. These are things you'd want to use in legends or headers or footers or in explanatory text. 

Here is a before and after demonstrating using the directive to not waste so much space describing the name and type of a dataset in a report.

<img width="1075" alt="Screenshot 2024-10-30 at 4 08 39 PM" src="https://github.com/user-attachments/assets/215d86fc-c056-4ec9-9b53-e48a2e46e868">

-----
-----

<img width="1116" alt="Screenshot 2024-10-30 at 4 08 48 PM" src="https://github.com/user-attachments/assets/6f78a9ae-d137-49ab-ab38-887dae5616b3">

The page content demonstrating the embedded Markdown syntax.

<img width="1177" alt="Screenshot 2024-10-30 at 4 11 08 PM" src="https://github.com/user-attachments/assets/6a0092a1-20dc-4dc1-b35f-4c031d5b9b61">

I've been planning this syntax for years and many of the directives that don't make a lot of sense on their own - links, names, types, etc... were designed with this in mind some day. The tool reports #19054 & #19067 have a bunch of obvious use cases things you'd want to include (and that would also make sense in a workflow) that would benefit from this work. Two being - the tool name and the tool parameter name or text.  Rendering all that dynamically would keep the report and the XML in syntax automatically.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
