### PR TITLE
[24.2] Fix tool search constantly loading bug

### DIFF
--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -74,7 +74,9 @@ const localFilterText = computed({
         return props.query !== null ? props.query : "";
     },
     set: (newVal: any) => {
-        checkQuery(newVal);
+        if (newVal.trim() || props.query.trim()) {
+            checkQuery(newVal);
+        }
     },
 });
 


### PR DESCRIPTION
On initialize, the `localFilterText` here would be set to "" again, and we trigger a worker message which keeps the `queryPending`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
