### PR TITLE
[24.2] Show message for mixed extensions in collection creator

### DIFF
--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -175,7 +175,7 @@ function _isElementInvalid(element: HistoryItemSummary): string | null {
         element.extension &&
         !datatypesMapper.value?.isSubTypeOfAny(element.extension, props.extensions!)
     ) {
-        return localize(`has an invalid extension: ${element.extension}`);
+        return localize(`has an invalid format: ${element.extension}`);
     }
     return null;
 }
@@ -572,7 +572,7 @@ function renameElement(element: any, name: string) {
                                 )
                             }}
                             <div v-if="extensions?.length">
-                                {{ localize("The following extensions are required for this list: ") }}
+                                {{ localize("The following format(s) are required for this list: ") }}
                                 <ul>
                                     <li v-for="extension in extensions" :key="extension">
                                         {{ extension }}

--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -16,6 +16,7 @@ import { useDatatypesMapperStore } from "@/stores/datatypesMapperStore";
 import localize from "@/utils/localization";
 
 import FormSelectMany from "../Form/Elements/FormSelectMany/FormSelectMany.vue";
+import HelpText from "../Help/HelpText.vue";
 import CollectionCreator from "@/components/Collections/common/CollectionCreator.vue";
 import DatasetCollectionElementView from "@/components/Collections/ListDatasetCollectionElementView.vue";
 
