### PR TITLE
Fix `test_mulled_build.py::test_mulled_build_files_cli` with `use_mamba=True`

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/invfile.lua
+++ b/lib/galaxy/tool_util/deps/mulled/invfile.lua
@@ -88,13 +88,14 @@ inv.task('build')
     .using(conda_image)
         .withHostConfig({binds = bind_args})
         .run('/bin/sh', '-c', preinstall
+            .. conda_bin .. ' create --quiet --yes -p /usr/local/env --copy  && '
             .. conda_bin .. ' install '
             .. channel_args .. ' '
             .. target_args
-            .. ' --strict-channel-priority -p /usr/local --copy --yes '
+            .. ' --strict-channel-priority -p /usr/local/env --copy --yes '
             .. verbose
             .. postinstall)
-    .wrap('build/dist')
+    .wrap('build/dist/env')
         .at('/usr/local')
         .inImage(destination_base_image)
         .as(repo)

--- a/lib/galaxy/tool_util/deps/mulled/invfile.lua
+++ b/lib/galaxy/tool_util/deps/mulled/invfile.lua
@@ -72,14 +72,8 @@ else
 end
 
 local preinstall = VAR.PREINSTALL
-if preinstall ~= '' then
-    preinstall = preinstall .. ' && '
-end
 
 local postinstall = VAR.POSTINSTALL
-if postinstall ~= '' then
-    postinstall = '&&' .. postinstall
-end
 
 inv.task('build')
     .using(conda_image)
@@ -87,14 +81,11 @@ inv.task('build')
         .run('rm', '-rf', '/data/dist')
     .using(conda_image)
         .withHostConfig({binds = bind_args})
-        .run('/bin/sh', '-c', preinstall
-            .. conda_bin .. ' create --quiet --yes -p /usr/local/env --copy  && '
-            .. conda_bin .. ' install '
-            .. channel_args .. ' '
-            .. target_args
-            .. ' --strict-channel-priority -p /usr/local/env --copy --yes '
-            .. verbose
-            .. postinstall)
+        .run('/bin/sh', '-c', preinstall)
+        .run('/bin/sh', '-c', conda_bin .. ' create --quiet --yes -p /usr/local/env --copy')
+        .run('/bin/sh', '-c', conda_bin .. ' install ' .. channel_args .. ' ' .. target_args
+             .. ' --strict-channel-priority -p /usr/local/env --copy --yes ' .. verbose)
+        .run('/bin/sh', '-c', postinstall)
     .wrap('build/dist/env')
         .at('/usr/local')
         .inImage(destination_base_image)

--- a/lib/galaxy/tool_util/deps/mulled/invfile.lua
+++ b/lib/galaxy/tool_util/deps/mulled/invfile.lua
@@ -72,8 +72,14 @@ else
 end
 
 local preinstall = VAR.PREINSTALL
+if preinstall ~= '' then
+    preinstall = preinstall .. ' && '
+end
 
 local postinstall = VAR.POSTINSTALL
+if postinstall ~= '' then
+    postinstall = '&&' .. postinstall
+end
 
 inv.task('build')
     .using(conda_image)
@@ -81,11 +87,14 @@ inv.task('build')
         .run('rm', '-rf', '/data/dist')
     .using(conda_image)
         .withHostConfig({binds = bind_args})
-        .run('/bin/sh', '-c', preinstall)
-        .run('/bin/sh', '-c', conda_bin .. ' create --quiet --yes -p /usr/local/env --copy')
-        .run('/bin/sh', '-c', conda_bin .. ' install ' .. channel_args .. ' ' .. target_args
-             .. ' --strict-channel-priority -p /usr/local/env --copy --yes ' .. verbose)
-        .run('/bin/sh', '-c', postinstall)
+        .run('/bin/sh', '-c', preinstall
+            .. conda_bin .. ' create --quiet --yes -p /usr/local/env --copy  && '
+            .. conda_bin .. ' install '
+            .. channel_args .. ' '
+            .. target_args
+            .. ' --strict-channel-priority -p /usr/local/env --copy --yes '
+            .. verbose
+            .. postinstall)
     .wrap('build/dist/env')
         .at('/usr/local')
         .inImage(destination_base_image)


### PR DESCRIPTION
Just a quick attempt at reducing the amount of failing tests, feel free to step in with a better solution.

---

Test `tests/tool_util/mulled/test_mulled_build.py::test_mulled_build_files_cli[True]`, where `[True]` refers to the parameter `use_mamba`, fails because if `conda install --quiet --yes 'mamba='` (the preinstall command) runs before `mamba install -p /usr/local`, then the latter expects either `/usr/local` not to exist or to be an existing environment.

To work this around, create an environment in `/usr/local/env`, but still put it on the expected location `/usr/local` later.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
