### PR TITLE
[24.0] Update title of edited PRs only if base ref changed

### DIFF
--- a/.github/workflows/pr-title-update.yml
+++ b/.github/workflows/pr-title-update.yml
@@ -2,17 +2,17 @@ name: Update PR title
 
 on:
   pull_request_target:
-    types: [opened, edited]
+    types: [opened, edited, reopened]
     branches:
       - "release_**"
 
 jobs:
   update-title:
+    if: github.event.action != 'edited' || github.event.changes.base.ref.from != ''
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
       - name: Update PR title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -23,5 +23,5 @@ jobs:
           VERSION=$(echo $TARGET_BRANCH | grep -oP '\d+\.\d+')
           if [[ -n "$VERSION" && ! "$PR_TITLE" =~ ^\[$VERSION\] ]]; then
             NEW_TITLE="[$VERSION] $PR_TITLE"
-            gh pr edit $PR_NUMBER --title "$NEW_TITLE"
+            gh pr edit $PR_NUMBER --repo "${{ github.repository }}" --title "$NEW_TITLE"
           fi


### PR DESCRIPTION
Also:
- Update title of reopened PRs too.
- Don't unnecessarily checkout the repo.

Alternative to https://github.com/galaxyproject/galaxy/pull/19177 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
