### PR TITLE
Avoid persisting credentials on checkout step of the Github actions

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -50,6 +50,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/bioblend.yaml
+++ b/.github/workflows/bioblend.yaml
@@ -39,11 +39,13 @@ jobs:
         with:
           fetch-depth: 1
           path: galaxy
+          persist-credentials: false
       - name: Checkout Bioblend
         uses: actions/checkout@v4
         with:
           repository: galaxyproject/bioblend
           path: bioblend
+          persist-credentials: false
       - name: Cache pip dir
         uses: actions/cache@v4
         with:

--- a/.github/workflows/build_client.yaml
+++ b/.github/workflows/build_client.yaml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # https://stackoverflow.com/questions/59810838/how-to-get-the-short-sha-for-the-github-workflow
       - name: Set outputs
         id: commit
@@ -75,6 +77,8 @@ jobs:
     if: github.repository_owner == 'galaxyproject'
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # https://stackoverflow.com/questions/59810838/how-to-get-the-short-sha-for-the-github-workflow
       - name: Set outputs
         id: commit

--- a/.github/workflows/check_test_class_names.yaml
+++ b/.github/workflows/check_test_class_names.yaml
@@ -17,6 +17,8 @@ jobs:
         python-version: ['3.9']
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
@@ -46,6 +47,7 @@ jobs:
         with:
           repository: galaxyproject/galaxy-test-data
           path: galaxy-test-data
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/cwl_conformance.yaml
+++ b/.github/workflows/cwl_conformance.yaml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/db_indexes.yaml
+++ b/.github/workflows/db_indexes.yaml
@@ -44,6 +44,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.9'

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/framework_tools.yaml
+++ b/.github/workflows/framework_tools.yaml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/framework_workflows.yaml
+++ b/.github/workflows/framework_workflows.yaml
@@ -44,6 +44,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -70,6 +70,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -53,6 +53,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/jest.yaml
+++ b/.github/workflows/jest.yaml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'client/.node_version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/js_lint.yaml
+++ b/.github/workflows/js_lint.yaml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'client/.node_version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,6 +29,8 @@ jobs:
       CORE_PATH: 'lib/galaxy/dependencies/pinned-requirements.txt'
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/lint_openapi_schema.yml
+++ b/.github/workflows/lint_openapi_schema.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/osx_startup.yaml
+++ b/.github/workflows/osx_startup.yaml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -44,6 +44,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish_artifacts.yaml
+++ b/.github/workflows/publish_artifacts.yaml
@@ -12,6 +12,8 @@ jobs:
             python-version: ['3.9']
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/reports_startup.yaml
+++ b/.github/workflows/reports_startup.yaml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -53,6 +53,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/test_galaxy_packages.yaml
+++ b/.github/workflows/test_galaxy_packages.yaml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/test_galaxy_packages_for_pulsar.yaml
+++ b/.github/workflows/test_galaxy_packages_for_pulsar.yaml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test_galaxy_release.yaml
+++ b/.github/workflows/test_galaxy_release.yaml
@@ -25,5 +25,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Run tests
         run: ./test/release.sh

--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/unit-postgres.yaml
+++ b/.github/workflows/unit-postgres.yaml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
+          persist-credentials: false
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Adding `persist-credentials: false` into the [checkout step](https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4) of the Github action workflows will prevent storing sensitive credentials for future jobs, which will increase the security of workflows.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
