### PR TITLE
Remove apptainer-version pin

### DIFF
--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -41,8 +41,6 @@ jobs:
           key: tox-cache-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-mulled
       - name: Install Apptainer's singularity
         uses: eWaterCycle/setup-apptainer@v2
-        with:
-          apptainer-version: 1.3.6  # https://github.com/eWaterCycle/setup-apptainer/pull/68
       - name: Install tox
         run: pip install tox
       - name: Run tests


### PR DESCRIPTION
Not necessary any more now that https://github.com/eWaterCycle/setup-apptainer/pull/68 was merged.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
