### PR TITLE
[24.0] Linter: allow dynamic option definition by from_url

### DIFF
--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -710,12 +710,14 @@ class InputsSelectOptionsDefinesOptions(Linter):
             # TODO check if input param is present for from_dataset
             from_dataset = options.get("from_dataset", None)
             from_data_table = options.get("from_data_table", None)
+            from_url = options.get("from_url", None)
 
             if (
                 from_file is None
                 and from_parameter is None
                 and from_dataset is None
                 and from_data_table is None
+                and from_url is None
                 and not filter_adds_options
             ):
                 lint_ctx.error(


### PR DESCRIPTION
follow up on https://github.com/galaxyproject/galaxy/pull/17087

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
