### PR TITLE
[24.2] List private file sources first in Remote Files Dialog

### DIFF
--- a/client/src/components/FilesDialog/FilesDialog.test.ts
+++ b/client/src/components/FilesDialog/FilesDialog.test.ts
@@ -130,6 +130,14 @@ describe("FilesDialog, file mode", () => {
         expect(utils.getRenderedRows().length).toBe(pdbResponse.length);
     });
 
+    it("should list the user defined file sources first", async () => {
+        await utils.openRoot();
+        const rows = utils.getRenderedRows();
+        const firstItem = rows[0];
+        expect(firstItem).toBeDefined();
+        expect(firstItem!.url).toContain("gxuserfiles://");
+    });
+
     it("should allow selecting files and update OK button accordingly", async () => {
         await utils.openRootDirectory();
         const filesInResponse = pdbResponse.filter((item) => item.class === "File");
@@ -291,9 +299,13 @@ class Utils {
         this.wrapper = wrapper;
     }
 
-    async openRootDirectory() {
+    async openRoot() {
         expect(this.wrapper.findComponent(SelectionDialog).exists()).toBe(true);
         expect(this.getRenderedRows().length).toBe(rootResponse.length);
+    }
+
+    async openRootDirectory() {
+        await this.openRoot();
         await this.openDirectoryById(rootId);
     }
 

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -21,6 +21,7 @@ import {
 import { useConfig } from "@/composables/config";
 import { useFileSources } from "@/composables/fileSources";
 import { errorMessageAsString } from "@/utils/simple-error";
+import { USER_FILE_PREFIX } from "@/utils/upload-payload";
 
 import { Model } from "./model";
 
@@ -249,7 +250,9 @@ function load(record?: SelectionItem) {
                 const convertedItems = results
                     .filter((item) => !props.requireWritable || item.writable)
                     .map(fileSourcePluginToItem);
-                items.value = convertedItems;
+
+                const sortedItems = convertedItems.sort(sortPrivateFileSourcesFirst);
+                items.value = sortedItems;
                 formatRows();
                 optionsShow.value = true;
                 showTime.value = false;
@@ -293,6 +296,20 @@ function load(record?: SelectionItem) {
                 errorMessage.value = errorMessageAsString(error);
             });
     }
+}
+
+function isPrivateFileSource(item: SelectionItem): boolean {
+    return item.url.startsWith(USER_FILE_PREFIX);
+}
+
+function sortPrivateFileSourcesFirst(a: SelectionItem, b: SelectionItem): number {
+    if (isPrivateFileSource(a) && !isPrivateFileSource(b)) {
+        return -1;
+    }
+    if (!isPrivateFileSource(a) && isPrivateFileSource(b)) {
+        return 1;
+    }
+    return 0;
 }
 
 /**

--- a/client/src/components/FilesDialog/testingData.ts
+++ b/client/src/components/FilesDialog/testingData.ts
@@ -69,6 +69,20 @@ export const rootResponse: BrowsableFilesSourcePlugin[] = [
             sorting: false,
         },
     },
+    {
+        id: "c5504eb8-51cf-4b44-88f8-24347c031f52",
+        type: "ftp",
+        label: "My own FTP",
+        doc: "This FTP is accessible only by me",
+        browsable: true,
+        writable: true,
+        supports: {
+            pagination: true,
+            search: true,
+            sorting: false,
+        },
+        uri_root: "gxuserfiles://c5504eb8-51cf-4b44-88f8-24347c031f52",
+    },
 ];
 
 export const pdbResponse: RemoteFilesList = [

--- a/client/src/utils/upload-payload.js
+++ b/client/src/utils/upload-payload.js
@@ -1,4 +1,5 @@
 export const DEFAULT_FILE_NAME = "New File";
+export const USER_FILE_PREFIX = "gxuserfiles://";
 export const URI_PREFIXES = [
     "http://",
     "https://",
@@ -7,7 +8,7 @@ export const URI_PREFIXES = [
     "gxfiles://",
     "gximport://",
     "gxuserimport://",
-    "gxuserfiles://",
+    USER_FILE_PREFIX,
     "gxftp://",
     "drs://",
     "invenio://",


### PR DESCRIPTION
Addresses #19438

The simplest way of addressing this is to list the user-defined sources at the top. We can think of more fancy ways to display this after consolidating these dialogs with Data Libraries, etc.

![image](https://github.com/user-attachments/assets/cb927ed3-b567-4ab4-8a92-f9c1462ec708)

![image](https://github.com/user-attachments/assets/6a7998aa-5017-4f49-8277-b4c762004d5b)


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
