### PR TITLE
Support setting and displaying timezone with the core metrics plugin

### DIFF
--- a/doc/source/admin/job_metrics.rst
+++ b/doc/source/admin/job_metrics.rst
@@ -27,23 +27,37 @@ If no configuration is specified, the default is to load only the ``core`` plugi
 Available Job Metrics Plugins
 -----------------------------
 
-The list of metrics plugins implemented in the code can be found at ``lib/galaxy/job_metrics/instrumenters``.
+The list of metrics plugins implemented in the code can be found at ``lib/galaxy/job_metrics/instrumenters``. A list of
+available plugins and example configurations follows.
 
 
 core
 ~~~~
 
-The core plugin captures the number of cores allocated to the job (``$GALAXY_SLOTS``), the start and end time of job (in
-seconds since epoch) and computes the runtime in seconds.
-
-It has no options.
-
 .. code-block:: yaml
 
     - type: core
+      timezone: UTC
+
+The core plugin captures the number of cores allocated to the job (``$GALAXY_SLOTS``), the start and end time of job (in
+seconds since epoch) and computes the runtime in seconds.
+
+The optional ``timezone`` option (default: ``null``) controls how times are displayed in the UI. If unset, times are
+displayed in server local time. Note that not all values respect daylight savings time; for example, ``US/Eastern``,
+``America/New_York``, and ``EST5EDT`` do, whereas ``EST`` does not. Possible values are determined by the server time
+zone library and can be listed with the following command:
+
+.. code-block:: shell
+
+    python3 -c 'import zoneinfo; list(map(print, sorted(zoneinfo.available_timezones())))'
 
 cpuinfo
 ~~~~~~~
+
+.. code-block:: yaml
+
+    - type: cpuinfo
+      verbose: false
 
 The cpuinfo plugin captures the processor count on the system that that job ran on (note that this may differ from the
 number of CPUs actually allocated to the job).
@@ -53,53 +67,42 @@ The optional ``verbose`` option (default: ``false``) captures details (likely fa
 
 The cpuinfo plugin works on Linux only.
 
-.. code-block:: yaml
-
-    - type: cpuinfo
-      verbose: false
-
 meminfo
 ~~~~~~~
+
+.. code-block:: yaml
+
+    - type: meminfo
 
 The meminfo plugin captures the memory information on the system that the job ran on (note that this may differ from the
 amount of memory actually allocated to the job).
 
 It has no options.
 
-.. code-block:: yaml
-
-    - type: meminfo
-
 hostname
 ~~~~~~~~
-
-The hostname plugin captures the output of ``hostname`` on the system that the job ran on.
-
-It has no options.
 
 .. code-block:: yaml
 
     - type: hostname
 
-uname
-~~~~~
-
-The uname plugin captures the output of ``uname -a`` on the system that the job ran on.
+The hostname plugin captures the output of ``hostname`` on the system that the job ran on.
 
 It has no options.
+
+uname
+~~~~~
 
 .. code-block:: yaml
 
     - type: uname
 
+The uname plugin captures the output of ``uname -a`` on the system that the job ran on.
+
+It has no options.
+
 env
 ~~~
-
-The env plugin captures environment variables set in the job's executing environment.
-
-By default, it captures **all** environment variables, which is likely excessive but may be useful for debugging. The
-optional ``variables`` option can be set to a list of variables to capture (if set). For legacy purposes, this can also
-be a comma-separated string of variable names.
 
 .. code-block:: yaml
 
@@ -109,8 +112,23 @@ be a comma-separated string of variable names.
         - SLURM_CPUS_ON_NODE
         - SLURM_JOBID
 
+The env plugin captures environment variables set in the job's executing environment.
+
+By default, it captures **all** environment variables, which is likely excessive but may be useful for debugging. The
+optional ``variables`` option can be set to a list of variables to capture (if set). For legacy purposes, this can also
+be a comma-separated string of variable names.
+
 cgroup
 ~~~~~~
+
+.. code-block:: yaml
+
+    - type: cgroup
+      verbose: false
+      version: 2
+      params:
+        - cpu.stat
+        - memory.peak
 
 The cgroup plugin captures values set by `Linux Control Groups (cgroups)
 <https://docs.kernel.org/admin-guide/cgroup-v2.html>`_. This is most useful if your jobs run in unique per-job Cgroups
@@ -131,15 +149,6 @@ list of parameter names (files in the controller directory) to capture. For lega
 comma-separated string of cgroup parameter names.
 
 The cgroup plugin works on Linux only.
-
-.. code-block:: yaml
-
-    - type: cgroup
-      verbose: false
-      version: 2
-      params:
-        - cpu.stat
-        - memory.peak
 
 Overriding the Global Job Metrics Configuration
 -----------------------------------------------

--- a/lib/galaxy/job_metrics/__init__.py
+++ b/lib/galaxy/job_metrics/__init__.py
@@ -96,6 +96,7 @@ class JobMetrics:
             formatter = plugin_class.formatter
         else:
             formatter = DEFAULT_FORMATTER
+        assert formatter
         return formatter.format(key, value)
 
     def dictifiable_metrics(self, raw_metrics: List[RawMetric], allowed_safety: Safety) -> List[DictifiableMetric]:

--- a/lib/galaxy/job_metrics/instrumenters/__init__.py
+++ b/lib/galaxy/job_metrics/instrumenters/__init__.py
@@ -29,7 +29,7 @@ InstrumentableT = Optional[Union[str, List[str]]]
 class InstrumentPlugin(metaclass=ABCMeta):
     """Describes how to instrument job scripts and retrieve collected metrics."""
 
-    formatter = formatting.JobMetricFormatter()
+    formatter: Optional[formatting.JobMetricFormatter] = formatting.JobMetricFormatter()
     default_safety = DEFAULT_SAFETY
 
     @property

--- a/lib/galaxy/job_metrics/instrumenters/core.py
+++ b/lib/galaxy/job_metrics/instrumenters/core.py
@@ -1,12 +1,14 @@
 """The module describes the ``core`` job metrics plugin."""
 
+import datetime
 import json
 import logging
-import time
+import zoneinfo
 from typing import (
     Any,
     Dict,
     List,
+    Optional,
 )
 
 from . import InstrumentPlugin
@@ -29,6 +31,16 @@ CONTAINER_TYPE = "container_type"
 
 
 class CorePluginFormatter(JobMetricFormatter):
+    def __init__(self, timezone: Optional[str]):
+        self.tz = None
+        self.strftime_format = "%Y-%m-%d %H:%M:%S"
+        self.__init_tz(timezone)
+
+    def __init_tz(self, timezone: Optional[str]):
+        if timezone:
+            self.tz = zoneinfo.ZoneInfo(timezone)
+            self.strftime_format = "%Y-%m-%d %H:%M:%S %Z (%z)"
+
     def format(self, key: str, value: Any) -> FormattedMetric:
         if key == CONTAINER_ID:
             return FormattedMetric("Container ID", value)
@@ -42,9 +54,9 @@ class CorePluginFormatter(JobMetricFormatter):
         elif key == RUNTIME_SECONDS_KEY:
             return FormattedMetric("Job Runtime (Wall Clock)", seconds_to_str(value))
         else:
-            # TODO: Use localized version of this from galaxy.ini
             title = "Job Start Time" if key == START_EPOCH_KEY else "Job End Time"
-            return FormattedMetric(title, time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(value)))
+            dt = datetime.datetime.fromtimestamp(value, tz=self.tz)
+            return FormattedMetric(title, dt.strftime(self.strftime_format))
 
 
 class CorePlugin(InstrumentPlugin):
