### PR TITLE
[24.0] Remove unnecessary quoting in conda package specification

### DIFF
--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -48,7 +48,7 @@ IS_OS_X = sys.platform == "darwin"
 VERSIONED_ENV_DIR_NAME = re.compile(r"__(.*)@(.*)")
 UNVERSIONED_ENV_DIR_NAME = re.compile(r"__(.*)@_uv_")
 USE_PATH_EXEC_DEFAULT = False
-CONDA_PACKAGE_SPECS = ("conda>=23.7.0", "conda-libmamba-solver", "'pyopenssl>=22.1.0'")
+CONDA_PACKAGE_SPECS = ("conda>=23.7.0", "conda-libmamba-solver", "pyopenssl>=22.1.0")
 CONDA_BUILD_SPECS = ("conda-build>=3.22.0",)
 USE_LOCAL_DEFAULT = False
 


### PR DESCRIPTION
Fix the following error in:
- test/unit/tool_util/test_conda_resolution.py::test_install_conda_build
- test/integration/test_resolvers.py::TestCondaResolutionIntegration::test_dependency_install
- test/integration/test_resolvers.py::TestCondaResolutionIntegration::test_uninstall_through_tools_api

```
InvalidMatchSpec: Invalid spec ''pyopenssl>=22.1.0'': Invalid version '22.1.0'': invalid character(s)
```

This probably started happening with a recent conda update.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
