### PR TITLE
Normalize usernames to lowercase in OIDC authentication

### DIFF
--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -487,7 +487,7 @@ class OIDCAuthnzBase(IdentityProvider):
         username = userinfo.get("preferred_username", userinfo["email"])
         if "@" in username:
             username = username.split("@")[0]  # username created from username portion of email
-        username = util.ready_name_for_url(username)
+        username = util.ready_name_for_url(username).lower()
         if trans.sa_session.query(trans.app.model.User).filter_by(username=username).first():
             # if username already exists in database, append integer and iterate until unique username found
             count = 0


### PR DESCRIPTION
Ensure that usernames are consistently stored in lowercase format during the OIDC authentication process.
Fixes #19087

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
