### PR TITLE
Run ``uv lock`` under Python 3.9

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -8,14 +8,15 @@ jobs:
     name: Update dependencies
     if: github.repository_owner == 'galaxyproject'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.8']
     steps:
       - uses: actions/checkout@v4
+      # Install Python 3.8 for update_lint_requirements.sh
+      # Install Python 3.9 (as default) to allow `uv lock` to generate metadata for rucio-clients
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: |
+            3.8
+            3.9
       - name: Update dependencies
         run: make update-dependencies
       - name: Create pull request


### PR DESCRIPTION
Fix:

```
Using CPython 3.8.18 interpreter at: /opt/hostedtoolcache/Python/3.8.18/x64/bin/python
  × No solution found when resolving dependencies for split
  │ (python_full_version == '3.9.*'):
  ╰─▶ Because only the following versions of rucio-clients{python_full_version >= '3.9'} are available:
          rucio-clients{python_full_version >= '3.9'}<=33.6.1
          rucio-clients{python_full_version >= '3.9'}>=34.0.0,<=34.6.0
          rucio-clients{python_full_version >= '3.9'}>=35.0.0
      and all of:
          rucio-clients{python_full_version >= '3.9'}>=33.6.0,<=33.6.1
          rucio-clients{python_full_version >= '3.9'}>=34.0.0,<=34.6.0
          rucio-clients{python_full_version >= '3.9'}>=35.0.0
      require Python >=3.9, <4, we can conclude that all of:
          rucio-clients{python_full_version >= '3.9'}>=33.6.0,<33.6.1
          ...
          rucio-clients{python_full_version >= '3.9'}>35.4.1,<35.5.0
          rucio-clients{python_full_version >= '3.9'}>35.5.0
       are incompatible.
      And because galaxy:dev depends on rucio-clients{python_full_version >=
      '3.9'}>=33.6.0 and your project depends on galaxy:dev, we can conclude
      that your project's requirements are unsatisfiable.

      hint: The source distribution for rucio-clients{python_full_version >=
      '3.9'}==35.5.0 does not include static metadata. Generating metadata for
      this package requires Python >=3.9, <4, but Python 3.8.18 is installed.
```

See https://github.com/galaxyproject/galaxy/actions/runs/11684632042/job/32536277008

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. I've tested this on my fork: https://github.com/nsoranzo/galaxy/actions/runs/11694467700/job/32568116605

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
