### PR TITLE
[24.2] Fix CollectionCreatorModal being reopened on history

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -145,6 +145,7 @@
             :filter-text="filterText"
             :selected-items="collectionSelection"
             :show-modal.sync="collectionModalShow"
+            hide-modal-on-create
             default-hide-source-items
             @created-collection="createdCollection" />
     </section>


### PR DESCRIPTION
Fixes #19270

The CollectionCreatorModal.hideModal() function is only called on Cancel or when we explicitly set the prop hideModalOnCreate to true. If we don't set this prop, and we create a collection, it leaves the `collectionModalShow` ref set to true as the event to change it to false never gets fired.

@ahmedhamidawan do you think this might affect other usages of CollectionCreatorModal? Is there any use case for not setting hideModalOnCreate to true by default?

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
