### PR TITLE
Hide outdated visualizations from visualizations activity panel

### DIFF
--- a/config/plugins/visualizations/jqplot/jqplot_bar/config/jqplot_bar.xml
+++ b/config/plugins/visualizations/jqplot/jqplot_bar/config/jqplot_bar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Bar diagram (jqPlot)" visible="false">
+<visualization name="Bar diagram (jqPlot)" hidden="true">
     <macros>
         <import>jqplot_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/jqplot/jqplot_bar/config/jqplot_bar.xml
+++ b/config/plugins/visualizations/jqplot/jqplot_bar/config/jqplot_bar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Bar diagram (jqPlot)">
+<visualization name="Bar diagram (jqPlot)" visible="false">
     <macros>
         <import>jqplot_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/jqplot/jqplot_box/config/jqplot_box.xml
+++ b/config/plugins/visualizations/jqplot/jqplot_box/config/jqplot_box.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Box plot (jqPlot)" embeddable="false" visible="false">
+<visualization name="Box plot (jqPlot)" embeddable="false" hidden="true">
     <macros>
         <import>../../jqplot_bar/config/jqplot_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/jqplot/jqplot_box/config/jqplot_box.xml
+++ b/config/plugins/visualizations/jqplot/jqplot_box/config/jqplot_box.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Box plot (jqPlot)" embeddable="false">
+<visualization name="Box plot (jqPlot)" embeddable="false" visible="false">
     <macros>
         <import>../../jqplot_bar/config/jqplot_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/jqplot/jqplot_histogram/config/jqplot_histogram.xml
+++ b/config/plugins/visualizations/jqplot/jqplot_histogram/config/jqplot_histogram.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Discrete Histogram (jqPlot)" embeddable="false">
+<visualization name="Discrete Histogram (jqPlot)" embeddable="false" visible="false">
     <macros>
         <import>../../jqplot_bar/config/jqplot_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/jqplot/jqplot_histogram/config/jqplot_histogram.xml
+++ b/config/plugins/visualizations/jqplot/jqplot_histogram/config/jqplot_histogram.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Discrete Histogram (jqPlot)" embeddable="false" visible="false">
+<visualization name="Discrete Histogram (jqPlot)" embeddable="false" hidden="true">
     <macros>
         <import>../../jqplot_bar/config/jqplot_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/jqplot/jqplot_line/config/jqplot_line.xml
+++ b/config/plugins/visualizations/jqplot/jqplot_line/config/jqplot_line.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Line chart (jqPlot)" visible="false">
+<visualization name="Line chart (jqPlot)" hidden="true">
     <macros>
         <import>../../jqplot_bar/config/jqplot_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/jqplot/jqplot_line/config/jqplot_line.xml
+++ b/config/plugins/visualizations/jqplot/jqplot_line/config/jqplot_line.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Line chart (jqPlot)">
+<visualization name="Line chart (jqPlot)" visible="false">
     <macros>
         <import>../../jqplot_bar/config/jqplot_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/jqplot/jqplot_scatter/config/jqplot_scatter.xml
+++ b/config/plugins/visualizations/jqplot/jqplot_scatter/config/jqplot_scatter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Scatter plot (jqPlot)">
+<visualization name="Scatter plot (jqPlot)" visible="false">
     <macros>
         <import>../../jqplot_bar/config/jqplot_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/jqplot/jqplot_scatter/config/jqplot_scatter.xml
+++ b/config/plugins/visualizations/jqplot/jqplot_scatter/config/jqplot_scatter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Scatter plot (jqPlot)" visible="false">
+<visualization name="Scatter plot (jqPlot)" hidden="true">
     <macros>
         <import>../../jqplot_bar/config/jqplot_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_bar/config/nvd3_bar.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_bar/config/nvd3_bar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Bar diagram (NVD3)" visible="False">
+<visualization name="Bar diagram (NVD3)" visible="false">
     <macros>
         <import>nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_bar/config/nvd3_bar.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_bar/config/nvd3_bar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Bar diagram (NVD3)" visible="false">
+<visualization name="Bar diagram (NVD3)" hidden="true">
     <macros>
         <import>nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_bar/config/nvd3_bar.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_bar/config/nvd3_bar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Bar diagram (NVD3)">
