### PR TITLE
[24.2] Fix default value handling for parameters connected to required parameters

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8174,10 +8174,6 @@ class WorkflowStep(Base, RepresentById, UsesCreateAndUpdateTime):
         assert self.is_input_type, "step.input_type can only be called on input step types"
         return self.STEP_TYPE_TO_INPUT_TYPE[self.type]
 
-    @property
-    def input_default_value(self):
-        self.get_input_default_value(None)
-
     def get_input_default_value(self, default_default):
         # parameter_input and the data parameters handle this slightly differently
         # unfortunately.

--- a/lib/galaxy/tool_util/models.py
+++ b/lib/galaxy/tool_util/models.py
@@ -172,6 +172,7 @@ class TestJob(StrictModel):
     doc: Optional[str]
     job: JobDict
     outputs: Dict[str, TestOutputAssertions]
+    expect_failure: Optional[bool] = False
 
 
 Tests = RootModel[List[TestJob]]
@@ -185,6 +186,7 @@ OutputsDict = Dict[str, OutputChecks]
 class TestJobDict(TypedDict):
     doc: NotRequired[str]
     job: NotRequired[JobDict]
+    expect_failure: NotRequired[bool]
     outputs: OutputsDict
 
 

--- a/lib/galaxy/tool_util/parser/parameter_validators.py
+++ b/lib/galaxy/tool_util/parser/parameter_validators.py
@@ -313,7 +313,7 @@ class EmptyFieldParameterValidatorModel(StaticValidatorModel):
 
     @staticmethod
     def empty_validate(value: Any, validator: "ValidatorDescription"):
-        raise_error_if_valiation_fails((value != ""), validator)
+        raise_error_if_valiation_fails((value not in ("", None)), validator)
 
     def statically_validate(self, value: Any) -> None:
         EmptyFieldParameterValidatorModel.empty_validate(value, self)

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -368,11 +368,7 @@ class SimpleTextToolParameter(ToolParameter):
 
     def to_json(self, value, app, use_security):
         """Convert a value to a string representation suitable for persisting"""
-        if value is None:
-            rval = "" if not self.optional else None
-        else:
-            rval = unicodify(value)
-        return rval
+        return unicodify(value)
 
     def get_initial_value(self, trans, other_values):
         return self.value

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1260,12 +1260,15 @@ class InputParameterModule(WorkflowModule):
 
             when_true = ConditionalWhen()
             when_true.value = "true"
-            when_true.inputs = {}
-            when_true.inputs["default"] = specify_default_cond
+            when_true.inputs = {"default": specify_default_cond}
 
             when_false = ConditionalWhen()
             when_false.value = "false"
-            when_false.inputs = {}
+            # This is only present for backwards compatibility,
+            # We don't need this conditional since you can set
+            # a default value for optional and required parameters.
+            # TODO: version the state and upgrade it to a simpler version
+            when_false.inputs = {"default": specify_default_cond}
 
             optional_cases = [when_true, when_false]
             optional_cond.cases = optional_cases
@@ -1504,6 +1507,7 @@ class InputParameterModule(WorkflowModule):
         parameter_def = self._parse_state_into_dict()
         parameter_type = parameter_def["parameter_type"]
         optional = parameter_def["optional"]
+        default_value_set = "default" in parameter_def
         default_value = parameter_def.get("default", self.default_default_value)
         if parameter_type not in ["text", "boolean", "integer", "float", "color", "directory_uri"]:
             raise ValueError("Invalid parameter type for workflow parameters encountered.")
@@ -1557,7 +1561,7 @@ class InputParameterModule(WorkflowModule):
 
         parameter_class = parameter_types[client_parameter_type]
 
-        if optional:
+        if default_value_set:
             if client_parameter_type == "select":
                 parameter_kwds["selected"] = default_value
             else:
@@ -1633,7 +1637,6 @@ class InputParameterModule(WorkflowModule):
         if "default" in state:
             default_set = True
             default_value = state["default"]
-            state["optional"] = True
         multiple = state.get("multiple")
         source_validators = state.get("validators")
         restrictions = state.get("restrictions")

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -588,7 +588,8 @@ class WorkflowProgress:
                         )
                     )
             elif step_id in self.inputs_by_step_id:
-                outputs["output"] = self.inputs_by_step_id[step_id]
+                if self.inputs_by_step_id[step_id] is not None or "output" not in outputs:
+                    outputs["output"] = self.inputs_by_step_id[step_id]
 
         if step.label and step.type == "parameter_input" and "output" in outputs:
             self.runtime_replacements[step.label] = str(outputs["output"])

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -574,8 +574,8 @@ class WorkflowProgress:
         if self.inputs_by_step_id:
             step_id = step.id
             if step_id not in self.inputs_by_step_id and "output" not in outputs:
-                default_value = step.input_default_value
-                if default_value or step.input_optional:
+                default_value = step.get_input_default_value(modules.NO_REPLACEMENT)
+                if default_value is not modules.NO_REPLACEMENT:
                     outputs["output"] = default_value
                 else:
                     log.error(f"{step.log_str()} not found in inputs_step_id {self.inputs_by_step_id}")

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3212,7 +3212,7 @@ steps:
 """,
                 test_data="""
 num_lines_param:
-  type: int
+  type: raw
   value: 2
 input collection 1:
   collection_type: list
@@ -7034,12 +7034,14 @@ inputs:
   outer_input_1:
     type: int
     default: 1
