### PR TITLE
[24.2] Add Python 3.13 classifier to packages

### DIFF
--- a/packages/app/setup.cfg
+++ b/packages/app/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/auth/setup.cfg
+++ b/packages/auth/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/config/setup.cfg
+++ b/packages/config/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/data/setup.cfg
+++ b/packages/data/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/files/setup.cfg
+++ b/packages/files/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/job_execution/setup.cfg
+++ b/packages/job_execution/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/job_metrics/setup.cfg
+++ b/packages/job_metrics/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/meta/setup.cfg
+++ b/packages/meta/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Scientific/Engineering :: Bio-Informatics
     Topic :: Software Development
     Topic :: Software Development :: Code Generators

--- a/packages/navigation/setup.cfg
+++ b/packages/navigation/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/objectstore/setup.cfg
+++ b/packages/objectstore/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/schema/setup.cfg
+++ b/packages/schema/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/selenium/setup.cfg
+++ b/packages/selenium/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/test_api/setup.cfg
+++ b/packages/test_api/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/test_base/setup.cfg
+++ b/packages/test_base/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/test_driver/setup.cfg
+++ b/packages/test_driver/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/test_selenium/setup.cfg
+++ b/packages/test_selenium/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/tool_shed/setup.cfg
+++ b/packages/tool_shed/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/tool_util/setup.cfg
+++ b/packages/tool_util/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/tours/setup.cfg
+++ b/packages/tours/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/util/setup.cfg
+++ b/packages/util/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/web_apps/setup.cfg
+++ b/packages/web_apps/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/web_framework/setup.cfg
+++ b/packages/web_framework/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing

--- a/packages/web_stack/setup.cfg
+++ b/packages/web_stack/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing


### PR DESCRIPTION
Follow-up on https://github.com/galaxyproject/galaxy/pull/18449 .

Also re-adding the missing newlines at the end of the `setup.cfg` files, see https://github.com/galaxyproject/galaxy-release-util/pull/29 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
