### PR TITLE
Ensure JSON encoding supports non-ASCII characters in uploads

### DIFF
--- a/lib/galaxy/model/custom_types.py
+++ b/lib/galaxy/model/custom_types.py
@@ -29,6 +29,10 @@ log = logging.getLogger(__name__)
 
 
 class SafeJsonEncoder(json.JSONEncoder):
+    def __init__(self, *args, **kwargs):
+        kwargs["ensure_ascii"] = False
+        super().__init__(*args, **kwargs)
+
     def default(self, obj):
         if isinstance(obj, numpy.int_):
             return int(obj)

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -2174,7 +2174,7 @@ class DirectoryModelExportStore(ModelExportStore):
         history_attrs = history.serialize(app.security, self.serialization_options)
         history_attrs_filename = os.path.join(export_directory, ATTRS_FILENAME_HISTORY)
         with open(history_attrs_filename, "w") as history_attrs_out:
-            dump(history_attrs, history_attrs_out)
+            dump(history_attrs, history_attrs_out, ensure_ascii=False)
 
         sa_session = app.model.session
 

--- a/lib/galaxy/tools/actions/upload.py
+++ b/lib/galaxy/tools/actions/upload.py
@@ -140,7 +140,7 @@ class FetchUploadToolAction(BaseUploadToolAction):
             if destination_type == "hdca":
                 _precreate_fetched_collection_instance(trans, history, target, outputs)
 
-        incoming["request_json"] = json.dumps(request)
+        incoming["request_json"] = json.dumps(request, ensure_ascii=False)
         return self._create_job(trans, incoming, tool, None, outputs, history=history)
 
 

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -86,7 +86,7 @@ class ToolsService(ServiceBase):
             clean_payload[key] = value
         clean_payload["check_content"] = self.config.check_upload_content
         validate_and_normalize_targets(trans, clean_payload)
-        request = dumps(clean_payload)
+        request = dumps(clean_payload, ensure_ascii=False)
         create_payload = {
             "tool_id": "__DATA_FETCH__",
             "history_id": history_id,


### PR DESCRIPTION
Update JSON encoding in upload requests to handle non-ASCII characters correctly.
Fixes step 2 of https://github.com/galaxyproject/galaxy/issues/18584

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
