### PR TITLE
Reset invocation export wizard after completion

### DIFF
--- a/client/src/components/Workflow/Invocation/Export/InvocationExportWizard.vue
+++ b/client/src/components/Workflow/Invocation/Export/InvocationExportWizard.vue
@@ -178,6 +178,15 @@ watch(
     }
 );
 
+watch(
+    () => isWizardBusy.value,
+    (newValue, oldValue) => {
+        if (oldValue && !newValue) {
+            resetWizard();
+        }
+    }
+);
+
 function onRecordSelected(recordUri: string) {
     exportData.remoteUri = recordUri;
 }
@@ -304,6 +313,12 @@ function initializeExportData(): InvocationExportData {
             authorization: "",
         },
     };
+}
+
+function resetWizard() {
+    const initialExportData = initializeExportData();
+    Object.assign(exportData, initialExportData);
+    wizard.goTo("select-format");
 }
 </script>
 

--- a/client/src/components/Workflow/Invocation/Export/InvocationExportWizard.vue
+++ b/client/src/components/Workflow/Invocation/Export/InvocationExportWizard.vue
@@ -66,19 +66,7 @@ const errorMessage = ref<string>();
 
 const existingProgress = ref<InstanceType<typeof ExistingInvocationExportProgressCard>>();
 
-const exportData: InvocationExportData = reactive({
-    exportPluginFormat: "ro-crate",
-    destination: "download",
-    remoteUri: "",
-    outputFileName: "",
-    includeData: true,
-    bcoDatabase: {
-        serverBaseUrl: "https://biocomputeobject.org",
-        table: "GALXY",
-        ownerGroup: "",
-        authorization: "",
-    },
-});
+const exportData: InvocationExportData = reactive(initializeExportData());
 
 const exportButtonLabel = computed(() => {
     switch (exportData.destination) {
@@ -300,6 +288,22 @@ Examples of RDM repositories include [Zenodo](https://zenodo.org/), [Invenio RDM
     }
 
     return destinations;
+}
+
+function initializeExportData(): InvocationExportData {
+    return {
+        exportPluginFormat: "ro-crate",
+        destination: "download",
+        remoteUri: "",
+        outputFileName: "",
+        includeData: true,
+        bcoDatabase: {
+            serverBaseUrl: "https://biocomputeobject.org",
+            table: "GALXY",
+            ownerGroup: "",
+            authorization: "",
+        },
+    };
 }
 </script>
 


### PR DESCRIPTION
Addresses #19419 comment:
> after a successful export, the wizard window will hide and I only get the "all is good" message

Instead of hiding the wizard, I decided to reset the wizard so it is ready for another potential export to a different destination, or whatever the user wants. This is the default behavior if the user leaves the page and returns anyway, so it seems a bit more consistent.

Thanks @martenson for the feedback!

https://github.com/user-attachments/assets/22a1e94d-0a44-43b4-bd5c-7a6298aee2fa

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Follow the steps in #19419 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
