### PR TITLE
Include dataset hash in job search

### DIFF
--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -789,10 +789,12 @@ class TestDatasetsApi(ApiTestCase):
         hda_details = self.dataset_populator.get_history_dataset_details(history_id, dataset=hda)
         self.assert_hash_value(hda_details, "940cbe15c94d7e339dc15550f6bdcf4d", "MD5")
 
-    def test_compute_sha1_on_composite_dataset(self, history_id):
+    def test_compute_sha256_on_composite_dataset_by_default(self, history_id):
         output = self.dataset_populator.fetch_hda(history_id, COMPOSITE_DATA_FETCH_REQUEST_1, wait=True)
-        self.dataset_populator.compute_hash(output["id"], hash_function="SHA-256", extra_files_path="Roadmaps")
         hda_details = self.dataset_populator.get_history_dataset_details(history_id, dataset=output)
+        self.assert_hash_value(
+            hda_details, "94e09ae129f1ec32d1736af833160e8bdaa3a75cef2982712076c7bcd7d155d3", "SHA-256"
+        )
         self.assert_hash_value(
             hda_details,
             "3cbd311889963528954fe03b28b68a09685ea7a75660bd2268d5b44cafbe0d22",


### PR DESCRIPTION
This means we find equivalent jobs if an input hda either points at the same dataset id (existing behavior), or if the dataset ~~source_uri, transform and~~ hashes match. All further restrictions still apply (same metadata etc).

Builds on #19108 and https://github.com/galaxyproject/galaxy/pull/19110 .

Also:
- Drop `test_run_deferred_dataset` and `test_run_deferred_dataset_with_metadata_options_filter`
  tests from `lib/galaxy_test/api/test_tools.py` which are duplicates
  of `test_deferred_with_cached_input` and `test_deferred_with_metadata_options_filter` in
  `lib/galaxy_test/api/test_tool_execute.py` .
- Improve type annotations

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
