### PR TITLE
[24.2] Fix simple activity panel item style

### DIFF
--- a/client/src/components/ActivityBar/ActivitySettings.vue
+++ b/client/src/components/ActivityBar/ActivitySettings.vue
@@ -70,8 +70,8 @@ function executeActivity(activity: Activity) {
 </script>
 
 <template>
-    <div class="activity-settings rounded no-highlight">
-        <div v-if="foundActivities" class="activity-settings-content">
+    <div class="no-highlight">
+        <div v-if="foundActivities">
             <button
                 v-for="activity in filteredActivities"
                 :key="activity.id"
@@ -122,7 +122,7 @@ function executeActivity(activity: Activity) {
                 </div>
             </button>
         </div>
-        <div v-else class="activity-settings-content">
+        <div v-else>
             <b-alert v-localize class="py-1 px-2" show> No matching activities found. </b-alert>
         </div>
     </div>
@@ -131,16 +131,6 @@ function executeActivity(activity: Activity) {
 <style lang="scss">
 @import "theme/blue.scss";
 
-.activity-settings {
-    overflow-y: hidden;
-    display: flex;
-    flex-direction: column;
-}
-
-.activity-settings-content {
-    overflow-y: auto;
-}
-
 .activity-settings-item {
     background: none;
     border: none;
@@ -148,6 +138,7 @@ function executeActivity(activity: Activity) {
     transition: none;
     width: 100%;
 }
+
 .activity-settings-item:hover {
     background: $gray-200;
 }

--- a/client/src/components/ActivityBar/ActivitySettings.vue
+++ b/client/src/components/ActivityBar/ActivitySettings.vue
@@ -70,7 +70,7 @@ function executeActivity(activity: Activity) {
 </script>
 
 <template>
-    <div class="no-highlight">
+    <div>
         <div v-if="foundActivities">
             <button
                 v-for="activity in filteredActivities"

--- a/client/src/components/Panels/VisualizationPanel.vue
+++ b/client/src/components/Panels/VisualizationPanel.vue
@@ -104,11 +104,11 @@ onMounted(() => {
             <h3>Create Visualization</h3>
             <DelayedInput :delay="100" placeholder="Search visualizations" @change="query = $event" />
         </template>
-        <div class="overflow-y mt-2">
+        <div>
             <LoadingSpan v-if="isLoading" message="Loading visualizations" />
             <div v-else-if="filteredPlugins.length > 0">
                 <div v-for="plugin in filteredPlugins" :key="plugin.name">
-                    <button :data-plugin-name="plugin.name" @click="selectVisualization(plugin)">
+                    <button class="plugin-item" :data-plugin-name="plugin.name" @click="selectVisualization(plugin)">
                         <div class="d-flex">
                             <div class="plugin-thumbnail mr-2">
                                 <img v-if="plugin.logo" alt="visualization" :src="absPath(plugin.logo)" />
@@ -143,6 +143,20 @@ onMounted(() => {
 </template>
 
 <style lang="scss">
+@import "theme/blue.scss";
+
+.plugin-item {
+    background: none;
+    border: none;
+    text-align: left;
+    transition: none;
+    width: 100%;
+}
+
+.plugin-item:hover {
+    background: $gray-200;
+}
+
 .plugin-thumbnail {
     img {
         width: 2rem;


### PR DESCRIPTION
This PR adjusts for recent changes to the activity panel. Unnecessary styles are removed from the activity settings panel and now missing styles are restored for the visualizations panel.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. Navigate to the Visualizations Panel
  2. Without this PR: Notice that the options are misaligned
  3. With this PR: Verify that the Settings Activity Panel and the Visualizations Panel item look and behave the same

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