@@ -53,11 +65,15 @@ class CorePlugin(InstrumentPlugin):
     """
 
     plugin_type = "core"
-    formatter = CorePluginFormatter()
+    formatter = None
     default_safety = Safety.SAFE
 
     def __init__(self, **kwargs):
-        pass
+        self.__init_formatter(kwargs.get("timezone"))
+
+    def __init_formatter(self, timezone: Optional[str]):
+        if CorePlugin.formatter is None:
+            CorePlugin.formatter = CorePluginFormatter(timezone)
 
     def pre_execute_instrument(self, job_directory: str) -> List[str]:
         commands = []

--- a/lib/galaxy/job_metrics/instrumenters/core.py
+++ b/lib/galaxy/job_metrics/instrumenters/core.py
@@ -32,7 +32,7 @@ CONTAINER_TYPE = "container_type"
 
 class CorePluginFormatter(JobMetricFormatter):
     def __init__(self, timezone: Optional[str]):
-        self.tz = None
+        self.tz: Optional[zoneinfo.ZoneInfo] = None
         self.strftime_format = "%Y-%m-%d %H:%M:%S"
         self.__init_tz(timezone)
 


### PR DESCRIPTION
I confused myself and spent too much time this morning looking at the zoneless time displayed under the core metrics for a job, hence this effort to clarify.

When the `timezone` metric param is unset the behavior remains the same as before. I wanted to get the local server timezone so that we could at least display the name/offset in this case, but doing so is non-trivial using the standard lib. We do have both [dateutil](https://pypi.org/project/python-dateutil/) (direct) and [tzlocal](https://pypi.org/project/tzlocal/) (indirect) as dependencies, but only use dateutil in one place and I didn't want to add another use on a library we could easily rewrite out.

| | |
| --- | --- |
Before / no timezone set | ![image](https://github.com/user-attachments/assets/5da17fc2-e677-4aad-91cf-eee79911df7b)
Set to UTC | ![image](https://github.com/user-attachments/assets/2f0e007b-8d92-4016-bb58-21e8a747e294)
Set to EST5EDT | ![image](https://github.com/user-attachments/assets/242db11a-0d81-4a8e-8d2f-68de3159f171)

 For a global server like usegalaxy.org it makes sense to just set it to UTC imo.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
