### PR TITLE
Use popper wrapper for help text popover

### DIFF
--- a/client/src/components/Help/HelpPopover.vue
+++ b/client/src/components/Help/HelpPopover.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
-import { BPopover } from "bootstrap-vue";
-
 import HelpTerm from "./HelpTerm.vue";
+import Popper from "@/components/Popper/Popper.vue";
 
 interface Props {
-    target: any;
+    target: HTMLElement;
     term: string;
 }
 
@@ -12,7 +11,7 @@ defineProps<Props>();
 </script>
 
 <template>
-    <BPopover v-if="target" :target="target" triggers="hover" placement="bottom">
-        <HelpTerm :term="term" />
-    </BPopover>
+    <Popper v-if="target" :reference-el="target" mode="light">
+        <HelpTerm :term="term" class="p-2" />
+    </Popper>
 </template>

--- a/client/src/components/Help/HelpTerm.vue
+++ b/client/src/components/Help/HelpTerm.vue
@@ -21,7 +21,7 @@ const { loading, hasHelp, help } = useHelpForTerm(toRef(props, "term"));
         <div v-if="loading">
             <LoadingSpan message="Loading Galaxy help terms" />
         </div>
-        <div v-else-if="hasHelp">
+        <div v-else-if="hasHelp && help">
             <ConfigurationMarkdown :markdown="help" :admin="true" />
         </div>
         <div v-else>

--- a/client/src/components/Help/HelpText.vue
+++ b/client/src/components/Help/HelpText.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { ref } from "vue";
+
 import HelpPopover from "./HelpPopover.vue";
 
 interface Props {
@@ -10,17 +12,13 @@ interface Props {
 withDefaults(defineProps<Props>(), {
     forTitle: false,
 });
+
+const helpTarget = ref();
 </script>
 
 <template>
     <span>
-        <HelpPopover
-            :target="
-                () => {
-                    return $refs.helpTarget;
-                }
-            "
-            :term="uri" />
+        <HelpPopover :target="helpTarget" :term="uri" />
         <span ref="helpTarget" class="help-text" :class="{ 'title-help-text': forTitle }">{{ text }}</span>
     </span>
 </template>

--- a/client/src/components/Popper/Popper.vue
+++ b/client/src/components/Popper/Popper.vue
@@ -3,7 +3,7 @@
         <span v-if="!referenceEl" ref="reference">
             <slot name="reference" />
         </span>
-        <div v-show="visible" ref="popper" class="popper-element mt-1" :class="`popper-element-${mode}`">
+        <div v-show="visible" ref="popper" class="popper-element m-1" :class="`popper-element-${mode}`">
             <div v-if="arrow" class="popper-arrow" data-popper-arrow />
             <div v-if="title" class="popper-header px-2 py-1 rounded-top d-flex justify-content-between">
                 <span class="px-1">{{ title }}</span>

--- a/client/src/components/Popper/Popper.vue
+++ b/client/src/components/Popper/Popper.vue
@@ -3,7 +3,7 @@
         <span v-if="!referenceEl" ref="reference">
             <slot name="reference" />
         </span>
-        <div v-show="visible" ref="popper" class="popper-element m-1" :class="`popper-element-${mode}`">
+        <div v-show="visible" ref="popper" class="popper-element mt-1" :class="`popper-element-${mode}`">
             <div v-if="arrow" class="popper-arrow" data-popper-arrow />
             <div v-if="title" class="popper-header px-2 py-1 rounded-top d-flex justify-content-between">
                 <span class="px-1">{{ title }}</span>

--- a/client/src/components/Popper/Popper.vue
+++ b/client/src/components/Popper/Popper.vue
@@ -1,6 +1,6 @@
 <template>
     <span>
-        <span ref="reference">
+        <span v-if="!referenceEl" ref="reference">
             <slot name="reference" />
         </span>
         <div v-show="visible" ref="popper" class="popper-element mt-1" :class="`popper-element-${mode}`">
@@ -33,11 +33,12 @@ const props = defineProps({
     disabled: { type: Boolean, default: false },
     mode: { type: String, default: "dark" },
     placement: String as PropType<Placement>,
+    referenceEl: HTMLElement,
     title: String,
     trigger: String as PropType<Trigger>,
 });
 
-const reference = ref();
+const reference = props.referenceEl ? ref(props.referenceEl) : ref();
 const popper = ref();
 
 const { visible } = usePopper(reference, popper, {

--- a/client/src/components/Popper/usePopper.ts
+++ b/client/src/components/Popper/usePopper.ts
@@ -40,6 +40,8 @@ export function usePopper(
         } else if (trigger === "hover") {
             addEventListener(reference.value, "mouseover", doOpen);
             addEventListener(reference.value, "mouseout", doClose);
+            addEventListener(popper.value, "mouseover", doOpen);
+            addEventListener(popper.value, "mouseout", doClose);
         }
     });
 


### PR DESCRIPTION
Requires #19337. Improves alignment, arrow position, scrolling behavior and prevents help text popover to be cut off on small screens.

Previous:
<img width="954" alt="Screenshot 2024-12-17 at 7 25 22 PM" src="https://github.com/user-attachments/assets/345c86cf-bb78-481a-a1ae-b17e4dd9bc98" />

Now:
![popper2](https://github.com/user-attachments/assets/b4217967-950a-4a7b-b979-36c0ac9e6cff)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
