### PR TITLE
[24.1] Record implicitly converted dataset as input dataset

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -847,7 +847,11 @@ class Data(metaclass=DataMeta):
         job, converted_datasets, *_ = converter.execute(
             trans, incoming=params, set_output_hid=visible, history=history, flush_job=False
         )
+        # We should only have a single converted output, but let's be defensive here
+        n_converted_datasets = len(converted_datasets)
         for converted_dataset in converted_datasets.values():
+            if converted_dataset.extension == "auto" and n_converted_datasets == 1:
+                converted_dataset.extension = target_type
             original_dataset.attach_implicitly_converted_dataset(trans.sa_session, converted_dataset, target_type)
         trans.app.job_manager.enqueue(job, tool=converter)
         if len(params) > 0:

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -2511,6 +2511,24 @@ class TestToolsApi(ApiTestCase, TestsTools):
                 exception_raised = e
             assert exception_raised, "Expected invalid column selection to fail job"
 
+    @skip_without_tool("implicit_conversion_format_input")
+    def test_implicit_conversion_input_dataset_tracking(self):
+        with self.dataset_populator.test_history() as history_id:
+            compressed_path = self.test_data_resolver.get_filename("1.fastqsanger.gz")
+            with open(compressed_path, "rb") as fh:
+                dataset = self.dataset_populator.new_dataset(
+                    history_id, content=fh, file_type="fastqsanger.gz", wait=True
+                )
+            outputs = self._run(
+                "Grep1", history_id=history_id, inputs={"data": {"src": "hda", "id": dataset["id"]}}, assert_ok=True
+            )
+            job_details = self.dataset_populator.get_job_details(outputs["jobs"][0]["id"], full=True).json()
+            assert job_details["inputs"]["input"]["id"] != dataset["id"]
+            converted_input = self.dataset_populator.get_history_dataset_details(
+                history_id=history_id, content_id=job_details["inputs"]["input"]["id"]
+            )
+            assert converted_input["extension"] == "fastqsanger"
+
     @skip_without_tool("column_multi_param")
     def test_implicit_conversion_and_reduce(self):
         with self.dataset_populator.test_history() as history_id:


### PR DESCRIPTION
by fixing the converter's output dataset extension to the requested extension.

We don't need to wait for the galaxy.json collection, we know the exact target type already. That fixes the retrieval in
`get_converted_files_by_type`.

I believe this was always the intention and is how it works if the dataset already exists (i.e. on a re-run), and for all converters that don't use galaxy.json The converter records the dataset that the user chose, so there's no gap in the provenance either.

This somewhat addresses https://github.com/galaxyproject/total-perspective-vortex/issues/141 so you can (reliably) differentiate your rules on the input datatype and filesize combination.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
