### PR TITLE
Fix wrong id in test_combined_mapping_and_subcollection_mapping

### DIFF
--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -2366,7 +2366,7 @@ class TestToolsApi(ApiTestCase, TestsTools):
             create_response = self.dataset_collection_populator.create_list_in_history(
                 history_id, contents=["xxx\n", "yyy\n"], wait=True
             )
-            list_id = create_response.json()["outputs"][0]["id"]
+            list_id = create_response.json()["output_collections"][0]["id"]
             inputs = {
                 "f1": {
                     "batch": True,


### PR DESCRIPTION
We weren't actually testing what we thought we did here ...

Just noticed this while adding another test in that file. May save some debugging time in the future.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
