### PR TITLE
[24.2] Fix workflow metrics chart style

### DIFF
--- a/client/src/components/WorkflowInvocationState/VegaWrapper.vue
+++ b/client/src/components/WorkflowInvocationState/VegaWrapper.vue
@@ -1,5 +1,5 @@
 <template>
-    <div ref="chartContainer" class="chart" :style="style"></div>
+    <div ref="chartContainer" :style="style"></div>
 </template>
 
 <script setup lang="ts">
@@ -49,8 +49,3 @@ onBeforeUnmount(() => {
     }
 });
 </script>
-
-<style scoped>
-.chart {
-}
-</style>

--- a/client/src/components/WorkflowInvocationState/VegaWrapper.vue
+++ b/client/src/components/WorkflowInvocationState/VegaWrapper.vue
@@ -9,15 +9,18 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
 export interface VisSpec {
     spec: VisualizationSpec;
-    width: string;
+    fillWidth?: boolean;
 }
 
 const props = withDefaults(defineProps<VisSpec>(), {
-    width: "100%",
+    fillWidth: true,
 });
 
 const style = computed(() => {
-    return { width: props.width };
+    if (props.fillWidth) {
+        return { width: "100%" };
+    }
+    return {};
 });
 
 const chartContainer = ref<HTMLDivElement | null>(null);

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
@@ -372,6 +372,10 @@ function getTimingInTitle(timing: string): string {
 const timingInTitles = computed(() => {
     return getTimingInTitle(timing.value);
 });
+
+const groupByInTitles = computed(() => {
+    return attributeToLabel[groupBy.value];
+});
 </script>
 
 <template>
@@ -384,7 +388,7 @@ const timingInTitles = computed(() => {
                         <b-dropdown-item @click="timing = 'minutes'">{{ getTimingInTitle("minutes") }}</b-dropdown-item>
                         <b-dropdown-item @click="timing = 'hours'">{{ getTimingInTitle("hours") }}</b-dropdown-item>
                     </b-dropdown>
-                    <b-dropdown right text="Group By: Tool">
+                    <b-dropdown right :text="'Group By: ' + groupByInTitles">
                         <b-dropdown-item @click="groupBy = 'tool_id'">Tool</b-dropdown-item>
                         <b-dropdown-item @click="groupBy = 'step_id'">Workflow Step</b-dropdown-item>
                     </b-dropdown>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
@@ -275,18 +275,7 @@ function itemToPieChartSpec(item: piechartData) {
                 type: "nominal",
                 legend: {
                     type: "symbol",
-                    title: "", // should be item.category_title but it doesn't align right so just hide it
-                    direction: "vertical",
-                    titleAlign: "right",
-                    padding: 10,
-                    // rowPadding: 3,
-                    labelOffset: 40,
-                    // symbolOffset: 50,
-                    labelLimit: 120,
-                    // labelAlign: 'center',
-                    columnPadding: 5,
-                    // clipHeight: 20,
-                    titleOrient: "top",
+                    title: item.category_title,
                 },
             },
             tooltip: [

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
@@ -276,6 +276,8 @@ function itemToPieChartSpec(item: piechartData) {
                 legend: {
                     type: "symbol",
                     title: item.category_title,
+                    titleFontSize: 16,
+                    labelFontSize: 14,
                 },
             },
             tooltip: [

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
@@ -395,15 +395,15 @@ const groupByInTitles = computed(() => {
                 </BButtonGroup>
             </BRow>
             <BRow>
-                <BCol v-if="wallclockAggregate && wallclockAggregate.values">
+                <BCol v-if="wallclockAggregate && wallclockAggregate.values" class="text-center">
                     <h2 class="h-l truncate text-center">
                         Aggregate
                         <HelpText :for-title="true" uri="galaxy.jobs.metrics.walltime" text="Runtime Time" /> (in
                         {{ timingInTitles }})
                     </h2>
-                    <VegaWrapper :spec="itemToPieChartSpec(wallclockAggregate)" />
+                    <VegaWrapper :spec="itemToPieChartSpec(wallclockAggregate)" :fill-width="false" />
                 </BCol>
-                <BCol v-if="allocatedCoreTimeAggregate && allocatedCoreTimeAggregate.values">
+                <BCol v-if="allocatedCoreTimeAggregate && allocatedCoreTimeAggregate.values" class="text-center">
                     <h2 class="h-l truncate text-center">
                         Aggregate
                         <HelpText
@@ -412,14 +412,14 @@ const groupByInTitles = computed(() => {
                             text="Allocated Core Time" />
                         (in {{ timingInTitles }})
                     </h2>
-                    <VegaWrapper :spec="itemToPieChartSpec(allocatedCoreTimeAggregate)" />
+                    <VegaWrapper :spec="itemToPieChartSpec(allocatedCoreTimeAggregate)" :fill-width="false" />
                 </BCol>
             </BRow>
             <BRow v-for="({ spec, item }, key) in metrics" :key="key">
                 <BCol>
                     <h2 class="h-l truncate text-center">
                         <span v-if="item.helpTerm">
-                            <HelpText :for-title="true" :uri="item.helpTerm" :text="key" />
+                            <HelpText :for-title="true" :uri="item.helpTerm" :text="`${key}`" />
                         </span>
                         <span v-else>
                             {{ key }}


### PR DESCRIPTION
Fixes #19289

Another set of enh... ehem! **fixes** for Workflow Invocation metrics:
- Fixed the legend alignment issue. It now matches the one on the Vega editor.
- Center the Pie Charts horizontally as much as I could.
- Fixed the dropdown label for `Group by`. It was fixed to `Tool ID`.

![image](https://github.com/user-attachments/assets/563412c5-6aa5-41b6-a63e-edaf6407fe7c)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
