### PR TITLE
[24.2] Downgrade 'InteractiveTools are not enabled' to warning

### DIFF
--- a/lib/galaxy/tool_util/toolbox/__init__.py
+++ b/lib/galaxy/tool_util/toolbox/__init__.py
@@ -3,6 +3,7 @@
 from .base import (
     AbstractToolBox,
     AbstractToolTagManager,
+    ToolLoadConfigurationConflict,
     ToolLoadError,
 )
 from .panel import (
@@ -15,6 +16,7 @@ __all__ = (
     "AbstractToolBox",
     "AbstractToolTagManager",
     "panel_item_types",
+    "ToolLoadConfigurationConflict",
     "ToolLoadError",
     "ToolSection",
     "ToolSectionLabel",

--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -137,6 +137,10 @@ class ToolLoadError(Exception):
     pass
 
 
+class ToolLoadConfigurationConflict(Exception):
+    pass
+
+
 class AbstractToolBox(ManagesIntegratedToolPanelMixin):
     """
     Abstract container for managing a ToolPanel - containing tools and
@@ -1077,6 +1081,8 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
                     self._load_tool_panel_views()
                     self._save_integrated_tool_panel()
                 return tool.id
+            except ToolLoadConfigurationConflict as e:
+                log.warning(f"Configuration does not permit loading tool {tool_file} - {e}")
             except ToolLoadError as e:
                 # no need for full stack trace - ToolLoadError corresponds to a known load
                 # error with defined cause that is included in the message

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -99,6 +99,7 @@ from galaxy.tool_util.provided_metadata import parse_tool_provided_metadata
 from galaxy.tool_util.toolbox import (
     AbstractToolBox,
     AbstractToolTagManager,
+    ToolLoadConfigurationConflict,
     ToolLoadError,
     ToolSection,
 )
@@ -3200,7 +3201,9 @@ class InteractiveTool(Tool):
 
     def __init__(self, config_file, tool_source, app, **kwd):
         if not app.config.interactivetools_enable:
-            raise ToolLoadError("Trying to load an InteractiveTool, but InteractiveTools are not enabled.")
+            raise ToolLoadConfigurationConflict(
+                "Trying to load an InteractiveTool, but InteractiveTools are not enabled."
+            )
         super().__init__(config_file, tool_source, app, **kwd)
 
     def __remove_interactivetool_by_job(self, job):


### PR DESCRIPTION
We don't really have a choice when loading tools from CVMFS to just disable them for the VGP instance. Fixes https://github.com/galaxyproject/galaxy/issues/19517

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
