### PR TITLE
[24.2] Fix handling of step id offsets when duplicating selections

### DIFF
--- a/client/src/components/Workflow/Editor/modules/model.ts
+++ b/client/src/components/Workflow/Editor/modules/model.ts
@@ -48,9 +48,15 @@ export async function fromSimple(
     // If workflow being copied into another, wipe UUID and let
     // Galaxy assign new ones.
     if (options?.reassignIds ?? appendData) {
-        const stepIdOffset = stepStore.getStepIndex + 1;
+        const highestStepId = stepStore.getStepIndex;
 
-        Object.values(data.steps).forEach((step) => {
+        const stepArray = Object.values(data.steps);
+        const stepIds = Object.keys(data.steps).map((id) => parseInt(id));
+        const lowestStepId = Math.min(...stepIds);
+
+        const stepIdOffset = highestStepId - lowestStepId + 1;
+
+        stepArray.forEach((step) => {
             delete step.uuid;
             if (!step.position) {
                 // Should only happen for manually authored editor content,


### PR DESCRIPTION
Ids were incremented by too much when the duplicated partial Workflow passed to the `fromSimple` function contained Ids, which did not start at 0, and could cause gaps in the workflows step ids. This was an unreachable state before selection duplication, which is why this bug appeared now.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
