### PR TITLE
[24.2] Fix help text overflow breaking tool inspector

### DIFF
--- a/client/src/components/Common/IdleLoad.vue
+++ b/client/src/components/Common/IdleLoad.vue
@@ -24,7 +24,7 @@ onMounted(() => {
 </script>
 
 <template>
-    <div class="idle-load" :class="{ center: props.center }">
+    <div class="idle-load" :class="{ center: props.center && !render }">
         <slot v-if="render"></slot>
         <BSpinner v-else-if="props.spinner"></BSpinner>
     </div>


### PR DESCRIPTION
fix #19463

the issue was a unwanted `display: grid` breaking the propagation of the width, which in turn didn't allow `pre` elements in help texts to overflow, causing a utility component to overflow instead.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
