### PR TITLE
Prevent users from reusing a banned email after account is purged

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1825,21 +1825,34 @@
     E-mail ban file is used to specify email addresses that have been
     banned. If a user attempts to register a new account using an
     email address listed in this file, registration will be denied.
-    This file does not affect user sign-in.
-    Email addresses are matched against a canonical address
-    representation based on the following set of rules. - Values are
-    not case-sensitive (RickDeckard@foo.cOM == rickdeckard@foo.com) -
-    Plus suffixes in the local-part of a Gmail account are ignored
-    (rickdeckard+anything@gmail.com == rickdeckard@gmail.com) -
-    Periods in the local_part of a Gmail account are ignored
-    (rick.deckard@gmail.com == rickdeckard@gmail.com)
-    The file should include one email address per line. Lines starting
-    with the "#" character are ignored.
-    Example value 'banned_emails.conf'
+    This file does not affect user sign-in. Email addresses are
+    matched against a canonical address representation based on rules
+    defined in <canonical_email_rules>. The file should include one
+    email address per line. Lines starting with the "#" character are
+    ignored.
+    Example value "banned_emails.conf"
     The value of this option will be resolved with respect to
     <config_dir>.
 :Default: ``None``
 :Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~
+``canonical_email_rules``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Specifies how email addresses are reduced to their canonical form
+    by assigning rules to email service domains and domain aliases.
+    Available rules - ignore_case   Values are not case-sensitive
+    (RickDeckard@foo.cOM == rickdeckard@foo.com) - ignore_dots
+    Periods in the local-part of an email address are ignored
+    (rick.deckard@foo.com == rickdeckard@foo.com) - sub_addressing
+    Suffixes prefixed with <sub_addressing_delim> in the local-part of
+    an email address are ignored   (rickdeckard+anything@foo.com ==
+    rickdeckard@foo.com if delimiter is the character '+')
+:Default: ``{'all': {'ignore_case': False, 'ignore_dots': False, 'sub_addressing': False, 'sub_addressing_delim': '+'}, 'gmail.com': {'aliases': ['googlemail.com'], 'ignore_case': True, 'ignore_dots': True, 'sub_addressing': True}, 'proton.me': {'aliases': ['pm.me', 'protonmail.com'], 'ignore_case': True, 'sub_addressing': True}}``
+:Type: map
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1817,6 +1817,31 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~
+``email_ban_file``
+~~~~~~~~~~~~~~~~~~
+
+:Description:
+    E-mail ban file is used to specify email addresses that have been
+    banned. If a user attempts to register a new account using an
+    email address listed in this file, registration will be denied.
+    This file does not affect user sign-in.
+    Email addresses are matched against a canonical address
+    representation based on the following set of rules. - Values are
+    not case-sensitive (RickDeckard@foo.cOM == rickdeckard@foo.com) -
+    Plus suffixes in the local-part of a Gmail account are ignored
+    (rickdeckard+anything@gmail.com == rickdeckard@gmail.com) -
+    Periods in the local_part of a Gmail account are ignored
+    (rick.deckard@gmail.com == rickdeckard@gmail.com)
+    The file should include one email address per line. Lines starting
+    with the "#" character are ignored.
+    Example value 'banned_emails.conf'
+    The value of this option will be resolved with respect to
+    <config_dir>.
+:Default: ``None``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``registration_warning_message``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -226,6 +226,7 @@ class MockAppConfig(GalaxyDataTestConfig, CommonConfigurationMixin):
         self.custom_activation_email_message = "custom_activation_email_message"
         self.email_domain_allowlist_content = None
         self.email_domain_blocklist_content = None
+        self.email_ban_file = None
         self.email_from = "email_from"
         self.enable_old_display_applications = True
         self.error_email_to = "admin@email.to"

--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -227,6 +227,7 @@ class MockAppConfig(GalaxyDataTestConfig, CommonConfigurationMixin):
         self.email_domain_allowlist_content = None
         self.email_domain_blocklist_content = None
         self.email_ban_file = None
+        self.canonical_email_rules = None
         self.email_from = "email_from"
         self.enable_old_display_applications = True
         self.error_email_to = "admin@email.to"

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -26,6 +26,8 @@ try:
 except ImportError:
     settings_to_sample = None
 
