### PR TITLE
Add IGB display support for CRAM files

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -57,6 +57,7 @@
     <datatype extension="probam" type="galaxy.datatypes.binary:ProBam" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="cram" type="galaxy.datatypes.binary:CRAM" mimetype="application/octet-stream" display_in_upload="true" description="CRAM is a file format for highly efficient and tunable reference-based compression of alignment data." description_url="http://www.ebi.ac.uk/ena/software/cram-usage">
       <converter file="cram_to_bam_converter.xml" target_datatype="bam"/>
+      <display file="igb/cram.xml"/>
     </datatype>
     <datatype extension="bed" type="galaxy.datatypes.interval:Bed" display_in_upload="true" description="BED format provides a flexible way to define the data lines that are displayed in an annotation track. BED lines have three required columns and nine additional optional columns. The three required columns are chrom, chromStart and chromEnd." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Bed">
       <converter file="bed_to_gff_converter.xml" target_datatype="gff"/>

--- a/lib/galaxy/datatypes/display_applications/configs/igb/cram.xml
+++ b/lib/galaxy/datatypes/display_applications/configs/igb/cram.xml
@@ -1,0 +1,13 @@
+<display id="igb_cram" version="0.0.0" name="display in IGB">
+    <link id="View" name="View">
+        <url>http://bioviz.org/galaxy.html?version=${cram_file.dbkey}&amp;feature_url_0=${cram_file.url}&amp;sym_name_0=${niceName}&amp;sym_method_0=${cram_file.url}&amp;query_url=${cram_file.url}&amp;server_url=galaxy</url>
+        <param type="data" name="cram_file_for_name" viewable="False"/>
+        <param type="template" name="niceName" viewable="False" strip="True">
+            #import re
+            #set nm=$cram_file_for_name.name
+            ${re.sub('\W',"_",nm)}
+        </param>
+        <param type="data" name="crai_file" url="${niceName}.cram.crai" metadata="cram_index" />
+        <param type="data" name="cram_file" url="${niceName}.cram" />
+    </link>
+</display>


### PR DESCRIPTION
Added a new XML definition file for the CRAM file format and edited the datatypes configuration file accordingly. This enables IGB to appear as a display option when the Visualize icon is selected for CRAM datasets in Galaxy History's.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
