### PR TITLE
[24.2] Build collection only if populated in collection builder

### DIFF
--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -41,6 +41,7 @@ const invalidElements = ref<string[]>([]);
 const workingElements = ref<HDASummary[]>([]);
 const selectedDatasetElements = ref<string[]>([]);
 const hideSourceItems = ref(props.defaultHideSourceItems || false);
+const atLeastOneElement = ref(true);
 
 const atLeastOneDatasetIsSelected = computed(() => {
     return selectedDatasetElements.value.length > 0;
@@ -232,8 +233,9 @@ function clickedCreate(collectionName: string) {
     checkForDuplicates();
 
     const returnedElements = props.fromSelection ? workingElements.value : inListElements.value;
+    atLeastOneElement.value = returnedElements.length > 0;
 
-    if (state.value !== "error") {
+    if (state.value !== "error" && atLeastOneElement.value) {
         emit("clicked-create", returnedElements, collectionName, hideSourceItems.value);
     }
 }
@@ -367,6 +369,18 @@ function renameElement(element: any, name: string) {
                             {{ problem }}
                         </li>
                     </ul>
+                </BAlert>
+            </div>
+
+            <div v-if="!atLeastOneElement">
+                <BAlert show variant="warning" dismissible @dismissed="atLeastOneElement = true">
+                    {{ localize("At least one element is needed for the list.") }}
+                    <span v-if="fromSelection">
+                        <a class="cancel-text" href="javascript:void(0)" role="button" @click="emit('on-cancel')">
+                            {{ localize("Cancel") }}
+                        </a>
+                        {{ localize("and reselect new elements.") }}
+                    </span>
                 </BAlert>
             </div>
 

--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -9,6 +9,7 @@ import { computed, ref, watch } from "vue";
 import draggable from "vuedraggable";
 
 import type { HDASummary, HistoryItemSummary } from "@/api";
+import { useConfirmDialog } from "@/composables/confirmDialog";
 import { Toast } from "@/composables/toast";
 import STATES from "@/mvc/dataset/states";
 import { useDatatypesMapperStore } from "@/stores/datatypesMapperStore";
@@ -228,14 +229,24 @@ function clickSelectAll() {
         return element.id;
     });
 }
+const { confirm } = useConfirmDialog();
 
-function clickedCreate(collectionName: string) {
+async function clickedCreate(collectionName: string) {
     checkForDuplicates();
 
     const returnedElements = props.fromSelection ? workingElements.value : inListElements.value;
     atLeastOneElement.value = returnedElements.length > 0;
 
-    if (state.value !== "error" && atLeastOneElement.value) {
+    let confirmed = false;
+    if (!atLeastOneElement.value) {
+        confirmed = await confirm("Are you sure you want to create a list with no datasets?", {
+            title: "Create an empty list",
+            okTitle: "Create",
+            okVariant: "primary",
+        });
+    }
+
+    if (state.value !== "error" && (atLeastOneElement.value || confirmed)) {
         emit("clicked-create", returnedElements, collectionName, hideSourceItems.value);
     }
 }

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -553,32 +553,6 @@ function _addToUnpaired(dataset: HDASummary) {
 
     workingElements.value.splice(binSearchSortedIndex(0, workingElements.value.length), 0, dataset);
 }
-// /** add a dataset to the unpaired list in it's proper order */
-// _addToUnpaired: function (dataset) {
-//     // currently, unpaired is natural sorted by name, use binary search to find insertion point
-//     var binSearchSortedIndex = (low, hi) => {
-//         if (low === hi) {
-//             return low;
-//         }
-
-//         var mid = Math.floor((hi - low) / 2) + low;
-
-//         var compared = naturalSort(dataset.name, this.workingElements[mid].name);
-
-//         if (compared < 0) {
-//             return binSearchSortedIndex(low, mid);
-//         } else if (compared > 0) {
-//             return binSearchSortedIndex(mid + 1, hi);
-//         }
-//         // walk the equal to find the last
-//         while (this.workingElements[mid] && this.workingElements[mid].name === dataset.name) {
-//             mid++;
-//         }
-//         return mid;
-//     };
-
-//     this.workingElements.splice(binSearchSortedIndex(0, this.workingElements.length), 0, dataset);
-// },
 
 /**
  * Unpair a pair, removing it from paired, and adding the fwd,rev

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -81,6 +81,7 @@ const invalidElements = ref<string[]>([]);
 const generatedPairs = ref<DatasetPair[]>([]);
 const selectedForwardElement = ref<HDASummary | null>(null);
 const selectedReverseElement = ref<HDASummary | null>(null);
+const atLeastOnePair = ref(true);
 
 // Filters
 const forwardFilter = ref(COMMON_FILTERS[DEFAULT_FILTER][0] || "");
@@ -751,7 +752,8 @@ function addUploadedFiles(files: HDASummary[]) {
 
 async function clickedCreate(collectionName: string) {
     checkForDuplicates();
-    if (state.value == "build") {
+    atLeastOnePair.value = generatedPairs.value.length > 0;
+    if (state.value == "build" && atLeastOnePair.value) {
         emit("clicked-create", generatedPairs.value, collectionName, hideSourceItems.value);
     }
 }
@@ -827,6 +829,19 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                     </ul>
                 </BAlert>
             </div>
+
+            <div v-if="!atLeastOnePair">
+                <BAlert show variant="warning" dismissible @dismissed="atLeastOnePair = true">
+                    {{ localize("At least one pair is needed for the paired list.") }}
+                    <span v-if="fromSelection">
+                        <a class="cancel-text" href="javascript:void(0)" role="button" @click="emit('on-cancel')">
+                            {{ localize("Cancel") }}
+                        </a>
+                        {{ localize("and reselect new elements.") }}
+                    </span>
+                </BAlert>
+            </div>
+
             <div v-if="!autoPairsPossible">
                 <BAlert show variant="danger" dismissible @dismissed="autoPairsPossible = true">
                     {{
@@ -842,6 +857,7 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                     </span>
                 </BAlert>
             </div>
+
             <div v-if="state == 'duplicates'">
                 <BAlert show variant="danger">
                     {{
@@ -853,6 +869,7 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                     {{ localize("Please fix these duplicates and try again.") }}
                 </BAlert>
             </div>
+
             <CollectionCreator
                 :oncancel="() => emit('on-cancel')"
                 :history-id="props.historyId"


### PR DESCRIPTION
Fixes #19243 

![firefox_lILouMTE6Y](https://github.com/user-attachments/assets/ee0e3037-90f5-45c4-9879-4c8d63d4c95d)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Have a workflow input which creates a collection (list for e.g.)
  2. Click on the plus icon next to the form input
  3. Collection builder will open, try giving it a name and saving
  4. A confirmation dialog opens up that gives you the choice of creating an empty collection if that's what you want
  5. Clicking create will create it, cancel will take you back

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
