### PR TITLE
Documentation around highlighting PRs for release notes.

### DIFF
--- a/doc/source/project/issues.rst
+++ b/doc/source/project/issues.rst
@@ -217,6 +217,20 @@ special purpose.
   bug affects the actual current Galaxy development branch and isn't a usage
   issue, a previously fixed issue, etc..
 
+- ``highlight`` is a tag that indicates at least one contributor thinks this
+   pull request should be highlighted in some way in the relevant release's
+   release notes. The person assembling release notes has final say about
+   which pull requests are actually highlighted.
+
+- ``highlight/user`` is a tag that indicates assigner of the tag thinks this
+   pull request should be highlighted prominently in the relevant release's
+   user facing release notes. The assigner of this tag is giving a strong
+   endorsement of this highlight and is willing to do the work of writing
+   the blurb for the release notes. If selected, the blurb should be written
+   with target audience in mind - researchers using the Galaxy user interface.
+   The person assembling the user release notes has final say about which
+   pull requests are actually highlighted.
+
 The Roadmap
 ===========
 


### PR DESCRIPTION
Introduces a new Github tag that lets contributors indicate they endorse including a PR in the user release notes and will do the work. This can be assigned by the PR author, reviewer, or any contributor willing to do the work to highlight the PR. The person assembling the user facing release notes will still have final say about what is included but this is a way of indicating to that person a strong preference for including a PR and willingness to help them do the work. 

## How to test the changes?

Does not apply.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
