### PR TITLE
Avoid using custos refresh tokens which are expired

### DIFF
--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -121,6 +121,8 @@ class OIDCAuthnzBase(IdentityProvider):
         # do not refresh tokens if the id_token didn't reach its half-life
         if int(id_token_decoded["iat"]) + int(id_token_decoded["exp"]) > 2 * int(time.time()):
             return False
+        if not custos_authnz_token.refresh_token:
+            return False
         refresh_token_decoded = self._decode_token_no_signature(custos_authnz_token.refresh_token)
         # do not attempt to use refresh token that is already expired
         if int(refresh_token_decoded["exp"]) > int(time.time()):


### PR DESCRIPTION
if merged, I would like to backport this to release_24.2

- this will prevent galaxy spamming the auth provider endpoint with doomed refresh attempts for each of these users' request 
- afaik the consensus is that we do not log out user in this case atm, details in https://github.com/galaxyproject/galaxy/pull/15300
- this PR also avoids calling the endpoint if we have no refresh_token, which is a common situation (see https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1341 and https://github.com/galaxyproject/galaxy/pull/19385)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. set up OIDC
  2. craft an expired token (or receive & wait)
  3. observe no request is issued and no exception thrown

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
