### PR TITLE
[24.2] Backport fix from #19396

### DIFF
--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -123,25 +123,27 @@ class WorkflowRunCrateProfileBuilder:
     def _add_files(self, crate: ROCrate):
         for wfda in self.invocation.input_datasets:
             if not self.file_entities.get(wfda.dataset.dataset.id):
-                properties = {
-                    "exampleOfWork": {"@id": f"#{wfda.dataset.dataset.uuid}"},
-                }
-                file_entity = self._add_file(wfda.dataset, properties, crate)
                 dataset_formal_param = self._add_dataset_formal_parameter(wfda.dataset, crate)
                 crate.mainEntity.append_to("input", dataset_formal_param)
+                properties = {
+                    "exampleOfWork": {"@id": dataset_formal_param.id},
+                }
+                file_entity = self._add_file(wfda.dataset, properties, crate)
                 self.create_action.append_to("object", file_entity)
 
         for wfda in self.invocation.output_datasets:
             if not self.file_entities.get(wfda.dataset.dataset.id):
-                properties = {
-                    "exampleOfWork": {"@id": f"#{wfda.dataset.dataset.uuid}"},
-                }
-                file_entity = self._add_file(wfda.dataset, properties, crate)
                 dataset_formal_param = self._add_dataset_formal_parameter(wfda.dataset, crate)
                 crate.mainEntity.append_to("output", dataset_formal_param)
+                properties = {
+                    "exampleOfWork": {"@id": dataset_formal_param.id},
+                }
+                file_entity = self._add_file(wfda.dataset, properties, crate)
                 self.create_action.append_to("result", file_entity)
 
-    def _add_collection(self, hdca: HistoryDatasetCollectionAssociation, crate: ROCrate) -> ContextEntity:
+    def _add_collection(
+        self, hdca: HistoryDatasetCollectionAssociation, crate: ROCrate, collection_formal_param: ContextEntity
+    ) -> ContextEntity:
         name = hdca.name
         dataset_ids = []
         for hda in hdca.dataset_instances:
@@ -158,7 +160,7 @@ class WorkflowRunCrateProfileBuilder:
             "@type": "Collection",
             "additionalType": self._get_collection_additional_type(hdca.collection.collection_type),
             "hasPart": dataset_ids,
-            "exampleOfWork": {"@id": f"#{hdca.type_id}-param"},
+            "exampleOfWork": {"@id": collection_formal_param.id},
         }
         collection_entity = crate.add(
             ContextEntity(
@@ -185,14 +187,14 @@ class WorkflowRunCrateProfileBuilder:
 
     def _add_collections(self, crate: ROCrate):
         for wfdca in self.invocation.input_dataset_collections:
-            collection_entity = self._add_collection(wfdca.dataset_collection, crate)
             collection_formal_param = self._add_collection_formal_parameter(wfdca.dataset_collection, crate)
+            collection_entity = self._add_collection(wfdca.dataset_collection, crate, collection_formal_param)
             crate.mainEntity.append_to("input", collection_formal_param)
             self.create_action.append_to("object", collection_entity)
 
         for wfdca in self.invocation.output_dataset_collections:
-            collection_entity = self._add_collection(wfdca.dataset_collection, crate)
             collection_formal_param = self._add_collection_formal_parameter(wfdca.dataset_collection, crate)
+            collection_entity = self._add_collection(wfdca.dataset_collection, crate, collection_formal_param)
             crate.mainEntity.append_to("output", collection_formal_param)
             self.create_action.append_to("result", collection_entity)
 
@@ -336,31 +338,14 @@ class WorkflowRunCrateProfileBuilder:
     def _add_parameters(self, crate: ROCrate):
         for step in self.invocation.steps:
             if step.workflow_step.type == "parameter_input":
-                property_value = self._add_step_parameter_pv(step, crate)
-                formal_param = self._add_step_parameter_fp(step, crate)
-                crate.mainEntity.append_to("input", formal_param)
+                property_value = self._add_step_parameter(step, crate)
                 self.create_action.append_to("object", property_value)
 
-    def _add_step_parameter_pv(self, step: WorkflowInvocationStep, crate: ROCrate):
-        param_id = step.workflow_step.label
-        return crate.add(
-            ContextEntity(
-                crate,
-                f"{param_id}-pv",
-                properties={
-                    "@type": "PropertyValue",
-                    "name": f"{param_id}",
-                    "value": step.output_value.value,
-                    "exampleOfWork": {"@id": f"#{param_id}-param"},
-                },
-            )
-        )
-
-    def _add_step_parameter_fp(self, step: WorkflowInvocationStep, crate: ROCrate):
+    def _add_step_parameter(self, step: WorkflowInvocationStep, crate: ROCrate) -> ContextEntity:
         param_id = step.workflow_step.label
         assert step.workflow_step.tool_inputs
         param_type = step.workflow_step.tool_inputs["parameter_type"]
-        return crate.add(
+        formal_param = crate.add(
             ContextEntity(
                 crate,
                 f"{param_id}-param",
@@ -373,19 +358,16 @@ class WorkflowRunCrateProfileBuilder:
                 },
             )
         )
-
-    def _add_step_tool_pv(self, step: WorkflowInvocationStep, tool_input: str, crate: ROCrate):
-        param_id = tool_input
-        assert step.workflow_step.tool_inputs
+        crate.mainEntity.append_to("input", formal_param)
         return crate.add(
             ContextEntity(
                 crate,
                 f"{param_id}-pv",
                 properties={
                     "@type": "PropertyValue",
-                    "name": f"{step.workflow_step.label}",
-                    "value": step.workflow_step.tool_inputs[tool_input],
-                    "exampleOfWork": {"@id": f"#{param_id}-param"},
+                    "name": f"{param_id}",
+                    "value": step.output_value.value,
+                    "exampleOfWork": {"@id": formal_param.id},
                 },
             )
         )
@@ -419,7 +401,9 @@ class WorkflowRunCrateProfileBuilder:
             )
         )
 
