### PR TITLE
[24.1] Fix version flicker on job rerun

### DIFF
--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -305,6 +305,7 @@ export default {
             console.debug("ToolForm - Requesting tool.", this.id);
             return getToolFormData(this.id, this.currentVersion, this.job_id, this.history_id)
                 .then((data) => {
+                    this.currentVersion = data.version;
                     this.formConfig = data;
                     this.remapAllowed = this.job_id && data.job_remap;
                     this.showForm = true;

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -595,6 +595,7 @@ tool_form:
     drilldown_select_all: 'div.ui-form-element[id="form-element-${parameter}"] div.select-all-checkbox'
     drilldown_option: '.drilldown-option'
     drilldown_expand: '.fa-caret-down'
+    tool_version_button: ".tool-versions"
 
   labels:
     generate_tour: 'Generate Tour'

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -171,6 +171,20 @@ class TestToolForm(SeleniumTestCase, UsesHistoryItemAssertions):
         self._check_dataset_details_for_inttest_value(2)
 
     @selenium_test
+    def test_rerun_with_non_latest_version(self):
+        version = "0.1+galaxy6"
+        self._run_multiple_version_test_tool(version)
+        self.history_panel_wait_for_hid_ok(1)
+        self.hda_click_primary_action_button(1, "rerun")
+        self.components.tool_form.tool_version_button.wait_for_and_click()
+        menu_element = self.wait_for_selector_visible(".dropdown-menu.show")
+        menu_options = menu_element.find_elements(By.CSS_SELECTOR, "a.dropdown-item")
+        for menu_option in menu_options:
+            if f"Selected {version}" in menu_option.text:
+                return
+        raise Exception("Tool version does not match job version")
+
+    @selenium_test
     def test_rerun_deleted_dataset(self):
         # upload a first dataset that should not become selected on re-run
         test_path = self.get_filename("1.tabular")
@@ -312,6 +326,13 @@ class TestToolForm(SeleniumTestCase, UsesHistoryItemAssertions):
         self.home()
         self.tool_open("environment_variables")
         self.tool_set_value("inttest", inttest_value)
+        self.tool_form_execute()
+
+    def _run_multiple_version_test_tool(self, version):
+        self.home()
+        self.tool_open("multiple_versions")
+        self.components.tool_form.tool_version_button.wait_for_and_click()
+        self.select_dropdown_item(f"Switch to {version}")
         self.tool_form_execute()
 
 


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/19477, which should be a problem for built-in tools where the rerun shouldn't use the latest version. This is because built-in tools don't contain the version in the tool id, and we didnt' persist the verson in the ToolForm data. Made worse by https://github.com/galaxyproject/galaxy/issues/18848#issuecomment-2393830406

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

`WEBPACK_PORT=8082 CHANGE_ORIGIN=true GALAXY_URL="https://usegalaxy.org/" yarn run develop`
and try re-running any built-in tool where the original job doesn't use the latest tool version.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
