### PR TITLE
WIP: Allow link_only for posix file sources

### DIFF
--- a/lib/galaxy/files/sources/posix.py
+++ b/lib/galaxy/files/sources/posix.py
@@ -26,6 +26,7 @@ from . import (
 DEFAULT_ENFORCE_SYMLINK_SECURITY = True
 DEFAULT_DELETE_ON_REALIZE = False
 DEFAULT_ALLOW_SUBDIR_CREATION = True
+DEFAULT_LINK_ONLY = False
 
 
 class PosixFilesSourceProperties(FilesSourceProperties, total=False):
@@ -33,6 +34,7 @@ class PosixFilesSourceProperties(FilesSourceProperties, total=False):
     enforce_symlink_security: bool
     delete_on_realize: bool
     allow_subdir_creation: bool
+    link_only: bool
 
 
 class PosixFilesSource(BaseFilesSource):
@@ -50,6 +52,7 @@ class PosixFilesSource(BaseFilesSource):
         self.root = props.get("root")
         if not self.root:
             self.writable = False
+        self.link_only = props.get("link_only", DEFAULT_LINK_ONLY)
         self.enforce_symlink_security = props.get("enforce_symlink_security", DEFAULT_ENFORCE_SYMLINK_SECURITY)
         self.delete_on_realize = props.get("delete_on_realize", DEFAULT_DELETE_ON_REALIZE)
         self.allow_subdir_creation = props.get("allow_subdir_creation", DEFAULT_ALLOW_SUBDIR_CREATION)

--- a/lib/galaxy/files/sources/posix.py
+++ b/lib/galaxy/files/sources/posix.py
@@ -106,7 +106,9 @@ class PosixFilesSource(BaseFilesSource):
             source_native_path = os.path.normpath(source_native_path)
             assert source_native_path.startswith(os.path.normpath(effective_root))
 
-        if not self.delete_on_realize:
+        if self.link_only:
+            os.symlink(source_native_path, native_path)
+        elif not self.delete_on_realize:
             shutil.copyfile(source_native_path, native_path)
         else:
             shutil.move(source_native_path, native_path)

--- a/lib/galaxy/files/sources/posix.py
+++ b/lib/galaxy/files/sources/posix.py
@@ -187,6 +187,7 @@ class PosixFilesSource(BaseFilesSource):
             "enforce_symlink_security": self.enforce_symlink_security,
             "delete_on_realize": self.delete_on_realize,
             "allow_subdir_creation": self.allow_subdir_creation,
+            "link_only": self.link_only,
         }
 
     @property


### PR DESCRIPTION
Early draft exploring options to avoid duplication of datasets when library filesystem is mounted by compute nodes.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
