### PR TITLE
Add workflow selection and bulk actions

### DIFF
--- a/client/src/components/Common/ListHeader.vue
+++ b/client/src/components/Common/ListHeader.vue
@@ -2,7 +2,7 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faAngleDown, faAngleUp, faBars, faGripVertical } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton, BFormCheckbox } from "bootstrap-vue";
+import { BButton, BButtonGroup, BFormCheckbox } from "bootstrap-vue";
 import { computed, ref } from "vue";
 
 import { useUserStore } from "@/stores/userStore";
@@ -74,32 +74,34 @@ defineExpose({
         </div>
 
         <div class="list-header-filters">
-            Sort by:
-            <BButtonGroup>
-                <BButton
-                    id="sortby-name"
-                    v-b-tooltip.hover
-                    size="sm"
-                    :title="sortDesc ? 'Sort by name ascending' : 'Sort by name descending'"
-                    :pressed="sortBy === 'name'"
-                    variant="outline-primary"
-                    @click="onSort('name')">
-                    <FontAwesomeIcon v-show="sortBy === 'name'" :icon="sortDesc ? faAngleDown : faAngleUp" />
-                    Name
-                </BButton>
+            <div>
+                Sort by:
+                <BButtonGroup>
+                    <BButton
+                        id="sortby-name"
+                        v-b-tooltip.hover
+                        size="sm"
+                        :title="sortDesc ? 'Sort by name ascending' : 'Sort by name descending'"
+                        :pressed="sortBy === 'name'"
+                        variant="outline-primary"
+                        @click="onSort('name')">
+                        <FontAwesomeIcon v-show="sortBy === 'name'" :icon="sortDesc ? faAngleDown : faAngleUp" />
+                        Name
+                    </BButton>
 
-                <BButton
-                    id="sortby-update-time"
-                    v-b-tooltip.hover
-                    size="sm"
-                    :title="sortDesc ? 'Sort by update time ascending' : 'Sort by update time descending'"
-                    :pressed="sortBy === 'update_time'"
-                    variant="outline-primary"
-                    @click="onSort('update_time')">
-                    <FontAwesomeIcon v-show="sortBy === 'update_time'" :icon="sortDesc ? faAngleDown : faAngleUp" />
-                    Update time
-                </BButton>
-            </BButtonGroup>
+                    <BButton
+                        id="sortby-update-time"
+                        v-b-tooltip.hover
+                        size="sm"
+                        :title="sortDesc ? 'Sort by update time ascending' : 'Sort by update time descending'"
+                        :pressed="sortBy === 'update_time'"
+                        variant="outline-primary"
+                        @click="onSort('update_time')">
+                        <FontAwesomeIcon v-show="sortBy === 'update_time'" :icon="sortDesc ? faAngleDown : faAngleUp" />
+                        Update time
+                    </BButton>
+                </BButtonGroup>
+            </div>
 
             <slot name="extra-filter" />
         </div>
@@ -141,7 +143,7 @@ defineExpose({
 
     .list-header-filters {
         display: flex;
-        gap: 0.25rem;
+        gap: 1rem;
         flex-wrap: wrap;
         align-items: center;
     }

--- a/client/src/components/Common/ListHeader.vue
+++ b/client/src/components/Common/ListHeader.vue
@@ -2,7 +2,7 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faAngleDown, faAngleUp, faBars, faGripVertical } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton } from "bootstrap-vue";
+import { BButton, BFormCheckbox } from "bootstrap-vue";
 import { computed, ref } from "vue";
 
 import { useUserStore } from "@/stores/userStore";
@@ -13,12 +13,24 @@ type ListView = "grid" | "list";
 type SortBy = "create_time" | "update_time" | "name";
 
 interface Props {
+    allSelected?: boolean;
+    showSelectAll?: boolean;
     showViewToggle?: boolean;
+    selectAllDisabled?: boolean;
+    indeterminateSelected?: boolean;
 }
 
 withDefaults(defineProps<Props>(), {
+    allSelected: false,
+    showSelectAll: false,
     showViewToggle: false,
+    selectAllDisabled: false,
+    indeterminateSelected: false,
 });
+
+const emit = defineEmits<{
+    (e: "select-all"): void;
+}>();
 
 const userStore = useUserStore();
 
@@ -47,6 +59,20 @@ defineExpose({
 
 <template>
     <div class="list-header">
+        <div class="list-header-select-all">
+            <slot name="select-all">
+                <BFormCheckbox
+                    v-if="showSelectAll"
+                    id="list-header-select-all"
+                    :disabled="selectAllDisabled"
+                    :checked="allSelected"
+                    :indeterminate="indeterminateSelected"
+                    @change="emit('select-all')">
+                    Select all
+                </BFormCheckbox>
+            </slot>
+        </div>
+
         <div class="list-header-filters">
             Sort by:
             <BButtonGroup>

--- a/client/src/components/Common/TagsSelectionDialog.vue
+++ b/client/src/components/Common/TagsSelectionDialog.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { BModal } from "bootstrap-vue";
+import { ref } from "vue";
+
+import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
+
+interface Props {
+    title?: string;
+    initialTags?: string[];
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    title: "Select tags to add",
+    initialTags: () => [],
+});
+
+const tags = ref(props.initialTags);
+
+const emit = defineEmits<{
+    (e: "cancel"): void;
+    (e: "ok", tags: string[]): void;
+}>();
+
+function onTagsChange(newTags: string[]) {
+    tags.value = newTags;
+}
+</script>
+
+<template>
+    <BModal visible centered size="lg" :title="title" @ok="emit('ok', tags)" @hide="emit('cancel')">
+        <StatelessTags :value="tags" @input="onTagsChange($event)" />
+    </BModal>
+</template>

--- a/client/src/components/Workflow/List/WorkflowCard.vue
+++ b/client/src/components/Workflow/List/WorkflowCard.vue
@@ -5,6 +5,7 @@ import { BButton, BFormCheckbox, BLink } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 
+import { type StoredWorkflowDetailed } from "@/api/workflows";
 import { updateWorkflow } from "@/components/Workflow/workflows.services";
 import { useUserStore } from "@/stores/userStore";
 
@@ -16,7 +17,7 @@ import WorkflowIndicators from "@/components/Workflow/List/WorkflowIndicators.vu
 import WorkflowInvocationsCount from "@/components/Workflow/WorkflowInvocationsCount.vue";
 
 interface Props {
-    workflow: any;
+    workflow: StoredWorkflowDetailed;
     gridView?: boolean;
     hideRuns?: boolean;
     filterable?: boolean;
@@ -61,7 +62,7 @@ const shared = computed(() => {
 
 const description = computed(() => {
     if (workflow.value.annotations && workflow.value.annotations.length > 0) {
-        return workflow.value.annotations[0].trim();
+        return workflow.value.annotations[0]?.trim();
     } else {
         return null;
     }

--- a/client/src/components/Workflow/List/WorkflowCard.vue
+++ b/client/src/components/Workflow/List/WorkflowCard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faPen } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton, BLink } from "bootstrap-vue";
+import { BButton, BFormCheckbox, BLink } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 
@@ -23,6 +23,8 @@ interface Props {
     publishedView?: boolean;
     editorView?: boolean;
     current?: boolean;
+    selected?: boolean;
+    selectable?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -32,9 +34,12 @@ const props = withDefaults(defineProps<Props>(), {
     filterable: true,
     editorView: false,
     current: false,
+    selected: false,
+    selectable: false,
 });
 
 const emit = defineEmits<{
+    (e: "select", workflow: any): void;
     (e: "tagClick", tag: string): void;
     (e: "refreshList", overlayLoading?: boolean, silent?: boolean): void;
     (e: "updateFilter", key: string, value: any): void;
@@ -85,8 +90,17 @@ const dropdownOpen = ref(false);
             class="workflow-card-container"
             :class="{
                 'workflow-shared': workflow.published,
+                'workflow-card-selected': props.selected,
             }">
             <div class="workflow-card-header">
+                <BFormCheckbox
+                    v-if="props.selectable && !shared"
+                    v-b-tooltip.hover.noninteractive
+                    :checked="props.selected"
+                    class="workflow-card-select-checkbox"
+                    title="Select for bulk actions"
+                    @change="emit('select', workflow)" />
+
                 <WorkflowIndicators
                     class="workflow-card-indicators"
                     :workflow="workflow"
@@ -117,6 +131,7 @@ const dropdownOpen = ref(false);
                         @click.stop.prevent="emit('preview', props.workflow.id)">
                         {{ workflow.name }}
                     </BLink>
+
                     <BButton
                         v-if="!props.current && !shared && !workflow.deleted"
                         v-b-tooltip.hover.noninteractive
@@ -190,7 +205,13 @@ const dropdownOpen = ref(false);
         gap: 0.5rem;
         flex-direction: column;
         justify-content: space-between;
-        border: 1px solid $brand-secondary;
+        border: 0.1rem solid $brand-secondary;
+
+        &.workflow-card-selected {
+            background-color: $brand-light;
+            border: 0.1rem solid $brand-primary;
+        }
+
         border-radius: 0.5rem;
         padding: 0.5rem;
 
@@ -203,21 +224,28 @@ const dropdownOpen = ref(false);
             position: relative;
             align-items: start;
             grid-template-areas:
-                "i b"
-                "n n"
-                "s s";
+                "i d b"
+                "n n n"
+                "s s s";
+
+            grid-template-columns: auto 1fr auto;
 
             &:has(.invocations-count) {
                 @container workflow-card (max-width: #{$breakpoint-xs}) {
                     grid-template-areas:
-                        "i b"
-                        "n b"
-                        "s s";
+                        "i d b"
+                        "n n b"
+                        "s s s";
                 }
             }
 
-            .workflow-card-indicators {
+            .workflow-card-select-checkbox {
                 grid-area: i;
+                margin: 0%;
+            }
+
+            .workflow-card-indicators {
+                grid-area: d;
             }
 
             .workflow-count-actions {

--- a/client/src/components/Workflow/List/WorkflowCardList.vue
+++ b/client/src/components/Workflow/List/WorkflowCardList.vue
@@ -16,11 +16,21 @@ interface Props {
     publishedView?: boolean;
     editorView?: boolean;
     currentWorkflowId?: string;
+    selectedWorkflowIds?: Workflow[];
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+    gridView: false,
+    hideRuns: false,
+    filterable: true,
+    publishedView: false,
+    editorView: false,
+    currentWorkflowId: "",
+    selectedWorkflowIds: () => [],
+});
 
 const emit = defineEmits<{
+    (e: "select", workflow: Workflow): void;
     (e: "tagClick", tag: string): void;
     (e: "refreshList", overlayLoading?: boolean, silent?: boolean): void;
     (e: "updateFilter", key: string, value: any): void;
@@ -39,6 +49,7 @@ const modalOptions = reactive({
 });
 
 const showRename = ref(false);
+const showPreview = ref(false);
 
 function onRenameClose() {
     showRename.value = false;
@@ -50,8 +61,6 @@ function onRename(id: string, name: string) {
     modalOptions.rename.name = name;
     showRename.value = true;
 }
-
-const showPreview = ref(false);
 
 function onPreview(id: string) {
     modalOptions.preview.id = id;
@@ -74,6 +83,8 @@ function onInsertSteps(workflow: Workflow) {
             v-for="workflow in props.workflows"
             :key="workflow.id"
             :workflow="workflow"
+            :selectable="!publishedView && !editorView"
+            :selected="props.selectedWorkflowIds.some((w) => w.id === workflow.id)"
             :grid-view="props.gridView"
             :hide-runs="props.hideRuns"
             :filterable="props.filterable"
@@ -81,6 +92,7 @@ function onInsertSteps(workflow: Workflow) {
             :editor-view="props.editorView"
             :current="workflow.id === props.currentWorkflowId"
             class="workflow-card"
+            @select="(...args) => emit('select', ...args)"
             @tagClick="(...args) => emit('tagClick', ...args)"
             @refreshList="(...args) => emit('refreshList', ...args)"
             @updateFilter="(...args) => emit('updateFilter', ...args)"
@@ -130,15 +142,20 @@ function onInsertSteps(workflow: Workflow) {
         width: 100%;
     }
 
-    &.grid .workflow-card {
-        width: calc(100% / 3);
+    &.grid {
+        // it is overwriting the base non used css for the grid class
+        padding-top: 0 !important;
 
-        @container card-list (max-width: #{$breakpoint-xl}) {
-            width: calc(100% / 2);
-        }
+        .workflow-card {
+            width: calc(100% / 3);
 
-        @container card-list (max-width: #{$breakpoint-sm}) {
-            width: 100%;
+            @container card-list (max-width: #{$breakpoint-xl}) {
+                width: calc(100% / 2);
+            }
+
+            @container card-list (max-width: #{$breakpoint-sm}) {
+                width: 100%;
+            }
         }
     }
 }

--- a/client/src/components/Workflow/List/WorkflowCardList.vue
+++ b/client/src/components/Workflow/List/WorkflowCardList.vue
@@ -134,6 +134,7 @@ function onInsertSteps(workflow: Workflow) {
 @import "_breakpoints.scss";
 
 .workflow-card-list {
+    overflow: auto;
     container: card-list / inline-size;
     display: flex;
     flex-wrap: wrap;

--- a/client/src/components/Workflow/List/WorkflowList.vue
+++ b/client/src/components/Workflow/List/WorkflowList.vue
@@ -27,7 +27,7 @@ import WorkflowListActions from "@/components/Workflow/List/WorkflowListActions.
 type ListView = "grid" | "list";
 type WorkflowsList = Record<string, never>[];
 
-// Temporary interface to match the `Workflow` interface from `WorkflowCard`
+// Interface to match the `Workflow` interface from `WorkflowCard`
 interface SelectedWorkflow {
     id: string;
     name: string;

--- a/client/src/components/Workflow/List/WorkflowList.vue
+++ b/client/src/components/Workflow/List/WorkflowList.vue
@@ -342,9 +342,7 @@ async function onBulkTagsAdd(tags: string[]) {
 watch([filterText, sortBy, sortDesc], async () => {
     offset.value = 0;
 
-    if (showDeleted.value) {
-        selectedWorkflowIds.value = [];
-    }
+    selectedWorkflowIds.value = [];
 
     await load(true);
 });
@@ -547,7 +545,8 @@ onMounted(() => {
                 :value="currentPage"
                 :total-rows="totalWorkflows"
                 :per-page="limit"
-                align="center"
+                align="right"
+                size="sm"
                 first-number
                 last-number
                 @change="onPageChange" />
@@ -585,6 +584,7 @@ onMounted(() => {
     }
 
     .cards-list {
+        height: 100%;
         scroll-behavior: smooth;
         min-height: 150px;
         display: flex;
@@ -596,6 +596,7 @@ onMounted(() => {
 
     .workflow-list-footer {
         display: flex;
+        align-items: center;
         margin-top: 0.5rem;
 
         .workflow-list-footer-bulk-actions {

--- a/client/src/components/Workflow/List/WorkflowList.vue
+++ b/client/src/components/Workflow/List/WorkflowList.vue
@@ -93,6 +93,10 @@ const validFilters = computed(() => workflowFilters.value.getValidFilters(rawFil
 const invalidFilters = computed(() => workflowFilters.value.getValidFilters(rawFilters.value, true).invalidFilters);
 const isSurroundedByQuotes = computed(() => /^["'].*["']$/.test(filterText.value));
 const hasInvalidFilters = computed(() => !isSurroundedByQuotes.value && Object.keys(invalidFilters.value).length > 0);
+const indeterminateSelected = computed(() => selectedWorkflowIds.value.length > 0 && !allSelected.value);
+const allSelected = computed(
+    () => selectedWorkflowIds.value.length !== 0 && selectedWorkflowIds.value.length === workflowsLoaded.value.length
+);
 
 function updateFilterValue(filterKey: string, newValue: any) {
     const currentFilterText = filterText.value;
@@ -196,6 +200,20 @@ function onSelectWorkflow(w: SelectedWorkflow) {
     }
 }
 
+function onSelectAllWorkflows() {
+    if (selectedWorkflowIds.value.length === workflowsLoaded.value.length) {
+        selectedWorkflowIds.value = [];
+    } else {
+        selectedWorkflowIds.value = workflowsLoaded.value.map((w: any) => {
+            return {
+                id: w.id,
+                name: w.name,
+                published: w.published,
+            };
+        });
+    }
+}
+
 
 watch([filterText, sortBy, sortDesc], async () => {
     offset.value = 0;
@@ -260,7 +278,14 @@ onMounted(() => {
                 </template>
             </FilterMenu>
 
-            <ListHeader ref="listHeader" show-view-toggle>
+            <ListHeader
+                ref="listHeader"
+                show-view-toggle
+                :show-select-all="!published && !sharedWithMe"
+                :select-all-disabled="loading || overlay || noItems || noResults"
+                :all-selected="allSelected"
+                :indeterminate-selected="indeterminateSelected"
+                @select-all="onSelectAllWorkflows">
                 <template v-slot:extra-filter>
                     <div v-if="activeList === 'my'">
                         Filter:

--- a/client/src/components/Workflow/List/WorkflowList.vue
+++ b/client/src/components/Workflow/List/WorkflowList.vue
@@ -26,6 +26,13 @@ library.add(faStar, faTrash);
 type ListView = "grid" | "list";
 type WorkflowsList = Record<string, never>[];
 
+// Temporary interface to match the `Workflow` interface from `WorkflowCard`
+interface SelectedWorkflow {
+    id: string;
+    name: string;
+    published: boolean;
+}
+
 interface Props {
     activeList?: "my" | "shared_with_me" | "published";
 }
@@ -46,6 +53,7 @@ const totalWorkflows = ref(0);
 const showAdvanced = ref(false);
 const listHeader = ref<any>(null);
 const workflowsLoaded = ref<WorkflowsList>([]);
+const selectedWorkflowIds = ref<SelectedWorkflow[]>([]);
 
 const searchPlaceHolder = computed(() => {
     let placeHolder = "Search my workflows";
@@ -178,8 +186,24 @@ function validatedFilterText() {
     return workflowFilters.value.getFilterText(validFilters.value, true);
 }
 
+function onSelectWorkflow(w: SelectedWorkflow) {
+    const index = selectedWorkflowIds.value.findIndex((selected) => selected.id === w.id);
+
+    if (index === -1) {
+        selectedWorkflowIds.value.push(w);
+    } else {
+        selectedWorkflowIds.value.splice(index, 1);
+    }
+}
+
+
 watch([filterText, sortBy, sortDesc], async () => {
     offset.value = 0;
+
+    if (showDeleted.value) {
+        selectedWorkflowIds.value = [];
+    }
+
     await load(true);
 });
 
@@ -310,6 +334,8 @@ onMounted(() => {
                 :workflows="workflowsLoaded"
                 :published-view="published"
                 :grid-view="view === 'grid'"
+                :selected-workflow-ids="selectedWorkflowIds"
+                @select="onSelectWorkflow"
                 @refreshList="load"
                 @tagClick="(tag) => updateFilterValue('tag', `'${tag}'`)"
                 @updateFilter="updateFilterValue" />


### PR DESCRIPTION
This PR introduces selectable workflow cards, enabling users to select multiple workflows for bulk actions such as delete, restore, and add tags. It also adds a new component to select tags, `TagsSelectionDialog,` and includes some logic and UI enhancements.
Bulk actions are only available in the `My workflows` tab.

![image](https://github.com/user-attachments/assets/5b6251a8-f7e0-4914-9dc8-556fa9123a9c)


https://github.com/user-attachments/assets/b13854d0-4624-4a25-9872-e91254128d39



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open `My Workflows` list
  2. Select some workflows
  3. Delete or Add tags to the selected workflows using the displayed button on the bottom
  4. To restore deleted workflows, activate the `Show deleted` filter and select workflows to restore

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
