### PR TITLE
Restore access to saved visualizations

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/visualization.py
+++ b/lib/galaxy/webapps/galaxy/controllers/visualization.py
@@ -11,7 +11,7 @@ from galaxy import (
     model,
     web,
 )
-from galaxy.exceptions import MessageException
+from galaxy.exceptions import MessageException, ObjectNotFound
 from galaxy.managers.hdas import HDAManager
 from galaxy.managers.sharable import SlugBuilder
 from galaxy.model.base import transaction
@@ -40,6 +40,16 @@ class VisualizationController(
 
     def __init__(self, app: StructuredApp):
         super().__init__(app)
+
+    def get_visualization(self, trans, visualization_id, check_ownership=True, check_accessible=False):
+        """
+        Get a Visualization from the database by id, verifying ownership.
+        """
+        visualization = trans.sa_session.get(model.Visualization, trans.security.decode_id(visualization_id))
+        if not visualization:
+            raise ObjectNotFound("Visualization not found")
+        else:
+            return self.security_check(trans, visualization, check_ownership, check_accessible)
 
     #
     # -- Functions for operating on visualizations. --

--- a/lib/galaxy/webapps/galaxy/controllers/visualization.py
+++ b/lib/galaxy/webapps/galaxy/controllers/visualization.py
@@ -11,7 +11,7 @@ from galaxy import (
     model,
     web,
 )
-from galaxy.exceptions import MessageException, ObjectNotFound
+from galaxy.exceptions import MessageException
 from galaxy.managers.hdas import HDAManager
 from galaxy.managers.sharable import SlugBuilder
 from galaxy.model.base import transaction
@@ -47,7 +47,7 @@ class VisualizationController(
         """
         visualization = trans.sa_session.get(model.Visualization, trans.security.decode_id(visualization_id))
         if not visualization:
-            raise ObjectNotFound("Visualization not found")
+            raise MessageException("Visualization not found")
         else:
             return self.security_check(trans, visualization, check_ownership, check_accessible)
 


### PR DESCRIPTION
Restores controller helper function to access saved visualizations. This function was stripped while modernizing the api. Fixes: #18947.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Create and Save a Visualization
  2. Attempt to Access the Saved Visualization from the Visualizations Grid

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
