### PR TITLE
Prevent purged users from logging in

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -161,6 +161,9 @@ class User(BaseUIController, UsesFormDefinitionsMixin):
             message, user = self.__autoregistration(trans, login, password)
             if message:
                 return self.message_exception(trans, message)
+        elif user.purged:
+            message = "This account has been permanently deleted."
+            return self.message_exception(trans, message, sanitize=False)
         elif user.deleted:
             message = (
                 "This account has been marked deleted, contact your local Galaxy administrator to restore the account."


### PR DESCRIPTION
This was possible if account was marked purged and not deleted. This may have happened on older Galaxy instances (see discussion on galaxyadmin slack). On newer versions this guards against the case of incorrect data in the db when a user is marked as purged without their email and/or username being redacted (which would have to be caused by a bug).

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
