### PR TITLE
[24.2] Fix workflowID assignment in Markdown.vue

### DIFF
--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -130,7 +130,7 @@ export default {
             workflows: {},
             invocations: {},
             loading: true,
-            workflowID: "",
+            workflowID: undefined,
         };
     },
     computed: {
@@ -159,7 +159,7 @@ export default {
             return "unavailable";
         },
         workflowVersions() {
-            return this.getStoredWorkflowByInstanceId(this.workflowID);
+            return this.workflowID ? this.getStoredWorkflowByInstanceId(this.workflowID) : undefined;
         },
         version() {
             return this.markdownConfig.generate_version || "Unknown Galaxy Version";
@@ -172,7 +172,9 @@ export default {
     },
     created() {
         this.initConfig();
-        this.fetchWorkflowForInstanceId(this.workflowID);
+        if (this.workflowID) {
+            this.fetchWorkflowForInstanceId(this.workflowID);
+        }
     },
     methods: {
         ...mapActions(useWorkflowStore, ["getStoredWorkflowByInstanceId", "fetchWorkflowForInstanceId"]),
@@ -188,7 +190,7 @@ export default {
                 this.workflows = config.workflows || {};
                 this.invocations = config.invocations || {};
                 this.loading = false;
-                this.workflowID = Object.keys(this.markdownConfig?.workflows ?? {})[0] ?? "";
+                this.workflowID = Object.keys(this.markdownConfig?.workflows ?? {})[0];
             }
         },
         splitMarkdown(markdown) {

--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -188,7 +188,7 @@ export default {
                 this.workflows = config.workflows || {};
                 this.invocations = config.invocations || {};
                 this.loading = false;
-                this.workflowID = Object.keys(this.markdownConfig.workflows)[0];
+                this.workflowID = Object.keys(this.markdownConfig?.workflows ?? {})[0] ?? "";
             }
         },
         splitMarkdown(markdown) {


### PR DESCRIPTION
Fixes #19503

`this.markdownConfig` might not have `workflows`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
