### PR TITLE
[24.0] Fix libraries folder include deleted

### DIFF
--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -450,7 +450,12 @@ export default {
                 }
             });
 
-            return this.selected.length + unselectable === this.$refs.folder_content_table.computedItems.length;
+            const numComputedItems = this.$refs.folder_content_table.computedItems.length;
+            if (numComputedItems === 0 || numComputedItems === unselectable) {
+                return false;
+            }
+
+            return this.selected.length + unselectable === numComputedItems;
         },
         toggleSelect() {
             this.unselected = [];

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -203,7 +203,7 @@ export default {
             return this.folderContents.find((el) => el.type === "folder" || el.type === "file");
         },
         canDelete: function () {
-            return !!(this.contains_file_or_folder && this.is_admin);
+            return !!this.is_admin;
         },
         dataset_manipulation: function () {
             const Galaxy = getGalaxyInstance();


### PR DESCRIPTION
Fixes #19509

It now displays the "include deleted" option for admins regardless of the current contents.

![image](https://github.com/user-attachments/assets/7b24908f-c075-4f3d-9014-40c3aecdef32)

## Extra fix
In addition, it fixes the "select all" checkbox being checked when the table is empty or does not have selectable items.

### Before
Notice the "select all" is always checked with an empty table.
![image](https://github.com/user-attachments/assets/abed65c0-5571-4e35-a2fb-929be5ec14de)

### After
![image](https://github.com/user-attachments/assets/236c89d4-eed3-43f2-8243-15741c8004f0)



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
