### PR TITLE
Refactor and use `ScrollList` component in more places

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -356,7 +356,7 @@ defineExpose({
             <VisualizationPanel v-else-if="isActiveSideBar('visualizations')" />
             <MultiviewPanel v-else-if="isActiveSideBar('multiview')" />
             <NotificationsPanel v-else-if="isActiveSideBar('notifications')" />
-            <UserToolPanel v-if="isActiveSideBar('user-defined-tools')" />
+            <UserToolPanel v-if="isActiveSideBar('user-defined-tools')" in-panel />
             <InteractiveToolsPanel v-else-if="isActiveSideBar('interactivetools')" />
             <SettingsPanel
                 v-else-if="isActiveSideBar('settings')"

--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -323,17 +323,17 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
                                             inline
                                             class="d-inline"
                                             :size="props.titleSize">
-                                            <FontAwesomeIcon
-                                                v-if="props.titleIcon?.icon"
-                                                :icon="props.titleIcon.icon"
-                                                :class="props.titleIcon.class"
-                                                :title="props.titleIcon.title"
-                                                :size="props.titleIcon.size"
-                                                fixed-width />
-
                                             <span
                                                 class="g-card-title-with-actions"
                                                 :class="{ 'wrap-lines': props.titleNLines }">
+                                                <FontAwesomeIcon
+                                                    v-if="props.titleIcon?.icon"
+                                                    :icon="props.titleIcon.icon"
+                                                    :class="props.titleIcon.class"
+                                                    :title="props.titleIcon.title"
+                                                    :size="props.titleIcon.size"
+                                                    class="g-card-title-icon"
+                                                    fixed-width />
                                                 <BLink
                                                     v-if="typeof title === 'object'"
                                                     :id="getElementId(props.id, 'title-link')"
@@ -351,18 +351,20 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
                                                     </span>
                                                 </template>
 
-                                                <slot name="titleActions">
-                                                    <BButton
-                                                        v-if="props.canRenameTitle"
-                                                        :id="getElementId(props.id, 'rename')"
-                                                        v-b-tooltip.hover.noninteractive
-                                                        class="inline-icon-button g-card-rename"
-                                                        variant="link"
-                                                        :title="localize(props.renameTitle)"
-                                                        @click="emit('rename')">
-                                                        <FontAwesomeIcon :icon="faPen" fixed-width />
-                                                    </BButton>
-                                                </slot>
+                                                <span class="g-card-title-actions">
+                                                    <slot name="titleActions">
+                                                        <BButton
+                                                            v-if="props.canRenameTitle"
+                                                            :id="getElementId(props.id, 'rename')"
+                                                            v-b-tooltip.hover.noninteractive
+                                                            class="inline-icon-button g-card-rename"
+                                                            variant="link"
+                                                            :title="localize(props.renameTitle)"
+                                                            @click="emit('rename')">
+                                                            <FontAwesomeIcon :icon="faPen" fixed-width />
+                                                        </BButton>
+                                                    </slot>
+                                                </span>
                                             </span>
                                         </Heading>
                                     </slot>
@@ -687,8 +689,9 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
     }
 
     .g-card-title-with-actions {
-        // TODO: If n === 1, this could be done differently maybe?
+        display: inline;
 
+        // If there is the prop to truncate the title to a certain number of lines
         &.wrap-lines {
             display: -webkit-box;
             -webkit-box-orient: vertical;
@@ -698,19 +701,41 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
             -webkit-line-clamp: var(--title-n-lines, 3);
             line-clamp: var(--title-n-lines, 3);
             position: relative;
-            padding-right: 1.5rem;
+            vertical-align: top;
+
+            // Only add padding-right if there are any title actions present
+            // This is needed to prevent the actions appearing on top of the title text
+            &:has(.g-card-title-actions:not(:empty)) {
+                padding-right: 1.5rem;
+            }
+
+            .g-card-title-icon {
+                display: inline;
+                margin-right: 0.1rem;
+            }
 
             .g-card-title-link,
             .g-card-title-text {
-                height: inherit;
-                display: block;
+                display: inline;
+
+                // TODO: Dilemma: If we replace the current height setting with this,
+                //       the current tooltip bug with the tooltip appearing at end of
+                //       overflowing but hidden text will be fixed, but this breaks the
+                //       inline behavior of the case where we have an icon before the title.
+                // height: inherit;
+                // display: block;
             }
 
-            .g-card-rename {
+            .g-card-title-actions {
                 position: absolute;
                 right: 0;
                 bottom: 0;
                 margin-left: 0.25rem;
+                display: inline;
+            }
+
+            .g-card-rename {
+                display: inline;
             }
         }
     }

--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -3,7 +3,7 @@ import { faStar as farStar } from "@fortawesome/free-regular-svg-icons";
 import { faCaretDown, faEdit, faPen, faSpinner, faStar, type IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BBadge, BButton, BButtonGroup, BDropdown, BDropdownItem, BFormCheckbox, BLink } from "bootstrap-vue";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 import { useMarkdown } from "@/composables/markdown";
 import { useUid } from "@/composables/utils/uid";
@@ -274,6 +274,11 @@ const getElementId = (cardId: string, element: string) => `g-card-${element}-${c
 const getIndicatorId = (cardId: string, indicatorId: string) => `g-card-indicator-${indicatorId}-${cardId}`;
 const getBadgeId = (cardId: string, badgeId: string) => `g-card-badge-${badgeId}-${cardId}`;
 const getActionId = (cardId: string, actionId: string) => `g-card-action-${actionId}-${cardId}`;
+
+/**
+ * Number of lines before title truncation (undefined = no truncation)
+ */
+const allowedTitleLines = computed(() => props.titleNLines);
 </script>
 
 <template>
@@ -289,7 +294,6 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
             { 'g-card-published': published },
             containerClass,
         ]"
-        :style="{ '--title-n-lines': props.titleNLines }"
         :tabindex="props.clickable ? 0 : undefined"
         @click="props.clickable ? emit('click') : undefined"
         @keydown.enter="props.clickable ? emit('click') : undefined">
@@ -702,8 +706,8 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
         .g-card-title-truncate {
             display: -webkit-box;
             -webkit-box-orient: vertical;
-            -webkit-line-clamp: var(--title-n-lines);
-            line-clamp: var(--title-n-lines);
+            -webkit-line-clamp: v-bind(allowedTitleLines);
+            line-clamp: v-bind(allowedTitleLines);
             overflow: hidden;
             line-height: 1.2;
             white-space: normal;

--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -301,7 +301,7 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
                                     <slot name="select">
                                         <BFormCheckbox
                                             :id="getElementId(props.id, 'select')"
-                                            v-b-tooltip.hover
+                                            v-b-tooltip.hover.noninteractive
                                             :checked="selected"
                                             :title="props.selectTitle || localize('Select for bulk actions')"
                                             @change="emit('select')" />
@@ -327,7 +327,7 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
                                             <BLink
                                                 v-if="typeof title === 'object'"
                                                 :id="getElementId(props.id, 'title-link')"
-                                                v-b-tooltip.hover
+                                                v-b-tooltip.hover.noninteractive
                                                 :title="localize(title.title)"
                                                 @click.stop.prevent="title.handler">
                                                 {{ title.label }}
@@ -360,7 +360,7 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
                                             v-if="badge.visible ?? true"
                                             :id="getBadgeId(props.id, badge.id)"
                                             :key="badge.id"
-                                            v-b-tooltip.hover
+                                            v-b-tooltip.hover.noninteractive
                                             :pill="badge.type !== 'badge'"
                                             class="mt-1"
                                             :class="{
@@ -391,7 +391,7 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
                                                 props.bookmarked ? 'bookmark-remove' : 'bookmark-add'
                                             )
                                         "
-                                        v-b-tooltip.hover
+                                        v-b-tooltip.hover.noninteractive
                                         class="inline-icon-button"
                                         variant="link"
                                         :title="props.bookmarked ? 'Remove bookmark' : 'Add to bookmarks'"
@@ -401,7 +401,7 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
                                     <BButton
                                         v-else
                                         :id="getElementId(props.id, 'bookmark-loading')"
-                                        v-b-tooltip.hover
+                                        v-b-tooltip.hover.noninteractive
                                         class="inline-icon-button"
                                         variant="link"
                                         :title="localize('Bookmarking...')"
@@ -486,7 +486,7 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
                                                 v-if="(indicator.visible ?? true) && !indicator.disabled"
                                                 :id="getIndicatorId(props.id, indicator.id)"
                                                 :key="indicator.id"
-                                                v-b-tooltip.hover
+                                                v-b-tooltip.hover.noninteractive
                                                 class="inline-icon-button"
                                                 :title="localize(indicator.title)"
                                                 :variant="indicator.variant || 'outline-secondary'"
@@ -506,7 +506,7 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
                                                 v-else-if="(indicator.visible ?? true) && indicator.disabled"
                                                 :id="getIndicatorId(props.id, indicator.id)"
                                                 :key="indicator.id"
-                                                v-b-tooltip.hover
+                                                v-b-tooltip.hover.noninteractive
                                                 :title="localize(indicator.title)"
                                                 :icon="indicator.icon"
                                                 :size="indicator.size || 'sm'"
@@ -575,7 +575,7 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
                                             v-if="sa.visible ?? true"
                                             :id="getActionId(props.id, sa.id)"
                                             :key="sa.id"
-                                            v-b-tooltip.hover
+                                            v-b-tooltip.hover.noninteractive
                                             :disabled="sa.disabled"
                                             :title="localize(sa.title)"
                                             :variant="sa.variant || 'outline-primary'"
@@ -604,7 +604,7 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
                                             v-if="pa.visible ?? true"
                                             :id="getActionId(props.id, pa.id)"
                                             :key="pa.id"
-                                            v-b-tooltip.hover
+                                            v-b-tooltip.hover.noninteractive
                                             :disabled="pa.disabled"
                                             :title="localize(pa.title)"
                                             :variant="pa.variant || 'primary'"

--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -275,7 +275,7 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
         :is="'div'"
         :id="`g-card-${props.id}`"
         :role="props.clickable ? 'button' : undefined"
-        class="g-card pt-0 px-1 pb-2"
+        class="g-card pt-0 px-1 mb-2"
         :class="[
             { 'g-card-grid-view': gridView },
             { 'g-card-selected': selected },

--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -321,51 +321,46 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
                                             :id="getElementId(props.id, 'title')"
                                             bold
                                             inline
-                                            class="d-inline"
+                                            class="align-items-baseline"
                                             :size="props.titleSize">
-                                            <span
-                                                class="g-card-title-with-actions"
-                                                :class="{ 'wrap-lines': props.titleNLines }">
-                                                <FontAwesomeIcon
-                                                    v-if="props.titleIcon?.icon"
-                                                    :icon="props.titleIcon.icon"
-                                                    :class="props.titleIcon.class"
-                                                    :title="props.titleIcon.title"
-                                                    :size="props.titleIcon.size"
-                                                    class="g-card-title-icon"
-                                                    fixed-width />
-                                                <BLink
-                                                    v-if="typeof title === 'object'"
-                                                    :id="getElementId(props.id, 'title-link')"
+                                            <FontAwesomeIcon
+                                                v-if="props.titleIcon?.icon"
+                                                :icon="props.titleIcon.icon"
+                                                :class="props.titleIcon.class"
+                                                :title="props.titleIcon.title"
+                                                :size="props.titleIcon.size"
+                                                fixed-width />
+                                            <BLink
+                                                v-if="typeof title === 'object'"
+                                                :id="getElementId(props.id, 'title-link')"
+                                                v-b-tooltip.hover.noninteractive
+                                                :title="localize(title.title)"
+                                                :class="{ 'g-card-title-truncate': props.titleNLines }"
+                                                @click.stop.prevent="title.handler">
+                                                {{ title.label }}
+                                            </BLink>
+                                            <template v-else>
+                                                <span
+                                                    :id="getElementId(props.id, 'title-text')"
                                                     v-b-tooltip.hover.noninteractive
-                                                    :title="localize(title.title)"
-                                                    class="g-card-title-link"
-                                                    @click.stop.prevent="title.handler">
-                                                    {{ title.label }}
-                                                </BLink>
-                                                <template v-else>
-                                                    <span
-                                                        :id="getElementId(props.id, 'title-text')"
-                                                        class="g-card-title-text">
-                                                        {{ title }}
-                                                    </span>
-                                                </template>
-
-                                                <span class="g-card-title-actions">
-                                                    <slot name="titleActions">
-                                                        <BButton
-                                                            v-if="props.canRenameTitle"
-                                                            :id="getElementId(props.id, 'rename')"
-                                                            v-b-tooltip.hover.noninteractive
-                                                            class="inline-icon-button g-card-rename"
-                                                            variant="link"
-                                                            :title="localize(props.renameTitle)"
-                                                            @click="emit('rename')">
-                                                            <FontAwesomeIcon :icon="faPen" fixed-width />
-                                                        </BButton>
-                                                    </slot>
+                                                    :title="localize(title)"
+                                                    :class="{ 'g-card-title-truncate': props.titleNLines }">
+                                                    {{ title }}
                                                 </span>
-                                            </span>
+                                            </template>
+
+                                            <slot name="titleActions">
+                                                <BButton
+                                                    v-if="props.canRenameTitle"
+                                                    :id="getElementId(props.id, 'rename')"
+                                                    v-b-tooltip.hover.noninteractive
+                                                    class="inline-icon-button g-card-rename"
+                                                    variant="link"
+                                                    :title="localize(props.renameTitle)"
+                                                    @click="emit('rename')">
+                                                    <FontAwesomeIcon :icon="faPen" fixed-width />
+                                                </BButton>
+                                            </slot>
                                         </Heading>
                                     </slot>
                                 </div>
@@ -688,58 +683,6 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
         border-left: 0.25rem solid $brand-primary;
     }
 
-    .g-card-title-with-actions {
-        display: inline;
-
-        // If there is the prop to truncate the title to a certain number of lines
-        &.wrap-lines {
-            display: -webkit-box;
-            -webkit-box-orient: vertical;
-            overflow: hidden;
-            word-break: break-word;
-            overflow-wrap: break-word;
-            -webkit-line-clamp: var(--title-n-lines, 3);
-            line-clamp: var(--title-n-lines, 3);
-            position: relative;
-            vertical-align: top;
-
-            // Only add padding-right if there are any title actions present
-            // This is needed to prevent the actions appearing on top of the title text
-            &:has(.g-card-title-actions:not(:empty)) {
-                padding-right: 1.5rem;
-            }
-
-            .g-card-title-icon {
-                display: inline;
-                margin-right: 0.1rem;
-            }
-
-            .g-card-title-link,
-            .g-card-title-text {
-                display: inline;
-
-                // TODO: Dilemma: If we replace the current height setting with this,
-                //       the current tooltip bug with the tooltip appearing at end of
-                //       overflowing but hidden text will be fixed, but this breaks the
-                //       inline behavior of the case where we have an icon before the title.
-                // height: inherit;
-                // display: block;
-            }
-
-            .g-card-title-actions {
-                position: absolute;
-                right: 0;
-                bottom: 0;
-                margin-left: 0.25rem;
-                display: inline;
-            }
-
-            .g-card-rename {
-                display: inline;
-            }
-        }
-    }
-
     .g-card-rename {
         visibility: hidden;
     }
@@ -755,6 +698,17 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
         background-color: $body-bg;
         border: 1px solid $brand-secondary;
         border-radius: 0.5rem;
+
+        .g-card-title-truncate {
+            display: -webkit-box;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: var(--title-n-lines);
+            line-clamp: var(--title-n-lines);
+            overflow: hidden;
+            line-height: 1.2;
+            white-space: normal;
+            text-overflow: unset;
+        }
 
         .g-card-secondary-action-label {
             @container g-card (max-width: #{$breakpoint-sm}) {

--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -152,6 +152,11 @@ interface Props {
      */
     titleIcon?: TitleIcon;
 
+    /** Whether the title should be truncated to a certain number of lines
+     * @default undefined
+     */
+    titleNLines?: number;
+
     /** Size of the card title
      * @default "sm"
      */
@@ -197,6 +202,7 @@ const props = withDefaults(defineProps<Props>(), {
     title: "",
     titleBadges: () => [],
     titleIcon: undefined,
+    titleNLines: undefined,
     titleSize: "sm",
     updateTime: "",
     updateTimeIcon: () => faEdit,
@@ -283,6 +289,7 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
             { 'g-card-published': published },
             containerClass,
         ]"
+        :style="{ '--title-n-lines': props.titleNLines }"
         :tabindex="props.clickable ? 0 : undefined"
         @click="props.clickable ? emit('click') : undefined"
         @keydown.enter="props.clickable ? emit('click') : undefined">
@@ -324,30 +331,39 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
                                                 :size="props.titleIcon.size"
                                                 fixed-width />
 
-                                            <BLink
-                                                v-if="typeof title === 'object'"
-                                                :id="getElementId(props.id, 'title-link')"
-                                                v-b-tooltip.hover.noninteractive
-                                                :title="localize(title.title)"
-                                                @click.stop.prevent="title.handler">
-                                                {{ title.label }}
-                                            </BLink>
-                                            <template v-else>
-                                                <span :id="getElementId(props.id, 'title-text')">{{ title }}</span>
-                                            </template>
-
-                                            <slot name="titleActions">
-                                                <BButton
-                                                    v-if="props.canRenameTitle"
-                                                    :id="getElementId(props.id, 'rename')"
+                                            <span
+                                                class="g-card-title-with-actions"
+                                                :class="{ 'wrap-lines': props.titleNLines }">
+                                                <BLink
+                                                    v-if="typeof title === 'object'"
+                                                    :id="getElementId(props.id, 'title-link')"
                                                     v-b-tooltip.hover.noninteractive
-                                                    class="inline-icon-button g-card-rename"
-                                                    variant="link"
-                                                    :title="localize(props.renameTitle)"
-                                                    @click="emit('rename')">
-                                                    <FontAwesomeIcon :icon="faPen" fixed-width />
-                                                </BButton>
-                                            </slot>
+                                                    :title="localize(title.title)"
+                                                    class="g-card-title-link"
+                                                    @click.stop.prevent="title.handler">
+                                                    {{ title.label }}
+                                                </BLink>
+                                                <template v-else>
+                                                    <span
+                                                        :id="getElementId(props.id, 'title-text')"
+                                                        class="g-card-title-text">
+                                                        {{ title }}
+                                                    </span>
+                                                </template>
+
+                                                <slot name="titleActions">
+                                                    <BButton
+                                                        v-if="props.canRenameTitle"
+                                                        :id="getElementId(props.id, 'rename')"
+                                                        v-b-tooltip.hover.noninteractive
+                                                        class="inline-icon-button g-card-rename"
+                                                        variant="link"
+                                                        :title="localize(props.renameTitle)"
+                                                        @click="emit('rename')">
+                                                        <FontAwesomeIcon :icon="faPen" fixed-width />
+                                                    </BButton>
+                                                </slot>
+                                            </span>
                                         </Heading>
                                     </slot>
                                 </div>
@@ -668,6 +684,35 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
 
     &.g-card-published .g-card-content {
         border-left: 0.25rem solid $brand-primary;
+    }
+
+    .g-card-title-with-actions {
+        // TODO: If n === 1, this could be done differently maybe?
+
+        &.wrap-lines {
+            display: -webkit-box;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            word-break: break-word;
+            overflow-wrap: break-word;
+            -webkit-line-clamp: var(--title-n-lines, 3);
+            line-clamp: var(--title-n-lines, 3);
+            position: relative;
+            padding-right: 1.5rem;
+
+            .g-card-title-link,
+            .g-card-title-text {
+                height: inherit;
+                display: block;
+            }
+
+            .g-card-rename {
+                position: absolute;
+                right: 0;
+                bottom: 0;
+                margin-left: 0.25rem;
+            }
+        }
     }
 
     .g-card-rename {

--- a/client/src/components/Common/TextSummary.vue
+++ b/client/src/components/Common/TextSummary.vue
@@ -54,7 +54,7 @@ const textTooLong = computed(() => {
             role="button"
             tabindex="0"
             @keyup.enter="showDetails = !showDetails"
-            @click="showDetails = !showDetails">
+            @click.prevent.stop="showDetails = !showDetails">
             <template v-if="showExpandText">
                 <template v-if="showDetails">Show less</template>
                 <template v-else>Show more</template>

--- a/client/src/components/History/HistoryScrollList.vue
+++ b/client/src/components/History/HistoryScrollList.vue
@@ -7,10 +7,10 @@ import { computed, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { type AnyHistory, type HistorySummary, userOwnsHistory } from "@/api";
+import type { CardAction, CardBadge } from "@/components/Common/GCard.types";
 import { useHistoryStore } from "@/stores/historyStore";
 import { useUserStore } from "@/stores/userStore";
 
-import type { CardAction, CardBadge } from "@/components/Common/GCard.types";
 import { HistoriesFilters } from "./HistoriesFilters";
 
 import GCard from "@/components/Common/GCard.vue";

--- a/client/src/components/History/HistoryScrollList.vue
+++ b/client/src/components/History/HistoryScrollList.vue
@@ -289,7 +289,6 @@ function getHistoryTitleBadges(history: HistorySummary) {
         </template>
 
         <template v-slot:item="{ item: history }">
-            <!-- TODO: Long history names should be truncated, esp in multiview panel -->
             <GCard
                 :id="`history-${history.id}`"
                 :data-pk="history.id"
@@ -308,15 +307,12 @@ function getHistoryTitleBadges(history: HistorySummary) {
                 title-size="text"
                 :title-badges="getHistoryTitleBadges(history)"
                 :title-n-lines="2"
+                :description="isMultiviewPanel ? undefined : history.annotation || undefined"
                 :update-time="history.update_time"
                 @select="historyClicked(history)"
                 @tagClick="setFilterValue('tag', $event)"
                 @title-click="historyClicked(history)"
-                @click="() => historyClicked(history)">
-                <template v-slot:description>
-                    <small v-if="!isMultiviewPanel && history.annotation" class="my-1">{{ history.annotation }}</small>
-                </template>
-            </GCard>
+                @click="() => historyClicked(history)" />
         </template>
 
         <template v-slot:footer-button-area>

--- a/client/src/components/History/HistoryScrollList.vue
+++ b/client/src/components/History/HistoryScrollList.vue
@@ -15,7 +15,6 @@ import { HistoriesFilters } from "./HistoriesFilters";
 
 import GCard from "@/components/Common/GCard.vue";
 import ScrollList from "@/components/ScrollList/ScrollList.vue";
-import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 
 type AdditionalOptions = "set-current" | "multi" | "center";
 type PinnedHistory = { id: string };
@@ -303,23 +302,18 @@ function getHistoryTitleBadges(history: HistorySummary) {
                 :select-title="isMultiviewPanel ? 'Pin history' : 'Add/remove history from selection'"
                 :badges="getHistoryBadges(history)"
                 :secondary-actions="getHistorySecondaryActions(history)"
+                :tags="history.tags"
+                :max-visible-tags="isMultiviewPanel ? 1 : 10"
                 :title="history.name"
                 title-size="text"
                 :title-badges="getHistoryTitleBadges(history)"
                 :update-time="history.update_time"
                 @select="historyClicked(history)"
+                @tagClick="setFilterValue('tag', $event)"
                 @title-click="historyClicked(history)"
                 @click="() => historyClicked(history)">
                 <template v-slot:description>
                     <small v-if="!isMultiviewPanel && history.annotation" class="my-1">{{ history.annotation }}</small>
-
-                    <StatelessTags
-                        v-if="history.tags.length > 0"
-                        class="my-1"
-                        :value="history.tags"
-                        :disabled="true"
-                        :max-visible-tags="isMultiviewPanel ? 1 : 10"
-                        @tag-click="setFilterValue('tag', $event)" />
                 </template>
             </GCard>
         </template>

--- a/client/src/components/History/HistoryScrollList.vue
+++ b/client/src/components/History/HistoryScrollList.vue
@@ -307,6 +307,7 @@ function getHistoryTitleBadges(history: HistorySummary) {
                 :title="history.name"
                 title-size="text"
                 :title-badges="getHistoryTitleBadges(history)"
+                :title-n-lines="2"
                 :update-time="history.update_time"
                 @select="historyClicked(history)"
                 @tagClick="setFilterValue('tag', $event)"

--- a/client/src/components/History/HistoryScrollList.vue
+++ b/client/src/components/History/HistoryScrollList.vue
@@ -10,11 +10,11 @@ import { type AnyHistory, type HistorySummary, userOwnsHistory } from "@/api";
 import { useHistoryStore } from "@/stores/historyStore";
 import { useUserStore } from "@/stores/userStore";
 
-import type { CardAction, CardBadge } from "../Common/GCard.types";
+import type { CardAction, CardBadge } from "@/components/Common/GCard.types";
 import { HistoriesFilters } from "./HistoriesFilters";
 
-import GCard from "../Common/GCard.vue";
-import ScrollList from "../ScrollList/ScrollList.vue";
+import GCard from "@/components/Common/GCard.vue";
+import ScrollList from "@/components/ScrollList/ScrollList.vue";
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 
 type AdditionalOptions = "set-current" | "multi" | "center";

--- a/client/src/components/History/HistoryScrollList.vue
+++ b/client/src/components/History/HistoryScrollList.vue
@@ -262,7 +262,7 @@ function getHistoryTitleBadges(history: HistorySummary) {
     if (props.multiple && !isMultiviewPanel.value && isPinned(history.id)) {
         badges.push({
             id: "pinned",
-            label: "currently pinned",
+            label: isActiveItem(history) ? "currently pinned" : "will be unpinned",
             title: "This history is currently pinned in the multi-history view",
             variant: "info",
         });

--- a/client/src/components/History/Modals/SelectorModal.test.js
+++ b/client/src/components/History/Modals/SelectorModal.test.js
@@ -1,6 +1,5 @@
 import { getFakeRegisteredUser } from "@tests/test-data";
 import { mount } from "@vue/test-utils";
-import { BListGroupItem } from "bootstrap-vue";
 import flushPromises from "flush-promises";
 import { createPinia } from "pinia";
 import { getLocalVue } from "tests/jest/helpers";
@@ -10,6 +9,7 @@ import { useHistoryStore } from "@/stores/historyStore";
 import { useUserStore } from "@/stores/userStore";
 
 import SelectorModal from "./SelectorModal.vue";
+import GCard from "components/Common/GCard.vue";
 
 const localVue = getLocalVue();
 
@@ -35,7 +35,8 @@ const PROPS_FOR_MODAL_MULTIPLE_SELECT = {
     multiple: true,
 };
 
-const CURRENT_HISTORY_INDICATION_TEXT = "(Current)";
+const CURRENT_HISTORY_INDICATION_CLASS = "g-card-current";
+const SELECTED_HISTORY_CLASS = "g-card-selected";
 
 const CURRENT_USER = {
     email: "email",
@@ -89,24 +90,24 @@ describe("History SelectorModal.vue", () => {
         await mountWith(PROPS_FOR_MODAL);
 
         const currentHistoryRow = wrapper.find(`[data-pk="${CURRENT_HISTORY_ID}"]`);
-        expect(currentHistoryRow.html()).toContain(CURRENT_HISTORY_INDICATION_TEXT);
+        expect(currentHistoryRow.classes()).toContain(CURRENT_HISTORY_INDICATION_CLASS);
     });
 
     it("paginates the histories", async () => {
         await mountWith(PROPS_FOR_MODAL);
 
-        let displayedRows = wrapper.findAllComponents(BListGroupItem).wrappers;
+        let displayedRows = wrapper.findAllComponents(GCard).wrappers;
         expect(displayedRows.length).toBe(10);
-        expect(wrapper.find("[data-description='load more histories button']").exists()).toBe(true);
+        expect(wrapper.find("[data-description='load more items button']").exists()).toBe(true);
 
         await historyStore.loadHistories();
         await wrapper.setProps({
             histories: historyStore.histories,
         });
 
-        displayedRows = wrapper.findAllComponents(BListGroupItem).wrappers;
+        displayedRows = wrapper.findAllComponents(GCard).wrappers;
         expect(displayedRows.length).toBe(15);
-        expect(wrapper.find("[data-description='load more histories button']").exists()).toBe(false);
+        expect(wrapper.find("[data-description='load more items button']").exists()).toBe(false);
     });
 
     it("emits selectHistory with the correct history ID when a row is clicked", async () => {
@@ -136,7 +137,7 @@ describe("History SelectorModal.vue", () => {
             const targetRow2 = wrapper.find(`[data-pk="${targetHistoryId2}"]`);
             await targetRow2.trigger("click");
 
-            const selectedHistories = wrapper.findAll(".list-group-item.active").wrappers;
+            const selectedHistories = wrapper.findAll(`.${SELECTED_HISTORY_CLASS}`).wrappers;
             expect(selectedHistories.length).toBe(2);
 
             const button = wrapper.find("[data-description='change selected histories button']");

--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { BButton, BFormGroup } from "bootstrap-vue";
+import { BFormGroup } from "bootstrap-vue";
 import { orderBy } from "lodash";
 import isEqual from "lodash.isequal";
 import { storeToRefs } from "pinia";
@@ -10,6 +10,8 @@ import { HistoriesFilters } from "@/components/History/HistoriesFilters";
 import { useHistoryStore } from "@/stores/historyStore";
 import localize from "@/utils/localization";
 
+import GButton from "@/components/BaseComponents/GButton.vue";
+import GLink from "@/components/BaseComponents/GLink.vue";
 import GModal from "@/components/BaseComponents/GModal.vue";
 import FilterMenu from "@/components/Common/FilterMenu.vue";
 import HistoryList from "@/components/History/HistoryScrollList.vue";
@@ -144,24 +146,24 @@ const modalBodyClasses = computed(() => {
             @setFilter="setFilterValue">
             <template v-slot:footer-button-area>
                 <span class="d-flex align-items-center">
-                    <a
+                    <GLink
                         v-if="multiple"
-                        v-b-tooltip.noninteractive.hover
+                        tooltip
+                        data-description="switch to history link"
                         :title="localize('Click here to reset selection')"
                         class="mr-2"
-                        href="javascript:void(0)"
                         @click="selectedHistories = []">
                         <i>{{ selectedHistories.length }} histories selected</i>
-                    </a>
-                    <BButton
+                    </GLink>
+                    <GButton
                         v-if="multiple"
                         v-localize
                         data-description="change selected histories button"
                         :disabled="pinnedSelectedEqual || showAdvanced"
-                        variant="primary"
+                        color="blue"
                         @click="selectHistories">
                         Change Selected
-                    </BButton>
+                    </GButton>
                     <span v-else v-localize> Click a history to switch to it </span>
                 </span>
             </template>

--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -142,7 +142,7 @@ const modalBodyClasses = computed(() => {
             :loading.sync="busy"
             @selectHistory="selectHistory"
             @setFilter="setFilterValue">
-            <template v-slot:modal-button-area>
+            <template v-slot:footer-button-area>
                 <span class="d-flex align-items-center">
                     <a
                         v-if="multiple"

--- a/client/src/components/Panels/UserToolPanel.vue
+++ b/client/src/components/Panels/UserToolPanel.vue
@@ -8,9 +8,9 @@ import { useRoute, useRouter } from "vue-router/composables";
 import type { UnprivilegedToolResponse } from "@/api";
 import { useUnprivilegedToolStore } from "@/stores/unprivilegedToolStore";
 
-import GButton from "../BaseComponents/GButton.vue";
-import GButtonGroup from "../BaseComponents/GButtonGroup.vue";
-import GCard from "../Common/GCard.vue";
+import GButton from "@/components/BaseComponents/GButton.vue";
+import GButtonGroup from "@/components/BaseComponents/GButtonGroup.vue";
+import GCard from "@/components/Common/GCard.vue";
 import ActivityPanel from "./ActivityPanel.vue";
 import Heading from "@/components/Common/Heading.vue";
 import ScrollList from "@/components/ScrollList/ScrollList.vue";

--- a/client/src/components/Panels/UserToolPanel.vue
+++ b/client/src/components/Panels/UserToolPanel.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { library } from "@fortawesome/fontawesome-svg-core";
 import { faEye } from "@fortawesome/free-regular-svg-icons";
-import { faArrowDown, faInfoCircle, faPlus, faWrench } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faWrench } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BListGroupItem } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed } from "vue";
 import { useRoute, useRouter } from "vue-router/composables";
@@ -10,6 +10,8 @@ import { useRoute, useRouter } from "vue-router/composables";
 import type { UnprivilegedToolResponse } from "@/api";
 import { useUnprivilegedToolStore } from "@/stores/unprivilegedToolStore";
 
+import GButton from "../BaseComponents/GButton.vue";
+import GButtonGroup from "../BaseComponents/GButtonGroup.vue";
 import ActivityPanel from "./ActivityPanel.vue";
 import Heading from "@/components/Common/Heading.vue";
 import ScrollList from "@/components/ScrollList/ScrollList.vue";
@@ -28,8 +30,6 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits(["unprivileged-tool-clicked", "onInsertTool", "onEditTool", "onCreateTool"]);
-
-library.add(faEye, faArrowDown, faInfoCircle, faPlus);
 
 const unprivilegedToolStore = useUnprivilegedToolStore();
 const { unprivilegedTools, canUseUnprivilegedTools } = storeToRefs(unprivilegedToolStore);
@@ -82,27 +82,26 @@ function newTool() {
 <template>
     <ActivityPanel v-if="canUseUnprivilegedTools" title="Custom Tools">
         <template v-slot:header-buttons>
-            <BButtonGroup>
-                <BButton
-                    v-b-tooltip.bottom.hover
+            <GButtonGroup>
+                <GButton
                     data-description="create new custom tool"
-                    size="sm"
-                    variant="link"
+                    size="small"
+                    tooltip
                     title="Create a new custom tool"
+                    transparent
                     @click="newTool">
                     <FontAwesomeIcon :icon="faPlus" fixed-width />
-                </BButton>
-            </BButtonGroup>
+                </GButton>
+            </GButtonGroup>
         </template>
         <!-- key ScrollList on length of unprivilegedTools so that we rerender if the tools in the store change-->
         <ScrollList
             :key="unprivilegedTools?.length"
             :loader="loadUnprivilegedTools"
             :item-key="(tool) => tool.uuid"
-            :in-panel="inPanel">
-            <template v-slot:header>
-                <p>Loading...</p>
-            </template>
+            :in-panel="inPanel"
+            name="custom tool"
+            name-plural="custom tools">
             <template v-slot:item="{ item: tool }">
                 <BListGroupItem
                     button
@@ -141,14 +140,6 @@ function newTool() {
                         <FontAwesomeIcon v-if="tool.id === currentItemId" :icon="faEye" size="lg" />
                     </div>
                 </BListGroupItem>
-            </template>
-
-            <template v-slot:loading>
-                <p>Loading...</p>
-            </template>
-
-            <template v-slot:footer>
-                <p>All items loaded</p>
             </template>
         </ScrollList>
     </ActivityPanel>

--- a/client/src/components/Panels/UserToolPanel.vue
+++ b/client/src/components/Panels/UserToolPanel.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { faEye } from "@fortawesome/free-regular-svg-icons";
 import { faEdit, faPlus, faWrench } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { storeToRefs } from "pinia";
@@ -144,12 +143,6 @@ function getToolSecondaryActions(tool: UnprivilegedToolResponse) {
                                 {{ tool.representation.description }}
                             </small>
                         </Heading>
-                    </template>
-
-                    <template v-slot:extra-actions>
-                        <div v-if="props.inPanel">
-                            <FontAwesomeIcon v-if="tool.uuid === currentItemId" :icon="faEye" />
-                        </div>
                     </template>
                 </GCard>
             </template>

--- a/client/src/components/Panels/UserToolPanel.vue
+++ b/client/src/components/Panels/UserToolPanel.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import { faEye } from "@fortawesome/free-regular-svg-icons";
-import { faPlus, faWrench } from "@fortawesome/free-solid-svg-icons";
+import { faEdit, faPlus, faWrench } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BListGroupItem } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed } from "vue";
 import { useRoute, useRouter } from "vue-router/composables";
@@ -12,10 +11,10 @@ import { useUnprivilegedToolStore } from "@/stores/unprivilegedToolStore";
 
 import GButton from "../BaseComponents/GButton.vue";
 import GButtonGroup from "../BaseComponents/GButtonGroup.vue";
+import GCard from "../Common/GCard.vue";
 import ActivityPanel from "./ActivityPanel.vue";
 import Heading from "@/components/Common/Heading.vue";
 import ScrollList from "@/components/ScrollList/ScrollList.vue";
-import UtcDate from "@/components/UtcDate.vue";
 
 interface Props {
     inPanel?: boolean;
@@ -77,6 +76,28 @@ function newTool() {
     }
     router.push(route);
 }
+
+function getToolBadges(tool: UnprivilegedToolResponse) {
+    return [
+        {
+            id: "version",
+            label: tool.representation.version,
+            title: "Version of this custom tool",
+        },
+    ];
+}
+
+function getToolSecondaryActions(tool: UnprivilegedToolResponse) {
+    return [
+        {
+            id: "edit",
+            label: "Edit",
+            icon: faEdit,
+            title: "Edit this custom tool",
+            handler: () => editTool(tool.uuid),
+        },
+    ];
+}
 </script>
 
 <template>
@@ -103,43 +124,34 @@ function newTool() {
             name="custom tool"
             name-plural="custom tools">
             <template v-slot:item="{ item: tool }">
-                <BListGroupItem
+                <GCard
+                    :id="`custom-tool-${tool.uuid}`"
+                    clickable
                     button
-                    class="d-flex"
-                    :class="{
-                        current: tool.uuid === currentItemId,
-                        'panel-item': props.inPanel,
-                    }"
-                    :active="tool.uuid === currentItemId">
-                    <div class="overflow-auto w-100" @click="() => cardClicked(tool)">
-                        <Heading bold size="text" :icon="faWrench">
-                            <div style="flex-direction: column">
-                                <span class="truncate-n-lines three-lines">
-                                    {{ tool.representation.name }}
-                                </span>
-                                <small class="text-muted truncate-n-lines two-lines">
-                                    {{ tool.representation.description }}
-                                </small>
-                            </div>
+                    :current="tool.uuid === currentItemId"
+                    :active="tool.uuid === currentItemId"
+                    :badges="getToolBadges(tool)"
+                    :secondary-actions="getToolSecondaryActions(tool)"
+                    :title="tool.representation.name"
+                    :title-icon="{ icon: faWrench }"
+                    title-size="text"
+                    :update-time="tool.create_time"
+                    @title-click="cardClicked(tool)"
+                    @click="() => cardClicked(tool)">
+                    <template v-slot:description>
+                        <Heading class="m-0" size="text">
+                            <small class="text-muted truncate-n-lines two-lines">
+                                {{ tool.representation.description }}
+                            </small>
                         </Heading>
-                        <div class="d-flex justify-content-between">
-                            <BBadge v-b-tooltip.noninteractive.hover pill>
-                                <UtcDate :date="tool.create_time" mode="elapsed" />
-                            </BBadge>
-                            <BBadge v-b-tooltip.noninteractive.hover pill>
-                                {{ tool.representation.version }}
-                            </BBadge>
-                            <BBadge @click.stop="() => editTool(tool.uuid)">
-                                <FontAwesomeIcon icon="fa-edit" />
-                                <span v-localize>Edit</span>
-                            </BBadge>
-                        </div>
-                    </div>
+                    </template>
 
-                    <div v-if="props.inPanel" class="position-absolute mr-3" style="right: 0">
-                        <FontAwesomeIcon v-if="tool.id === currentItemId" :icon="faEye" size="lg" />
-                    </div>
-                </BListGroupItem>
+                    <template v-slot:extra-actions>
+                        <div v-if="props.inPanel">
+                            <FontAwesomeIcon v-if="tool.uuid === currentItemId" :icon="faEye" />
+                        </div>
+                    </template>
+                </GCard>
             </template>
         </ScrollList>
     </ActivityPanel>

--- a/client/src/components/Panels/UserToolPanel.vue
+++ b/client/src/components/Panels/UserToolPanel.vue
@@ -8,10 +8,10 @@ import { useRoute, useRouter } from "vue-router/composables";
 import type { UnprivilegedToolResponse } from "@/api";
 import { useUnprivilegedToolStore } from "@/stores/unprivilegedToolStore";
 
+import ActivityPanel from "./ActivityPanel.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GButtonGroup from "@/components/BaseComponents/GButtonGroup.vue";
 import GCard from "@/components/Common/GCard.vue";
-import ActivityPanel from "./ActivityPanel.vue";
 import Heading from "@/components/Common/Heading.vue";
 import ScrollList from "@/components/ScrollList/ScrollList.vue";
 

--- a/client/src/components/Panels/WorkflowPanel.vue
+++ b/client/src/components/Panels/WorkflowPanel.vue
@@ -178,6 +178,7 @@ function createNew(event: Event) {
                 :filterable="false"
                 :current-workflow-id="props.currentWorkflowId"
                 editor-view
+                compact
                 @insertWorkflow="(...args) => emit('insertWorkflow', ...args)"
                 @insertWorkflowSteps="(...args) => emit('insertWorkflowSteps', ...args)"
                 @refreshList="refresh" />

--- a/client/src/components/ScrollList/ScrollList.vue
+++ b/client/src/components/ScrollList/ScrollList.vue
@@ -8,8 +8,8 @@ import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useAnimationFrameResizeObserver } from "@/composables/sensors/animationFrameResizeObserver";
 import { useAnimationFrameScroll } from "@/composables/sensors/animationFrameScroll";
 
-import GButton from "../BaseComponents/GButton.vue";
-import LoadingSpan from "../LoadingSpan.vue";
+import GButton from "@/components/BaseComponents/GButton.vue";
+import LoadingSpan from "@/components/LoadingSpan.vue";
 import ScrollToTopButton from "@/components/ToolsList/ScrollToTopButton.vue";
 
 interface LoaderResult<T> {

--- a/client/src/components/ScrollList/ScrollList.vue
+++ b/client/src/components/ScrollList/ScrollList.vue
@@ -157,13 +157,15 @@ watch(
                         <slot name="item" :item="item" :index="index" />
                     </div>
 
-                    <slot v-if="allLoaded && items.length === 0" name="none-loaded-footer">
-                        <div class="text-center">No {{ props.namePlural }} found</div>
-                    </slot>
+                    <template v-if="!busy">
+                        <slot v-if="allLoaded && items.length === 0" name="none-loaded-footer">
+                            <div class="list-end">- No {{ props.namePlural }} found -</div>
+                        </slot>
 
-                    <slot v-else-if="allLoaded" name="all-loaded-footer">
-                        <div class="text-center">All {{ props.namePlural }} loaded</div>
-                    </slot>
+                        <slot v-else-if="allLoaded" name="all-loaded-footer">
+                            <div class="list-end">- All {{ props.namePlural }} loaded -</div>
+                        </slot>
+                    </template>
                 </BListGroup>
             </div>
             <ScrollToTopButton :offset="scrollTop" @click="scrollToTop" />

--- a/client/src/components/ScrollList/ScrollList.vue
+++ b/client/src/components/ScrollList/ScrollList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts" generic="T extends Record<string, any>">
-import { faArrowDown } from "@fortawesome/free-solid-svg-icons";
+import { faArrowDown, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { useInfiniteScroll } from "@vueuse/core";
 import { BAlert, BListGroup } from "bootstrap-vue";
@@ -152,10 +152,11 @@ watch(
                     data-description="load more items button"
                     size="small"
                     tooltip
+                    :disabled="busy"
                     title="Load More"
                     transparent
                     @click="loadItems()">
-                    <FontAwesomeIcon :icon="faArrowDown" />
+                    <FontAwesomeIcon :icon="busy ? faSpinner : faArrowDown" :spin="busy" />
                 </GButton>
             </div>
         </div>

--- a/client/src/components/ScrollList/ScrollList.vue
+++ b/client/src/components/ScrollList/ScrollList.vue
@@ -1,127 +1,104 @@
-<script lang="ts">
-import { library } from "@fortawesome/fontawesome-svg-core";
+<script setup lang="ts" generic="T extends Record<string, any>">
 import { faArrowDown } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { useInfiniteScroll } from "@vueuse/core";
-import { BAlert } from "bootstrap-vue";
-import type { PropType } from "vue";
-import { computed, defineComponent, onMounted, onUnmounted, ref, watch } from "vue";
+import { BAlert, BListGroup } from "bootstrap-vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 
 import { useAnimationFrameResizeObserver } from "@/composables/sensors/animationFrameResizeObserver";
 import { useAnimationFrameScroll } from "@/composables/sensors/animationFrameScroll";
 
+import GButton from "../BaseComponents/GButton.vue";
+import LoadingSpan from "../LoadingSpan.vue";
 import ScrollToTopButton from "@/components/ToolsList/ScrollToTopButton.vue";
-
-library.add(faArrowDown);
 
 interface LoaderResult<T> {
     items: T[];
     total: number;
 }
 
-export default defineComponent({
-    name: "ScrollList",
-    components: {
-        FontAwesomeIcon,
-        ScrollToTopButton,
-    },
-    props: {
-        loader: {
-            type: Function as PropType<(offset: number, limit: number) => Promise<LoaderResult<any>>>, // we'll override `any` later
-            required: true,
-        },
-        limit: {
-            type: Number,
-            default: 20,
-        },
-        itemKey: {
-            type: Function as PropType<(item: any) => string | number>, // override later
-            required: true,
-        },
-        inPanel: {
-            type: Boolean,
-            default: false,
-        },
-    },
-    emits: ["item-clicked"],
-    setup(props, { emit }) {
-        const scrollableDiv = ref<HTMLElement | null>(null);
-        const items = ref<unknown[]>([]);
-        const totalItemCount = ref<number | undefined>(undefined);
-        const currentPage = ref(0);
-        const busy = ref(false);
-        const errorMessage = ref("");
+interface Props<T> {
+    loader: (offset: number, limit: number) => Promise<LoaderResult<T>>;
+    limit?: number;
+    itemKey: (item: T) => string | number;
+    inPanel?: boolean;
+    name?: string;
+    namePlural?: string;
+}
 
-        // check if we have scrolled to the top or bottom of the scrollable div
-        const { arrived, scrollTop } = useAnimationFrameScroll(scrollableDiv);
-        const isScrollable = ref(false);
-        useAnimationFrameResizeObserver(scrollableDiv, ({ clientSize, scrollSize }) => {
-            isScrollable.value = scrollSize.height >= clientSize.height + 1;
-        });
-        const scrolledTop = computed(() => !isScrollable.value || arrived.top);
-        const scrolledBottom = computed(() => !isScrollable.value || arrived.bottom);
-
-        const allLoaded = computed(
-            () => totalItemCount.value !== undefined && totalItemCount.value <= items.value.length
-        );
-
-        async function loadItems() {
-            if (!busy.value && !allLoaded.value) {
-                busy.value = true;
-                try {
-                    const offset = props.limit * currentPage.value;
-                    const { items: newItems, total } = await props.loader(offset, props.limit);
-                    items.value = items.value.concat(newItems);
-                    totalItemCount.value = total;
-                    currentPage.value += 1;
-                    errorMessage.value = "";
-                } catch (e) {
-                    errorMessage.value = `Failed to load items: ${e}`;
-                } finally {
-                    busy.value = false;
-                }
-            }
-        }
-
-        function scrollToTop() {
-            scrollableDiv.value?.scrollTo({ top: 0, behavior: "smooth" });
-        }
-
-        onMounted(async () => {
-            useInfiniteScroll(scrollableDiv.value, () => loadItems());
-        });
-
-        onUnmounted(() => {
-            // Remove the infinite scrolling behavior
-            useInfiniteScroll(scrollableDiv.value, () => {});
-        });
-
-        watch(
-            () => isScrollable.value,
-            (scrollable: boolean) => {
-                if (!scrollable && !allLoaded.value) {
-                    loadItems();
-                }
-            }
-        );
-
-        return {
-            scrollableDiv,
-            items,
-            allLoaded,
-            busy,
-            errorMessage,
-            loadItems,
-            totalItemCount,
-            BAlert,
-            faArrowDown,
-            scrolledTop,
-            scrolledBottom,
-            scrollTop,
-            scrollToTop,
-        };
-    },
+// TODO: In Vue 3, we'll be able to use generic types directly in the template, so we can remove this type assertion
+// eslint-disable-next-line no-undef
+const props = withDefaults(defineProps<Props<T>>(), {
+    limit: 20,
+    inPanel: false,
+    name: "item",
+    namePlural: "items",
 });
+
+// const emit = defineEmits(["item-clicked"]);
+
+const scrollableDiv = ref<HTMLElement | null>(null);
+
+// TODO: In Vue 3, we'll be able to use generic types directly in the template, so we can remove this type assertion
+// eslint-disable-next-line no-undef
+const items = ref<T[]>([]);
+
+const totalItemCount = ref<number | undefined>(undefined);
+const currentPage = ref(0);
+const busy = ref(false);
+const errorMessage = ref("");
+
+// check if we have scrolled to the top or bottom of the scrollable div
+const { arrived, scrollTop } = useAnimationFrameScroll(scrollableDiv);
+const isScrollable = ref(false);
+useAnimationFrameResizeObserver(scrollableDiv, ({ clientSize, scrollSize }) => {
+    isScrollable.value = scrollSize.height >= clientSize.height + 1;
+});
+const scrolledTop = computed(() => !isScrollable.value || arrived.top);
+const scrolledBottom = computed(() => !isScrollable.value || arrived.bottom);
+
+const allLoaded = computed(() => totalItemCount.value !== undefined && totalItemCount.value <= items.value.length);
+
+async function loadItems() {
+    if (!busy.value && !allLoaded.value) {
+        busy.value = true;
+        try {
+            const offset = props.limit * currentPage.value;
+            const { items: newItems, total } = await props.loader(offset, props.limit);
+            // @ts-ignore - Vue 2.7 generic type compatibility issue, fix in Vue 3
+            items.value = items.value.concat(newItems);
+            totalItemCount.value = total;
+            currentPage.value += 1;
+            errorMessage.value = "";
+        } catch (e) {
+            errorMessage.value = `Failed to load items: ${e}`;
+        } finally {
+            busy.value = false;
+        }
+    }
+}
+
+function scrollToTop() {
+    scrollableDiv.value?.scrollTo({ top: 0, behavior: "smooth" });
+}
+
+onMounted(async () => {
+    useInfiniteScroll(scrollableDiv.value, () => loadItems());
+});
+
+onUnmounted(() => {
+    // Remove the infinite scrolling behavior
+    useInfiniteScroll(scrollableDiv.value, () => {});
+});
+
+watch(
+    () => isScrollable.value,
+    (scrollable: boolean) => {
+        if (!scrollable && !allLoaded.value) {
+            loadItems();
+        }
+    }
+);
 </script>
 
 <template>
@@ -143,14 +120,24 @@ export default defineComponent({
                 role="list">
                 <BAlert v-if="errorMessage" variant="danger" show>{{ errorMessage }}</BAlert>
                 <BListGroup v-else>
-                    <slot v-if="busy && items.length === 0" name="loading" />
+                    <slot v-if="busy && items.length === 0" name="loading">
+                        <BAlert variant="info" show>
+                            <LoadingSpan :message="`Loading ${props.namePlural}`" />
+                        </BAlert>
+                    </slot>
 
                     <!-- Wrap slot in a template to use v-for -->
                     <div v-for="(item, index) in items" :key="itemKey(item)">
                         <slot name="item" :item="item" :index="index" />
                     </div>
 
-                    <slot v-if="allLoaded" name="footer" />
+                    <slot v-if="allLoaded && items.length === 0" name="none-loaded-footer">
+                        <div class="text-center">No {{ props.namePlural }} found</div>
+                    </slot>
+
+                    <slot v-else-if="allLoaded" name="all-loaded-footer">
+                        <div class="text-center">All {{ props.namePlural }} loaded</div>
+                    </slot>
                 </BListGroup>
             </div>
             <ScrollToTopButton :offset="scrollTop" @click="scrollToTop" />
@@ -160,16 +147,16 @@ export default defineComponent({
                 v-if="!allLoaded"
                 class="mr-auto d-flex justify-content-center align-items-center"
                 :class="inPanel && 'mt-1'">
-                <i class="mr-1">Loaded {{ items.length }} out of {{ totalItemCount }} invocations</i>
-                <BButton
-                    v-b-tooltip.noninteractive.hover
-                    data-description="load more invocations button"
-                    size="sm"
+                <i class="mr-1">Loaded {{ items.length }} out of {{ totalItemCount }} {{ props.namePlural }}</i>
+                <GButton
+                    data-description="load more items button"
+                    size="small"
+                    tooltip
                     title="Load More"
-                    variant="link"
+                    transparent
                     @click="loadItems()">
                     <FontAwesomeIcon :icon="faArrowDown" />
-                </BButton>
+                </GButton>
             </div>
         </div>
     </div>

--- a/client/src/components/Visualizations/VisualizationPanel.vue
+++ b/client/src/components/Visualizations/VisualizationPanel.vue
@@ -6,7 +6,7 @@ import { fetchPlugins, type Plugin } from "@/api/plugins";
 
 import { getTestExtensions } from "./utilities";
 
-import ScrollList from "../ScrollList/ScrollList.vue";
+import ScrollList from "@/components/ScrollList/ScrollList.vue";
 import ButtonPlain from "@/components/Common/ButtonPlain.vue";
 import DelayedInput from "@/components/Common/DelayedInput.vue";
 import ActivityPanel from "@/components/Panels/ActivityPanel.vue";

--- a/client/src/components/Visualizations/VisualizationPanel.vue
+++ b/client/src/components/Visualizations/VisualizationPanel.vue
@@ -91,16 +91,20 @@ onMounted(() => {
 </script>
 
 <template>
-    <ActivityPanel
+    <component
+        :is="props.datasetId ? 'div' : ActivityPanel"
         title="Visualizations"
         :go-to-all-title="datasetId ? undefined : 'Saved Visualizations'"
         href="/visualizations/list">
         <template v-slot:header>
             <DelayedInput :delay="100" class="my-2" placeholder="search visualizations" @change="query = $event" />
         </template>
+        <template v-if="props.datasetId">
+            <DelayedInput :delay="100" class="my-2" placeholder="search visualizations" @change="query = $event" />
+        </template>
         <ScrollList
             :item-key="(plugin) => plugin.name"
-            in-panel
+            :in-panel="!props.datasetId"
             name="visualization"
             name-plural="visualizations"
             load-disabled
@@ -116,7 +120,7 @@ onMounted(() => {
                 </ButtonPlain>
             </template>
         </ScrollList>
-    </ActivityPanel>
+    </component>
 </template>
 
 <style lang="scss">

--- a/client/src/components/Visualizations/VisualizationPanel.vue
+++ b/client/src/components/Visualizations/VisualizationPanel.vue
@@ -6,10 +6,10 @@ import { fetchPlugins, type Plugin } from "@/api/plugins";
 
 import { getTestExtensions } from "./utilities";
 
-import ScrollList from "@/components/ScrollList/ScrollList.vue";
 import ButtonPlain from "@/components/Common/ButtonPlain.vue";
 import DelayedInput from "@/components/Common/DelayedInput.vue";
 import ActivityPanel from "@/components/Panels/ActivityPanel.vue";
+import ScrollList from "@/components/ScrollList/ScrollList.vue";
 import VisualizationHeader from "@/components/Visualizations/VisualizationHeader.vue";
 
 const router = useRouter();

--- a/client/src/components/Visualizations/VisualizationPanel.vue
+++ b/client/src/components/Visualizations/VisualizationPanel.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { BAlert } from "bootstrap-vue";
 import { computed, onMounted, type Ref, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
@@ -7,9 +6,9 @@ import { fetchPlugins, type Plugin } from "@/api/plugins";
 
 import { getTestExtensions } from "./utilities";
 
+import ScrollList from "../ScrollList/ScrollList.vue";
 import ButtonPlain from "@/components/Common/ButtonPlain.vue";
 import DelayedInput from "@/components/Common/DelayedInput.vue";
-import LoadingSpan from "@/components/LoadingSpan.vue";
 import ActivityPanel from "@/components/Panels/ActivityPanel.vue";
 import VisualizationHeader from "@/components/Visualizations/VisualizationHeader.vue";
 
@@ -99,20 +98,24 @@ onMounted(() => {
         <template v-slot:header>
             <DelayedInput :delay="100" class="my-2" placeholder="search visualizations" @change="query = $event" />
         </template>
-        <div>
-            <LoadingSpan v-if="isLoading" message="Loading visualizations" />
-            <div v-else-if="filteredPlugins.length > 0">
-                <div v-for="plugin in filteredPlugins" :key="plugin.name">
-                    <ButtonPlain
-                        class="plugin-item rounded p-2"
-                        :data-plugin-name="plugin.name"
-                        @click="selectVisualization(plugin)">
-                        <VisualizationHeader :plugin="plugin" />
-                    </ButtonPlain>
-                </div>
-            </div>
-            <BAlert v-else v-localize variant="info" show> No matching visualization found. </BAlert>
-        </div>
+        <ScrollList
+            :item-key="(plugin) => plugin.name"
+            in-panel
+            name="visualization"
+            name-plural="visualizations"
+            load-disabled
+            :prop-items="filteredPlugins"
+            :prop-total-count="plugins.length"
+            :prop-busy="isLoading">
+            <template v-slot:item="{ item: plugin }">
+                <ButtonPlain
+                    class="plugin-item rounded p-2"
+                    :data-plugin-name="plugin.name"
+                    @click="selectVisualization(plugin)">
+                    <VisualizationHeader :plugin="plugin" />
+                </ButtonPlain>
+            </template>
+        </ScrollList>
     </ActivityPanel>
 </template>
 

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -109,6 +109,7 @@
                 <UserToolPanel
                     v-if="isActiveSideBar('workflow-editor-user-defined-tools')"
                     :in-workflow-editor="true"
+                    in-panel
                     @onInsertTool="onInsertTool" />
             </template>
         </ActivityBar>

--- a/client/src/components/Workflow/Invocation/InvocationScrollList.vue
+++ b/client/src/components/Workflow/Invocation/InvocationScrollList.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { library } from "@fortawesome/fontawesome-svg-core";
 import { faEye } from "@fortawesome/free-regular-svg-icons";
-import { faArrowDown, faHdd, faInfoCircle, faSitemap } from "@fortawesome/free-solid-svg-icons";
+import { faHdd, faSitemap } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed } from "vue";
 import { useRoute, useRouter } from "vue-router/composables";
@@ -29,8 +28,6 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits(["invocation-clicked"]);
-
-library.add(faEye, faArrowDown, faInfoCircle);
 
 const stateClasses: Record<string, string> = {
     ready: "waiting",
@@ -94,7 +91,12 @@ function getInvocationBadges(invocation: WorkflowInvocation) {
 </script>
 
 <template>
-    <ScrollList :loader="loadInvocations" :item-key="(invocation) => invocation.id" :in-panel="inPanel">
+    <ScrollList
+        :loader="loadInvocations"
+        :item-key="(invocation) => invocation.id"
+        :in-panel="inPanel"
+        name="invocation"
+        name-plural="invocations">
         <template v-slot:item="{ item: invocation }">
             <GCard
                 :id="`invocation-${invocation.id}`"
@@ -125,14 +127,6 @@ function getInvocationBadges(invocation: WorkflowInvocation) {
                     </div>
                 </template>
             </GCard>
-        </template>
-
-        <template v-slot:loading>
-            <p>Loading...</p>
-        </template>
-
-        <template v-slot:footer>
-            <p>All items loaded</p>
         </template>
     </ScrollList>
 </template>

--- a/client/src/components/Workflow/Invocation/InvocationScrollList.vue
+++ b/client/src/components/Workflow/Invocation/InvocationScrollList.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { faEye } from "@fortawesome/free-regular-svg-icons";
 import { faHdd, faSitemap } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed } from "vue";
@@ -119,12 +118,6 @@ function getInvocationBadges(invocation: WorkflowInvocation) {
                             {{ historyName(invocation.history_id) }}
                         </small>
                     </Heading>
-                </template>
-
-                <template v-slot:extra-actions>
-                    <div v-if="props.inPanel">
-                        <FontAwesomeIcon v-if="invocation.id === currentItemId" :icon="faEye" />
-                    </div>
                 </template>
             </GCard>
         </template>

--- a/client/src/components/Workflow/Invocation/InvocationScrollList.vue
+++ b/client/src/components/Workflow/Invocation/InvocationScrollList.vue
@@ -106,6 +106,7 @@ function getInvocationBadges(invocation: WorkflowInvocation) {
                 :badges="getInvocationBadges(invocation)"
                 :title="workflowName(invocation.workflow_id)"
                 :title-icon="{ icon: faSitemap }"
+                :title-n-lines="2"
                 title-size="text"
                 :update-time="invocation.create_time"
                 @title-click="workflowName(invocation.workflow_id)"

--- a/client/src/components/Workflow/List/WorkflowCard.vue
+++ b/client/src/components/Workflow/List/WorkflowCard.vue
@@ -18,6 +18,7 @@ interface Props {
     filterable?: boolean;
     publishedView?: boolean;
     editorView?: boolean;
+    compact?: boolean;
     current?: boolean;
     selected?: boolean;
     selectable?: boolean;
@@ -29,6 +30,7 @@ const props = withDefaults(defineProps<Props>(), {
     hideRuns: false,
     filterable: true,
     editorView: false,
+    compact: false,
     current: false,
     selected: false,
     selectable: false,
@@ -114,6 +116,7 @@ const workflowCardTitle = computed(() => {
         can-rename-title
         :title="workflowCardTitle"
         :title-badges="workflowCardTitleBadges"
+        :title-n-lines="props.compact ? 2 : undefined"
         :description="description || ''"
         :grid-view="props.gridView"
         :badges="workflowCardBadges"

--- a/client/src/components/Workflow/List/WorkflowCardList.vue
+++ b/client/src/components/Workflow/List/WorkflowCardList.vue
@@ -18,6 +18,7 @@ interface Props {
     filterable?: boolean;
     publishedView?: boolean;
     editorView?: boolean;
+    compact?: boolean;
     currentWorkflowId?: string;
     selectedWorkflowIds?: SelectedWorkflow[];
 }
@@ -28,6 +29,7 @@ const props = withDefaults(defineProps<Props>(), {
     filterable: true,
     publishedView: false,
     editorView: false,
+    compact: false,
     currentWorkflowId: "",
     selectedWorkflowIds: () => [],
 });
@@ -95,6 +97,7 @@ const workflowPublished = ref<InstanceType<typeof WorkflowPublished>>();
             :filterable="props.filterable"
             :published-view="props.publishedView"
             :editor-view="props.editorView"
+            :compact="props.compact"
             :current="workflow.id === props.currentWorkflowId"
             @select="(...args) => emit('select', ...args)"
             @tagClick="(...args) => emit('tagClick', ...args)"


### PR DESCRIPTION
# Custom Tools Panel updates
The Custom Tools panel now uses `GCard` in the existing `ScrollList`. This allows for nicer action buttons and badges.

| Before | After |
| ---- | ---- |
| <img width="337" height="864" alt="firefox_VGv46860af" src="https://github.com/user-attachments/assets/c7c952f6-f269-4b45-8683-de82a2f38c19" /> | <img width="337" height="864" alt="AiDPsKKJ1L" src="https://github.com/user-attachments/assets/147fcda5-0358-4047-9622-b2460c487083" /> |


# HistoryScrollList updates
The `HistoryScrollList` component now uses `ScrollList` and `GCard`.

## Current History Selector

| Before | After |
| ---- | ---- |
| <img width="722" height="842" alt="firefox_xlPpzFX9n2" src="https://github.com/user-attachments/assets/69838e3e-a028-4123-a57b-d372dc353c59" /> | <img width="722" height="842" alt="H56w2jcrTl" src="https://github.com/user-attachments/assets/d46f13ae-c2d0-45be-9b25-5bead6c50878" /> |


## History Multiview Selector Modal

| Before | After |
| ---- | ---- |
| <img width="722" height="841" alt="GM6SNXLDA2" src="https://github.com/user-attachments/assets/c1a652dd-f4a5-48c3-8916-a29aeffebacd" /> | <img width="722" height="841" alt="4kgGDwdUhs" src="https://github.com/user-attachments/assets/75cb5821-4923-446f-a9dd-5f3a0ea16493" /> |





## History Multiview Selector Panel

| Before | After |
| ---- | ---- |
| <img width="334" height="863" alt="firefox_PqwcJxsp3v" src="https://github.com/user-attachments/assets/d75c550a-76a2-4cca-8402-db5ce5b187cb" /> | <img width="334" height="863" alt="pp5RdlV7e2" src="https://github.com/user-attachments/assets/dec85a39-f63a-468a-ab65-d31154c2cfec" /> |



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
