### PR TITLE
Enable specifying dataset hash in test jobs

### DIFF
--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -930,9 +930,7 @@ def replace_request_syntax_sugar(obj):
                     new_hashes.append({"hash_function": key, "hash_value": obj[key.lower()]})
                     del obj[key.lower()]
 
-            if "hashes" not in obj:
-                obj["hashes"] = []
-            obj["hashes"].extend(new_hashes)
+            obj.setdefault("hashes", []).extend(new_hashes)
 
 
 class DiscoveredFile(NamedTuple):

--- a/lib/galaxy/tool_util/client/staging.py
+++ b/lib/galaxy/tool_util/client/staging.py
@@ -107,6 +107,7 @@ class StagingInterface(metaclass=abc.ABCMeta):
                     dbkey=dbkey,
                     to_posix_lines=to_posix_lines,
                     decompress=upload_target.properties.get("decompress") or DEFAULT_DECOMPRESS,
+                    hashes=upload_target.properties.get("hashes"),
                 )
                 name = _file_path_to_name(file_path)
                 if file_path is not None:
@@ -177,11 +178,7 @@ class StagingInterface(metaclass=abc.ABCMeta):
                 file_path = upload_target.path
                 file_type = upload_target.properties.get("filetype", None) or DEFAULT_FILE_TYPE
                 dbkey = upload_target.properties.get("dbkey", None) or DEFAULT_DBKEY
-                upload_payload = _upload_payload(
-                    history_id,
-                    file_type=file_type,
-                    to_posix_lines=dbkey,
-                )
+                upload_payload = _upload_payload(history_id, file_type=file_type, to_posix_lines=dbkey)
                 name = _file_path_to_name(file_path)
                 upload_payload["inputs"]["files_0|auto_decompress"] = False
                 upload_payload["inputs"]["auto_decompress"] = False
@@ -334,6 +331,8 @@ def _fetch_payload(history_id, file_type=DEFAULT_FILE_TYPE, dbkey=DEFAULT_DBKEY,
     for arg in ["to_posix_lines", "space_to_tab"]:
         if arg in kwd:
             element[arg] = kwd[arg]
+    if kwd.get("hashes"):
+        element["hashes"] = kwd["hashes"]
     if "file_name" in kwd:
         element["name"] = kwd["file_name"]
     if "decompress" in kwd:

--- a/lib/galaxy/tool_util/cwl/util.py
+++ b/lib/galaxy/tool_util/cwl/util.py
@@ -235,6 +235,8 @@ def galactic_job_json(
             kwd["dbkey"] = value.get("dbkey")
         if "decompress" in value:
             kwd["decompress"] = value["decompress"]
+        if value.get("hashes"):
+            kwd["hashes"] = value["hashes"]
         if composite_data_raw:
             composite_data = []
             for entry in composite_data_raw:

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -254,6 +254,7 @@ class TestToolsUpload(ApiTestCase):
                 "class": "File",
                 "format": "txt",
                 "path": "test-data/simple_line_no_newline.txt",
+                "hashes": [{"hash_function": "SHA-1", "hash_value": "f030155d3459c233efd37e13bc1061c1dc744ebf"}],
             }
         }
         inputs, datasets = stage_inputs(self.galaxy_interactor, history_id, job, use_path_paste=False)
@@ -261,6 +262,8 @@ class TestToolsUpload(ApiTestCase):
         content = self.dataset_populator.get_history_dataset_content(history_id=history_id, dataset=dataset)
         # By default this appends the newline.
         assert content == "This is a line of text.\n"
+        dataset = self.dataset_populator.get_history_dataset_details(history_id, content_id=dataset["id"])
+        assert dataset["hashes"][0]["hash_value"] == "f030155d3459c233efd37e13bc1061c1dc744ebf"
 
     def test_stage_object(self, history_id: str) -> None:
         job = {"input1": "randomstr"}


### PR DESCRIPTION
Intermediate goal here is that we add hashes to all IWC test job definitions, which would make it easy to re-run all of the IWC workflows using the job cache and find more cornercases where the job cache doesn't work.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
