### PR TITLE
Fix phylocanvas visualization build

### DIFF
--- a/config/plugins/visualizations/phylocanvas/package.json
+++ b/config/plugins/visualizations/phylocanvas/package.json
@@ -15,6 +15,7 @@
         "build": "parcel build src/script.js --dist-dir static"
     },
     "devDependencies": {
+        "buffer": "^6.0.3",
         "parcel": "^2.12.0",
         "process": "^0.11.10"
     }


### PR DESCRIPTION
Attempt to fix:
```
Building phylocanvas
$ parcel build src/script.js --dist-dir static
Building...
🚨 Build failed.

@parcel/core: Failed to resolve 'buffer' from 
'./node_modules/@loaders.gl/loader-utils/dist/esm/lib/filesystems/readable-file.js'
  /home/runner/work/galaxy/galaxy/galaxy root/config/plugins/visualizations/phylocanvas/node_modules/@loaders.gl/loader-utils/dist/esm/lib/filesystems/readable-file.js:15:54
    14 |       return Buffer.from(arrayBuffer);
  > 15 |     },
  >    |       ^
    16 |     close: async () => {},
    17 |     size: blob.size


@parcel/resolver-default: Node builtin polyfill "buffer/" is not installed, but 
auto install is disabled.
  /home/runner/work/galaxy/galaxy/galaxy root/config/plugins/visualizations/phylocanvas/node_modules/@loaders.gl/loader-utils/src/lib/filesystems/readable-file.ts:15:54
    14 |     return {
  > 15 | ) => Buffer.from(data, start, length),
  >    |      ^^^^^^ used here
    16 |       close: async () => {},
    17 |       size: arrayBuffer.byteLength


  💡 Install the "buffer/" package with your package manager, and run Parcel 
     again.
```

Those visualizations will hopefully be soon migrated to the pre-built system, this is just an attempt to keep the tests in the dev branch working.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
