### PR TITLE
[24.2] Serialize message exceptions on execution error

### DIFF
--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -154,10 +154,13 @@ class ToolInputsNotReadyException(MessageException):
 
 
 class ToolInputsNotOKException(MessageException):
-    def __init__(self, err_msg: Optional[str] = None, type="info", *, src: str, id: int, **extra_error_info):
-        super().__init__(err_msg, type, **extra_error_info)
+    def __init__(
+        self, err_msg: Optional[str] = None, type="info", *, src: str, id: str, input_name: str, **extra_error_info
+    ):
+        super().__init__(err_msg, type, src=src, id=id, input_name=input_name, **extra_error_info)
         self.src = src
         self.id = id
+        self.input_name = input_name
 
     status_code = 400
     error_code = error_codes_by_name["TOOL_INPUTS_NOT_OK"]

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1996,7 +1996,11 @@ class Tool(UsesDictVisibleKeys):
         if raise_execution_exception:
             example_error = execution_tracker.execution_errors[0]
             assert example_error
-            raise exceptions.MessageException(str(example_error))
+            if isinstance(example_error, exceptions.MessageException):
+                raise example_error
+            else:
+                # Fallback, though everything here should already be a MessageException.
+                raise exceptions.MessageException(str(example_error))
 
         return dict(
             out_data=execution_tracker.output_datasets,
@@ -3335,32 +3339,34 @@ class DatabaseOperationTool(Tool):
     def allow_errored_inputs(self):
         return not self.require_dataset_ok
 
-    def check_inputs_ready(self, input_datasets, input_dataset_collections):
-        def check_dataset_state(state):
+    def check_inputs_ready(self, input_datasets, input_dataset_collections, security):
+        def check_dataset_state(input_key, state):
             if self.require_terminal_states and state in model.Dataset.non_ready_states:
                 raise ToolInputsNotReadyException("An input dataset is pending.")
 
             if self.require_dataset_ok:
                 if state != model.Dataset.states.OK:
+                    # TODO: frontend component should intercept and point to problematic input
                     raise ToolInputsNotOKException(
-                        f"Tool requires inputs to be in valid state, but dataset {input_dataset} is in state '{input_dataset.state}'",
+                        f"Tool requires inputs to be in valid state, but dataset with hid {input_dataset.hid} is in state '{input_dataset.state}'",
                         src="hda",
                         id=input_dataset.id,
+                        input_name=input_key,
                     )
 
-        for input_dataset in input_datasets.values():
+        for input_key, input_dataset in input_datasets.items():
             if input_dataset:
                 # None is a possible input for optional inputs
-                check_dataset_state(input_dataset.state)
+                check_dataset_state(input_key, input_dataset.state)
 
-        for input_dataset_collection_pairs in input_dataset_collections.values():
+        for input_key, input_dataset_collection_pairs in input_dataset_collections.items():
             for input_dataset_collection, _ in input_dataset_collection_pairs:
                 if not input_dataset_collection.collection.populated_optimized:
                     raise ToolInputsNotReadyException("An input collection is not populated.")
 
             states, _ = input_dataset_collection.collection.dataset_states_and_extensions_summary
             for state in states:
-                check_dataset_state(state)
+                check_dataset_state(input_key, state)
 
     def _add_datasets_to_history(self, history, elements, datasets_visible=False):
         for element_object in elements:

--- a/lib/galaxy/tools/actions/model_operations.py
+++ b/lib/galaxy/tools/actions/model_operations.py
@@ -46,7 +46,7 @@ class ModelOperationToolAction(DefaultToolAction):
             tool, trans, incoming, history, current_user_roles, collection_info
         )
 
