### PR TITLE
Make conditional discriminators literals instead of generic string/bool

### DIFF
--- a/lib/galaxy/tool_util/parameters/models.py
+++ b/lib/galaxy/tool_util/parameters/models.py
@@ -1099,7 +1099,7 @@ class ConditionalParameterModel(BaseGalaxyToolParameterModelDefinition):
             else:
                 initialize_test = None
             tag = str(discriminator) if not is_boolean else str(discriminator).lower()
-            extra_kwd = {test_param_name: (Union[str, bool], initialize_test)}
+            extra_kwd = {test_param_name: (Literal[when.discriminator], initialize_test)}
             when_types.append(
                 cast(
                     Type[BaseModel],

--- a/test/unit/tool_util/test_parameter_specification.py
+++ b/test/unit/tool_util/test_parameter_specification.py
@@ -28,7 +28,10 @@ from galaxy.tool_util.parameters import (
     validate_workflow_step_linked,
     ValidationFunctionT,
 )
-from galaxy.tool_util.parameters.json import to_json_schema_string
+from galaxy.tool_util.parameters.json import (
+    to_json_schema,
+    to_json_schema_string,
+)
 from galaxy.tool_util.unittest_utils.parameters import (
     parameter_bundle_for_file,
     parameter_bundle_for_framework_tool,
@@ -223,7 +226,11 @@ def test_decode_gx_int():
 def test_json_schema_for_conditional():
     input_bundle = parameter_bundle_for_file("gx_conditional_boolean")
     tool_state = RequestToolState.parameter_model_for(input_bundle)
-    print(to_json_schema_string(tool_state))
+    json_schema = to_json_schema(tool_state)
+    assert json_schema["$defs"]["When_test_parameter_False"]["properties"]["test_parameter"]["const"] is False
+    assert json_schema["$defs"]["When_test_parameter_True"]["properties"]["test_parameter"]["const"] is True
+    assert "test_parameter" not in json_schema["$defs"]["When_test_parameter___absent"]["properties"]
+    assert to_json_schema_string(tool_state)
 
 
 def test_encode_gx_data():
@@ -244,7 +251,7 @@ if __name__ == "__main__":
     parameter_models_json = {}
     for file in parameter_spec.keys():
         tool_parameter_model = parameter_bundle_for_file(file)
-        parameter_models_json[file] = tool_parameter_model.dict()
+        parameter_models_json[file] = tool_parameter_model.model_dump()
     yaml_str = yaml.safe_dump(parameter_models_json)
     with open("client/src/components/Tool/parameter_models.yml", "w") as f:
         f.write("# auto generated file for JavaScript testing, do not modify manually\n")


### PR DESCRIPTION
That's a much better consumer experience. A model generated for gx_conditional.xml would look like
```typescript
export type ConditionalType =
  | WhenTestParameterA
  | WhenTestParameterB
  | WhenTestParameterC
export type TestParameter = "a"
export type IntegerParameter = number
export type TestParameter1 = "b"
export type BooleanParameter = boolean
export type TestParameter2 = "c"
export type ColorParameter = string

export interface MySchema {
  conditional_parameter: ConditionalType
}
export interface WhenTestParameterA {
  test_parameter: TestParameter
  integer_parameter: IntegerParameter
}
export interface WhenTestParameterB {
  test_parameter: TestParameter1
  boolean_parameter: BooleanParameter
}
export interface WhenTestParameterC {
  test_parameter: TestParameter2
  color_parameter: ColorParameter
}

```
instead of
```typescript
export type ConditionalType =
  | WhenTestParameterA
  | WhenTestParameterB
  | WhenTestParameterC
export type TestParameter = string | boolean
export type IntegerParameter = number
export type TestParameter1 = string | boolean
export type BooleanParameter = boolean
export type TestParameter2 = string | boolean
export type ColorParameter = string

export interface MySchema {
  conditional_parameter: ConditionalType
}
export interface WhenTestParameterA {
  test_parameter: TestParameter
  integer_parameter: IntegerParameter
}
export interface WhenTestParameterB {
  test_parameter: TestParameter1
  boolean_parameter: BooleanParameter
}
export interface WhenTestParameterC {
  test_parameter: TestParameter2
  color_parameter: ColorParameter
}

```
With the new model I can write an input object without looking at the tool source, with the previous one I don't know what string I would need to supply.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
