### PR TITLE
[24.2] Fix "export datasets" tool displaying dialog right away

### DIFF
--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -44,6 +44,8 @@ interface FilesDialogProps {
     requireWritable?: boolean;
     /** Optional selected item to start browsing from */
     selectedItem?: SelectionItem;
+    /** Whether the dialog is visible at the start */
+    isOpen?: boolean;
 }
 
 const props = withDefaults(defineProps<FilesDialogProps>(), {
@@ -54,6 +56,7 @@ const props = withDefaults(defineProps<FilesDialogProps>(), {
     multiple: false,
     requireWritable: false,
     selectedItem: undefined,
+    isOpen: true,
 });
 
 const { config, isConfigLoaded } = useConfig();
@@ -66,7 +69,7 @@ const errorMessage = ref<string>();
 const filter = ref();
 const items = ref<SelectionItem[]>([]);
 const itemsProvider = ref<ItemsProvider>();
-const modalShow = ref(true);
+const modalShow = ref(props.isOpen);
 const optionsShow = ref(false);
 const undoShow = ref(false);
 const hasValue = ref(false);

--- a/client/src/components/Form/Elements/FormDirectory.vue
+++ b/client/src/components/Form/Elements/FormDirectory.vue
@@ -4,7 +4,12 @@
             <b-button id="select-btn" @click="reset">
                 <FontAwesomeIcon icon="folder-open" /> {{ selectText }}
             </b-button>
-            <FilesDialog :key="modalKey" mode="directory" :callback="setUrl" :require-writable="true" />
+            <FilesDialog
+                :key="modalKey"
+                mode="directory"
+                :callback="setUrl"
+                :require-writable="true"
+                :is-open="isModalShown" />
         </div>
         <b-breadcrumb v-if="url">
             <b-breadcrumb-item title="Select another folder" class="align-items-center" @click="reset">
@@ -83,6 +88,7 @@ export default {
         // https://michaelnthiessen.com/force-re-render/
         redrawModal() {
             this.modalKey += 1;
+            this.isModalShown = true;
         },
         removeLastPath(event) {
             // check whether the last item is editable

--- a/client/src/components/Form/Elements/FormDirectory.vue
+++ b/client/src/components/Form/Elements/FormDirectory.vue
@@ -74,6 +74,9 @@ export default {
             return regex.test(this.currentDirectoryName);
         },
     },
+    mounted() {
+        this.updateURL(true);
+    },
     methods: {
         removePath(index) {
             this.pathChunks = this.pathChunks.slice(0, index);


### PR DESCRIPTION
Fixes #19539

This PR also fixes the initial state for `directory_uri` in the Tool Form which will appear as "set" and let you run the tool even if you didn't specify any remote directory.

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/9bfc17cc-0754-41e9-ac46-22cd4d22cd18)   | ![image](https://github.com/user-attachments/assets/fa3bd9c0-00bf-4f5d-8dfc-6675309d2c46)  |

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Follow the steps in #19539

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
