### PR TITLE
Handles S3 listing errors

### DIFF
--- a/lib/galaxy/files/sources/s3fs.py
+++ b/lib/galaxy/files/sources/s3fs.py
@@ -13,6 +13,7 @@ from typing_extensions import (
     Unpack,
 )
 
+from galaxy import exceptions
 from galaxy.files import OptionalUserContext
 from . import (
     AnyRemoteEntry,
@@ -93,7 +94,10 @@ class S3FsFilesSource(BaseFilesSource):
             return res, len(res)
         else:
             bucket_path = self._bucket_path(_bucket_name, path)
-            res = fs.ls(bucket_path, detail=True)
+            try:
+                res = fs.ls(bucket_path, detail=True)
+            except Exception as e:
+                raise exceptions.MessageException(f"Error listing {bucket_path}: {e}")
             to_dict = functools.partial(self._resource_info_to_dict, path)
             return list(map(to_dict, res)), len(res)
 


### PR DESCRIPTION
Closes #19445
Adds exception handling for S3 bucket listing to provide clearer error messages when listing fails.
![image](https://github.com/user-attachments/assets/09406e14-e6ea-4695-b769-a284042fafe1)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open a object store which has an invalid key

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
