### PR TITLE
Switch update annotate image to new script entry_point

### DIFF
--- a/config/plugins/visualizations/annotate_image/config/annotate_image.xml
+++ b/config/plugins/visualizations/annotate_image/config/annotate_image.xml
@@ -13,5 +13,5 @@
     <params>
         <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>
     </params>
-    <entry_point entry_point_type="chart" src="script.js" css="jquery.contextMenu.css"/>
+    <entry_point entry_point_type="script" src="script.js" css="jquery.contextMenu.css"/>
 </visualization>

--- a/config/plugins/visualizations/annotate_image/package.json
+++ b/config/plugins/visualizations/annotate_image/package.json
@@ -19,7 +19,7 @@
     },
     "scripts": {
         "build": "yarn build-css && yarn build-js",
-        "build-css": "cp 'node_modules/jquery-contextmenu/dist/jquery.contextMenu.css' 'static/'",
+        "build-css": "cp -f 'node_modules/jquery-contextmenu/dist/jquery.contextMenu.css' 'static/'",
         "build-js": "parcel build src/script.js --dist-dir static"
     }
 }

--- a/config/plugins/visualizations/annotate_image/src/script.js
+++ b/config/plugins/visualizations/annotate_image/src/script.js
@@ -463,7 +463,7 @@ function render(downloadUrl) {
         });
 };
 
-const { visualization_config, root } = JSON.parse(document.getElementById("app").dataset.incoming);
+const { root, visualization_config } = JSON.parse(document.getElementById("app").dataset.incoming);
 
 const datasetId = visualization_config.dataset_id;
 

--- a/config/plugins/visualizations/example/static/script.js
+++ b/config/plugins/visualizations/example/static/script.js
@@ -1,4 +1,4 @@
-const { visualization_config, visualization_plugin, root } = JSON.parse(document.getElementById("app").dataset.incoming);
+const { root, visualization_config, visualization_plugin } = JSON.parse(document.getElementById("app").dataset.incoming);
 
 const div = Object.assign(document.createElement("div"), {
     style: "border: 2px solid #25537b; border-radius: 1rem; padding: 1rem"


### PR DESCRIPTION
PR switches the update annotate image viewer from deprecated backbone-based client bundle to updated script entry point. Instead of requiring the Galaxy client bundle, the visualization now just collects the required dataset id from the DOM container attribute.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
