### PR TITLE
Fix wrong URI written to `ExportObjectResultMetadata` when exporting histories to eLabFTW

### DIFF
--- a/lib/galaxy/files/sources/elabftw.py
+++ b/lib/galaxy/files/sources/elabftw.py
@@ -742,7 +742,7 @@ class eLabFTWFilesSource(BaseFilesSource):  # noqa
         :type user_context: OptionalUserContext
         :param opts: A set of options to exercise additional control over this method. Defaults to ``None``
         :type opts: Optional[FilesSourceOptions], optional
-        :return: URI *assigned by eLabFTW* to the uploaded file.
+        :return: Path *assigned by eLabFTW* to the uploaded file.
         :rtype: str
 
         :raises requests.RequestException: When there is a connection error.
@@ -804,7 +804,7 @@ class eLabFTWFilesSource(BaseFilesSource):  # noqa
         entity_type, entity_id, attachment_id = match.groups()
         entity_type = entity_type.replace("items", "resources")
 
-        return f"elabftw://{location.netloc}/{entity_type}/{entity_id}/{attachment_id}"
+        return f"/{entity_type}/{entity_id}/{attachment_id}"
 
     def _realize_to(
         self,


### PR DESCRIPTION
Fix history exports to eLabFTW having a wrong URI saved to `ExportObjectResultMetadata.uri`, which results in not being able to reimport the histories.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run eLabFTW, for example [using Docker Compose](https://github.com/elabftw/elabimg/blob/master/src/docker-compose.yml-EXAMPLE) (or use https://demo.elabftw.net).
  2. Copy the configuration samples from file_sources_conf.yml.sample and user_preferences_extra_conf.yml.sample to your own configuration files.
  3. Create an account and generate an API Key on eLabFTW (or use the demo account from https://demo.elabftw.net).
  4. Configure the endpoint and API Key on the user preferences page.
  5. Create an experiment or resource in eLabFTW.
  6. Export a history to eLabFTW as an attachment of the created experiment or resource.
  7. Reimport the history.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
