### PR TITLE
Stabilize HistoryView.test.js

### DIFF
--- a/client/src/components/History/HistoryView.test.js
+++ b/client/src/components/History/HistoryView.test.js
@@ -17,6 +17,11 @@ jest.mock("stores/services/history.services");
 
 const { server, http } = useServerMock();
 
+jest.mock("vue-router/composables", () => ({
+    useRoute: jest.fn(() => ({})),
+    useRouter: jest.fn(() => ({})),
+}));
+
 function create_history(historyId, userId, purged = false, archived = false) {
     const historyName = `${userId}'s History ${historyId}`;
     return {


### PR DESCRIPTION
The test goes kind of crazy without this - producing dozens of error messages as some component or the other tries over and over to render. The same mocking is used ContentItem.test.js. I have a bunch of logging cleanup stuff and errors fixes in https://github.com/galaxyproject/galaxy/pull/19164 - but none of them rise to this level - I think this has a chance of stabilizing the test suite. There is a still a single error in the test output but it is cosmetic and I'll include the fix in #19164.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. cd client; yarn test HistoryView.test.js

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
