### PR TITLE
[24.2] Avoid a class of unhelpful accepted format drop downs.

### DIFF
--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -90,6 +90,14 @@ const dragTarget: Ref<EventTarget | null> = ref(null);
 const collectionModalShow = ref(false);
 const collectionModalType = ref<"list" | "list:paired" | "paired">("list");
 const { currentHistoryId } = storeToRefs(useHistoryStore());
+const restrictsExtensions = computed(() => {
+    const extensions = props.extensions;
+    if (!extensions || extensions.length == 0 || extensions.indexOf("data") >= 0) {
+        return false;
+    } else {
+        return true;
+    }
+});
 
 /** Store options which need to be preserved **/
 const keepOptions: Record<string, SelectOption> = {};
@@ -649,7 +657,7 @@ const noOptionsWarningMessage = computed(() => {
                     </BButton>
                 </BButtonGroup>
             </BButtonGroup>
-            <div v-if="extensions && extensions.length > 0">
+            <div v-if="restrictsExtensions">
                 <BButton :id="formatsButtonId" class="ui-link" @click="formatsVisible = !formatsVisible">
                     accepted formats
                     <FontAwesomeIcon v-if="formatsVisible" :icon="faCaretUp" />


### PR DESCRIPTION
Users do not know what 'data' means and displaying a drop down that just displays 'data' is unhelpful. If 'data' is in the list of accepted formats - the tool accepts anything so we don't need to mention any restrictions. The alternative here is a message that says - this inputs accepts datasets of any datatype - I can add that instead if we'd prefer.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Open a tool that does not restrict dataset extensions or a workflow input that doesn't and check that the message is gone.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
