### PR TITLE
[24.2] Fix to not display upload when creating collections from existing datasets.

### DIFF
--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -414,6 +414,7 @@ function renameElement(element: any, name: string) {
                 :extensions="extensions"
                 collection-type="list"
                 :no-items="props.initialElements.length == 0 && !props.fromSelection"
+                :show-upload="!fromSelection"
                 @add-uploaded-files="addUploadedFiles"
                 @on-update-datatype-toggle="changeDatatypeFilter"
                 @onUpdateHideSourceItems="onUpdateHideSourceItems"

--- a/client/src/components/Collections/PairCollectionCreator.vue
+++ b/client/src/components/Collections/PairCollectionCreator.vue
@@ -376,6 +376,7 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                 :extensions-toggle="removeExtensions"
                 collection-type="paired"
                 :no-items="props.initialElements.length == 0 && !props.fromSelection"
+                :show-upload="!fromSelection"
                 @add-uploaded-files="addUploadedFiles"
                 @onUpdateHideSourceItems="onUpdateHideSourceItems"
                 @clicked-create="clickedCreate"

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -881,6 +881,7 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                 :extensions="extensions"
                 collection-type="list:paired"
                 :no-items="props.initialElements.length == 0 && !props.fromSelection"
+                :show-upload="!fromSelection"
                 @add-uploaded-files="addUploadedFiles"
                 @onUpdateHideSourceItems="hideSourceItems = $event"
                 @clicked-create="clickedCreate"

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -233,7 +233,6 @@ watch(
                     <FontAwesomeIcon :icon="faUpload" fixed-width />
                     <span>{{ localize("Upload Files to Add to Collection") }}</span>
                 </template>
-                <!-- TODO: This is incomplete; need to return uploadValues to parent -->
                 <DefaultBox
                     v-if="configOptions && extensionsSet"
                     :chunk-upload-size="configOptions.chunkUploadSize"

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faPlus, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BButton, BLink, BTab, BTabs } from "bootstrap-vue";
+import { BAlert, BLink, BTab, BTabs } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 
@@ -13,6 +13,7 @@ import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";
 import { orList } from "@/utils/strings";
 
+import CollectionCreatorFooterButtons from "./CollectionCreatorFooterButtons.vue";
 import CollectionCreatorHelpHeader from "./CollectionCreatorHelpHeader.vue";
 import CollectionCreatorShowExtensions from "./CollectionCreatorShowExtensions.vue";
 import CollectionCreatorSourceOptions from "./CollectionCreatorSourceOptions.vue";
@@ -185,19 +186,11 @@ watch(
                         </div>
                     </div>
 
-                    <div class="actions vertically-spaced d-flex justify-content-between">
-                        <BButton tabindex="-1" @click="cancelCreate">
-                            {{ localize("Cancel") }}
-                        </BButton>
-
-                        <BButton
-                            class="create-collection"
-                            variant="primary"
-                            :disabled="!validInput"
-                            @click="emit('clicked-create', collectionName)">
-                            {{ localize("Create " + shortWhatIsBeingCreated) }}
-                        </BButton>
-                    </div>
+                    <CollectionCreatorFooterButtons
+                        :short-what-is-being-created="shortWhatIsBeingCreated"
+                        :valid-input="validInput"
+                        @clicked-cancel="cancelCreate"
+                        @clicked-create="emit('clicked-create', collectionName)" />
                 </div>
             </div>
         </BTab>

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faPlus, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BLink, BTab, BTabs } from "bootstrap-vue";
+import { BAlert, BTab, BTabs } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 
@@ -15,6 +15,7 @@ import { orList } from "@/utils/strings";
 
 import CollectionCreatorFooterButtons from "./CollectionCreatorFooterButtons.vue";
 import CollectionCreatorHelpHeader from "./CollectionCreatorHelpHeader.vue";
+import CollectionCreatorNoItemsMessage from "./CollectionCreatorNoItemsMessage.vue";
 import CollectionCreatorShowExtensions from "./CollectionCreatorShowExtensions.vue";
 import CollectionCreatorSourceOptions from "./CollectionCreatorSourceOptions.vue";
 import CollectionNameInput from "./CollectionNameInput.vue";
@@ -153,13 +154,7 @@ watch(
     <BTabs v-model="currentTab" fill justified>
         <BTab class="collection-creator" :title="localize('Create Collection')">
             <div v-if="props.noItems">
-                <BAlert variant="info" show>
-                    {{ localize("No items available to create a collection.") }}
-                    {{ localize("Exit and change your current history, or") }}
-                    <BLink class="text-decoration-none" @click.stop.prevent="currentTab = Tabs.upload">
-                        {{ localize("Upload some datasets.") }}
-                    </BLink>
-                </BAlert>
+                <CollectionCreatorNoItemsMessage @click-upload="currentTab = Tabs.upload" />
             </div>
             <div v-else>
                 <CollectionCreatorHelpHeader>

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faChevronDown, faChevronUp, faPlus, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BButton, BFormCheckbox, BFormGroup, BLink, BTab, BTabs } from "bootstrap-vue";
+import { BAlert, BButton, BLink, BTab, BTabs } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 
@@ -13,6 +13,7 @@ import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";
 import { orList } from "@/utils/strings";
 
+import CollectionCreatorSourceOptions from "./CollectionCreatorSourceOptions.vue";
 import CollectionNameInput from "./CollectionNameInput.vue";
 import HelpText from "@/components/Help/HelpText.vue";
 import DefaultBox from "@/components/Upload/DefaultBox.vue";
@@ -132,6 +133,10 @@ function cancelCreate() {
     props.oncancel();
 }
 
+function removeExtensionsToggle() {
+    emit("remove-extensions-toggle");
+}
+
 async function loadExtensions() {
     listExtensions.value = await getUploadDatatypes(false, AUTO_EXTENSION);
     extensionsSet.value = true;
@@ -210,24 +215,11 @@ watch(
                         </div>
 
                         <div class="d-flex align-items-center justify-content-between">
-                            <BFormGroup class="inputs-form-group">
-                                <BFormCheckbox
-                                    v-if="renderExtensionsToggle"
-                                    name="remove-extensions"
-                                    switch
-                                    :checked="extensionsToggle"
-                                    @input="emit('remove-extensions-toggle')">
-                                    {{ localize("Remove file extensions?") }}
-                                </BFormCheckbox>
-
-                                <div data-description="hide original elements">
-                                    <BFormCheckbox v-model="localHideSourceItems" name="hide-originals" switch>
-                                        <HelpText
-                                            uri="galaxy.collections.collectionBuilder.hideOriginalElements"
-                                            :text="localize('Hide original elements')" />
-                                    </BFormCheckbox>
-                                </div>
-                            </BFormGroup>
+                            <CollectionCreatorSourceOptions
+                                v-model="localHideSourceItems"
+                                :render-extensions-toggle="renderExtensionsToggle"
+                                :extensions-toggle="extensionsToggle"
+                                @remove-extensions-toggle="removeExtensionsToggle" />
                             <CollectionNameInput
                                 v-model="collectionName"
                                 :short-what-is-being-created="shortWhatIsBeingCreated" />

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faChevronDown, faChevronUp, faPlus, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BButton, BFormCheckbox, BFormGroup, BFormInput, BLink, BTab, BTabs } from "bootstrap-vue";
+import { BAlert, BButton, BFormCheckbox, BFormGroup, BLink, BTab, BTabs } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 
@@ -13,6 +13,7 @@ import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";
 import { orList } from "@/utils/strings";
 
+import CollectionNameInput from "./CollectionNameInput.vue";
 import HelpText from "@/components/Help/HelpText.vue";
 import DefaultBox from "@/components/Upload/DefaultBox.vue";
 
@@ -227,20 +228,9 @@ watch(
                                     </BFormCheckbox>
                                 </div>
                             </BFormGroup>
-
-                            <BFormGroup
-                                class="flex-gapx-1 d-flex align-items-center w-50 inputs-form-group"
-                                :label="localize('Name:')"
-                                label-for="collection-name">
-                                <BFormInput
-                                    id="collection-name"
-                                    v-model="collectionName"
-                                    class="collection-name"
-                                    :placeholder="localize('Enter a name for your new ' + shortWhatIsBeingCreated)"
-                                    size="sm"
-                                    required
-                                    :state="!collectionName ? false : null" />
-                            </BFormGroup>
+                            <CollectionNameInput
+                                v-model="collectionName"
+                                :short-what-is-being-created="shortWhatIsBeingCreated" />
                         </div>
                     </div>
 

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faChevronDown, faChevronUp, faPlus, faUpload } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BButton, BLink, BTab, BTabs } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
@@ -13,6 +13,7 @@ import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";
 import { orList } from "@/utils/strings";
 
+import CollectionCreatorHelpHeader from "./CollectionCreatorHelpHeader.vue";
 import CollectionCreatorSourceOptions from "./CollectionCreatorSourceOptions.vue";
 import CollectionNameInput from "./CollectionNameInput.vue";
 import HelpText from "@/components/Help/HelpText.vue";
@@ -58,7 +59,6 @@ const emit = defineEmits<{
     (e: "add-uploaded-files", value: HDASummary[]): void;
 }>();
 
-const isExpanded = ref(false);
 const currentTab = ref(Tabs.create);
 const collectionName = ref(props.suggestedName);
 const localHideSourceItems = ref(props.hideSourceItems);
@@ -124,11 +124,6 @@ function addUploadedFiles(value: HDASummary[]) {
     emit("add-uploaded-files", value);
 }
 
-function clickForHelp() {
-    isExpanded.value = !isExpanded.value;
-    return isExpanded.value;
-}
-
 function cancelCreate() {
     props.oncancel();
 }
@@ -165,39 +160,9 @@ watch(
                 </BAlert>
             </div>
             <div v-else>
-                <div class="header flex-row no-flex">
-                    <div class="main-help well clear" :class="{ expanded: isExpanded }">
-                        <a
-                            class="more-help"
-                            href="javascript:void(0);"
-                            role="button"
-                            :title="localize('Expand or Close Help')"
-                            @click="clickForHelp">
-                            <div v-if="!isExpanded">
-                                <FontAwesomeIcon :icon="faChevronDown" />
-                                <span class="sr-only">{{ localize("Expand Help") }}</span>
-                            </div>
-                            <div v-else>
-                                <FontAwesomeIcon :icon="faChevronUp" />
-                                <span class="sr-only">{{ localize("Close Help") }}</span>
-                            </div>
-                        </a>
-
-                        <div class="help-content">
-                            <!-- each collection that extends this will add their own help content -->
-                            <slot name="help-content"></slot>
-
-                            <a
-                                class="more-help"
-                                href="javascript:void(0);"
-                                role="button"
-                                :title="localize('Expand or Close Help')"
-                                @click="clickForHelp">
-                                <span class="sr-only">{{ localize("Expand Help") }}</span>
-                            </a>
-                        </div>
-                    </div>
-                </div>
+                <CollectionCreatorHelpHeader>
+                    <slot name="help-content"></slot>
+                </CollectionCreatorHelpHeader>
 
                 <div class="middle flex-row flex-row-container">
                     <slot name="middle-content"></slot>

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -14,6 +14,7 @@ import localize from "@/utils/localization";
 import { orList } from "@/utils/strings";
 
 import CollectionCreatorHelpHeader from "./CollectionCreatorHelpHeader.vue";
+import CollectionCreatorShowExtensions from "./CollectionCreatorShowExtensions.vue";
 import CollectionCreatorSourceOptions from "./CollectionCreatorSourceOptions.vue";
 import CollectionNameInput from "./CollectionNameInput.vue";
 import HelpText from "@/components/Help/HelpText.vue";
@@ -170,14 +171,7 @@ watch(
 
                 <div class="footer flex-row">
                     <div class="vertically-spaced">
-                        <div class="d-flex align-items-center justify-content-between">
-                            <BAlert v-if="extensions?.length" class="w-100 py-0" variant="secondary" show>
-                                <HelpText
-                                    uri="galaxy.collections.collectionBuilder.filteredExtensions"
-                                    :text="localize('Filtered extensions: ')" />
-                                <strong>{{ orList(extensions) }}</strong>
-                            </BAlert>
-                        </div>
+                        <CollectionCreatorShowExtensions :extensions="extensions" />
 
                         <div class="d-flex align-items-center justify-content-between">
                             <CollectionCreatorSourceOptions

--- a/client/src/components/Collections/common/CollectionCreatorFooterButtons.vue
+++ b/client/src/components/Collections/common/CollectionCreatorFooterButtons.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import localize from "@/utils/localization";
+
+interface Props {
+    validInput: boolean;
+    shortWhatIsBeingCreated: string;
+}
+
+defineProps<Props>();
+
+const emit = defineEmits<{
+    (e: "clicked-create"): void;
+    (e: "clicked-cancel"): void;
+}>();
+</script>
+
+<template>
+    <div class="actions vertically-spaced d-flex justify-content-between">
+        <BButton tabindex="-1" @click="emit('clicked-cancel')">
+            {{ localize("Cancel") }}
+        </BButton>
+
+        <BButton class="create-collection" variant="primary" :disabled="!validInput" @click="emit('clicked-create')">
+            {{ localize("Create " + shortWhatIsBeingCreated) }}
+        </BButton>
+    </div>
+</template>

--- a/client/src/components/Collections/common/CollectionCreatorHelpHeader.vue
+++ b/client/src/components/Collections/common/CollectionCreatorHelpHeader.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { ref } from "vue";
+
+import localize from "@/utils/localization";
+
+const isExpanded = ref(false);
+
+function clickForHelp() {
+    isExpanded.value = !isExpanded.value;
+    return isExpanded.value;
+}
+</script>
+
+<template>
+    <div class="header flex-row no-flex">
+        <div class="main-help well clear" :class="{ expanded: isExpanded }">
+            <a
+                class="more-help"
+                href="javascript:void(0);"
+                role="button"
+                :title="localize('Expand or Close Help')"
+                @click="clickForHelp">
+                <div v-if="!isExpanded">
+                    <FontAwesomeIcon :icon="faChevronDown" />
+                    <span class="sr-only">{{ localize("Expand Help") }}</span>
+                </div>
+                <div v-else>
+                    <FontAwesomeIcon :icon="faChevronUp" />
+                    <span class="sr-only">{{ localize("Close Help") }}</span>
+                </div>
+            </a>
+
+            <div class="help-content">
+                <!-- each collection that extends this will add their own help content -->
+                <slot></slot>
+
+                <a
+                    class="more-help"
+                    href="javascript:void(0);"
+                    role="button"
+                    :title="localize('Expand or Close Help')"
+                    @click="clickForHelp">
+                    <span class="sr-only">{{ localize("Expand Help") }}</span>
+                </a>
+            </div>
+        </div>
+    </div>
+</template>

--- a/client/src/components/Collections/common/CollectionCreatorNoItemsMessage.vue
+++ b/client/src/components/Collections/common/CollectionCreatorNoItemsMessage.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { BAlert, BLink } from "bootstrap-vue";
+
+import localize from "@/utils/localization";
+
+const emit = defineEmits<{
+    (e: "clicked-upload"): void;
+}>();
+</script>
+<template>
+    <BAlert variant="info" show>
+        {{ localize("No items available to create a collection.") }}
+        {{ localize("Exit and change your current history, or") }}
+        <BLink class="text-decoration-none" @click.stop.prevent="emit('clicked-upload')">
+            {{ localize("Upload some datasets.") }}
+        </BLink>
+    </BAlert>
+</template>

--- a/client/src/components/Collections/common/CollectionCreatorShowExtensions.vue
+++ b/client/src/components/Collections/common/CollectionCreatorShowExtensions.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { BAlert } from "bootstrap-vue";
+
+import localize from "@/utils/localization";
+import { orList } from "@/utils/strings";
+
+import HelpText from "@/components/Help/HelpText.vue";
+
+interface Props {
+    extensions?: string[];
+}
+
+defineProps<Props>();
+</script>
+
+<template>
+    <div class="d-flex align-items-center justify-content-between">
+        <BAlert v-if="extensions?.length" class="w-100 py-0" variant="secondary" show>
+            <HelpText
+                uri="galaxy.collections.collectionBuilder.filteredExtensions"
+                :text="localize('Filtered extensions: ')" />
+            <strong>{{ orList(extensions) }}</strong>
+        </BAlert>
+    </div>
+</template>

--- a/client/src/components/Collections/common/CollectionCreatorSourceOptions.vue
+++ b/client/src/components/Collections/common/CollectionCreatorSourceOptions.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { BFormCheckbox, BFormGroup } from "bootstrap-vue";
+import { ref, watch } from "vue";
+
+import localize from "@/utils/localization";
+
+import HelpText from "@/components/Help/HelpText.vue";
+
+interface Props {
+    value: boolean;
+    extensionsToggle?: boolean;
+    renderExtensionsToggle?: boolean;
+}
+
+const props = defineProps<Props>();
+
+const localHideSourceItems = ref(props.value);
+
+const emit = defineEmits<{
+    (e: "input", value: boolean): void;
+    (e: "remove-extensions-toggle"): void;
+}>();
+
+// Watch for external updates to value and sync with innerValue
+watch(
+    () => props.value,
+    (newValue) => {
+        localHideSourceItems.value = newValue;
+    }
+);
+
+watch(localHideSourceItems, (newValue) => {
+    emit("input", newValue);
+});
+</script>
+
+<template>
+    <BFormGroup class="inputs-form-group">
+        <BFormCheckbox
+            v-if="renderExtensionsToggle"
+            name="remove-extensions"
+            switch
+            :checked="extensionsToggle"
+            @input="emit('remove-extensions-toggle')">
+            {{ localize("Remove file extensions?") }}
+        </BFormCheckbox>
+
+        <div data-description="hide original elements">
+            <BFormCheckbox v-model="localHideSourceItems" name="hide-originals" switch>
+                <HelpText
+                    uri="galaxy.collections.collectionBuilder.hideOriginalElements"
+                    :text="localize('Hide original elements')" />
+            </BFormCheckbox>
+        </div>
+    </BFormGroup>
+</template>

--- a/client/src/components/Collections/common/CollectionNameInput.vue
+++ b/client/src/components/Collections/common/CollectionNameInput.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { BFormGroup, BFormInput } from "bootstrap-vue";
+import { ref, watch } from "vue";
+
+import localize from "@/utils/localization";
+
+interface Props {
+    value: string;
+    shortWhatIsBeingCreated: string;
+}
+
+const props = defineProps<Props>();
+
+const name = ref(props.value);
+
+const emit = defineEmits<{
+    (e: "input", value: string): void;
+}>();
+
+// Watch for external updates to value and sync with innerValue
+watch(
+    () => props.value,
+    (newValue) => {
+        name.value = newValue;
+    }
+);
+
+watch(name, (newValue) => {
+    emit("input", newValue);
+});
+</script>
+
+<template>
+    <BFormGroup
+        class="flex-gapx-1 d-flex align-items-center w-50 inputs-form-group"
+        :label="localize('Name:')"
+        label-for="collection-name">
+        <BFormInput
+            id="collection-name"
+            v-model="name"
+            class="collection-name"
+            :placeholder="localize('Enter a name for your new ' + shortWhatIsBeingCreated)"
+            size="sm"
+            required
+            :state="!name ? false : null" />
+    </BFormGroup>
+</template>


### PR DESCRIPTION
I don't think the dialog option makes sense in that context and it consumes a lot of space. I love the feature overall and it makes perfect sense in the upload modal or when on the tool form and you don't have datasets in the history or you want to add new ones. But having the tab even when you've just selected some history contents or library contents I think feels off. There is a few refactorings of things to prevent a huge copy and paste inside and outside the tab component for this. There might be a better way to make tabbing optional - I'd be happy to hear it but these are still good refactorings I think (just not ideal for a bug fix on a stable release).

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
