### PR TITLE
[24.2] Fix to only show ChatGXY when available.

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -1093,8 +1093,9 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
 
         self._process_celery_config()
 
-        # load in the chat_prompts if openai is enabled
-        self._load_chat_prompts()
+        # load in the chat_prompts if openai api key is configured
+        if self.openai_api_key:
+            self._load_chat_prompts()
 
         self.pretty_datetime_format = expand_pretty_datetime_format(self.pretty_datetime_format)
         try:
@@ -1257,21 +1258,20 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             self.file_source_temp_dir = os.path.abspath(self.file_source_temp_dir)
 
     def _load_chat_prompts(self):
-        if self.openai_api_key:
-            current_dir = os.path.dirname(os.path.abspath(__file__))
-            chat_prompts_path = os.path.join(current_dir, "chat_prompts.json")
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        chat_prompts_path = os.path.join(current_dir, "chat_prompts.json")
 
-            if os.path.exists(chat_prompts_path):
-                try:
-                    with open(chat_prompts_path, encoding="utf-8") as file:
-                        data = json.load(file)
-                        self.chat_prompts = data.get("prompts", {})
-                except json.JSONDecodeError as e:
-                    log.error(f"JSON decoding error in chat prompts file: {e}")
-                except Exception as e:
-                    log.error(f"An error occurred while reading chat prompts file: {e}")
-            else:
-                log.warning(f"Chat prompts file not found at {chat_prompts_path}")
+        if os.path.exists(chat_prompts_path):
+            try:
+                with open(chat_prompts_path, encoding="utf-8") as file:
+                    data = json.load(file)
+                    self.chat_prompts = data.get("prompts", {})
+            except json.JSONDecodeError as e:
+                log.error(f"JSON decoding error in chat prompts file: {e}")
+            except Exception as e:
+                log.error(f"An error occurred while reading chat prompts file: {e}")
+        else:
+            log.warning(f"Chat prompts file not found at {chat_prompts_path}")
 
     def _process_celery_config(self):
         if self.celery_conf and self.celery_conf.get("result_backend") is None:

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -229,6 +229,7 @@ class ConfigSerializer(base.ModelSerializer):
             "fixed_delegated_auth": _defaults_to(False),
             "help_forum_api_url": _use_config,
             "enable_help_forum_tool_panel_integration": _use_config,
+            "llm_api_configured": lambda item, key, **context: bool(item.openai_api_key),
         }
 
 


### PR DESCRIPTION
Exposes whether or not an llm api is configured to the client config, uses this to only display error wizard when it is.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
