### PR TITLE
[24.2] Fix Activity Bar state lost on page reload

### DIFF
--- a/client/src/composables/persistentRef.ts
+++ b/client/src/composables/persistentRef.ts
@@ -32,7 +32,7 @@ export function syncRefToLocalStorage<T>(key: string, refToSync: Ref<T>) {
         window.localStorage.setItem(key, stringified);
     };
 
-    if (stored) {
+    if (stored !== null) {
         try {
             refToSync.value = parse(stored, typeof refToSync.value as "string" | "number" | "boolean" | "object");
         } catch (e) {


### PR DESCRIPTION
fixes #19424

ref syncing did not work on empty strings, due to empty strings type casting to false

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
