### PR TITLE
[24.0] Fix admin cancel job message not being displayed to the user

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -281,7 +281,7 @@ class JobManager:
 
     def stop(self, job, message=None):
         if not job.finished:
-            job.mark_deleted(self.app.config.track_jobs_in_database)
+            job.mark_deleted(self.app.config.track_jobs_in_database, message)
             session = self.app.model.session
             with transaction(session):
                 session.commit()

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1751,7 +1751,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
         else:
             self.state = Job.states.STOPPED
 
-    def mark_deleted(self, track_jobs_in_database=False):
+    def mark_deleted(self, track_jobs_in_database=False, message=None):
         """
         Mark this job as deleted, and mark any output datasets as discarded.
         """
@@ -1762,7 +1762,8 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
             self.state = Job.states.DELETING
         else:
             self.state = Job.states.DELETED
-        self.info = "Job output deleted by user before job completed."
+        info = message or "Job output deleted by user before job completed."
+        self.info = info
         for jtoda in self.output_datasets:
             output_hda = jtoda.dataset
             output_hda.deleted = True
@@ -1772,7 +1773,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
                 shared_hda.deleted = True
                 shared_hda.blurb = "deleted"
                 shared_hda.peek = "Job deleted"
-                shared_hda.info = "Job output deleted by user before job completed"
+                shared_hda.info = info
 
     def mark_failed(self, info="Job execution failed", blurb=None, peek=None):
         """

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -1020,6 +1020,24 @@ steps:
         assert len(empty_search_response.json()) == 0
 
     @pytest.mark.require_new_history
+    def test_delete_job_with_message(self, history_id):
+        input_dataset_id = self.__history_with_ok_dataset(history_id)
+        inputs = json.dumps({"input1": {"src": "hda", "id": input_dataset_id}})
+        search_payload = self._search_payload(history_id=history_id, tool_id="cat1", inputs=inputs)
+        # create a job
+        tool_response = self._post("tools", data=search_payload).json()
+        job_id = tool_response["jobs"][0]["id"]
+        output_dataset_id = tool_response["outputs"][0]["id"]
+        # delete the job with message
+        expected_message = "test message"
+        delete_job_response = self._delete(f"jobs/{job_id}", data={"message": expected_message}, json=True)
+        self._assert_status_code_is(delete_job_response, 200)
+        # Check the output dataset is deleted and the info field contains the message
+        dataset_details = self._get(f"histories/{history_id}/contents/{output_dataset_id}").json()
+        assert dataset_details["deleted"] is True
+        assert dataset_details["misc_info"] == expected_message
+
+    @pytest.mark.require_new_history
     def test_destination_params(self, history_id):
         dataset_id = self.__history_with_ok_dataset(history_id)
         inputs = json.dumps({"input1": {"src": "hda", "id": dataset_id}})


### PR DESCRIPTION
Fixes #19487

I'm not sure when this stopped working so I targeted `24.0` but all this code seems untouched for a long time :thinking:

It looked like the message should be set somehow in:

https://github.com/galaxyproject/galaxy/blob/062cdda88595728d2a40a6f8ce455955c7e9d8fe/lib/galaxy/managers/jobs.py#L288

but this function does nothing in my testing, the actual dataset info seems to be set in `job.mark_deleted` so I moved it there with these changes. I hope this is the right fix.

I will follow up with the feature request to optionally send notifications to the users in a new PR targeting `dev`.

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/3967ec0e-fd03-4a94-a37c-4a02e36abace)   | ![image](https://github.com/user-attachments/assets/de1be0cc-8c32-4070-b386-8112cb1e29c8)  |




## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
