### PR TITLE
Better handling of public pages and workflows authored by deleted users

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -16375,6 +16375,11 @@ export interface components {
                 | (components["schemas"]["Person"] | components["schemas"]["galaxy__schema__schema__Organization"])[]
                 | null;
             /**
+             * Creator deleted or purged
+             * @description Whether the creator of this Workflow has been deleted or purged.
+             */
+            creator_deleted_or_purged: boolean;
+            /**
              * Deleted
              * @description Whether this item is marked as deleted.
              */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -14718,10 +14718,10 @@ export interface components {
         /** PageDetails */
         PageDetails: {
             /**
-             * Author deleted or purged
-             * @description Whether the author of this Page has been deleted or purged.
+             * Author deleted
+             * @description Whether the author of this Page has been deleted.
              */
-            author_deleted_or_purged: boolean;
+            author_deleted: boolean;
             /**
              * Content
              * @description Raw text contents of the last page revision (type dependent on content_format).
@@ -14821,10 +14821,10 @@ export interface components {
         /** PageSummary */
         PageSummary: {
             /**
-             * Author deleted or purged
-             * @description Whether the author of this Page has been deleted or purged.
+             * Author deleted
+             * @description Whether the author of this Page has been deleted.
              */
-            author_deleted_or_purged: boolean;
+            author_deleted: boolean;
             /**
              * Create Time
              * Format: date-time
@@ -16375,10 +16375,10 @@ export interface components {
                 | (components["schemas"]["Person"] | components["schemas"]["galaxy__schema__schema__Organization"])[]
                 | null;
             /**
-             * Creator deleted or purged
-             * @description Whether the creator of this Workflow has been deleted or purged.
+             * Creator deleted
+             * @description Whether the creator of this Workflow has been deleted.
              */
-            creator_deleted_or_purged: boolean;
+            creator_deleted: boolean;
             /**
              * Deleted
              * @description Whether this item is marked as deleted.

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -14718,6 +14718,11 @@ export interface components {
         /** PageDetails */
         PageDetails: {
             /**
+             * Author deleted or purged
+             * @description Whether the author of this Page has been deleted or purged.
+             */
+            author_deleted_or_purged: boolean;
+            /**
              * Content
              * @description Raw text contents of the last page revision (type dependent on content_format).
              * @default
@@ -14815,6 +14820,11 @@ export interface components {
         };
         /** PageSummary */
         PageSummary: {
+            /**
+             * Author deleted or purged
+             * @description Whether the author of this Page has been deleted or purged.
+             */
+            author_deleted_or_purged: boolean;
             /**
              * Create Time
              * Format: date-time

--- a/client/src/components/Common/PublishedItem.vue
+++ b/client/src/components/Common/PublishedItem.vue
@@ -12,6 +12,7 @@ interface Item {
     owner?: string;
     username?: string;
     email_hash?: string;
+    author_deleted_or_purged?: boolean;
     tags?: string[];
     title?: string;
 }
@@ -37,8 +38,14 @@ const plural = computed(() => {
     return `${modelTitle.value}s`;
 });
 
+const owner = computed(() => {
+    if (props.item?.author_deleted_or_purged) {
+        return "Archived author";
+    }
+    return props.item?.owner ?? props.item?.username ?? "Unavailable";
+});
+
 const gravatarSource = computed(() => `https://secure.gravatar.com/avatar/${props.item?.email_hash}?d=identicon`);
-const owner = computed(() => props.item?.owner ?? props.item?.username ?? "Unavailable");
 const pluralPath = computed(() => plural.value.toLowerCase());
 const publishedByUser = computed(() => `/${pluralPath.value}/list_published?f-username=${owner.value}`);
 const urlAll = computed(() => `/${pluralPath.value}/list_published`);
@@ -76,7 +83,7 @@ const urlAll = computed(() => `/${pluralPath.value}/list_published`);
                     <router-link :to="urlAll">All published {{ plural }}</router-link>
                 </div>
 
-                <div>
+                <div v-if="!props.item?.author_deleted_or_purged">
                     <router-link :to="publishedByUser"> Published {{ plural }} by {{ owner }}</router-link>
                 </div>
             </div>

--- a/client/src/components/Common/PublishedItem.vue
+++ b/client/src/components/Common/PublishedItem.vue
@@ -12,7 +12,7 @@ interface Item {
     owner?: string;
     username?: string;
     email_hash?: string;
-    author_deleted_or_purged?: boolean;
+    author_deleted?: boolean;
     tags?: string[];
     title?: string;
 }
@@ -39,7 +39,7 @@ const plural = computed(() => {
 });
 
 const owner = computed(() => {
-    if (props.item?.author_deleted_or_purged) {
+    if (props.item?.author_deleted) {
         return "Archived author";
     }
     return props.item?.owner ?? props.item?.username ?? "Unavailable";
@@ -83,7 +83,7 @@ const urlAll = computed(() => `/${pluralPath.value}/list_published`);
                     <router-link :to="urlAll">All published {{ plural }}</router-link>
                 </div>
 
-                <div v-if="!props.item?.author_deleted_or_purged">
+                <div v-if="!props.item?.author_deleted">
                     <router-link :to="publishedByUser"> Published {{ plural }} by {{ owner }}</router-link>
                 </div>
             </div>

--- a/client/src/components/Workflow/Published/WorkflowInformation.vue
+++ b/client/src/components/Workflow/Published/WorkflowInformation.vue
@@ -45,7 +45,7 @@ const userOwned = computed(() => {
 });
 
 const owner = computed(() => {
-    if (props.workflowInfo?.creator_deleted_or_purged) {
+    if (props.workflowInfo?.creator_deleted) {
         return "Archived author";
     }
     return props.workflowInfo.owner;
@@ -71,7 +71,7 @@ const owner = computed(() => {
             <img alt="User Avatar" :src="gravatarSource" class="mb-2" />
 
             <RouterLink
-                v-if="!props.workflowInfo?.creator_deleted_or_purged"
+                v-if="!props.workflowInfo?.creator_deleted"
                 :to="publishedByUser"
                 :target="props.embedded ? '_blank' : ''">
                 All published Workflows by {{ workflowInfo.owner }}

--- a/client/src/components/Workflow/Published/WorkflowInformation.vue
+++ b/client/src/components/Workflow/Published/WorkflowInformation.vue
@@ -43,6 +43,13 @@ const fullLink = computed(() => {
 const userOwned = computed(() => {
     return userStore.matchesCurrentUsername(props.workflowInfo.owner);
 });
+
+const owner = computed(() => {
+    if (props.workflowInfo?.creator_deleted_or_purged) {
+        return "Archived author";
+    }
+    return props.workflowInfo.owner;
+});
 </script>
 
 <template>
@@ -58,12 +65,15 @@ const userOwned = computed(() => {
         <div class="workflow-info-box">
             <hgroup class="mb-2">
                 <Heading h3 size="md" class="mb-0">Author</Heading>
-                <span class="ml-2">{{ workflowInfo.owner }}</span>
+                <span class="ml-2">{{ owner }}</span>
             </hgroup>
 
             <img alt="User Avatar" :src="gravatarSource" class="mb-2" />
 
-            <RouterLink :to="publishedByUser" :target="props.embedded ? '_blank' : ''">
+            <RouterLink
+                v-if="!props.workflowInfo?.creator_deleted_or_purged"
+                :to="publishedByUser"
+                :target="props.embedded ? '_blank' : ''">
                 All published Workflows by {{ workflowInfo.owner }}
             </RouterLink>
         </div>

--- a/lib/galaxy/managers/pages.py
+++ b/lib/galaxy/managers/pages.py
@@ -18,6 +18,7 @@ from typing import (
 
 import sqlalchemy
 from sqlalchemy import (
+    and_,
     desc,
     false,
     func,
@@ -157,6 +158,10 @@ class PageManager(sharable.SharableModelManager, UsesAnnotations):
             raise exceptions.RequestParameterInvalidException(message)
 
         stmt = select(self.model_class)
+
+        # Do not include pages authored by deleted users
+        if show_published:
+            stmt = stmt.join(Page.user).where(and_(User.deleted == false(), User.purged == false()))
 
         filters = []
         if show_own or (not show_published and not show_shared and not is_admin):

--- a/lib/galaxy/managers/pages.py
+++ b/lib/galaxy/managers/pages.py
@@ -18,7 +18,6 @@ from typing import (
 
 import sqlalchemy
 from sqlalchemy import (
-    and_,
     desc,
     false,
     func,
@@ -161,7 +160,7 @@ class PageManager(sharable.SharableModelManager, UsesAnnotations):
 
         # Do not include pages authored by deleted users
         if show_published:
-            stmt = stmt.join(Page.user).where(and_(User.deleted == false(), User.purged == false()))
+            stmt = stmt.join(Page.user).where(User.deleted == false())
 
         filters = []
         if show_own or (not show_published and not show_shared and not is_admin):

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -197,6 +197,11 @@ class WorkflowsManager(sharable.SharableModelManager, deletable.DeletableManager
             filters.append(StoredWorkflow.published == true())
 
         stmt = select(StoredWorkflow)
+
+        # Do not include workflows authored by deleted users
+        if show_published or show_shared:
+            stmt = stmt.join(StoredWorkflow.user).where(and_(User.deleted == false(), User.purged == false()))
+
         if show_shared:
             stmt = stmt.outerjoin(StoredWorkflow.users_shared_with)
         stmt = stmt.outerjoin(StoredWorkflow.tags)

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -200,7 +200,7 @@ class WorkflowsManager(sharable.SharableModelManager, deletable.DeletableManager
 
         # Do not include workflows authored by deleted users
         if show_published or show_shared:
-            stmt = stmt.join(StoredWorkflow.user).where(and_(User.deleted == false(), User.purged == false()))
+            stmt = stmt.join(StoredWorkflow.user).where(User.deleted == false())
 
         if show_shared:
             stmt = stmt.outerjoin(StoredWorkflow.users_shared_with)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7859,7 +7859,7 @@ class StoredWorkflow(Base, HasTags, Dictifiable, RepresentById, UsesCreateAndUpd
         rval["latest_workflow_uuid"] = (lambda uuid: str(uuid) if self.latest_workflow.uuid else None)(
             self.latest_workflow.uuid
         )
-        rval["creator_deleted_or_purged"] = self.user.deleted or self.user.purged
+        rval["creator_deleted"] = self.user.deleted
         return rval
 
 
@@ -10492,7 +10492,7 @@ class Page(Base, HasTags, Dictifiable, RepresentById, UsesCreateAndUpdateTime):
         "deleted",
         "username",
         "email_hash",
-        "author_deleted_or_purged",
+        "author_deleted",
         "create_time",
         "update_time",
     ]
@@ -10521,8 +10521,8 @@ class Page(Base, HasTags, Dictifiable, RepresentById, UsesCreateAndUpdateTime):
 
     # needed to determine how to display page details
     @property
-    def author_deleted_or_purged(self):
-        return self.user.deleted or self.user.purged
+    def author_deleted(self):
+        return self.user.deleted
 
 
 class PageRevision(Base, Dictifiable, RepresentById):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -10491,6 +10491,7 @@ class Page(Base, HasTags, Dictifiable, RepresentById, UsesCreateAndUpdateTime):
         "deleted",
         "username",
         "email_hash",
+        "author_deleted_or_purged",
         "create_time",
         "update_time",
     ]
@@ -10516,6 +10517,11 @@ class Page(Base, HasTags, Dictifiable, RepresentById, UsesCreateAndUpdateTime):
     @property
     def email_hash(self):
         return md5_hash_str(self.user.email)
+
+    # needed to determine how to display page details
+    @property
+    def author_deleted_or_purged(self):
+        return self.user.deleted or self.user.purged
 
 
 class PageRevision(Base, Dictifiable, RepresentById):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7859,6 +7859,7 @@ class StoredWorkflow(Base, HasTags, Dictifiable, RepresentById, UsesCreateAndUpd
         rval["latest_workflow_uuid"] = (lambda uuid: str(uuid) if self.latest_workflow.uuid else None)(
             self.latest_workflow.uuid
         )
+        rval["creator_deleted_or_purged"] = self.user.deleted or self.user.purged
         return rval
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3788,6 +3788,11 @@ class PageSummary(PageSummaryBase, WithModelClass):
         title="Encoded email",
         description="The encoded email of the user.",
     )
+    author_deleted_or_purged: bool = Field(
+        ...,  # Required
+        title="Author deleted or purged",
+        description="Whether the author of this Page has been deleted or purged.",
+    )
     published: bool = Field(
         ...,  # Required
         title="Published",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3788,10 +3788,10 @@ class PageSummary(PageSummaryBase, WithModelClass):
         title="Encoded email",
         description="The encoded email of the user.",
     )
-    author_deleted_or_purged: bool = Field(
+    author_deleted: bool = Field(
         ...,  # Required
-        title="Author deleted or purged",
-        description="Whether the author of this Page has been deleted or purged.",
+        title="Author deleted",
+        description="Whether the author of this Page has been deleted.",
     )
     published: bool = Field(
         ...,  # Required

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -225,10 +225,10 @@ class StoredWorkflowDetailed(StoredWorkflowSummary):
         title="Creator",
         description=("Additional information about the creator (or multiple creators) of this workflow."),
     )
-    creator_deleted_or_purged: bool = Field(
+    creator_deleted: bool = Field(
         ...,
-        title="Creator deleted or purged",
-        description="Whether the creator of this Workflow has been deleted or purged.",
+        title="Creator deleted",
+        description="Whether the creator of this Workflow has been deleted.",
     )
     steps: Dict[
         int,

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -225,6 +225,11 @@ class StoredWorkflowDetailed(StoredWorkflowSummary):
         title="Creator",
         description=("Additional information about the creator (or multiple creators) of this workflow."),
     )
+    creator_deleted_or_purged: bool = Field(
+        ...,
+        title="Creator deleted or purged",
+        description="Whether the creator of this Workflow has been deleted or purged.",
+    )
     steps: Dict[
         int,
         Annotated[


### PR DESCRIPTION
Ref: #19343

to do:
- [x] list of public pages: do not display pages authored by deleted users 
- [x] list of public workflows: do not display workflows authored by deleted users 
- [x] public page view: replace purged user hash with "archived user"; remove link
- [x] public workflow view: same as above

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Create 2 new users
  2. Login as each user and create a page and a workflow; publish page and workflow, share workflow with your main user
  3. Delete one of the users
  4. Login as main user
  5. View public pages; verify that pages by the deleted user are not displayed
  6. View public workflows; verify that workflows by the deleted user are not displayed.
  7. View shared workflows, verify same as above.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