-    def _add_collection_formal_parameter(self, hdca: HistoryDatasetCollectionAssociation, crate: ROCrate):
+    def _add_collection_formal_parameter(
+        self, hdca: HistoryDatasetCollectionAssociation, crate: ROCrate
+    ) -> ContextEntity:
         return crate.add(
             ContextEntity(
                 crate,


### PR DESCRIPTION
Use `id` entity attribute when setting `exampleOfWork` property.

Fix the following error in 3 unit tests when using rocrate 0.13.0 (e.g. in `test_galaxy_packages` tests run on Python 3.13):

```
______________________ test_export_invocation_to_ro_crate ______________________

tmp_path = PosixPath('/tmp/pytest-of-runner/pytest-5/test_export_invocation_to_ro_c0')

    def test_export_invocation_to_ro_crate(tmp_path):
        app = _mock_app()
        workflow_invocation = _setup_invocation(app)
        crate_directory = tmp_path / "crate"
        with store.ROCrateModelExportStore(crate_directory, app=app) as export_store:
            export_store.export_workflow_invocation(workflow_invocation)
>       validate_invocation_crate_directory(crate_directory)

tests/data/model/test_model_store.py:627:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/data/model/test_model_store.py:564: in validate_invocation_crate_directory
    validate_create_action(crate)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

ro_crate = <rocrate.rocrate.ROCrate object at 0x7fb4673c2520>

    def validate_create_action(ro_crate: ROCrate):
        workflow = ro_crate.mainEntity
        actions = [_ for _ in ro_crate.contextual_entities if "CreateAction" in _.type]
        assert len(actions) == 1
        wf_action = actions[0]
        assert wf_action["instrument"]
        assert wf_action["instrument"] is workflow
        wf_objects = wf_action["object"]
        wf_results = wf_action["result"]
        assert len(wf_objects) == 1
        assert len(wf_results) == 1
        for entity in wf_results:
            if entity.id.endswith(".txt"):
                assert "File" in entity.type
                wf_output_file = entity
                assert wf_output_file["encodingFormat"] == "text/plain"
>               assert wf_output_file["exampleOfWork"] is workflow["output"][0]
E               AssertionError: assert '#d2ed04ef-36f8-49ae-86ce-47cb03a856c0' is <d2ed04ef-36f8-49ae-86ce-47cb03a856c0 FormalParameter>

tests/data/model/test_model_store.py:540: AssertionError
```

Also:
- Remove unused `_add_step_tool_pv` method, unused since commit 01782c0b74fb62bb711ccd8f29a7280d63c4a4c5.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
