### PR TITLE
[24.2] Fix some collection builder help and language choices.

### DIFF
--- a/client/src/components/Collections/CollectionCreatorModal.vue
+++ b/client/src/components/Collections/CollectionCreatorModal.vue
@@ -113,22 +113,25 @@ watch(
     }
 );
 
+const extensionInTitle = computed<string>(() => {
+    const extensions = props.extensions;
+    if (!extensions || extensions.length == 0 || extensions.indexOf("data") >= 0) {
+        return "";
+    } else {
+        return orList(extensions);
+    }
+});
+
 const modalTitle = computed(() => {
     if (props.collectionType === "list") {
-        return localize(
-            `Create a collection from a list of ${fromSelection.value ? "selected" : ""} ${
-                props.extensions?.length ? orList(props.extensions) : ""
-            } datasets`
-        );
+        return localize(`Create a list of ${fromSelection.value ? "selected" : ""} ${extensionInTitle.value} datasets`);
     } else if (props.collectionType === "list:paired") {
         return localize(
-            `Create a collection of ${fromSelection.value ? "selected" : ""} ${
-                props.extensions?.length ? orList(props.extensions) : ""
-            } dataset pairs`
+            `Create a list of ${fromSelection.value ? "selected" : ""} ${extensionInTitle.value} paired datasets`
         );
     } else if (props.collectionType === "paired") {
         return localize(
-            `Create a ${props.extensions?.length ? orList(props.extensions) : ""} dataset pair collection ${
+            `Create a ${extensionInTitle.value} paired dataset collection ${
                 fromSelection.value ? "from selected items" : ""
             }`
         );

--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -423,17 +423,27 @@ function renameElement(element: any, name: string) {
                         {{
                             localize(
                                 [
-                                    "Collections of datasets are permanent, ordered lists of datasets that can be passed to tools ",
+                                    "Lists are a type of Galaxy dataset collection that are a permanent, ordered lists of datasets that can be passed to tools ",
                                     "and workflows in order to have analyses done on each member of the entire group. This interface allows ",
-                                    "you to create a collection and re-order the final collection.",
+                                    "you to create and re-order a list of datasets. The datasets in a Galaxy collection have an identifier that is preserved accross ",
+                                    "tool executions and server as a form of sample tracking - setting the name in this form will pick the identifier for that element ",
+                                    "of the list but will not change the dataset's actual name in Galaxy.",
                                 ].join("")
                             )
                         }}
                     </p>
 
                     <ul>
+                        <li v-if="!fromSelection">
+                            Move datsets from the "Unselected" column to the "Selected" column below to compose the
+                            list in the intended order and with the intended datasets.
+                        </li>
+
+                        <li v-if="!fromSelection">
+                            The filter textbox can be used to rapidly find the datasets of interest by name.
+                        </li>
                         <li>
-                            {{ localize("Rename elements in the list by clicking on") }}
+                            {{ localize("Change the identifier of elements in the list by clicking on") }}
                             <i data-target=".collection-element .name">
                                 {{ localize("the existing name") }}
                             </i>
@@ -442,13 +452,16 @@ function renameElement(element: any, name: string) {
 
                         <li>
                             {{ localize("Discard elements from the final created list by clicking on the ") }}
-                            <i data-target=".collection-element .discard">
-                                {{ localize("Discard") }}
+                            <i v-if="fromSelection" data-target=".collection-element .discard">
+                                {{ localize("Remove") }}
+                            </i>
+                            <i v-else data-target=".collection-element .discard">
+                                {{ localize("discard") }}
                             </i>
                             {{ localize("button.") }}
                         </li>
 
-                        <li>
+                        <li v-if="fromSelection">
                             {{
                                 localize(
                                     "Reorder the list by clicking and dragging elements. Select multiple elements by clicking on"
@@ -468,7 +481,7 @@ function renameElement(element: any, name: string) {
                             {{ localize("link.") }}
                         </li>
 
-                        <li>
+                        <li v-if="fromSelection">
                             {{ localize("Click ") }}
                             <i data-target=".reset">
                                 <FontAwesomeIcon :icon="faUndo" />
@@ -476,7 +489,7 @@ function renameElement(element: any, name: string) {
                             {{ localize("to begin again as if you had just opened the interface.") }}
                         </li>
 
-                        <li>
+                        <li v-if="fromSelection">
                             {{ localize("Click ") }}
                             <i data-target=".sort-items">
                                 <FontAwesomeIcon :icon="faSortAlphaDown" />

--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -412,7 +412,7 @@ function renameElement(element: any, name: string) {
                 :history-id="props.historyId"
                 :hide-source-items="hideSourceItems"
                 :extensions="extensions"
-                collectionType="list"
+                collection-type="list"
                 :no-items="props.initialElements.length == 0 && !props.fromSelection"
                 @add-uploaded-files="addUploadedFiles"
                 @on-update-datatype-toggle="changeDatatypeFilter"
@@ -423,7 +423,8 @@ function renameElement(element: any, name: string) {
                         {{
                             localize(
                                 [
-                                    "Lists are a type of Galaxy dataset collection that are a permanent, ordered lists of datasets that can be passed to tools ",
+                                    "This interface allows you to build a new Galaxy list of datasets. ",
+                                    "A list is a type of Galaxy dataset collection that is a permanent, ordered list of datasets that can be passed to tools ",
                                     "and workflows in order to have analyses done on each member of the entire group. This interface allows ",
                                     "you to create and re-order a list of datasets. The datasets in a Galaxy collection have an identifier that is preserved accross ",
                                     "tool executions and serves as a form of sample tracking - setting the name in this form will pick the identifier for that element ",
@@ -435,8 +436,8 @@ function renameElement(element: any, name: string) {
 
                     <ul>
                         <li v-if="!fromSelection">
-                            Move datsets from the "Unselected" column to the "Selected" column below to compose the
-                            list in the intended order and with the intended datasets.
+                            Move datsets from the "Unselected" column to the "Selected" column below to compose the list
+                            in the intended order and with the intended datasets.
                         </li>
                         <li v-if="!fromSelection">
                             The filter textbox can be used to rapidly find the datasets of interest by name.

--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -412,13 +412,13 @@ function renameElement(element: any, name: string) {
                 :history-id="props.historyId"
                 :hide-source-items="hideSourceItems"
                 :extensions="extensions"
+                collectionType="list"
                 :no-items="props.initialElements.length == 0 && !props.fromSelection"
                 @add-uploaded-files="addUploadedFiles"
                 @on-update-datatype-toggle="changeDatatypeFilter"
                 @onUpdateHideSourceItems="onUpdateHideSourceItems"
                 @clicked-create="clickedCreate">
                 <template v-slot:help-content>
-                    <!-- TODO: Update help content for case where `fromSelection` is false -->
                     <p>
                         {{
                             localize(

--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -426,7 +426,7 @@ function renameElement(element: any, name: string) {
                                     "Lists are a type of Galaxy dataset collection that are a permanent, ordered lists of datasets that can be passed to tools ",
                                     "and workflows in order to have analyses done on each member of the entire group. This interface allows ",
                                     "you to create and re-order a list of datasets. The datasets in a Galaxy collection have an identifier that is preserved accross ",
-                                    "tool executions and server as a form of sample tracking - setting the name in this form will pick the identifier for that element ",
+                                    "tool executions and serves as a form of sample tracking - setting the name in this form will pick the identifier for that element ",
                                     "of the list but will not change the dataset's actual name in Galaxy.",
                                 ].join("")
                             )
@@ -438,7 +438,6 @@ function renameElement(element: any, name: string) {
                             Move datsets from the "Unselected" column to the "Selected" column below to compose the
                             list in the intended order and with the intended datasets.
                         </li>
-
                         <li v-if="!fromSelection">
                             The filter textbox can be used to rapidly find the datasets of interest by name.
                         </li>

--- a/client/src/components/Collections/PairCollectionCreator.vue
+++ b/client/src/components/Collections/PairCollectionCreator.vue
@@ -374,6 +374,7 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                 :suggested-name="initialSuggestedName"
                 :extensions="props.extensions"
                 :extensions-toggle="removeExtensions"
+                collection-type="paired"
                 :no-items="props.initialElements.length == 0 && !props.fromSelection"
                 @add-uploaded-files="addUploadedFiles"
                 @onUpdateHideSourceItems="onUpdateHideSourceItems"
@@ -423,7 +424,7 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                         <i data-target=".collection-name"> {{ localize("name") }}</i>
                         {{ localize("and click ") }}
                         <i data-target=".create-collection">
-                            {{ localize("Create list") }}
+                            {{ localize("Create dataset pair") }}
                         </i>
                         {{ localize(".") }}
                     </p>

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -876,9 +876,9 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                         {{
                             localize(
                                 [
-                                    "Collections of paired datasets are ordered lists of dataset pairs (often forward and reverse reads). ",
-                                    "These collections can be passed to tools and workflows in order to have analyses done on each member of ",
-                                    "the entire group. This interface allows you to create a collection, choose which datasets are paired, ",
+                                    "Lists of pairs are an ordered list of individual dataset paired together in their own collection (often forward and reverse reads). ",
+                                    "These lists can be passed to tools and workflows in order to have analyses done on each member of ",
+                                    "the entire group. This interface allows you to create such a list of paired datasets, choose which datasets are paired, ",
                                     "and re-order the final collection.",
                                 ].join("")
                             )

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -876,7 +876,8 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                         {{
                             localize(
                                 [
-                                    "Lists of pairs are an ordered list of individual dataset paired together in their own collection (often forward and reverse reads). ",
+                                    "This interface allows you to build a new Galaxy list of pairs. List of pairs are an ordered list of ",
+                                    "individual dataset paired together in their own paired collection (often forward and reverse reads). ",
                                     "These lists can be passed to tools and workflows in order to have analyses done on each member of ",
                                     "the entire group. This interface allows you to create such a list of paired datasets, choose which datasets are paired, ",
                                     "and re-order the final collection.",

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -864,6 +864,7 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                 render-extensions-toggle
                 :extensions-toggle="removeExtensions"
                 :extensions="extensions"
+                collection-type="list:paired"
                 :no-items="props.initialElements.length == 0 && !props.fromSelection"
                 @add-uploaded-files="addUploadedFiles"
                 @onUpdateHideSourceItems="hideSourceItems = $event"
@@ -994,7 +995,7 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                         </i>
                         {{ localize("and click ") }}
                         <i data-target=".create-collection">
-                            {{ localize("Create list") }}
+                            {{ localize("Create list or pairs") }}
                         </i>
                         {{ localize(". (Note: you do not have to pair all unpaired datasets to finish.)") }}
                     </p>

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -39,6 +39,7 @@ interface Props {
     extensions?: string[];
     extensionsToggle?: boolean;
     noItems?: boolean;
+    collectionType?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -99,6 +100,19 @@ const defaultExtension = computed(() => {
         return configOptions.value.defaultExtension || "auto";
     } else {
         return props.extensions[0];
+    }
+});
+
+const shortWhatIsBeingCreated = computed<string>(() => {
+    // plain language for what is being created
+    if (props.collectionType === "list") {
+        return "list";
+    } else if (props.collectionType === "list:paired") {
+        return "list of pairs";
+    } else if (props.collectionType == "paired") {
+        return "dataset pair";
+    } else {
+        return "collection";
     }
 });
 
@@ -222,7 +236,7 @@ watch(
                                     id="collection-name"
                                     v-model="collectionName"
                                     class="collection-name"
-                                    :placeholder="localize('Enter a name for your new collection')"
+                                    :placeholder="localize('Enter a name for your new ' + shortWhatIsBeingCreated)"
                                     size="sm"
                                     required
                                     :state="!collectionName ? false : null" />
@@ -240,7 +254,7 @@ watch(
                             variant="primary"
                             :disabled="!validInput"
                             @click="emit('clicked-create', collectionName)">
-                            {{ localize("Create collection") }}
+                            {{ localize("Create " + shortWhatIsBeingCreated) }}
                         </BButton>
                     </div>
                 </div>

--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -607,10 +607,20 @@ watch(
 const formatsVisible = ref(false);
 const formatsButtonId = useUid("form-data-formats-");
 
+function collectionTypeToText(collectionType: string): string {
+    if (collectionType == "list:paired") {
+        return "list of pairs";
+    } else {
+        return collectionType;
+    }
+}
+
 const warningListAmount = 4;
 const noOptionsWarningMessage = computed(() => {
     const itemType = props.type === "data" ? "datasets" : "dataset collections";
-    const collectionTypeLabel = props.collectionTypes?.length ? `${orList(props.collectionTypes)} ` : "";
+    const collectionTypeLabel = props.collectionTypes?.length
+        ? `${orList(props.collectionTypes.map(collectionTypeToText))} `
+        : "";
     if (!props.extensions || props.extensions.length === 0 || props.extensions.includes("data")) {
         return `No ${collectionTypeLabel}${itemType} available`;
     } else if (props.extensions.length <= warningListAmount) {


### PR DESCRIPTION
The list help instructions are just wrong and didn't dispatch on the type of components being rendered and even for the right modality was using old names of buttons. That part should be an uncontroversial bug fix. The other commit is language choices - I consider a lot of the old language both too pedantic and then overtly incorrect in places despite that - I prefer all these language choices here more. Incorrect language here and in training documentation and tools has resulted in collections seeming a lot more complex and a lot less beautiful than they are - and I should have worked harder to review everything as it came in. 

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