+from pykwalify.errors import RuleError
+
 try:
     from pykwalify.core import Core
 except ImportError:
@@ -373,7 +375,13 @@ def _validate(args: Namespace, app_desc: App) -> None:
             schema_files=[fp.name],
         )
     os.remove(config_p.name)
-    c.validate()
+    try:
+        c.validate()
+    except RuleError as error:
+        if error.error_key == "default.not_scalar":
+            # Default values are not supported by pykwalify (or kwalify) for map types. Yet, it is
+            # beneficial to provide those defaults since they are loaded with the schema.
+            pass
 
 
 def _run_conversion(args: Namespace, app_desc: App) -> None:

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1220,20 +1220,42 @@ galaxy:
   # E-mail ban file is used to specify email addresses that have been
   # banned. If a user attempts to register a new account using an email
   # address listed in this file, registration will be denied. This file
-  # does not affect user sign-in.
-  # Email addresses are matched against a canonical address
-  # representation based on the following set of rules. - Values are not
-  # case-sensitive (RickDeckard@foo.cOM == rickdeckard@foo.com) - Plus
-  # suffixes in the local-part of a Gmail account are ignored
-  # (rickdeckard+anything@gmail.com == rickdeckard@gmail.com) - Periods
-  # in the local_part of a Gmail account are ignored
-  # (rick.deckard@gmail.com == rickdeckard@gmail.com)
-  # The file should include one email address per line. Lines starting
-  # with the "#" character are ignored.
-  # Example value 'banned_emails.conf'
+  # does not affect user sign-in. Email addresses are matched against a
+  # canonical address representation based on rules defined in
+  # <canonical_email_rules>. The file should include one email address
+  # per line. Lines starting with the "#" character are ignored.
+  # Example value "banned_emails.conf"
   # The value of this option will be resolved with respect to
   # <config_dir>.
   #email_ban_file: null
+
+  # Specifies how email addresses are reduced to their canonical form by
+  # assigning rules to email service domains and domain aliases.
+  # Available rules - ignore_case   Values are not case-sensitive
+  # (RickDeckard@foo.cOM == rickdeckard@foo.com) - ignore_dots   Periods
+  # in the local-part of an email address are ignored
+  # (rick.deckard@foo.com == rickdeckard@foo.com) - sub_addressing
+  # Suffixes prefixed with <sub_addressing_delim> in the local-part of
+  # an email address are ignored   (rickdeckard+anything@foo.com ==
+  # rickdeckard@foo.com if delimiter is the character '+')
+  #canonical_email_rules:
+  #  all:
+  #    ignore_case: false
+  #    ignore_dots: false
+  #    sub_addressing: false
+  #    sub_addressing_delim: +
+  #  gmail.com:
+  #    aliases:
+  #    - googlemail.com
+  #    ignore_case: true
+  #    ignore_dots: true
+  #    sub_addressing: true
+  #  proton.me:
+  #    aliases:
+  #    - pm.me
+  #    - protonmail.com
+  #    ignore_case: true
+  #    sub_addressing: true
 
   # Registration warning message is used to discourage people from
   # registering multiple accounts.  Applies mostly for the main Galaxy

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1217,6 +1217,24 @@ galaxy:
   # <config_dir>.
   #email_domain_allowlist_file: null
 
+  # E-mail ban file is used to specify email addresses that have been
+  # banned. If a user attempts to register a new account using an email
+  # address listed in this file, registration will be denied. This file
+  # does not affect user sign-in.
+  # Email addresses are matched against a canonical address
+  # representation based on the following set of rules. - Values are not
+  # case-sensitive (RickDeckard@foo.cOM == rickdeckard@foo.com) - Plus
+  # suffixes in the local-part of a Gmail account are ignored
+  # (rickdeckard+anything@gmail.com == rickdeckard@gmail.com) - Periods
+  # in the local_part of a Gmail account are ignored
+  # (rick.deckard@gmail.com == rickdeckard@gmail.com)
+  # The file should include one email address per line. Lines starting
+  # with the "#" character are ignored.
+  # Example value 'banned_emails.conf'
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #email_ban_file: null
+
   # Registration warning message is used to discourage people from
   # registering multiple accounts.  Applies mostly for the main Galaxy
   # instance. If no message specified the warning box will not be shown.

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -322,6 +322,24 @@ tool_shed:
   # <email_domain_blocklist_file> will be ignored.
   #email_domain_allowlist_file: null
 
