### PR TITLE
[24.2] Workflow Inputs Activity

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -66,6 +66,7 @@
     "elkjs": "^0.8.2",
     "file-saver": "^2.0.5",
     "flush-promises": "^1.0.2",
+    "font-awesome-6": "npm:@fortawesome/free-solid-svg-icons@6",
     "glob": "^10.3.10",
     "handsontable": "^4.0.0",
     "hsluv": "^1.0.1",

--- a/client/src/components/Panels/ActivityPanel.vue
+++ b/client/src/components/Panels/ActivityPanel.vue
@@ -79,17 +79,6 @@ const hasGoToAll = computed(() => props.goToAllTitle && props.href);
         flex-grow: 1;
         overflow-y: auto;
         position: relative;
-        button:first-child {
-            background: none;
-            border: none;
-            text-align: left;
-            transition: none;
-            width: 100%;
-            border-color: transparent;
-        }
-        button:first-child:hover {
-            background: $gray-200;
-        }
     }
 
     .activity-panel-footer {

--- a/client/src/components/Panels/InputPanel.vue
+++ b/client/src/components/Panels/InputPanel.vue
@@ -20,11 +20,12 @@ const emit = defineEmits<{
             <button
                 v-for="(input, index) in props.inputs"
                 :key="index"
+                :data-id="input.id ?? input.moduleId"
                 class="workflow-input-button"
-                @click="emit('insertModule', input.id, input.title, input.stateOverwrites)">
+                @click="emit('insertModule', input.moduleId, input.title, input.stateOverwrites)">
                 <FontAwesomeIcon class="input-icon" fixed-width :icon="input.icon" />
-                <span class="input-title">{{ input.title }}</span>
-                <span class="input-description">{{ input.description }}</span>
+                <span class="input-title"> {{ input.title }} </span>
+                <span class="input-description"> {{ input.description }} </span>
             </button>
         </div>
     </ActivityPanel>

--- a/client/src/components/Panels/InputPanel.vue
+++ b/client/src/components/Panels/InputPanel.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+
+import type { WorkflowInput } from "../Workflow/Editor/modules/inputs";
+
+import ActivityPanel from "./ActivityPanel.vue";
+
+const props = defineProps<{
+    inputs: WorkflowInput[];
+}>();
+
+const emit = defineEmits<{
+    (e: "insertModule", id: string, name: string, state: WorkflowInput["stateOverwrites"]): void;
+}>();
+</script>
+
+<template>
+    <ActivityPanel title="Inputs">
+        <div class="input-list">
+            <button
+                v-for="(input, index) in props.inputs"
+                :key="index"
+                class="workflow-input-button"
+                @click="emit('insertModule', input.id, input.title, input.stateOverwrites)">
+                <FontAwesomeIcon class="input-icon" fixed-width :icon="input.icon" />
+                <span class="input-title">{{ input.title }}</span>
+                <span class="input-description">{{ input.description }}</span>
+            </button>
+        </div>
+    </ActivityPanel>
+</template>
+
+<style lang="scss" scoped>
+@import "theme/blue.scss";
+
+.input-list {
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.workflow-input-button {
+    border-radius: 0.5rem;
+    border: 1px solid $gray-300;
+    background: transparent;
+
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-areas:
+        "i t"
+        "d d";
+
+    text-align: left;
+    gap: 0.25rem;
+    align-items: center;
+
+    &:hover,
+    &:focus {
+        background-color: $gray-100;
+        border-color: $brand-primary;
+    }
+
+    &:active {
+        background-color: $gray-200;
+        border-color: $brand-primary;
+    }
+
+    .input-icon {
+        grid-area: i;
+    }
+
+    .input-title {
+        grid-area: t;
+        font-weight: bold;
+    }
+
+    .input-description {
+        grid-area: d;
+    }
+}
+</style>

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -33,7 +33,6 @@ const props = defineProps({
     panelView: { type: String, required: true },
     showAdvanced: { type: Boolean, default: false, required: true },
     panelQuery: { type: String, required: true },
-    editorWorkflows: { type: Array, default: null },
     dataManagers: { type: Array, default: null },
     moduleSections: { type: Array as PropType<Record<string, any>>, default: null },
 });

--- a/client/src/components/Panels/ToolPanel.vue
+++ b/client/src/components/Panels/ToolPanel.vue
@@ -17,7 +17,6 @@ import Heading from "@/components/Common/Heading.vue";
 
 const props = defineProps({
     workflow: { type: Boolean, default: false },
-    editorWorkflows: { type: Array, default: null },
     dataManagers: { type: Array, default: null },
     moduleSections: { type: Array, default: null },
 });
@@ -198,7 +197,6 @@ watch(
             :panel-query.sync="query"
             :panel-view="currentPanelView"
             :show-advanced.sync="showAdvanced"
-            :editor-workflows="editorWorkflows"
             :data-managers="dataManagers"
             :module-sections="moduleSections"
             @updatePanelView="updatePanelView"

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.test.js
@@ -24,6 +24,7 @@ describe("FormDefault", () => {
                     contentId: "id",
                     annotation: "annotation",
                     label: "label",
+                    name: "name",
                     type: "subworkflow",
                     configForm: {
                         inputs: [],
@@ -42,7 +43,7 @@ describe("FormDefault", () => {
 
     it("check initial value and value change", async () => {
         const title = wrapper.find(".portlet-title-text").text();
-        expect(title).toBe("label");
+        expect(title).toBe("name");
         const inputCount = wrapper.findAll("input").length;
         expect(inputCount).toBe(4);
         const outputLabelCount = wrapper.findAll("#__label__output-name").length;

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -97,9 +97,6 @@ const { stepId, contentId, annotation, label, name, type, configForm } = useStep
 const { stepStore } = useWorkflowStores();
 const uniqueErrorLabel = useUniqueLabelError(stepStore, label.value);
 const stepTitle = computed(() => {
-    if (label.value) {
-        return label.value;
-    }
     if (isSubworkflow.value) {
         return name.value;
     } else {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -51,6 +51,10 @@
                     @onInsertModule="onInsertModule"
                     @onInsertWorkflow="onInsertWorkflow"
                     @onInsertWorkflowSteps="onInsertWorkflowSteps" />
+                <InputPanel
+                    v-if="isActiveSideBar('workflow-editor-inputs')"
+                    :inputs="inputs"
+                    @insertModule="onInsertModule" />
                 <WorkflowLint
                     v-else-if="isActiveSideBar('workflow-best-practices')"
                     :untyped-parameters="parameters"
@@ -205,6 +209,7 @@ import { InsertStepAction, useStepActions } from "./Actions/stepActions";
 import { CopyIntoWorkflowAction, SetValueActionHandler } from "./Actions/workflowActions";
 import { defaultPosition } from "./composables/useDefaultStepPosition";
 import { useActivityLogic, useSpecialWorkflowActivities, workflowEditorActivities } from "./modules/activities";
+import { getWorkflowInputs } from "./modules/inputs";
 import { fromSimple } from "./modules/model";
 import { getModule, getVersions, loadWorkflow, saveWorkflow } from "./modules/services";
 import { getStateUpgradeMessages } from "./modules/utilities";
@@ -220,6 +225,7 @@ import WorkflowAttributes from "./WorkflowAttributes.vue";
 import WorkflowGraph from "./WorkflowGraph.vue";
 import ActivityBar from "@/components/ActivityBar/ActivityBar.vue";
 import MarkdownEditor from "@/components/Markdown/MarkdownEditor.vue";
+import InputPanel from "@/components/Panels/InputPanel.vue";
 import ToolPanel from "@/components/Panels/ToolPanel.vue";
 import WorkflowPanel from "@/components/Panels/WorkflowPanel.vue";
 import UndoRedoStack from "@/components/UndoRedo/UndoRedoStack.vue";
@@ -242,6 +248,7 @@ export default {
         UndoRedoStack,
         WorkflowPanel,
         NodeInspector,
+        InputPanel,
     },
     props: {
         workflowId: {
@@ -460,6 +467,7 @@ export default {
         );
 
         const { confirm } = useConfirmDialog();
+        const inputs = getWorkflowInputs();
 
         return {
             id,
@@ -504,6 +512,7 @@ export default {
             isNewTempWorkflow,
             saveWorkflowTitle,
             confirm,
+            inputs,
         };
     },
     data() {
@@ -657,8 +666,8 @@ export default {
         onInsertTool(tool_id, tool_name) {
             this._insertStep(tool_id, tool_name, "tool");
         },
-        onInsertModule(module_id, module_name) {
-            this._insertStep(module_name, module_name, module_id);
+        async onInsertModule(module_id, module_name, state) {
+            this._insertStep(module_name, module_name, module_id, state);
         },
         onInsertWorkflow(workflow_id, workflow_name) {
             this._insertStep(workflow_id, workflow_name, "subworkflow");
@@ -907,7 +916,7 @@ export default {
                 this._loadCurrent(this.id, version);
             }
         },
-        _insertStep(contentId, name, type) {
+        async _insertStep(contentId, name, type, state) {
             const action = new InsertStepAction(this.stepStore, this.stateStore, {
                 contentId,
                 name,
@@ -918,22 +927,24 @@ export default {
             this.undoRedoStore.applyAction(action);
             const stepData = action.getNewStepData();
 
-            getModule({ name, type, content_id: contentId }, stepData.id, this.stateStore.setLoadingState).then(
-                (response) => {
-                    const updatedStep = {
-                        ...stepData,
-                        tool_state: response.tool_state,
-                        inputs: response.inputs,
-                        outputs: response.outputs,
-                        config_form: response.config_form,
-                    };
-
-                    this.stepStore.updateStep(updatedStep);
-                    action.updateStepData = updatedStep;
-
-                    this.stateStore.activeNodeId = stepData.id;
-                }
+            const response = await getModule(
+                { name, type, content_id: contentId, tool_state: state },
+                stepData.id,
+                this.stateStore.setLoadingState
             );
+
+            const updatedStep = {
+                ...stepData,
+                tool_state: response.tool_state,
+                inputs: response.inputs,
+                outputs: response.outputs,
+                config_form: response.config_form,
+            };
+
+            this.stepStore.updateStep(updatedStep);
+            action.updateStepData = updatedStep;
+
+            this.stateStore.activeNodeId = stepData.id;
         },
         async _loadEditorData(data) {
             if (data.name !== undefined) {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -47,7 +47,6 @@
                     workflow
                     :module-sections="moduleSections"
                     :data-managers="dataManagers"
-                    :editor-workflows="workflows"
                     @onInsertTool="onInsertTool"
                     @onInsertModule="onInsertModule"
                     @onInsertWorkflow="onInsertWorkflow"
@@ -262,10 +261,6 @@ export default {
             required: true,
         },
         dataManagers: {
-            type: Array,
-            required: true,
-        },
-        workflows: {
             type: Array,
             required: true,
         },

--- a/client/src/components/Workflow/Editor/modules/activities.ts
+++ b/client/src/components/Workflow/Editor/modules/activities.ts
@@ -13,6 +13,7 @@ import {
     faWrench,
 } from "@fortawesome/free-solid-svg-icons";
 import { watchImmediate } from "@vueuse/core";
+import { faDiagramNext } from "font-awesome-6";
 import { computed, type Ref } from "vue";
 
 import { type Activity, useActivityStore } from "@/stores/activityStore";
@@ -25,6 +26,15 @@ export const workflowEditorActivities = [
         description: "View and edit the attributes of this workflow.",
         panel: true,
         icon: faPencilAlt,
+        visible: true,
+    },
+    {
+        title: "Inputs",
+        id: "workflow-editor-inputs",
+        tooltip: "Add input steps to your workflow",
+        description: "Add input steps to your workflow.",
+        icon: faDiagramNext,
+        panel: true,
         visible: true,
     },
     {

--- a/client/src/components/Workflow/Editor/modules/inputs.ts
+++ b/client/src/components/Workflow/Editor/modules/inputs.ts
@@ -3,7 +3,8 @@ import { faPencilAlt } from "@fortawesome/free-solid-svg-icons";
 import { type IconDefinition } from "font-awesome-6";
 
 export interface WorkflowInput {
-    id: string;
+    id?: string; // unique ID. defaults to module ID
+    moduleId: string;
     title: string;
     description: string;
     stateOverwrites?: {
@@ -15,19 +16,19 @@ export interface WorkflowInput {
 export function getWorkflowInputs(): WorkflowInput[] {
     return [
         {
-            id: "data_input",
+            moduleId: "data_input",
             title: "Input Dataset",
             description: "Single dataset input",
             icon: faFile,
         },
         {
-            id: "data_collection_input",
+            moduleId: "data_collection_input",
             title: "Input Dataset Collection",
             description: "Input for a collection of datasets",
             icon: faFolder,
         },
         {
-            id: "parameter_input",
+            moduleId: "parameter_input",
             title: "Text Input",
             description: "Text parameter used for workflow logic",
             icon: faPencilAlt,
@@ -36,7 +37,8 @@ export function getWorkflowInputs(): WorkflowInput[] {
             },
         },
         {
-            id: "parameter_input",
+            id: "parameter_input_integer",
+            moduleId: "parameter_input",
             title: "Integer Input",
             description: "Whole number parameter used for workflow logic",
             icon: faPencilAlt,
@@ -45,7 +47,8 @@ export function getWorkflowInputs(): WorkflowInput[] {
             },
         },
         {
-            id: "parameter_input",
+            id: "parameter_input_float",
+            moduleId: "parameter_input",
             title: "Float Input",
             description: "Imprecise decimal number parameter used for workflow logic",
             icon: faPencilAlt,
@@ -54,7 +57,8 @@ export function getWorkflowInputs(): WorkflowInput[] {
             },
         },
         {
-            id: "parameter_input",
+            id: "parameter_input_boolean",
+            moduleId: "parameter_input",
             title: "Boolean Input",
             description: "True / False parameter used for workflow logic",
             icon: faPencilAlt,
@@ -63,7 +67,8 @@ export function getWorkflowInputs(): WorkflowInput[] {
             },
         },
         {
-            id: "parameter_input",
+            id: "parameter_input_color",
+            moduleId: "parameter_input",
             title: "Color Input",
             description: "Color parameter used for workflow logic",
             icon: faPencilAlt,
@@ -72,7 +77,8 @@ export function getWorkflowInputs(): WorkflowInput[] {
             },
         },
         {
-            id: "parameter_input",
+            id: "parameter_input_directory_uri",
+            moduleId: "parameter_input",
             title: "Directory Input",
             description: "Directory parameter used for workflow logic",
             icon: faPencilAlt,

--- a/client/src/components/Workflow/Editor/modules/inputs.ts
+++ b/client/src/components/Workflow/Editor/modules/inputs.ts
@@ -1,0 +1,84 @@
+import { faFile, faFolder } from "@fortawesome/free-regular-svg-icons";
+import { faPencilAlt } from "@fortawesome/free-solid-svg-icons";
+import { type IconDefinition } from "font-awesome-6";
+
+export interface WorkflowInput {
+    id: string;
+    title: string;
+    description: string;
+    stateOverwrites?: {
+        parameter_type?: "text" | "integer" | "boolean" | "color" | "float" | "directory_uri";
+    };
+    icon: IconDefinition;
+}
+
+export function getWorkflowInputs(): WorkflowInput[] {
+    return [
+        {
+            id: "data_input",
+            title: "Input Dataset",
+            description: "Single dataset input",
+            icon: faFile,
+        },
+        {
+            id: "data_collection_input",
+            title: "Input Dataset Collection",
+            description: "Input for a collection of datasets",
+            icon: faFolder,
+        },
+        {
+            id: "parameter_input",
+            title: "Text Input",
+            description: "Text parameter used for workflow logic",
+            icon: faPencilAlt,
+            stateOverwrites: {
+                parameter_type: "text",
+            },
+        },
+        {
+            id: "parameter_input",
+            title: "Integer Input",
+            description: "Whole number parameter used for workflow logic",
+            icon: faPencilAlt,
+            stateOverwrites: {
+                parameter_type: "integer",
+            },
+        },
+        {
+            id: "parameter_input",
+            title: "Float Input",
+            description: "Imprecise decimal number parameter used for workflow logic",
+            icon: faPencilAlt,
+            stateOverwrites: {
+                parameter_type: "float",
+            },
+        },
+        {
+            id: "parameter_input",
+            title: "Boolean Input",
+            description: "True / False parameter used for workflow logic",
+            icon: faPencilAlt,
+            stateOverwrites: {
+                parameter_type: "boolean",
+            },
+        },
+        {
+            id: "parameter_input",
+            title: "Color Input",
+            description: "Color parameter used for workflow logic",
+            icon: faPencilAlt,
+            stateOverwrites: {
+                parameter_type: "color",
+            },
+        },
+        {
+            id: "parameter_input",
+            title: "Directory Input",
+            description: "Directory parameter used for workflow logic",
+            icon: faPencilAlt,
+            stateOverwrites: {
+                parameter_type: "directory_uri",
+            },
+        },
+    ];
+}

--- a/client/src/entry/analysis/modules/WorkflowEditor.vue
+++ b/client/src/entry/analysis/modules/WorkflowEditor.vue
@@ -7,7 +7,6 @@
         :initial-version="editorConfig.initialVersion"
         :module-sections="editorConfig.moduleSections"
         :workflow-tags="editorConfig.tags"
-        :workflows="editorConfig.workflows"
         @update:confirmation="$emit('update:confirmation', $event)" />
 </template>
 <script>

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -750,6 +750,11 @@ workflow_editor:
       freehand_comment: ".freehand-workflow-comment"
       freehand_path: ".freehand-workflow-comment path"
       delete: "button[title='Delete comment']"
+  inputs:
+    selectors:
+      activity_button: "#activity-workflow-editor-inputs"
+      activity_panel: ".activity-panel[data-description='Inputs']"
+      input: ".workflow-input-button[data-id='${id}']"
   selectors:
     node_inspector: '.tool-inspector'
     node_inspector_close: ".tool-inspector [title='close']"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1456,6 +1456,11 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.1.tgz#411e02a820744d3f7e0d8d9df9d82b471beaa073"
   integrity sha512-Sz07mnQrTekFWLz5BMjOzHl/+NooTdW8F8kDQxjWwbpOJcnoSg4vUDng8d/WR1wOxM0O+CY9Zw0nR054riNYtQ==
 
+"@fortawesome/fontawesome-common-types@6.7.1":
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.1.tgz#6201640f39fdcf8e41cd9d1a92b2da3a96817fa4"
+  integrity sha512-gbDz3TwRrIPT3i0cDfujhshnXO9z03IT1UKRIVi/VEjpNHtSBIP2o5XSm+e816FzzCFEzAxPw09Z13n20PaQJQ==
+
 "@fortawesome/fontawesome-common-types@^0.2.36":
   version "0.2.36"
   resolved "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz"
@@ -6334,6 +6339,13 @@ follow-redirects@^1.0.0, follow-redirects@^1.15.6:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+
+"font-awesome-6@npm:@fortawesome/free-solid-svg-icons@6":
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.1.tgz#c1f9a6c25562a12c283e87e284f9d82a5b0dbcc0"
+  integrity sha512-BTKc0b0mgjWZ2UDKVgmwaE0qt0cZs6ITcDgjrti5f/ki7aF5zs+N91V6hitGo3TItCFtnKg6cUVGdTmBFICFRg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.7.1"
 
 for-each@^0.3.3:
   version "0.3.3"

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1209,12 +1209,11 @@ class NavigatesGalaxy(HasDriver):
         # Make sure we're on the workflow editor and not clicking the main tool panel.
         editor.canvas_body.wait_for_visible()
 
-        self.open_toolbox()
-        editor.tool_menu_section_link(section_name="inputs").wait_for_and_click()
-        editor.tool_menu_item_link(item_name=item_name).wait_for_and_click()
+        if editor.inputs.activity_panel.is_absent:
+            editor.inputs.activity_button.wait_for_and_click()
 
-    def workflow_editor_add_parameter_input(self):
-        self.workflow_editor_add_input(item_name="parameter_input")
+        editor.inputs.input(id=item_name).wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
 
     def workflow_editor_set_license(self, license: str) -> None:
         license_selector = self.components.workflow_editor.license_selector

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -531,12 +531,12 @@ class WorkflowsAPIController(
         inputs = payload.get("inputs", {})
         trans.workflow_building_mode = workflow_building_modes.ENABLED
         module = module_factory.from_dict(trans, payload, from_tool_form=True)
-        if "tool_state" not in payload:
-            module_state: Dict[str, Any] = {}
-            errors: ParameterValidationErrorsT = {}
-            populate_state(trans, module.get_inputs(), inputs, module_state, errors=errors, check=True)
-            module.recover_state(module_state, from_tool_form=True)
-            module.check_and_update_state()
+
+        module_state: Dict[str, Any] = {}
+        errors: ParameterValidationErrorsT = {}
+        populate_state(trans, module.get_inputs(), inputs, module_state, errors=errors, check=True)
+        module.recover_state(module_state, from_tool_form=True)
+        module.check_and_update_state()
         step_dict = {
             "name": module.get_name(),
             "tool_state": module_state,

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2567,23 +2567,6 @@ def load_module_sections(trans):
     is configured with.
     """
     module_sections = {}
-    module_sections["inputs"] = {
-        "name": "inputs",
-        "title": "Inputs",
-        "modules": [
-            {"name": "data_input", "title": "Input Dataset", "description": "Input dataset"},
-            {
-                "name": "data_collection_input",
-                "title": "Input Dataset Collection",
-                "description": "Input dataset collection",
-            },
-            {
-                "name": "parameter_input",
-                "title": "Parameter Input",
-                "description": "Simple inputs used for workflow logic",
-            },
-        ],
-    }
 
     if trans.app.config.enable_beta_workflow_modules:
         module_sections["experimental"] = {

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -102,7 +102,7 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows):
 
         parameter_name = "text_param"
         name = self.create_and_wait_for_new_workflow_in_editor()
-        self.workflow_editor_add_parameter_input()
+        self.workflow_editor_add_input("parameter_input_text")
         editor.label_input.wait_for_and_send_keys(parameter_name)
         # this really should be parameterized with the repeat name
         self.components.tool_form.repeat_insert.wait_for_and_click()
@@ -131,7 +131,7 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows):
 
         parameter_name = "int_param"
         name = self.create_and_wait_for_new_workflow_in_editor()
-        self.workflow_editor_add_parameter_input()
+        self.workflow_editor_add_input("parameter_input_text")
         editor.label_input.wait_for_and_send_keys(parameter_name)
         select_field = self.components.tool_form.parameter_select(parameter="parameter_definition|parameter_type")
         self.select_set_value(select_field, "integer")
@@ -157,10 +157,8 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows):
 
         parameter_name = "float_param"
         name = self.create_and_wait_for_new_workflow_in_editor()
-        self.workflow_editor_add_parameter_input()
+        self.workflow_editor_add_input("parameter_input_float")
         editor.label_input.wait_for_and_send_keys(parameter_name)
-        select_field = self.components.tool_form.parameter_select(parameter="parameter_definition|parameter_type")
-        self.select_set_value(select_field, "float")
         self.components.tool_form.parameter_input(parameter="parameter_definition|max").wait_for_and_send_keys("3.14")
         self.save_after_node_form_changes()
 

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -102,7 +102,7 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows):
 
         parameter_name = "text_param"
         name = self.create_and_wait_for_new_workflow_in_editor()
-        self.workflow_editor_add_input("parameter_input_text")
+        self.workflow_editor_add_input("parameter_input")
         editor.label_input.wait_for_and_send_keys(parameter_name)
         # this really should be parameterized with the repeat name
         self.components.tool_form.repeat_insert.wait_for_and_click()
@@ -131,7 +131,7 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows):
 
         parameter_name = "int_param"
         name = self.create_and_wait_for_new_workflow_in_editor()
-        self.workflow_editor_add_input("parameter_input_text")
+        self.workflow_editor_add_input("parameter_input")
         editor.label_input.wait_for_and_send_keys(parameter_name)
         select_field = self.components.tool_form.parameter_select(parameter="parameter_definition|parameter_type")
         self.select_set_value(select_field, "integer")


### PR DESCRIPTION
Moves inputs to it's own activity.
This will likely break a bunch of tests. Here's a picture:

![image](https://github.com/user-attachments/assets/263e1335-7a17-4050-b7b2-0fca06bfb808)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
