### PR TITLE
[24.2] Cleanup vega descriptions for workflow metrics.

### DIFF
--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
@@ -55,12 +55,14 @@ interface boxplotData {
     x_title: string;
     y_title: string;
     values?: { x: string; y: Number }[];
+    description: string;
 }
 
 function metricToSpecData(
     jobMetrics: components["schemas"]["WorkflowJobMetric"][] | undefined,
     metricName: string,
     yTitle: string,
+    description: string,
     transform?: (param: number) => number
 ) {
     const wallclock = jobMetrics?.filter((jobMetric) => jobMetric.name == metricName);
@@ -78,29 +80,41 @@ function metricToSpecData(
         x_title: attributeToLabel[groupBy.value],
         y_title: yTitle,
         values,
+        description,
     };
 }
 
 const wallclock: ComputedRef<boxplotData> = computed(() => {
-    return metricToSpecData(jobMetrics.value, "runtime_seconds", "Runtime (in Seconds)");
+    return metricToSpecData(jobMetrics.value, "runtime_seconds", "Runtime (in Seconds)", "Boxplot of runtime");
 });
 
 const coresAllocated: ComputedRef<boxplotData> = computed(() => {
-    return metricToSpecData(jobMetrics.value, "galaxy_slots", "Cores Allocated");
+    return metricToSpecData(jobMetrics.value, "galaxy_slots", "Cores Allocated", "Boxplot of cores allocated");
 });
 
 const memoryAllocated: ComputedRef<boxplotData> = computed(() => {
-    return metricToSpecData(jobMetrics.value, "galaxy_memory_mb", "Memory Allocated (in MB)");
+    return metricToSpecData(
+        jobMetrics.value,
+        "galaxy_memory_mb",
+        "Memory Allocated (in MB)",
+        "Boxplot of memory allocated"
+    );
 });
 
 const peakMemory: ComputedRef<boxplotData> = computed(() => {
-    return metricToSpecData(jobMetrics.value, "memory.peak", "Max memory usage recorded (in MB)", (v) => v / 1024 ** 2);
+    return metricToSpecData(
+        jobMetrics.value,
+        "memory.peak",
+        "Max memory usage recorded (in MB)",
+        "Boxplot of peak memory consumed",
+        (v) => v / 1024 ** 2
+    );
 });
 
 function itemToSpec(item: boxplotData) {
     const spec: VisualizationSpec = {
         $schema: "https://vega.github.io/schema/vega-lite/v5.json",
-        description: "A boxplot with jittered points.",
+        description: item.description,
         data: {
             values: item.values!,
         },


### PR DESCRIPTION
It isn't exposed explicitly but seeing this text when opening the Vega source or using the Vega editor from the link on the widget was a little off-putting. I thought maybe the data was random at first but the jitter is only added in the x direction for reasons that make sense once you think about but isn't something I think should be forefronted.

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. View the metrics in the Vega editor.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
