### PR TITLE
[24.2] Fix job parameter summary for inputs without label

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -1084,7 +1084,11 @@ def summarize_job_parameters(trans, job: Job):
                         is_valid = False
                     if is_valid:
                         rval.append(
-                            dict(text=input.test_param.label, depth=depth, value=input.cases[current_case].value)
+                            dict(
+                                text=input.test_param.label or input.test_param.name,
+                                depth=depth,
+                                value=input.cases[current_case].value,
+                            )
                         )
                         rval.extend(
                             inputs_recursive(


### PR DESCRIPTION
`label` is not a required attribute, so if it's `None` it would fail in the pydantic model if it wasn't for the xml parser returning an empty string for all label attributes. Taking the name in the absence of a label is surely better than using an empty string as well.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
