### PR TITLE
[24.2] Fix usability of workflow best practice attribute checking. 

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -60,7 +60,11 @@
                     :license="license"
                     :steps="steps"
                     :datatypes-mapper="datatypesMapper"
-                    @onAttributes="showAttributes"
+                    @onAttributes="
+                        (e) => {
+                            showAttributes(e);
+                        }
+                    "
                     @onHighlight="onHighlight"
                     @onUnhighlight="onUnhighlight"
                     @onRefactor="onAttemptRefactor"
@@ -75,6 +79,7 @@
                     v-else-if="isActiveSideBar('workflow-editor-attributes')"
                     :id="id"
                     :tags="tags"
+                    :highlight="highlightAttribute"
                     :parameters="parameters"
                     :annotation="annotation"
                     :name="name"
@@ -296,10 +301,13 @@ export default {
             parameters.value = getUntypedWorkflowParameters(steps.value);
         }
 
-        function showAttributes() {
+        function showAttributes(args) {
             ensureParametersSet();
             stateStore.activeNodeId = null;
             activityBar.value?.setActiveSideBar("workflow-editor-attributes");
+            if (args.highlight) {
+                this.highlightAttribute = args.highlight;
+            }
         }
 
         const name = ref("Unnamed Workflow");
@@ -521,6 +529,7 @@ export default {
             refactorActions: [],
             scrollToId: null,
             highlightId: null,
+            highlightAttribute: null,
             messageTitle: null,
             messageBody: null,
             messageIsError: false,

--- a/client/src/components/Workflow/Editor/Lint.vue
+++ b/client/src/components/Workflow/Editor/Lint.vue
@@ -7,26 +7,21 @@
             :okay="checkAnnotation"
             success-message="This workflow is annotated. Ideally, this helps the executors of the workflow
                     understand the purpose and usage of the workflow."
-            warning-message="This workflow is not annotated. Providing an annotation helps workflow executors
-                    understand the purpose and usage of the workflow."
+            :warning-message="bestPracticeWarningAnnotation"
             attribute-link="Annotate your Workflow."
-            @onClick="onAttributes" />
+            @onClick="onAttributes('annotation')" />
         <LintSection
             :okay="checkCreator"
             success-message="This workflow defines creator information."
-            warning-message="This workflow does not specify creator(s). This is important metadata for workflows
-                    that will be published and/or shared to help workflow executors know how to cite the
-                    workflow authors."
+            :warning-message="bestPracticeWarningCreator"
             attribute-link="Provide Creator Details."
-            @onClick="onAttributes" />
+            @onClick="onAttributes('creator')" />
         <LintSection
             :okay="checkLicense"
             success-message="This workflow defines a license."
-            warning-message="This workflow does not specify a license. This is important metadata for workflows
-                    that will be published and/or shared to help workflow executors understand how it
-                    may be used."
+            :warning-message="bestPracticeWarningLicense"
             attribute-link="Specify a License."
-            @onClick="onAttributes" />
+            @onClick="onAttributes('license')" />
         <LintSection
             success-message="Workflow parameters are using formal input parameters."
             warning-message="This workflow uses legacy workflow parameters. They should be replaced with
@@ -79,6 +74,9 @@ import { DatatypesMapperModel } from "@/components/Datatypes/model";
 import { useWorkflowStores } from "@/composables/workflowStores";
 
 import {
+    bestPracticeWarningAnnotation,
+    bestPracticeWarningCreator,
+    bestPracticeWarningLicense,
     fixAllIssues,
     fixDisconnectedInput,
     fixUnlabeledOutputs,
@@ -135,6 +133,13 @@ export default {
         const { hasActiveOutputs } = storeToRefs(stepStore);
         return { stores, connectionStore, stepStore, hasActiveOutputs, stateStore };
     },
+    data() {
+        return {
+            bestPracticeWarningAnnotation: bestPracticeWarningAnnotation,
+            bestPracticeWarningCreator: bestPracticeWarningCreator,
+            bestPracticeWarningLicense: bestPracticeWarningLicense,
+        };
+    },
     computed: {
         showRefactor() {
             // we could be even more precise here and check the inputs and such, because
@@ -177,8 +182,9 @@ export default {
         },
     },
     methods: {
-        onAttributes() {
-            this.$emit("onAttributes");
+        onAttributes(highlight) {
+            const args = { highlight: highlight };
+            this.$emit("onAttributes", args);
         },
         onFixUntypedParameter(item) {
             if (

--- a/client/src/components/Workflow/Editor/WorkflowAttributes.vue
+++ b/client/src/components/Workflow/Editor/WorkflowAttributes.vue
@@ -28,7 +28,10 @@
                 </b-list-group-item>
             </b-list-group>
         </div>
-        <div id="workflow-annotation-area" class="mt-2">
+        <div
+            id="workflow-annotation-area"
+            class="mt-2"
+            :class="{ 'bg-secondary': showAnnotationHightlight, 'highlight-attribute': showAnnotationHightlight }">
             <b>Annotation</b>
             <meta itemprop="description" :content="annotationCurrent" />
             <b-textarea
@@ -36,14 +39,50 @@
                 v-model="annotationCurrent"
                 @keyup="$emit('update:annotationCurrent', annotationCurrent)" />
             <div class="form-text text-muted">These notes will be visible when this workflow is viewed.</div>
+            <b-popover
+                custom-class="best-practice-popover"
+                target="workflow-annotation"
+                boundary="window"
+                placement="right"
+                :show.sync="showAnnotationHightlight"
+                triggers="manual"
+                title="Best Practice"
+                :content="bestPracticeWarningAnnotation">
+            </b-popover>
         </div>
-        <div id="workflow-license-area" class="mt-2">
+        <div
+            id="workflow-license-area"
+            class="mt-2"
+            :class="{ 'bg-secondary': showLicenseHightlight, 'highlight-attribute': showLicenseHightlight }">
             <b>License</b>
-            <LicenseSelector :input-license="license" @onLicense="onLicense" />
+            <LicenseSelector id="license-selector" :input-license="license" @onLicense="onLicense" />
+            <b-popover
+                custom-class="best-practice-popover"
+                target="license-selector"
+                boundary="window"
+                placement="right"
+                :show.sync="showLicenseHightlight"
+                triggers="manual"
+                title="Best Practice"
+                :content="bestPracticeWarningLicense">
+            </b-popover>
         </div>
-        <div id="workflow-creator-area" class="mt-2">
+        <div
+            id="workflow-creator-area"
+            class="mt-2"
+            :class="{ 'bg-secondary': showCreatorHightlight, 'highlight-attribute': showCreatorHightlight }">
             <b>Creator</b>
-            <CreatorEditor :creators="creatorAsList" @onCreators="onCreator" />
+            <CreatorEditor id="creator-editor" :creators="creatorAsList" @onCreators="onCreator" />
+            <b-popover
+                custom-class="best-practice-popover"
+                target="creator-editor"
+                boundary="window"
+                placement="right"
+                :show.sync="showCreatorHightlight"
+                triggers="manual"
+                title="Best Practice"
+                :content="bestPracticeWarningCreator">
+            </b-popover>
         </div>
         <div class="mt-2">
             <b>Tags</b>
@@ -60,12 +99,19 @@ import { format, parseISO } from "date-fns";
 
 import { Services } from "@/components/Workflow/services";
 
+import {
+    bestPracticeWarningAnnotation,
+    bestPracticeWarningCreator,
+    bestPracticeWarningLicense,
+} from "./modules/linting";
 import { UntypedParameters } from "./modules/parameters";
 
 import LicenseSelector from "@/components/License/LicenseSelector.vue";
 import ActivityPanel from "@/components/Panels/ActivityPanel.vue";
 import CreatorEditor from "@/components/SchemaOrg/CreatorEditor.vue";
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
+
+const bestPracticeHighlightTime = 10000;
 
 export default {
     name: "WorkflowAttributes",
@@ -81,6 +127,10 @@ export default {
             required: true,
         },
         name: {
+            type: String,
+            default: null,
+        },
+        highlight: {
             type: String,
             default: null,
         },
@@ -115,11 +165,17 @@ export default {
     },
     data() {
         return {
+            bestPracticeWarningAnnotation: bestPracticeWarningAnnotation,
+            bestPracticeWarningCreator: bestPracticeWarningCreator,
+            bestPracticeWarningLicense: bestPracticeWarningLicense,
             message: null,
             messageVariant: null,
             versionCurrent: this.version,
             annotationCurrent: this.annotation,
             nameCurrent: this.name,
+            showAnnotationHightlight: false,
+            showLicenseHightlight: false,
+            showCreatorHightlight: false,
         };
     },
     computed: {
@@ -179,6 +235,36 @@ export default {
         name() {
             this.nameCurrent = this.name;
         },
+        highlight: {
+            immediate: true,
+            handler(newHighlight, oldHighlight) {
+                if (newHighlight == oldHighlight) {
+                    return;
+                }
+                if (newHighlight == "annotation") {
+                    this.showAnnotationHightlight = true;
+                    this.showCreatorHightlight = false;
+                    this.showLicenseHightlight = false;
+                    setTimeout(() => {
+                        this.showAnnotationHightlight = false;
+                    }, bestPracticeHighlightTime);
+                } else if (newHighlight == "creator") {
+                    this.showAnnotationHightlight = false;
+                    this.showCreatorHightlight = true;
+                    this.showLicenseHightlight = false;
+                    setTimeout(() => {
+                        this.showCreatorHightlight = false;
+                    }, bestPracticeHighlightTime);
+                } else if (newHighlight == "license") {
+                    this.showAnnotationHightlight = false;
+                    this.showCreatorHightlight = false;
+                    this.showLicenseHightlight = true;
+                    setTimeout(() => {
+                        this.showLicenseHightlight = false;
+                    }, bestPracticeHighlightTime);
+                }
+            },
+        },
     },
     created() {
         this.services = new Services();
@@ -211,3 +297,14 @@ export default {
     },
 };
 </script>
+
+<style>
+.highlight-attribute {
+    border: 1px outset;
+    padding: 10px;
+}
+
+.best-practice-popover {
+    max-width: 250px !important;
+}
+</style>

--- a/client/src/components/Workflow/Editor/modules/linting.ts
+++ b/client/src/components/Workflow/Editor/modules/linting.ts
@@ -15,6 +15,13 @@ interface LintState {
     autofix?: boolean;
 }
 
+export const bestPracticeWarningAnnotation =
+    "This workflow is not annotated. Providing an annotation helps workflow executors understand the purpose and usage of the workflow.";
+export const bestPracticeWarningCreator =
+    "This workflow does not specify creator(s). This is important metadata for workflows that will be published and/or shared to help workflow executors know how to cite the workflow authors.";
+export const bestPracticeWarningLicense =
+    "This workflow does not specify a license. This is important metadata for workflows that will be published and/or shared to help workflow executors understand how it may be used.";
+
 export function getDisconnectedInputs(
     steps: Steps = {},
     datatypesMapper: DatatypesMapperModel,


### PR DESCRIPTION
We have these links that just bring up the attributes page without any added context about which parameter you clicked or why you want to edit it. I think this is jarring and a usability bug (I'd like to backport this to 24.2 after the activity bar stuff is merged).

<img width="499" alt="Screenshot 2024-12-02 at 10 13 54 AM" src="https://github.com/user-attachments/assets/5c0ed48b-b3ba-4e22-a2cb-9f448bc01ffd">

With these changes it now highlights the attribute you clicked the link for and displays the same message about why it is important from the best practice panel as a popover:

<img width="681" alt="Screenshot 2024-12-02 at 10 14 01 AM" src="https://github.com/user-attachments/assets/db71a2d6-ca31-4fbe-966c-c3e5600c56ec">

I'd love to allow the editing of these things inline also (#10989) but I think that guiding users to the correct place to edit these things and explaining why in context has its own value.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Create a workflow without an annotation or creator or license and open the best practice panel and click the respective links. Notice the new popover and highlight. 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
