### PR TITLE
Access public history in job cache / job search

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -8755,7 +8755,7 @@ export interface components {
             user_email?: string | null;
             /**
              * User Id
-             * @description User ID of user that ran ran job
+             * @description User ID of user that ran this job
              */
             user_id?: string | null;
         };
@@ -16184,7 +16184,7 @@ export interface components {
             user_email?: string | null;
             /**
              * User Id
-             * @description User ID of user that ran ran job
+             * @description User ID of user that ran this job
              */
             user_id?: string | null;
         };

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -8753,6 +8753,11 @@ export interface components {
              * @description The email of the user that owns this job. Only the owner of the job and administrators can see this value.
              */
             user_email?: string | null;
+            /**
+             * User Id
+             * @description User ID of user that ran ran job
+             */
+            user_id?: string | null;
         };
         /** EncodedJobParameterHistoryItem */
         EncodedJobParameterHistoryItem: {
@@ -16177,6 +16182,11 @@ export interface components {
              * @description The email of the user that owns this job. Only the owner of the job and administrators can see this value.
              */
             user_email?: string | null;
+            /**
+             * User Id
+             * @description User ID of user that ran ran job
+             */
+            user_id?: string | null;
         };
         /**
          * Src

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -493,11 +493,18 @@ class JobSearch:
         self, tool_id: str, user_id: int, tool_version: Optional[str], job_state, wildcard_param_dump
     ):
         """Build subquery that selects a job with correct job parameters."""
-        stmt = select(model.Job.id).where(
-            and_(
-                model.Job.tool_id == tool_id,
-                model.Job.user_id == user_id,
-                model.Job.copied_from_job_id.is_(None),  # Always pick original job
+        stmt = (
+            select(model.Job.id)
+            .join(model.History, model.Job.history_id == model.History.id)
+            .where(
+                and_(
+                    model.Job.tool_id == tool_id,
+                    or_(
+                        model.Job.user_id == user_id,
+                        model.History.published == true(),
+                    ),
+                    model.Job.copied_from_job_id.is_(None),  # Always pick original job
+                )
             )
         )
         if tool_version:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1549,6 +1549,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
         "galaxy_version",
         "command_version",
         "copied_from_job_id",
+        "user_id",
     ]
 
     _numeric_metric = JobMetricNumeric

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -191,6 +191,7 @@ class EncodedJobDetails(JobSummary):
         title="Output collections",
         description="",
     )
+    user_id: Optional[EncodedDatabaseIdField] = Field(default=None, description="User ID of user that ran ran job")
 
 
 class JobDestinationParams(Model):

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -191,7 +191,7 @@ class EncodedJobDetails(JobSummary):
         title="Output collections",
         description="",
     )
-    user_id: Optional[EncodedDatabaseIdField] = Field(default=None, description="User ID of user that ran ran job")
+    user_id: Optional[EncodedDatabaseIdField] = Field(default=None, description="User ID of user that ran this job")
 
 
 class JobDestinationParams(Model):

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -147,7 +147,7 @@ class UsesApiTestCaseMixin:
         return user, self._post(f"users/{user['id']}/api_key", admin=True).json()
 
     @contextmanager
-    def _different_user(self, email: Optional[str] = OTHER_USER, anon=False):
+    def _different_user(self, email: Optional[str] = None, anon=False):
         """Use in test cases to switch get/post operations to act as new user
 
         ..code-block:: python
@@ -156,7 +156,6 @@ class UsesApiTestCaseMixin:
                 self._get("histories")  # Gets other_user@bx.psu.edu histories.
 
         """
-        email = OTHER_USER if email is None else email
         original_api_key = self.user_api_key
         original_interactor_key = self.galaxy_interactor.api_key
         original_cookies = self.galaxy_interactor.cookies
@@ -165,6 +164,7 @@ class UsesApiTestCaseMixin:
             self.galaxy_interactor.cookies = cookies
             new_key = None
         else:
+            email = OTHER_USER if email is None else email
             _, new_key = self._setup_user_get_key(email)
         try:
             self.user_api_key = new_key

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -147,7 +147,7 @@ class UsesApiTestCaseMixin:
         return user, self._post(f"users/{user['id']}/api_key", admin=True).json()
 
     @contextmanager
-    def _different_user(self, email=OTHER_USER, anon=False):
+    def _different_user(self, email: Optional[str] = OTHER_USER, anon=False):
         """Use in test cases to switch get/post operations to act as new user
 
         ..code-block:: python
@@ -156,6 +156,7 @@ class UsesApiTestCaseMixin:
                 self._get("histories")  # Gets other_user@bx.psu.edu histories.
 
         """
+        email = OTHER_USER if email is None else email
         original_api_key = self.user_api_key
         original_interactor_key = self.galaxy_interactor.api_key
         original_cookies = self.galaxy_interactor.cookies


### PR DESCRIPTION
I think this is ready, but maybe want to make it configurable on the user side if we want to pick up public results ?

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
