### PR TITLE
Allow to send notifications when Admins cancel jobs

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -13219,6 +13219,11 @@ export interface components {
              * @description The email of the user that owns this job. Only the owner of the job and administrators can see this value.
              */
             user_email?: string | null;
+            /**
+             * User ID
+             * @description The encoded ID of the user that owns this job.
+             */
+            user_id?: string | null;
         };
         /**
          * LabelValuePair

--- a/client/src/components/admin/JobsList.vue
+++ b/client/src/components/admin/JobsList.vue
@@ -263,7 +263,8 @@ export default {
         onRefresh() {
             this.update();
         },
-        async sendNotificationToUsers(cancelReason) {
+        async sendNotificationToUsers() {
+            const cancelReason = this.stopMessage || "No reason provided";
             const jobsToCancel = this.unfinishedJobs.filter((job) => this.selectedStopJobIds.includes(job.id));
             // Group jobs by user
             const userJobsMap = jobsToCancel.reduce((acc, job) => {
@@ -322,8 +323,8 @@ export default {
         },
         onStopJobs() {
             axios.all(this.selectedStopJobIds.map((jobId) => cancelJob(jobId, this.stopMessage))).then((res) => {
-                if (this.sendNotification && this.stopMessage) {
-                    this.sendNotificationToUsers(this.stopMessage);
+                if (this.sendNotification) {
+                    this.sendNotificationToUsers();
                 }
                 this.update();
                 this.selectedStopJobIds = [];

--- a/client/src/components/admin/JobsList.vue
+++ b/client/src/components/admin/JobsList.vue
@@ -290,7 +290,7 @@ export default {
                             category: "message",
                             subject: "Jobs Cancelled by Admin",
                             message: `The following jobs (${jobs
-                                .map((job) => `**${job.id}**`)
+                                .map((job) => `**[${job.tool_id || job.id}](${this.getJobViewLink(job.id)})**`)
                                 .join(", ")}) were cancelled by an administrator. Reason: **${cancelReason}**.`,
                         },
                     },
@@ -315,6 +315,9 @@ export default {
                 this.message = `Notification sent to ${numSuccess} out of ${totalUsers} users.`;
                 this.status = "success";
             }
+        },
+        getJobViewLink(jobId) {
+            return `${getAppRoot()}jobs/${jobId}/view`;
         },
         onStopJobs() {
             axios.all(this.selectedStopJobIds.map((jobId) => cancelJob(jobId, this.stopMessage))).then((res) => {

--- a/client/src/components/admin/JobsList.vue
+++ b/client/src/components/admin/JobsList.vue
@@ -51,9 +51,12 @@
                         </b-input-group-append>
                     </b-input-group>
                 </b-form-group>
-                <b-form-checkbox id="send-notification" v-model="sendNotification" switch class="mb-4">
-                    Send a warning notification to users (must provide stop message)
-                </b-form-checkbox>
+                <b-form-group
+                    description="Only one notification will be sent for each user containing the reason and the list of affected jobs.">
+                    <b-form-checkbox id="send-notification" v-model="sendNotification" switch>
+                        Send a warning notification to users
+                    </b-form-checkbox>
+                </b-form-group>
             </b-form>
         </transition>
         <h3 class="mb-0 h-sm">Unfinished Jobs</h3>

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2120,6 +2120,11 @@ class JobSummary(JobBaseModel):
             "Only the owner of the job and administrators can see this value."
         ),
     )
+    user_id: Optional[EncodedDatabaseIdField] = Field(
+        None,
+        title="User ID",
+        description="The encoded ID of the user that owns this job.",
+    )
 
 
 class DatasetSourceIdBase(Model):

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -94,6 +94,7 @@ class JobsService(ServiceBase):
                 job_dict["decoded_job_id"] = job.id
             if user_details:
                 job_dict["user_email"] = job.get_user_email()
+                job_dict["user_id"] = job.user_id
             out.append(job_dict)
 
         return out


### PR DESCRIPTION
Stretch goal for #19487, thank you, @GarethPrice-Aus for proposing it.

## Sending job canceled notifications
Admins can now decide to notify users when they cancel any of their jobs.

After selecting the jobs to cancel and providing a message, admins can enable the switch to send notifications. One notification will be sent per user (even if multiple jobs belonging to the same user were canceled).

![image](https://github.com/user-attachments/assets/15098169-58b3-457e-b901-3f0b2a9c8f4c)

The notification will be displayed to the user after a few seconds and potentially get an email if the user has the appropriate notification settings. If multiple jobs for the same user were canceled then all of them will be listed in the notification.

![image](https://github.com/user-attachments/assets/352e903b-832c-4dc1-a8a0-424e0480b0c2)

Clicking any of the jobs (tool IDs) listed in the notification will display a new page with the job details.

![image](https://github.com/user-attachments/assets/2e1d0c87-9c96-4c50-96c6-98e37bd9ad06)

## Small API change
Listing jobs with `user_details` will include the `user_id` in addition to the existing `user_email` for convenience.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
