### PR TITLE
Set safe default extraction filter for tar archives

### DIFF
--- a/lib/galaxy/datatypes/isa.py
+++ b/lib/galaxy/datatypes/isa.py
@@ -247,7 +247,8 @@ class _Isa(Data):
             # perform extraction
             # For some ZIP files CompressedFile::extract() extract the file inside <output_folder>/<file_name> instead of outputing it inside <output_folder>. So we first create a temporary folder, extract inside it, and move content to final destination.
             temp_folder = tempfile.mkdtemp()
-            CompressedFile(file_name).extract(temp_folder)
+            with CompressedFile(file_name) as cf:
+                cf.extract(temp_folder)
             shutil.rmtree(output_path)
             extracted_files = os.listdir(temp_folder)
             logger.debug(" ".join(extracted_files))

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -3075,7 +3075,8 @@ def source_to_import_store(
             if ModelStoreFormat.is_compressed(model_store_format):
                 try:
                     temp_dir = mkdtemp()
-                    target_dir = CompressedFile(target_path).extract(temp_dir)
+                    with CompressedFile(target_path) as cf:
+                        target_dir = cf.extract(temp_dir)
                 finally:
                     if delete:
                         os.remove(target_path)

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -5,7 +5,6 @@ import os
 import re
 import shutil
 import sys
-import tarfile
 import tempfile
 import time
 import urllib.parse
@@ -45,6 +44,7 @@ from galaxy.tool_util.parser.interface import (
 )
 from galaxy.util import requests
 from galaxy.util.bunch import Bunch
+from galaxy.util.compression_utils import CompressedFile
 from galaxy.util.hash_util import (
     memory_bound_hexdigest,
     parse_checksum_hash,
@@ -434,7 +434,14 @@ class GalaxyInteractorApi:
             return result
         raise Exception(result["err_msg"])
 
-    def test_data_download(self, tool_id, filename, mode="file", is_output=True, tool_version=None):
+    def test_data_download(
+        self,
+        tool_id: str,
+        filename: str,
+        mode: Literal["directory", "file"] = "file",
+        is_output: bool = True,
+        tool_version: Optional[str] = None,
+    ):
         result = None
         local_path = None
 
@@ -453,10 +460,7 @@ class GalaxyInteractorApi:
                             contents.extractall(path=path)
                     else:
                         # Galaxy < 21.01
-                        with tarfile.open(fileobj=fileobj) as tar_contents:
-                            tar_contents.extraction_filter = getattr(
-                                tarfile, "data_filter", (lambda member, path: member)
-                            )
+                        with CompressedFile.open_tar(fileobj) as tar_contents:
                             tar_contents.extractall(path=path)
                     result = path
         else:

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -454,6 +454,9 @@ class GalaxyInteractorApi:
                     else:
                         # Galaxy < 21.01
                         with tarfile.open(fileobj=fileobj) as tar_contents:
+                            tar_contents.extraction_filter = getattr(
+                                tarfile, "data_filter", (lambda member, path: member)
+                            )
                             tar_contents.extractall(path=path)
                     result = path
         else:

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -442,8 +442,8 @@ def _decompress_target(upload_config: "UploadConfig", target: Dict[str, Any]):
     # fuzzy_root to False to literally interpret the target.
     fuzzy_root = target.get("fuzzy_root", True)
     temp_directory = os.path.abspath(tempfile.mkdtemp(prefix=elements_from_name, dir=upload_config.working_directory))
-    cf = CompressedFile(elements_from_path)
-    result = cf.extract(temp_directory)
+    with CompressedFile(elements_from_path) as cf:
+        result = cf.extract(temp_directory)
     return result if fuzzy_root else temp_directory
 
 

--- a/lib/galaxy/tools/imp_exp/unpack_tar_gz_archive.py
+++ b/lib/galaxy/tools/imp_exp/unpack_tar_gz_archive.py
@@ -60,9 +60,9 @@ def unpack_archive(archive_file, dest_dir):
         with zipfile.ZipFile(archive_file, "r") as zip_archive:
             zip_archive.extractall(path=dest_dir)
     else:
-        archive_fp = tarfile.open(archive_file, mode="r")
-        archive_fp.extractall(path=dest_dir)
-        archive_fp.close()
+        with tarfile.open(archive_file, mode="r") as archive_fp:
+            archive_fp.extraction_filter = getattr(tarfile, "data_filter", (lambda member, path: member))
+            archive_fp.extractall(path=dest_dir)
 
 
 def main(options, args):

--- a/lib/galaxy/tools/imp_exp/unpack_tar_gz_archive.py
+++ b/lib/galaxy/tools/imp_exp/unpack_tar_gz_archive.py
@@ -16,6 +16,7 @@ from base64 import b64decode
 
 from galaxy.files import ConfiguredFileSources
 from galaxy.files.uris import stream_url_to_file
+from galaxy.util.compression_utils import CompressedFile
 
 # Set max size of archive/file that will be handled to be 100 GB. This is
 # arbitrary and should be adjusted as needed.
@@ -52,19 +53,6 @@ def check_archive(archive_file, dest_dir):
     return True
 
 
-def unpack_archive(archive_file, dest_dir):
-    """
-    Unpack a tar and/or gzipped archive into a destination directory.
-    """
-    if zipfile.is_zipfile(archive_file):
-        with zipfile.ZipFile(archive_file, "r") as zip_archive:
-            zip_archive.extractall(path=dest_dir)
-    else:
-        with tarfile.open(archive_file, mode="r") as archive_fp:
-            archive_fp.extraction_filter = getattr(tarfile, "data_filter", (lambda member, path: member))
-            archive_fp.extractall(path=dest_dir)
-
-
 def main(options, args):
     is_url = bool(options.is_url)
     is_file = bool(options.is_file)
@@ -84,7 +72,8 @@ def main(options, args):
 
     # Unpack archive.
     check_archive(archive_file, dest_dir)
-    unpack_archive(archive_file, dest_dir)
+    with CompressedFile(archive_file) as cf:
+        cf.archive.extractall(dest_dir)
 
 
 if __name__ == "__main__":

--- a/lib/galaxy/util/compression_utils.py
+++ b/lib/galaxy/util/compression_utils.py
@@ -345,18 +345,24 @@ class CompressedFile:
             return True
         return False
 
-    def open_tar(self, filepath: StrPath, mode: Literal["a", "r", "w", "x"]) -> tarfile.TarFile:
-        tf = tarfile.open(filepath, mode, errorlevel=0)
+    @staticmethod
+    def open_tar(file: Union[StrPath, IO[bytes]], mode: Literal["a", "r", "w", "x"] = "r") -> tarfile.TarFile:
+        if isinstance(file, (str, os.PathLike)):
+            tf = tarfile.open(file, mode=mode, errorlevel=0)
+        else:
+            tf = tarfile.open(mode=mode, fileobj=file, errorlevel=0)
         # Set a safe default ("data_filter") for the extraction filter if
         # available, reverting to Python 3.11 behavior otherwise, see
         # https://docs.python.org/3/library/tarfile.html#supporting-older-python-versions
         tf.extraction_filter = getattr(tarfile, "data_filter", (lambda member, path: member))
         return tf
 
-    def open_zip(self, filepath: StrPath, mode: Literal["a", "r", "w", "x"]) -> zipfile.ZipFile:
-        return zipfile.ZipFile(filepath, mode)
+    @staticmethod
+    def open_zip(file: Union[StrPath, IO[bytes]], mode: Literal["a", "r", "w", "x"] = "r") -> zipfile.ZipFile:
+        return zipfile.ZipFile(file, mode)
 
-    def zipfile_ok(self, path_to_archive: StrPath) -> bool:
+    @staticmethod
+    def zipfile_ok(path_to_archive: StrPath) -> bool:
         """
         This function is a bit pedantic and not functionally necessary.  It checks whether there is
         no file pointing outside of the extraction, because ZipFile.extractall() has some potential

--- a/lib/galaxy/util/compression_utils.py
+++ b/lib/galaxy/util/compression_utils.py
@@ -337,7 +337,12 @@ class CompressedFile:
         return False
 
     def open_tar(self, filepath: StrPath, mode: Literal["a", "r", "w", "x"]) -> tarfile.TarFile:
-        return tarfile.open(filepath, mode, errorlevel=0)
+        tf = tarfile.open(filepath, mode, errorlevel=0)
+        # Set a safe default ("data_filter") for the extraction filter if
+        # available, reverting to Python 3.11 behavior otherwise, see
+        # https://docs.python.org/3/library/tarfile.html#supporting-older-python-versions
+        tf.extraction_filter = getattr(tarfile, "data_filter", (lambda member, path: member))
+        return tf
 
     def open_zip(self, filepath: StrPath, mode: Literal["a", "r", "w", "x"]) -> zipfile.ZipFile:
         return zipfile.ZipFile(filepath, mode)

--- a/lib/tool_shed/test/functional/test_shed_repositories.py
+++ b/lib/tool_shed/test/functional/test_shed_repositories.py
@@ -228,7 +228,8 @@ class TestShedRepositoriesApi(ShedApiTestCase):
 
     def test_repo_tars(self):
         for index, repo_path in enumerate(repo_tars("column_maker")):
-            path = CompressedFile(repo_path).extract(tempfile.mkdtemp())
+            with CompressedFile(repo_path) as cf:
+                path = cf.extract(tempfile.mkdtemp())
             tool_xml_path = os.path.join(path, "column_maker.xml")
             tool_source = get_tool_source(config_file=tool_xml_path)
             tool_version = tool_source.parse_version()

--- a/lib/tool_shed/util/repository_content_util.py
+++ b/lib/tool_shed/util/repository_content_util.py
@@ -37,6 +37,7 @@ def tar_open(uploaded_file):
         tar = tarfile.open(uploaded_file, "r:*")
     else:
         tar = tarfile.open(uploaded_file)
+    tar.extraction_filter = getattr(tarfile, "data_filter", (lambda member, path: member))
     return tar
 
 
@@ -49,14 +50,12 @@ def upload_tar(
     dry_run: bool = False,
     remove_repo_files_not_in_tar: bool = True,
     new_repo_alert: bool = False,
-    tar=None,
     rdah: Optional[RepositoryDependencyAttributeHandler] = None,
     tdah: Optional[ToolDependencyAttributeHandler] = None,
 ) -> ChangeResponseT:
     host = trans.repositories_hostname
     app = trans.app
-    if tar is None:
-        tar = tar_open(uploaded_file)
+    tar = tar_open(uploaded_file)
     rdah = rdah or RepositoryDependencyAttributeHandler(trans, unpopulate=False)
     tdah = tdah or ToolDependencyAttributeHandler(trans, unpopulate=False)
     # Upload a tar archive of files.

--- a/test/integration/test_workflow_tasks.py
+++ b/test/integration/test_workflow_tasks.py
@@ -60,11 +60,13 @@ class TestWorkflowTasksIntegration(PosixFileSourceSetup, IntegrationTestCase, Us
 
     def test_export_ro_crate_basic(self):
         ro_crate_path = self._export_invocation_to_format(extension="rocrate.zip", to_uri=False)
-        assert CompressedFile(ro_crate_path).file_type == "zip"
+        with CompressedFile(ro_crate_path) as cf:
+            assert cf.file_type == "zip"
 
     def test_export_ro_crate_to_uri(self):
         ro_crate_path = self._export_invocation_to_format(extension="rocrate.zip", to_uri=True)
-        assert CompressedFile(ro_crate_path).file_type == "zip"
+        with CompressedFile(ro_crate_path) as cf:
+            assert cf.file_type == "zip"
 
     def test_export_bco_basic(self):
         bco_path = self._export_invocation_to_format(extension="bco.json", to_uri=False)

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -646,9 +646,9 @@ def test_export_invocation_to_ro_crate_archive(tmp_path):
     crate_zip = tmp_path / "crate.zip"
     with store.ROCrateArchiveModelExportStore(crate_zip, app=app, export_files="symlink") as export_store:
         export_store.export_workflow_invocation(workflow_invocation)
-    compressed_file = CompressedFile(crate_zip)
-    assert compressed_file.file_type == "zip"
-    compressed_file.extract(tmp_path)
+    with CompressedFile(crate_zip) as compressed_file:
+        assert compressed_file.file_type == "zip"
+        compressed_file.extract(tmp_path)
     crate_directory = tmp_path / "crate"
     validate_invocation_crate_directory(crate_directory)
 
@@ -1249,7 +1249,8 @@ class Options:
 
 def import_archive(archive_path, app, user, import_options=None):
     dest_parent = mkdtemp()
-    dest_dir = CompressedFile(archive_path).extract(dest_parent)
+    with CompressedFile(archive_path) as cf:
+        dest_dir = cf.extract(dest_parent)
 
     import_options = import_options or store.ImportOptions()
     model_store = store.get_import_model_store_for_directory(

--- a/test/unit/tool_shed/test_shed_index.py
+++ b/test/unit/tool_shed/test_shed_index.py
@@ -29,7 +29,9 @@ def community_file_dir():
     response = requests.get(URL)
     response.raise_for_status()
     b = BytesIO(response.content)
-    tarfile.open(fileobj=b, mode="r:gz").extractall(extracted_archive_dir)
+    with tarfile.open(fileobj=b, mode="r:gz") as tar:
+        tar.extraction_filter = getattr(tarfile, "data_filter", (lambda member, path: member))
+        tar.extractall(extracted_archive_dir)
     try:
         yield extracted_archive_dir
     finally:

--- a/test/unit/tool_shed/test_shed_index.py
+++ b/test/unit/tool_shed/test_shed_index.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import tarfile
 import tempfile
 from collections import namedtuple
 from io import BytesIO
@@ -9,6 +8,7 @@ import pytest
 import requests
 from whoosh import index
 
+from galaxy.util.compression_utils import CompressedFile
 from tool_shed.util.shed_index import build_index
 
 URL = "https://github.com/mvdbeek/toolshed-test-data/blob/master/toolshed_community_files.tgz?raw=true"
@@ -29,8 +29,7 @@ def community_file_dir():
     response = requests.get(URL)
     response.raise_for_status()
     b = BytesIO(response.content)
-    with tarfile.open(fileobj=b, mode="r:gz") as tar:
-        tar.extraction_filter = getattr(tarfile, "data_filter", (lambda member, path: member))
+    with CompressedFile.open_tar(b) as tar:
         tar.extractall(extracted_archive_dir)
     try:
         yield extracted_archive_dir

--- a/test/unit/util/test_compression_util.py
+++ b/test/unit/util/test_compression_util.py
@@ -15,6 +15,7 @@ class TestCompressionUtil(TestCase):
         self.assert_safety("test-data/unsafe.zip", False)
         self.assert_safety("test-data/4.bed.zip", True)
         self.assert_safety("test-data/testdir.tar", True)
+        self.assert_safety("test-data/testdir1.tar.gz", True)
         self.assert_safety("test-data/safetar_with_symlink.tar", True)
         self.assert_safety("test-data/safe_relative_symlink.tar", True)
 
@@ -30,10 +31,12 @@ class TestCompressionUtil(TestCase):
         temp_dir = tempfile.mkdtemp()
         try:
             if expected_to_be_safe:
-                CompressedFile(path).extract(temp_dir)
+                with CompressedFile(path) as cf:
+                    cf.extract(temp_dir)
             else:
                 with self.assertRaisesRegex(Exception, "is blocked"):
-                    CompressedFile(path).extract(temp_dir)
+                    with CompressedFile(path) as cf:
+                        cf.extract(temp_dir)
         finally:
             shutil.rmtree(temp_dir, ignore_errors=True)
 

--- a/tools/data_source/upload.py
+++ b/tools/data_source/upload.py
@@ -226,7 +226,8 @@ def add_composite_file(dataset, registry, output_path, files_path):
             # a little more explicitly so we didn't need to dispatch on the datatype and so we
             # could attach arbitrary extra composite data to an existing composite datatype if
             # if need be? Perhaps that would be a mistake though.
-            CompressedFile(dp).extract(files_path)
+            with CompressedFile(dp) as cf:
+                cf.extract(files_path)
         else:
             tmpdir = output_adjacent_tmpdir(output_path)
             tmp_prefix = "data_id_%s_convert_" % dataset.dataset_id


### PR DESCRIPTION
[PEP 706](https://peps.python.org/pep-0706/), first implemented in Python 3.11.4, mitigates some of the security issues of `TarFile.extract()` and `TarFile.extractall()` by allowing to specify a `filter` keyword-only parameter.
Set a safe default (`data_filter`) for the filter if available, reverting to Python 3.11 behavior ('fully_trusted') otherwise, see https://docs.python.org/3/library/tarfile.html#supporting-older-python-versions

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
