### PR TITLE
Clarify that higher python versions are also supported

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Community support is available at `Galaxy Help <https://help.galaxyproject.org/>
 Galaxy Quickstart
 =================
 
-Galaxy requires Python 3.8 . To check your Python version, run:
+Galaxy requires Python 3.8 or higher. To check your Python version, run:
 
 .. code:: console
 


### PR DESCRIPTION
I've encountered users in the wild that assumed that this is a hard requirement and Galaxy only runs under py3.8

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
