### PR TITLE
Minor drag style adjustment for activities

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -98,6 +98,10 @@ const dragItem: Ref<Activity | null> = ref(null);
 // drag state
 const isDragging = ref(false);
 
+// computed values
+const canDrag = computed(() => isActiveSideBar("settings"));
+const isSideBarOpen = computed(() => activityStore.toggledSideBar !== "");
+
 /**
  * Checks if the route of an activity is currently being visited and panels are collapsed
  */
@@ -111,8 +115,6 @@ function isActiveRoute(activityTo?: string | null) {
 function isActiveSideBar(menuKey: string) {
     return activityStore.toggledSideBar === menuKey;
 }
-
-const isSideBarOpen = computed(() => activityStore.toggledSideBar !== "");
 
 /**
  * Checks if an activity that has a panel should have the `is-active` prop
@@ -188,10 +190,6 @@ function onActivityClicked(activity: Activity) {
 function setActiveSideBar(key: string) {
     activityStore.toggledSideBar = key;
 }
-
-const canDrag = computed(() => {
-    return isActiveSideBar("settings");
-});
 
 defineExpose({
     isActiveSideBar,

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -222,7 +222,7 @@ defineExpose({
                     <div
                         v-for="(activity, activityIndex) in activities"
                         :key="activityIndex"
-                        :class="{ 'can-drag': canDrag }">
+                        :class="{ 'activity-can-drag': canDrag }">
                         <div v-if="activity.visible && (activity.anonymous || !isAnonymous)">
                             <UploadItem
                                 v-if="activity.id === 'upload'"
@@ -352,6 +352,12 @@ defineExpose({
     display: none;
 }
 
+.activity-can-drag {
+    border-radius: $border-radius-extralarge;
+    outline: 2px dashed $border-color;
+    outline-offset: -3px;
+}
+
 .activity-chosen-class {
     background: $brand-secondary;
     border-radius: $border-radius-extralarge;
@@ -385,12 +391,5 @@ defineExpose({
 .vertical-overflow {
     overflow-y: auto;
     overflow-x: hidden;
-}
-
-.can-drag {
-    border-radius: 12px;
-    border: 1px;
-    outline: dashed darkgray;
-    outline-offset: -3px;
 }
 </style>

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -352,7 +352,7 @@ defineExpose({
     display: none;
 }
 
-.activity-can-drag {
+.activity-can-drag .activity-item {
     border-radius: $border-radius-extralarge;
     outline: 2px dashed $border-color;
     outline-offset: -3px;


### PR DESCRIPTION
Very minor style follow-up for: #19258. Avoids highlighting hidden activities, such as e.g. Interactive tools and uses theme attributes. Thanks a lot for the elegant implementation @jmchilton.

Before:
<img width="91" alt="image" src="https://github.com/user-attachments/assets/a3aa5bd6-8f97-4d2f-a4fe-fe29e71c0caf">

After:
<img width="87" alt="image" src="https://github.com/user-attachments/assets/1745e6b1-0425-4a48-96ee-978e249bf3e6">

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
