### PR TITLE
[24.1] Paginate tabular datasets in tables to load invocation reports quicker

### DIFF
--- a/client/src/components/Markdown/Elements/HistoryDatasetDisplay.test.js
+++ b/client/src/components/Markdown/Elements/HistoryDatasetDisplay.test.js
@@ -1,15 +1,26 @@
+import { createTestingPinia } from "@pinia/testing";
 import { mount } from "@vue/test-utils";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
-import { typesAndMappingResponse } from "components/Datatypes/test_fixtures";
 import { getLocalVue } from "tests/jest/helpers";
+
+import { testDatatypesMapper } from "@/components/Datatypes/test_fixtures";
+import { useDatatypesMapperStore } from "@/stores/datatypesMapperStore";
 
 import HistoryDatasetDisplay from "./HistoryDatasetDisplay.vue";
 
 const localVue = getLocalVue();
 
 const args = { history_dataset_id: "someId" };
-const api_paths_map = new Map([["/api/datatypes/types_and_mapping", typesAndMappingResponse]]);
+
+function setUpDatatypesStore() {
+    const pinia = createTestingPinia({ stubActions: false });
+
+    const datatypesStore = useDatatypesMapperStore();
+    datatypesStore.datatypesMapper = testDatatypesMapper;
+
+    return pinia;
+}
 
 describe("History Tabular Dataset Display", () => {
     let wrapper;
@@ -23,15 +34,14 @@ describe("History Tabular Dataset Display", () => {
 
     beforeEach(async () => {
         axiosMock = new MockAdapter(axios);
-
-        for (const [path, response] of api_paths_map.entries()) {
-            axiosMock.onGet(path).reply(200, response);
-        }
-
         axiosMock.onGet(`/api/datasets/${args.history_dataset_id}`).reply(200, tabularMetaData);
         axiosMock.onGet(`/api/datasets/${args.history_dataset_id}/get_content_as_text`).reply(200, tabular);
 
-        wrapper = mount(HistoryDatasetDisplay, { localVue, propsData: { datasets: tabularDatasets, args } });
+        wrapper = mount(HistoryDatasetDisplay, {
+            localVue,
+            propsData: { datasets: tabularDatasets, args },
+            pinia: setUpDatatypesStore(),
+        });
     });
 
     afterEach(() => {
@@ -55,13 +65,13 @@ describe("History Text Dataset Display", () => {
     beforeEach(async () => {
         axiosMock = new MockAdapter(axios);
 
-        for (const [path, response] of api_paths_map.entries()) {
-            axiosMock.onGet(path).reply(200, response);
-        }
-
         axiosMock.onGet(`/api/datasets/${args.history_dataset_id}/get_content_as_text`).reply(200, text);
 
-        wrapper = mount(HistoryDatasetDisplay, { localVue, propsData: { datasets: textDatasets, args } });
+        wrapper = mount(HistoryDatasetDisplay, {
+            localVue,
+            propsData: { datasets: textDatasets, args },
+            pinia: setUpDatatypesStore(),
+        });
     });
 
     afterEach(() => {

--- a/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
@@ -84,12 +84,12 @@
                                         hover
                                         :per-page="perPage"
                                         :current-page="currentPage"
-                                        :fields="Object.freeze(getFields(metaData))"
-                                        :items="Object.freeze(getItems(itemContent.item_data, metaData))" />
+                                        :fields="getFields(metaData)"
+                                        :items="getItems(itemContent.item_data, metaData)" />
                                     <b-pagination
                                         v-model="currentPage"
                                         align="center"
-                                        :total-rows="Object.freeze(getItems(itemContent.item_data, metaData)).length"
+                                        :total-rows="getItems(itemContent.item_data, metaData).length"
                                         :per-page="perPage"
                                         aria-controls="tabular-dataset-table" />
                                 </div>

--- a/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
@@ -141,7 +141,7 @@ export default {
         return {
             currentPage: 1,
             expanded: false,
-            perPage: 200,
+            perPage: 100,
         };
     },
     computed: {


### PR DESCRIPTION
Tries to improve performance of invocations reports as reported in https://github.com/galaxyproject/galaxy/issues/19439

The `b-table` was crashing the browser tab for tabular datasets with many rows. Using `b-pagination` here to fix that. We were also making a call to fetch datatypes for each dataset in the invocation report. Now we use the store.
Viewing reports is faster now.

https://github.com/user-attachments/assets/d7c18884-6e4c-4cd0-b20e-d28e7c6a18ab

@guerler 's upcoming work on reports in [Overhaul Workflow Reports and Pages #19452](https://github.com/galaxyproject/galaxy/issues/19452) could refactor this so that the `useDatatypesMapper` composable is called from within the `HistoryDatasetDetails` instead of using the store like I did here?

Note: _Targeting 24.1 because the invocation view was introduced then and users clicking on reports can get their whole tab frozen because of this..._

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
