### PR TITLE
[24.2] Release testing of various workflow features for 24.2.

### DIFF
--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -127,7 +127,9 @@ const showHelpForum = computed(() => isConfigLoaded.value && config.value.enable
                         <Heading h1 inline bold size="text" itemprop="name">{{ props.title }}</Heading>
                     </span>
                     <span itemprop="description">{{ props.description }}</span>
-                    <span>(Galaxy Version {{ props.version }})</span>
+                    <span data-description="galaxy tool version" :data-version="props.version"
+                        >(Galaxy Version {{ props.version }})</span
+                    >
                 </div>
                 <div class="d-flex flex-nowrap align-items-start flex-gapx-1">
                     <b-button-group class="tool-card-buttons">

--- a/client/src/components/UndoRedo/UndoRedoStack.vue
+++ b/client/src/components/UndoRedo/UndoRedoStack.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
 
-import { useUndoRedoStore } from "@/stores/undoRedoStore";
+import { type UndoRedoAction, useUndoRedoStore } from "@/stores/undoRedoStore";
 
 import ActivityPanel from "../Panels/ActivityPanel.vue";
 
@@ -15,6 +15,15 @@ watch(
     () => props.storeId,
     (id) => (currentStore.value = useUndoRedoStore(id))
 );
+
+function dataAttributes(action: UndoRedoAction): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (const [key, value] of Object.entries(action.dataAttributes)) {
+        result[`data-${key}`] = value;
+    }
+
+    return result;
+}
 
 function onInput(event: Event) {
     const value = (event.target as HTMLInputElement).value;
@@ -37,6 +46,7 @@ function updateSavedUndoActions() {
         <div class="scroll-list">
             <button
                 v-for="action in currentStore.redoActionStack"
+                v-bind="dataAttributes(action)"
                 :key="action.id"
                 class="action future"
                 @click="currentStore.rollForwardTo(action)">
@@ -51,6 +61,7 @@ function updateSavedUndoActions() {
 
             <button
                 v-for="action in [...currentStore.undoActionStack].reverse()"
+                v-bind="dataAttributes(action)"
                 :key="action.id"
                 class="action past"
                 @click="currentStore.rollBackTo(action)">

--- a/client/src/components/Workflow/Editor/Actions/stepActions.ts
+++ b/client/src/components/Workflow/Editor/Actions/stepActions.ts
@@ -269,6 +269,13 @@ export class InsertStepAction extends UndoRedoAction {
         return `insert ${this.stepData.name}`;
     }
 
+    get dataAttributes(): Record<string, string> {
+        return {
+            type: "step-insert",
+            "step-type": this.stepData.type as string,
+        };
+    }
+
     stepDataToTuple() {
         return Object.values(this.stepData) as Parameters<WorkflowStepStore["insertNewStep"]>;
     }

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -333,7 +333,8 @@ export default {
             undoRedoStore,
             (value) => (license.value = value),
             showAttributes,
-            "set license"
+            "set license",
+            "license"
         );
         /** user set license. queues an undo/redo action */
         function setLicense(newLicense) {
@@ -347,7 +348,8 @@ export default {
             undoRedoStore,
             (value) => (creator.value = value),
             showAttributes,
-            "set creator"
+            "set creator",
+            "creator"
         );
         /** user set creator. queues an undo/redo action */
         function setCreator(newCreator) {
@@ -359,7 +361,8 @@ export default {
             undoRedoStore,
             (value) => (annotation.value = value),
             showAttributes,
-            "modify annotation"
+            "modify annotation",
+            "annotation"
         );
         /** user set annotation. queues an undo/redo action */
         function setAnnotation(newAnnotation) {

--- a/client/src/components/Workflow/Editor/Lint.vue
+++ b/client/src/components/Workflow/Editor/Lint.vue
@@ -4,6 +4,7 @@
             <button class="refactor-button ui-link" @click="onRefactor">Try to automatically fix issues.</button>
         </template>
         <LintSection
+            data-description="linting has annotation"
             :okay="checkAnnotation"
             success-message="This workflow is annotated. Ideally, this helps the executors of the workflow
                     understand the purpose and usage of the workflow."
@@ -11,18 +12,21 @@
             attribute-link="Annotate your Workflow."
             @onClick="onAttributes('annotation')" />
         <LintSection
+            data-description="linting has creator"
             :okay="checkCreator"
             success-message="This workflow defines creator information."
             :warning-message="bestPracticeWarningCreator"
             attribute-link="Provide Creator Details."
             @onClick="onAttributes('creator')" />
         <LintSection
+            data-description="linting has license"
             :okay="checkLicense"
             success-message="This workflow defines a license."
             :warning-message="bestPracticeWarningLicense"
             attribute-link="Specify a License."
             @onClick="onAttributes('license')" />
         <LintSection
+            data-description="linting formal inputs"
             success-message="Workflow parameters are using formal input parameters."
             warning-message="This workflow uses legacy workflow parameters. They should be replaced with
                 formal workflow inputs. Formal input parameters make tracking workflow provenance, usage within subworkflows,
@@ -32,6 +36,7 @@
             @onMouseLeave="onUnhighlight"
             @onClick="onFixUntypedParameter" />
         <LintSection
+            data-description="linting connected"
             success-message="All non-optional inputs to workflow steps are connected to formal input parameters."
             warning-message="Some non-optional inputs are not connected to formal workflow inputs. Formal input parameters
                 make tracking workflow provenance, usage within subworkflows, and executing the workflow via the API more robust:"
@@ -40,6 +45,7 @@
             @onMouseLeave="onUnhighlight"
             @onClick="onFixDisconnectedInput" />
         <LintSection
+            data-description="linting input metadata"
             success-message="All workflow inputs have labels and annotations."
             warning-message="Some workflow inputs are missing labels and/or annotations:"
             :warning-items="warningMissingMetadata"
@@ -47,6 +53,7 @@
             @onMouseLeave="onUnhighlight"
             @onClick="openAndFocus" />
         <LintSection
+            data-description="linting output labels"
             success-message="This workflow has outputs and they all have valid labels."
             warning-message="The following workflow outputs have no labels, they should be assigned a useful label or
                     unchecked in the workflow editor to mark them as no longer being a workflow output:"

--- a/client/src/components/Workflow/Editor/LintSection.vue
+++ b/client/src/components/Workflow/Editor/LintSection.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="mb-2">
+    <div class="mb-2" :data-lint-status="isOkay ? 'ok' : 'warning'">
         <div v-if="isOkay">
             <FontAwesomeIcon icon="check" class="text-success" />
             <span>{{ successMessage }}</span>
@@ -16,7 +16,12 @@
                     @mouseover="onMouseOver(item)"
                     @focusout="onMouseLeave(item)"
                     @mouseleave="onMouseLeave(item)">
-                    <a href="#" class="scrolls" @click="onClick(item)">
+                    <a
+                        href="#"
+                        class="scrolls"
+                        :data-item-index="idx"
+                        v-bind="dataAttributes(item)"
+                        @click="onClick(item)">
                         <FontAwesomeIcon v-if="item.autofix" icon="magic" class="mr-1" />
                         <FontAwesomeIcon v-else icon="search" class="mr-1" />
                         {{ item.stepLabel }}: {{ item.warningLabel }}
@@ -36,6 +41,8 @@ import { faCheck, faExclamationTriangle, faMagic, faPencilAlt, faSearch } from "
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import BootstrapVue from "bootstrap-vue";
 import Vue from "vue";
+
+import { dataAttributes } from "./modules/linting";
 
 Vue.use(BootstrapVue);
 
@@ -80,6 +87,7 @@ export default {
         },
     },
     methods: {
+        dataAttributes: dataAttributes,
         onMouseOver(id) {
             this.$emit("onMouseOver", id);
         },

--- a/client/src/components/Workflow/Editor/modules/linting.ts
+++ b/client/src/components/Workflow/Editor/modules/linting.ts
@@ -13,6 +13,7 @@ interface LintState {
     name?: string;
     inputName?: string;
     autofix?: boolean;
+    data?: Record<string, string>;
 }
 
 export const bestPracticeWarningAnnotation =
@@ -57,23 +58,41 @@ export function getMissingMetadata(steps: Steps) {
             const noAnnotation = !step.annotation;
             const noLabel = !step.label;
             let warningLabel = null;
+            const data = {
+                "missing-label": "false",
+                "missing-annotation": "false",
+            };
             if (noLabel && noAnnotation) {
                 warningLabel = "Missing a label and annotation";
+                data["missing-label"] = "true";
+                data["missing-annotation"] = "true";
             } else if (noLabel) {
                 warningLabel = "Missing a label";
+                data["missing-label"] = "true";
             } else if (noAnnotation) {
                 warningLabel = "Missing an annotation";
+                data["missing-annotation"] = "true";
             }
             if (warningLabel) {
                 inputs.push({
                     stepId: step.id,
                     stepLabel: step.label || step.content_id || step.name,
                     warningLabel: warningLabel,
+                    data: data,
                 });
             }
         }
     });
     return inputs;
+}
+
+export function dataAttributes(action: LintState): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (const [key, value] of Object.entries(action.data || {})) {
+        result[`data-${key}`] = value;
+    }
+
+    return result;
 }
 
 export function getUnlabeledOutputs(steps: Steps) {

--- a/client/src/stores/undoRedoStore/undoRedoAction.ts
+++ b/client/src/stores/undoRedoStore/undoRedoAction.ts
@@ -31,6 +31,10 @@ export class UndoRedoAction {
     destroy() {
         return;
     }
+
+    get dataAttributes(): Record<string, string> {
+        return {};
+    }
 }
 
 export class LazyUndoRedoAction extends UndoRedoAction {

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -718,6 +718,12 @@ workflow_editor:
       connector_destroy_callout: "${_} [input-name='${name}'] + .delete-terminal-button"
       workflow_output_toggle: "${_} [data-output-name='${name}'] .callout-terminal "
       workflow_output_toggle_active: "${_} [data-output-name='${name}'] .mark-terminal-active"
+  changes:
+    selectors:
+      action_insert_data_input: ".action[data-type='step-insert'][data-step-type='data_input']"
+      action_insert_data_collection_input: ".action[data-type='step-insert'][data-step-type='data_collection_input']"
+      action_insert_parameter: ".action[data-type='step-insert'][data-step-type='parameter_input']"
+
   tool_bar:
     selectors:
       _: ".workflow-editor-toolbar"
@@ -738,6 +744,7 @@ workflow_editor:
       duplicate_selection: "[title='duplicate selected']"
       delete_selection: "[title='delete selected']"
       auto_layout: "#auto-layout-button"
+      changes: "#activity-workflow-undo-redo"
   comment:
     selectors:
       _: ".workflow-editor-comment"

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -724,6 +724,8 @@ workflow_editor:
       action_insert_data_input: ".action[data-type='step-insert'][data-step-type='data_input']"
       action_insert_data_collection_input: ".action[data-type='step-insert'][data-step-type='data_collection_input']"
       action_insert_parameter: ".action[data-type='step-insert'][data-step-type='parameter_input']"
+      action_set_license: ".action[data-type='set-license']"
+      action_set_annotation: ".action[data-type='set-annotation']"
 
   tool_bar:
     selectors:
@@ -745,6 +747,7 @@ workflow_editor:
       duplicate_selection: "[title='duplicate selected']"
       delete_selection: "[title='delete selected']"
       auto_layout: "#auto-layout-button"
+      attributes: "#activity-workflow-editor-attributes"
       changes: "#activity-workflow-undo-redo"
       upgrade_all: "#activity-workflow-upgrade"
   comment:

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -750,6 +750,13 @@ workflow_editor:
       attributes: "#activity-workflow-editor-attributes"
       changes: "#activity-workflow-undo-redo"
       upgrade_all: "#activity-workflow-upgrade"
+      best_practices: "#activity-workflow-best-practices"
+
+  best_practices:
+    selectors:
+      section_input_metadata: '[data-description="linting input metadata"]'
+      item_input_metadata: '[data-description="linting input metadata"] [data-item-index="${index}"]'
+
   comment:
     selectors:
       _: ".workflow-editor-comment"

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -565,6 +565,7 @@ registration:
 
 tool_form:
   selectors:
+    tool_version: '[data-description="galaxy tool version"]'
     options: '.tool-dropdown'
     execute: 'button#execute'
     parameter_div: 'div.ui-form-element[id="form-element-${parameter}"]'
@@ -745,6 +746,7 @@ workflow_editor:
       delete_selection: "[title='delete selected']"
       auto_layout: "#auto-layout-button"
       changes: "#activity-workflow-undo-redo"
+      upgrade_all: "#activity-workflow-upgrade"
   comment:
     selectors:
       _: ".workflow-editor-comment"

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1237,6 +1237,16 @@ class NavigatesGalaxy(HasDriver):
         editor.tool_version_button.wait_for_and_click()
         assert self.select_dropdown_item(f"Switch to {version}"), "Switch to tool version dropdown item not found"
 
+    def workflow_editor_set_node_label(self, label: str, node: Optional[EditorNodeReference] = None):
+        self.workflow_editor_ensure_tool_form_open(node)
+        editor = self.components.workflow_editor
+        editor.label_input.wait_for_and_clear_and_send_keys(label)
+
+    def workflow_editor_set_node_annotation(self, annotation: str, node: Optional[EditorNodeReference] = None):
+        self.workflow_editor_ensure_tool_form_open(node)
+        editor = self.components.workflow_editor
+        editor.annotation_input.wait_for_and_clear_and_send_keys(annotation)
+
     def workflow_editor_ensure_tool_form_open(self, node: Optional[EditorNodeReference] = None):
         # if node is_empty just assume current tool step is open
         editor = self.components.workflow_editor

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -64,6 +64,7 @@ GALAXY_MAIN_FRAME_ID = "galaxy_main"
 GALAXY_VISUALIZATION_FRAME_ID = "galaxy_visualization"
 
 WaitType = collections.namedtuple("WaitType", ["name", "default_length"])
+EditorNodeReference = Union[int, str]  # can reference nodes by order_index (starting at 0 as int or label)
 
 
 class HistoryEntry(NamedTuple):
@@ -1221,6 +1222,31 @@ class NavigatesGalaxy(HasDriver):
 
         license_selector_option = self.components.workflow_editor.license_selector_option
         license_selector_option.wait_for_and_click()
+
+    def workflow_editor_add_tool_step(self, tool_id: str):
+        self.tool_open(tool_id)
+
+    def workflow_editor_set_label(self, label: str, node: Optional[EditorNodeReference] = None):
+        editor = self.components.workflow_editor
+        self.workflow_editor_ensure_tool_form_open(node)
+        self.set_text_element(editor.label_input, label)
+
+    def workflow_editor_set_tool_vesrion(self, version: str, node: Optional[EditorNodeReference] = None) -> None:
+        editor = self.components.workflow_editor
+        self.workflow_editor_ensure_tool_form_open(node)
+        editor.tool_version_button.wait_for_and_click()
+        assert self.select_dropdown_item(f"Switch to {version}"), "Switch to tool version dropdown item not found"
+
+    def workflow_editor_ensure_tool_form_open(self, node: Optional[EditorNodeReference] = None):
+        # if node is_empty just assume current tool step is open
+        editor = self.components.workflow_editor
+        if node is not None:
+            if isinstance(node, int):
+                node = editor.node.by_id(id=node)
+            else:
+                node = editor.node._(label=node)
+            node.wait_for_and_click()
+        editor.node_inspector.wait_for_visible()
 
     def workflow_editor_click_option(self, option_label):
         self.workflow_editor_click_options()

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1223,13 +1223,13 @@ class NavigatesGalaxy(HasDriver):
         license_selector_option = self.components.workflow_editor.license_selector_option
         license_selector_option.wait_for_and_click()
 
+    def workflow_editor_license_text(self) -> str:
+        editor = self.components.workflow_editor
+        editor.license_selector.wait_for_visible()
+        return editor.license_current_value.wait_for_text()
+
     def workflow_editor_add_tool_step(self, tool_id: str):
         self.tool_open(tool_id)
-
-    def workflow_editor_set_label(self, label: str, node: Optional[EditorNodeReference] = None):
-        editor = self.components.workflow_editor
-        self.workflow_editor_ensure_tool_form_open(node)
-        self.set_text_element(editor.label_input, label)
 
     def workflow_editor_set_tool_vesrion(self, version: str, node: Optional[EditorNodeReference] = None) -> None:
         editor = self.components.workflow_editor
@@ -1242,10 +1242,10 @@ class NavigatesGalaxy(HasDriver):
         editor = self.components.workflow_editor
         if node is not None:
             if isinstance(node, int):
-                node = editor.node.by_id(id=node)
+                node_component = editor.node.by_id(id=node)
             else:
-                node = editor.node._(label=node)
-            node.wait_for_and_click()
+                node_component = editor.node._(label=node)
+            node_component.wait_for_and_click()
         editor.node_inspector.wait_for_visible()
 
     def workflow_editor_click_option(self, option_label):
@@ -1695,7 +1695,7 @@ class NavigatesGalaxy(HasDriver):
             name_component.wait_for_visible().clear()
         name_component.wait_for_and_send_keys(name)
         annotation = annotation or self._get_random_name()
-        self.components.workflow_editor.edit_annotation.wait_for_and_send_keys(annotation)
+        self.workflow_editor_set_annotation(annotation)
         if save_workflow:
             save_button = self.components.workflow_editor.save_button
             save_button.wait_for_visible()
@@ -1703,6 +1703,9 @@ class NavigatesGalaxy(HasDriver):
             save_button.wait_for_and_click()
             self.sleep_for(self.wait_types.UX_RENDER)
         return name
+
+    def workflow_editor_set_annotation(self, annotation: str):
+        self.components.workflow_editor.edit_annotation.wait_for_and_clear_and_send_keys(annotation)
 
     def invocation_index_table_elements(self):
         invocations = self.components.invocations

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -442,6 +442,52 @@ steps:
         self.assert_connected("input1#output", "first_cat#input1")
 
     @selenium_test
+    def test_editor_change_stack(self):
+        editor = self.components.workflow_editor
+        annotation = "change_stack_test"
+        name = self.workflow_create_new(annotation=annotation)
+
+        self.workflow_editor_set_license("MIT")
+        self.workflow_editor_click_save()
+
+        self.workflow_editor_add_input(item_name="data_input")
+        self.workflow_editor_add_input(item_name="data_collection_input")
+        self.workflow_editor_add_input(item_name="parameter_input")
+
+        editor.node.by_id(id=0).wait_for_present()
+        editor.node.by_id(id=1).wait_for_present()
+        editor.node.by_id(id=2).wait_for_present()
+
+        editor.tool_bar.changes.wait_for_and_click()
+        changes = editor.changes
+
+        changes.action_insert_data_input.wait_for_present()
+        changes.action_insert_data_collection_input.wait_for_present()
+        changes.action_insert_parameter.wait_for_present()
+
+        # Undo all of it by clicking the first node.
+        changes.action_insert_data_input.wait_for_and_click()
+        editor.node.by_id(id=0).assert_absent_or_hidden_after_transitions()
+        editor.node.by_id(id=1).assert_absent_or_hidden_after_transitions()
+        editor.node.by_id(id=2).assert_absent_or_hidden_after_transitions()
+
+        # now that same action has become a redo, so we should have a node back afterward.
+        changes.action_insert_data_input.wait_for_and_click()
+        editor.node.by_id(id=0).wait_for_present()
+        editor.node.by_id(id=1).assert_absent_or_hidden_after_transitions()
+        editor.node.by_id(id=2).assert_absent_or_hidden_after_transitions()
+
+        changes.action_insert_data_collection_input.wait_for_and_click()
+        editor.node.by_id(id=0).wait_for_present()
+        editor.node.by_id(id=1).wait_for_present()
+        editor.node.by_id(id=2).assert_absent_or_hidden_after_transitions()
+
+        changes.action_insert_parameter.wait_for_and_click()
+        editor.node.by_id(id=0).wait_for_present()
+        editor.node.by_id(id=1).wait_for_present()
+        editor.node.by_id(id=2).wait_for_present()
+
+    @selenium_test
     def test_rendering_output_collection_connections(self):
         self.open_in_workflow_editor(WORKFLOW_WITH_OUTPUT_COLLECTION)
         self.workflow_editor_maximize_center_pane()

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -85,15 +85,14 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows):
     def test_edit_license(self):
         editor = self.components.workflow_editor
         name = self.create_and_wait_for_new_workflow_in_editor()
-        editor.license_selector.wait_for_visible()
-        assert "Do not specify" in editor.license_current_value.wait_for_text()
+        editor.canvas_body.wait_for_visible()
+        assert "Do not specify" in self.workflow_editor_license_text()
 
         self.workflow_editor_set_license("MIT")
         self.workflow_editor_click_save()
 
         self.workflow_index_open_with_name(name)
-        editor.license_selector.wait_for_visible()
-        assert "MIT" in editor.license_current_value.wait_for_text()
+        assert "MIT" in self.workflow_editor_license_text()
 
     @selenium_test
     def test_parameter_regex_validation(self):
@@ -442,13 +441,10 @@ steps:
         self.assert_connected("input1#output", "first_cat#input1")
 
     @selenium_test
-    def test_editor_change_stack(self):
+    def test_editor_change_stack_inserting_inputs(self):
         editor = self.components.workflow_editor
-        annotation = "change_stack_test"
-        name = self.workflow_create_new(annotation=annotation)
-
-        self.workflow_editor_set_license("MIT")
-        self.workflow_editor_click_save()
+        annotation = "change_stack_test_inserting_inputs"
+        self.workflow_create_new(annotation=annotation)
 
         self.workflow_editor_add_input(item_name="data_input")
         self.workflow_editor_add_input(item_name="data_collection_input")
@@ -486,6 +482,38 @@ steps:
         editor.node.by_id(id=0).wait_for_present()
         editor.node.by_id(id=1).wait_for_present()
         editor.node.by_id(id=2).wait_for_present()
+
+    @selenium_test
+    def test_editor_change_stack_set_attributes(self):
+        editor = self.components.workflow_editor
+        annotation = "change_stack_test_set_attributes"
+        name = self.workflow_create_new(annotation=annotation)
+
+        assert "Do not specify" in self.workflow_editor_license_text()
+        self.workflow_editor_set_license("MIT")
+        assert "MIT" in self.workflow_editor_license_text()
+
+        editor.tool_bar.changes.wait_for_and_click()
+
+        changes = editor.changes
+        changes.action_set_license.wait_for_and_click()
+        # it switches back so this isn't needed per se
+        # editor.tool_bar.attributes.wait_for_and_click()
+        assert "Do not specify" in self.workflow_editor_license_text()
+
+        # for annotation we want to reset the change stack to dismiss
+        # the original setting of the annotation
+        name = self.workflow_index_open_with_name(name)
+
+        annotation_modified = "change_stack_test_set_attributes modified!!!"
+
+        self.workflow_editor_set_annotation(annotation_modified)
+        self.assert_wf_annotation_is(annotation_modified)
+
+        editor.tool_bar.changes.wait_for_and_click()
+        changes.action_set_annotation.wait_for_and_click()
+
+        self.assert_wf_annotation_is(annotation)
 
     @selenium_test
     def test_rendering_output_collection_connections(self):
@@ -625,7 +653,7 @@ steps:
         annotation = "upgarde_all_test"
         self.workflow_create_new(annotation=annotation)
         self.workflow_editor_add_tool_step("multiple_versions")
-        self.workflow_editor_set_label(label="target label")
+        self.workflow_editor_set_node_label(label="target label")
         self.workflow_editor_set_tool_vesrion("0.1")
         self.assert_workflow_has_changes_and_save()
 
@@ -807,7 +835,7 @@ steps:
         self.workflow_index_open()
         self.components.workflows.edit_button.wait_for_and_click()
         editor = self.components.workflow_editor
-        self.workflow_editor_set_label(label="source label", node="first_cat")
+        self.workflow_editor_set_node_label(label="source label", node="first_cat")
         # Select node using new label, ensures labels are synced between side panel and node
         cat_node = editor.node._(label="source label")
         self.assert_workflow_has_changes_and_save()

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -604,9 +604,7 @@ steps:
         self.workflow_index_open()
         self.components.workflows.edit_button.wait_for_and_click()
         editor = self.components.workflow_editor
-        editor.node._(label="multiple_versions").wait_for_and_click()
-        editor.tool_version_button.wait_for_and_click()
-        assert self.select_dropdown_item("Switch to 0.2"), "Switch to tool version dropdown item not found"
+        self.workflow_editor_set_tool_vesrion("0.2", node="multiple_versions")
         self.screenshot("workflow_editor_version_update")
         self.sleep_for(self.wait_types.UX_RENDER)
         self.assert_workflow_has_changes_and_save()
@@ -620,6 +618,22 @@ steps:
         self.assert_workflow_has_changes_and_save()
         workflow = self.workflow_populator.download_workflow(workflow_id)
         assert workflow["steps"]["0"]["tool_version"] == "0.1+galaxy6"
+
+    @selenium_test
+    def test_editor_tool_upgrade_all_tools(self):
+        editor = self.components.workflow_editor
+        annotation = "upgarde_all_test"
+        self.workflow_create_new(annotation=annotation)
+        self.workflow_editor_add_tool_step("multiple_versions")
+        self.workflow_editor_set_label(label="target label")
+        self.workflow_editor_set_tool_vesrion("0.1")
+        self.assert_workflow_has_changes_and_save()
+
+        editor.tool_bar.upgrade_all.wait_for_and_click()
+        self.workflow_editor_ensure_tool_form_open(node=0)
+        node = self.components.tool_form.tool_version.wait_for_present()
+        version = node.get_attribute("data-version")
+        assert version == "0.2"
 
     @selenium_test
     def test_editor_tool_upgrade_message(self):
@@ -793,9 +807,7 @@ steps:
         self.workflow_index_open()
         self.components.workflows.edit_button.wait_for_and_click()
         editor = self.components.workflow_editor
-        cat_node = editor.node._(label="first_cat")
-        cat_node.wait_for_and_click()
-        self.set_text_element(editor.label_input, "source label")
+        self.workflow_editor_set_label(label="source label", node="first_cat")
         # Select node using new label, ensures labels are synced between side panel and node
         cat_node = editor.node._(label="source label")
         self.assert_workflow_has_changes_and_save()
@@ -1344,7 +1356,7 @@ steps:
         canvas = editor.canvas_body.wait_for_visible()
 
         # place tool in center of canvas
-        self.tool_open("cat")
+        self.workflow_editor_add_tool_step("cat")
         self.sleep_for(self.wait_types.UX_RENDER)
         editor.label_input.wait_for_and_send_keys("tool_node")
         tool_node = editor.node._(label="tool_node").wait_for_present()


### PR DESCRIPTION
Redo of https://github.com/galaxyproject/galaxy/pull/19216 correctly targeting 24.2 now that all the relevant workflow changes have been back ported and merged.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
