### PR TITLE
Add test that verifies workflow source_metadata is preserved on landing claim

### DIFF
--- a/lib/galaxy_test/api/test_landing.py
+++ b/lib/galaxy_test/api/test_landing.py
@@ -106,6 +106,20 @@ class TestLandingApi(ApiTestCase):
         _cannot_claim_request(self.dataset_populator, response)
         _cannot_use_request(self.dataset_populator, response)
 
+    def test_landing_claim_preserves_source_metadata(self):
+        request = CreateWorkflowLandingRequestPayload(
+            workflow_id="https://dockstore.org/api/ga4gh/trs/v2/tools/#workflow/github.com/iwc-workflows/chipseq-pe/main/versions/v0.12",
+            workflow_target_type="trs_url",
+            request_state={},
+            public=True,
+        )
+        response = self.dataset_populator.create_workflow_landing(request)
+        landing_request = self.dataset_populator.use_workflow_landing(response.uuid)
+        workflow_id = landing_request.workflow_id
+        workflow = self.workflow_populator._get(f"/api/workflows/{workflow_id}?instance=true").json()
+        assert workflow["source_metadata"]["trs_tool_id"] == "#workflow/github.com/iwc-workflows/chipseq-pe/main"
+        assert workflow["source_metadata"]["trs_version_id"] == "v0.12"
+
 
 def _workflow_request_state() -> Dict[str, Any]:
     deferred = False


### PR DESCRIPTION
This was kind of missing from https://github.com/galaxyproject/galaxy/pull/19070. It all works though, so just targeting dev here.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
