### PR TITLE
[24.2] Fix saved visualization (non-trackster ones) not displaying

### DIFF
--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -618,7 +618,7 @@ def populate_api_routes(webapp, app):
         "/plugins/visualizations/{visualization_name}/saved",
         controller="visualization",
         action="saved",
-        conditions={"method": ["POST"]},
+        conditions={"method": ["GET"]},
     )
     # Deprecated in favor of POST /api/workflows with 'workflow' in payload.
     webapp.mapper.connect(


### PR DESCRIPTION
Fixes #19557

Change the saved visualizations route method from POST to GET. That was the intention in #19495

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
