### PR TITLE
[24.1] Make runtime value in optional parameter open legacy workflow run form

### DIFF
--- a/client/src/components/Workflow/Run/model.js
+++ b/client/src/components/Workflow/Run/model.js
@@ -136,34 +136,30 @@ export class WorkflowRunModel {
         // or if an explicit reference is specified as data_ref and available
         _.each(this.steps, (step) => {
             if (step.step_type == "tool") {
-                var data_resolved = true;
+                let dataResolved = true;
                 visitInputs(step.inputs, (input, name, context) => {
-                    var is_runtime_value = input.value && input.value.__class__ == "RuntimeValue";
-                    var is_data_input = ["data", "data_collection"].indexOf(input.type) != -1;
-                    var data_ref = context[input.data_ref];
+                    const isRuntimeValue = input.value && input.value.__class__ == "RuntimeValue";
+                    const isDataInput = ["data", "data_collection"].indexOf(input.type) != -1;
+                    const dataRef = context[input.data_ref];
                     if (input.step_linked && !isDataStep(input.step_linked)) {
-                        data_resolved = false;
+                        dataResolved = false;
                     }
-                    if (input.options && ((input.options.length == 0 && !data_resolved) || input.wp_linked)) {
+                    if (input.options && ((input.options.length == 0 && !dataResolved) || input.wp_linked)) {
                         input.is_workflow = true;
                     }
-                    if (data_ref) {
+                    if (dataRef) {
                         input.is_workflow =
-                            (data_ref.step_linked && !isDataStep(data_ref.step_linked)) || input.wp_linked;
+                            (dataRef.step_linked && !isDataStep(dataRef.step_linked)) || input.wp_linked;
                     }
-                    if (
-                        !input.optional &&
-                        (is_data_input ||
-                            (input.value && input.value.__class__ == "RuntimeValue" && !input.step_linked))
-                    ) {
+                    if ((isDataInput && !input.optional) || (!isDataInput && isRuntimeValue && !input.step_linked)) {
                         step.expanded = true;
                         hasOpenToolSteps = true;
                     }
-                    if (is_runtime_value) {
+                    if (isRuntimeValue) {
                         input.value = null;
                     }
                     input.flavor = "workflow";
-                    if (!is_runtime_value && !is_data_input && input.type !== "hidden" && !input.wp_linked) {
+                    if (!isRuntimeValue && !isDataInput && input.type !== "hidden" && !input.wp_linked) {
                         if (input.optional || (!isEmpty(input.value) && input.value !== "")) {
                             input.collapsible_value = input.value;
                             input.collapsible_preview = true;

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -77,6 +77,29 @@ class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows
 
     @selenium_test
     @managed_history
+    def test_runtime_parameters_simple_optional(self):
+        self.workflow_run_open_workflow(
+            """
+class: GalaxyWorkflow
+inputs: {}
+steps:
+  int_step:
+    tool_id: expression_null_handling_integer
+    runtime_inputs:
+      - int_input
+"""
+        )
+        self.tool_parameter_div("int_input")
+        self._set_num_lines_to_3("int_input")
+        self.screenshot("workflow_run_optional_runtime_parameters_modified")
+        self.workflow_run_submit()
+        self.workflow_run_wait_for_ok(hid=1)
+        history_id = self.current_history_id()
+        content = self.dataset_populator.get_history_dataset_content(history_id, hid=1)
+        assert json.loads(content) == 3
+
+    @selenium_test
+    @managed_history
     def test_subworkflows_expanded(self):
         self.perform_upload(self.get_filename("1.txt"))
         self.wait_for_history()


### PR DESCRIPTION
We can only accept disconnected optional data inputs, for all other
parameters we need to replace the runtime value placeholder.

Partial fix for https://github.com/galaxyproject/galaxy/issues/18545#issuecomment-2485132219

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
