### PR TITLE
[24.1] remove mamba special handling

### DIFF
--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -738,7 +738,6 @@ class BuildMulledDockerContainerResolver(CliContainerResolver):
             "namespace": namespace,
             "hash_func": self.hash_func,
             "command": "build-and-test",
-            "use_mamba": True,
         }
         self._mulled_kwds["channels"] = default_mulled_conda_channels_from_env() or self._get_config_option(
             "mulled_channels", DEFAULT_CHANNELS
@@ -789,7 +788,6 @@ class BuildMulledSingularityContainerResolver(SingularityCliContainerResolver):
             "namespace": "local",
             "singularity": True,
             "singularity_image_dir": self.cache_directory.path,
-            "use_mamba": True,
         }
         self.involucro_context = InvolucroContext(**self._involucro_context_kwds)
         auto_init = self._get_config_option("involucro_auto_init", True)

--- a/lib/galaxy/tool_util/deps/mulled/invfile.lua
+++ b/lib/galaxy/tool_util/deps/mulled/invfile.lua
@@ -42,7 +42,7 @@ end
 
 local conda_image = VAR.CONDA_IMAGE
 if conda_image == '' then
-    conda_image = 'quay.io/condaforge/mambaforge:latest'
+    conda_image = 'quay.io/condaforge/miniforge3:latest'
 end
 
 local conda_bin = VAR.CONDA_BIN

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -30,9 +30,8 @@ def test_base_image_for_targets(target, version, base_image):
     assert base_image_for_targets([target], conda_context) == base_image
 
 
-@pytest.mark.parametrize("use_mamba", [False, True])
 @external_dependency_management
-def test_mulled_build_files_cli(use_mamba: bool, tmpdir) -> None:
+def test_mulled_build_files_cli(tmpdir) -> None:
     singularity_image_dir = tmpdir.mkdir("singularity image dir")
     target = build_target("zlib", version="1.2.13", build="h166bdaf_4")
     involucro_context = InvolucroContext(involucro_bin=os.path.join(tmpdir, "involucro"))
@@ -41,7 +40,6 @@ def test_mulled_build_files_cli(use_mamba: bool, tmpdir) -> None:
         involucro_context=involucro_context,
         command="build-and-test",
         singularity=True,
-        use_mamba=use_mamba,
         singularity_image_dir=singularity_image_dir,
     )
     assert exit_code == 0


### PR DESCRIPTION
I hope this fixes the failing tests we see in PRs but also the inability to build mulled-containers on IUC and co.

I suspect that the new mamba-2.0 broke things. I'm not sure we really need mamba these days, conda is fast enough and both share the same solver.

