### PR TITLE
[24.2] Fix WSGI response status handling in controller methods

### DIFF
--- a/lib/galaxy/web/framework/base.py
+++ b/lib/galaxy/web/framework/base.py
@@ -492,7 +492,7 @@ class Response:
         """
         Create a new Response defaulting to HTML content and "200 OK" status
         """
-        self.status = "200 OK"
+        self.status: int = 200
         self.headers = HeaderDict({"content-type": "text/html; charset=UTF-8"})
         self.cookies = SimpleCookie()
 

--- a/lib/galaxy/webapps/galaxy/controllers/root.py
+++ b/lib/galaxy/webapps/galaxy/controllers/root.py
@@ -110,18 +110,18 @@ class RootController(controller.JSAppLauncher, UsesAnnotations):
             ):
                 pass
             else:
-                trans.response.status = "403"
+                trans.response.status = 403
                 return "You are not allowed to access this dataset."
             try:
                 self.app.hda_manager.ensure_dataset_on_disk(trans, data)
             except exceptions.MessageException as e:
-                trans.response.status = str(e.status_code)
+                trans.response.status = e.status_code
                 return str(e)
             trans.response.set_content_type(data.get_mime())
             trans.log_event(f"Formatted dataset id {str(id)} for display at {display_app}")
             return data.as_display_type(display_app, **kwd)
         else:
-            trans.response.status = "400"
+            trans.response.status = 400
             return "No data with id=%d" % id
 
     @web.expose


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/19519. If a string is being set it can't just be the status code cast to a string (which would be correct for ASGI), as that fails in a2wsgi.

Easiest and most consistent is to just set the status code to an int and have the wsgi_status method look up the correct description.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
