### PR TITLE
[24.2] Fixes window manager scrolling and resizing

### DIFF
--- a/client/src/components/Masthead/Masthead.vue
+++ b/client/src/components/Masthead/Masthead.vue
@@ -191,7 +191,7 @@ onMounted(() => {
                         position: absolute;
                         left: 1.6rem;
                         top: 1.6rem;
-                        font-size: 0.4rem;
+                        font-size: 0.6rem;
                         font-weight: bold;
                     }
                 }

--- a/client/src/style/scss/windows.scss
+++ b/client/src/style/scss/windows.scss
@@ -1,6 +1,6 @@
 .winbox {
     border-radius: $border-radius-base;
-    margin-top: 3rem;
+    margin-top: $masthead-height;
 }
 
 .winbox.min {

--- a/client/src/style/scss/windows.scss
+++ b/client/src/style/scss/windows.scss
@@ -1,6 +1,15 @@
 .winbox {
     border-radius: $border-radius-base;
-    margin-top: $masthead-height;
+    margin-left: 1px;
+    margin-top: calc($masthead-height + 1px);
+}
+
+.winbox.max {
+    border-radius: 0;
+    margin: 0;
+    .wb-header {
+        border-radius: 0;
+    }
 }
 
 .winbox.min {
@@ -8,8 +17,9 @@
 }
 
 .wb-header {
-    border-radius: $border-radius-base;
     background: $brand-info;
+    border-top-left-radius: $border-radius-base;
+    border-top-right-radius: $border-radius-base;
 }
 
 .wb-icon * {


### PR DESCRIPTION
Minor style fixes for the window manager, slightly increases the size notification icon and allows users to scroll to the bottom of a maximized window. When the window is maximized masthead options do not work, since the center panel remains invisible.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
