### PR TITLE
[24.1] Fix config template validation for file sources and object store templates 

### DIFF
--- a/lib/galaxy/util/config_templates.py
+++ b/lib/galaxy/util/config_templates.py
@@ -57,7 +57,7 @@ EnvironmentDict = Dict[str, str]
 
 
 class StrictModel(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", coerce_numbers_to_str=True)
 
 
 class BaseTemplateVariable(StrictModel):


### PR DESCRIPTION
Fixes #19078

When the user provides only numbers for a config field (defined as a string in the Pydantic model) the Jinja templating renders the value as an integer which fails the model validation. This will coerce the value to a string when the field type is declared as a string.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Follow the steps described in #19078

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