@@ -544,9 +545,13 @@ function renameElement(element: any, name: string) {
                 </template>
 
                 <template v-slot:middle-content>
-                    <BAlert v-if="listHasMixedExtensions" show variant="warning">
-                        {{ localize("The selected datasets have mixed extensions.") }}
-                        {{ localize("You can still create the list but its elements will have different extensions.") }}
+                    <BAlert v-if="listHasMixedExtensions" show variant="warning" dismissible>
+                        {{ localize("The selected datasets have mixed formats.") }}
+                        {{ localize("You can still create the list but generally") }}
+                        {{ localize("dataset lists should contain datasets of the same type.") }}
+                        <HelpText
+                            uri="galaxy.collections.collectionBuilder.whyHomogenousCollections"
+                            :text="localize('Why?')" />
                     </BAlert>
                     <div v-if="noInitialElements">
                         <BAlert show variant="warning" dismissible>

--- a/client/src/components/Collections/ListDatasetCollectionElementView.vue
+++ b/client/src/components/Collections/ListDatasetCollectionElementView.vue
@@ -13,6 +13,7 @@ interface Props {
     selected?: boolean;
     hasActions?: boolean;
     notEditable?: boolean;
+    hideExtension?: boolean;
 }
 
 const props = defineProps<Props>();
@@ -48,7 +49,7 @@ function clickDiscard() {
                 <ClickToEdit v-if="!notEditable" v-model="elementName" :title="localize('Click to rename')" />
                 <span v-else>{{ elementName }}</span>
             </strong>
-            <i v-if="element.extension"> ({{ element.extension }}) </i>
+            <i v-if="!hideExtension && element.extension"> ({{ element.extension }}) </i>
         </span>
 
         <div v-if="hasActions" class="float-right">

--- a/client/src/components/Collections/PairCollectionCreator.vue
+++ b/client/src/components/Collections/PairCollectionCreator.vue
@@ -15,6 +15,7 @@ import localize from "@/utils/localization";
 import type { DatasetPair } from "../History/adapters/buildCollectionModal";
 
 import DelayedInput from "../Common/DelayedInput.vue";
+import HelpText from "../Help/HelpText.vue";
 import DatasetCollectionElementView from "./ListDatasetCollectionElementView.vue";
 import CollectionCreator from "@/components/Collections/common/CollectionCreator.vue";
 
@@ -517,12 +518,12 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                                     </span>
                                 </BAlert>
                                 <BAlert v-else-if="pairHasMixedExtensions" show variant="warning">
-                                    {{ localize("The selected datasets have mixed extensions.") }}
-                                    {{
-                                        localize(
-                                            "You can still create the pair but its elements will have different extensions."
-                                        )
-                                    }}
+                                    {{ localize("The selected datasets have mixed formats.") }}
+                                    {{ localize("You can still create the pair but generally") }}
+                                    {{ localize("dataset pairs should contain datasets of the same type.") }}
+                                    <HelpText
+                                        uri="galaxy.collections.collectionBuilder.whyHomogenousCollections"
+                                        :text="localize('Why?')" />
                                 </BAlert>
                                 <BAlert v-else show variant="success">
                                     {{ localize("The Dataset Pair is ready to be created.") }}

--- a/client/src/components/Collections/PairCollectionCreator.vue
+++ b/client/src/components/Collections/PairCollectionCreator.vue
@@ -14,6 +14,7 @@ import localize from "@/utils/localization";
 
 import type { DatasetPair } from "../History/adapters/buildCollectionModal";
 
+import DelayedInput from "../Common/DelayedInput.vue";
 import DatasetCollectionElementView from "./ListDatasetCollectionElementView.vue";
 import CollectionCreator from "@/components/Collections/common/CollectionCreator.vue";
 
@@ -44,6 +45,13 @@ const removeExtensions = ref(true);
 const initialSuggestedName = ref("");
 const invalidElements = ref<string[]>([]);
 const workingElements = ref<HDASummary[]>([]);
+const filterText = ref("");
+
+const filteredElements = computed(() => {
+    return workingElements.value.filter((element) => {
+        return `${element.hid}: ${element.name}`.toLowerCase().includes(filterText.value.toLowerCase());
+    });
+});
 
 /** If not `fromSelection`, the manually added elements that will become the pair */
 const inListElements = ref<SelectedDatasetPair>({ forward: undefined, reverse: undefined });
@@ -539,17 +547,19 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                         </div>
 
                         <div v-if="!fromSelection">
+                            <DelayedInput v-model="filterText" placeholder="search datasets" :delay="800" />
                             <strong>
                                 {{
                                     localize("Manually select a forward and reverse dataset to create a dataset pair:")
                                 }}
                             </strong>
                             <div
+                                v-if="filteredElements.length"
                                 class="scroll-list-container"
                                 :class="{ 'scrolled-top': scrolledTop, 'scrolled-bottom': scrolledBottom }">
                                 <div ref="scrollableDiv" class="collection-elements">
                                     <DatasetCollectionElementView
-                                        v-for="element in workingElements"
+                                        v-for="element in filteredElements"
                                         :key="element.id"
                                         :class="{
                                             selected: [pairElements.forward, pairElements.reverse].includes(element),
@@ -561,6 +571,9 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                                         @onRename="(name) => (element.name = name)" />
                                 </div>
                             </div>
+                            <BAlert v-else show variant="info">
+                                {{ localize(`No datasets found${filterText ? " matching '" + filterText + "'" : ""}`) }}
+                            </BAlert>
                         </div>
                     </div>
                 </template>

--- a/client/src/components/Collections/PairCollectionCreator.vue
+++ b/client/src/components/Collections/PairCollectionCreator.vue
@@ -66,6 +66,13 @@ const pairElements = computed<SelectedDatasetPair>(() => {
         return inListElements.value;
     }
 });
+const pairHasMixedExtensions = computed(() => {
+    return (
+        pairElements.value.forward?.extension &&
+        pairElements.value.reverse?.extension &&
+        pairElements.value.forward.extension !== pairElements.value.reverse.extension
+    );
+});
 
 // variables for datatype mapping and then filtering
 const datatypesMapperStore = useDatatypesMapperStore();
@@ -355,7 +362,7 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                     </ul>
                 </BAlert>
             </div>
-            <div v-if="!exactlyTwoValidElements">
+            <div v-else-if="!exactlyTwoValidElements">
                 <BAlert show variant="warning" dismissible>
                     {{ localize("Exactly two elements are needed for the pair.") }}
                     <span v-if="fromSelection">
@@ -364,6 +371,18 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                         </a>
                         {{ localize("and reselect new elements.") }}
                     </span>
+                </BAlert>
+            </div>
+            <div v-else-if="pairHasMixedExtensions">
+                <BAlert show variant="warning">
+                    {{ localize("The selected datasets have mixed extensions.") }}
+                    {{ localize("You can still create the pair but its elements will have different extensions.") }}
+                </BAlert>
+            </div>
+            <div v-else>
+                <BAlert v-if="!fromSelection" show variant="success">
+                    {{ localize("The Dataset Pair is ready to be created.") }}
+                    {{ localize("Provide a name and click the button below to create the pair.") }}
                 </BAlert>
             </div>
 

--- a/client/src/components/Collections/PairCollectionCreator.vue
+++ b/client/src/components/Collections/PairCollectionCreator.vue
@@ -215,7 +215,7 @@ function _isElementInvalid(element: HistoryItemSummary) {
         element.extension &&
         !datatypesMapper.value?.isSubTypeOfAny(element.extension, props.extensions!)
     ) {
-        return localize(`has an invalid extension: ${element.extension}`);
+        return localize(`has an invalid format: ${element.extension}`);
     }
     return null;
 }
