### PR TITLE
Migrate WF Collection Input Form Definition to Client Side

### DIFF
--- a/client/src/components/Form/Elements/FormSelection.vue
+++ b/client/src/components/Form/Elements/FormSelection.vue
@@ -100,7 +100,7 @@ watch(
 );
 
 const showSelectPreference = computed(
-    () => props.multiple && props.display !== "checkboxes" && props.display !== "radio"
+    () => props.multiple && props.display !== "checkboxes" && props.display !== "radio" && props.display !== "simple"
 );
 
 const displayMany = computed(() => showSelectPreference.value && useMany.value);

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -458,4 +458,52 @@ function onAlert(value: string | undefined) {
 
 <style lang="scss" scoped>
 @import "./_form-elements.scss";
+@import "base.scss";
+
+// Workflow Run Form
+.workflow-run-element {
+    // when a temporary focus is applied to the element
+    &.temp-focus {
+        border: solid 3px $brand-primary;
+    }
+    &:not(.temp-focus) {
+        border: solid 1px $portlet-bg-color;
+        box-shadow: 0 0 5px $portlet-bg-color;
+    }
+
+    .ui-form-title {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+
+        // inherit the border radius from the parent .alert class
+        border-top-left-radius: inherit;
+        border-top-right-radius: inherit;
+
+        &:deep(.form-element-header-badge) {
+            display: flex;
+            align-items: center;
+            font-weight: normal;
+            font-size: 100%;
+            padding-left: $spacer;
+            padding-right: $spacer;
+
+            &.populated {
+                background-color: $state-success-bg;
+            }
+            &.unpopulated {
+                background-color: $state-info-bg;
+            }
+        }
+    }
+    .form-element-content {
+        display: flex;
+        flex-direction: column;
+        row-gap: 0.25rem;
+
+        .ui-form-info {
+            order: -1;
+        }
+    }
+}
 </style>

--- a/client/src/components/Form/_form-elements.scss
+++ b/client/src/components/Form/_form-elements.scss
@@ -1,6 +1,4 @@
-@import "theme/blue.scss";
 @import "base.scss";
-@import "~@fortawesome/fontawesome-free/scss/_variables";
 
 .ui-form-element {
     margin-top: $margin-v * 0.25;

--- a/client/src/components/Form/_form-elements.scss
+++ b/client/src/components/Form/_form-elements.scss
@@ -1,57 +1,11 @@
-@import "base.scss";
+@import "theme/blue.scss";
+@import "~@fortawesome/fontawesome-free/scss/_variables";
 
 .ui-form-element {
     margin-top: $margin-v * 0.25;
     margin-bottom: $margin-v * 0.5;
     overflow: visible;
     clear: both;
-
-    // Workflow Run Form
-    &.workflow-run-element {
-        // when a temporary focus is applied to the element
-        &.temp-focus {
-            border: solid 3px $brand-primary;
-        }
-        &:not(.temp-focus) {
-            border: solid 1px $portlet-bg-color;
-            box-shadow: 0 0 5px $portlet-bg-color;
-        }
-
-        .ui-form-title {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-
-            // inherit the border radius from the parent .alert class
-            border-top-left-radius: inherit;
-            border-top-right-radius: inherit;
-
-            &:deep(.form-element-header-badge) {
-                display: flex;
-                align-items: center;
-                font-weight: normal;
-                font-size: 100%;
-                padding-left: $spacer;
-                padding-right: $spacer;
-
-                &.populated {
-                    background-color: map-get($galaxy-state-bg, "ok");
-                }
-                &.unpopulated {
-                    background-color: $state-info-bg;
-                }
-            }
-        }
-        .form-element-content {
-            display: flex;
-            flex-direction: column;
-            row-gap: 0.25rem;
-
-            .ui-form-info {
-                order: -1;
-            }
-        }
-    }
 
     .ui-form-title {
         word-wrap: break-word;

--- a/client/src/components/Workflow/Editor/Forms/FormCollectionType.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormCollectionType.vue
@@ -44,11 +44,11 @@ const emit = defineEmits(["onChange"]);
     <FormElement
         id="collection_type"
         :value="currentValue"
-        :attributes="{ datalist: collectionTypeOptions }"
+        :attributes="{ data: collectionTypeOptions, display: 'simple' }"
         :warning="warning ?? undefined"
         :error="error ?? undefined"
         title="Collection type"
         :optional="true"
-        type="text"
+        type="select"
         @input="onInput" />
 </template>

--- a/client/src/components/Workflow/Editor/Forms/FormCollectionType.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormCollectionType.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { ref, watch } from "vue";
+
+import { isValidCollectionTypeStr } from "@/components/Workflow/Editor/modules/collectionTypeDescription";
+
+import FormElement from "@/components/Form/FormElement.vue";
+
+interface Props {
+    value?: string;
+}
+
+const props = defineProps<Props>();
+
+const currentValue = ref<string | undefined>(undefined);
+const warning = ref<string | null>(null);
+const error = ref<string | null>(null);
+
+function onInput(newCollectionType: string | undefined) {
+    emit("onChange", newCollectionType);
+}
+
+const collectionTypeOptions = [
+    { value: "list", label: "List of Datasets" },
+    { value: "paired", label: "Dataset Pair" },
+    { value: "list:paired", label: "List of Dataset Pairs" },
+];
+
+function updateValue(newValue: string | undefined) {
+    currentValue.value = newValue;
+    warning.value = null;
+    error.value = null;
+    if (!newValue) {
+        warning.value = "Typically, a value for this collection type should be specified.";
+    } else if (!isValidCollectionTypeStr(newValue)) {
+        error.value = "Invalid collection type";
+    }
+}
+
+watch(() => props.value, updateValue, { immediate: true });
+const emit = defineEmits(["onChange"]);
+</script>
+
+<template>
+    <FormElement
+        id="collection_type"
+        :value="currentValue"
+        :attributes="{ datalist: collectionTypeOptions }"
+        :warning="warning ?? undefined"
+        :error="error ?? undefined"
+        title="Collection type"
+        :optional="true"
+        type="text"
+        @input="onInput" />
+</template>

--- a/client/src/components/Workflow/Editor/Forms/FormDatatype.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDatatype.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref, watch } from "vue";
 
 import type { DatatypesMapperModel } from "@/components/Datatypes/model";
 
@@ -8,16 +8,27 @@ import FormElement from "@/components/Form/FormElement.vue";
 const props = withDefaults(
     defineProps<{
         id: string;
-        value?: string;
+        value?: string | string[];
         title: string;
         help: string;
+        multiple?: boolean;
         datatypes: DatatypesMapperModel["datatypes"];
     }>(),
     {
         value: undefined,
+        multiple: false,
     }
 );
 
+const currentValue = ref<string | string[] | undefined>(undefined);
+
+watch(
+    () => props.value,
+    (newValue) => {
+        currentValue.value = newValue;
+    },
+    { immediate: true }
+);
 const emit = defineEmits(["onChange"]);
 
 const datatypeExtensions = computed(() => {
@@ -34,25 +45,28 @@ const datatypeExtensions = computed(() => {
         0: "Roadmaps",
         1: "Roadmaps",
     });
-    extensions.unshift({
-        0: "Leave unchanged",
-        1: "",
-    });
+    if (!props.multiple) {
+        extensions.unshift({
+            0: "Leave unchanged",
+            1: "",
+        });
+    }
     return extensions;
 });
 
-function onChange(newDatatype: unknown) {
-    emit("onChange", newDatatype);
+function onInput(newDatatype: string) {
+    currentValue.value = newDatatype;
+    emit("onChange", currentValue.value);
 }
 </script>
 
 <template>
     <FormElement
         :id="id"
-        :value="value"
-        :attributes="{ options: datatypeExtensions }"
+        :value="currentValue"
+        :attributes="{ options: datatypeExtensions, multiple: multiple, display: 'simple', optional: true }"
         :title="title"
         type="select"
         :help="help"
-        @input="onChange" />
+        @input="onInput" />
 </template>

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -43,8 +43,15 @@
                 v-if="isSubworkflow"
                 :step="step"
                 @onUpdateStep="(id, step) => emit('onUpdateStep', id, step)" />
+            <FormInputCollection
+                v-if="type == 'data_collection_input'"
+                :step="step"
+                :datatypes="datatypes"
+                :inputs="configForm?.inputs"
+                @onChange="onChange">
+            </FormInputCollection>
             <FormDisplay
-                v-if="configForm?.inputs"
+                v-else-if="configForm?.inputs"
                 :id="formDisplayId"
                 :key="formKey"
                 :inputs="configForm.inputs"
@@ -78,6 +85,7 @@ import FormConditional from "./FormConditional.vue";
 import FormCard from "@/components/Form/FormCard.vue";
 import FormDisplay from "@/components/Form/FormDisplay.vue";
 import FormElement from "@/components/Form/FormElement.vue";
+import FormInputCollection from "@/components/Workflow/Editor/Forms/FormInputCollection.vue";
 import FormOutputLabel from "@/components/Workflow/Editor/Forms/FormOutputLabel.vue";
 
 const props = defineProps<{

--- a/client/src/components/Workflow/Editor/Forms/FormInputCollection.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormInputCollection.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import { computed, toRef } from "vue";
+
+import type { DatatypesMapperModel } from "@/components/Datatypes/model";
+import type { Step } from "@/stores/workflowStepStore";
+
+import { useToolState } from "../composables/useToolState";
+
+import FormElement from "@/components/Form/FormElement.vue";
+import FormCollectionType from "@/components/Workflow/Editor/Forms/FormCollectionType.vue";
+import FormDatatype from "@/components/Workflow/Editor/Forms/FormDatatype.vue";
+
+interface ToolState {
+    collection_type: string | null;
+    optional: boolean;
+    format: string | null;
+    tag: string | null;
+}
+
+const props = defineProps<{
+    step: Step;
+    datatypes: DatatypesMapperModel["datatypes"];
+}>();
+
+const stepRef = toRef(props, "step");
+const { toolState } = useToolState(stepRef);
+
+function cleanToolState(): ToolState {
+    if (toolState.value) {
+        return { ...toolState.value } as unknown as ToolState;
+    } else {
+        return {
+            collection_type: null,
+            optional: false,
+            tag: null,
+            format: null,
+        };
+    }
+}
+
+const emit = defineEmits(["onChange"]);
+
+function onDatatype(newDatatype: string[]) {
+    const state = cleanToolState();
+    state.format = newDatatype.join(",");
+    emit("onChange", state);
+}
+
+function onTags(newTags: string | null) {
+    const state = cleanToolState();
+    state.tag = newTags;
+    emit("onChange", state);
+}
+
+function onOptional(newOptional: boolean) {
+    const state = cleanToolState();
+    state.optional = newOptional;
+    emit("onChange", state);
+}
+
+function onCollectionType(newCollectionType: string | null) {
+    const state = cleanToolState();
+    state.collection_type = newCollectionType;
+    emit("onChange", state);
+}
+
+const formatsAsList = computed(() => {
+    const formatStr = toolState.value?.format as string | string[] | null;
+    if (formatStr && typeof formatStr === "string") {
+        return formatStr.split(/\s*,\s*/);
+    } else if (formatStr) {
+        return formatStr;
+    } else {
+        return [];
+    }
+});
+
+const collectionType = computed(() => {
+    return toolState.value.collection_type as string | undefined;
+});
+
+// Terrible Hack: The parent component (./FormDefault.vue) ignores the first update, so
+// I am sending a dummy update here. Ideally, the parent FormDefault would not expect this.
+emit("onChange", cleanToolState());
+</script>
+
+<template>
+    <div>
+        <FormCollectionType :value="collectionType" :optional="true" @onChange="onCollectionType" />
+        <FormElement id="optional" :value="toolState?.optional" title="Optional" type="boolean" @input="onOptional" />
+        <FormDatatype
+            id="format"
+            :value="formatsAsList"
+            :datatypes="datatypes"
+            title="Format(s)"
+            :multiple="true"
+            help="Leave empty to auto-generate filtered list at runtime based on connections."
+            @onChange="onDatatype" />
+        <FormElement
+            id="tag"
+            :value="toolState?.tag"
+            title="Tag filter"
+            :optional="true"
+            type="text"
+            help="Tags to automatically filter inputs"
+            @input="onTags" />
+    </div>
+</template>

--- a/client/src/components/Workflow/Editor/composables/useStepProps.ts
+++ b/client/src/components/Workflow/Editor/composables/useStepProps.ts
@@ -12,6 +12,7 @@ export function useStepProps(step: Ref<Step>) {
         inputs: stepInputs,
         outputs: stepOutputs,
         post_job_actions: postJobActions,
+        tool_state: toolState,
     } = toRefs(step);
 
     const label = computed(() => step.value.label ?? undefined);
@@ -29,5 +30,6 @@ export function useStepProps(step: Ref<Step>) {
         stepOutputs,
         configForm,
         postJobActions,
+        toolState,
     };
 }

--- a/client/src/components/Workflow/Editor/composables/useToolState.ts
+++ b/client/src/components/Workflow/Editor/composables/useToolState.ts
@@ -1,0 +1,40 @@
+import { toRefs } from "@vueuse/core";
+import { computed, type Ref } from "vue";
+
+import { type Step } from "@/stores/workflowStepStore";
+
+export function useToolState(step: Ref<Step>) {
+    const { tool_state: rawToolStateRef } = toRefs(step);
+
+    const toolState = computed(() => {
+        const rawToolState: Record<string, unknown> = rawToolStateRef.value;
+        const parsedToolState: Record<string, unknown> = {};
+
+        // This is less than ideal in a couple ways. The fact the JSON response
+        // has encoded JSON is gross and it would be great for module types that
+        // do not use the tool form to just return a simple JSON blob without
+        // the extra encoded. As a step two if each of these module types could
+        // also define a schema so we could use typed entities shared between the
+        // client and server that would be ideal.
+        for (const key in rawToolState) {
+            if (Object.prototype.hasOwnProperty.call(rawToolState, key)) {
+                const value = rawToolState[key];
+                if (typeof value === "string") {
+                    try {
+                        const parsedValue = JSON.parse(value);
+                        parsedToolState[key] = parsedValue;
+                    } catch (error) {
+                        parsedToolState[key] = rawToolState[key];
+                    }
+                } else {
+                    parsedToolState[key] = rawToolState[key];
+                }
+            }
+        }
+        return parsedToolState;
+    });
+
+    return {
+        toolState,
+    };
+}

--- a/client/src/components/Workflow/Editor/modules/collectionTypeDescription.ts
+++ b/client/src/components/Workflow/Editor/modules/collectionTypeDescription.ts
@@ -128,3 +128,13 @@ export class CollectionTypeDescription implements CollectionTypeDescriptor {
         return str.indexOf(suffix, str.length - suffix.length) !== -1;
     }
 }
+
+const collectionTypeRegex = /^(list|paired)(:(list|paired))*$/;
+
+export function isValidCollectionTypeStr(collectionType: string | undefined) {
+    if (collectionType) {
+        return collectionTypeRegex.test(collectionType);
+    } else {
+        return true;
+    }
+}

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1123,34 +1123,8 @@ class InputDataCollectionModule(InputModule):
     collection_type = default_collection_type
 
     def get_inputs(self):
-        parameter_def = self._parse_state_into_dict()
-        collection_type = parameter_def["collection_type"]
-        tag = parameter_def["tag"]
-        optional = parameter_def["optional"]
-        collection_type_source = dict(
-            name="collection_type", label="Collection type", type="text", value=collection_type
-        )
-        collection_type_source["options"] = [
-            {"value": "list", "label": "List of Datasets"},
-            {"value": "paired", "label": "Dataset Pair"},
-            {"value": "list:paired", "label": "List of Dataset Pairs"},
-        ]
-        input_collection_type = TextToolParameter(None, collection_type_source)
-        tag_source = dict(
-            name="tag",
-            label="Tag filter",
-            type="text",
-            optional="true",
-            value=tag,
-            help="Tags to automatically filter inputs",
-        )
-        input_tag = TextToolParameter(None, tag_source)
-        inputs = {}
-        inputs["collection_type"] = input_collection_type
-        inputs["optional"] = optional_param(optional)
-        inputs["format"] = format_param(self.trans, parameter_def.get("format"))
-        inputs["tag"] = input_tag
-        return inputs
+        # migrated to frontend
+        return {}
 
     def get_runtime_inputs(self, step, connections: Optional[Iterable[WorkflowStepConnection]] = None):
         parameter_def = self._parse_state_into_dict()

--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -126,17 +126,6 @@ def test_data_collection_input_connections():
     assert output["collection_type"] == "list:paired"
 
 
-def test_data_collection_input_config_form():
-    module = __from_step(
-        type="data_collection_input",
-        tool_inputs={
-            "collection_type": "list:paired",
-        },
-    )
-    result = module.get_config_form()
-    assert result["inputs"][0]["value"], "list:paired"
-
-
 def test_cannot_create_tool_modules_for_missing_tools():
     trans = MockTrans()
     module = modules.module_factory.from_dict(trans, {"type": "tool", "tool_id": "cat1"})


### PR DESCRIPTION
This is the start of https://github.com/galaxyproject/galaxy/issues/19303. This already does two important things the old form did not - the datatypes look better (the component is reused and it multiple formats can be selected - matching what is possible in the workflow definition) and the collection type component is properly validated and provides some useful help I think.

If someone wants to take up this project and do the next steps I think they would be:
- Migrate simple data inputs the same way - there should be a lot of reuse with this.
- Address the relevant comments from the PR (one about the doubly the nested JSON, one about a schema for the tool state for module types that don't use the tool form, and one about ugly hack to workaround the hack in FormDefault that ignores the first update the form issues).
- And I think... though I'm less certain... eliminate the whole ``build_module`` server interaction on each update for this component (and any workflow module/step type that doesn't use the tool form). This validates its own data - there really isn't a reason I don't think for the build_module interaction at all. The state should just be saved in the store and persisted back to the server first as part of the regular save process.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage. (I think we have goodish selenium coverage of this stuff).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
