### PR TITLE
Always validate hashes when provided

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -14083,21 +14083,6 @@ export interface components {
              * @description The source of the content. Can be other history element to be copied or library elements.
              */
             source: components["schemas"]["DatasetSourceType"];
-            /**
-             * Validate hashes
-             * @description Set to true to enable dataset validation during materialization.
-             * @default false
-             */
-            validate_hashes: boolean;
-        };
-        /** MaterializeDatasetOptions */
-        MaterializeDatasetOptions: {
-            /**
-             * Validate hashes
-             * @description Set to true to enable dataset validation during materialization.
-             * @default false
-             */
-            validate_hashes: boolean;
         };
         /** MessageExceptionModel */
         MessageExceptionModel: {
@@ -24415,11 +24400,7 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["MaterializeDatasetOptions"] | null;
-            };
-        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -176,9 +176,7 @@ class HDAManager(
         else:
             dataset_instance = self.ldda_manager.get_accessible(request.content, user)
         history = self.app.history_manager.by_id(request.history_id)
-        new_hda = materializer.ensure_materialized(
-            dataset_instance, target_history=history, validate_hashes=request.validate_hashes, in_place=in_place
-        )
+        new_hda = materializer.ensure_materialized(dataset_instance, target_history=history, in_place=in_place)
         if not in_place:
             history.add_dataset(new_hda, set_hid=True)
         else:

--- a/lib/galaxy/model/unittest_utils/store_fixtures.py
+++ b/lib/galaxy/model/unittest_utils/store_fixtures.py
@@ -12,6 +12,7 @@ TEST_SOURCE_URI = "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/te
 TEST_SOURCE_URI_BAM = "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bam"
 TEST_HASH_FUNCTION = "MD5"
 TEST_HASH_VALUE = "f568c29421792b1b1df4474dafae01f1"
+TEST_HASH_VALUE_BAM = "34693a376f9878cbe53166db083e0e26"
 TEST_HISTORY_NAME = "My history in a model store"
 TEST_EXTENSION = "bed"
 TEST_LIBRARY_NAME = "My cool library"
@@ -339,7 +340,7 @@ def deferred_hda_model_store_dict_bam(
     dataset_hash = dict(
         model_class="DatasetHash",
         hash_function=TEST_HASH_FUNCTION,
-        hash_value=TEST_HASH_VALUE,
+        hash_value=TEST_HASH_VALUE_BAM,
         extra_files_path=None,
     )
     dataset_source: Dict[str, Any] = dict(

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3682,15 +3682,7 @@ class PageSummaryBase(Model):
     )
 
 
-class MaterializeDatasetOptions(Model):
-    validate_hashes: bool = Field(
-        False,
-        title="Validate hashes",
-        description="Set to true to enable dataset validation during materialization.",
-    )
-
-
-class MaterializeDatasetInstanceAPIRequest(MaterializeDatasetOptions):
+class MaterializeDatasetInstanceAPIRequest(Model):
     source: DatasetSourceType = Field(
         title="Source",
         description="The source of the content. Can be other history element to be copied or library elements.",

--- a/lib/galaxy/schema/tasks.py
+++ b/lib/galaxy/schema/tasks.py
@@ -108,11 +108,6 @@ class MaterializeDatasetInstanceTaskRequest(Model):
             "- The decoded id of the HDA\n"
         ),
     )
-    validate_hashes: bool = Field(
-        False,
-        title="Validate hashes",
-        description="Set to true to enable dataset validation during materialization.",
-    )
 
 
 class ComputeDatasetHashTaskRequest(Model):

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -260,7 +260,7 @@ def _fetch_target(upload_config: "UploadConfig", target: Dict[str, Any]):
                 hash_function = hash_dict.get("hash_function")
                 hash_value = hash_dict.get("hash_value")
                 try:
-                    _handle_hash_validation(upload_config, hash_function, hash_value, path)
+                    _handle_hash_validation(hash_function, hash_value, path)
                 except Exception as e:
                     error_message = str(e)
                     item["error_message"] = error_message
@@ -501,7 +501,7 @@ def _has_src_to_path(upload_config: "UploadConfig", item: Dict[str, Any], is_dat
             for hash_function in HASH_NAMES:
                 hash_value = item.get(hash_function)
                 if hash_value:
-                    _handle_hash_validation(upload_config, hash_function, hash_value, path)
+                    _handle_hash_validation(hash_function, hash_value, path)
         if name is None:
             name = url.split("/")[-1]
     elif src == "pasted":
@@ -516,11 +516,8 @@ def _has_src_to_path(upload_config: "UploadConfig", item: Dict[str, Any], is_dat
     return name, path
 
 
-def _handle_hash_validation(
-    upload_config: "UploadConfig", hash_function: HashFunctionNameEnum, hash_value: str, path: str
-):
-    if upload_config.validate_hashes:
-        verify_hash(path, hash_func_name=hash_function, hash_value=hash_value, what="upload")
+def _handle_hash_validation(hash_function: HashFunctionNameEnum, hash_value: str, path: str):
+    verify_hash(path, hash_func_name=hash_function, hash_value=hash_value, what="upload")
 
 
 def _arg_parser():
@@ -566,7 +563,6 @@ class UploadConfig:
         self.to_posix_lines = request.get("to_posix_lines", False)
         self.space_to_tab = request.get("space_to_tab", False)
         self.auto_decompress = request.get("auto_decompress", False)
-        self.validate_hashes = request.get("validate_hashes", False)
         self.deferred = request.get("deferred", False)
         self.link_data_only = _link_data_only(request)
         self.file_sources_dict = file_sources_dict

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -54,7 +54,6 @@ from galaxy.schema.schema import (
     HistoryContentType,
     MaterializeDatasetInstanceAPIRequest,
     MaterializeDatasetInstanceRequest,
-    MaterializeDatasetOptions,
     StoreExportPayload,
     UpdateHistoryContentsBatchPayload,
     UpdateHistoryContentsPayload,
@@ -1073,17 +1072,12 @@ class FastAPIHistoryContents:
         history_id: HistoryIDPathParam,
         id: HistoryItemIDPathParam,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        materialize_api_payload: Optional[MaterializeDatasetOptions] = Body(None),
     ) -> AsyncTaskResultSummary:
-        validate_hashes: bool = (
-            materialize_api_payload.validate_hashes if materialize_api_payload is not None else False
-        )
         # values are already validated, use model_construct
         materialize_request = MaterializeDatasetInstanceRequest.model_construct(
             history_id=history_id,
             source=DatasetSourceType.hda,
             content=id,
-            validate_hashes=validate_hashes,
         )
         rval = self.service.materialize(trans, materialize_request)
         return rval

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -573,7 +573,6 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
             history_id=request.history_id,
             source=request.source,
             content=request.content,
-            validate_hashes=request.validate_hashes,
             user=trans.async_request_user,
         )
         results = materialize_task.delay(request=task_request)

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -349,7 +349,6 @@ class WorkflowRequestMonitor(Monitors):
                     history_id=workflow_invocation.history.id,
                     source="hda",
                     content=hda.id,
-                    validate_hashes=True,
                 )
                 materialized_okay = self.app.hda_manager.materialize(task_request, in_place=True)
                 if not materialized_okay:

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -340,7 +340,6 @@ class TestLibrariesApi(ApiTestCase):
         payload = {
             "history_id": history_id,  # TODO: Shouldn't be needed :(
             "targets": targets,
-            "validate_hashes": True,
         }
         tool_response = self.dataset_populator.fetch(payload, assert_ok=False)
         job = self.dataset_populator.check_run(tool_response)

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -1025,7 +1025,6 @@ class TestToolsUpload(ApiTestCase):
             payload = {
                 "history_id": history_id,
                 "targets": targets,
-                "validate_hashes": True,
             }
             fetch_response = self.dataset_populator.fetch(payload)
             self._assert_status_code_is(fetch_response, 200)
@@ -1050,7 +1049,6 @@ class TestToolsUpload(ApiTestCase):
             payload = {
                 "history_id": history_id,
                 "targets": targets,
-                "validate_hashes": True,
             }
             fetch_response = self.dataset_populator.fetch(payload, assert_ok=True, wait=False)
             self._assert_status_code_is(fetch_response, 200)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1023,9 +1023,7 @@ class BaseDatasetPopulator(BasePopulator):
     def describe_tool_execution(self, tool_id: str) -> "DescribeToolExecution":
         return DescribeToolExecution(self, tool_id)
 
-    def materialize_dataset_instance(
-        self, history_id: str, id: str, source: str = "hda", validate_hashes: bool = False
-    ):
+    def materialize_dataset_instance(self, history_id: str, id: str, source: str = "hda"):
         payload: Dict[str, Any]
         if source == "ldda":
             url = f"histories/{history_id}/materialize"
@@ -1036,8 +1034,6 @@ class BaseDatasetPopulator(BasePopulator):
         else:
             url = f"histories/{history_id}/contents/datasets/{id}/materialize"
             payload = {}
-        if validate_hashes:
-            payload["validate_hashes"] = True
         create_response = self._post(url, payload, json=True)
         api_asserts.assert_status_code_is_ok(create_response)
         create_response_json = create_response.json()
@@ -2780,7 +2776,6 @@ class LibraryPopulator:
         payload = {
             "history_id": history_id,  # TODO: Shouldn't be needed :(
             "targets": targets,
-            "validate_hashes": True,
         }
         return library, self.dataset_populator.fetch(payload, assert_ok=assert_ok)
 

--- a/test/integration/test_materialize_dataset_instance_tasks.py
+++ b/test/integration/test_materialize_dataset_instance_tasks.py
@@ -89,7 +89,7 @@ class TestMaterializeDatasetInstanceTasaksIntegration(IntegrationTestCase, UsesC
         assert deferred_hda["state"] == "deferred"
         assert not deferred_hda["deleted"]
 
-        self.dataset_populator.materialize_dataset_instance(history_id, deferred_hda["id"], validate_hashes=True)
+        self.dataset_populator.materialize_dataset_instance(history_id, deferred_hda["id"])
         self.dataset_populator.wait_on_history_length(history_id, 2)
         new_hda_details = self.dataset_populator.get_history_dataset_details(
             history_id, hid=2, assert_ok=False, wait=False

--- a/test/unit/app/tools/test_data_fetch.py
+++ b/test/unit/app/tools/test_data_fetch.py
@@ -52,7 +52,6 @@ def test_simple_path_get(hash_value: str, error_message: Optional[str]):
                     ],
                 }
             ],
