### PR TITLE
[24.2] Use instance wide default ``real_system_username`` if not defined on destination

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2521,7 +2521,7 @@ class MinimalJobWrapper(HasResourceParameters):
         if self.__user_system_pwent is None:
             job = self.get_job()
             self.__user_system_pwent = job.user.system_user_pwent(
-                self.get_destination_configuration("real_system_username", None)
+                self.get_destination_configuration("real_system_username", self.app.config.real_system_username)
             )
         return self.__user_system_pwent
 


### PR DESCRIPTION
follow up to https://github.com/galaxyproject/galaxy/pull/18945 this was suggested in a [comment](https://github.com/galaxyproject/galaxy/pull/18945/files#r1788897351), but forgotten


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
