### PR TITLE
Enhance UTF-8 support for filename handling in downloads

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -19,7 +19,6 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
-from urllib.parse import quote
 
 from markupsafe import escape
 from typing_extensions import Literal
@@ -51,6 +50,7 @@ from galaxy.util import (
     FILENAME_VALID_CHARS,
     inflector,
     iter_start_of_line,
+    toContentDisposition,
     unicodify,
     UNKNOWN,
 )
@@ -431,16 +431,14 @@ class Data(metaclass=DataMeta):
         headers["content-type"] = (
             "application/octet-stream"  # force octet-stream so Safari doesn't append mime extensions to filename
         )
-        filename, utf8_encoded_filename = self._download_filename(
+        filename = self._download_filename(
             dataset,
             to_ext,
             hdca=kwd.get("hdca"),
             element_identifier=kwd.get("element_identifier"),
             filename_pattern=kwd.get("filename_pattern"),
         )
-        headers["Content-Disposition"] = (
-            f"attachment; filename=\"{filename}\"; filename*=UTF-8''{utf8_encoded_filename}"
-        )
+        headers["Content-Disposition"] = toContentDisposition(filename)
         return open(dataset.get_file_name(), mode="rb"), headers
 
     def to_archive(self, dataset: DatasetProtocol, name: str = "") -> Iterable:
@@ -476,7 +474,7 @@ class Data(metaclass=DataMeta):
             return self._archive_composite_dataset(trans, data, headers, do_action=kwd.get("do_action", "zip"))
         else:
             headers["Content-Length"] = str(file_size)
-            filename, utf8_encoded_filename = self._download_filename(
+            filename = self._download_filename(
                 data,
                 to_ext,
                 hdca=kwd.get("hdca"),
@@ -486,9 +484,7 @@ class Data(metaclass=DataMeta):
             headers["content-type"] = (
                 "application/octet-stream"  # force octet-stream so Safari doesn't append mime extensions to filename
             )
-            headers["Content-Disposition"] = (
-                f"attachment; filename=\"{filename}\"; filename*=UTF-8''{utf8_encoded_filename}"
-            )
+            headers["Content-Disposition"] = toContentDisposition(filename)
             return open(data.get_file_name(), "rb"), headers
 
     def _serve_binary_file_contents_as_text(self, trans, data, headers, file_size, max_peek_size):
@@ -664,17 +660,14 @@ class Data(metaclass=DataMeta):
         hdca: Optional[DatasetHasHidProtocol] = None,
         element_identifier: Optional[str] = None,
         filename_pattern: Optional[str] = None,
-    ) -> Tuple[str, str]:
-        def escape(raw_identifier):
-            return "".join(c in FILENAME_VALID_CHARS and c or "_" for c in raw_identifier)[0:150]
-
+    ) -> str:
         if not to_ext or to_ext == "data":
             # If a client requests to_ext with the extension 'data', they are
             # deferring to the server, set it based on datatype.
             to_ext = dataset.extension
 
         template_values = {
-            "name": escape(dataset.name),
+            "name": dataset.name,
             "ext": to_ext,
             "hid": dataset.hid,
         }
@@ -687,13 +680,12 @@ class Data(metaclass=DataMeta):
 
         if hdca is not None:
             # Use collection context to build up filename.
-            template_values["element_identifier"] = element_identifier
-            template_values["hdca_name"] = escape(hdca.name)
+            if element_identifier is not None:
+                template_values["element_identifier"] = element_identifier
+            template_values["hdca_name"] = hdca.name
             template_values["hdca_hid"] = hdca.hid
-        filename = string.Template(filename_pattern).substitute(**template_values)
-        template_values["name"] = quote(dataset.name, safe="")
-        utf8_encoded_filename = string.Template(filename_pattern).substitute(**template_values)
-        return filename, utf8_encoded_filename
+
+        return string.Template(filename_pattern).substitute(**template_values)
 
     def display_name(self, dataset: HasName) -> str:
         """Returns formatted html of dataset name"""

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -19,6 +19,7 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
+from urllib.parse import quote
 
 from markupsafe import escape
 from typing_extensions import Literal
@@ -430,14 +431,16 @@ class Data(metaclass=DataMeta):
         headers["content-type"] = (
             "application/octet-stream"  # force octet-stream so Safari doesn't append mime extensions to filename
         )
-        filename = self._download_filename(
+        filename, utf8_encoded_filename = self._download_filename(
             dataset,
             to_ext,
             hdca=kwd.get("hdca"),
             element_identifier=kwd.get("element_identifier"),
             filename_pattern=kwd.get("filename_pattern"),
         )
-        headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+        headers["Content-Disposition"] = (
+            f"attachment; filename=\"{filename}\"; filename*=UTF-8''{utf8_encoded_filename}"
+        )
         return open(dataset.get_file_name(), mode="rb"), headers
 
     def to_archive(self, dataset: DatasetProtocol, name: str = "") -> Iterable:
@@ -473,7 +476,7 @@ class Data(metaclass=DataMeta):
             return self._archive_composite_dataset(trans, data, headers, do_action=kwd.get("do_action", "zip"))
         else:
             headers["Content-Length"] = str(file_size)
-            filename = self._download_filename(
+            filename, utf8_encoded_filename = self._download_filename(
                 data,
                 to_ext,
                 hdca=kwd.get("hdca"),
@@ -483,7 +486,9 @@ class Data(metaclass=DataMeta):
             headers["content-type"] = (
                 "application/octet-stream"  # force octet-stream so Safari doesn't append mime extensions to filename
             )
-            headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+            headers["Content-Disposition"] = (
+                f"attachment; filename=\"{filename}\"; filename*=UTF-8''{utf8_encoded_filename}"
+            )
             return open(data.get_file_name(), "rb"), headers
 
     def _serve_binary_file_contents_as_text(self, trans, data, headers, file_size, max_peek_size):
@@ -659,7 +664,7 @@ class Data(metaclass=DataMeta):
         hdca: Optional[DatasetHasHidProtocol] = None,
         element_identifier: Optional[str] = None,
         filename_pattern: Optional[str] = None,
-    ) -> str:
+    ) -> Tuple[str, str]:
         def escape(raw_identifier):
             return "".join(c in FILENAME_VALID_CHARS and c or "_" for c in raw_identifier)[0:150]
 
@@ -685,8 +690,10 @@ class Data(metaclass=DataMeta):
             template_values["element_identifier"] = element_identifier
             template_values["hdca_name"] = escape(hdca.name)
             template_values["hdca_hid"] = hdca.hid
-
-        return string.Template(filename_pattern).substitute(**template_values)
+        filename = string.Template(filename_pattern).substitute(**template_values)
+        template_values["name"] = quote(dataset.name, safe="")
+        utf8_encoded_filename = string.Template(filename_pattern).substitute(**template_values)
+        return filename, utf8_encoded_filename
 
     def display_name(self, dataset: HasName) -> str:
         """Returns formatted html of dataset name"""

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -50,7 +50,7 @@ from galaxy.util import (
     FILENAME_VALID_CHARS,
     inflector,
     iter_start_of_line,
-    toContentDisposition,
+    to_content_disposition,
     unicodify,
     UNKNOWN,
 )
@@ -438,7 +438,7 @@ class Data(metaclass=DataMeta):
             element_identifier=kwd.get("element_identifier"),
             filename_pattern=kwd.get("filename_pattern"),
         )
-        headers["Content-Disposition"] = toContentDisposition(filename)
+        headers["Content-Disposition"] = to_content_disposition(filename)
         return open(dataset.get_file_name(), mode="rb"), headers
 
     def to_archive(self, dataset: DatasetProtocol, name: str = "") -> Iterable:
@@ -484,7 +484,7 @@ class Data(metaclass=DataMeta):
             headers["content-type"] = (
                 "application/octet-stream"  # force octet-stream so Safari doesn't append mime extensions to filename
             )
-            headers["Content-Disposition"] = toContentDisposition(filename)
+            headers["Content-Disposition"] = to_content_disposition(filename)
             return open(data.get_file_name(), "rb"), headers
 
     def _serve_binary_file_contents_as_text(self, trans, data, headers, file_size, max_peek_size):

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -2009,7 +2009,8 @@ def lowercase_alphanum_to_hex(lowercase_alphanum: str) -> str:
     return np.base_repr(int(lowercase_alphanum, 36), 16).lower()
 
 
-def toContentDisposition(filename: str) -> str:
-    sanitized_filename = "".join(c in FILENAME_VALID_CHARS and c or "_" for c in filename)[0:150]
-    utf8_encoded_filename = quote(filename, safe="")
+def to_content_disposition(target: str) -> str:
+    filename, ext = os.path.splitext(target)
+    sanitized_filename = "".join(c in FILENAME_VALID_CHARS and c or "_" for c in filename)[0:255] + ext
+    utf8_encoded_filename = quote(re.sub(r'[\/\\\?%*:|"<>]', "_", filename), safe="")[0:255] + ext
     return f"attachment; filename=\"{sanitized_filename}\"; filename*=UTF-8''{utf8_encoded_filename}"

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -2010,5 +2010,6 @@ def lowercase_alphanum_to_hex(lowercase_alphanum: str) -> str:
 
 
 def toContentDisposition(filename: str) -> str:
+    sanitized_filename = "".join(c in FILENAME_VALID_CHARS and c or "_" for c in filename)[0:150]
     utf8_encoded_filename = quote(filename, safe="")
-    return f"attachment; filename=\"{utf8_encoded_filename}\"; filename*=UTF-8''{utf8_encoded_filename}"
+    return f"attachment; filename=\"{sanitized_filename}\"; filename*=UTF-8''{utf8_encoded_filename}"

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -2011,6 +2011,7 @@ def lowercase_alphanum_to_hex(lowercase_alphanum: str) -> str:
 
 def to_content_disposition(target: str) -> str:
     filename, ext = os.path.splitext(target)
-    sanitized_filename = "".join(c in FILENAME_VALID_CHARS and c or "_" for c in filename)[0:255] + ext
-    utf8_encoded_filename = quote(re.sub(r'[\/\\\?%*:|"<>]', "_", filename), safe="")[0:255] + ext
+    character_limit = 255 - len(ext)
+    sanitized_filename = "".join(c in FILENAME_VALID_CHARS and c or "_" for c in filename)[0:character_limit] + ext
+    utf8_encoded_filename = quote(re.sub(r'[\/\\\?%*:|"<>]', "_", filename), safe="")[0:character_limit] + ext
     return f"attachment; filename=\"{sanitized_filename}\"; filename*=UTF-8''{utf8_encoded_filename}"

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -49,6 +49,7 @@ from typing import (
     Union,
 )
 from urllib.parse import (
+    quote,
     urlencode,
     urlparse,
     urlsplit,
@@ -2006,3 +2007,8 @@ def lowercase_alphanum_to_hex(lowercase_alphanum: str) -> str:
     import numpy as np
 
     return np.base_repr(int(lowercase_alphanum, 36), 16).lower()
+
+
+def toContentDisposition(filename: str) -> str:
+    utf8_encoded_filename = quote(filename, safe="")
+    return f"attachment; filename=\"{utf8_encoded_filename}\"; filename*=UTF-8''{utf8_encoded_filename}"

--- a/lib/galaxy/util/zipstream.py
+++ b/lib/galaxy/util/zipstream.py
@@ -11,6 +11,7 @@ from urllib.parse import quote
 
 import zipstream
 
+from galaxy.util import toContentDisposition
 from .path import safe_walk
 
 CRC32_MIN = 1444
@@ -41,11 +42,7 @@ class ZipstreamWrapper:
     def get_headers(self) -> Dict[str, str]:
         headers = {}
         if self.archive_name:
-            archive_name = self.archive_name.encode("latin-1", "replace").decode("latin-1")
-            utf8_encoded_filename = quote(self.archive_name, safe="")
-            headers["Content-Disposition"] = (
-                f"attachment; filename=\"{archive_name}.zip\"; filename*=UTF-8''{utf8_encoded_filename}.zip"
-            )
+            headers["Content-Disposition"] = toContentDisposition(f"{self.archive_name}.zip")
         if self.upstream_mod_zip:
             headers["X-Archive-Files"] = "zip"
         else:

--- a/lib/galaxy/util/zipstream.py
+++ b/lib/galaxy/util/zipstream.py
@@ -11,7 +11,7 @@ from urllib.parse import quote
 
 import zipstream
 
-from galaxy.util import toContentDisposition
+from galaxy.util import to_content_disposition
 from .path import safe_walk
 
 CRC32_MIN = 1444
@@ -42,7 +42,7 @@ class ZipstreamWrapper:
     def get_headers(self) -> Dict[str, str]:
         headers = {}
         if self.archive_name:
-            headers["Content-Disposition"] = toContentDisposition(f"{self.archive_name}.zip")
+            headers["Content-Disposition"] = to_content_disposition(f"{self.archive_name}.zip")
         if self.upstream_mod_zip:
             headers["X-Archive-Files"] = "zip"
         else:

--- a/lib/galaxy/util/zipstream.py
+++ b/lib/galaxy/util/zipstream.py
@@ -42,7 +42,10 @@ class ZipstreamWrapper:
         headers = {}
         if self.archive_name:
             archive_name = self.archive_name.encode("latin-1", "replace").decode("latin-1")
-            headers["Content-Disposition"] = f'attachment; filename="{archive_name}.zip"'
+            utf8_encoded_filename = quote(self.archive_name, safe="")
+            headers["Content-Disposition"] = (
+                f"attachment; filename=\"{archive_name}.zip\"; filename*=UTF-8''{utf8_encoded_filename}.zip"
+            )
         if self.upstream_mod_zip:
             headers["X-Archive-Files"] = "zip"
         else:

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -1,6 +1,7 @@
 import zipfile
 from io import BytesIO
 from typing import List
+from urllib.parse import quote
 
 from galaxy.util.unittest_utils import skip_if_github_down
 from galaxy_test.base.api_asserts import assert_object_id_error
@@ -189,6 +190,7 @@ class TestDatasetCollectionsApi(ApiTestCase):
             hdca_id = self.dataset_populator.fetch(payload, wait=True).json()["outputs"][0]["id"]
             create_response = self._download_dataset_collection(history_id=history_id, hdca_id=hdca_id)
             self._assert_status_code_is(create_response, 200)
+            assert quote(name, safe="") in create_response.headers["Content-Disposition"]
 
     @requires_new_user
     def test_hda_security(self):

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -6,6 +6,7 @@ from typing import (
     Dict,
     List,
 )
+from urllib.parse import quote
 
 from galaxy.model.unittest_utils.store_fixtures import (
     deferred_hda_model_store_dict,
@@ -897,3 +898,10 @@ class TestDatasetsApi(ApiTestCase):
         response = self._put(f"histories/{history_id}/contents/{hda_id}", data={"datatype": "tabular"}, json=True)
         self._assert_status_code_is(response, 403)
         assert response.json()["err_msg"] == "History is immutable"
+
+    def test_download_non_english_characters(self, history_id):
+        name = "دیتاست"
+        hda = self.dataset_populator.new_dataset(history_id=history_id, name=name, content="data", wait=True)
+        response = self._get(f"histories/{history_id}/contents/{hda['id']}/display?to_ext=json")
+        self._assert_status_code_is(response, 200)
+        assert quote(name, safe="") in response.headers["Content-Disposition"]


### PR DESCRIPTION
Fixes step 3 of #18584
Improve filename handling in data downloads and zipstream headers to support UTF-8 encoding, ensuring proper display of filenames with special characters.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
