### PR TITLE
[24.2] Use visualizations api in trackster

### DIFF
--- a/client/src/viz/trackster.js
+++ b/client/src/viz/trackster.js
@@ -74,23 +74,30 @@ export class TracksterUI extends Backbone.Model {
             },
             bookmarks: bookmarks,
         };
-
-        // Make call to save visualization.
-        return $.ajax({
-            url: `${getAppRoot()}visualization/save`,
-            type: "POST",
+        const request = {
             dataType: "json",
-            data: {
+            contentType: "application/json; charset=utf-8",
+            data: JSON.stringify({
                 id: this.view.vis_id,
                 title: this.view.config.get_value("name"),
                 dbkey: this.view.dbkey,
                 type: "trackster",
-                vis_json: JSON.stringify(viz_config),
-            },
-        })
+                config: viz_config,
+            }),
+        };
+        if (!this.view.vis_id) {
+            request.url = `${getAppRoot()}api/visualizations`;
+            request.type = "POST";
+        } else {
+            request.url = `${getAppRoot()}api/visualizations/${this.view.vis_id}`;
+            request.type = "PUT";
+        }
+
+        // Make call to save visualization.
+        return $.ajax(request)
             .success((vis_info) => {
                 Galaxy.modal.hide();
-                this.view.vis_id = vis_info.vis_id;
+                this.view.vis_id = vis_info.id;
                 this.view.has_changes = false;
 
                 // Needed to set URL when first saving a visualization.

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -618,6 +618,7 @@ def populate_api_routes(webapp, app):
         "/plugins/visualizations/{visualization_name}/saved",
         controller="visualization",
         action="saved",
+        conditions={"method": ["POST"]},
     )
     # Deprecated in favor of POST /api/workflows with 'workflow' in payload.
     webapp.mapper.connect(


### PR DESCRIPTION
The old controller method for saving visualizations is currently broken.
Only trackster uses it.

Also removes now unused methods.

Fixes https://github.com/galaxyproject/galaxy/issues/19475

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
