### PR TITLE
[24.2] Cleanup "typical" usage of list of pairs builder.

### DIFF
--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -1314,6 +1314,8 @@ $fa-font-path: "../../../node_modules/@fortawesome/fontawesome-free/webfonts/";
 @import "~@fortawesome/fontawesome-free/scss/solid";
 @import "~@fortawesome/fontawesome-free/scss/fontawesome";
 @import "~@fortawesome/fontawesome-free/scss/brands";
+@import "~bootstrap/scss/_functions.scss";
+@import "theme/blue.scss";
 .paired-column {
     text-align: center;
     // mess with these two to make center more/scss priority
@@ -1360,7 +1362,7 @@ li.dataset.paired {
             white-space: nowrap;
             overflow: hidden;
             border: 2px solid grey;
-            background: #aff1af;
+            background: $state-success-bg;
             text-align: center;
             span {
                 display: inline-block;

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -91,6 +91,10 @@ const hasFilter = computed(() => forwardFilter.value || reverseFilter.value);
 const strategy = ref(autoPairLCS);
 const duplicatePairNames = ref<string[]>([]);
 
+const canClearFilters = computed(() => {
+    return forwardFilter.value || reverseFilter.value;
+});
+
 const canAutoPair = computed(() => {
     return forwardFilter.value && reverseFilter.value;
 });
@@ -1140,6 +1144,7 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                                         <BButtonGroup vertical>
                                             <BButton
                                                 class="clear-filters-link"
+                                                :disabled="!canClearFilters"
                                                 size="sm"
                                                 :variant="hasFilter ? 'danger' : 'secondary'"
                                                 @click="clickClearFilters">

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -241,8 +241,11 @@ function initialFiltersSet() {
             illumina++;
         }
     });
-
-    if (illumina > dot12s && illumina > Rs) {
+    // if we cannot filter don't set an initial filter and hide all the data
+    if (illumina == 0 && dot12s == 0 && Rs == 0) {
+        forwardFilter.value = "";
+        reverseFilter.value = "";
+    } else if (illumina > dot12s && illumina > Rs) {
         changeFilters("illumina");
     } else if (dot12s > illumina && dot12s > Rs) {
         changeFilters("dot12s");

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -91,6 +91,10 @@ const hasFilter = computed(() => forwardFilter.value || reverseFilter.value);
 const strategy = ref(autoPairLCS);
 const duplicatePairNames = ref<string[]>([]);
 
+const canAutoPair = computed(() => {
+    return forwardFilter.value && reverseFilter.value;
+});
+
 const forwardElements = computed<HDASummary[]>(() => {
     return filterElements(workingElements.value, forwardFilter.value);
 });
@@ -115,7 +119,11 @@ const autoPairButton = computed(() => {
     let variant;
     let icon;
     let text;
-    if (!firstAutoPairDone.value && pairableElements.value.length > 0) {
+    if (!canAutoPair.value) {
+        variant = "secondary";
+        icon = faLink;
+        text = localize("Specify simple filters to divide datasets into forward and reverse reads for pairing.");
+    } else if (!firstAutoPairDone.value && pairableElements.value.length > 0) {
         variant = "primary";
         icon = faExclamationCircle;
         text = localize("Click to auto-pair datasets based on the current filters");
@@ -1137,6 +1145,7 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                                             </BButton>
                                             <BButton
                                                 class="autopair-link"
+                                                :disabled="!canAutoPair"
                                                 size="sm"
                                                 :title="autoPairButton.text"
                                                 :variant="autoPairButton.variant"

--- a/client/src/components/Collections/PairedListSummary.vue
+++ b/client/src/components/Collections/PairedListSummary.vue
@@ -1,0 +1,140 @@
+<script setup lang="ts">
+import { BCard, BCol, BContainer, BLink, BRow, BTable } from "bootstrap-vue";
+import { computed, ref } from "vue";
+
+import type { HDASummary } from "@/api";
+
+import type { DatasetPair } from "../History/adapters/buildCollectionModal";
+
+const hideUnmatched = ref(false);
+
+interface Props {
+    generatedPairs: DatasetPair[];
+    workingElements: HDASummary[];
+}
+
+const FIELDS = [
+    {
+        key: "identifier",
+        label: "List Identifier",
+    },
+    {
+        key: "forward",
+        label: "First Dataset",
+    },
+    {
+        key: "reverse",
+        label: "Second Dataset",
+    },
+];
+
+const UNMATCH_FIELDS = [
+    {
+        key: "name",
+        label: "Unpaired Dataset",
+    },
+];
+
+const pairedItems = computed(() => {
+    return props.generatedPairs.map((e) => {
+        return { identifier: e.name, forward: e.forward.name, reverse: e.reverse.name };
+    });
+});
+
+const unpairedItems = computed(() => {
+    return props.workingElements.map((e) => {
+        return { name: e.name };
+    });
+});
+
+const showUnpairedItems = computed(() => {
+    return !hideUnmatched.value && unpairedItems.value.length > 0;
+});
+
+const summaryText = computed(() => {
+    const numMatchedText = `Auto-matched ${props.generatedPairs.length} pair(s) of datasets from target datasets.`;
+    const numUnmatched = props.workingElements.length;
+    let numUnmatchedText = "";
+    if (numUnmatched > 0) {
+        numUnmatchedText = `${numUnmatched} dataset(s) were not paired and will not be included in the resulting list of pairs.`;
+    }
+    return `${numMatchedText} ${numUnmatchedText}`;
+});
+
+function clickHideUnmatched() {
+    hideUnmatched.value = true;
+}
+
+const props = defineProps<Props>();
+
+const emit = defineEmits<{
+    (e: "correctPairing"): void;
+    (e: "correctIdentifiers"): void;
+}>();
+</script>
+
+<template>
+    <BCard no-body>
+        <BContainer style="max-width: 100%">
+            <BRow>
+                <BCol>
+                    <p>{{ summaryText }}</p>
+                </BCol>
+            </BRow>
+            <BRow cols="12">
+                <BCol :cols="showUnpairedItems ? 8 : 12">
+                    <BTable
+                        sticky-header
+                        striped
+                        hover
+                        :items="pairedItems"
+                        :fields="FIELDS"
+                        :outlined="true"
+                        class="summary-table"
+                        :caption-top="true"
+                        :bordered="true">
+                        <template v-slot:table-caption
+                            ><i class="text-muted"
+                                >These pairs will make up the list of pairs being created.</i
+                            ></template
+                        >
+                    </BTable>
+                </BCol>
+                <BCol v-if="showUnpairedItems" cols="4">
+                    <BTable
+                        sticky-header
+                        striped
+                        hover
+                        :items="unpairedItems"
+                        :fields="UNMATCH_FIELDS"
+                        thead-class="d-none"
+                        :outlined="true"
+                        class="summary-table"
+                        :caption-top="true"
+                        :bordered="true">
+                        <template v-slot:table-caption
+                            ><i class="text-muted"
+                                >These datasets could not be auto-paired and will not appear in the created collection.
+                                <BLink @click="clickHideUnmatched">Hide this.</BLink></i
+                            ></template
+                        >
+                    </BTable>
+                </BCol>
+            </BRow>
+            <BRow>
+                <BCol>
+                    If this doesn't look correct, it can be manually fixed. Just let us know how it is incorrect.
+                    <b><BLink @click="emit('correctPairing')">The pairing is wrong</BLink></b> (datasets were not
+                    matched properly or datasets were not included in the matches that should be) or
+                    <b
+                        ><BLink @click="emit('correctIdentifiers')"
+                            >the list identifiers were derived incorrectly</BLink
+                        ></b
+                    >.
+                </BCol>
+            </BRow>
+        </BContainer>
+    </BCard>
+</template>
+
+<style lang="scss" scoped></style>

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -39,12 +39,15 @@ interface Props {
     extensions?: string[];
     extensionsToggle?: boolean;
     noItems?: boolean;
+    collectionType?: string;
+    showHelp?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
     suggestedName: "",
     extensions: undefined,
     extensionsToggle: false,
+    showHelp: true,
 });
 
 const emit = defineEmits<{
@@ -146,7 +149,7 @@ watch(
             </div>
             <div v-else>
                 <div class="header flex-row no-flex">
-                    <div class="main-help well clear" :class="{ expanded: isExpanded }">
+                    <div v-if="showHelp" class="main-help well clear" :class="{ expanded: isExpanded }">
                         <a
                             class="more-help"
                             href="javascript:void(0);"


### PR DESCRIPTION
https://github.com/galaxyproject/galaxy/pull/19248 is much more straight forward set of usability fixes for people who have messy data or data not prepped in a history for pairing. This PR cleans up the usage of the builder for users who have done everything right - they have preserved filenames with a common pattern we recognize, the datasets can be paired, and (optionally) they've selected only data they want to include in the collection. For this use case - the pair builder should just do what is needed by default and showing the pairing interface and its warning is messy and the showing the matching is... well fine... but not as clear as it could be if we weren't going to be doing pairing. For these users, I think they want to just give the collection a name and move one. This makes that a lot more clean.

If the user makes a selection that only includes pairable datasets:

<img width="1136" alt="Screenshot 2024-12-04 at 4 09 31 PM" src="https://github.com/user-attachments/assets/007f58a0-e350-42ee-8a5f-cc31f916d093">

In other contexts like auto-populating this from a history or a user mis-click - an additional little box shows the unmatched datasets - I think this is important for knowing what happens.

<img width="1142" alt="Screenshot 2024-12-04 at 4 09 15 PM" src="https://github.com/user-attachments/assets/dc5f1c50-9281-4b77-86f3-cfc51bcf74b1">

In most cases, hopefully the user can just review the table and move on. If there is an issue - there are two links to clarify what went wrong. If the problem is just with the identifiers and not the matching - we can switch the builder but hide the matching part (something added this release I think).

This component also deals with space better than the full builder and keeps the modal a reasonable size (bypassing #19249 or typical use cases).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. use cases and screenshots above above describe how to test

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
