### PR TITLE
[24.2] Fix error message when subworkflow input connection missing

### DIFF
--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -263,7 +263,7 @@ class WorkflowInvoker:
                 step_delayed = delayed_steps = True
                 self.progress.mark_step_outputs_delayed(step, why=de.why)
             except Exception as e:
-                log_function = log.exception
+                log_function = log.error
                 if isinstance(e, modules.FailWorkflowEvaluation) and e.why.reason in FAILURE_REASONS_EXPECTED:
                     log_function = log.info
                 log_function(

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -704,7 +704,8 @@ class WorkflowProgress:
         for input_subworkflow_step in subworkflow.input_steps:
             connection_found = False
             subworkflow_step_id = input_subworkflow_step.id
-            for input_connection in step.input_connections:
+            input_connections = step.input_connections
+            for input_connection in input_connections:
                 if input_connection.input_subworkflow_step_id == subworkflow_step_id:
                     is_data = input_connection.output_step.type != "parameter_input"
                     replacement = self.replacement_for_connection(
@@ -715,7 +716,18 @@ class WorkflowProgress:
                     connection_found = True
                     break
 
-            if not connection_found and not input_subworkflow_step.input_optional:
+            if not input_subworkflow_step.input_optional and not connection_found:
+
+                if not input_connections:
+                    # TODO: Prevent this on import / runtime !
+                    raise modules.FailWorkflowEvaluation(
+                        InvocationUnexpectedFailure(
+                            reason=FailureReason.unexpected_failure,
+                            workflow_step_id=step.id,
+                            details="Subworkflow has disconnected required input.",
+                        )
+                    )
+
                 raise modules.FailWorkflowEvaluation(
                     InvocationFailureOutputNotFound(
                         reason=FailureReason.output_not_found,

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -378,6 +378,7 @@ def build_workflow_run_configs(
             step = steps_by_id[key]
             if step.type == "parameter_input":
                 module_injector.inject(step)
+                assert step.module
                 input_param = step.module.get_runtime_inputs(step.module)["input"]
                 try:
                     input_param.validate(input_dict, trans=trans)
@@ -546,6 +547,7 @@ def workflow_run_config_to_request(
     for step in workflow.steps:
         steps_by_id[step.id] = step
         assert step.module
+        assert step.state
         serializable_runtime_state = step.module.encode_runtime_state(step, step.state)
 
         step_state = WorkflowRequestStepState()

--- a/test/unit/workflows/test_workflow_progress.py
+++ b/test/unit/workflows/test_workflow_progress.py
@@ -100,7 +100,7 @@ class TestWorkflowProgress(TestCase):
 
             workflow_invocation_step_state = model.WorkflowRequestStepState()
             workflow_invocation_step_state.workflow_step_id = step_id
-            workflow_invocation_step_state.value = cast(bytes, True)
+            workflow_invocation_step_state.value = {"my_param": True}
             self.invocation.step_states.append(workflow_invocation_step_state)
 
     def _step(self, index):


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/19511:

<img width="1448" alt="Screenshot 2025-02-03 at 11 02 51" src="https://github.com/user-attachments/assets/691ff975-d058-41be-9b3b-5571ed15e7bf" />

There's more we can do:
- Elevate disconnected required inputs to error in the best practice panel
- Show the best practice panel unconditionally
- Check for disconnected inputs on submission

I'll do some of these, but I think this would go beyond a simple bug fix

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