@@ -468,7 +468,7 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                                 )
                             }}
                             <div v-if="extensions?.length">
-                                {{ localize("The following extensions are required for this pair: ") }}
+                                {{ localize("The following formats are required for this pair: ") }}
                                 <ul>
                                     <li v-for="extension in extensions" :key="extension">
                                         {{ extension }}

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -304,7 +304,7 @@ function _isElementInvalid(element: HistoryItemSummary) {
         element.extension &&
         !datatypesMapper.value?.isSubTypeOfAny(element.extension, props.extensions!)
     ) {
-        return localize(`has an invalid extension: ${element.extension}`);
+        return localize(`has an invalid format: ${element.extension}`);
     }
     return null;
 }
@@ -1036,7 +1036,7 @@ function _naiveStartingAndEndingLCS(s1: string, s2: string) {
                                 )
                             }}
                             <span v-if="extensions?.length">
-                                {{ localize("The following extensions are required for this collection: ") }}
+                                {{ localize("The following format(s) are required for this collection: ") }}
                                 <ul>
                                     <li v-for="extension in extensions" :key="extension">
                                         {{ extension }}

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -254,7 +254,7 @@ watch(
                             <BAlert v-if="extensions?.length" class="w-100 py-0" variant="secondary" show>
                                 <HelpText
                                     uri="galaxy.collections.collectionBuilder.requiredUploadExtensions"
-                                    :text="localize('Required extensions: ')" />
+                                    :text="localize('Required format(s): ')" />
                                 <strong>{{ orList(extensions) }}</strong>
                             </BAlert>
                         </div>

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -54,6 +54,7 @@ const props = withDefaults(defineProps<Props>(), {
     extensions: undefined,
     extensionsToggle: false,
     showUpload: true,
+    collectionType: undefined,
 });
 
 const emit = defineEmits<{

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faPlus, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BTab, BTabs } from "bootstrap-vue";
+import { BTab, BTabs } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 
@@ -11,7 +11,6 @@ import { AUTO_EXTENSION, getUploadDatatypes } from "@/components/Upload/utils";
 import { useConfig } from "@/composables/config";
 import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";
-import { orList } from "@/utils/strings";
 
 import CollectionCreatorFooterButtons from "./CollectionCreatorFooterButtons.vue";
 import CollectionCreatorHelpHeader from "./CollectionCreatorHelpHeader.vue";
@@ -19,7 +18,6 @@ import CollectionCreatorNoItemsMessage from "./CollectionCreatorNoItemsMessage.v
 import CollectionCreatorShowExtensions from "./CollectionCreatorShowExtensions.vue";
 import CollectionCreatorSourceOptions from "./CollectionCreatorSourceOptions.vue";
 import CollectionNameInput from "./CollectionNameInput.vue";
-import HelpText from "@/components/Help/HelpText.vue";
 import DefaultBox from "@/components/Upload/DefaultBox.vue";
 
 const Tabs = {
@@ -250,14 +248,7 @@ watch(
                     @uploaded="addUploadedFiles"
                     @dismiss="currentTab = Tabs.create">
                     <template v-slot:footer>
-                        <div class="d-flex align-items-center justify-content-between mt-2">
-                            <BAlert v-if="extensions?.length" class="w-100 py-0" variant="secondary" show>
-                                <HelpText
-                                    uri="galaxy.collections.collectionBuilder.requiredUploadExtensions"
-                                    :text="localize('Required format(s): ')" />
-                                <strong>{{ orList(extensions) }}</strong>
-                            </BAlert>
-                        </div>
+                        <CollectionCreatorShowExtensions :extensions="extensions" upload />
                     </template>
                     <template v-slot:emit-btn-txt>
                         <FontAwesomeIcon :icon="faPlus" fixed-width />

--- a/client/src/components/Collections/common/CollectionCreatorShowExtensions.vue
+++ b/client/src/components/Collections/common/CollectionCreatorShowExtensions.vue
@@ -18,7 +18,7 @@ defineProps<Props>();
         <BAlert v-if="extensions?.length" class="w-100 py-0" variant="secondary" show>
             <HelpText
                 uri="galaxy.collections.collectionBuilder.filteredExtensions"
-                :text="localize('Filtered extensions: ')" />
+                :text="localize('Filtered format(s): ')" />
             <strong>{{ orList(extensions) }}</strong>
         </BAlert>
     </div>

--- a/client/src/components/Collections/common/CollectionCreatorShowExtensions.vue
+++ b/client/src/components/Collections/common/CollectionCreatorShowExtensions.vue
@@ -8,18 +8,32 @@ import HelpText from "@/components/Help/HelpText.vue";
 
 interface Props {
     extensions?: string[];
+    upload?: boolean;
 }
 
 defineProps<Props>();
 </script>
 
 <template>
-    <div class="d-flex align-items-center justify-content-between">
-        <BAlert v-if="extensions?.length" class="w-100 py-0" variant="secondary" show>
-            <HelpText
-                uri="galaxy.collections.collectionBuilder.filteredExtensions"
-                :text="localize('Filtered format(s): ')" />
-            <strong>{{ orList(extensions) }}</strong>
+    <div class="d-flex align-items-center justify-content-between mt-2">
+        <BAlert
+            v-if="extensions?.length"
+            class="w-100 py-0 d-flex justify-content-between flex-gapx-1"
+            variant="secondary"
+            show>
+            <div>
+                <HelpText
+                    :uri="`galaxy.collections.collectionBuilder.${
+                        upload ? 'requiredUploadExtensions' : 'filteredExtensions'
+                    }`"
+                    :text="localize(`${upload ? 'Required' : 'Filtered'} format(s):`)" />
+                <strong>{{ orList(extensions) }}</strong>
+            </div>
+            <strong>
+                <i>
+                    <HelpText uri="galaxy.datasets.formatVsDatatypeVsExtension" :text="localize('format?')" />
+                </i>
+            </strong>
         </BAlert>
     </div>
 </template>

--- a/client/src/components/DatasetInformation/DatasetInformation.vue
+++ b/client/src/components/DatasetInformation/DatasetInformation.vue
@@ -3,6 +3,7 @@ import { type HDADetailed } from "@/api";
 import { withPrefix } from "@/utils/redirect";
 import { bytesToString } from "@/utils/utils";
 
+import HelpText from "../Help/HelpText.vue";
 import DatasetHashes from "@/components/DatasetInformation/DatasetHashes.vue";
 import DatasetSources from "@/components/DatasetInformation/DatasetSources.vue";
 import DecodedId from "@/components/DecodedId.vue";
@@ -60,7 +61,9 @@ defineProps<Props>();
                 </tr>
 
                 <tr>
-                    <td>Format</td>
+                    <td>
+                        <HelpText uri="galaxy.datasets.formatVsDatatypeVsExtension" text="Format" />
+                    </td>
 
                     <td id="format">
                         {{ dataset.file_ext }}

--- a/client/src/components/Help/terms.yml
+++ b/client/src/components/Help/terms.yml
@@ -64,13 +64,13 @@ galaxy:
         Toggling this on means that the original history items that will become a part of the collection
         will be hidden from the history panel (they will still be searchable via the 'visible: false' filter).
       filteredExtensions: |
-        The history is filtered for the extensions that are required for this collection. You might see some
-        items with other extensions since those can still be valid inputs via implicit conversion.
+        The history is filtered for the formats that are required for this collection. You might see some
+        items with other formats since those can still be valid inputs via implicit conversion.
       requiredUploadExtensions: |
-        The extensions that are required for this collection. The files you upload will be assumed to have
-        these extensions. In the case of more than one extension, you can select a specific extension for
-        each individual file above. If there is only one extension, Galaxy will attempt to set that as the
-        extension for each file.
+        The formats that are required for this collection. The files you upload will be assumed to have
+        these formats. In the case of more than one format, you can select a specific format for
+        each individual file above. If there is only one format, Galaxy will attempt to set that as the
+        format for each file.
       whyHomogenousCollections: |
         Dataset collections are designed to streamline the analysis of large numbers of datasets by grouping
         them together into a single, manageable entity. Unlike generic folders on your computer, which can hold

--- a/client/src/components/Help/terms.yml
+++ b/client/src/components/Help/terms.yml
@@ -156,3 +156,19 @@ galaxy:
       to pass to the ``galaxy-upload`` command.
     ruleBased: |
       Galaxy can bulk import lists & tables of URLs into datasets or collections using reproducible rules.
+  
+  datasets:
+    formatVsDatatypeVsExtension: |
+      In Galaxy, the terms "datatype," "format," and "extension" are used to describe the nature of a dataset,
+      each with specific meanings.
+      
+      The ``datatype`` defines how a dataset is interpreted, validated, and processed, such as "fastqsanger", "bam",
+      or "vcf". Each datatype corresponds to a Python class that specifies how Galaxy should handle the file.
+      
+      The ``format`` is the user-facing label for the dataset's datatype, appearing in the Galaxy user interface
+      to indicate the structure and content expectations of the dataset.
+      
+      The ``extension`` is a string associated with each datatype, stored in Galaxy’s database to identify the
+      dataset’s datatype. This extension can match a file’s actual disk suffix (e.g., ".vcf") but may also be more
+      specialized (e.g., "fastqsanger"). Understanding these distinctions ensures that datasets are processed
+      correctly within Galaxy, maintaining the integrity and reproducibility of analyses.

--- a/client/src/components/Help/terms.yml
+++ b/client/src/components/Help/terms.yml
@@ -71,6 +71,15 @@ galaxy:
         these extensions. In the case of more than one extension, you can select a specific extension for
         each individual file above. If there is only one extension, Galaxy will attempt to set that as the
         extension for each file.
+      whyHomogenousCollections: |
+        Dataset collections are designed to streamline the analysis of large numbers of datasets by grouping
+        them together into a single, manageable entity. Unlike generic folders on your computer, which can hold
+        any mix of file types, dataset collections are specifically intended to be homogenous. This homogeneity
+        is crucial for consistency in processing. Homogeneous datasets ensure that each dataset in the collection
+        can be processed uniformly with the same tools and workflows. This eliminates the need for individual
+        adjustments, which can be time-consuming and prone to error. Most tools and workflows in Galaxy are designed
+        to operate on collections of similar data types. Homogeneous collections allow these tools to operate
+        uniformly over the collection.
 
   jobs:
     metrics:


### PR DESCRIPTION
Fixes #19277 

https://github.com/user-attachments/assets/98311d6a-3b34-45d5-8d10-f9362aca3fca

## Format explanation text also added to `DatasetInformation`:
> ... helptext link overs could be added. On format that describe it as having different names in Galaxy (dataytpe, format, extension) and explain the difference between file extensions of dataset datatypes and then reuse this help text in the history panel format label and dataset info format label. 

 _Originally posted by @jmchilton in [#19277](https://github.com/galaxyproject/galaxy/issues/19277#issuecomment-2596348065)_

![image](https://github.com/user-attachments/assets/d31daa42-3a48-4ce5-9731-3788e825449f)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
