### PR TITLE
[24.2] Fix activity-bar-id handling wrt activityStore

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -230,6 +230,7 @@ defineExpose({
                                 v-if="activity.id === 'upload'"
                                 :id="`${activity.id}`"
                                 :key="activity.id"
+                                :activity-bar-id="props.activityBarId"
                                 :icon="activity.icon"
                                 :title="activity.title"
                                 :tooltip="activity.tooltip" />
@@ -237,6 +238,7 @@ defineExpose({
                                 v-else-if="activity.to && activity.id === 'interactivetools'"
                                 :id="`${activity.id}`"
                                 :key="activity.id"
+                                :activity-bar-id="props.activityBarId"
                                 :icon="activity.icon"
                                 :is-active="isActiveRoute(activity.to)"
                                 :title="activity.title"
@@ -274,6 +276,7 @@ defineExpose({
                 <NotificationItem
                     v-if="isConfigLoaded && config.enable_notification_system"
                     id="notifications"
+                    :activity-bar-id="props.activityBarId"
                     :icon="faBell"
                     :is-active="isActiveSideBar('notifications') || isActiveRoute('/user/notifications')"
                     title="Notifications"

--- a/client/src/components/ActivityBar/Items/InteractiveItem.vue
+++ b/client/src/components/ActivityBar/Items/InteractiveItem.vue
@@ -17,6 +17,7 @@ export interface Props {
     icon: IconDefinition;
     isActive: boolean;
     to: string;
+    activityBarId: string;
 }
 
 defineProps<Props>();
@@ -27,7 +28,7 @@ const emit = defineEmits<{
 
 const tooltip = computed(() =>
     totalCount.value === 1
-        ? `You currently have 1 active interactive tool`
+        ? "You currently have 1 active interactive tool"
         : `You currently have ${totalCount.value} active interactive tools`
 );
 </script>
@@ -36,7 +37,7 @@ const tooltip = computed(() =>
     <ActivityItem
         v-if="totalCount > 0"
         :id="id"
-        :activity-bar-id="id"
+        :activity-bar-id="activityBarId"
         :icon="icon"
         :indicator="totalCount"
         :is-active="isActive"

--- a/client/src/components/ActivityBar/Items/NotificationItem.vue
+++ b/client/src/components/ActivityBar/Items/NotificationItem.vue
@@ -11,6 +11,7 @@ const { totalUnreadCount } = storeToRefs(useNotificationsStore());
 
 export interface Props {
     id: string;
+    activityBarId: string;
     title: string;
     icon: IconDefinition;
     isActive: boolean;
@@ -32,7 +33,7 @@ const tooltip = computed(() =>
 <template>
     <ActivityItem
         :id="id"
-        :activity-bar-id="'notifications'"
+        :activity-bar-id="activityBarId"
         :icon="icon"
         :indicator="totalUnreadCount"
         :is-active="isActive"

--- a/client/src/components/ActivityBar/Items/UploadItem.vue
+++ b/client/src/components/ActivityBar/Items/UploadItem.vue
@@ -14,6 +14,7 @@ export interface Props {
     title: string;
     icon: IconDefinition;
     tooltip: string;
+    activityBarId: string;
 }
 
 defineProps<Props>();
@@ -40,7 +41,7 @@ function onUploadModal() {
 <template>
     <ActivityItem
         :id="id"
-        :activity-bar-id="id"
+        :activity-bar-id="activityBarId"
         :title="title"
         :tooltip="tooltip"
         :icon="icon"

--- a/client/src/composables/userLocalStorage.ts
+++ b/client/src/composables/userLocalStorage.ts
@@ -13,9 +13,11 @@ import { useHashedUserId } from "./hashedUserId";
 export function useUserLocalStorage<T>(key: string, initialValue: T, user?: Ref<AnyUser>) {
     const { hashedUserId } = useHashedUserId(user);
 
+    let refSyncedRawValue = initialValue;
+
     const storedRef = computed(() => {
         if (hashedUserId.value) {
-            return useLocalStorage(`${key}-${hashedUserId.value}`, initialValue);
+            return useLocalStorage(`${key}-${hashedUserId.value}`, refSyncedRawValue);
         } else {
             return ref(initialValue);
         }
@@ -28,6 +30,7 @@ export function useUserLocalStorage<T>(key: string, initialValue: T, user?: Ref<
         },
         set(newValue) {
             storedRef.value.value = newValue;
+            refSyncedRawValue = newValue as T;
             trigger();
         },
     }));

--- a/client/src/stores/activityStore.ts
+++ b/client/src/stores/activityStore.ts
@@ -127,10 +127,7 @@ export const useActivityStore = defineScopedStore("activityStore", (scope) => {
             }
         });
 
-        // update activities stored in local cache only if changes were applied
-        if (JSON.stringify(activities.value) !== JSON.stringify(newActivities)) {
-            activities.value = newActivities;
-        }
+        activities.value = newActivities;
 
         // if toggled side-bar does not exist, choose the first option
         if (toggledSideBar.value !== "") {


### PR DESCRIPTION
Debugging something else, I noticed that we were creating extraneous/duplicate activity stores.  There should be two, the new workflow editor bar and the default (analysis view) bar.  We were unintentionally creating separate ones for upload, notifications, and interactive tools due to reuse of the wrong 'id' to name the store.

I'm not positive this was causing specific issues, but I wouldn't be surprised if it was to blame for some categories of glitches in changing activities and clicking on the bar.

Example of duplicate store arrangement/contents:

![image](https://github.com/user-attachments/assets/53026230-dc3e-4659-b4ba-1ce15b565faf)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
