### PR TITLE
[24.2] Also check `trs_tool_id` for imported workflow indicator

### DIFF
--- a/client/src/components/Workflow/List/WorkflowIndicators.vue
+++ b/client/src/components/Workflow/List/WorkflowIndicators.vue
@@ -51,10 +51,12 @@ const shared = computed(() => {
 });
 
 const sourceType = computed(() => {
-    if (props.workflow.source_metadata?.url) {
+    const { url, trs_server, trs_tool_id } = props.workflow.source_metadata || {};
+    const trs = trs_server || trs_tool_id;
+    if (url) {
         return "url";
-    } else if (props.workflow.source_metadata?.trs_server) {
-        return `trs_${props.workflow.source_metadata?.trs_server}`;
+    } else if (trs) {
+        return `trs_${trs}`;
     } else {
         return "";
     }


### PR DESCRIPTION
We wouldn't show the following indicator for an imported workflow if it did not have `trs_server` but still had `trs_tool_id` in its `source_metadata`:

![image](https://github.com/user-attachments/assets/83e97aaf-0ef9-4fb8-85af-2e3bbe0dcf29)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
