### PR TITLE
Require importlib-resources also for Python 3.9-3.11

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -87,7 +87,7 @@ h5py==3.12.1 ; python_full_version >= '3.9'
 humanfriendly==10.0
 idna==3.10
 importlib-metadata==8.5.0
-importlib-resources==6.4.5 ; python_full_version < '3.9'
+importlib-resources==6.4.5 ; python_full_version < '3.12'
 isa-rwval @ git+https://github.com/nsoranzo/isa-rwval.git@3d989181058d2765a93cb0e7ca85d6955e0eb6ef
 isal==1.7.1
 isodate==0.6.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "h5grove>=1.2.1",
     "h5py",  # Python 3.8 support
     "h5py>=3.12 ; python_version>='3.9'",  # Python 3.13 support
-    "importlib-resources ; python_version<'3.9'",  # for importlib.{abc.Traversable,resources.{files, Package}}
+    "importlib-resources ; python_version<'3.12'",  # for importlib.{abc.Traversable,resources.{files, Package}}
     "isa-rwval @ git+https://github.com/nsoranzo/isa-rwval.git@master",  # https://github.com/ISA-tools/isa-rwval/pull/17
     "isal>=1.7.0",  # Python 3.13 support
     "jinja2",


### PR DESCRIPTION
Broken in commit 78234720c4e25dc07dd056570fb216bb69feb0ee .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Delete your Galaxy virtualenv
  2. Start Galaxy under Python 3.9, 3.10 or 3.11

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
