### PR TITLE
Explicitly add cwl-utils to dependencies

### DIFF
--- a/lib/galaxy_ext/expressions/handle_job.py
+++ b/lib/galaxy_ext/expressions/handle_job.py
@@ -27,7 +27,7 @@ log = logging.getLogger(__name__)
 
 def run(environment_path=None):
     if expression is None:
-        raise Exception("Python library cwltool must be available to evaluate expressions.")
+        raise Exception("Python library cwl-utils must be available to evaluate expressions.")
 
     if environment_path is None:
         environment_path = os.environ.get("GALAXY_EXPRESSION_INPUTS")

--- a/packages/app/setup.cfg
+++ b/packages/app/setup.cfg
@@ -49,6 +49,7 @@ install_requires =
     bx-python
     celery
     cloudauthz==0.6.0
+    cwl-utils
     dparse
     gxformat2
     kombu>=5.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "circus",
     "conda-package-streaming",
     "CT3>=3.3.3",  # Python 3.13 support
+    "cwl-utils>=0.13",
     "cwltool>=3.1.20230624081518",  # save time, minimum needed by cwl-1.0 branch
     "dictobj",
     "dnspython",


### PR DESCRIPTION
Imported e.g. in `lib/galaxy/tools/expressions/evaluation.py` . No actual change to requirements files as it's already included as a dependency of cwltool.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
