### PR TITLE
[24.2] Fix object not found handling

### DIFF
--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -1074,10 +1074,10 @@ class DiskObjectStore(ConcreteObjectStore):
 
     def _delete(self, obj, entire_dir: bool = False, **kwargs) -> bool:
         """Override `ObjectStore`'s stub; delete the file or folder on disk."""
+        path = self._get_filename(obj, **kwargs)
+        extra_dir = kwargs.get("extra_dir", None)
+        obj_dir = kwargs.get("obj_dir", False)
         try:
-            path = self._get_filename(obj, **kwargs)
-            extra_dir = kwargs.get("extra_dir", None)
-            obj_dir = kwargs.get("obj_dir", False)
             if entire_dir and (extra_dir or obj_dir):
                 shutil.rmtree(path)
                 return True
@@ -1120,7 +1120,7 @@ class DiskObjectStore(ConcreteObjectStore):
                 return path
         path = self._construct_path(obj, **kwargs)
         if not os.path.exists(path):
-            raise FileNotFoundError
+            raise ObjectNotFound
         return path
 
     def _update_from_file(


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/19467, broken in
https://github.com/galaxyproject/galaxy/commit/52887744c2418caeab8858a2e487d805dbbeb31f. I assume this was faulty merge
and not an intentional change. Restores the 24.1 version.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
