### PR TITLE
[24.0] Prevent cycling through failing conversion jobs in trackster

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4692,11 +4692,16 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
     def display_info(self):
         return self.datatype.display_info(self)
 
-    def get_converted_files_by_type(self, file_type):
+    def get_converted_files_by_type(self, file_type, include_errored=False):
         for assoc in self.implicitly_converted_datasets:
             if not assoc.deleted and assoc.type == file_type:
                 item = assoc.dataset or assoc.dataset_ldda
-                if not item.deleted and item.state in Dataset.valid_input_states:
+                valid_states = (
+                    (Dataset.states.ERROR, *Dataset.valid_input_states)
+                    if include_errored
+                    else Dataset.valid_input_states
+                )
+                if not item.deleted and item.state in valid_states:
                     return item
         return None
 
@@ -4711,7 +4716,7 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
             depends_list = []
         return {dep: self.get_converted_dataset(trans, dep) for dep in depends_list}
 
-    def get_converted_dataset(self, trans, target_ext, target_context=None, history=None):
+    def get_converted_dataset(self, trans, target_ext, target_context=None, history=None, include_errored=False):
         """
         Return converted dataset(s) if they exist, along with a dict of dependencies.
         If not converted yet, do so and return None (the first time). If unconvertible, raise exception.
@@ -4723,7 +4728,7 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
         converted_dataset = self.get_metadata_dataset(target_ext)
         if converted_dataset:
             return converted_dataset
-        converted_dataset = self.get_converted_files_by_type(target_ext)
+        converted_dataset = self.get_converted_files_by_type(target_ext, include_errored=include_errored)
         if converted_dataset:
             return converted_dataset
         deps = {}
@@ -4945,7 +4950,8 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
 
         # Get converted dataset; this will start the conversion if necessary.
         try:
-            converted_dataset = self.get_converted_dataset(trans, target_type)
+            # Include errored datasets here, we let user chose to retry or view error
+            converted_dataset = self.get_converted_dataset(trans, target_type, include_errored=True)
         except NoConverterException:
             return self.conversion_messages.NO_CONVERTER
         except ConverterDependencyException as dep_error:


### PR DESCRIPTION
Or other clients that want to look at `converted_datasets_state`. We'd launch one job, then fail, then launch another whenever we wait for a conversion to complete.

Broken in https://github.com/galaxyproject/galaxy/pull/18850.

Restores this:

<img width="692" alt="Screenshot 2025-01-30 at 17 44 12" src="https://github.com/user-attachments/assets/ea297085-8327-482f-a38a-402bacf6e7b0" />


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

Upload a bam file and attempt to visualize it in trackster. Most likely the bam_to_bigwif converter is going to fail. Make sure you see the screenshot, not a whole bunch of conversion jobs.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