+<visualization name="Bar diagram (NVD3)" visible="False">
     <macros>
         <import>nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_bar_stacked/config/nvd3_bar_stacked.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_bar_stacked/config/nvd3_bar_stacked.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Bar Stacked (NVD3)">
+<visualization name="Bar Stacked (NVD3)" visible="false">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_bar_stacked/config/nvd3_bar_stacked.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_bar_stacked/config/nvd3_bar_stacked.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Bar Stacked (NVD3)" visible="false">
+<visualization name="Bar Stacked (NVD3)" hidden="true">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_histogram/config/nvd3_histogram.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_histogram/config/nvd3_histogram.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Histogram (NVD3)" embeddable="false" visible="false">
+<visualization name="Histogram (NVD3)" embeddable="false" hidden="true">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_histogram/config/nvd3_histogram.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_histogram/config/nvd3_histogram.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Histogram (NVD3)" embeddable="false">
+<visualization name="Histogram (NVD3)" embeddable="false" visible="false">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_histogram_discrete/config/nvd3_histogram_discrete.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_histogram_discrete/config/nvd3_histogram_discrete.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Histogram Discrete (NVD3)" embeddable="false">
+<visualization name="Histogram Discrete (NVD3)" embeddable="false" visible="false">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_histogram_discrete/config/nvd3_histogram_discrete.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_histogram_discrete/config/nvd3_histogram_discrete.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Histogram Discrete (NVD3)" embeddable="false" visible="false">
+<visualization name="Histogram Discrete (NVD3)" embeddable="false" hidden="true">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_horizontal/config/nvd3_horizontal.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_horizontal/config/nvd3_horizontal.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Bar Horizontal (NVD3)" visible="false">
+<visualization name="Bar Horizontal (NVD3)" hidden="true">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_horizontal/config/nvd3_horizontal.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_horizontal/config/nvd3_horizontal.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Bar Horizontal (NVD3)">
+<visualization name="Bar Horizontal (NVD3)" visible="false">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_horizontal_stacked/config/nvd3_horizontal_stacked.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_horizontal_stacked/config/nvd3_horizontal_stacked.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Bar Horizontal Stacked (NVD3)" visible="false">
+<visualization name="Bar Horizontal Stacked (NVD3)" hidden="true">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_horizontal_stacked/config/nvd3_horizontal_stacked.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_horizontal_stacked/config/nvd3_horizontal_stacked.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Bar Horizontal Stacked (NVD3)">
+<visualization name="Bar Horizontal Stacked (NVD3)" visible="false">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_line/config/nvd3_line.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_line/config/nvd3_line.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Line chart (NVD3)" visible="false">
+<visualization name="Line chart (NVD3)" hidden="true">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_line/config/nvd3_line.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_line/config/nvd3_line.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Line chart (NVD3)">
+<visualization name="Line chart (NVD3)" visible="false">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_line_focus/config/nvd3_line_focus.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_line_focus/config/nvd3_line_focus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Line with focus (NVD3)" visible="false">
+<visualization name="Line with focus (NVD3)" hidden="true">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_line_focus/config/nvd3_line_focus.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_line_focus/config/nvd3_line_focus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Line with focus (NVD3)">
+<visualization name="Line with focus (NVD3)" visible="false">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_pie/config/nvd3_pie.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_pie/config/nvd3_pie.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Pie chart (NVD3)">
+<visualization name="Pie chart (NVD3)" visible="false">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_pie/config/nvd3_pie.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_pie/config/nvd3_pie.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Pie chart (NVD3)" visible="false">
+<visualization name="Pie chart (NVD3)" hidden="true">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_scatter/config/nvd3_scatter.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_scatter/config/nvd3_scatter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Scatter plot (NVD3)">
+<visualization name="Scatter plot (NVD3)" visible="false">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_scatter/config/nvd3_scatter.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_scatter/config/nvd3_scatter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Scatter plot (NVD3)" visible="false">
+<visualization name="Scatter plot (NVD3)" hidden="true">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_stackedarea/config/nvd3_stackedarea.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_stackedarea/config/nvd3_stackedarea.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Stacked area (NVD3)" visible="false">
+<visualization name="Stacked area (NVD3)" hidden="true">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_stackedarea/config/nvd3_stackedarea.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_stackedarea/config/nvd3_stackedarea.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Stacked area (NVD3)">
+<visualization name="Stacked area (NVD3)" visible="false">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_stackedarea_full/config/nvd3_stackedarea_full.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_stackedarea_full/config/nvd3_stackedarea_full.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Expanded (NVD3)" visible="false">
+<visualization name="Expanded (NVD3)" hidden="true">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_stackedarea_full/config/nvd3_stackedarea_full.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_stackedarea_full/config/nvd3_stackedarea_full.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Expanded (NVD3)">
+<visualization name="Expanded (NVD3)" visible="false">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_stackedarea_stream/config/nvd3_stackedarea_stream.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_stackedarea_stream/config/nvd3_stackedarea_stream.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Stream (NVD3)">
+<visualization name="Stream (NVD3)" visible="false">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/nvd3/nvd3_stackedarea_stream/config/nvd3_stackedarea_stream.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_stackedarea_stream/config/nvd3_stackedarea_stream.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Stream (NVD3)" visible="false">
+<visualization name="Stream (NVD3)" hidden="true">
     <macros>
         <import>../../nvd3_bar/config/nvd3_shared.xml</import>
     </macros>

