### PR TITLE
[24.2] Fix PSA Redirect

### DIFF
--- a/client/src/components/User/ExternalIdentities/ExternalLogin.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalLogin.vue
@@ -86,8 +86,6 @@ async function submitOIDCLogin(idp: string) {
 
         const { data } = await axios.post(loginUrl, formData, { withCredentials: true });
 
-        console.debug("LOGIN POST DATA", data);
-
         if (data.redirect_uri) {
             window.location = data.redirect_uri;
         }

--- a/client/src/components/User/ExternalIdentities/ExternalLogin.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalLogin.vue
@@ -77,7 +77,16 @@ async function submitOIDCLogin(idp: string) {
     loading.value = true;
 
     try {
-        const { data } = await axios.post(withPrefix(`/authnz/${idp}/login`));
+        const loginUrl = withPrefix(`/authnz/${idp}/login`);
+        const urlParams = new URLSearchParams(window.location.search);
+        const redirectParam = urlParams.get("redirect");
+
+        const formData = new FormData();
+        formData.append("next", redirectParam || "");
+
+        const { data } = await axios.post(loginUrl, formData, { withCredentials: true });
+
+        console.debug("LOGIN POST DATA", data);
 
         if (data.redirect_uri) {
             window.location = data.redirect_uri;

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -73,7 +73,7 @@ class OIDC(JSAppLauncher):
 
     @web.json
     @web.expose
-    def login(self, trans, provider, idphint=None):
+    def login(self, trans, provider, idphint=None, next=None):
         if not trans.app.config.enable_oidc:
             msg = "Login to Galaxy using third-party identities is not enabled on this Galaxy instance."
             log.debug(msg)


### PR DESCRIPTION
The old trans.session storage used in strategy.session_get/session_set isn't an option here, so we use an oidc-login-next cookie.


Fixes https://github.com/galaxyproject/galaxy/issues/19082

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
