### PR TITLE
[24.2] Move invocation view running actions and improve styling of annotation section

### DIFF
--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -12,7 +12,7 @@
                 :run-disabled="hasValidationErrors || !canRunOnHistory"
                 :run-waiting="waitingForRequest"
                 @on-execute="onExecute">
-                <template v-slot:workflow-run-actions>
+                <template v-slot:workflow-title-actions>
                     <b-dropdown
                         v-if="showRuntimeSettings(currentUser)"
                         id="dropdown-form"

--- a/client/src/components/Workflow/Run/WorkflowRunSuccess.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunSuccess.vue
@@ -39,9 +39,9 @@ const wasNewHistoryTarget =
 
 <template>
     <div>
-        <div class="donemessagelarge">
+        <div v-if="props.invocations.length > 1" class="donemessagelarge">
             Successfully invoked workflow <b>{{ props.workflowName }}</b>
-            <em v-if="props.invocations.length > 1"> - {{ props.invocations.length }} times</em>.
+            <em> - {{ props.invocations.length }} times</em>.
             <span v-if="targetHistories.length > 1">
                 This workflow will generate results in multiple histories. You can observe progress in the
                 <router-link to="/histories/view_multiple">history multi-view</router-link>.

--- a/client/src/components/Workflow/WorkflowAnnotation.test.ts
+++ b/client/src/components/Workflow/WorkflowAnnotation.test.ts
@@ -116,7 +116,7 @@ async function mountWorkflowAnnotation(version: "run_form" | "invocation", ownsW
 }
 
 describe("WorkflowAnnotation renders", () => {
-    it("(always) the run count and history, not indicators if owned not published", async () => {
+    it("the run count and history, not indicators if owned not published", async () => {
         async function checkHasRunCount(version: "run_form" | "invocation") {
             const { wrapper } = await mountWorkflowAnnotation(version);
 
@@ -124,7 +124,11 @@ describe("WorkflowAnnotation renders", () => {
             expect(runCount.text()).toContain("workflow runs:");
             expect(runCount.text()).toContain(SAMPLE_RUN_COUNT.toString());
 
-            expect(wrapper.find(SELECTORS.SWITCH_TO_HISTORY_LINK).text()).toBe(TEST_HISTORY.name);
+            if (version === "run_form") {
+                expect(wrapper.find(SELECTORS.SWITCH_TO_HISTORY_LINK).exists()).toBe(false);
+            } else {
+                expect(wrapper.find(SELECTORS.SWITCH_TO_HISTORY_LINK).text()).toBe(TEST_HISTORY.name);
+            }
 
             // Since this is the user's own workflow, the indicators link
             // (to view all published workflows by the owner) should not be present

--- a/client/src/components/Workflow/WorkflowAnnotation.vue
+++ b/client/src/components/Workflow/WorkflowAnnotation.vue
@@ -69,8 +69,8 @@ const workflowTags = computed(() => {
                     </span>
                     <UtcDate :date="timeElapsed" mode="elapsed" data-description="workflow annotation date" />
                 </i>
-                <span class="d-flex flex-gapx-1 align-items-center">
-                    <FontAwesomeIcon :icon="faHdd" />Input History:
+                <span v-if="invocationUpdateTime" class="d-flex flex-gapx-1 align-items-center">
+                    <FontAwesomeIcon :icon="faHdd" />History:
                     <SwitchToHistoryLink :history-id="props.historyId" />
                     <BBadge
                         v-if="props.newHistoryTarget && useHistoryStore().currentHistoryId !== props.historyId"

--- a/client/src/components/Workflow/WorkflowAnnotation.vue
+++ b/client/src/components/Workflow/WorkflowAnnotation.vue
@@ -92,8 +92,9 @@ const workflowTags = computed(() => {
             </div>
         </div>
         <div v-if="props.showDetails">
-            <TextSummary v-if="description" class="my-1" :description="description" />
+            <TextSummary v-if="description" class="my-1" :description="description" one-line-summary component="span" />
             <StatelessTags v-if="workflowTags.length" :value="workflowTags" :disabled="true" />
+            <hr class="mb-0 mt-2" />
         </div>
     </div>
 </template>

--- a/client/src/components/Workflow/WorkflowNavigationTitle.vue
+++ b/client/src/components/Workflow/WorkflowNavigationTitle.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faEdit, faSitemap, faSpinner, faUpload } from "@fortawesome/free-solid-svg-icons";
+import { faEdit, faSitemap, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BButton, BButtonGroup } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
@@ -28,7 +28,6 @@ interface Props {
     workflowId: string;
     runDisabled?: boolean;
     runWaiting?: boolean;
-    invocationRunning?: boolean;
     success?: boolean;
 }
 
@@ -104,8 +103,7 @@ const workflowImportTitle = computed(() => {
                 <div class="d-flex portlet-header align-items-center">
                     <div class="flex-grow-1" data-description="workflow heading">
                         <div class="px-1">
-                            <FontAwesomeIcon v-if="props.invocationRunning" :icon="faSpinner" spin />
-                            <FontAwesomeIcon v-else :icon="faSitemap" />
+                            <FontAwesomeIcon :icon="faSitemap" />
                             <b class="mx-1">
                                 {{ props.invocation ? "Invoked " : "" }}Workflow: {{ getWorkflowName() }}
                             </b>

--- a/client/src/components/Workflow/WorkflowNavigationTitle.vue
+++ b/client/src/components/Workflow/WorkflowNavigationTitle.vue
@@ -29,6 +29,7 @@ interface Props {
     runDisabled?: boolean;
     runWaiting?: boolean;
     invocationRunning?: boolean;
+    success?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -85,20 +86,20 @@ const workflowImportTitle = computed(() => {
 
 <template>
     <div>
-        <div>
-            <BAlert v-if="importErrorMessage" variant="danger" dismissible show @dismissed="importErrorMessage = null">
-                {{ importErrorMessage }}
-            </BAlert>
-            <BAlert v-else-if="importedWorkflow" variant="info" dismissible show @dismissed="importedWorkflow = null">
-                <span>
-                    Workflow <b>{{ importedWorkflow.name }}</b> imported successfully.
-                </span>
-                <RouterLink to="/workflows/list">Click here</RouterLink> to view the imported workflow in the workflows
-                list.
-            </BAlert>
+        <BAlert v-if="importErrorMessage" variant="danger" dismissible show @dismissed="importErrorMessage = null">
+            {{ importErrorMessage }}
+        </BAlert>
+        <BAlert v-else-if="importedWorkflow" variant="info" dismissible show @dismissed="importedWorkflow = null">
+            <span>
+                Workflow <b>{{ importedWorkflow.name }}</b> imported successfully.
+            </span>
+            <RouterLink to="/workflows/list">Click here</RouterLink> to view the imported workflow in the workflows
+            list.
+        </BAlert>
 
-            <BAlert v-if="error" variant="danger" show>{{ error }}</BAlert>
+        <BAlert v-if="error" variant="danger" show>{{ error }}</BAlert>
 
+        <div class="position-relative">
             <div v-if="workflow" class="ui-portlet-section">
                 <div class="d-flex portlet-header align-items-center">
                     <div class="flex-grow-1" data-description="workflow heading">
@@ -165,6 +166,30 @@ const workflowImportTitle = computed(() => {
                     </BButtonGroup>
                 </div>
             </div>
+            <div v-if="props.success" class="donemessagelarge">
+                Successfully invoked workflow
+                <b>{{ getWorkflowName() }}</b>
+            </div>
         </div>
     </div>
 </template>
+
+<style scoped lang="scss">
+@keyframes fadeOut {
+    0% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+        display: none;
+        pointer-events: none;
+    }
+}
+
+.donemessagelarge {
+    top: 0;
+    position: absolute;
+    width: 100%;
+    animation: fadeOut 3s forwards;
+}
+</style>

--- a/client/src/components/Workflow/WorkflowNavigationTitle.vue
+++ b/client/src/components/Workflow/WorkflowNavigationTitle.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faEdit, faSitemap, faUpload } from "@fortawesome/free-solid-svg-icons";
+import { faEdit, faSitemap, faSpinner, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BButton, BButtonGroup } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
@@ -28,6 +28,7 @@ interface Props {
     workflowId: string;
     runDisabled?: boolean;
     runWaiting?: boolean;
+    invocationRunning?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -102,7 +103,8 @@ const workflowImportTitle = computed(() => {
                 <div class="d-flex portlet-header align-items-center">
                     <div class="flex-grow-1" data-description="workflow heading">
                         <div class="px-1">
-                            <FontAwesomeIcon :icon="faSitemap" />
+                            <FontAwesomeIcon v-if="props.invocationRunning" :icon="faSpinner" spin />
+                            <FontAwesomeIcon v-else :icon="faSitemap" />
                             <b class="mx-1">
                                 {{ props.invocation ? "Invoked " : "" }}Workflow: {{ getWorkflowName() }}
                             </b>

--- a/client/src/components/Workflow/WorkflowNavigationTitle.vue
+++ b/client/src/components/Workflow/WorkflowNavigationTitle.vue
@@ -138,7 +138,7 @@ const workflowImportTitle = computed(() => {
                             :action="onImport">
                         </AsyncButton>
 
-                        <slot name="workflow-run-actions" />
+                        <slot name="workflow-title-actions" />
 
                         <ButtonSpinner
                             v-if="!props.invocation"

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.ts
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.ts
@@ -15,7 +15,7 @@ const selectors = {
     invocationSummary: ".invocation-overview",
     bAlertStub: "balert-stub",
     spanElement: "span",
-    invocationReportTab: "btab-stub[title='Report']",
+    invocationReportTab: '[titleitemclass="invocation-report-tab"]',
     fullPageHeading: "anonymous-stub[h1='true']",
 };
 

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -341,6 +341,19 @@ function cancelWorkflowSchedulingLocal() {
             <BTab title="Metrics" :lazy="true">
                 <WorkflowInvocationMetrics :invocation-id="invocation.id"></WorkflowInvocationMetrics>
             </BTab>
+            <template v-slot:tabs-end>
+                <BButton
+                    v-if="!props.isFullPage && !invocationAndJobTerminal"
+                    v-b-tooltip.noninteractive.hover
+                    class="ml-auto my-1"
+                    title="Cancel scheduling of workflow invocation"
+                    data-description="cancel invocation button"
+                    size="sm"
+                    @click="onCancel">
+                    <FontAwesomeIcon :icon="faTimes" fixed-width />
+                    Cancel Workflow
+                </BButton>
+            </template>
         </BTabs>
     </div>
     <BAlert v-else-if="errorMessage" variant="danger" show>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -230,10 +230,11 @@ function cancelWorkflowSchedulingLocal() {
 <template>
     <div v-if="invocation" class="d-flex flex-column w-100" data-description="workflow invocation state">
         <WorkflowNavigationTitle
-            v-if="props.isFullPage && !props.success"
+            v-if="props.isFullPage"
             :invocation="invocation"
             :workflow-id="invocation.workflow_id"
-            :invocation-running="!invocationAndJobTerminal">
+            :invocation-running="!invocationAndJobTerminal"
+            :success="props.success">
             <template v-slot:workflow-title-actions>
                 <BButton
                     v-if="!invocationAndJobTerminal"

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -233,7 +233,6 @@ function cancelWorkflowSchedulingLocal() {
             v-if="props.isFullPage"
             :invocation="invocation"
             :workflow-id="invocation.workflow_id"
-            :invocation-running="!invocationAndJobTerminal"
             :success="props.success">
             <template v-slot:workflow-title-actions>
                 <BButton

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faExclamation, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { faExclamation, faSquare, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BBadge, BButton, BTab, BTabs } from "bootstrap-vue";
 import { computed, onUnmounted, ref, watch } from "vue";
@@ -233,7 +233,22 @@ function cancelWorkflowSchedulingLocal() {
             v-if="props.isFullPage && !props.success"
             :invocation="invocation"
             :workflow-id="invocation.workflow_id"
-            :invocation-running="!invocationAndJobTerminal" />
+            :invocation-running="!invocationAndJobTerminal">
+            <template v-slot:workflow-title-actions>
+                <BButton
+                    v-if="!invocationAndJobTerminal"
+                    v-b-tooltip.noninteractive.hover
+                    title="Cancel scheduling of workflow invocation"
+                    data-description="header cancel invocation button"
+                    size="sm"
+                    class="text-decoration-none"
+                    variant="link"
+                    @click="onCancel">
+                    <FontAwesomeIcon :icon="faSquare" fixed-width />
+                    Cancel
+                </BButton>
+            </template>
+        </WorkflowNavigationTitle>
         <WorkflowAnnotation
             v-if="props.isFullPage"
             :workflow-id="invocation.workflow_id"
@@ -274,17 +289,6 @@ function cancelWorkflowSchedulingLocal() {
                         :loading="!invocationAndJobTerminal"
                         class="jobs-progress" />
                 </div>
-                <BButton
-                    v-if="!invocationAndJobTerminal"
-                    v-b-tooltip.noninteractive.hover
-                    title="Cancel scheduling of workflow invocation"
-                    data-description="cancel invocation button"
-                    size="sm"
-                    pill
-                    variant="outline-danger"
-                    @click="onCancel">
-                    <FontAwesomeIcon :icon="faTimes" fixed-width />
-                </BButton>
             </template>
         </WorkflowAnnotation>
         <BTabs

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
-import { faDownload, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { faExclamation, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BButton, BNavItem, BTab, BTabs } from "bootstrap-vue";
+import { BAlert, BBadge, BButton, BTab, BTabs } from "bootstrap-vue";
 import { computed, onUnmounted, ref, watch } from "vue";
 
 import { type InvocationJobsSummary, type InvocationStep, type WorkflowInvocationElementView } from "@/api/invocations";
 import { useAnimationFrameResizeObserver } from "@/composables/sensors/animationFrameResizeObserver";
-import { getRootFromIndexLink } from "@/onload";
 import { useInvocationStore } from "@/stores/invocationStore";
 import { useWorkflowStore } from "@/stores/workflowStore";
 import { errorMessageAsString } from "@/utils/simple-error";
@@ -67,11 +66,15 @@ watch(
     }
 );
 
-// Report and PDF generation
-const generatePdfTooltip = "Generate PDF report for this workflow invocation";
-const invocationPdfLink = computed<string | null>(
-    () => getRootFromIndexLink() + `api/invocations/${props.invocationId}/report.pdf`
+const workflowStore = useWorkflowStore();
+const reportTabDisabled = computed(
+    () =>
+        !invocationStateSuccess.value ||
+        !invocation.value ||
+        !workflowStore.getStoredWorkflowByInstanceId(invocation.value.workflow_id)
 );
+
+/** Tooltip message for the report tab when it is disabled */
 const disabledReportTooltip = computed(() => {
     const state = invocationState.value;
     if (state != "scheduled") {
@@ -175,8 +178,6 @@ const jobStatesStr = computed(() => {
     return `${jobStr}.`;
 });
 
-const workflowStore = useWorkflowStore();
-
 watch(
     () => props.invocationId,
     async (id) => {
@@ -231,7 +232,8 @@ function cancelWorkflowSchedulingLocal() {
         <WorkflowNavigationTitle
             v-if="props.isFullPage && !props.success"
             :invocation="invocation"
-            :workflow-id="invocation.workflow_id" />
+            :workflow-id="invocation.workflow_id"
+            :invocation-running="!invocationAndJobTerminal" />
         <WorkflowAnnotation
             v-if="props.isFullPage"
             :workflow-id="invocation.workflow_id"
@@ -272,6 +274,17 @@ function cancelWorkflowSchedulingLocal() {
                         :loading="!invocationAndJobTerminal"
                         class="jobs-progress" />
                 </div>
+                <BButton
+                    v-if="!invocationAndJobTerminal"
+                    v-b-tooltip.noninteractive.hover
+                    title="Cancel scheduling of workflow invocation"
+                    data-description="cancel invocation button"
+                    size="sm"
+                    pill
+                    variant="outline-danger"
+                    @click="onCancel">
+                    <FontAwesomeIcon :icon="faTimes" fixed-width />
+                </BButton>
             </template>
         </WorkflowAnnotation>
         <BTabs
@@ -301,13 +314,20 @@ function cancelWorkflowSchedulingLocal() {
             </BTab> -->
             <BTab
                 v-if="!props.isSubworkflow"
-                title="Report"
                 title-item-class="invocation-report-tab"
-                :disabled="
-                    !invocationStateSuccess || !workflowStore.getStoredWorkflowByInstanceId(invocation.workflow_id)
-                "
+                :disabled="reportTabDisabled"
                 :lazy="reportLazy"
                 :active.sync="reportActive">
+                <template v-slot:title>
+                    <span>Report</span>
+                    <BBadge
+                        v-if="reportTabDisabled"
+                        v-b-tooltip.hover.noninteractive
+                        :title="disabledReportTooltip"
+                        variant="warning">
+                        <FontAwesomeIcon :icon="faExclamation" />
+                    </BBadge>
+                </template>
                 <InvocationReport v-if="invocationStateSuccess" :invocation-id="invocation.id" />
             </BTab>
             <BTab title="Export" lazy>
@@ -321,37 +341,6 @@ function cancelWorkflowSchedulingLocal() {
             <BTab title="Metrics" :lazy="true">
                 <WorkflowInvocationMetrics :invocation-id="invocation.id"></WorkflowInvocationMetrics>
             </BTab>
-            <template v-slot:tabs-end>
-                <BNavItem v-if="!invocationAndJobTerminal" class="ml-auto alert-info mr-1">
-                    <LoadingSpan message="Waiting to complete invocation" />
-                    <BButton
-                        v-b-tooltip.noninteractive.hover
-                        title="Cancel scheduling of workflow invocation"
-                        data-description="cancel invocation button"
-                        size="sm"
-                        variant="danger"
-                        @click="onCancel">
-                        <FontAwesomeIcon :icon="faTimes" fixed-width />
-                        Cancel Workflow
-                    </BButton>
-                </BNavItem>
-                <li
-                    role="presentation"
-                    class="nav-item align-self-center mr-2"
-                    :class="{ 'ml-auto': invocationAndJobTerminal }"
-                    data-description="generate pdf report button">
-                    <BButton
-                        v-b-tooltip.hover.bottom.noninteractive
-                        :title="invocationStateSuccess ? generatePdfTooltip : disabledReportTooltip"
-                        :disabled="!invocationStateSuccess"
-                        :href="invocationPdfLink"
-                        size="sm"
-                        target="_blank">
-                        <FontAwesomeIcon :icon="faDownload" fixed-width />
-                        Generate PDF
-                    </BButton>
-                </li>
-            </template>
         </BTabs>
     </div>
     <BAlert v-else-if="errorMessage" variant="danger" show>
@@ -364,6 +353,15 @@ function cancelWorkflowSchedulingLocal() {
         <span v-localize>Invocation not found.</span>
     </BAlert>
 </template>
+
+<style lang="scss">
+// To show the tooltip on the disabled report tab badge
+.invocation-report-tab {
+    .nav-link.disabled {
+        pointer-events: auto !important;
+    }
+}
+</style>
 
 <style scoped lang="scss">
 .progress-bars {


### PR DESCRIPTION
The actions for a currently running workflow were added in the `tabs-end` slot in #18615  Here, we remove controls from there and the `BAlert` and instead:
- The icon on the top left is a loading one when workflow is running
- The cancel button is ~~next to the progress bars~~ now in the title actions (next to the Play button)
- We remove the "Generate PDF" button entirely

Fixes https://github.com/galaxyproject/galaxy/issues/19158

Also lets the workflow description/annotation take up full width, and adds a `<hr>` below it to separate from the run form.

Fixes https://github.com/galaxyproject/galaxy/issues/19157

| Before 🟥  |
| ---- |
| ![invocation_controls_fix_BEFORE](https://github.com/user-attachments/assets/c25b0b21-0ce0-43d2-97ab-45ec7835501d) | 

| Now ✅ |
| ---- |
| ![invocation_controls_fix_AFTER](https://github.com/user-attachments/assets/4d7fb719-aa38-4520-94e9-225762eca596) |

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
