### PR TITLE
[24.1] Remove the default `Incoming` suffix in `GenericModel` class

### DIFF
--- a/lib/galaxy/schema/generics.py
+++ b/lib/galaxy/schema/generics.py
@@ -1,5 +1,7 @@
+import sys
 from typing import (
     Any,
+    Generic,
     Tuple,
     Type,
     TypeVar,
@@ -7,6 +9,7 @@ from typing import (
 
 from pydantic import BaseModel
 from pydantic.json_schema import GenerateJsonSchema
+from typing_extensions import override
 
 from galaxy.schema.fields import (
     DecodedDatabaseIdField,
@@ -50,3 +53,46 @@ class CustomJsonSchema(GenerateJsonSchema):
             for i, choice in enumerate(choices):
                 choices[i] = choice.replace(choices[0], ref_to_name[ref])  # type: ignore[call-overload]
         return full_def
+
+
+class PatchGenericPickle:
+    """A mixin that allows generic pydantic models to be serialized and deserialized with pickle.
+
+    Notes
+    ----
+    In general, pickle shouldn't be encouraged as a means of serialization since there are better,
+    safer options. In some cases e.g. Streamlit's `@st.cache_data there's no getting around
+    needing to use pickle.
+
+    As of Pydantic 2.7, generics don't properly work with pickle. The core issue is the following
+    1. For each specialized generic, pydantic creates a new subclass at runtime. This class
+       has a `__qualname__` that contains the type var argument e.g. `"MyGeneric[str]"` for a
+       `class MyGeneric(BaseModel, Generic[T])`.
+    2. Pickle attempts to find a symbol with the value of `__qualname__` in the module where the
+       class was defined, which fails since Pydantic defines that class dynamically at runtime.
+       Pydantic does attempt to register these dynamic classes but currently only for classes
+       defined at the top-level of the interpreter.
+
+    See Also
+    --------
+    - https://github.com/pydantic/pydantic/issues/9390
+    """
+
+    @classmethod
+    @override
+    def __init_subclass__(cls, **kwargs):
+        # Note: we're still in __init_subclass__, not yet in __pydantic_init_subclass__
+        #  not all model_fields are available at this point.
+        super().__init_subclass__(**kwargs)
+
+        if not issubclass(cls, BaseModel):
+            raise TypeError("PatchGenericPickle can only be used with subclasses of pydantic.BaseModel")
+        if not issubclass(cls, Generic):  # type: ignore [arg-type]
+            raise TypeError("PatchGenericPickle can only be used with Generic models")
+
+        qualname = cls.__qualname__
+        declaring_module = sys.modules[cls.__module__]
+        if qualname not in declaring_module.__dict__:
+            # This should work in all cases, but we might need to make this check and update more
+            # involved e.g. see pydantic._internal._generics.create_generic_submodel
+            declaring_module.__dict__[qualname] = cls

--- a/lib/galaxy/schema/notifications.py
+++ b/lib/galaxy/schema/notifications.py
@@ -26,6 +26,7 @@ from galaxy.schema.fields import (
 from galaxy.schema.generics import (
     DatabaseIdT,
     GenericModel,
+    PatchGenericPickle,
 )
 from galaxy.schema.schema import Model
 from galaxy.schema.types import (
@@ -264,7 +265,7 @@ class NotificationCreateData(Model):
     )
 
 
-class GenericNotificationRecipients(GenericModel, Generic[DatabaseIdT]):
+class GenericNotificationRecipients(GenericModel, Generic[DatabaseIdT], PatchGenericPickle):
     """The recipients of a notification. Can be a combination of users, groups and roles."""
 
     user_ids: List[DatabaseIdT] = Field(


### PR DESCRIPTION
Fixes:

```
Traceback (most recent call last):
  File "/opt/galaxy/venv/lib/python3.11/site-packages/celery/worker/worker.py", line 202, in start
    self.blueprint.start(self)
  File "/opt/galaxy/venv/lib/python3.11/site-packages/celery/bootsteps.py", line 116, in start
    step.start(parent)
  File "/opt/galaxy/venv/lib/python3.11/site-packages/celery/bootsteps.py", line 365, in start
    return self.obj.start()
           ^^^^^^^^^^^^^^^^
  File "/opt/galaxy/venv/lib/python3.11/site-packages/celery/worker/consumer/consumer.py", line 340, in start
    blueprint.start(self)
  File "/opt/galaxy/venv/lib/python3.11/site-packages/celery/bootsteps.py", line 116, in start
    step.start(parent)
  File "/opt/galaxy/venv/lib/python3.11/site-packages/celery/worker/consumer/consumer.py", line 746, in start
    c.loop(*c.loop_args())
  File "/opt/galaxy/venv/lib/python3.11/site-packages/celery/worker/loops.py", line 97, in asynloop
    next(loop)
  File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/asynchronous/hub.py", line 373, in create_loop
    cb(*cbargs)
  File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/transport/base.py", line 248, in on_readable
    reader(loop)
  File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/transport/base.py", line 230, in _read
    drain_events(timeout=0)
  File "/opt/galaxy/venv/lib/python3.11/site-packages/amqp/connection.py", line 526, in drain_events
    while not self.blocking_read(timeout):
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/galaxy/venv/lib/python3.11/site-packages/amqp/connection.py", line 532, in blocking_read
    return self.on_inbound_frame(frame)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/galaxy/venv/lib/python3.11/site-packages/amqp/method_framing.py", line 77, in on_frame
    callback(channel, msg.frame_method, msg.frame_args, msg)
  File "/opt/galaxy/venv/lib/python3.11/site-packages/amqp/connection.py", line 538, in on_inbound_method
    return self.channels[channel_id].dispatch_method(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/galaxy/venv/lib/python3.11/site-packages/amqp/abstract_channel.py", line 156, in dispatch_method
    listener(*args)
  File "/opt/galaxy/venv/lib/python3.11/site-packages/amqp/channel.py", line 1629, in _on_basic_deliver
    fun(msg)
  File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/messaging.py", line 656, in _receive_callback
    return on_m(message) if on_m else self.receive(decoded, message)
           ^^^^^^^^^^^^^
  File "/opt/galaxy/venv/lib/python3.11/site-packages/celery/worker/consumer/consumer.py", line 685, in on_task_received
    strategy(
  File "/opt/galaxy/venv/lib/python3.11/site-packages/celery/worker/strategy.py", line 207, in task_message_handler
    handle(req)
  File "/opt/galaxy/venv/lib/python3.11/site-packages/celery/worker/worker.py", line 220, in _process_task_sem
    return self._quick_acquire(self._process_task, req)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/galaxy/venv/lib/python3.11/site-packages/kombu/asynchronous/semaphore.py", line 75, in acquire
    callback(*partial_args, **partial_kwargs)
  File "/opt/galaxy/venv/lib/python3.11/site-packages/celery/worker/worker.py", line 225, in _process_task
    req.execute_using_pool(self.pool)
  File "/opt/galaxy/venv/lib/python3.11/site-packages/celery/worker/request.py", line 754, in execute_using_pool
    result = apply_async(
             ^^^^^^^^^^^^
  File "/opt/galaxy/venv/lib/python3.11/site-packages/celery/concurrency/base.py", line 153, in apply_async
    return self.on_apply(target, args, kwargs,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/galaxy/venv/lib/python3.11/site-packages/billiard/pool.py", line 1527, in apply_async
    self._quick_put((TASK, (result._job, None, func, args, kwds)))
  File "/opt/galaxy/venv/lib/python3.11/site-packages/celery/concurrency/asynpool.py", line 868, in send_job
    body = dumps(tup, protocol=protocol)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_pickle.PicklingError: Can't pickle <class 'galaxy.schema.notifications.NotificationRecipientsIncoming'>: attribute lookup NotificationRecipientsIncoming on galaxy.schema.notifications failed
```

Notice that this happens only with certain Python/Celery/Pydantic version combinations (i.e. Python3.11.5 / Celery5.4.0 / Pydantic2.7.4).

This issue was crashing every worker trying to pick up the task with a generic model in the parameters. In particular, `send_notification_to_recipients_async`.

The `NotificationRecipientsIncoming` dynamically created model from the generic is not yet available in the module. 

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
