### PR TITLE
[24.2] Fixes for console logging.

### DIFF
--- a/client/src/components/JobInformation/JobInformation.test.js
+++ b/client/src/components/JobInformation/JobInformation.test.js
@@ -67,8 +67,8 @@ describe("JobInformation/JobInformation.vue", () => {
         // table should exist
         expect(jobInfoTable).toBeTruthy();
         const rows = jobInfoTable.findAll("tr");
-        // should contain 9 rows
-        expect(rows.length).toBe(9);
+        // should contain 10 rows
+        expect(rows.length).toBe(10);
     });
 
     it("stdout and stderr should be rendered", async () => {
@@ -96,5 +96,6 @@ describe("JobInformation/JobInformation.vue", () => {
             { id: "encoded-copied-from-job-id", backend_key: "copied_from_job_id" },
         ];
         verifyValues(rendered_entries, jobInfoTable, jobResponse);
+        expect(wrapper.find('td[data-description="galaxy-job-state"]').exists()).toBe(true);
     });
 });

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -39,11 +39,15 @@ const stderr_position = computed(() => stderr_text.value.length);
 const runTime = computed(() => getJobDuration(job.value));
 
 function jobStateIsTerminal(jobState) {
-    return jobState && !NON_TERMINAL_STATES.includes(job.value.state);
+    return jobState && !NON_TERMINAL_STATES.includes(jobState);
+}
+
+function jobStateIsRunning(jobState) {
+    return jobState == "running";
 }
 
 const jobIsTerminal = computed(() => jobStateIsTerminal(job?.value?.state));
-
+const jobIsRunning = computed(() => jobStateIsRunning(job?.value?.state));
 const routeToInvocation = computed(() => `/workflows/invocations/${invocationId.value}`);
 
 const metadataDetail = ref({
@@ -127,6 +131,7 @@ watch(
     <div>
         <JobDetailsProvider auto-refresh :job-id="props.job_id" @update:result="updateJob" />
         <JobConsoleOutputProvider
+            v-if="jobIsRunning"
             auto-refresh
             :job-id="props.job_id"
             :stdout_position="stdout_position"

--- a/client/src/components/JobInformation/testData/jobInformationResponse.json
+++ b/client/src/components/JobInformation/testData/jobInformationResponse.json
@@ -7,5 +7,6 @@
     "command_line": "commandline",
     "job_messages": ["test-msg1", "test-msg2", "test-msg3", "test-msg4"],
     "id": "test_id",
-    "copied_from_job_id": "test_copied_from_job_id"
+    "copied_from_job_id": "test_copied_from_job_id",
+    "state": "running"
 }


### PR DESCRIPTION
Only poll for async console updates while job is running.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Enable the feature - setup a silly tool that sleeps and outputs randomly - watch the developer console while on the job info page for that tool. Note it still updates while running but doesn't make that call if it is not running.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