-            "validate_hashes": True,
         }
         execute_context.execute_request(request)
         output = _unnamed_output(execute_context)
@@ -111,7 +110,6 @@ def test_correct_md5():
                     ],
                 }
             ],
-            "validate_hashes": True,
         }
         execute_context.execute_request(request)
         output = _unnamed_output(execute_context)
@@ -142,7 +140,6 @@ def test_incorrect_md5():
                     ],
                 }
             ],
-            "validate_hashes": True,
         }
         execute_context.execute_request(request)
         output = _unnamed_output(execute_context)
@@ -175,7 +172,6 @@ def test_correct_sha1():
                     ],
                 }
             ],
-            "validate_hashes": True,
         }
         execute_context.execute_request(request)
         output = _unnamed_output(execute_context)
@@ -206,7 +202,6 @@ def test_incorrect_sha1():
                     ],
                 }
             ],
-            "validate_hashes": True,
         }
         execute_context.execute_request(request)
         output = _unnamed_output(execute_context)

--- a/test/unit/data/test_dataset_materialization.py
+++ b/test/unit/data/test_dataset_materialization.py
@@ -71,7 +71,7 @@ def test_hash_validate():
     _assert_2_bed_metadata(deferred_hda)
     assert deferred_hda.dataset.state == "deferred"
     materializer = materializer_factory(True, object_store=fixture_context.app.object_store)
