### PR TITLE
Improve asynchronous tasks error handling and reporting

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -4259,6 +4259,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/tasks/{task_id}/result": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get result message for task ID
+         * @description If the task is still running, pending, or is waiting for retry then the result is an empty string.
+         *     If the task failed, the result is an error message.
+         */
+        get: operations["get_result_api_tasks__task_id__result_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/tasks/{task_id}/state": {
         parameters: {
             query?: never;
@@ -16588,6 +16609,12 @@ export interface components {
             | "Page"
             | "StoredWorkflow"
             | "Visualization";
+        /** TaskResult */
+        TaskResult: {
+            /** Result */
+            result: string;
+            state: components["schemas"]["TaskState"];
+        };
         /**
          * TaskState
          * @description Enum representing the possible states of a task.
@@ -32283,6 +32310,46 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    get_result_api_tasks__task_id__result_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskResult"];
+                };
             };
             /** @description Request Error */
             "4XX": {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -16609,10 +16609,20 @@ export interface components {
             | "Page"
             | "StoredWorkflow"
             | "Visualization";
-        /** TaskResult */
+        /**
+         * TaskResult
+         * @description Contains information about the result of an asynchronous task.
+         */
         TaskResult: {
-            /** Result */
+            /**
+             * Result
+             * @description The result message of the task. Empty if the task is still running. If the task failed, this will contain the exception message.
+             */
             result: string;
+            /**
+             * State
+             * @description The current state of the task.
+             */
             state: components["schemas"]["TaskState"];
         };
         /**

--- a/client/src/components/Common/PersistentTaskProgressMonitorAlert.test.ts
+++ b/client/src/components/Common/PersistentTaskProgressMonitorAlert.test.ts
@@ -31,6 +31,7 @@ const FAKE_MONITOR: TaskMonitor = {
     isRunning: ref(false),
     isCompleted: ref(false),
     hasFailed: ref(false),
+    failureReason: ref(""),
     requestHasFailed: ref(false),
     taskStatus: ref(""),
     expirationTime: FAKE_EXPIRATION_TIME,

--- a/client/src/components/Common/PersistentTaskProgressMonitorAlert.vue
+++ b/client/src/components/Common/PersistentTaskProgressMonitorAlert.vue
@@ -58,7 +58,6 @@ const {
     failureReason,
     requestHasFailed,
     storedTaskId,
-    status,
     hasExpired,
     expirationDate,
     monitoringData,

--- a/client/src/components/Common/PersistentTaskProgressMonitorAlert.vue
+++ b/client/src/components/Common/PersistentTaskProgressMonitorAlert.vue
@@ -55,6 +55,7 @@ const {
     isRunning,
     isCompleted,
     hasFailed,
+    failureReason,
     requestHasFailed,
     storedTaskId,
     status,
@@ -142,8 +143,8 @@ function dismissAlert() {
         </BAlert>
         <BAlert v-else-if="hasFailed" variant="danger" show dismissible @dismissed="dismissAlert">
             <span>{{ failedMessage }}</span>
-            <span v-if="status">
-                Reason: <b>{{ status }}</b>
+            <span v-if="failureReason">
+                Reason: <b>{{ failureReason }}</b>
             </span>
         </BAlert>
         <BAlert v-else-if="requestHasFailed" variant="danger" show dismissible @dismissed="dismissAlert">

--- a/client/src/composables/genericTaskMonitor.ts
+++ b/client/src/composables/genericTaskMonitor.ts
@@ -5,6 +5,22 @@ import { errorMessageAsString } from "@/utils/simple-error";
 const DEFAULT_POLL_DELAY = 10000;
 
 /**
+ * Represents the data that can be stored and restored to monitor the status of a task.
+ */
+export interface StoredTaskStatus {
+    /**
+     * The status of the task when it was last checked.
+     * The meaning of the status string is up to the monitor implementation.
+     */
+    taskStatus?: string;
+
+    /**
+     * The reason why the task has failed in case of an error.
+     */
+    failureReason?: string;
+}
+
+/**
  * Represents a task monitor that can be used to wait for a background task to complete or
  * check its status.
  */
@@ -50,9 +66,9 @@ export interface TaskMonitor {
 
     /**
      * Loads the status of the task from a stored value.
-     * @param storedStatus The status string to load.
+     * @param persistedTaskStatus The stored state of the task.
      */
-    loadStatus: (storedStatus: string) => void;
+    loadStatus: (persistedTaskStatus: StoredTaskStatus) => void;
 
     /**
      * Determines if the status represents a final state.
@@ -115,8 +131,9 @@ export function useGenericMonitor(options: {
         return options.completedCondition(status) || options.failedCondition(status);
     }
 
-    function loadStatus(storedStatus: string) {
-        taskStatus.value = storedStatus;
+    function loadStatus(persistedTaskStatus: StoredTaskStatus) {
+        taskStatus.value = persistedTaskStatus.taskStatus;
+        failureReason.value = persistedTaskStatus.failureReason;
     }
 
     async function waitForTask(taskId: string, pollDelayInMs?: number) {

--- a/client/src/composables/genericTaskMonitor.ts
+++ b/client/src/composables/genericTaskMonitor.ts
@@ -33,6 +33,11 @@ export interface TaskMonitor {
     hasFailed: Readonly<Ref<boolean>>;
 
     /**
+     * The reason why the task has failed.
+     */
+    failureReason: Readonly<Ref<string | undefined>>;
+
+    /**
      * If true, the status of the task cannot be determined because of a request error.
      */
     requestHasFailed: Readonly<Ref<boolean>>;
@@ -40,7 +45,6 @@ export interface TaskMonitor {
     /**
      * The current status of the task.
      * The meaning of the status string is up to the monitor implementation.
-     * In case of an error, this will be the error message.
      */
     taskStatus: Readonly<Ref<string | undefined>>;
 
@@ -80,6 +84,9 @@ export function useGenericMonitor(options: {
     /** Function to determine if the task has failed. */
     failedCondition: (status?: string) => boolean;
 
+    /** Function to retrieve the error message when the task has failed. */
+    fetchFailureReason: (taskId: string) => Promise<string>;
+
     /** Default delay between polling requests in milliseconds.
      * By default, this is set to 10 seconds.
      * The delay can be overridden when calling `waitForTask`.
@@ -99,6 +106,7 @@ export function useGenericMonitor(options: {
     const taskStatus = ref<string>();
     const requestId = ref<string>();
     const requestHasFailed = ref(false);
+    const failureReason = ref<string>();
 
     const isCompleted = computed(() => options.completedCondition(taskStatus.value));
     const hasFailed = computed(() => options.failedCondition(taskStatus.value));
@@ -125,6 +133,10 @@ export function useGenericMonitor(options: {
             taskStatus.value = result;
             if (isCompleted.value || hasFailed.value) {
                 isRunning.value = false;
+                if (hasFailed.value) {
+                    const errorMessage = await options.fetchFailureReason(taskId);
+                    failureReason.value = errorMessage;
+                }
             } else {
                 pollAfterDelay(taskId);
             }
@@ -168,6 +180,7 @@ export function useGenericMonitor(options: {
         isRunning: readonly(isRunning),
         isCompleted: readonly(isCompleted),
         hasFailed: readonly(hasFailed),
+        failureReason: readonly(failureReason),
         requestHasFailed: readonly(requestHasFailed),
         taskStatus: readonly(taskStatus),
         expirationTime: options.expirationTime,

--- a/client/src/composables/persistentProgressMonitor.test.ts
+++ b/client/src/composables/persistentProgressMonitor.test.ts
@@ -29,6 +29,7 @@ function useMonitorMock(): TaskMonitor {
         isRunning,
         isCompleted: ref(false),
         hasFailed: ref(false),
+        failureReason: ref(),
         requestHasFailed: ref(false),
         taskStatus,
         expirationTime: 1000,

--- a/client/src/composables/persistentProgressMonitor.ts
+++ b/client/src/composables/persistentProgressMonitor.ts
@@ -96,7 +96,6 @@ export interface MonitoringData {
     /**
      * The status of the task when it was last checked.
      * The meaning of the status string is up to the monitor implementation.
-     * In case of an error, this will be the error message.
      */
     taskStatus?: string;
 }
@@ -119,6 +118,7 @@ export function usePersistentProgressTaskMonitor(
         isRunning,
         isCompleted,
         hasFailed,
+        failureReason,
         requestHasFailed,
         taskStatus,
         expirationTime,
@@ -221,6 +221,11 @@ export function usePersistentProgressTaskMonitor(
         hasFailed,
 
         /**
+         * The reason why the task has failed.
+         */
+        failureReason,
+
+        /**
          * If true, the status of the task cannot be determined because of a request error.
          */
         requestHasFailed,
@@ -238,7 +243,6 @@ export function usePersistentProgressTaskMonitor(
         /**
          * The current status of the task.
          * The meaning of the status string is up to the monitor implementation.
-         * In case of an error, this will be the error message.
          */
         status: taskStatus,
 

--- a/client/src/composables/shortTermStorageMonitor.test.ts
+++ b/client/src/composables/shortTermStorageMonitor.test.ts
@@ -4,6 +4,8 @@ import { suppressDebugConsole } from "tests/jest/helpers";
 import { useServerMock } from "@/api/client/__mocks__";
 import { useShortTermStorageMonitor } from "@/composables/shortTermStorageMonitor";
 
+import type { StoredTaskStatus } from "./genericTaskMonitor";
+
 const PENDING_TASK_ID = "pending-fake-task-id";
 const COMPLETED_TASK_ID = "completed-fake-task-id";
 const REQUEST_FAILED_TASK_ID = "request-failed-fake-task-id";
@@ -67,11 +69,14 @@ describe("useShortTermStorageMonitor", () => {
 
     it("should load the status from the stored monitoring data", async () => {
         const { loadStatus, isRunning, isCompleted, hasFailed, taskStatus } = useShortTermStorageMonitor();
-        const storedStatus = "READY";
+        const expectedStatus = "READY";
+        const storedStatus: StoredTaskStatus = {
+            taskStatus: expectedStatus,
+        };
 
         loadStatus(storedStatus);
 
-        expect(taskStatus.value).toBe(storedStatus);
+        expect(taskStatus.value).toBe(expectedStatus);
         expect(isRunning.value).toBe(false);
         expect(isCompleted.value).toBe(true);
         expect(hasFailed.value).toBe(false);

--- a/client/src/composables/shortTermStorageMonitor.ts
+++ b/client/src/composables/shortTermStorageMonitor.ts
@@ -30,6 +30,7 @@ export function useShortTermStorageMonitor() {
         fetchStatus,
         completedCondition: (status?: string) => status === READY_STATE,
         failedCondition: (status?: string) => typeof status === "string" && !VALID_STATES.includes(status),
+        fetchFailureReason: fetchStatus, // The error message is the status itself for short-term storage requests
         defaultPollDelay: DEFAULT_POLL_DELAY,
         expirationTime: DEFAULT_EXPIRATION_TIME,
     });

--- a/client/src/composables/taskMonitor.test.ts
+++ b/client/src/composables/taskMonitor.test.ts
@@ -77,7 +77,7 @@ describe("useTaskMonitor", () => {
     });
 
     it("should indicate the task has failed when the state is FAILED", async () => {
-        const { waitForTask, isRunning, hasFailed, taskStatus } = useTaskMonitor();
+        const { waitForTask, isRunning, hasFailed, taskStatus, failureReason } = useTaskMonitor();
 
         expect(hasFailed.value).toBe(false);
         waitForTask(FAILED_TASK_ID);
@@ -85,6 +85,7 @@ describe("useTaskMonitor", () => {
         expect(hasFailed.value).toBe(true);
         expect(isRunning.value).toBe(false);
         expect(taskStatus.value).toBe("FAILURE");
+        expect(failureReason.value).toBe("The failure reason");
     });
 
     it("should indicate the task status request failed when the request failed", async () => {
@@ -118,7 +119,7 @@ describe("useTaskMonitor", () => {
     it("should load the status from the stored monitoring data with failure reason", async () => {
         const { loadStatus, isRunning, isCompleted, hasFailed, taskStatus, failureReason } = useTaskMonitor();
         const expectedStatus = "FAILURE";
-        const expectedFailureReason = "The failure reason";
+        const expectedFailureReason = "The stored failure reason";
         const storedStatus: StoredTaskStatus = {
             taskStatus: expectedStatus,
             failureReason: expectedFailureReason,

--- a/client/src/composables/taskMonitor.ts
+++ b/client/src/composables/taskMonitor.ts
@@ -23,10 +23,23 @@ export function useTaskMonitor() {
 
         return data;
     };
+
+    const fetchFailureReason = async (taskId: string) => {
+        const { data, error } = await GalaxyApi().GET("/api/tasks/{task_id}/result", {
+            params: { path: { task_id: taskId } },
+        });
+
+        if (error) {
+            rethrowSimple(error);
+        }
+
+        return data.result;
+    };
     return useGenericMonitor({
         fetchStatus,
         completedCondition: (status?: string) => status === SUCCESS_STATE,
         failedCondition: (status?: string) => status === FAILURE_STATE,
+        fetchFailureReason,
         defaultPollDelay: DEFAULT_POLL_DELAY,
         expirationTime: DEFAULT_EXPIRATION_TIME,
     });

--- a/lib/galaxy/managers/tasks.py
+++ b/lib/galaxy/managers/tasks.py
@@ -2,35 +2,14 @@ from abc import (
     ABCMeta,
     abstractmethod,
 )
-from enum import Enum
 from uuid import UUID
 
 from celery.result import AsyncResult
-from pydantic import BaseModel
 
-
-class TaskState(str, Enum):
-    """Enum representing the possible states of a task."""
-
-    PENDING = "PENDING"
-    """The task is waiting for execution."""
-
-    STARTED = "STARTED"
-    """The task has been started."""
-
-    RETRY = "RETRY"
-    """The task is to be retried, possibly because of failure."""
-
-    FAILURE = "FAILURE"
-    """The task raised an exception, or has exceeded the retry limit."""
-
-    SUCCESS = "SUCCESS"
-    """The task executed successfully."""
-
-
-class TaskResult(BaseModel):
-    state: TaskState
-    result: str
+from galaxy.schema.tasks import (
+    TaskResult,
+    TaskState,
+)
 
 
 class AsyncTasksManager(metaclass=ABCMeta):

--- a/lib/galaxy/schema/tasks.py
+++ b/lib/galaxy/schema/tasks.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import (
     List,
     Optional,
@@ -119,3 +120,35 @@ class ComputeDatasetHashTaskRequest(Model):
 
 class PurgeDatasetsTaskRequest(Model):
     dataset_ids: List[int]
+
+
+class TaskState(str, Enum):
+    """Enum representing the possible states of a task."""
+
+    PENDING = "PENDING"
+    """The task is waiting for execution."""
+
+    STARTED = "STARTED"
+    """The task has been started."""
+
+    RETRY = "RETRY"
+    """The task is to be retried, possibly because of failure."""
+
+    FAILURE = "FAILURE"
+    """The task raised an exception, or has exceeded the retry limit."""
+
+    SUCCESS = "SUCCESS"
+    """The task executed successfully."""
+
+
+class TaskResult(Model):
+    """Contains information about the result of an asynchronous task."""
+
+    state: TaskState = Field(
+        title="State",
+        description="The current state of the task.",
+    )
+    result: str = Field(
+        title="Result",
+        description="The result message of the task. Empty if the task is still running. If the task failed, this will contain the exception message.",
+    )

--- a/lib/galaxy/webapps/galaxy/api/tasks.py
+++ b/lib/galaxy/webapps/galaxy/api/tasks.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from galaxy.managers.tasks import (
     AsyncTasksManager,
+    TaskResult,
     TaskState,
 )
 from . import (
@@ -31,3 +32,15 @@ class FastAPITasks:
     )
     def state(self, task_id: UUID) -> TaskState:
         return self.manager.get_state(task_id)
+
+    @router.get(
+        "/api/tasks/{task_id}/result",
+        public=True,
+        summary="Get result message for task ID",
+    )
+    def get_result(self, task_id: UUID) -> TaskResult:
+        """
+        If the task is still running, pending, or is waiting for retry then the result is an empty string.
+        If the task failed, the result is an error message.
+        """
+        return self.manager.get_result(task_id)

--- a/lib/galaxy/webapps/galaxy/api/tasks.py
+++ b/lib/galaxy/webapps/galaxy/api/tasks.py
@@ -5,8 +5,8 @@ API Controller providing experimental access to Celery Task State.
 import logging
 from uuid import UUID
 
-from galaxy.managers.tasks import (
-    AsyncTasksManager,
+from galaxy.managers.tasks import AsyncTasksManager
+from galaxy.schema.tasks import (
     TaskResult,
     TaskState,
 )


### PR DESCRIPTION
Closes #19419

When a Celery task failed, there was no way of getting the error message to the user to inform them exactly what the failure was.

This PR adds a new endpoint GET `/api/tasks/{task_id}/result` that will return the status and the final result message. In case of failures, the result message will contain the error message.

The rest of the changes adapt the task monitoring and persistence composables in the client code to display and store the error message accordingly.

## Before
![image](https://github.com/user-attachments/assets/7d141bfc-7520-4f7d-ad61-2eb4664eca44)

## After
![Screenshot from 2025-01-23 10-56-20](https://github.com/user-attachments/assets/6d58d530-5ebc-4538-a3b3-868126c9fb93)


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Follow the steps in #19419

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