--- a/config/plugins/visualizations/pv/config/pv.xml
+++ b/config/plugins/visualizations/pv/config/pv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="PV Protein Viewer">
+<visualization name="PV Protein Viewer" hidden="true">
     <description>PV is a pdb/protein viewer hosted at https://biasmv.github.io/pv/.</description>
     <data_sources>
         <data_source>

--- a/config/plugins/visualizations/scatterplot/config/scatterplot.xml
+++ b/config/plugins/visualizations/scatterplot/config/scatterplot.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Scatterplot">
+<visualization name="Scatterplot" visible="false">
     <description>Creates a 2D-scatterplot from tabular datapoints</description>
     <data_sources>
         <data_source>

--- a/config/plugins/visualizations/scatterplot/config/scatterplot.xml
+++ b/config/plugins/visualizations/scatterplot/config/scatterplot.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Scatterplot" visible="false">
+<visualization name="Scatterplot" hidden="true">
     <description>Creates a 2D-scatterplot from tabular datapoints</description>
     <data_sources>
         <data_source>

--- a/lib/galaxy/visualization/plugins/config_parser.py
+++ b/lib/galaxy/visualization/plugins/config_parser.py
@@ -81,9 +81,9 @@ class VisualizationsConfigParser:
             returned["embeddable"] = asbool(xml_tree.attrib.get("embeddable"))
 
         # record the visible flag - defaults to true
-        returned["visible"] = True
-        if "visible" in xml_tree.attrib:
-            returned["visible"] = asbool(xml_tree.attrib.get("visible"))
+        returned["hidden"] = False
+        if "hidden" in xml_tree.attrib:
+            returned["hidden"] = asbool(xml_tree.attrib.get("hidden"))
 
         # a (for now) text description of what the visualization does
         description = xml_tree.find("description")

--- a/lib/galaxy/visualization/plugins/config_parser.py
+++ b/lib/galaxy/visualization/plugins/config_parser.py
@@ -80,6 +80,11 @@ class VisualizationsConfigParser:
         if "embeddable" in xml_tree.attrib:
             returned["embeddable"] = asbool(xml_tree.attrib.get("embeddable"))
 
+        # record the visible flag - defaults to true
+        returned["visible"] = True
+        if "visible" in xml_tree.attrib:
+            returned["visible"] = asbool(xml_tree.attrib.get("visible"))
+
         # a (for now) text description of what the visualization does
         description = xml_tree.find("description")
         returned["description"] = description.text.strip() if description is not None else None

--- a/lib/galaxy/visualization/plugins/registry.py
+++ b/lib/galaxy/visualization/plugins/registry.py
@@ -230,7 +230,8 @@ class VisualizationsRegistry:
         for plugin in self.plugins.values():
             if embeddable and not plugin.config.get("embeddable"):
                 continue