-        tool.check_inputs_ready(inp_data, inp_dataset_collections)
+        tool.check_inputs_ready(inp_data, inp_dataset_collections, security=trans.security)
 
     def execute(
         self,

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -17,6 +17,7 @@ from galaxy import (
     util,
 )
 from galaxy.config import GalaxyAppConfiguration
+from galaxy.exceptions.utils import api_error_to_dict
 from galaxy.managers.collections_util import dictify_dataset_collection_instance
 from galaxy.managers.context import (
     ProvidesHistoryContext,
@@ -203,7 +204,17 @@ class ToolsService(ServiceBase):
         rval["produces_entry_points"] = tool.produces_entry_points
         if job_errors := vars.get("job_errors", []):
             # If we are here - some jobs were successfully executed but some failed.
-            rval["errors"] = job_errors
+            # TODO: We should probably alter the response status code and have a component that knows
+            # how to template in things like src and id, so we don't have to rely just on a textual error message.
+            execution_errors = [
+                (
+                    trans.security.encode_all_ids(api_error_to_dict(exception=e))
+                    if isinstance(e, exceptions.MessageException)
+                    else e
+                )
+                for e in job_errors
+            ]
+            rval["errors"] = execution_errors
 
         outputs = rval["outputs"]
         # TODO:?? poss. only return ids?

--- a/test/integration/test_tool_submission_errors.py
+++ b/test/integration/test_tool_submission_errors.py
@@ -1,0 +1,56 @@
+from sqlalchemy import select
+
+from galaxy.model import HistoryDatasetAssociation
+from galaxy_test.base.populators import (
+    DatasetCollectionPopulator,
+    DatasetPopulator,
+)
+from galaxy_test.driver import integration_util
+
+
+class TestFailJobWhenToolUnavailable(integration_util.IntegrationTestCase):
+    dataset_populator: DatasetPopulator
+    dataset_collection_populator: DatasetCollectionPopulator
+    require_admin_user = True
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
+
+    @property
+    def sa_session(self):
+        return self._app.model.session
+
+    def test_partial_job_success_error_handling(self):
+        with self.dataset_populator.test_history() as history_id:
+            create_response = self.dataset_collection_populator.create_list_in_history(
+                history_id, contents=["xxx\n", "yyy\n"], wait=True
+            ).json()
+            hdca_id = create_response["output_collections"][0]["id"]
+            first_hda_id = self.dataset_populator.get_history_collection_details(history_id, content_id=hdca_id)[
+                "elements"
+            ][0]["object"]["id"]
+            database_id = self._get(f"configuration/decode/{first_hda_id}").json()["decoded_id"]
+            hda = self.sa_session.scalar(
+                select(HistoryDatasetAssociation).where(HistoryDatasetAssociation.id == database_id)
+            )
+            assert hda
+            hda.state = HistoryDatasetAssociation.states.FAILED_METADATA
+            self.sa_session.add(hda)
+            self.sa_session.commit()
+            response = self.dataset_populator.run_tool_raw(
+                tool_id="__FILTER_NULL__",
+                inputs={"input": {"src": "hdca", "id": hdca_id}},
+                history_id=history_id,
+            ).json()
+            assert response["errors"] == [
+                {
+                    "err_code": 0,
+                    "err_msg": "Tool requires inputs to be in valid state, but "
+                    "dataset with hid 2 is in state 'failed_metadata'",
+                    "id": "eb142648ac45b77086610f67617bec2ad3808fd4409d175f",
+                    "input_name": "input1",
+                    "src": "hda",
+                }
+            ]


### PR DESCRIPTION
This fixes handling of `ToolInputsNotOK` exceptions, which would fail with
```
Message
Uncaught exception in exposed API method:
Stack Trace

Newest

TypeError: Object of type ToolInputsNotOKException is not JSON serializable
  File "galaxy/util/json.py", line 74, in safe_dumps
    dumped = json.dumps(obj, allow_nan=False, **kwargs)
  File "__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
  File "json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type ToolInputsNotOKException is not JSON serializable
  File "galaxy/web/framework/decorators.py", line 350, in decorator
    rval = format_return_as_json(rval, jsonp_callback, pretty=trans.debug)
  File "galaxy/web/framework/decorators.py", line 387, in format_return_as_json
    json = safe_dumps(rval, **dumps_kwargs)
  File "galaxy/util/json.py", line 77, in safe_dumps
    dumped = json.dumps(obj, allow_nan=False, **kwargs)
  File "__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
  File "json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
```

This also required making the tool form error modal dependent on the returned errors, instead of only popping up on non-200 status codes or if all jobs failed.

That's what submitting the `Tag elements` tool that requires datasets in OK state looks like if one dataset is in failed_metadata state. 
<img width="750" alt="Screenshot 2025-01-29 at 18 15 27" src="https://github.com/user-attachments/assets/e796ec20-0858-4bfa-b34d-362ce5e37503" />
This is much better than the just showing the API request as we used to do, and all the info is there for the UI team to show exactly which dataset is at fault.

Fixes https://github.com/galaxyproject/galaxy/issues/19482


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
