### PR TITLE
[24.2] Fix for empty string in regex validator message.

### DIFF
--- a/lib/galaxy/tool_util/parser/parameter_validators.py
+++ b/lib/galaxy/tool_util/parser/parameter_validators.py
@@ -668,9 +668,9 @@ def raise_error_if_valiation_fails(
         raise AssertionError("Validator logic problem - computed validation value must be boolean")
     if message is None:
         message = validator.message
-    if message is None:
+    if not message:
         message = DEFAULT_VALIDATOR_MESSAGE
-    assert message
+    assert message is not None
     if value_to_show and "%s" in message:
         message = message % value_to_show
     negate = validator.negate


### PR DESCRIPTION
xref https://github.com/galaxyproject/galaxy/issues/19386

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
