### PR TITLE
Add merge migration to merge 2 heads

### DIFF
--- a/lib/galaxy/model/migrations/alembic/versions_gxy/75348cfb3715_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/75348cfb3715_.py
@@ -1,0 +1,21 @@
+"""Merge head revisions
+
+Revision ID: 75348cfb3715
+Revises: 9a5207190a4d, cbc46035eba0
+Create Date: 2024-11-19 11:48:02.273303
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "75348cfb3715"
+down_revision = ("9a5207190a4d", "cbc46035eba0")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Fixes broken migration lineage introduced by merging #18966 and #15860 both of which contain migrations pointing to the same parent migration, which resulted in two head migrations.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
