### PR TITLE
[24.2] Fix minor typo in event name in collection creator

### DIFF
--- a/client/src/components/Collections/common/CollectionCreatorNoItemsMessage.vue
+++ b/client/src/components/Collections/common/CollectionCreatorNoItemsMessage.vue
@@ -4,14 +4,14 @@ import { BAlert, BLink } from "bootstrap-vue";
 import localize from "@/utils/localization";
 
 const emit = defineEmits<{
-    (e: "clicked-upload"): void;
+    (e: "click-upload"): void;
 }>();
 </script>
 <template>
     <BAlert variant="info" show>
         {{ localize("No items available to create a collection.") }}
         {{ localize("Exit and change your current history, or") }}
-        <BLink class="text-decoration-none" @click.stop.prevent="emit('clicked-upload')">
+        <BLink class="text-decoration-none" @click.stop.prevent="emit('click-upload')">
             {{ localize("Upload some datasets.") }}
         </BLink>
     </BAlert>


### PR DESCRIPTION
Parent component `CollectionCreator` expects the emit name to be `click-upload` and we had it as `clicked-upload` here.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
