### PR TITLE
[24.2] `mulled-build-tool` fix for packages wo version

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/mulled_build_tool.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build_tool.py
@@ -52,7 +52,7 @@ def requirements_to_mulled_targets(requirements) -> List["CondaTarget"]:
     Only package requirements are retained.
     """
     package_requirements = [r for r in requirements if r.type == "package"]
-    target_str = ",".join([f"{r.name}={r.version}" for r in package_requirements])
+    target_str = ",".join([f"{r.name}={r.version}" if r.version else r.name for r in package_requirements])
     targets = target_str_to_targets(target_str)
     return targets
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build_tool.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build_tool.py
@@ -52,7 +52,7 @@ def requirements_to_mulled_targets(requirements) -> List["CondaTarget"]:
     Only package requirements are retained.
     """
     package_requirements = [r for r in requirements if r.type == "package"]
-    target_str = ",".join([f"{r.name}={r.version}" if r.version else r.name for r in package_requirements])
+    target_str = ",".join(f"{r.name}={r.version}" if r.version else r.name for r in package_requirements)
     targets = target_str_to_targets(target_str)
     return targets
 


### PR DESCRIPTION
for tools with requirements without version this resulted in a conda install with requirement=None in the package specs which does not work

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
