### PR TITLE
[24.2] Fix import of previously-deleted TRS workflow

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -2083,6 +2083,7 @@ class WorkflowContentsManager(UsesAnnotations):
             .join(model.Workflow, model.Workflow.id == model.StoredWorkflow.latest_workflow_id)
             .filter(
                 and_(
+                    model.StoredWorkflow.deleted == false(),
                     to_json(model.Workflow.source_metadata, ["trs_tool_id"]) == trs_id,
                     to_json(model.Workflow.source_metadata, ["trs_version_id"]) == trs_version,
                 )
@@ -2094,7 +2095,7 @@ class WorkflowContentsManager(UsesAnnotations):
             )
         else:
             stmnt = stmnt.filter(model.StoredWorkflow.importable == true())
-        return sa_session.execute(stmnt).scalar()
+        return sa_session.execute(stmnt.order_by(model.StoredWorkflow.id.desc()).limit(1)).scalar()
 
 
 class RefactorRequest(RefactorActions):


### PR DESCRIPTION
By returning latest, non-deleted workflow in
`get_workflow_by_trs_id_and_version`.

Fixes https://github.com/galaxyproject/galaxy/issues/19263

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
