### PR TITLE
Support deferred datasets in visualizations

### DIFF
--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -47,7 +47,7 @@ const showRerun = computed(() => {
 });
 const showVisualizations = computed(() => {
     // TODO: Check hasViz, if visualizations are activated in the config
-    return !props.item.purged && ["ok", "failed_metadata", "error"].includes(props.item.state);
+    return !props.item.purged && ["ok", "failed_metadata", "error", "deferred"].includes(props.item.state);
 });
 const reportErrorUrl = computed(() => {
     return prependPath(props.itemUrls.reportError!);

--- a/config/plugins/visualizations/visualization.dtd
+++ b/config/plugins/visualizations/visualization.dtd
@@ -54,17 +54,18 @@
                 if result_type is 'datatype' the registry will assume the text is a datatype class name
                 and parse it into the proper class before the test (often 'isinstance') is run.
                 DEFAULT: no parsing (result should be a string)
-        allow_deferred: used in conjunction with type='isinstance' and test_attr='datatype'. If set to true,
-                the registry will allow the test to pass if the target is deferred (currently only HDAs can be deferred).
+        allow_uri_if_protocol: used in conjunction with type='isinstance' and test_attr='datatype'. Let you define
+                a list of protocols or schemes (e.g. 's3,https') that, in the case of a deferred target (e.g. currently only HDAs),
+                the registry will allow the test to pass if the the source URI has a scheme in the list.
                 This is useful for visualizations that can work directly with URIs.
-                DEFAULT: false
+                DEFAULT: []
                 
     -->
     <!ATTLIST test
-        type            CDATA #IMPLIED
-        test_attr       CDATA #IMPLIED
-        result_type     CDATA #IMPLIED
-        allow_deferred  CDATA #IMPLIED
+        type                    CDATA #IMPLIED
+        test_attr               CDATA #IMPLIED
+        result_type             CDATA #IMPLIED
+        allow_uri_if_protocol   CDATA #IMPLIED
     >
 
     <!ELEMENT to_param (#PCDATA)>

--- a/config/plugins/visualizations/visualization.dtd
+++ b/config/plugins/visualizations/visualization.dtd
@@ -54,11 +54,17 @@
                 if result_type is 'datatype' the registry will assume the text is a datatype class name
                 and parse it into the proper class before the test (often 'isinstance') is run.
                 DEFAULT: no parsing (result should be a string)
+        allow_deferred: used in conjunction with type='isinstance' and test_attr='datatype'. If set to true,
+                the registry will allow the test to pass if the target is deferred (currently only HDAs can be deferred).
+                This is useful for visualizations that can work directly with URIs.
+                DEFAULT: false
+                
     -->
     <!ATTLIST test
-        type        CDATA #IMPLIED
-        test_attr   CDATA #IMPLIED
-        result_type CDATA #IMPLIED
+        type            CDATA #IMPLIED
+        test_attr       CDATA #IMPLIED
+        result_type     CDATA #IMPLIED
+        allow_deferred  CDATA #IMPLIED
     >
 
     <!ELEMENT to_param (#PCDATA)>

--- a/lib/galaxy/visualization/plugins/config_parser.py
+++ b/lib/galaxy/visualization/plugins/config_parser.py
@@ -302,7 +302,7 @@ class DataSourceParser:
             test_result_type = test_elem.get("result_type", "string")
 
             # allow_deferred indicates that the visualization can work with deferred data_sources
-            # Can only be used with certain test types (e.g. isinstance)
+            # Can only be used with isinstance tests. By default, no visualization can work with deferred data_sources.
             allow_deferred = False
 
             # test functions should be sent an object to test, and the parsed result expected from the test

--- a/lib/galaxy/visualization/plugins/config_parser.py
+++ b/lib/galaxy/visualization/plugins/config_parser.py
@@ -301,8 +301,14 @@ class DataSourceParser:
             # result type should tell the registry how to convert the result before the test
             test_result_type = test_elem.get("result_type", "string")
 
+            # allow_deferred indicates that the visualization can work with deferred data_sources
+            # Can only be used with certain test types (e.g. isinstance)
+            allow_deferred = False
+
             # test functions should be sent an object to test, and the parsed result expected from the test
             if test_type == "isinstance":
+                allow_deferred = asbool(test_elem.get("allow_deferred", False))
+
                 # is test_attr attribute an instance of result
                 # TODO: wish we could take this further but it would mean passing in the datatypes_registry
                 def test_fn(o, result, getter=getter):
@@ -328,7 +334,15 @@ class DataSourceParser:
                 def test_fn(o, result, getter=getter):
                     return str(getter(o)) == result
 
-            tests.append({"type": test_type, "result": test_result, "result_type": test_result_type, "fn": test_fn})
+            tests.append(
+                {
+                    "type": test_type,
+                    "result": test_result,
+                    "result_type": test_result_type,
+                    "fn": test_fn,
+                    "allow_deferred": allow_deferred,
+                }
+            )
 
         return tests
 

--- a/lib/galaxy/visualization/plugins/config_parser.py
+++ b/lib/galaxy/visualization/plugins/config_parser.py
@@ -6,7 +6,10 @@ from typing import (
 )
 
 import galaxy.model
-from galaxy.util import asbool
+from galaxy.util import (
+    asbool,
+    listify,
+)
 from galaxy.util.xml_macros import load
 
 log = logging.getLogger(__name__)
@@ -301,13 +304,15 @@ class DataSourceParser:
             # result type should tell the registry how to convert the result before the test
             test_result_type = test_elem.get("result_type", "string")
 
-            # allow_deferred indicates that the visualization can work with deferred data_sources
-            # Can only be used with isinstance tests. By default, no visualization can work with deferred data_sources.
-            allow_deferred = False
+            # allow_uri_if_protocol indicates that the visualization can work with deferred data_sources which source URI
+            # matches any of the given protocols in this list. This is useful for visualizations that can work with URIs.
+            # Can only be used with isinstance tests. By default, an empty list means that the visualization doesn't support
+            # deferred data_sources.
+            allow_uri_if_protocol = []
 
             # test functions should be sent an object to test, and the parsed result expected from the test
             if test_type == "isinstance":
-                allow_deferred = asbool(test_elem.get("allow_deferred", False))
+                allow_uri_if_protocol = listify(test_elem.get("allow_uri_if_protocol"))
 
                 # is test_attr attribute an instance of result
                 # TODO: wish we could take this further but it would mean passing in the datatypes_registry
@@ -340,7 +345,7 @@ class DataSourceParser:
                     "result": test_result,
                     "result_type": test_result_type,
                     "fn": test_fn,
-                    "allow_deferred": allow_deferred,
+                    "allow_uri_if_protocol": allow_uri_if_protocol,
                 }
             )
 

--- a/lib/galaxy/visualization/plugins/registry.py
+++ b/lib/galaxy/visualization/plugins/registry.py
@@ -263,11 +263,13 @@ class VisualizationsRegistry:
         it can be applied to the target_object.
         """
         # log.debug( 'is_object_applicable( self, trans, %s, %s )', target_object, data_source_tests )
+        is_deferred_target = getattr(target_object, "state", None) == "deferred"
         for test in data_source_tests:
             test_type = test["type"]
             result_type = test["result_type"]
             test_result = test["result"]
             test_fn = test["fn"]
+            allow_deferred = test.get("allow_deferred", False)
             # log.debug( '%s %s: %s, %s, %s, %s', str( target_object ), 'is_object_applicable',
             #           test_type, result_type, test_result, test_fn )
 
@@ -286,7 +288,7 @@ class VisualizationsRegistry:
                         continue
 
             # NOTE: tests are OR'd, if any test passes - the visualization can be applied
-            if test_fn(target_object, test_result):
+            if test_fn(target_object, test_result) and (not is_deferred_target or allow_deferred):
                 # log.debug( '\t test passed' )
                 return True
 

--- a/lib/galaxy/visualization/plugins/registry.py
+++ b/lib/galaxy/visualization/plugins/registry.py
@@ -316,6 +316,9 @@ class VisualizationsRegistry:
         if not supported_protocols:
             return False  # no protocols defined, means no support for deferred objects
 
+        if "*" in supported_protocols:
+            return True  # wildcard support for all protocols
+
         deferred_source_uri = self._deferred_source_uri(target_object)
         if deferred_source_uri:
             protocol = deferred_source_uri.split("://")[0]

--- a/lib/galaxy/visualization/plugins/registry.py
+++ b/lib/galaxy/visualization/plugins/registry.py
@@ -263,7 +263,7 @@ class VisualizationsRegistry:
         it can be applied to the target_object.
         """
         # log.debug( 'is_object_applicable( self, trans, %s, %s )', target_object, data_source_tests )
-        is_deferred_target = getattr(target_object, "state", None) == "deferred"
+        is_deferred_target = self._is_deferred(target_object)
         for test in data_source_tests:
             test_type = test["type"]
             result_type = test["result_type"]
@@ -293,3 +293,6 @@ class VisualizationsRegistry:
                 return True
 
         return False
+
+    def _is_deferred(self, target_object):
+        return getattr(target_object, "state", None) == "deferred"


### PR DESCRIPTION
There are some visualization plugins that can work directly with remote URIs (see #19061). This PR adds a new attribute `allow_uri_if_protocol` to test conditions for visualizations that tells the visualization registry that a visualization plugin can work with a deferred dataset of a particular datatype and allows some URI schemes. By default, this attribute is set to an empty list, so it is opt-in. An empty list means there is no support for deferred datasets. You can also use the wildcard "*" to indicate that any protocol is supported.

For example:
```xml
<test type="isinstance" test_attr="datatype" result_type="datatype" allow_uri_if_protocol="https,s3">data.ZarrDirectory</test>
```

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Upload a deferred dataset
  - Install a galaxy visualization that can work with remote URIs (an example is here https://github.com/davelopez/galaxy-visualizations/tree/vizarr/packages/vizarr or check out #19061)
  - Observe that deferred datasets will show associated visualizations if they pass the test.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
