### PR TITLE
[24.0] Replace mambaforge Docker image with miniforge3

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/invfile.lua
+++ b/lib/galaxy/tool_util/deps/mulled/invfile.lua
@@ -42,7 +42,7 @@ end
 
 local conda_image = VAR.CONDA_IMAGE
 if conda_image == '' then
-    conda_image = 'quay.io/condaforge/mambaforge:latest'
+    conda_image = 'quay.io/condaforge/miniforge3:latest'
 end
 
 local conda_bin = VAR.CONDA_BIN


### PR DESCRIPTION
mambaforge is deprecated upstream, see:

https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/ https://github.com/conda-forge/miniforge-images/blob/b5f19cb22e4c9e3a6524ae714cce8d4933e7765b/ubuntu/mambaforge_deprecation.sh

Suggested in

https://github.com/galaxyproject/galaxy/pull/19293#discussion_r1878522140

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
