### PR TITLE
New Messaging for Tool Form Modal Errors

### DIFF
--- a/client/src/components/Common/ErrorPluginTracker.vue
+++ b/client/src/components/Common/ErrorPluginTracker.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { getGalaxyInstance } from "@/app";
+import { computed } from "vue";
+
+const errorReportingAvailable = computed(() =>{
+    const Galaxy = getGalaxyInstance();
+    if (!!Galaxy.Sentry.isInitialized) {
+        return "Your error has been logged in Sentry to improve your experience.";
+    }
+});
+</script>
+<template>
+    <span v-localize>
+        {{ errorReportingAvailable }}
+    </span>
+</template>

--- a/client/src/components/Common/ErrorPluginTracker.vue
+++ b/client/src/components/Common/ErrorPluginTracker.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
-import { getGalaxyInstance } from "@/app";
 import { computed } from "vue";
 
-const errorReportingAvailable = computed(() =>{
+import { getGalaxyInstance } from "@/app";
+
+const errorReportingAvailable = computed(() => {
     const Galaxy = getGalaxyInstance();
-    if (!!Galaxy.Sentry.isInitialized) {
-        return "Your error has been logged in Sentry to improve your experience.";
-    }
+    return Galaxy.Sentry.isInitialized ?? "Your error has been logged in Sentry to improve your experience.";
 });
 </script>
 <template>

--- a/client/src/components/DatasetInformation/DatasetErrorDetails.vue
+++ b/client/src/components/DatasetInformation/DatasetErrorDetails.vue
@@ -35,7 +35,7 @@ const hasDetails = computed(() => {
 
         <div v-if="toolStderr">
             <p>Tool generated the following standard error:</p>
-
+            
             <pre id="dataset-error-tool-stderr" class="rounded code">
                 {{ toolStderr }}
             </pre>

--- a/client/src/components/DatasetInformation/DatasetErrorDetails.vue
+++ b/client/src/components/DatasetInformation/DatasetErrorDetails.vue
@@ -35,7 +35,7 @@ const hasDetails = computed(() => {
 
         <div v-if="toolStderr">
             <p>Tool generated the following standard error:</p>
-            
+
             <pre id="dataset-error-tool-stderr" class="rounded code">
                 {{ toolStderr }}
             </pre>

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -13,6 +13,7 @@
         <b-modal v-model="showError" size="sm" :title="errorTitle | l" scrollable ok-only>
             <b-alert v-if="errorMessage" show variant="danger">
                 {{ errorMessage }}
+                <ErrorPluginTracker />
             </b-alert>
             <b-alert v-if="submissionRequestFailed" show variant="warning">
                 The server could not complete this request. Please verify your parameter settings, retry submission and
@@ -133,6 +134,7 @@ import ToolCard from "./ToolCard";
 import { allowCachedJobs } from "./utilities";
 
 import FormSelect from "@/components/Form/Elements/FormSelect.vue";
+import ErrorPluginTracker from "../Common/ErrorPluginTracker.vue";
 
 export default {
     components: {
@@ -145,6 +147,7 @@ export default {
         ToolEntryPoints,
         ToolRecommendation,
         Heading,
+        ErrorPluginTracker,
     },
     props: {
         id: {

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -141,6 +141,7 @@ import { getToolFormData, submitJob, updateToolFormData } from "./services";
 import ToolCard from "./ToolCard";
 import { allowCachedJobs } from "./utilities";
 
+import ErrorPluginTracker from "@/components/Common/ErrorPluginTracker.vue";
 import FormSelect from "@/components/Form/Elements/FormSelect.vue";
 
 export default {
@@ -266,7 +267,7 @@ export default {
             return "Run Tool";
         },
         expandedIcon() {
-            return this.isExpanded ? '-' : '+';
+            return this.isExpanded ? "-" : "+";
         },
     },
     watch: {

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -19,9 +19,16 @@
                 The server could not complete this request. Please verify your parameter settings, retry submission and
                 contact the Galaxy Team if this error persists. A transcript of the submitted data is shown below.
             </b-alert>
-            <small class="text-muted">
-                <pre>{{ errorContentPretty }}</pre>
-            </small>
+            <BLink
+                :aria-expanded="isExpanded ? 'true' : 'false'"
+                aria-controls="collapse-previous"
+                @click="isExpanded = !isExpanded">
+                ({{ expandedIcon }}) Error transcript:
+            </BLink>
+            <BCollapse id="collapse-previous" v-model="isExpanded">
+                <pre class="rounded code">{{ errorContentPretty }}</pre>
+            </BCollapse>
+            <br />
         </b-modal>
         <ToolRecommendation v-if="showRecommendation" :tool-id="formConfig.id" />
         <ToolCard
@@ -112,6 +119,7 @@
 
 <script>
 import { getGalaxyInstance } from "app";
+import { BCollapse, BLink } from "bootstrap-vue";
 import ButtonSpinner from "components/Common/ButtonSpinner";
 import Heading from "components/Common/Heading";
 import FormDisplay from "components/Form/FormDisplay";
@@ -134,7 +142,6 @@ import ToolCard from "./ToolCard";
 import { allowCachedJobs } from "./utilities";
 
 import FormSelect from "@/components/Form/Elements/FormSelect.vue";
-import ErrorPluginTracker from "../Common/ErrorPluginTracker.vue";
 
 export default {
     components: {
@@ -148,6 +155,8 @@ export default {
         ToolRecommendation,
         Heading,
         ErrorPluginTracker,
+        BCollapse,
+        BLink,
     },
     props: {
         id: {
@@ -208,6 +217,7 @@ export default {
             ],
             immutableHistoryMessage:
                 "This history is immutable and you cannot run tools in it. Please switch to a different history.",
+            isExpanded: false,
         };
     },
     computed: {
@@ -254,6 +264,9 @@ export default {
         },
         runButtonTitle() {
             return "Run Tool";
+        },
+        expandedIcon() {
+            return this.isExpanded ? '-' : '+';
         },
     },
     watch: {


### PR DESCRIPTION
`Your error has been logged in Sentry to improve your experience.`
![Greenshot 2025-02-06 12 29 07](https://github.com/user-attachments/assets/d813e973-6635-45e4-a8b6-38d727262e00)

Added clarity for errors before Job ID or Dataset ID creation:
* Componentized for: default (ErrorPlugin) or third-party (Sentry)
* Extensible for future user error-tracking (Event-ID) information

Reported by @hexylena in issue
https://github.com/galaxyproject/galaxy/issues/17560

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
