### PR TITLE
Enable cloning subworkflows

### DIFF
--- a/client/src/components/Workflow/Editor/Node.test.ts
+++ b/client/src/components/Workflow/Editor/Node.test.ts
@@ -42,18 +42,17 @@ describe("Node", () => {
             },
         });
         await flushPromises();
+
         // fa-wrench is the tool icon ...
         expect(wrapper.findAll(".fa-wrench")).toHaveLength(1);
-        const toolLinks = wrapper.findAll("i");
-        expect(toolLinks.length).toBe(3);
         await wrapper.setProps({
             step: { label: "step label", type: "subworkflow", inputs: [], outputs: [], position: { top: 0, left: 0 } },
         });
+
         // fa-sitemap is the subworkflow icon ...
         expect(wrapper.findAll(".fa-sitemap")).toHaveLength(1);
         expect(wrapper.findAll(".fa-wrench")).toHaveLength(0);
-        const subworkflowLinks = wrapper.findAll("i");
-        expect(subworkflowLinks.length).toBe(2);
+
         const workflowTitle = wrapper.find(".node-title");
         expect(workflowTitle.text()).toBe("step label");
     });

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -25,7 +25,7 @@
             <b-button-group class="float-right">
                 <LoadingSpan v-if="isLoading" spinner-only />
                 <b-button
-                    v-if="canClone && !readonly"
+                    v-if="!readonly"
                     v-b-tooltip.hover
                     class="node-clone py-0"
                     variant="primary"
@@ -241,7 +241,6 @@ const title = computed(() => props.step.label || props.step.name);
 const idString = computed(() => `wf-node-step-${props.id}`);
 const showRule = computed(() => props.step.inputs?.length > 0 && props.step.outputs?.length > 0);
 const iconClass = computed(() => `icon fa fa-fw ${WorkflowIcons[props.step.type]}`);
-const canClone = computed(() => props.step.type !== "subworkflow"); // Why ?
 const isEnabled = getGalaxyInstance().config.enable_tool_recommendations; // getGalaxyInstance is not reactive
 
 const isActive = computed(() => props.id === props.activeNodeId);


### PR DESCRIPTION
closes #19144

Since cloning sub-workflows works fine with node selection, this should work the same.

Button is shown just like on other nodes.

![image](https://github.com/user-attachments/assets/8afc44ff-d2dd-4eb9-8d9e-e94c9326795a)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
