### PR TITLE
[24.1] Fix collection load error handling

### DIFF
--- a/client/src/components/Collections/common/CollectionEditView.vue
+++ b/client/src/components/Collections/common/CollectionEditView.vue
@@ -55,18 +55,26 @@ const collectionChangeKey = ref(0);
 const attributesData = computed(() => {
     return collectionAttributesStore.getAttributes(props.collectionId);
 });
-const attributesLoadError = computed(() =>
-    errorMessageAsString(collectionAttributesStore.hasItemLoadError(props.collectionId))
-);
+
+const attributesLoadError = computed(() => {
+    const itemLoadError = collectionAttributesStore.getItemLoadError(props.collectionId);
+    if (itemLoadError) {
+        return errorMessageAsString(itemLoadError);
+    }
+    return undefined;
+});
 
 const collection = computed(() => {
     return collectionStore.getCollectionById(props.collectionId);
 });
 const collectionLoadError = computed(() => {
     if (collection.value) {
-        return errorMessageAsString(collectionStore.hasLoadingCollectionElementsError(collection.value));
+        const collectionElementLoadError = collectionStore.getLoadingCollectionElementsError(collection.value);
+        if (collectionElementLoadError) {
+            return errorMessageAsString(collectionElementLoadError);
+        }
     }
-    return "";
+    return undefined;
 });
 watch([attributesLoadError, collectionLoadError], () => {
     if (attributesLoadError.value) {

--- a/client/src/components/History/CurrentCollection/CollectionPanel.vue
+++ b/client/src/components/History/CurrentCollection/CollectionPanel.vue
@@ -57,7 +57,7 @@ watch(
 
 const collectionElements = computed(() => collectionElementsStore.getCollectionElements(dsc.value) ?? []);
 const loading = computed(() => collectionElementsStore.isLoadingCollectionElements(dsc.value));
-const error = computed(() => collectionElementsStore.hasLoadingCollectionElementsError(dsc.value));
+const error = computed(() => collectionElementsStore.getLoadingCollectionElementsError(dsc.value));
 const jobState = computed(() => ("job_state_summary" in dsc.value ? dsc.value.job_state_summary : undefined));
 const populatedStateMsg = computed(() =>
     "populated_state_message" in dsc.value ? dsc.value.populated_state_message : undefined

--- a/client/src/composables/keyedCache.ts
+++ b/client/src/composables/keyedCache.ts
@@ -108,11 +108,11 @@ export function useKeyedCache<T>(
          */
         getItemById,
         /**
-         * A computed function that returns true if the item with the given id is currently being fetched.
+         * A computed function holding errors
          */
         getItemLoadError,
         /**
-         * A computed function holding errors
+         * A computed function that returns true if the item with the given id is currently being fetched.
          */
         isLoadingItem,
         /**

--- a/client/src/composables/keyedCache.ts
+++ b/client/src/composables/keyedCache.ts
@@ -70,7 +70,7 @@ export function useKeyedCache<T>(
         };
     });
 
-    const hasItemLoadError = computed(() => {
+    const getItemLoadError = computed(() => {
         return (id: string) => {
             return loadingErrors.value[id] ?? null;
         };
@@ -110,7 +110,7 @@ export function useKeyedCache<T>(
         /**
          * A computed function that returns true if the item with the given id is currently being fetched.
          */
-        hasItemLoadError,
+        getItemLoadError,
         /**
          * A computed function holding errors
          */

--- a/client/src/stores/collectionAttributesStore.ts
+++ b/client/src/stores/collectionAttributesStore.ts
@@ -5,7 +5,7 @@ import { fetchCollectionAttributes } from "@/api/datasetCollections";
 import { useKeyedCache } from "@/composables/keyedCache";
 
 export const useCollectionAttributesStore = defineStore("collectionAttributesStore", () => {
-    const { storedItems, getItemById, isLoadingItem, hasItemLoadError } = useKeyedCache<DatasetCollectionAttributes>(
+    const { storedItems, getItemById, isLoadingItem, getItemLoadError } = useKeyedCache<DatasetCollectionAttributes>(
         (params) => fetchCollectionAttributes({ id: params.id, instance_type: "history" })
     );
 
@@ -13,6 +13,6 @@ export const useCollectionAttributesStore = defineStore("collectionAttributesSto
         storedAttributes: storedItems,
         getAttributes: getItemById,
         isLoadingAttributes: isLoadingItem,
-        hasItemLoadError: hasItemLoadError,
+        getItemLoadError: getItemLoadError,
     };
 });

--- a/client/src/stores/collectionElementsStore.ts
+++ b/client/src/stores/collectionElementsStore.ts
@@ -64,7 +64,7 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
         };
     });
 
-    const hasLoadingCollectionElementsError = computed(() => {
+    const getLoadingCollectionElementsError = computed(() => {
         return (collection: CollectionEntry) => {
             return loadingCollectionElementsErrors.value[getCollectionKey(collection)] ?? false;
         };
@@ -214,7 +214,7 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
         storedCollectionElements,
         getCollectionElements,
         isLoadingCollectionElements,
-        hasLoadingCollectionElementsError,
+        getLoadingCollectionElementsError,
         loadingCollectionElementsErrors,
         getCollectionById,
         fetchCollection,


### PR DESCRIPTION
We'd pass null to `errorMessageAsString` and that would result in an error message where none was required.
Fixes a bug @blankenberg reported.

![image](https://github.com/user-attachments/assets/36c6df9b-e9cf-4787-a457-8eaae34d6df3)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
