### PR TITLE
[24.1] Add missing ActivityBar to PageEditor

### DIFF
--- a/client/src/components/PageEditor/PageEditor.vue
+++ b/client/src/components/PageEditor/PageEditor.vue
@@ -1,12 +1,15 @@
 <template>
-    <LoadingSpan v-if="loading" message="Loading Page" class="m-3" />
-    <PageEditorMarkdown
-        v-else
-        :title="title"
-        :page-id="pageId"
-        :public-url="publicUrl"
-        :content="content"
-        :content-data="contentData" />
+    <div id="columns" class="d-flex">
+        <ActivityBar />
+        <LoadingSpan v-if="loading" message="Loading Page" class="m-3" />
+        <PageEditorMarkdown
+            v-else
+            :title="title"
+            :page-id="pageId"
+            :public-url="publicUrl"
+            :content="content"
+            :content-data="contentData" />
+    </div>
 </template>
 
 <script>
@@ -18,10 +21,13 @@ import { rethrowSimple } from "utils/simple-error";
 
 import PageEditorMarkdown from "./PageEditorMarkdown";
 
+import ActivityBar from "@/components/ActivityBar/ActivityBar.vue";
+
 export default {
     components: {
         PageEditorMarkdown,
         LoadingSpan,
+        ActivityBar,
     },
     props: {
         pageId: {


### PR DESCRIPTION
Fixes #19441

![image](https://github.com/user-attachments/assets/2b54879c-26bb-49cb-848d-debfe6851402)


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Go to `/pages/list`
  - Edit the content of one of your pages
  - It should show the Activity Bar

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
