### PR TITLE
[24.2] Provide guidance in case of deadlock during db migration

### DIFF
--- a/doc/source/admin/db_migration.md
+++ b/doc/source/admin/db_migration.md
@@ -542,6 +542,12 @@ After that, run the upgrade script: `./manage_db.sh upgrade`. And you're done!
 
 ## Troubleshooting
 
+### Deadlock detected
+
+If you see a deadlock error, that may have been caused by a migration script requiring exclusive access
+to a database object, such as a row or a table. To avoid this error, it is recommended to shut down
+all Galaxy processes during database migration.
+
 ### How to handle migrations.IncorrectVersionError
 
 If you see this error, you'll need to upgrade or downgrade your database *before* upgrading to
@@ -552,4 +558,3 @@ is 181. Please see [this issue](https://github.com/galaxyproject/galaxy/issues/1
 
 #### Please help us improve this page:
 If you encounter any migration-related errors or issues, please [open an issue](https://github.com/galaxyproject/galaxy/issues/new?assignees=&labels=&template=bug_report.md&title=), and we will add the solution with any relevant context to this page.
-

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/9a5207190a4d_remove_unique_constraint_from_role_name.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/9a5207190a4d_remove_unique_constraint_from_role_name.py
@@ -6,6 +6,11 @@ Create Date: 2024-10-08 14:08:28.418055
 
 """
 
+import logging
+
+from alembic import op
+from sqlalchemy import text
+
 from galaxy.model.database_object_names import build_index_name
 from galaxy.model.migrations.util import (
     alter_column,
@@ -13,6 +18,8 @@ from galaxy.model.migrations.util import (
     drop_index,
     transaction,
 )
+
+log = logging.getLogger(__name__)
 
 # revision identifiers, used by Alembic.
 revision = "9a5207190a4d"
@@ -35,6 +42,15 @@ def upgrade():
 
 def downgrade():
     with transaction():
-        drop_index(index_name, table_name)
         alter_column(table_name, column_name, nullable=True)
-        create_index(index_name, table_name, [column_name], unique=True)
+
+        stmt = text("SELECT 1 FROM role GROUP BY name HAVING count(*) > 1")
+        has_nonunique_values = op.get_bind().scalar(stmt)
+        if not has_nonunique_values:
+            drop_index(index_name, table_name)
+            create_index(index_name, table_name, [column_name], unique=True)
+        else:
+            msg = f"""This downgrade requires creating a unique index on the `{table_name}.{column_name}` field.
+This operation cannot proceed due to the existence of non-unique values in that column, which are the result of Galaxy v24.2 (and above)
+operating under normal conditions. The current non-unique index will remain unchanged."""
+            log.error(msg)


### PR DESCRIPTION
Ref: #19512
This will catch all PostgreSQL deadlock errors during migrations and will display a helpful message. Also added a troubleshooting note to Galaxy's db migration documentation.

Also fixes downgrading to a unique index on `role.name`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
