### PR TITLE
Allow a posix file source to prefer linking.

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -115,6 +115,14 @@ LOGGING_CONFIG_DEFAULT: Dict[str, Any] = {
             "level": "INFO",
             "qualname": "watchdog.observers.inotify_buffer",
         },
+        "py.warnings": {
+            "level": "ERROR",
+            "qualname": "py.warnings",
+        },
+        "celery.utils.functional": {
+            "level": "INFO",
+            "qualname": "celery.utils.functional",
+        },
     },
     "filters": {
         "stack": {

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -277,6 +277,10 @@ class SingleFileSource(metaclass=abc.ABCMeta):
         context doesn't need to be present after the plugin is re-hydrated.
         """
 
+    @abc.abstractmethod
+    def prefer_links(self) -> bool:
+        """Prefer linking to files."""
+
 
 class SupportsBrowsing(metaclass=abc.ABCMeta):
     """An interface indicating that this filesource is browsable.
@@ -350,6 +354,9 @@ class BaseFilesSource(FilesSource):
             or user_context.is_admin
             or (self._user_has_required_roles(user_context) and self._user_has_required_groups(user_context))
         )
+
+    def prefer_links(self) -> bool:
+        return False
 
     @property
     def user_context_required(self) -> bool:

--- a/lib/galaxy/files/sources/posix.py
+++ b/lib/galaxy/files/sources/posix.py
@@ -26,6 +26,7 @@ from . import (
 DEFAULT_ENFORCE_SYMLINK_SECURITY = True
 DEFAULT_DELETE_ON_REALIZE = False
 DEFAULT_ALLOW_SUBDIR_CREATION = True
+DEFAULT_PREFER_LINKS = False
 
 
 class PosixFilesSourceProperties(FilesSourceProperties, total=False):
@@ -33,6 +34,7 @@ class PosixFilesSourceProperties(FilesSourceProperties, total=False):
     enforce_symlink_security: bool
     delete_on_realize: bool
     allow_subdir_creation: bool
+    prefer_links: bool
 
 
 class PosixFilesSource(BaseFilesSource):
@@ -53,6 +55,10 @@ class PosixFilesSource(BaseFilesSource):
         self.enforce_symlink_security = props.get("enforce_symlink_security", DEFAULT_ENFORCE_SYMLINK_SECURITY)
         self.delete_on_realize = props.get("delete_on_realize", DEFAULT_DELETE_ON_REALIZE)
         self.allow_subdir_creation = props.get("allow_subdir_creation", DEFAULT_ALLOW_SUBDIR_CREATION)
+        self._prefer_links = props.get("prefer_links", DEFAULT_PREFER_LINKS)
+
+    def prefer_links(self) -> bool:
+        return self._prefer_links
 
     def _list(
         self,
@@ -182,6 +188,7 @@ class PosixFilesSource(BaseFilesSource):
             "enforce_symlink_security": self.enforce_symlink_security,
             "delete_on_realize": self.delete_on_realize,
             "allow_subdir_creation": self.allow_subdir_creation,
+            "prefer_links": self._prefer_links,
         }
 
     @property

--- a/lib/galaxy/files/uris.py
+++ b/lib/galaxy/files/uris.py
@@ -49,8 +49,7 @@ def stream_url_to_file(
     target_path: Optional[str] = None,
     file_source_opts: Optional[FilesSourceOptions] = None,
 ) -> str:
-    if file_sources is None:
-        file_sources = ConfiguredFileSources.from_dict(None, load_stock_plugins=True)
+    file_sources = ensure_file_sources(file_sources)
     file_source, rel_path = file_sources.get_file_source_path(url)
     if file_source:
         if not target_path:
@@ -60,6 +59,12 @@ def stream_url_to_file(
         return target_path
     else:
         raise NoMatchingFileSource(f"Could not find a matching handler for: {url}")
+
+
+def ensure_file_sources(file_sources: Optional["ConfiguredFileSources"]) -> "ConfiguredFileSources":
+    if file_sources is None:
+        file_sources = ConfiguredFileSources.from_dict(None, load_stock_plugins=True)
+    return file_sources
 
 
 def stream_to_file(stream, suffix="", prefix="", dir=None, text=False, **kwd):

--- a/test/integration/test_remote_files_posix.py
+++ b/test/integration/test_remote_files_posix.py
@@ -112,6 +112,7 @@ class TestPosixFileSourceIntegration(PosixFileSourceSetup, integration_util.Inte
 
 class TestPreferLinksPosixFileSourceIntegration(PosixFileSourceSetup, integration_util.IntegrationTestCase):
     dataset_populator: DatasetPopulator
+    framework_tool_and_types = True
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
@@ -146,3 +147,14 @@ class TestPreferLinksPosixFileSourceIntegration(PosixFileSourceSetup, integratio
             assert dataset.external_filename.endswith("/root/a")
             assert os.path.exists(dataset.external_filename)
             assert open(dataset.external_filename).read() == "a\n"
+            payload = self.dataset_populator.run_tool(
+                tool_id="cat",
+                inputs={
+                    "input1": {"src": "hda", "id": new_dataset["id"]},
+                },
+                history_id=history_id,
+            )
+            derived_dataset = payload["outputs"][0]
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            derived_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=derived_dataset)
+            assert derived_content.strip() == "a"

--- a/test/integration/test_remote_files_posix.py
+++ b/test/integration/test_remote_files_posix.py
@@ -1,8 +1,8 @@
-# Before running this test, start nginx+webdav in Docker using following command:
-# docker run -v `pwd`/test/integration/webdav/data:/media  -e WEBDAV_USERNAME=alice -e WEBDAV_PASSWORD=secret1234 -p 7083:7083 jmchilton/webdavdev
-# Apache Docker host (shown next) doesn't work because displayname not set in response.
-# docker run -v `pwd`/test/integration/webdav:/var/lib/dav  -e AUTH_TYPE=Basic -e USERNAME=alice -e PASSWORD=secret1234  -e LOCATION=/ -p 7083:80 bytemark/webdav
+import os
 
+from sqlalchemy import select
+
+from galaxy.model import Dataset
 from galaxy_test.base import api_asserts
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
@@ -108,3 +108,41 @@ class TestPosixFileSourceIntegration(PosixFileSourceSetup, integration_util.Inte
 
     def _assert_access_forbidden_response(self, response):
         api_asserts.assert_status_code_is(response, 403)
+
+
+class TestPreferLinksPosixFileSourceIntegration(PosixFileSourceSetup, integration_util.IntegrationTestCase):
+    dataset_populator: DatasetPopulator
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        PosixFileSourceSetup.handle_galaxy_config_kwds(
+            config,
+            cls,
+            prefer_links=True,
+        )
+
+    def setUp(self):
+        super().setUp()
+        self._write_file_fixtures()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+
+    def test_links_by_default(self):
+        with self.dataset_populator.test_history() as history_id:
+            element = dict(src="url", url="gxfiles://linking_source/a")
+            target = {
+                "destination": {"type": "hdas"},
+                "elements": [element],
+            }
+            targets = [target]
+            payload = {
+                "history_id": history_id,
+                "targets": targets,
+            }
+            new_dataset = self.dataset_populator.fetch(payload, assert_ok=True).json()["outputs"][0]
+            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=new_dataset)
+            assert content == "a\n", content
+            stmt = select(Dataset).order_by(Dataset.create_time.desc()).limit(1)
+            dataset = self._app.model.session.execute(stmt).unique().scalar_one()
+            assert dataset.external_filename.endswith("/root/a")
+            assert os.path.exists(dataset.external_filename)
+            assert open(dataset.external_filename).read() == "a\n"


### PR DESCRIPTION
The linking upload parameters will still be respected, but if none of them are set data fetch will default to just linking files during upload. This uses Dataset.external_filename instead of symlinks in the objectstore so that Galaxy has better tracking of the links and so this works closer to the way data libraries have always worked.

Alternative to https://github.com/galaxyproject/galaxy/pull/19125.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
