### PR TITLE
Extend repeat test for min=0 and default=1

### DIFF
--- a/lib/galaxy_test/api/test_tool_execute.py
+++ b/lib/galaxy_test/api/test_tool_execute.py
@@ -126,6 +126,16 @@ def test_identifier_multiple_reduce_in_repeat(
     execute.assert_has_single_job.assert_has_single_output.with_contents_stripped("forward\nreverse")
 
 
+@requires_tool_id("repeat_min")
+def test_repeat_min(
+    target_history: TargetHistory, required_tool: RequiredTool, tool_input_format: DescribeToolInputs
+):
+    hdca = target_history.with_pair()
+    execute = required_tool.execute.with_inputs({})
+    execute.assert_has_single_job.assert_has_single_output.with_contents_stripped("")
+
+
+
 @requires_tool_id("output_action_change_format")
 def test_map_over_with_output_format_actions(
     target_history: TargetHistory, required_tool: RequiredTool, tool_input_format: DescribeToolInputs

--- a/test/functional/tools/min_repeat.xml
+++ b/test/functional/tools/min_repeat.xml
@@ -10,6 +10,10 @@
         <repeat name="queries2" title="Dataset" min="1">
             <param name="input2" type="data" label="Select" />
         </repeat>
+        <!-- test if its possible to define an optional repeat -->
+        <repeat name="queries3" title="Dataset" min="0" default="1">
+            <param name="input2" type="data" label="Select" />
+        </repeat>
     </inputs>
     <outputs>
         <data name="out_file1" format="txt" label="Repeat 1 Datasets on ${on_string}" />

--- a/test/functional/tools/repeat_min.xml
+++ b/test/functional/tools/repeat_min.xml
@@ -1,0 +1,26 @@
+<tool id="repeat_min" name="repeat_min" version="1.0.0">
+    <command><![CDATA[
+#for $repeat_instance in $the_repeat#
+    echo $repeat_instance.bool_param &&
+#end for#
+true
+    ]]></command>
+    <inputs>
+        <repeat name="the_repeat" title="Repeat Inputs" min="0" default="1">
+            <param name="bool_param" type="boolean" />
+            <param name="data_param" type="data" format="txt"/>
+        </repeat>
+    </inputs>
+    <outputs>
+        <data name="output1" format="tabular" from_work_dir="output1" />
+    </outputs>
+    <tests>
+        <test>
+            <output name="output1">
+                <assert_contents>
+                    <has_n_lines n="0"/>
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>


### PR DESCRIPTION
it should be possible to execute tool without
any repeat elements.

but tool tests require a value for the data parameter even if no repeat is given.

I guess this broke in https://github.com/galaxyproject/galaxy/pull/17018 But if I revert the backend change tools do not
load anymore.

Also wondering why we use the legace branch in this [if](https://github.com/galaxyproject/galaxy/blob/3b9f75c6a8595f39b2b9c38ccc890448087a57f0/lib/galaxy/tools/parameters/__init__.py#L430) (even if I use a legacy tool profile).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
