### PR TITLE
Expand workflow metadata for readme. 

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -386,9 +386,7 @@ export default {
             "modify readme"
         );
         function setReadme(newReadme) {
-            console.log("IN SET README>.....");
             if (readme.value !== newReadme) {
-                console.log("setting with the readme handler...");
                 setReadmeHandler.set(readme.value, newReadme);
             }
         }

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -91,12 +91,18 @@
                     :versions="versions"
                     :license="license"
                     :creator="creator"
+                    :logo-url="logoUrl"
+                    :readme="readme"
+                    :help="help"
                     @version="onVersion"
                     @tags="setTags"
                     @license="onLicense"
                     @creator="onCreator"
                     @update:nameCurrent="setName"
-                    @update:annotationCurrent="setAnnotation" />
+                    @update:annotationCurrent="setAnnotation"
+                    @update:logoUrlCurrent="setLogoUrl"
+                    @update:readmeCurrent="setReadme"
+                    @update:helpCurrent="setHelp" />
             </template>
         </ActivityBar>
         <template v-if="reportActive">
@@ -372,6 +378,47 @@ export default {
             }
         }
 
+        const readme = ref(null);
+        const setReadmeHandler = new SetValueActionHandler(
+            undoRedoStore,
+            (value) => (readme.value = value),
+            showAttributes,
+            "modify readme"
+        );
+        function setReadme(newReadme) {
+            console.log("IN SET README>.....");
+            if (readme.value !== newReadme) {
+                console.log("setting with the readme handler...");
+                setReadmeHandler.set(readme.value, newReadme);
+            }
+        }
+
+        const help = ref(null);
+        const setHelpHandler = new SetValueActionHandler(
+            undoRedoStore,
+            (value) => (help.value = value),
+            showAttributes,
+            "modify help"
+        );
+        function setHelp(newHelp) {
+            if (help.value !== newHelp) {
+                setHelpHandler.set(help.value, newHelp);
+            }
+        }
+
+        const logoUrl = ref(null);
+        const setLogoUrlHandler = new SetValueActionHandler(
+            undoRedoStore,
+            (value) => (logoUrl.value = value),
+            showAttributes,
+            "modify logo url"
+        );
+        function setLogoUrl(newLogoUrl) {
+            if (logoUrl.value !== newLogoUrl) {
+                setLogoUrlHandler.set(logoUrl.value, newLogoUrl);
+            }
+        }
+
         const tags = ref([]);
 
         watch(
@@ -496,6 +543,12 @@ export default {
             setCreator,
             annotation,
             setAnnotation,
+            readme,
+            setReadme,
+            help,
+            setHelp,
+            logoUrl,
+            setLogoUrl,
             tags,
             setTags,
             rightPanelElement,
@@ -578,6 +631,21 @@ export default {
         },
         name(newName, oldName) {
             if (newName != oldName) {
+                this.hasChanges = true;
+            }
+        },
+        readme(newReadme, oldReadme) {
+            if (newReadme != oldReadme) {
+                this.hasChanges = true;
+            }
+        },
+        help(newHelp, oldHelp) {
+            if (newHelp != oldHelp) {
+                this.hasChanges = true;
+            }
+        },
+        logoUrl(newLogoUrl, oldLogoUrl) {
+            if (newLogoUrl != oldLogoUrl) {
                 this.hasChanges = true;
             }
         },
@@ -975,6 +1043,15 @@ export default {
             }
             if (data.annotation !== undefined) {
                 this.annotation = data.annotation;
+            }
+            if (data.readme !== undefined) {
+                this.readme = data.readme;
+            }
+            if (data.help !== undefined) {
+                this.help = data.help;
+            }
+            if (data.logo_url !== undefined) {
+                this.logoUrl = data.logo_url;
             }
             if (data.version !== undefined) {
                 this.version = data.version;

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -369,7 +369,7 @@ export default {
             undoRedoStore,
             (value) => (annotation.value = value),
             showAttributes,
-            "modify annotation"
+            "modify short description"
         );
         /** user set annotation. queues an undo/redo action */
         function setAnnotation(newAnnotation) {

--- a/client/src/components/Workflow/Editor/Lint.test.js
+++ b/client/src/components/Workflow/Editor/Lint.test.js
@@ -110,14 +110,16 @@ describe("Lint", () => {
     });
 
     it("test checked vs unchecked issues", async () => {
+        const numLintChecksPassing = 4;
+        const numLintChecksFailing = 5;
         const checked = wrapper.findAll("[data-icon='check']");
-        expect(checked.length).toBe(2);
+        expect(checked.length).toBe(numLintChecksPassing);
 
         const unchecked = wrapper.findAll("[data-icon='exclamation-triangle']");
-        expect(unchecked.length).toBe(5);
+        expect(unchecked.length).toBe(numLintChecksFailing);
 
         const links = wrapper.findAll("a");
-        expect(links.length).toBe(5);
+        expect(links.length).toBe(numLintChecksFailing);
         expect(links.at(0).text()).toContain("Provide Creator Details.");
         expect(links.at(1).text()).toContain("Specify a License.");
         expect(links.at(2).text()).toContain("untyped_parameter");

--- a/client/src/components/Workflow/Editor/Lint.vue
+++ b/client/src/components/Workflow/Editor/Lint.vue
@@ -8,13 +8,19 @@
             success-message="This workflow has a short description. Ideally, this helps the executors of the workflow
                     understand the purpose and usage of the workflow."
             :warning-message="bestPracticeWarningAnnotation"
-            attribute-link="Annotate your Workflow."
+            attribute-link="Describe your Workflow."
+            @onClick="onAttributes('annotation')" />
+        <LintSection
+            :okay="checkAnnotationLength"
+            :success-message="annotationLengthSuccessMessage"
+            :warning-message="bestPracticeWarningAnnotationLength"
+            attribute-link="Shorten your Workflow Description."
             @onClick="onAttributes('annotation')" />
         <LintSection
             :okay="checkReadme"
             success-message="This workflow has a readme. Ideally, this helps the researchers understand the purpose, limitations, and usage of the workflow."
             :warning-message="bestPracticeWarningReadme"
-            attribute-link="Annotate your Workflow."
+            attribute-link="Provider Readme for your Workflow."
             @onClick="onAttributes('readme')" />
         <LintSection
             :okay="checkCreator"
@@ -81,6 +87,7 @@ import { useWorkflowStores } from "@/composables/workflowStores";
 
 import {
     bestPracticeWarningAnnotation,
+    bestPracticeWarningAnnotationLength,
     bestPracticeWarningCreator,
     bestPracticeWarningLicense,
     bestPracticeWarningReadme,
@@ -143,6 +150,7 @@ export default {
     data() {
         return {
             bestPracticeWarningAnnotation: bestPracticeWarningAnnotation,
+            bestPracticeWarningAnnotationLength: bestPracticeWarningAnnotationLength,
             bestPracticeWarningCreator: bestPracticeWarningCreator,
             bestPracticeWarningLicense: bestPracticeWarningLicense,
             bestPracticeWarningReadme: bestPracticeWarningReadme,
@@ -156,6 +164,20 @@ export default {
         },
         checkAnnotation() {
             return !!this.annotation;
+        },
+        checkAnnotationLength() {
+            const annotation = this.annotation;
+            if (annotation && annotation.length > 250) {
+                return false;
+            }
+            return true;
+        },
+        annotationLengthSuccessMessage() {
+            if (this.annotation) {
+                return "This workflow has a short description of appropriate length.";
+            } else {
+                return "This workflow does not have a short description.";
+            }
         },
         checkReadme() {
             return !!this.annotation;

--- a/client/src/components/Workflow/Editor/Lint.vue
+++ b/client/src/components/Workflow/Editor/Lint.vue
@@ -5,11 +5,17 @@
         </template>
         <LintSection
             :okay="checkAnnotation"
-            success-message="This workflow is annotated. Ideally, this helps the executors of the workflow
+            success-message="This workflow has a short description. Ideally, this helps the executors of the workflow
                     understand the purpose and usage of the workflow."
             :warning-message="bestPracticeWarningAnnotation"
             attribute-link="Annotate your Workflow."
             @onClick="onAttributes('annotation')" />
+        <LintSection
+            :okay="checkReadme"
+            success-message="This workflow has a readme. Ideally, this helps the researchers understand the purpose, limitations, and usage of the workflow."
+            :warning-message="bestPracticeWarningReadme"
+            attribute-link="Annotate your Workflow."
+            @onClick="onAttributes('readme')" />
         <LintSection
             :okay="checkCreator"
             success-message="This workflow defines creator information."
@@ -77,6 +83,7 @@ import {
     bestPracticeWarningAnnotation,
     bestPracticeWarningCreator,
     bestPracticeWarningLicense,
+    bestPracticeWarningReadme,
     fixAllIssues,
     fixDisconnectedInput,
     fixUnlabeledOutputs,
@@ -138,6 +145,7 @@ export default {
             bestPracticeWarningAnnotation: bestPracticeWarningAnnotation,
             bestPracticeWarningCreator: bestPracticeWarningCreator,
             bestPracticeWarningLicense: bestPracticeWarningLicense,
+            bestPracticeWarningReadme: bestPracticeWarningReadme,
         };
     },
     computed: {
@@ -147,6 +155,9 @@ export default {
             return !this.checkUntypedParameters || !this.checkDisconnectedInputs || !this.checkUnlabeledOutputs;
         },
         checkAnnotation() {
+            return !!this.annotation;
+        },
+        checkReadme() {
             return !!this.annotation;
         },
         checkLicense() {

--- a/client/src/components/Workflow/Editor/WorkflowAttributes.vue
+++ b/client/src/components/Workflow/Editor/WorkflowAttributes.vue
@@ -301,6 +301,7 @@ export default {
                     this.showAnnotationHightlight = true;
                     this.showCreatorHightlight = false;
                     this.showLicenseHightlight = false;
+                    this.showReadmeHightlight = false;
                     setTimeout(() => {
                         this.showAnnotationHightlight = false;
                     }, bestPracticeHighlightTime);
@@ -308,6 +309,7 @@ export default {
                     this.showAnnotationHightlight = false;
                     this.showCreatorHightlight = true;
                     this.showLicenseHightlight = false;
+                    this.showReadmeHightlight = false;
                     setTimeout(() => {
                         this.showCreatorHightlight = false;
                     }, bestPracticeHighlightTime);
@@ -315,8 +317,17 @@ export default {
                     this.showAnnotationHightlight = false;
                     this.showCreatorHightlight = false;
                     this.showLicenseHightlight = true;
+                    this.showReadmeHightlight = false;
                     setTimeout(() => {
                         this.showLicenseHightlight = false;
+                    }, bestPracticeHighlightTime);
+                } else if (newHighlight == "readme") {
+                    this.showAnnotationHighlight = false;
+                    this.showCreatorHightlight = false;
+                    this.showLicenseHightlight = false;
+                    this.showReadmeHightlight = true;
+                    setTimeout(() => {
+                        this.showReadmeHightlight = false;
                     }, bestPracticeHighlightTime);
                 }
             },

--- a/client/src/components/Workflow/Editor/WorkflowAttributes.vue
+++ b/client/src/components/Workflow/Editor/WorkflowAttributes.vue
@@ -32,13 +32,16 @@
             id="workflow-annotation-area"
             class="mt-2"
             :class="{ 'bg-secondary': showAnnotationHightlight, 'highlight-attribute': showAnnotationHightlight }">
-            <b>Annotation</b>
+            <b>Short Description</b>
             <meta itemprop="description" :content="annotationCurrent" />
             <b-textarea
                 id="workflow-annotation"
                 v-model="annotationCurrent"
                 @keyup="$emit('update:annotationCurrent', annotationCurrent)" />
-            <div class="form-text text-muted">These notes will be visible when this workflow is viewed.</div>
+            <div class="form-text text-muted">
+                This short description will be visible when this workflow is viewed and should be limited to a sentence
+                or two.
+            </div>
             <b-popover
                 custom-class="best-practice-popover"
                 target="workflow-annotation"
@@ -89,6 +92,35 @@
             <StatelessTags :value="tags" @input="onTags" />
             <div class="form-text text-muted">
                 Apply tags to make it easy to search for and find items with the same tag.
+            </div>
+        </div>
+        <div class="mt-2">
+            <b>Readme</b>
+            <b-textarea
+                id="workflow-readme"
+                v-model="readmeCurrent"
+                @keyup="$emit('update:readmeCurrent', readmeCurrent)" />
+            <div class="form-text text-muted">
+                A detailed description of what the workflow does. It is best to include descriptions of what kinds of
+                data are required. Researchers looking for the workflow will see this text. Markdown is enabled.
+            </div>
+        </div>
+        <div class="mt-2">
+            <b>Help</b>
+            <b-textarea id="workflow-help" v-model="helpCurrent" @keyup="$emit('update:helpCurrent', helpCurrent)" />
+            <div class="form-text text-muted">
+                A detailed description of how to use the workflow and debug problems with it. Researchers running this
+                workflow will see this text. Markdown is enabled.
+            </div>
+        </div>
+        <div class="mt-2">
+            <b>Logo URL</b>
+            <b-input
+                id="workflow-logo-url"
+                v-model="logoUrlCurrent"
+                @keyup="$emit('update:logoUrlCurrent', logoUrlCurrent)" />
+            <div class="form-text text-muted">
+                An logo image used when generating publication artifacts for your workflow. This is completely optional.
             </div>
         </div>
     </ActivityPanel>
@@ -150,6 +182,18 @@ export default {
             type: Array,
             default: null,
         },
+        logoUrl: {
+            type: String,
+            default: null,
+        },
+        readme: {
+            type: String,
+            default: null,
+        },
+        help: {
+            type: String,
+            default: null,
+        },
         version: {
             type: Number,
             default: null,
@@ -173,6 +217,9 @@ export default {
             versionCurrent: this.version,
             annotationCurrent: this.annotation,
             nameCurrent: this.name,
+            logoUrlCurrent: this.logoUrl,
+            readmeCurrent: this.readme,
+            helpCurrent: this.help,
             showAnnotationHightlight: false,
             showLicenseHightlight: false,
             showCreatorHightlight: false,
@@ -234,6 +281,15 @@ export default {
         },
         name() {
             this.nameCurrent = this.name;
+        },
+        readme() {
+            this.readmeCurrent = this.readme;
+        },
+        help() {
+            this.helpCurrent = this.help;
+        },
+        logoUrl() {
+            this.logoUrlCurrent = this.logoUrl;
         },
         highlight: {
             immediate: true,

--- a/client/src/components/Workflow/Editor/WorkflowAttributes.vue
+++ b/client/src/components/Workflow/Editor/WorkflowAttributes.vue
@@ -50,7 +50,7 @@
                 :show.sync="showAnnotationHightlight"
                 triggers="manual"
                 title="Best Practice"
-                :content="bestPracticeWarningAnnotation">
+                :content="annotationBestPracticeMessage">
             </b-popover>
         </div>
         <div
@@ -133,6 +133,7 @@ import { Services } from "@/components/Workflow/services";
 
 import {
     bestPracticeWarningAnnotation,
+    bestPracticeWarningAnnotationLength,
     bestPracticeWarningCreator,
     bestPracticeWarningLicense,
 } from "./modules/linting";
@@ -209,7 +210,6 @@ export default {
     },
     data() {
         return {
-            bestPracticeWarningAnnotation: bestPracticeWarningAnnotation,
             bestPracticeWarningCreator: bestPracticeWarningCreator,
             bestPracticeWarningLicense: bestPracticeWarningLicense,
             message: null,
@@ -259,6 +259,13 @@ export default {
             }
             return versions;
         },
+        annotationBestPracticeMessage() {
+            if (this.annotationCurrent) {
+                return bestPracticeWarningAnnotationLength;
+            } else {
+                return bestPracticeWarningAnnotation;
+            }
+        },
     },
     watch: {
         version() {
@@ -277,6 +284,7 @@ export default {
             this.creatorCurrent = creator;
         },
         annotation() {
+            this.showAnnotationHightlight = false;
             this.annotationCurrent = this.annotation;
         },
         name() {

--- a/client/src/components/Workflow/Editor/WorkflowAttributes.vue
+++ b/client/src/components/Workflow/Editor/WorkflowAttributes.vue
@@ -95,7 +95,10 @@
             </div>
         </div>
         <div class="mt-2">
-            <b>Readme</b>
+            <b
+                >Readme
+                <FontAwesomeIcon :icon="faEye" @click="showReadmePreview = true" />
+            </b>
             <b-textarea
                 id="workflow-readme"
                 v-model="readmeCurrent"
@@ -123,10 +126,16 @@
                 An logo image used when generating publication artifacts for your workflow. This is completely optional.
             </div>
         </div>
+        <BModal v-model="showReadmePreview" hide-header centered ok-only>
+            <ToolHelpMarkdown :content="readmePreviewMarkdown" />
+        </BModal>
     </ActivityPanel>
 </template>
 
 <script>
+import { faEye } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BModal } from "bootstrap-vue";
 import { format, parseISO } from "date-fns";
 
 import { Services } from "@/components/Workflow/services";
@@ -143,16 +152,20 @@ import LicenseSelector from "@/components/License/LicenseSelector.vue";
 import ActivityPanel from "@/components/Panels/ActivityPanel.vue";
 import CreatorEditor from "@/components/SchemaOrg/CreatorEditor.vue";
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
+import ToolHelpMarkdown from "@/components/Tool/ToolHelpMarkdown.vue";
 
 const bestPracticeHighlightTime = 10000;
 
 export default {
     name: "WorkflowAttributes",
     components: {
+        FontAwesomeIcon,
         StatelessTags,
         LicenseSelector,
         CreatorEditor,
         ActivityPanel,
+        BModal,
+        ToolHelpMarkdown,
     },
     props: {
         id: {
@@ -223,6 +236,8 @@ export default {
             showAnnotationHightlight: false,
             showLicenseHightlight: false,
             showCreatorHightlight: false,
+            showReadmePreview: false,
+            faEye,
         };
     },
     computed: {
@@ -237,6 +252,19 @@ export default {
         },
         hasParameters() {
             return this.parameters && this.parameters.parameters.length > 0;
+        },
+        readmePreviewMarkdown() {
+            let content = "";
+            if (this.nameCurrent) {
+                content += `# ${this.nameCurrent}\n\n`;
+            }
+            if (this.logoUrlCurrent) {
+                content += `![${this.nameCurrent || "workflow"} logo](${this.logoUrlCurrent})\n\n`;
+            }
+            if (this.readmeCurrent) {
+                content += this.readmeCurrent;
+            }
+            return content;
         },
         versionOptions() {
             const versions = [];

--- a/client/src/components/Workflow/Editor/modules/linting.ts
+++ b/client/src/components/Workflow/Editor/modules/linting.ts
@@ -17,6 +17,8 @@ interface LintState {
 
 export const bestPracticeWarningAnnotation =
     "This workflow does not provide a short description. Providing a short description helps workflow executors understand the purpose and usage of the workflow.";
+export const bestPracticeWarningAnnotationLength =
+    "This workflow includes a very long short description. The best practice is to break up long descriptions of a workflow into readme and help text and keep the short description field a relatively brief description of the workflow appropriate for displaying in lists of workflows.";
 export const bestPracticeWarningCreator =
     "This workflow does not specify creator(s). This is important metadata for workflows that will be published and/or shared to help workflow executors know how to cite the workflow authors.";
 export const bestPracticeWarningLicense =

--- a/client/src/components/Workflow/Editor/modules/linting.ts
+++ b/client/src/components/Workflow/Editor/modules/linting.ts
@@ -16,11 +16,13 @@ interface LintState {
 }
 
 export const bestPracticeWarningAnnotation =
-    "This workflow is not annotated. Providing an annotation helps workflow executors understand the purpose and usage of the workflow.";
+    "This workflow does not provide a short description. Providing a short description helps workflow executors understand the purpose and usage of the workflow.";
 export const bestPracticeWarningCreator =
     "This workflow does not specify creator(s). This is important metadata for workflows that will be published and/or shared to help workflow executors know how to cite the workflow authors.";
 export const bestPracticeWarningLicense =
     "This workflow does not specify a license. This is important metadata for workflows that will be published and/or shared to help workflow executors understand how it may be used.";
+export const bestPracticeWarningReadme =
+    "This workflow does not provide a readme. Providing a detailed readme helps workflow executors understand the details, purpose, and limitations of the workflow.";
 
 export function getDisconnectedInputs(
     steps: Steps = {},

--- a/client/src/components/Workflow/Editor/modules/model.ts
+++ b/client/src/components/Workflow/Editor/modules/model.ts
@@ -19,6 +19,9 @@ export interface Workflow {
     steps: Steps;
     comments: WorkflowComment[];
     tags: string[];
+    logo_url?: string | null;
+    readme?: string | null;
+    help?: string | null;
 }
 
 export interface LoadWorkflowOptions {
@@ -138,6 +141,9 @@ export function toSimple(id: string, workflow: Workflow): Omit<Workflow, "versio
     const annotation = workflow.annotation;
     const name = workflow.name;
     const tags = workflow.tags;
+    const logo_url = workflow.logo_url;
+    const readme = workflow.readme;
+    const help = workflow.help;
 
     const commentStore = useWorkflowCommentStore(id);
     commentStore.resolveCommentsInFrames();
@@ -145,5 +151,5 @@ export function toSimple(id: string, workflow: Workflow): Omit<Workflow, "versio
 
     const comments = workflow.comments.filter((comment) => !(comment.type === "text" && comment.data.text === ""));
 
-    return { steps, report, license, creator, annotation, name, comments, tags };
+    return { steps, report, license, creator, annotation, name, comments, tags, readme, help, logo_url };
 }

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -817,6 +817,13 @@ class WorkflowContentsManager(UsesAnnotations):
         workflow.license = data.get("license")
         workflow.creator_metadata = data.get("creator")
 
+        if "logo_url" in data:
+            workflow.logo_url = data["logo_url"]
+        if "help" in data:
+            workflow.help = data["help"]
+        if "readme" in data:
+            workflow.readme = data["readme"]
+
         if getattr(workflow_state_resolution_options, "archive_source", None):
             source_metadata = {}
             if workflow_state_resolution_options.archive_source in ("trs_tool", "trs_url"):
@@ -1232,6 +1239,9 @@ class WorkflowContentsManager(UsesAnnotations):
         data["report"] = workflow.reports_config or {}
         data["license"] = workflow.license
         data["creator"] = workflow.creator_metadata
+        data["readme"] = workflow.readme
+        data["help"] = workflow.help
+        data["logo_url"] = workflow.logo_url
         data["source_metadata"] = workflow.source_metadata
         data["annotation"] = self.get_item_annotation_str(trans.sa_session, trans.user, stored) or ""
         data["comments"] = [comment.to_dict() for comment in workflow.comments]
@@ -1488,6 +1498,13 @@ class WorkflowContentsManager(UsesAnnotations):
             data["license"] = workflow.license
         if workflow.source_metadata:
             data["source_metadata"] = workflow.source_metadata
+        if workflow.readme is not None:
+            data["readme"] = workflow.readme
+        if workflow.help is not None:
+            data["help"] = workflow.help
+        if workflow.logo_url is not None:
+            data["logo_url"] = workflow.logo_url
+
         # For each step, rebuild the form and encode the state
         for step in workflow.steps:
             # Load from database representation
@@ -1691,6 +1708,10 @@ class WorkflowContentsManager(UsesAnnotations):
         item["license"] = workflow.license
         item["creator"] = workflow.creator_metadata
         item["source_metadata"] = workflow.source_metadata
+        item["readme"] = workflow.readme
+        item["help"] = workflow.help
+        item["logo_url"] = workflow.logo_url
+
         steps = {}
         steps_to_order_index = {}
         for step in workflow.steps:

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -819,10 +819,13 @@ class WorkflowContentsManager(UsesAnnotations):
 
         if "logo_url" in data:
             workflow.logo_url = data["logo_url"]
-        if "help" in data:
-            workflow.help = data["help"]
-        if "readme" in data:
-            workflow.readme = data["readme"]
+        try:
+            if "help" in data:
+                workflow.help = data["help"]
+            if "readme" in data:
+                workflow.readme = data["readme"]
+        except ValueError as e:
+            raise exceptions.RequestParameterInvalidException(str(e))
 
         if getattr(workflow_state_resolution_options, "archive_source", None):
             source_metadata = {}

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7880,6 +7880,9 @@ class Workflow(Base, Dictifiable, RepresentById):
     creator_metadata: Mapped[Optional[List[Dict[str, Any]]]] = mapped_column(JSONType)
     license: Mapped[Optional[str]] = mapped_column(TEXT)
     source_metadata: Mapped[Optional[Dict[str, str]]] = mapped_column(JSONType)
+    readme: Mapped[Optional[str]] = mapped_column(TEXT)
+    logo_url: Mapped[Optional[str]] = mapped_column(TEXT)
+    help: Mapped[Optional[str]] = mapped_column(TEXT)
     uuid: Mapped[Optional[Union[UUID, str]]] = mapped_column(UUIDType)
 
     steps: Mapped[List["WorkflowStep"]] = relationship(

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7883,9 +7883,9 @@ class Workflow(Base, Dictifiable, RepresentById):
     creator_metadata: Mapped[Optional[List[Dict[str, Any]]]] = mapped_column(JSONType)
     license: Mapped[Optional[str]] = mapped_column(TEXT)
     source_metadata: Mapped[Optional[Dict[str, str]]] = mapped_column(JSONType)
-    readme: Mapped[Optional[str]] = mapped_column(TEXT)
-    logo_url: Mapped[Optional[str]] = mapped_column(TEXT)
-    help: Mapped[Optional[str]] = mapped_column(TEXT)
+    readme: Mapped[Optional[str]] = mapped_column(Text)
+    logo_url: Mapped[Optional[str]] = mapped_column(Text)
+    help: Mapped[Optional[str]] = mapped_column(Text)
     uuid: Mapped[Optional[Union[UUID, str]]] = mapped_column(UUIDType)
 
     steps: Mapped[List["WorkflowStep"]] = relationship(

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -124,6 +124,7 @@ from sqlalchemy.orm import (
     reconstructor,
     registry,
     relationship,
+    validates,
 )
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.orm.collections import attribute_keyed_dict
@@ -235,6 +236,8 @@ log = logging.getLogger(__name__)
 
 _datatypes_registry = None
 
+MAX_WORKFLOW_README_SIZE = 20000
+MAX_WORKFLOW_HELP_SIZE = 40000
 STR_TO_STR_DICT = Dict[str, str]
 
 
@@ -7919,6 +7922,26 @@ class Workflow(Base, Dictifiable, RepresentById):
     def __init__(self, uuid=None):
         self.user = None
         self.uuid = get_uuid(uuid)
+
+    @validates("readme")
+    def validates_readme(self, key, readme):
+        if readme is None:
+            return None
+        size = len(readme)
+        if size > MAX_WORKFLOW_README_SIZE:
+            raise ValueError(
+                f"Workflow readme too large ({size}), maximum allowed length ({MAX_WORKFLOW_README_SIZE})."
+            )
+        return readme
+
+    @validates("help")
+    def validates_help(self, key, help):
+        if help is None:
+            return None
+        size = len(help)
+        if size > MAX_WORKFLOW_HELP_SIZE:
+            raise ValueError(f"Workflow help too large ({size}), maximum allowed length ({MAX_WORKFLOW_HELP_SIZE}).")
+        return help
 
     def has_outputs_defined(self):
         """

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/71eeb8d91f92_workflow_readme.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/71eeb8d91f92_workflow_readme.py
@@ -1,0 +1,34 @@
+"""Implement fields needed for a workflow readme & help.
+
+Revision ID: 71eeb8d91f92
+Revises: a4c3ef999ab5
+Create Date: 2025-02-11 11:57:14.477337
+
+"""
+
+import sqlalchemy as sa
+
+from galaxy.model.migrations.util import (
+    add_column,
+    drop_column,
+)
+
+workflow_table_name = "workflow"
+
+# revision identifiers, used by Alembic.
+revision = "71eeb8d91f92"
+down_revision = "a4c3ef999ab5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    add_column(workflow_table_name, sa.Column("readme", sa.TEXT, nullable=True))
+    add_column(workflow_table_name, sa.Column("help", sa.TEXT, nullable=True))
+    add_column(workflow_table_name, sa.Column("logo_url", sa.TEXT, nullable=True))
+
+
+def downgrade():
+    drop_column(workflow_table_name, "readme")
+    drop_column(workflow_table_name, "help")
+    drop_column(workflow_table_name, "logo_url")

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/71eeb8d91f92_workflow_readme.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/71eeb8d91f92_workflow_readme.py
@@ -23,9 +23,9 @@ depends_on = None
 
 
 def upgrade():
-    add_column(workflow_table_name, sa.Column("readme", sa.TEXT, nullable=True))
-    add_column(workflow_table_name, sa.Column("help", sa.TEXT, nullable=True))
-    add_column(workflow_table_name, sa.Column("logo_url", sa.TEXT, nullable=True))
+    add_column(workflow_table_name, sa.Column("readme", sa.Text, nullable=True))
+    add_column(workflow_table_name, sa.Column("help", sa.Text, nullable=True))
+    add_column(workflow_table_name, sa.Column("logo_url", sa.Text, nullable=True))
 
 
 def downgrade():

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -27,6 +27,7 @@ from requests import (
 
 from galaxy.exceptions import error_codes
 from galaxy.util import UNKNOWN
+from galaxy.util.unittest_utils import skip_if_github_down
 from galaxy_test.base import rules_test_data
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
@@ -1175,6 +1176,7 @@ steps:
             other_import_response = self.__import_workflow(workflow_id)
             self._assert_status_code_is(other_import_response, 403)
 
+    @skip_if_github_down
     def test_url_import(self):
         url = "https://raw.githubusercontent.com/galaxyproject/galaxy/release_19.09/test/base/data/test_workflow_1.ga"
         workflow_id = self._post("workflows", data={"archive_source": url}).json()["id"]

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1194,6 +1194,25 @@ steps:
         workflow = self._download_workflow(workflow_id)
         assert "TestWorkflow1" in workflow["name"]
 
+    def test_readme_metadata(self):
+        base_workflow_json = json.loads(workflow_str)
+        readme = "This is the body of my readme..."
+        logo_url = "https://galaxyproject.org/images/galaxy_logo_hub_white.svg"
+        help = "This is my instruction for the workflow!"
+        base_workflow_json["readme"] = readme
+        base_workflow_json["logo_url"] = logo_url
+        base_workflow_json["help"] = help
+        workflow_with_metadata_str = json.dumps(base_workflow_json)
+        base64_url = "base64://" + base64.b64encode(workflow_with_metadata_str.encode("utf-8")).decode("utf-8")
+        response = self._post("workflows", data={"archive_source": base64_url})
+        response.raise_for_status()
+        workflow_id = response.json()["id"]
+        workflow = self._download_workflow(workflow_id)
+        assert "TestWorkflow1" in workflow["name"]
+        assert workflow["readme"] == readme
+        assert workflow["help"] == help
+        assert workflow["logo_url"] == logo_url
+
     def test_trs_import(self):
         trs_payload = {
             "archive_source": "trs_tool",


### PR DESCRIPTION
So far just the first part of https://github.com/galaxyproject/galaxy/issues/19559.

Added help and readme field. Also added a logo url so we can generate workflow repository readmes using a template like

    # {{ workflow.name }}

    {% if workflow.logo_url  %}
    ![{{ workflow.name }} logo]({{ workflow.logo_url }})
    {% endif %}

    {{ workflow.readme }}


I've also renamed the workflow annotation in the UI to "short description". I think this is more clear in light of the new metadata fields. Previously I've seen annotation used for all three purposes - I hope this cleans that up some and makes the workflows more uniform in the workflow index for instance.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
