### PR TITLE
[24.1] Use select_from_url test data from github, not usegalaxy.org

### DIFF
--- a/lib/galaxy/tools/parameters/cancelable_request.py
+++ b/lib/galaxy/tools/parameters/cancelable_request.py
@@ -23,7 +23,7 @@ async def fetch_url(
     method: REQUEST_METHOD = "GET",
 ):
     async with session.request(method=method, url=url, params=params, data=data, headers=headers) as response:
-        return await response.json()
+        return await response.json(content_type=None)
 
 
 async def async_request_with_timeout(

--- a/test/functional/tools/select_from_url.xml
+++ b/test/functional/tools/select_from_url.xml
@@ -7,12 +7,11 @@ echo '$url_param_value_header_and_body' > '$param_value_header_and_body'
     ]]></command>
     <inputs>
         <param name="url_param_value" type="select">
-            <options from_url="https://usegalaxy.org/api/genomes">
-            </options>
+            <options from_url="https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/refs/heads/url_select/genomes.json"></options>
         </param>
         <param name="dynamic_param_filtered_with_validator" type="select">
             <!-- tested in test_build_module_filter_dynamic_select -->
-            <options from_url="https://usegalaxy.org/api/genomes">
+            <options from_url="https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/refs/heads/url_select/genomes.json">
                 <filter type="param_value" ref="url_param_value" column="1" />
             </options>
             <validator type="no_options" message="Need at least one option here" />
@@ -24,14 +23,14 @@ echo '$url_param_value_header_and_body' > '$param_value_header_and_body'
         </param>
         -->
         <param name="url_param_value_postprocessed" type="select">
-            <options from_url="https://usegalaxy.org/api/genomes/dm6">
+            <options from_url="https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/refs/heads/url_select/dm6.json">
                 <postprocess_expression type="ecma5.1"><![CDATA[
                     $( Object.values(inputs.chrom_info).map((v) => [v.chrom, v.len]) )
                 ]]></postprocess_expression>
             </options>
         </param>
         <param name="invalid_url_param_value_postprocessed" type="select">
-            <options from_url="https://usegalaxy.or/api/genomes/dm6">
+            <options from_url="https://usegalaxy.or">
                 <postprocess_expression type="ecma5.1"><![CDATA[${
                     if (inputs) {
                         return Object.values(inputs.chrom_info).map((v) => [v.chrom, v.len])

--- a/test/functional/tools/select_from_url.xml
+++ b/test/functional/tools/select_from_url.xml
@@ -23,7 +23,7 @@ echo '$url_param_value_header_and_body' > '$param_value_header_and_body'
         </param>
         -->
         <param name="url_param_value_postprocessed" type="select">
-            <options from_url="https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/refs/heads/master/genomes.json">
+            <options from_url="https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/refs/heads/master/dm6.json">
                 <postprocess_expression type="ecma5.1"><![CDATA[
                     $( Object.values(inputs.chrom_info).map((v) => [v.chrom, v.len]) )
                 ]]></postprocess_expression>

--- a/test/functional/tools/select_from_url.xml
+++ b/test/functional/tools/select_from_url.xml
@@ -7,11 +7,11 @@ echo '$url_param_value_header_and_body' > '$param_value_header_and_body'
     ]]></command>
     <inputs>
         <param name="url_param_value" type="select">
-            <options from_url="https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/refs/heads/url_select/genomes.json"></options>
+            <options from_url="https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/refs/heads/master/genomes.json"></options>
         </param>
         <param name="dynamic_param_filtered_with_validator" type="select">
             <!-- tested in test_build_module_filter_dynamic_select -->
-            <options from_url="https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/refs/heads/url_select/genomes.json">
+            <options from_url="https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/refs/heads/master/genomes.json">
                 <filter type="param_value" ref="url_param_value" column="1" />
             </options>
             <validator type="no_options" message="Need at least one option here" />
@@ -23,7 +23,7 @@ echo '$url_param_value_header_and_body' > '$param_value_header_and_body'
         </param>
         -->
         <param name="url_param_value_postprocessed" type="select">
-            <options from_url="https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/refs/heads/url_select/dm6.json">
+            <options from_url="https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/refs/heads/master/genomes.json">
                 <postprocess_expression type="ecma5.1"><![CDATA[
                     $( Object.values(inputs.chrom_info).map((v) => [v.chrom, v.len]) )
                 ]]></postprocess_expression>


### PR DESCRIPTION
Should be more stable. Includes minor fix so JSON is decoded even if response headers indicate it's text.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
