### PR TITLE
Fix word wrapping in invocation panel list items

### DIFF
--- a/client/src/components/Workflow/Invocation/InvocationScrollList.vue
+++ b/client/src/components/Workflow/Invocation/InvocationScrollList.vue
@@ -204,10 +204,14 @@ function workflowName(workflowId: string) {
                         @click="() => cardClicked(invocation)">
                         <div class="overflow-auto w-100">
                             <Heading bold size="text" icon="fa-sitemap">
-                                <span class="truncate-3-lines">{{ workflowName(invocation.workflow_id) }}</span>
+                                <span class="truncate-n-lines three-lines">
+                                    {{ workflowName(invocation.workflow_id) }}
+                                </span>
                             </Heading>
                             <Heading size="text" icon="fa-hdd">
-                                <small class="text-muted">{{ historyName(invocation.history_id) }}</small>
+                                <small class="text-muted truncate-n-lines two-lines">
+                                    {{ historyName(invocation.history_id) }}
+                                </small>
                             </Heading>
                             <div class="d-flex justify-content-between">
                                 <BBadge v-b-tooltip.noninteractive.hover pill>
@@ -257,12 +261,19 @@ function workflowName(workflowId: string) {
 </template>
 
 <style scoped lang="scss">
-@import "theme/blue.scss";
-
-.truncate-3-lines {
+.truncate-n-lines {
     display: -webkit-box;
-    -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     overflow: hidden;
+    word-break: break-word;
+    overflow-wrap: break-word;
+    &.three-lines {
+        -webkit-line-clamp: 3;
+        line-clamp: 3;
+    }
+    &.two-lines {
+        -webkit-line-clamp: 2;
+        line-clamp: 2;
+    }
 }
 </style>


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/18920

<img width="308" alt="image" src="https://github.com/user-attachments/assets/7e7aa9ea-84c9-40c2-a91a-ec083f4dbf4d">

Workflow name clamps to a max of 3 lines, history name to 2 lines.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
