### PR TITLE
Do not overwrite PR title on edit

### DIFF
--- a/.github/workflows/pr-title-update.yml
+++ b/.github/workflows/pr-title-update.yml
@@ -2,7 +2,7 @@ name: Update PR title
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, reopened]
     branches:
       - "release_**"
 

--- a/.github/workflows/pr-title-update.yml
+++ b/.github/workflows/pr-title-update.yml
@@ -2,7 +2,7 @@ name: Update PR title
 
 on:
   pull_request_target:
-    types: [opened, edited]
+    types: [opened]
     branches:
       - "release_**"
 


### PR DESCRIPTION
The new title bot will overwrite the PR title even if you edit that title manually. I think that's not what we want it to do: there may be legitimate cases when we remove the version prefix from the title, and we don't want the bot to immediately add it back.

This change ensures the title is auto-updated only once, when the PR is opened.



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
