### PR TITLE
[24.2] Login redirect followup

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -79,7 +79,10 @@ class OIDC(JSAppLauncher):
             log.debug(msg)
             return trans.show_error_message(msg)
         if next:
-            trans.set_cookie(value=next, name=LOGIN_NEXT_COOKIE_NAME)
+            trans.set_cookie(value=next, name=LOGIN_NEXT_COOKIE_NAME, age=1)
+        else:
+            # If no next parameter is provided, ensure we unset any existing next cookie.
+            trans.set_cookie(value="/", name=LOGIN_NEXT_COOKIE_NAME)
         success, message, redirect_uri = trans.app.authnz_manager.authenticate(provider, trans, idphint)
         if success:
             return {"redirect_uri": redirect_uri}
@@ -138,6 +141,8 @@ class OIDC(JSAppLauncher):
         trans.handle_user_login(user)
         # Record which idp provider was logged into, so we can logout of it later
         trans.set_cookie(value=provider, name=PROVIDER_COOKIE_NAME)
+        # Clear the login next cookie back to default.
+        trans.set_cookie(value="/", name=LOGIN_NEXT_COOKIE_NAME)
         return trans.response.send_redirect(url_for(redirect_url))
 
     @web.expose


### PR DESCRIPTION
Sets expiration to 24h, clears to default if next isn't provided, and clears after use.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
