### PR TITLE
Rework some form components for reuse.

### DIFF
--- a/client/src/components/Form/FormListElementOperations.vue
+++ b/client/src/components/Form/FormListElementOperations.vue
@@ -24,30 +24,32 @@ const emit = defineEmits<{
 <template>
     <span class="float-right">
         <BButtonGroup>
-            <BButton
-                :id="upButtonId"
-                v-b-tooltip.hover.bottom
-                :disabled="index == 0"
-                title="move up"
-                role="button"
-                variant="link"
-                size="sm"
-                class="ml-0"
-                @click="() => emit('swap-up')">
-                <FontAwesomeIcon :icon="faCaretUp" />
-            </BButton>
-            <BButton
-                :id="downButtonId"
-                v-b-tooltip.hover.bottom
-                :disabled="index >= numElements - 1"
-                title="move down"
-                role="button"
-                variant="link"
-                size="sm"
-                class="ml-0"
-                @click="() => emit('swap-down')">
-                <FontAwesomeIcon :icon="faCaretDown" />
-            </BButton>
+            <span v-b-tooltip.hover.bottom title="move up">
+                <BButton
+                    :id="upButtonId"
+                    v-b-tooltip.hover.bottom
+                    :disabled="index == 0"
+                    role="button"
+                    variant="link"
+                    size="sm"
+                    class="ml-0"
+                    @click="() => emit('swap-up')">
+                    <FontAwesomeIcon :icon="faCaretUp" />
+                </BButton>
+            </span>
+            <span v-b-tooltip.hover.bottom title="move down">
+                <BButton
+                    :id="downButtonId"
+                    :disabled="index >= numElements - 1"
+                    title="move down"
+                    role="button"
+                    variant="link"
+                    size="sm"
+                    class="ml-0"
+                    @click="() => emit('swap-down')">
+                    <FontAwesomeIcon :icon="faCaretDown" />
+                </BButton>
+            </span>
         </BButtonGroup>
 
         <span v-b-tooltip.hover.bottom :title="deleteTooltip">

--- a/client/src/components/Form/FormListElementOperations.vue
+++ b/client/src/components/Form/FormListElementOperations.vue
@@ -1,11 +1,7 @@
 <script setup lang="ts">
-import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCaretDown, faCaretUp, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton, BButtonGroup } from "bootstrap-vue";
-
-// @ts-ignore: bad library types
-library.add(faTrashAlt, faCaretUp, faCaretDown);
 
 interface Props {
     index: number;
@@ -38,7 +34,7 @@ const emit = defineEmits<{
                 size="sm"
                 class="ml-0"
                 @click="() => emit('swap-up')">
-                <FontAwesomeIcon icon="caret-up" />
+                <FontAwesomeIcon :icon="faCaretUp" />
             </BButton>
             <BButton
                 :id="downButtonId"
@@ -50,7 +46,7 @@ const emit = defineEmits<{
                 size="sm"
                 class="ml-0"
                 @click="() => emit('swap-down')">
-                <FontAwesomeIcon icon="caret-down" />
+                <FontAwesomeIcon :icon="faCaretDown" />
             </BButton>
         </BButtonGroup>
 
@@ -63,7 +59,7 @@ const emit = defineEmits<{
                 size="sm"
                 class="ml-0"
                 @click="() => emit('delete')">
-                <FontAwesomeIcon icon="trash-alt" />
+                <FontAwesomeIcon :icon="faTrashAlt" />
             </BButton>
         </span>
     </span>

--- a/client/src/components/Form/FormListElementOperations.vue
+++ b/client/src/components/Form/FormListElementOperations.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faCaretDown, faCaretUp, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BButton, BButtonGroup } from "bootstrap-vue";
+
+// @ts-ignore: bad library types
+library.add(faTrashAlt, faCaretUp, faCaretDown);
+
+interface Props {
+    index: number;
+    numElements: number;
+    upButtonId: string;
+    downButtonId: string;
+    canDelete: boolean;
+    deleteTooltip: string;
+}
+
+defineProps<Props>();
+
+const emit = defineEmits<{
+    (e: "delete"): void;
+    (e: "swap-up"): void;
+    (e: "swap-down"): void;
+}>();
+</script>
+
+<template>
+    <span class="float-right">
+        <BButtonGroup>
+            <BButton
+                :id="upButtonId"
+                v-b-tooltip.hover.bottom
+                :disabled="index == 0"
+                title="move up"
+                role="button"
+                variant="link"
+                size="sm"
+                class="ml-0"
+                @click="() => emit('swap-up')">
+                <FontAwesomeIcon icon="caret-up" />
+            </BButton>
+            <BButton
+                :id="downButtonId"
+                v-b-tooltip.hover.bottom
+                :disabled="index >= numElements - 1"
+                title="move down"
+                role="button"
+                variant="link"
+                size="sm"
+                class="ml-0"
+                @click="() => emit('swap-down')">
+                <FontAwesomeIcon icon="caret-down" />
+            </BButton>
+        </BButtonGroup>
+
+        <span v-b-tooltip.hover.bottom :title="deleteTooltip">
+            <BButton
+                :disabled="!canDelete"
+                title="delete"
+                role="button"
+                variant="link"
+                size="sm"
+                class="ml-0"
+                @click="() => emit('delete')">
+                <FontAwesomeIcon icon="trash-alt" />
+            </BButton>
+        </span>
+    </span>
+</template>

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -132,6 +132,7 @@ const { keyObject } = useKeyedObjects();
                         <b-button
                             :id="getButtonId(cacheId, 'up')"
                             v-b-tooltip.hover.bottom
+                            :disabled="cacheId == 0"
                             title="move up"
                             role="button"
                             variant="link"
@@ -143,6 +144,7 @@ const { keyObject } = useKeyedObjects();
                         <b-button
                             :id="getButtonId(cacheId, 'down')"
                             v-b-tooltip.hover.bottom
+                            :disabled="cacheId >= props.input.cache?.length - 1"
                             title="move down"
                             role="button"
                             variant="link"

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faCaretDown, faCaretUp, faPlus, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
+import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { defineAsyncComponent, nextTick, type PropType } from "vue";
 import { computed } from "vue";
@@ -9,6 +9,7 @@ import { useKeyedObjects } from "@/composables/keyedObjects";
 import localize from "@/utils/localization";
 
 import FormCard from "./FormCard.vue";
+import FormListElementOperations from "./FormListElementOperations.vue";
 
 const FormNode = defineAsyncComponent(() => import("./FormInputs.vue"));
 
@@ -68,7 +69,7 @@ const emit = defineEmits<{
 }>();
 
 // @ts-ignore: bad library types
-library.add(faPlus, faTrashAlt, faCaretUp, faCaretDown);
+library.add(faPlus);
 
 function onInsert() {
     emit("insert");
@@ -127,47 +128,17 @@ const { keyObject } = useKeyedObjects();
             class="card"
             :title="getTitle(cacheId)">
             <template v-slot:operations>
-                <span v-if="!props.sustainRepeats" class="float-right">
-                    <b-button-group>
-                        <b-button
-                            :id="getButtonId(cacheId, 'up')"
-                            v-b-tooltip.hover.bottom
-                            :disabled="cacheId == 0"
-                            title="move up"
-                            role="button"
-                            variant="link"
-                            size="sm"
-                            class="ml-0"
-                            @click="() => swap(cacheId, cacheId - 1, 'up')">
-                            <FontAwesomeIcon icon="caret-up" />
-                        </b-button>
-                        <b-button
-                            :id="getButtonId(cacheId, 'down')"
-                            v-b-tooltip.hover.bottom
-                            :disabled="cacheId >= props.input.cache?.length - 1"
-                            title="move down"
-                            role="button"
-                            variant="link"
-                            size="sm"
-                            class="ml-0"
-                            @click="() => swap(cacheId, cacheId + 1, 'down')">
-                            <FontAwesomeIcon icon="caret-down" />
-                        </b-button>
-                    </b-button-group>
-
-                    <span v-b-tooltip.hover.bottom :title="deleteTooltip">
-                        <b-button
-                            :disabled="!minRepeats"
-                            title="delete"
-                            role="button"
-                            variant="link"
-                            size="sm"
-                            class="ml-0"
-                            @click="() => onDelete(cacheId)">
-                            <FontAwesomeIcon icon="trash-alt" />
-                        </b-button>
-                    </span>
-                </span>
+                <FormListElementOperations
+                    v-if="!props.sustainRepeats"
+                    :index="cacheId"
+                    :num-elements="props.input.cache?.length || 0"
+                    :up-button-id="getButtonId(cacheId, 'up')"
+                    :down-button-id="getButtonId(cacheId, 'down')"
+                    :delete-tooltip="deleteTooltip"
+                    :can-delete="minRepeats"
+                    @swap-up="() => swap(cacheId, cacheId - 1, 'up')"
+                    @swap-down="() => swap(cacheId, cacheId + 1, 'down')"
+                    @delete="() => onDelete(cacheId)" />
             </template>
 
             <template v-slot:body>

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { library } from "@fortawesome/fontawesome-svg-core";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { defineAsyncComponent, nextTick, type PropType } from "vue";
@@ -67,9 +66,6 @@ const emit = defineEmits<{
     (e: "delete", index: number): void;
     (e: "swap", a: number, b: number): void;
 }>();
-
-// @ts-ignore: bad library types
-library.add(faPlus);
 
 function onInsert() {
     emit("insert");
@@ -148,7 +144,7 @@ const { keyObject } = useKeyedObjects();
 
         <span v-b-tooltip.hover :title="buttonTooltip">
             <b-button v-if="!props.sustainRepeats" :disabled="maxRepeats" @click="onInsert">
-                <FontAwesomeIcon icon="plus" class="mr-1" />
+                <FontAwesomeIcon :icon="faPlus" class="mr-1" />
                 <span data-description="repeat insert">Insert {{ props.input.title || "Repeat" }}</span>
             </b-button>
         </span>

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -139,8 +139,9 @@ class TestToolForm(SeleniumTestCase, UsesHistoryItemAssertions):
         assert_input_order(["Text B", "Text C", "Text A"])
         self.components.tool_form.repeat_move_up(parameter="the_repeat_1").wait_for_and_click()
         assert_input_order(["Text C", "Text B", "Text A"])
-        self.components.tool_form.repeat_move_up(parameter="the_repeat_0").wait_for_and_click()
-        assert_input_order(["Text C", "Text B", "Text A"])
+        # no longer clickable, don't need to check the no-op here anymore.
+        # self.components.tool_form.repeat_move_up(parameter="the_repeat_0").wait_for_and_click()
+        # assert_input_order(["Text C", "Text B", "Text A"])
 
         self.tool_form_execute()
         self.history_panel_wait_for_hid_ok(1)


### PR DESCRIPTION
Centralize the logic for the collection types we have builders for and some refactoring of Repeats. I extracted the operations out so I can build cards for other types of lists of things in the workflow editor and have the same options and look and feel. Also a small user facing change is to disable buttons that don't make sense - "moving up from the top of the list" and "moving down from the bottom".

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