+    optional: true
     position:
       left: 0
       top: 0
   outer_input_2:
     type: int
     default: 2
+    optional: true
     position:
       left: 100
       top: 0

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -3362,8 +3362,6 @@ def load_data_dict(
             hda = dataset_populator.new_dataset(history_id, content=value)
             label_map[key] = dataset_populator.ds_entry(hda)
             inputs[key] = hda
-        else:
-            raise ValueError(f"Invalid test_data def {test_data}")
 
     return inputs, label_map, has_uploads
 

--- a/lib/galaxy_test/base/workflow_fixtures.py
+++ b/lib/galaxy_test/base/workflow_fixtures.py
@@ -617,6 +617,7 @@ inputs:
   int_input:
     type: integer
     default: 3
+    optional: true
 steps:
   random:
     tool_id: random_lines1

--- a/lib/galaxy_test/workflow/default_values.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/default_values.gxwf-tests.yml
@@ -8,7 +8,7 @@
       - that: has_text
         text: "1"
 - doc: |
-    Test that null is replaced with default value
+    Test that null is replaced with default value (follows https://www.commonwl.org/v1.2/Workflow.html#WorkflowInputParameter)
   job:
     required_int_with_default:
       type: raw
@@ -21,6 +21,7 @@
         text: "1"
 - doc: |
     Test that empty string is not replaced and fails
+  expect_failure: true
   job:
     required_int_with_default:
       type: raw

--- a/lib/galaxy_test/workflow/default_values.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/default_values.gxwf-tests.yml
@@ -1,0 +1,10 @@
+- doc: |
+    Test that default value doesn't need to be supplied
+  job:
+    input: {}
+  outputs:
+    out:
+      class: File
+      asserts:
+      - that: has_text
+        text: "1"

--- a/lib/galaxy_test/workflow/default_values.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/default_values.gxwf-tests.yml
@@ -1,7 +1,30 @@
 - doc: |
     Test that default value doesn't need to be supplied
+  job: {}
+  outputs:
+    out:
+      class: File
+      asserts:
+      - that: has_text
+        text: "1"
+- doc: |
+    Test that null is replaced with default value
   job:
-    input: {}
+    required_int_with_default:
+      type: raw
+      value: null
+  outputs:
+    out:
+      class: File
+      asserts:
+      - that: has_text
+        text: "1"
+- doc: |
+    Test that empty string is not replaced and fails
+  job:
+    required_int_with_default:
+      type: raw
+      value: ""
   outputs:
     out:
       class: File

--- a/lib/galaxy_test/workflow/default_values.gxwf.yml
+++ b/lib/galaxy_test/workflow/default_values.gxwf.yml
@@ -1,0 +1,17 @@
+class: GalaxyWorkflow
+inputs:
+  required_int_with_default:
+    type: int
+    default: 1
+outputs:
+  out:
+    outputSource: integer_default/out_file1
+steps:
+  integer_default:
+    tool_id: integer_default
+    tool_state:
+      input1: 0
+      input2: 0
+    in:
+      input3:
+        source: required_int_with_default

--- a/lib/galaxy_test/workflow/default_values_optional.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/default_values_optional.gxwf-tests.yml
@@ -1,0 +1,34 @@
+- doc: |
+    Test that default value doesn't need to be supplied
+  job: {}
+  outputs:
+    out:
+      class: File
+      asserts:
+      - that: has_text
+        text: "1"
+- doc: |
+    Test that null is replaced with default value (follows https://www.commonwl.org/v1.2/Workflow.html#WorkflowInputParameter)
+  job:
+    optional_int_with_default:
+      type: raw
+      value: null
+  outputs:
+    out:
+      class: File
+      asserts:
+      - that: has_text
+        text: "1"
+- doc: |
+    Test that empty string is not replaced and fails
+  expect_failure: true
+  job:
+    optional_int_with_default:
+      type: raw
+      value: ""
+  outputs:
+    out:
+      class: File
+      asserts:
+      - that: has_text
+        text: "1"

--- a/lib/galaxy_test/workflow/default_values_optional.gxwf.yml
+++ b/lib/galaxy_test/workflow/default_values_optional.gxwf.yml
@@ -1,0 +1,18 @@
+class: GalaxyWorkflow
+inputs:
+  optional_int_with_default:
+    type: int
+    default: 1
+    optional: true
+outputs:
+  out:
+    outputSource: integer_default/out_file1
+steps:
+  integer_default:
+    tool_id: integer_default
+    tool_state:
+      input1: 0
+      input2: 0
+    in:
+      input3:
+        source: optional_int_with_default


### PR DESCRIPTION
and allow authors to set a default value for optional and non-optional parameters.

https://github.com/galaxyproject/galaxy/pull/19219/commits/59dc2a4b571f22353754df294a18f712581b35b0 fails tests prior to this PR, the fix for that is in 8546b50aab80e12a3728647fd18011fc368809e1 which is why I think we should add this to 24.2.

For optional and non-optional parameters we fill the run form with the default value and allow users to change it. The run form will prevent submitting the workflow for a non-optional value if the user has removed the default value, while for an optional parameter the workflow will be submitted with null as input. That aligns with optional input parameter outputs only being connectable to optional inputs.

With this PR we align with https://www.commonwl.org/v1.2/Workflow.html#WorkflowInputParameter:
> The default value to use for this parameter if the parameter is missing from the input object, or if the value of the parameter in the input object is null.

See default_values.gxwf-tests.yml for a test case exercising this

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
