### PR TITLE
Use resource_path for datatypes linter

### DIFF
--- a/lib/galaxy/tool_util/linters/datatypes.py
+++ b/lib/galaxy/tool_util/linters/datatypes.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 DATATYPES_CONF = resource_path(linters, "datatypes_conf.xml.sample")
 
 
-def _parse_datatypes(datatype_conf_path: str) -> Set[str]:
+def _parse_datatypes(datatype_conf_path) -> Set[str]:
     datatypes = set()
     tree = parse_xml(datatype_conf_path)
     root = tree.getroot()

--- a/lib/galaxy/tool_util/linters/datatypes.py
+++ b/lib/galaxy/tool_util/linters/datatypes.py
@@ -5,17 +5,19 @@ from typing import (
 )
 
 # from galaxy import config
+from galaxy.tool_util import linters
 from galaxy.tool_util.lint import Linter
 from galaxy.util import (
     listify,
     parse_xml,
 )
+from galaxy.util.resources import resource_path
 
 if TYPE_CHECKING:
     from galaxy.tool_util.lint import LintContext
     from galaxy.tool_util.parser import ToolSource
 
-DATATYPES_CONF = os.path.join(os.path.dirname(__file__), "datatypes_conf.xml.sample")
+DATATYPES_CONF = resource_path(linters, "datatypes_conf.xml.sample")
 
 
 def _parse_datatypes(datatype_conf_path: str) -> Set[str]:


### PR DESCRIPTION
https://github.com/galaxyproject/galaxy/pull/17600#discussion_r1854230715

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