-    materialized_hda = materializer.ensure_materialized(deferred_hda, validate_hashes=True)
+    materialized_hda = materializer.ensure_materialized(deferred_hda)
     materialized_dataset = materialized_hda.dataset
     assert materialized_dataset.state == "ok"
 
@@ -86,7 +86,7 @@ def test_hash_invalid():
     _assert_2_bed_metadata(deferred_hda)
     assert deferred_hda.dataset.state == "deferred"
     materializer = materializer_factory(True, object_store=fixture_context.app.object_store)
-    materialized_hda = materializer.ensure_materialized(deferred_hda, validate_hashes=True)
+    materialized_hda = materializer.ensure_materialized(deferred_hda)
     materialized_dataset = materialized_hda.dataset
     assert materialized_dataset.state == "error"
 
@@ -103,7 +103,7 @@ def test_hash_validate_source_of_download():
     _assert_2_bed_metadata(deferred_hda)
     assert deferred_hda.dataset.state == "deferred"
     materializer = materializer_factory(True, object_store=fixture_context.app.object_store)
-    materialized_hda = materializer.ensure_materialized(deferred_hda, validate_hashes=True)
+    materialized_hda = materializer.ensure_materialized(deferred_hda)
     materialized_dataset = materialized_hda.dataset
     assert materialized_dataset.state == "ok", materialized_hda.info
 
@@ -120,7 +120,7 @@ def test_hash_invalid_source_of_download():
     _assert_2_bed_metadata(deferred_hda)
     assert deferred_hda.dataset.state == "deferred"
     materializer = materializer_factory(True, object_store=fixture_context.app.object_store)
-    materialized_hda = materializer.ensure_materialized(deferred_hda, validate_hashes=True)
+    materialized_hda = materializer.ensure_materialized(deferred_hda)
     materialized_dataset = materialized_hda.dataset
     assert materialized_dataset.state == "error", materialized_hda.info
 


### PR DESCRIPTION
Currently when uploading datasets with associated hashes, this were only validated if `validate_hashes=True` was also passed in the request.

This commit drops `validate_hashes` completely and always validates hashes when they were provided.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