+  # E-mail ban file is used to specify email addresses that have been
+  # banned. If a user attempts to register a new account using an email
+  # address listed in this file, registration will be denied. This file
+  # does not affect user sign-in.
+  # Email addresses are matched against a canonical address
+  # representation based on the following set of rules. - Values are not
+  # case-sensitive (RickDeckard@foo.cOM == rickdeckard@foo.com) - Plus
+  # suffixes in the local-part of a Gmail account are ignored
+  # (rickdeckard+anything@gmail.com == rickdeckard@gmail.com) - Periods
+  # in the local_part of a Gmail account are ignored
+  # (rick.deckard@gmail.com == rickdeckard@gmail.com)
+  # The file should include one email address per line. Lines starting
+  # with the "#" character are ignored.
+  # Example value 'banned_emails.conf'
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #email_ban_file: null
+
   # Append "/{brand}" to the "Galaxy" text in the masthead.
   #brand: null
 

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -325,20 +325,42 @@ tool_shed:
   # E-mail ban file is used to specify email addresses that have been
   # banned. If a user attempts to register a new account using an email
   # address listed in this file, registration will be denied. This file
-  # does not affect user sign-in.
-  # Email addresses are matched against a canonical address
-  # representation based on the following set of rules. - Values are not
-  # case-sensitive (RickDeckard@foo.cOM == rickdeckard@foo.com) - Plus
-  # suffixes in the local-part of a Gmail account are ignored
-  # (rickdeckard+anything@gmail.com == rickdeckard@gmail.com) - Periods
-  # in the local_part of a Gmail account are ignored
-  # (rick.deckard@gmail.com == rickdeckard@gmail.com)
-  # The file should include one email address per line. Lines starting
-  # with the "#" character are ignored.
-  # Example value 'banned_emails.conf'
+  # does not affect user sign-in. Email addresses are matched against a
+  # canonical address representation based on rules defined in
+  # <canonical_email_rules>. The file should include one email address
+  # per line. Lines starting with the "#" character are ignored.
+  # Example value "banned_emails.conf"
   # The value of this option will be resolved with respect to
   # <config_dir>.
   #email_ban_file: null
+
+  # Specifies how email addresses are reduced to their canonical form by
+  # assigning rules to email service domains and domain aliases.
+  # Available rules - ignore_case   Values are not case-sensitive
+  # (RickDeckard@foo.cOM == rickdeckard@foo.com) - ignore_dots   Periods
+  # in the local-part of an email address are ignored
+  # (rick.deckard@foo.com == rickdeckard@foo.com) - sub_addressing
+  # Suffixes prefixed with <sub_addressing_delim> in the local-part of
+  # an email address are ignored   (rickdeckard+anything@foo.com ==
+  # rickdeckard@foo.com if delimiter is the character '+')
+  #canonical_email_rules:
+  #  all:
+  #    ignore_case: false
+  #    ignore_dots: false
+  #    sub_addressing: false
+  #    sub_addressing_delim: +
+  #  gmail.com:
+  #    aliases:
+  #    - googlemail.com
+  #    ignore_case: true
+  #    ignore_dots: true
+  #    sub_addressing: true
+  #  proton.me:
+  #    aliases:
+  #    - pm.me
+  #    - protonmail.com
+  #    ignore_case: true
+  #    sub_addressing: true
 
   # Append "/{brand}" to the "Galaxy" text in the masthead.
   #brand: null

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -1303,6 +1303,24 @@ mapping:
 
           The value of this option will be resolved with respect to <config_dir>.
 
+      email_ban_file:
+        type: str
+        path_resolves_to: config_dir
+        required: false
+        desc: |
+          E-mail ban file is used to specify email addresses that have been banned.
+          If a user attempts to register a new account using an email address listed in this file,
+          registration will be denied. This file does not affect user sign-in.
+
+          Email addresses are matched against a canonical address representation based on the following set of rules.
+          - Values are not case-sensitive (RickDeckard@foo.cOM == rickdeckard@foo.com)
+          - Plus suffixes in the local-part of a Gmail account are ignored (rickdeckard+anything@gmail.com == rickdeckard@gmail.com)
+          - Periods in the local_part of a Gmail account are ignored (rick.deckard@gmail.com == rickdeckard@gmail.com)
+
+          The file should include one email address per line. Lines starting with the "#" character are ignored.
+
+          Example value 'banned_emails.conf'
+
       registration_warning_message:
         type: str
         default: >-

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -1310,16 +1310,79 @@ mapping:
         desc: |
           E-mail ban file is used to specify email addresses that have been banned.
           If a user attempts to register a new account using an email address listed in this file,
