### PR TITLE
Don't calculate dataset hash for datasets in non-OK state

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2042,7 +2042,7 @@ class MinimalJobWrapper(HasResourceParameters):
         # Calculate dataset hash
         for dataset_assoc in output_dataset_associations:
             dataset = dataset_assoc.dataset.dataset
-            if not dataset.purged and dataset.state != Dataset.states.DEFERRED and not dataset.hashes:
+            if not dataset.purged and dataset.state == Dataset.states.OK and not dataset.hashes:
                 if self.app.config.calculate_dataset_hash == "always" or (
                     self.app.config.calculate_dataset_hash == "upload" and job.tool_id in ("upload1", "__DATA_FETCH__")
                 ):

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -161,8 +161,11 @@ class DatasetManager(base.ModelManager[Dataset], secured.AccessibleManagerMixin,
             sa_session.commit()
 
     def compute_hash(self, request: ComputeDatasetHashTaskRequest):
-        # For files in extra_files_path
         dataset = self.by_id(request.dataset_id)
+        if dataset.purged:
+            log.warning("Unable to calculate hash for purged dataset [%s].", dataset.id)
+            return
+        # For files in extra_files_path
         extra_files_path = request.extra_files_path
         if extra_files_path:
             extra_dir = dataset.extra_files_path_name
@@ -192,7 +195,7 @@ class DatasetManager(base.ModelManager[Dataset], secured.AccessibleManagerMixin,
                     f"Re-calculated dataset hash for dataset [{dataset.id}] and new hash value [{calculated_hash_value}] does not equal previous hash value [{old_hash_value}]."
                 )
             else:
-                log.debug("Duplicated dataset hash request, no update to the database.")
+                log.debug("Duplicated dataset hash request for dataset [%s], no update to the database.", dataset.id)
 
     # TODO: implement above for groups
     # TODO: datatypes?


### PR DESCRIPTION
Also:
- Check again that the dataset hasn't been purged right before hash calculation starts.

Address comments in
https://github.com/galaxyproject/galaxy/pull/19181/files#r1853605980

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
