### PR TITLE
Allow directory_uri workflow parameters. 

### DIFF
--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -379,7 +379,7 @@ def build_workflow_run_configs(
                 module_injector.inject(step)
                 input_param = step.module.get_runtime_inputs(step.module)["input"]
                 try:
-                    input_param.validate(input_dict)
+                    input_param.validate(input_dict, trans=trans)
                 except ParameterValueError as e:
                     raise exceptions.RequestParameterInvalidException(
                         f"{step.label or step.order_index + 1}: {e.message_suffix}"

--- a/lib/galaxy/workflow/workflow_parameter_input_definitions.py
+++ b/lib/galaxy/workflow/workflow_parameter_input_definitions.py
@@ -7,12 +7,13 @@ from typing import (
 from galaxy.tools.parameters.basic import (
     BooleanToolParameter,
     ColorToolParameter,
+    DirectoryUriToolParameter,
     FloatToolParameter,
     IntegerToolParameter,
     TextToolParameter,
 )
 
-param_types = Literal["text", "integer", "float", "color", "boolean"]
+param_types = Literal["text", "integer", "float", "color", "boolean", "directory_uri"]
 default_source_type = Dict[str, Union[int, float, bool, str]]
 tool_param_type = Union[
     TextToolParameter,
@@ -20,6 +21,7 @@ tool_param_type = Union[
     FloatToolParameter,
     BooleanToolParameter,
     ColorToolParameter,
+    DirectoryUriToolParameter,
 ]
 
 
@@ -36,6 +38,7 @@ def get_default_parameter(param_type: param_types) -> tool_param_type:
             FloatToolParameter,
             BooleanToolParameter,
             ColorToolParameter,
+            DirectoryUriToolParameter,
         ] = TextToolParameter(None, default_source)
     elif param_type == "integer":
         input_default_value = IntegerToolParameter(None, default_source)
@@ -45,4 +48,6 @@ def get_default_parameter(param_type: param_types) -> tool_param_type:
         input_default_value = BooleanToolParameter(None, default_source)
     elif param_type == "color":
         input_default_value = ColorToolParameter(None, default_source)
+    elif param_type == "directory_uri":
+        input_default_value = DirectoryUriToolParameter(None, default_source)
     return input_default_value


### PR DESCRIPTION
Implements #13184 as requested by @Delphine-L for the VGP workflows.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Create a workflow with a new directory URI input and connect it to a ``directory_uri`` input. If you run Galaxy with ``GALAXY_RUN_WITH_TEST_TOOLS=1``, then ``gx_directory_uri`` will be available. You will need to mark that input as connectable so the input appears in the editor.
  2. Click run the workflow - pick an output directory and run the workflow. 
  3. See everything turn green.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
