### PR TITLE
[24.2] Don't show published workflows in workflow activity of workflow editor

### DIFF
--- a/client/src/components/Panels/WorkflowPanel.vue
+++ b/client/src/components/Panels/WorkflowPanel.vue
@@ -52,7 +52,7 @@ const loadWorkflowsOptions = {
     sortBy: "update_time",
     sortDesc: true,
     limit: 20,
-    showPublished: true,
+    showPublished: false,
     skipStepCounts: false,
 } as const;
 


### PR DESCRIPTION
If we want to do this we need to separate owned and published, then make a new copy or reference as we insert the public workflow. As it stands you won't be finding your own workflows, since the public workflows are far more numerous then any one user's workflows.

Fixes https://github.com/galaxyproject/galaxy/issues/19265

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