-          registration will be denied. This file does not affect user sign-in.
-
-          Email addresses are matched against a canonical address representation based on the following set of rules.
-          - Values are not case-sensitive (RickDeckard@foo.cOM == rickdeckard@foo.com)
-          - Plus suffixes in the local-part of a Gmail account are ignored (rickdeckard+anything@gmail.com == rickdeckard@gmail.com)
-          - Periods in the local_part of a Gmail account are ignored (rick.deckard@gmail.com == rickdeckard@gmail.com)
-
+          registration will be denied. This file does not affect user sign-in. Email addresses are
+          matched against a canonical address representation based on rules defined in <canonical_email_rules>.
           The file should include one email address per line. Lines starting with the "#" character are ignored.
 
-          Example value 'banned_emails.conf'
+          Example value "banned_emails.conf"
+
+      canonical_email_rules:
+        type: map
+        desc: |
+          Specifies how email addresses are reduced to their canonical form by assigning rules to
+          email service domains and domain aliases.
+
+          Available rules
+          - ignore_case
+            Values are not case-sensitive (RickDeckard@foo.cOM == rickdeckard@foo.com)
+          - ignore_dots
+            Periods in the local-part of an email address are ignored (rick.deckard@foo.com == rickdeckard@foo.com)
+          - sub_addressing
+            Suffixes prefixed with <sub_addressing_delim> in the local-part of an email address are ignored
+            (rickdeckard+anything@foo.com == rickdeckard@foo.com if delimiter is the character '+')
+
+        default:
+          all:
+            ignore_case: false
+            ignore_dots: false
+            sub_addressing: false
+            sub_addressing_delim: "+"
+          gmail.com:
+            aliases:
+              - googlemail.com
+            ignore_case: true
+            ignore_dots: true
+            sub_addressing: true
+          proton.me:
+            aliases:
+              - pm.me
+              - protonmail.com
+            ignore_case: true
+            sub_addressing: true
+
+        mapping:
+          regex;(.+):
+            type: map
+            desc: |
+              Email service domain name. Note that "all" is a reserved keyword used to refer to all email service domain names.
+              Example value "gmail.com"
+            mapping:
+              aliases:
+                type: seq
+                desc: |
+                  Domain aliases used by email service.
+                sequence:
+                  - type: str
+              ignore_dots:
+                type: bool
+                default: false
+                desc: |
+                  Periods in the local-part of an email address will be ignored.
+              ignore_case:
+                type: bool
+                default: false
+                desc: |
+                  Email addresses are not case-sensitive.
+              sub_addressing:
+                type: bool
+                default: false
+                desc: |
+                  In the email address's local-part, ignore the suffix prefixed with <sub_addressing_delim>.
+              sub_addressing_delim:
+                type: str
+                default: "+"
+                desc: |
+                  The delimiter used to separate the address from the optional sub-addressing suffix.
 
       registration_warning_message:
         type: str

--- a/lib/galaxy/config/schemas/tool_shed_config_schema.yml
+++ b/lib/galaxy/config/schemas/tool_shed_config_schema.yml
@@ -577,16 +577,79 @@ mapping:
         desc: |
           E-mail ban file is used to specify email addresses that have been banned.
           If a user attempts to register a new account using an email address listed in this file,
-          registration will be denied. This file does not affect user sign-in.
-
-          Email addresses are matched against a canonical address representation based on the following set of rules.
-          - Values are not case-sensitive (RickDeckard@foo.cOM == rickdeckard@foo.com)
-          - Plus suffixes in the local-part of a Gmail account are ignored (rickdeckard+anything@gmail.com == rickdeckard@gmail.com)
-          - Periods in the local_part of a Gmail account are ignored (rick.deckard@gmail.com == rickdeckard@gmail.com)
-
+          registration will be denied. This file does not affect user sign-in. Email addresses are
+          matched against a canonical address representation based on rules defined in <canonical_email_rules>.
           The file should include one email address per line. Lines starting with the "#" character are ignored.
 
