### PR TITLE
[24.0] Fix type annotations for pysam 0.23.0

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -570,7 +570,7 @@ class BamNative(CompressedArchive, _BamOrSam):
         :param split_files: List of bam file paths to merge
         :param output_file: Write merged bam file to this location
         """
-        pysam.merge("-O", "BAM", output_file, *split_files)  # type: ignore[attr-defined]
+        pysam.merge("-O", "BAM", output_file, *split_files)  # type: ignore[attr-defined, unused-ignore]
 
     def init_meta(self, dataset: HasMetadata, copy_from: Optional[HasMetadata] = None) -> None:
         Binary.init_meta(self, dataset, copy_from=copy_from)
@@ -638,7 +638,7 @@ class BamNative(CompressedArchive, _BamOrSam):
             [f"-@{slots}", file_name, "-T", tmp_sorted_dataset_file_name_prefix, "-O", "BAM", "-o", sorted_file_name]
         )
         try:
-            pysam.sort(*sort_args)  # type: ignore[attr-defined]
+            pysam.sort(*sort_args)  # type: ignore[attr-defined, unused-ignore]
         except Exception:
             shutil.rmtree(tmp_dir, ignore_errors=True)
             raise
@@ -835,9 +835,9 @@ class Bam(BamNative):
             )
         if index_flag == "-b":
             # IOError: No such file or directory: '-b' if index_flag is set to -b (pysam 0.15.4)
-            pysam.index("-o", index_file.get_file_name(), dataset.get_file_name())  # type: ignore [attr-defined]
+            pysam.index("-o", index_file.get_file_name(), dataset.get_file_name())  # type: ignore[attr-defined, unused-ignore]
         else:
-            pysam.index(index_flag, "-o", index_file.get_file_name(), dataset.get_file_name())  # type: ignore [attr-defined]
+            pysam.index(index_flag, "-o", index_file.get_file_name(), dataset.get_file_name())  # type: ignore[attr-defined, unused-ignore]
         dataset.metadata.bam_index = index_file
 
     def sniff(self, filename: str) -> bool:
@@ -1028,7 +1028,7 @@ class CRAM(Binary):
 
     def set_index_file(self, dataset: HasFileName, index_file) -> bool:
         try:
-            pysam.index("-o", index_file.get_file_name(), dataset.get_file_name())  # type: ignore [attr-defined]
+            pysam.index("-o", index_file.get_file_name(), dataset.get_file_name())  # type: ignore[attr-defined, unused-ignore]
             return True
         except Exception as exc:
             log.warning("%s, set_index_file Exception: %s", self, exc)

--- a/test/unit/data/datatypes/test_bam.py
+++ b/test/unit/data/datatypes/test_bam.py
@@ -1,6 +1,6 @@
 import json
 
-from pysam import (  # type: ignore[attr-defined]
+from pysam import (  # type: ignore[attr-defined, unused-ignore]
     AlignmentFile,
     view,
 )
@@ -16,8 +16,12 @@ from .util import (
 def test_merge_bam():
     with get_input_files("1.bam", "1.bam") as input_files, get_tmp_path() as outpath:
         Bam.merge(input_files, outpath)
-        alignment_count_output = int(view("-c", outpath).strip())
-        alignment_count_input = int(view("-c", input_files[0]).strip()) * 2
+        ret = view("-c", outpath)
+        assert isinstance(ret, str)
+        alignment_count_output = int(ret.strip())
+        ret = view("-c", input_files[0])
+        assert isinstance(ret, str)
+        alignment_count_input = int(ret.strip()) * 2
         assert alignment_count_input == alignment_count_output
 
 


### PR DESCRIPTION
Partial backport of commit faa752ed03a8b2a9c37b103c23b5bbc235ff52d3 to fix test_galaxy_packages tests.
For lines where the `type: ignore` comment is not needed any more, here we add `unused-ignore` instead of removing the comment, so that the (non-package) mypy tests don't fail (since those still use an older pysam).

When merging forward, choose removing the comment (i.e. the dev version).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
