### PR TITLE
Update tiff viewer to use script entry_point

### DIFF
--- a/config/plugins/visualizations/annotate_image/config/annotate_image.xml
+++ b/config/plugins/visualizations/annotate_image/config/annotate_image.xml
@@ -13,5 +13,5 @@
     <params>
         <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>
     </params>
-    <entry_point entry_point_type="chart" src="script.js" css="jquery.contextMenu.css"/>
+    <entry_point entry_point_type="script" src="script.js" css="jquery.contextMenu.css"/>
 </visualization>

--- a/config/plugins/visualizations/annotate_image/package.json
+++ b/config/plugins/visualizations/annotate_image/package.json
@@ -19,7 +19,7 @@
     },
     "scripts": {
         "build": "yarn build-css && yarn build-js",
-        "build-css": "cp 'node_modules/jquery-contextmenu/dist/jquery.contextMenu.css' 'static/'",
+        "build-css": "cp -f 'node_modules/jquery-contextmenu/dist/jquery.contextMenu.css' 'static/'",
         "build-js": "parcel build src/script.js --dist-dir static"
     }
 }

--- a/config/plugins/visualizations/annotate_image/src/script.js
+++ b/config/plugins/visualizations/annotate_image/src/script.js
@@ -463,7 +463,7 @@ function render(downloadUrl) {
         });
 };
 
-const { visualization_config, root } = JSON.parse(document.getElementById("app").dataset.incoming);
+const { root, visualization_config } = JSON.parse(document.getElementById("app").dataset.incoming);
 
 const datasetId = visualization_config.dataset_id;
 

--- a/config/plugins/visualizations/example/static/script.js
+++ b/config/plugins/visualizations/example/static/script.js
@@ -1,4 +1,4 @@
-const { visualization_config, visualization_plugin, root } = JSON.parse(document.getElementById("app").dataset.incoming);
+const { root, visualization_config, visualization_plugin } = JSON.parse(document.getElementById("app").dataset.incoming);
 
 const div = Object.assign(document.createElement("div"), {
     style: "border: 2px solid #25537b; border-radius: 1rem; padding: 1rem"

--- a/config/plugins/visualizations/tiffviewer/config/tiffviewer.xml
+++ b/config/plugins/visualizations/tiffviewer/config/tiffviewer.xml
@@ -14,5 +14,5 @@
     <params>
         <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>
     </params>
-    <entry_point entry_point_type="chart" src="script.js" css="script.css"/>
+    <entry_point entry_point_type="script" src="script.js" css="script.css"/>
 </visualization>

--- a/config/plugins/visualizations/tiffviewer/config/tiffviewer.xml
+++ b/config/plugins/visualizations/tiffviewer/config/tiffviewer.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
 <visualization name="Tiff Viewer">
-    <description>Basic Tiff Image visualization</description>
+    <description>Tiff Image Viewer</description>
     <data_sources>
         <data_source>
             <model_class>HistoryDatasetAssociation</model_class>
-
             <test type="isinstance" test_attr="datatype" result_type="datatype">images.Tiff</test>
-
             <to_param param_attr="id">dataset_id</to_param>
         </data_source>
     </data_sources>

--- a/config/plugins/visualizations/tiffviewer/src/script.js
+++ b/config/plugins/visualizations/tiffviewer/src/script.js
@@ -8,22 +8,15 @@ const App = (props) => {
     return <TIFFViewer tiff={props.dataset_url} paginate="bottom" />;
 };
 
-/* This will be part of the charts/viz standard lib in 23.1 */
-const slashCleanup = /(\/)+/g;
-function prefixedDownloadUrl(root, path) {
-    return `${root}/${path}`.replace(slashCleanup, "/");
-}
+const { root, visualization_config } = JSON.parse(document.getElementById("app").dataset.incoming);
 
-window.bundleEntries = window.bundleEntries || {};
-window.bundleEntries.load = function (options) {
-    const dataset = options.dataset;
-    const url = prefixedDownloadUrl(options.root, dataset.download_url);
-    const root = createRoot(document.getElementById(options.target));
-    root.render(
-        <StrictMode>
-            <App dataset_url={url} />
-        </StrictMode>
-    );
-    options.chart.state("ok", "Done.");
-    options.process.resolve();
-};
+const datasetId = visualization_config.dataset_id;
+
+const url = window.location.origin + root + "api/datasets/" + datasetId + "/display";
+
+const rootElement = createRoot(document.getElementById("app"));
+rootElement.render(
+    <StrictMode>
+        <App dataset_url={url} />
+    </StrictMode>
+);


### PR DESCRIPTION
Similar to #19150, but applied to the Tiff viewer. This PR removes the overhead of having to embed the Tiff viewer into Galaxy's client bundle by using the recently revised script entry_point. See: #18651.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