-          Example value 'banned_emails.conf'
+          Example value "banned_emails.conf"
+
+      canonical_email_rules:
+        type: map
+        desc: |
+          Specifies how email addresses are reduced to their canonical form by assigning rules to
+          email service domains and domain aliases.
+
+          Available rules
+          - ignore_case
+            Values are not case-sensitive (RickDeckard@foo.cOM == rickdeckard@foo.com)
+          - ignore_dots
+            Periods in the local-part of an email address are ignored (rick.deckard@foo.com == rickdeckard@foo.com)
+          - sub_addressing
+            Suffixes prefixed with <sub_addressing_delim> in the local-part of an email address are ignored
+            (rickdeckard+anything@foo.com == rickdeckard@foo.com if delimiter is the character '+')
+
+        default:
+          all:
+            ignore_case: false
+            ignore_dots: false
+            sub_addressing: false
+            sub_addressing_delim: "+"
+          gmail.com:
+            aliases:
+              - googlemail.com
+            ignore_case: true
+            ignore_dots: true
+            sub_addressing: true
+          proton.me:
+            aliases:
+              - pm.me
+              - protonmail.com
+            ignore_case: true
+            sub_addressing: true
+
+        mapping:
+          regex;(.+):
+            type: map
+            desc: |
+              Email service domain name. Note that "all" is a reserved keyword used to refer to all email service domain names.
+              Example value "gmail.com"
+            mapping:
+              aliases:
+                type: seq
+                desc: |
+                  Domain aliases used by email service.
+                sequence:
+                  - type: str
+              ignore_dots:
+                type: bool
+                default: false
+                desc: |
+                  Periods in the local-part of an email address will be ignored.
+              ignore_case:
+                type: bool
+                default: false
+                desc: |
+                  Email addresses are not case-sensitive.
+              sub_addressing:
+                type: bool
+                default: false
+                desc: |
+                  In the email address's local-part, ignore the suffix prefixed with <sub_addressing_delim>.
+              sub_addressing_delim:
+                type: str
+                default: "+"
+                desc: |
+                  The delimiter used to separate the address from the optional sub-addressing suffix.
 
       brand:
         type: str

--- a/lib/galaxy/config/schemas/tool_shed_config_schema.yml
+++ b/lib/galaxy/config/schemas/tool_shed_config_schema.yml
@@ -570,6 +570,24 @@ mapping:
           therefore, in case <email_domain_allowlist_file> is set and is not empty,
           <email_domain_blocklist_file> will be ignored.
 
+      email_ban_file:
+        type: str
+        path_resolves_to: config_dir
+        required: false
+        desc: |
+          E-mail ban file is used to specify email addresses that have been banned.
+          If a user attempts to register a new account using an email address listed in this file,
+          registration will be denied. This file does not affect user sign-in.
+
+          Email addresses are matched against a canonical address representation based on the following set of rules.
+          - Values are not case-sensitive (RickDeckard@foo.cOM == rickdeckard@foo.com)
+          - Plus suffixes in the local-part of a Gmail account are ignored (rickdeckard+anything@gmail.com == rickdeckard@gmail.com)
+          - Periods in the local_part of a Gmail account are ignored (rick.deckard@gmail.com == rickdeckard@gmail.com)
+
+          The file should include one email address per line. Lines starting with the "#" character are ignored.
+
+          Example value 'banned_emails.conf'
+
       brand:
         type: str
         required: false

--- a/lib/galaxy/security/validate_user_input.py
+++ b/lib/galaxy/security/validate_user_input.py
@@ -8,6 +8,7 @@ user inputs - so these methods do not need to be escaped.
 import logging
 import re
 from typing import (
+    Dict,
     List,
     Optional,
 )
