### PR TITLE
[24.1] Use correct label to display in ObjectStoreActions

### DIFF
--- a/client/src/components/User/DiskUsage/Visualizations/ObjectStoreActions.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/ObjectStoreActions.vue
@@ -17,7 +17,7 @@ const props = defineProps<Props>();
 
 library.add(faChartBar);
 
-const label = computed(() => props.data.id);
+const label = computed(() => props.data.label);
 const viewDetailsIcon = computed(() => "chart-bar");
 
 const emit = defineEmits<{


### PR DESCRIPTION
Minor UI fix discovered while working on #19323

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/9fd0b3d2-4dea-41e2-9336-2fc8b7e468df)   | ![image](https://github.com/user-attachments/assets/d4739eaf-0b7f-4172-843e-0ed5452c271e) |

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
