### PR TITLE
[24.1] Fix extracting workflows from purged and deleted histories

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3645,6 +3645,10 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
         """Return all active contents ordered by hid."""
         return self.contents_iter(types=["dataset", "dataset_collection"], deleted=False, visible=True)
 
+    @property
+    def visible_contents(self):
+        return self.contents_iter(types=["dataset", "dataset_collection"], visible=True)
+
     def contents_iter(self, **kwds):
         """
         Fetch filtered list of contents of history.

--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -283,7 +283,7 @@ class WorkflowSummary:
         # just grab the implicitly mapped jobs and handle in second pass. Second pass is
         # needed because cannot allow selection of individual datasets from an implicit
         # mapping during extraction - you get the collection or nothing.
-        for content in self.history.active_contents:
+        for content in self.history.visible_contents:
             self.__summarize_content(content)
 
     def __summarize_content(self, content):

--- a/templates/webapps/galaxy/workflow/build_from_current_history.mako
+++ b/templates/webapps/galaxy/workflow/build_from_current_history.mako
@@ -112,6 +112,7 @@ into a workflow will be shown in gray.</p>
     <%
     cls = "toolForm"
     tool_name = "Unknown"
+    checked_job = "checked" if any(True for d in datasets if not d[1].deleted) else ""
     if hasattr( job, 'is_fake' ) and job.is_fake:
         cls += " toolFormDisabled"
         disabled = True
@@ -142,7 +143,10 @@ into a workflow will be shown in gray.</p>
                     %if disabled:
                         <div style="font-style: italic; color: gray">${disabled_why}</div>
                     %else:
-                        <div><input type="checkbox" name="job_ids" value="${job.id}" checked="true" />Include "${tool_name}" in workflow</div>
+                        <div><input type="checkbox" name="job_ids" value="${job.id}" ${checked_job} />Include "${tool_name}" in workflow</div>
+                        %if not checked_job:
+                            ${ render_msg( "All job outputs have been deleted", status="info" ) }
+                        %endif
                         %if tool_version_warning:
                             ${ render_msg( tool_version_warning, status="warning" ) }
                         %endif

--- a/templates/webapps/galaxy/workflow/build_from_current_history.mako
+++ b/templates/webapps/galaxy/workflow/build_from_current_history.mako
@@ -88,7 +88,7 @@ into a workflow will be shown in gray.</p>
     <div class="warningmark">${warning}</div>
 %endfor
 
-<form method="post" action="${h.url_for(controller='workflow', action='build_from_current_history')}">
+<form method="post" action="${h.url_for(controller='workflow', action='build_from_current_history', history_id=trans.security.encode_id(history.id))}">
 <div class='form-row'>
     <label>Workflow name</label>
     <input name="workflow_name" type="text" value="Workflow constructed from history '${ util.unicodify( history.name )}'" size="60"/>

--- a/test/unit/workflows/test_extract_summary.py
+++ b/test/unit/workflows/test_extract_summary.py
@@ -121,6 +121,10 @@ class MockHistory:
     def active_contents(self):
         return self.active_datasets
 
+    @property
+    def visible_contents(self):
+        return self.active_contents
+
 
 class MockTrans:
     def __init__(self, history):


### PR DESCRIPTION
I'm pretty sure this used to work. Anyway, this also fixes extracting workflows from histories where some / all datasets are deleted. No tests -- we should port this over to use the API.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