@@ -88,7 +89,7 @@ def validate_email(trans, email, user=None, check_dup=True, allow_empty=False, v
         message = validate_email_domain_name(domain)
 
     if not message:
-        if is_email_banned(email, trans.app.config.email_ban_file):
+        if is_email_banned(email, trans.app.config.email_ban_file, trans.app.config.canonical_email_rules):
             message = "This email address has been banned."
 
     stmt = select(trans.app.model.User).filter(func.lower(trans.app.model.User.email) == email.lower()).limit(1)
@@ -175,33 +176,81 @@ def validate_preferred_object_store_id(
     return object_store.validate_selected_object_store_id(trans.user, preferred_object_store_id) or ""
 
 
-def is_email_banned(email: str, filepath: Optional[str]) -> bool:
+def is_email_banned(email: str, filepath: Optional[str], canonical_email_rules: Optional[Dict]) -> bool:
     if not filepath:
         return False
-    email = _make_canonical_email(email)
+    normalizer = EmailAddressNormalizer(canonical_email_rules)
+    email = normalizer.normalize(email)
     banned_emails = _read_email_ban_list(filepath)
     for address in banned_emails:
-        if email == _make_canonical_email(address):
+        if email == normalizer.normalize(address):
             return True
     return False
-
-
-def _make_canonical_email(email: str) -> str:
-    """
-    Transform to canonical representation:
-    - lowercase
-    - gmail: drop periods in local-part
-    - gmail: drop plus suffixes in local-part
-    """
-    email = email.lower()
-    localpart, domain = email.split("@")
-    if domain == "gmail.com":
-        localpart = localpart.replace(".", "")
-        if localpart.find("+") > -1:
-            localpart = localpart[: localpart.index("+")]
-    return f"{localpart}@{domain}"
 
 
 def _read_email_ban_list(filepath: str) -> List[str]:
     with open(filepath) as f:
         return [line.strip() for line in f if not line.startswith("#")]
+
+
+class EmailAddressNormalizer:
+    IGNORE_CASE_RULE = "ignore_case"
+    IGNORE_DOTS_RULE = "ignore_dots"
+    SUB_ADDRESSING_RULE = "sub_addressing"
+    SUB_ADDRESSING_DELIM = "sub_addressing_delim"
+    SUB_ADDRESSING_DELIM_DEFAULT = "+"
+    ALL = "all"
+
+    def __init__(self, canonical_email_rules: Optional[Dict]) -> None:
+        self.config = canonical_email_rules
+
+    def normalize(self, email: str) -> str:
+        """Transform email to its canonical form."""
+
+        email_localpart, email_domain = email.split("@")
+        # the domain part of an email address is case-insensitive (RFC1035)
+        email_domain = email_domain.lower()
+
+        # Step 1: If no rules are set, do not modify local-part
+        if not self.config:
+            return f"{email_localpart}@{email_domain}"
+
+        # Step 2: Apply rules defined for all services before applying rules defined for specific services
+        if self.ALL in self.config:
+            email_localpart = self._apply_rules(email_localpart, self.ALL)
+
+        # Step 3: Apply rules definied for each email service if email matches service
+        for service in (s for s in self.config if s != self.ALL):
+            service = service.lower()  # ensure domain is lowercase
+            apply_rules = False
+
+            if email_domain == service:
+                apply_rules = True
+            elif self.config[service].get("aliases"):
+                service_aliases = [
+                    a.lower() for a in self.config[service]["aliases"]
+                ]  # ensure domain aliases are lowercase
+                if email_domain in service_aliases:
+                    # email domain is an alias of the service. Change it to the service's primary domain name.
+                    email_domain = service
+                    apply_rules = True
+
+            if apply_rules:
+                email_localpart = self._apply_rules(email_localpart, service)
+
+        return f"{email_localpart}@{email_domain}"
+
+    def _apply_rules(self, email_localpart: str, service: str) -> str:
+        assert self.config
+        config = self.config[service]
+
+        if config.get(self.IGNORE_CASE_RULE, False):
+            email_localpart = email_localpart.lower()
+        if config.get(self.IGNORE_DOTS_RULE, False):
+            email_localpart = email_localpart.replace(".", "")
+        if config.get(self.SUB_ADDRESSING_RULE, False):
+            delim = config.get(self.SUB_ADDRESSING_DELIM, self.SUB_ADDRESSING_DELIM_DEFAULT)
+            if email_localpart.find(delim) > -1:
+                email_localpart = email_localpart[: email_localpart.index(delim)]
+
+        return email_localpart

--- a/lib/galaxy/security/validate_user_input.py
+++ b/lib/galaxy/security/validate_user_input.py
@@ -7,7 +7,10 @@ user inputs - so these methods do not need to be escaped.
 
 import logging
 import re
-from typing import Optional
+from typing import (
+    List,
+    Optional,
+)
 
 import dns.resolver
 from dns.exception import DNSException
@@ -73,7 +76,9 @@ def validate_publicname_str(publicname):
 
 def validate_email(trans, email, user=None, check_dup=True, allow_empty=False, validate_domain=False):
     """
-    Validates the email format, also checks whether the domain is blocklisted in the disposable domains configuration.
+    Validates the email format.
+    Checks whether the domain is blocklisted in the disposable domains configuration.
+    Checks whether the email address is banned.
     """
     if (user and user.email == email) or (email == "" and allow_empty):
         return ""
@@ -81,6 +86,10 @@ def validate_email(trans, email, user=None, check_dup=True, allow_empty=False, v
     if not message and validate_domain:
         domain = extract_domain(email)
         message = validate_email_domain_name(domain)
+
+    if not message:
+        if is_email_banned(email, trans.app.config.email_ban_file):
+            message = "This email address has been banned."
 
     stmt = select(trans.app.model.User).filter(func.lower(trans.app.model.User.email) == email.lower()).limit(1)
     if not message and check_dup and trans.sa_session.scalars(stmt).first():
@@ -164,3 +173,35 @@ def validate_preferred_object_store_id(
     trans, object_store: ObjectStore, preferred_object_store_id: Optional[str]
 ) -> str:
     return object_store.validate_selected_object_store_id(trans.user, preferred_object_store_id) or ""
+
+
+def is_email_banned(email: str, filepath: Optional[str]) -> bool:
+    if not filepath:
+        return False
+    email = _make_canonical_email(email)
+    banned_emails = _read_email_ban_list(filepath)
+    for address in banned_emails:
+        if email == _make_canonical_email(address):
+            return True
+    return False
+
+
+def _make_canonical_email(email: str) -> str:
+    """
+    Transform to canonical representation:
+    - lowercase
+    - gmail: drop periods in local-part
+    - gmail: drop plus suffixes in local-part
+    """
+    email = email.lower()
+    localpart, domain = email.split("@")
+    if domain == "gmail.com":
+        localpart = localpart.replace(".", "")
+        if localpart.find("+") > -1:
+            localpart = localpart[: localpart.index("+")]
+    return f"{localpart}@{domain}"
+
+
+def _read_email_ban_list(filepath: str) -> List[str]:
+    with open(filepath) as f:
+        return [line.strip() for line in f if not line.startswith("#")]

--- a/test/unit/data/security/test_validate_user_input.py
+++ b/test/unit/data/security/test_validate_user_input.py
@@ -1,5 +1,7 @@
+from galaxy.security import validate_user_input
 from galaxy.security.validate_user_input import (
     extract_domain,
+    is_email_banned,
     validate_email_domain_name,
     validate_email_str,
     validate_publicname_str,
@@ -46,3 +48,17 @@ def test_validate_email_str():
     assert validate_email_str('"i-like-to-break-email-valid@tors"@foo.com') != ""
     too_long_email = "N" * 255 + "@foo.com"
     assert validate_email_str(too_long_email) != ""
+
+
+def test_is_email_banned(monkeypatch):
+    mock_ban_list = ["ab@foo.com", "ab@gmail.com", "Not.Canonical+email+gmail+address@gmail.com"]
+    monkeypatch.setattr(validate_user_input, "_read_email_ban_list", lambda a: mock_ban_list)
+
+    assert is_email_banned("a.b@gmail.com", "_")
+    assert is_email_banned("ab@gmail.com", "_")
+    assert is_email_banned("a.b+c@gmail.com", "_")
+    assert is_email_banned("Ab@foo.com", "_")
+    assert is_email_banned("a.b.+c.d@gmail.com", "_")
+    assert is_email_banned("not.canonical@gmail.com", "_")
+    assert not is_email_banned("ab@not-gmail.com", "_")
+    assert not is_email_banned("a.b+c@not-gmail.com", "_")


### PR DESCRIPTION
Implements #19095

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. enable new config option, add a list of banned emails
  2. try to register using a banned email (for gmail, try inserting periods and using plus addressing)

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
