### PR TITLE
[24.2] Various list of pairs builder usability fixes.

### DIFF
--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -1318,6 +1318,8 @@ $fa-font-path: "../../../node_modules/@fortawesome/fontawesome-free/webfonts/";
 @import "~@fortawesome/fontawesome-free/scss/solid";
 @import "~@fortawesome/fontawesome-free/scss/fontawesome";
 @import "~@fortawesome/fontawesome-free/scss/brands";
+@import "~bootstrap/scss/_functions.scss";
+@import "theme/blue.scss";
 .paired-column {
     text-align: center;
     // mess with these two to make center more/scss priority
@@ -1364,7 +1366,7 @@ li.dataset.paired {
             white-space: nowrap;
             overflow: hidden;
             border: 2px solid grey;
-            background: #aff1af;
+            background: $state-success-bg;
             text-align: center;
             span {
                 display: inline-block;

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -243,8 +243,11 @@ function initialFiltersSet() {
             illumina++;
         }
     });
-
-    if (illumina > dot12s && illumina > Rs) {
+    // if we cannot filter don't set an initial filter and hide all the data
+    if (illumina == 0 && dot12s == 0 && Rs == 0) {
+        forwardFilter.value = "";
+        reverseFilter.value = "";
+    } else if (illumina > dot12s && illumina > Rs) {
         changeFilters("illumina");
     } else if (dot12s > illumina && dot12s > Rs) {
         changeFilters("dot12s");

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -93,6 +93,10 @@ const hasFilter = computed(() => forwardFilter.value || reverseFilter.value);
 const strategy = ref(autoPairLCS);
 const duplicatePairNames = ref<string[]>([]);
 
+const canAutoPair = computed(() => {
+    return forwardFilter.value && reverseFilter.value;
+});
+
 const forwardElements = computed<HDASummary[]>(() => {
     return filterElements(workingElements.value, forwardFilter.value);
 });
@@ -117,7 +121,11 @@ const autoPairButton = computed(() => {
     let variant;
     let icon;
     let text;
-    if (!firstAutoPairDone.value && pairableElements.value.length > 0) {
+    if (!canAutoPair.value) {
+        variant = "secondary";
+        icon = faLink;
+        text = localize("Specify simple filters to divide datasets into forward and reverse reads for pairing.");
+    } else if (!firstAutoPairDone.value && pairableElements.value.length > 0) {
         variant = "primary";
         icon = faExclamationCircle;
         text = localize("Click to auto-pair datasets based on the current filters");
@@ -1141,6 +1149,7 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                                             </BButton>
                                             <BButton
                                                 class="autopair-link"
+                                                :disabled="!canAutoPair"
                                                 size="sm"
                                                 :title="autoPairButton.text"
                                                 :variant="autoPairButton.variant"

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -93,6 +93,10 @@ const hasFilter = computed(() => forwardFilter.value || reverseFilter.value);
 const strategy = ref(autoPairLCS);
 const duplicatePairNames = ref<string[]>([]);
 
+const canClearFilters = computed(() => {
+    return forwardFilter.value || reverseFilter.value;
+});
+
 const canAutoPair = computed(() => {
     return forwardFilter.value && reverseFilter.value;
 });
@@ -1144,6 +1148,7 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                                         <BButtonGroup vertical>
                                             <BButton
                                                 class="clear-filters-link"
+                                                :disabled="!canClearFilters"
                                                 size="sm"
                                                 :variant="hasFilter ? 'danger' : 'secondary'"
                                                 @click="clickClearFilters">

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -98,7 +98,7 @@ const canClearFilters = computed(() => {
 });
 
 const canAutoPair = computed(() => {
-    return forwardFilter.value && reverseFilter.value;
+    return forwardFilter.value && reverseFilter.value && pairableElements.value.length > 0;
 });
 
 const forwardElements = computed<HDASummary[]>(() => {

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -914,8 +914,7 @@ class NavigatesGalaxy(HasDriver):
         if not hide_source_items:
             self.collection_builder_hide_originals()
 
-        self.collection_builder_clear_filters()
-        # TODO: generalize and loop these clicks so we don't need the assert
+        self.ensure_collection_builder_filters_cleared()
         assert len(test_paths) == 2
         self.collection_builder_click_paired_item("forward", 0)
         self.collection_builder_click_paired_item("reverse", 1)
@@ -2053,8 +2052,15 @@ class NavigatesGalaxy(HasDriver):
     def collection_builder_create(self):
         self.wait_for_and_click_selector("button.create-collection")
 
+    def ensure_collection_builder_filters_cleared(self):
+        clear_filters = self.components.collection_builders.clear_filters
+        element = clear_filters.wait_for_present()
+        if "disabled" not in element.get_attribute("class").split(" "):
+            self.collection_builder_clear_filters()
+
     def collection_builder_clear_filters(self):
-        self.wait_for_and_click_selector("button.clear-filters-link")
+        clear_filters = self.components.collection_builders.clear_filters
+        clear_filters.wait_for_and_click()
 
     def collection_builder_click_paired_item(self, forward_or_reverse, item):
         assert forward_or_reverse in ["forward", "reverse"]

--- a/lib/galaxy_test/selenium/test_collection_builders.py
+++ b/lib/galaxy_test/selenium/test_collection_builders.py
@@ -39,7 +39,6 @@ class TestCollectionBuilders(SeleniumTestCase):
         self.perform_upload(self.get_filename("2.tabular"))
         self._wait_for_and_select([1, 2])
         self._collection_dropdown("build list of pairs")
-        self.collection_builder_clear_filters()
         self.collection_builder_click_paired_item("forward", 0)
         self.collection_builder_click_paired_item("reverse", 1)
         self.collection_builder_set_name("my awesome paired list")
@@ -61,7 +60,7 @@ class TestCollectionBuilders(SeleniumTestCase):
         self._wait_for_and_select([1, 2])
         self._collection_dropdown("build list of pairs")
         collection_builders = self.components.collection_builders
-        collection_builders.clear_filters.wait_for_and_click()
+        self.ensure_collection_builder_filters_cleared()
         forward_column = collection_builders.forward_datasets.wait_for_visible()
         first_datset_forward = forward_column.find_elements(self.by.CSS_SELECTOR, "li")[0]
         first_datset_forward.click()


### PR DESCRIPTION
- Disable buttons when they don't make sense.
- Don't auto-pair on empty filters. 
- Don't auto-pair at the start if nothing matches - the user did nothing wrong and we're scaring them with red buttons and all the data disappearing - if we cannot auto-pair the datasets we should just give them manual control and let them do it - the component is much simpler to understand with this new behavior in the no-matches case.
- Update an old Galaxy green to the newer style.

The cognitive load of not needing to understand the filters if they don't work out is so much lower. Jumping into the component with wrong filters pre-configured and hiding your data is confusing, scary, and generally unpleasant I think. 

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
