### PR TITLE
[24.2] Bump typescript target to es2020

### DIFF
--- a/client/src/composables/__mocks__/filter.ts
+++ b/client/src/composables/__mocks__/filter.ts
@@ -1,5 +1,5 @@
 import { toValue } from "@vueuse/core";
-import { computed, Ref } from "vue";
+import { computed, type Ref } from "vue";
 
 import type { useFilterObjectArray as UseFilterObjectArray } from "@/composables/filter";
 

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "@vue/tsconfig/tsconfig.json",
     "compilerOptions": {
-        "target": "es2016",
+        "target": "es2020",
         "module": "es2020",
 
         "verbatimModuleSyntax": true,


### PR DESCRIPTION
fix #19457 (hopefully)

more details on bug in linked issue.

Even if this shouldn't fix the issue, it just enables keeping features from being transpiled which we have been using outside of typescript anyways, bringing the feature transpilation for our templates and modules to a similar level.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
