### PR TITLE
Cleanup test output console for tool panel tests.

### DIFF
--- a/client/src/components/Panels/Common/ToolSearch.test.js
+++ b/client/src/components/Panels/Common/ToolSearch.test.js
@@ -21,6 +21,7 @@ describe("ToolSearch", () => {
                 showAdvanced: false,
                 toolsList: [],
                 currentPanel: {},
+                useWorker: false,
             },
             localVue,
             router,

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -36,6 +36,7 @@ const props = defineProps({
     editorWorkflows: { type: Array, default: null },
     dataManagers: { type: Array, default: null },
     moduleSections: { type: Array as PropType<Record<string, any>>, default: null },
+    useSearchWorker: { type: Boolean, default: true },
 });
 
 library.add(faEye, faEyeSlash);
@@ -200,6 +201,7 @@ function onToggle() {
                 :current-panel="localSectionsById"
                 :query="query"
                 :query-pending="queryPending"
+                :use-worker="useSearchWorker"
                 @onQuery="(q) => (query = q)"
                 @onResults="onResults" />
             <section v-if="!propShowAdvanced">

--- a/client/src/components/Panels/ToolPanel.test.ts
+++ b/client/src/components/Panels/ToolPanel.test.ts
@@ -44,6 +44,7 @@ describe("ToolPanel", () => {
                 editorWorkflows: null,
                 dataManagers: null,
                 moduleSections: null,
+                useSearchWorker: false,
             },
             localVue,
             stubs: {

--- a/client/src/components/Panels/ToolPanel.vue
+++ b/client/src/components/Panels/ToolPanel.vue
@@ -20,6 +20,7 @@ const props = defineProps({
     editorWorkflows: { type: Array, default: null },
     dataManagers: { type: Array, default: null },
     moduleSections: { type: Array, default: null },
+    useSearchWorker: { type: Boolean, default: true },
 });
 
 const emit = defineEmits<{
@@ -201,6 +202,7 @@ watch(
             :editor-workflows="editorWorkflows"
             :data-managers="dataManagers"
             :module-sections="moduleSections"
+            :use-search-worker="useSearchWorker"
             @updatePanelView="updatePanelView"
             @onInsertTool="onInsertTool"
             @onInsertModule="onInsertModule"


### PR DESCRIPTION
For jest tests - do not use Worker for tool search. Really cleans up the errors in the console for these tests.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