-            result.append(plugin.to_dict())
+            if plugin.config.get("visible"):
+                result.append(plugin.to_dict())
         return sorted(result, key=lambda k: k.get("html"))
 
     # -- building links to visualizations from objects --

--- a/lib/galaxy/visualization/plugins/registry.py
+++ b/lib/galaxy/visualization/plugins/registry.py
@@ -233,7 +233,7 @@ class VisualizationsRegistry:
         """
         result = []
         for vis_name, vis_plugin in self.plugins.items():
-            if not vis_plugin.config.get("visible"):
+            if vis_plugin.config.get("hidden"):
                 continue
             if embeddable and not vis_plugin.config.get("embeddable"):
                 continue

--- a/lib/galaxy/visualization/plugins/registry.py
+++ b/lib/galaxy/visualization/plugins/registry.py
@@ -225,27 +225,22 @@ class VisualizationsRegistry:
             raise ObjectNotFound(f"Unknown or invalid visualization: {key}")
         return self.plugins[key]
 
-    def get_plugins(self, embeddable=None):
-        result = []
-        for plugin in self.plugins.values():
-            if embeddable and not plugin.config.get("embeddable"):
-                continue
-            if plugin.config.get("visible"):
-                result.append(plugin.to_dict())
-        return sorted(result, key=lambda k: k.get("html"))
-
     # -- building links to visualizations from objects --
-    def get_visualizations(self, trans, target_object):
+    def get_visualizations(self, trans, target_object=None, embeddable=None):
         """
         Get the names of visualizations usable on the `target_object` and
         the urls to call in order to render the visualizations.
         """
-        applicable_visualizations = []
-        for vis_name in self.plugins:
-            url_data = self.get_visualization(trans, vis_name, target_object)
-            if url_data:
-                applicable_visualizations.append(url_data)
-        return sorted(applicable_visualizations, key=lambda k: k.get("html"))
+        result = []
+        for vis_name, vis_plugin in self.plugins.items():
+            if not vis_plugin.config.get("visible"):
+                continue
+            if embeddable and not vis_plugin.config.get("embeddable"):
+                continue
+            if target_object is not None and self.get_visualization(trans, vis_name, target_object) is None:
+                continue
+            result.append(vis_plugin.to_dict())
+        return sorted(result, key=lambda k: k.get("html"))
 
     def get_visualization(self, trans, visualization_name, target_object):
         """

--- a/lib/galaxy/webapps/galaxy/api/plugins.py
+++ b/lib/galaxy/webapps/galaxy/api/plugins.py
@@ -36,12 +36,11 @@ class PluginsController(BaseGalaxyAPIController):
         GET /api/plugins:
         """
         registry = self._get_registry()
+        embeddable = asbool(kwargs.get("embeddable"))
+        target_object = None
         if (dataset_id := kwargs.get("dataset_id")) is not None:
-            hda = self.hda_manager.get_accessible(self.decode_id(dataset_id), trans.user)
-            return registry.get_visualizations(trans, hda)
-        else:
-            embeddable = asbool(kwargs.get("embeddable"))
-            return registry.get_plugins(embeddable=embeddable)
+            target_object = self.hda_manager.get_accessible(self.decode_id(dataset_id), trans.user)
+        return registry.get_visualizations(trans, target_object=target_object, embeddable=embeddable)
 
     @expose_api
     def show(self, trans, id, **kwargs):


### PR DESCRIPTION
This PR introduces a visibility flag to the visualization XML, allowing legacy visualizations to be hidden from the visualizations activity panel when users create new visualizations. However, previously saved legacy visualizations will still be accessible via the saved visualizations grid.

The deprecated visualizations include nvd3 and jqplot. Going forward, plotly is the recommended choice. It not only provides enhanced functionality and better support compared to the legacy visualization types but also utilizes a modern vite/vue3-based build system that is far more reliable. Previously, visualizations needed to be rebuilt within the context of the Galaxy client, which often resulted in build failures. With the new system, visualizations are built independently of Galaxy client internals and build bundles, and then published to npm, ensuring a more streamlined and robust process.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
