### PR TITLE
Allow controlling strict channel priority in mulled-build

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/invfile.lua
+++ b/lib/galaxy/tool_util/deps/mulled/invfile.lua
@@ -22,6 +22,13 @@ for i = 1, #channels do
     channel_args = channel_args .. " -c '" .. channels[i] .. "'"
 end
 
+local strict_channel_priority = VAR.STRICT_CHANNEL_PRIORITY
+if strict_channel_priority == '' then
+    strict_channel_priority = ''
+else
+    strict_channel_priority = '--strict-channel-priority'
+end
+
 local target_args = ''
 local targets = VAR.TARGETS:split(",")
 for i = 1, #targets do
@@ -90,8 +97,9 @@ inv.task('build')
         .run('/bin/sh', '-c', preinstall
             .. conda_bin .. ' install '
             .. channel_args .. ' '
+            .. strict_channel_priority .. ' '
             .. target_args
-            .. ' --strict-channel-priority -p /usr/local --copy --yes '
+            .. ' -p /usr/local --copy --yes '
             .. verbose
             .. postinstall)
     .wrap('build/dist')

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -386,10 +386,10 @@ class InvolucroContext(installable.InstallableContext):
         self.shell_exec = shell_exec or commands.shell
         self.verbose = verbose
 
-    def build_command(self, involucro_args):
+    def build_command(self, involucro_args: List[str]) -> List[str]:
         return [self.involucro_bin, f"-v={self.verbose}"] + involucro_args
 
-    def exec_command(self, involucro_args) -> int:
+    def exec_command(self, involucro_args: List[str]) -> int:
         cmd = self.build_command(involucro_args)
         # Create ./build dir manually, otherwise Docker will do it as root
         created_build_dir = False


### PR DESCRIPTION
for the creation of conda environments we try

1. strict channel priority
2. if this fails try without

see [here](https://github.com/galaxyproject/galaxy/blob/5f484fca6255fbbc8a66016601c3fcab20271c81/lib/galaxy/tool_util/deps/conda_util.py#L282).

For the creation of mulled containers we don't do this, yet. I stumbled over this a few times when creating containers for older tools, where a bioconda package was used that is now in conda-forge (and with strict priority only the newer conda-forge packages can be installed)

Also restructured slightly. Before the `build` command was appended to the `involucro_args` early. Therefore some inserts were needed in the middle of the list.

Fix verbose option which was ignored before.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. Run `mulled-build-tool build` on  https://github.com/workflow4metabolomics/wrapper-bank-massbank-spectrum_search/blob/dev_fg/massbank_ws_searchspectrum.xml

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
