### PR TITLE
Do not use python3.8 in update lint requirements script

### DIFF
--- a/lib/galaxy/dependencies/update_lint_requirements.sh
+++ b/lib/galaxy/dependencies/update_lint_requirements.sh
@@ -10,7 +10,7 @@ THIS_DIRECTORY="$(cd "$(dirname "$0")" > /dev/null && pwd)"
 
 update_pinned_reqs() {
     VENV=$(mktemp -d "${TMPDIR:-/tmp}/$1_venv.XXXXXXXXXX")
-    python3.8 -m venv "${VENV}"
+    python3 -m venv "${VENV}"
     . "${VENV}/bin/activate"
     pip install --upgrade pip setuptools
     pip install -r "${THIS_DIRECTORY}/$1-requirements.txt"


### PR DESCRIPTION
## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
