### PR TITLE
[24.0] Fix ``test_storage_show`` API test

### DIFF
--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -708,7 +708,6 @@ class TestDatasetsApi(ApiTestCase):
         for purged_source_id in expected_purged_source_ids:
             self.dataset_populator.wait_for_purge(history_id, purged_source_id["id"])
 
-    @requires_new_history
     @requires_new_library
     def test_delete_batch_lddas(self):
         # Create a library dataset
@@ -859,9 +858,7 @@ class TestDatasetsApi(ApiTestCase):
 
     def test_storage_show(self, history_id):
         hda = self.dataset_populator.new_dataset(history_id, wait=True)
-        hda_details = self.dataset_populator.get_history_dataset_details(history_id, dataset=hda)
-        dataset_id = hda_details["dataset_id"]
-        storage_info_dict = self.dataset_populator.dataset_storage_info(dataset_id)
+        storage_info_dict = self.dataset_populator.dataset_storage_info(hda["id"])
         assert_has_keys(storage_info_dict, "object_store_id", "name", "description")
 
     def test_storage_show_on_discarded(self, history_id):


### PR DESCRIPTION
Pass hda id instead of dataset id to ``dataset_storage_info()``.

Fix the following traceback:

```
    def test_storage_show(self, history_id):
        hda = self.dataset_populator.new_dataset(history_id, wait=True)
        hda_details = self.dataset_populator.get_history_dataset_details(history_id, dataset=hda)
        dataset_id = hda_details["dataset_id"]
>       storage_info_dict = self.dataset_populator.dataset_storage_info(dataset_id)

...

        if http_error_msg:
>           raise HTTPError(http_error_msg, response=self)
E           requests.exceptions.HTTPError: 404 Client Error: Not Found for url: http://127.0.0.1:9129/api/datasets/9a58064fb2c43d99/storage

http_error_msg = ('404 Client Error: Not Found for url: '
 'http://127.0.0.1:9129/api/datasets/9a58064fb2c43d99/storage')
reason     = 'Not Found'
self       = <Response [404]>
```

Broken since the test was introduced in commit c5bf63bc91cc1d2534abea5eea9552a7b739cc7e .

Started failing after https://github.com/galaxyproject/galaxy/pull/19506 , but probably just because of database ids changing.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
