### PR TITLE
[24.2] Set content-type to text/plain if dataset not safe

### DIFF
--- a/client/src/entry/analysis/modules/CenterFrame.vue
+++ b/client/src/entry/analysis/modules/CenterFrame.vue
@@ -1,46 +1,97 @@
-<template>
-    <iframe
-        :id="id"
-        :name="id"
-        :src="srcWithRoot"
-        class="center-frame"
-        frameborder="0"
-        title="galaxy frame"
-        width="100%"
-        height="100%"
-        @load="onLoad" />
-</template>
-<script>
-import { withPrefix } from "utils/redirect";
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
 
-export default {
-    props: {
-        id: {
-            type: String,
-            default: "frame",
-        },
-        src: {
-            type: String,
-            default: "",
-        },
-    },
-    computed: {
-        srcWithRoot() {
-            return withPrefix(this.src);
-        },
-    },
-    methods: {
-        onLoad(ev) {
-            const iframe = ev.currentTarget;
-            const location = iframe.contentWindow && iframe.contentWindow.location;
+import { useUserStore } from "@/stores/userStore";
+import { withPrefix } from "@/utils/redirect";
+
+import Alert from "@/components/Alert.vue";
+import LoadingSpan from "@/components/LoadingSpan.vue";
+
+const emit = defineEmits(["load"]);
+const props = withDefaults(
+    defineProps<{
+        id?: string;
+        src?: string;
+        isPreview?: boolean;
+    }>(),
+    {
+        id: "frame",
+        src: "",
+        isPreview: false,
+    }
+);
+
+const { isAdmin } = useUserStore();
+const srcWithRoot = computed(() => withPrefix(props.src));
+const sanitizedImport = ref(false);
+const sanitizedToolId = ref<String | false>(false);
+const isLoading = ref(true);
+watch(
+    () => srcWithRoot.value,
+    async () => {
+        sanitizedImport.value = false;
+        sanitizedToolId.value = false;
+        if (props.isPreview) {
             try {
-                if (location && location.host && location.pathname != "/") {
-                    this.$emit("load");
+                const response = await fetch(srcWithRoot.value, { method: "HEAD" });
+                const isImported = response.headers.get("x-sanitized-job-imported");
+                const toolId = response.headers.get("x-sanitized-tool-id");
+                if (isImported !== null) {
+                    sanitizedImport.value = true;
+                } else if (toolId !== null) {
+                    sanitizedToolId.value = toolId;
                 }
-            } catch (err) {
-                console.warn("CenterFrame - onLoad location access forbidden.", ev, location);
+            } catch (e) {
+                // I guess that's fine and the center panel will show something
+                console.error(e);
             }
-        },
+        }
     },
-};
+    { immediate: true }
+);
+
+const plainText = "Contents are shown as plain text.";
+const sanitizedMessage = computed(() => {
+    if (sanitizedImport.value) {
+        return `Dataset has been imported. ${plainText}`;
+    } else if (sanitizedToolId.value) {
+        return `Dataset created by a tool that is not known to create safe HTML. ${plainText}`;
+    }
+    return undefined;
+});
+
+function onLoad(ev: Event) {
+    isLoading.value = false;
+    const iframe = ev.currentTarget as HTMLIFrameElement;
+    const location = iframe?.contentWindow && iframe.contentWindow.location;
+    try {
+        if (location && location.host && location.pathname != "/") {
+            emit("load");
+        }
+    } catch (err) {
+        console.warn("CenterFrame - onLoad location access forbidden.", ev, location);
+    }
+}
 </script>
+<template>
+    <div>
+        <Alert v-if="sanitizedMessage" :dismissible="true" variant="warning">
+            {{ sanitizedMessage }}
+            <p v-if="isAdmin && sanitizedToolId">
+                <router-link to="/admin/sanitize_allow">Review Allowlist</router-link> if outputs of
+                {{ sanitizedToolId }} are trusted and should be shown as HTML.
+            </p>
+        </Alert>
+        <LoadingSpan v-if="isLoading">Loading ...</LoadingSpan>
+        <iframe
+            :id="id"
+            :name="id"
+            :src="srcWithRoot"
+            class="center-frame"
+            frameborder="0"
+            title="galaxy frame"
+            width="100%"
+            height="100%"
+            @load="onLoad" />
+    </div>
+</template>

--- a/client/src/entry/analysis/modules/CenterFrame.vue
+++ b/client/src/entry/analysis/modules/CenterFrame.vue
@@ -78,10 +78,11 @@ function onLoad(ev: Event) {
     <div class="h-100">
         <Alert v-if="sanitizedMessage" :dismissible="true" variant="warning" data-description="sanitization warning">
             {{ sanitizedMessage }}
-            <p v-if="isAdmin && sanitizedToolId">
+            <span v-if="isAdmin && sanitizedToolId">
+                <br />
                 <router-link data-description="allowlist link" to="/admin/sanitize_allow">Review Allowlist</router-link>
                 if outputs of {{ sanitizedToolId }} are trusted and should be shown as HTML.
-            </p>
+            </span>
         </Alert>
         <LoadingSpan v-if="isLoading">Loading ...</LoadingSpan>
         <iframe

--- a/client/src/entry/analysis/modules/CenterFrame.vue
+++ b/client/src/entry/analysis/modules/CenterFrame.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 
 import { useUserStore } from "@/stores/userStore";
@@ -21,7 +22,7 @@ const props = withDefaults(
     }
 );
 
-const { isAdmin } = useUserStore();
+const { isAdmin } = storeToRefs(useUserStore());
 const srcWithRoot = computed(() => withPrefix(props.src));
 const sanitizedImport = ref(false);
 const sanitizedToolId = ref<String | false>(false);
@@ -74,12 +75,12 @@ function onLoad(ev: Event) {
 }
 </script>
 <template>
-    <div>
-        <Alert v-if="sanitizedMessage" :dismissible="true" variant="warning">
+    <div class="h-100">
+        <Alert v-if="sanitizedMessage" :dismissible="true" variant="warning" data-description="sanitization warning">
             {{ sanitizedMessage }}
             <p v-if="isAdmin && sanitizedToolId">
-                <router-link to="/admin/sanitize_allow">Review Allowlist</router-link> if outputs of
-                {{ sanitizedToolId }} are trusted and should be shown as HTML.
+                <router-link data-description="allowlist link" to="/admin/sanitize_allow">Review Allowlist</router-link>
+                if outputs of {{ sanitizedToolId }} are trusted and should be shown as HTML.
             </p>
         </Alert>
         <LoadingSpan v-if="isLoading">Loading ...</LoadingSpan>

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -238,6 +238,7 @@ export function getRouter(Galaxy) {
                         component: CenterFrame,
                         props: (route) => ({
                             src: `/datasets/${route.params.datasetId}/display/?preview=True`,
+                            isPreview: true,
                         }),
                     },
                     {

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -641,8 +641,10 @@ class Data(metaclass=DataMeta):
             content_type = "text/html"
             if from_dataset.creating_job.imported:
                 content_type = "text/plain"
+                headers["x-sanitized-job-imported"] = True
             if not from_dataset.creating_job.tool_id.startswith(tuple(trans.app.config.sanitize_allowlist)):
                 content_type = "text/plain"
+                headers["x-sanitized-tool-id"] = from_dataset.creating_job.tool_id
             headers["content-type"] = content_type
 
         return open(filename, mode="rb")

--- a/lib/galaxy/selenium/has_driver.py
+++ b/lib/galaxy/selenium/has_driver.py
@@ -116,6 +116,9 @@ class HasDriver:
     def element_absent(self, selector_template: Target) -> bool:
         return len(self.find_elements(selector_template)) == 0
 
+    def switch_to_frame(self, name: str = "frame"):
+        return self._wait_on(ec.frame_to_be_available_and_switch_to_it((By.NAME, name)))
+
     def wait_for_xpath(self, xpath: str, **kwds) -> WebElement:
         element = self._wait_on(
             ec.presence_of_element_located((By.XPATH, xpath)), f"XPATH selector [{xpath}] to become present", **kwds

--- a/test/functional/tools/html_output.xml
+++ b/test/functional/tools/html_output.xml
@@ -1,0 +1,25 @@
+<tool id="html_output" name="html_output" version="1.0.0">
+    <command><![CDATA[
+cp '$html_file' '$output'
+    ]]></command>
+    <configfiles>
+        <configfile name="html_file"><![CDATA[
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title data-description="hello-world">Hello World</title>
+</head>
+<body>
+    <main>
+       <h1>Hello, World!</h1>
+    </main>
+</body>
+</html>
+        ]]></configfile>
+    </configfiles>
+    <outputs>
+        <data name="output" format="html" />
+    </outputs>
+</tool>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -243,6 +243,7 @@
 
   <tool file="multiple_versions_changes_v01.xml" />
   <tool file="multiple_versions_changes_v02.xml" />
+  <tool file="html_output.xml" />
 
   <tool file="interactivetool_simple.xml" />
   <tool file="interactivetool_two_entry_points.xml" />

--- a/test/integration_selenium/test_allowlist_sanitization.py
+++ b/test/integration_selenium/test_allowlist_sanitization.py
@@ -1,0 +1,52 @@
+from .framework import (
+    selenium_test,
+    SeleniumIntegrationTestCase,
+)
+
+
+class TestAllowListSanitization(SeleniumIntegrationTestCase):
+    run_as_admin = True
+    axe_skip = True  # skip testing iframe contents
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        config["sanitize_all_html"] = True
+
+    def run_html_output(self):
+        history_id = self.dataset_populator.new_history()
+        run_response = self.dataset_populator.run_tool("html_output", {}, history_id=history_id)
+        hda_id = run_response["outputs"][0]["id"]
+        self.dataset_populator.wait_for_dataset(history_id, dataset_id=hda_id)
+        return hda_id
+
+    @selenium_test
+    def test_html_output_sanitized(self):
+        self.login()
+        hda_id = self.run_html_output()
+        self.get(f"datasets/{hda_id}/preview")
+        self.wait_for_selector_visible("[data-description='sanitization warning']")
+        self.assert_selector_absent("[data-description='allowlist link']")
+        self.screenshot("sanitization warning")
+        assert self.switch_to_frame()
+        self.assert_selector_absent("[data-description='hello-world']")
+
+    @selenium_test
+    def test_html_output_sanitized_admin(self):
+        self.admin_login()
+        hda_id = self.run_html_output()
+        self.get(f"datasets/{hda_id}/preview")
+        self.wait_for_selector_visible("[data-description='sanitization warning']")
+        self.wait_for_selector_visible("[data-description='allowlist link']")
+        self.screenshot("sanitization warning admin")
+        try:
+            self._put(
+                "/api/sanitize_allow?tool_id=html_output", data={"params": {"tool_id": "html_output"}}, admin=True
+            ).raise_for_status()
+            self.driver.refresh()
+            self.assert_selector_absent("[data-description='sanitization warning']")
+            self.assert_selector_absent("[data-description='allowlist link']")
+            assert self.switch_to_frame()
+            self.wait_for_selector("[data-description='hello-world']")
+        finally:
+            self._delete("/api/sanitize_allow?tool_id=html_output", admin=True)


### PR DESCRIPTION
We only care about XSS in the context of the webapp, and for that it is sufficient to set the content-type to text/plain.
We might be passing large secondary files through this which has performance implications.

Also adds a sanitization message and a loading indicator for the iframe content if we're hitting a preview route.

<img width="756" alt="Screenshot 2025-02-07 at 20 04 47" src="https://github.com/user-attachments/assets/7c9f1eb2-11c7-4777-831c-a85a8cff2695" />

The allow list link is only shown for admins.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

Create an HTML file with a tool that creates HTML files (multiqc, fastqc etc). Click on the eye icon and see that the file is displayed as text if it is not on the allow list. Hardcode content-type on line 647 to `text/html` to see that now it is rendered as html. Hardcode it back to `text/plan` and see it displayed as text.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
