### PR TITLE
Only allow moving activity bar icons when editing the bar.

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -189,6 +189,10 @@ function setActiveSideBar(key: string) {
     activityStore.toggledSideBar = key;
 }
 
+const canDrag = computed(() => {
+    return isActiveSideBar("settings");
+});
+
 defineExpose({
     isActiveSideBar,
     setActiveSideBar,
@@ -209,6 +213,7 @@ defineExpose({
                 <draggable
                     :list="activities"
                     :class="{ 'activity-popper-disabled': isDragging }"
+                    :disabled="!canDrag"
                     :force-fallback="true"
                     chosen-class="activity-chosen-class"
                     :delay="DRAG_DELAY"
@@ -216,7 +221,10 @@ defineExpose({
                     ghost-class="activity-chosen-class"
                     @start="isDragging = true"
                     @end="isDragging = false">
-                    <div v-for="(activity, activityIndex) in activities" :key="activityIndex">
+                    <div
+                        v-for="(activity, activityIndex) in activities"
+                        :key="activityIndex"
+                        :class="{ 'can-drag': canDrag }">
                         <div v-if="activity.visible && (activity.anonymous || !isAnonymous)">
                             <UploadItem
                                 v-if="activity.id === 'upload'"
@@ -379,5 +387,12 @@ defineExpose({
 .vertical-overflow {
     overflow-y: auto;
     overflow-x: hidden;
+}
+
+.can-drag {
+    border-radius: 12px;
+    border: 1px;
+    outline: dashed darkgray;
+    outline-offset: -3px;
 }
 </style>


### PR DESCRIPTION
Add small visual indicator that they can be moved.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Try to move the icons outside of the settings panel - notice they don't.
  2. Click activity bar settings - notice the icons can now be moved and have a small dashed border.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
