### PR TITLE
[24.2] Fix missing name in user-defined object store list

### DIFF
--- a/client/src/components/ObjectStore/Instances/ManageIndex.vue
+++ b/client/src/components/ObjectStore/Instances/ManageIndex.vue
@@ -9,6 +9,7 @@ import { useFiltering } from "@/components/ConfigTemplates/useInstanceFiltering"
 import { useObjectStoreInstancesStore } from "@/stores/objectStoreInstancesStore";
 import _l from "@/utils/localization";
 
+import InstanceDropdown from "./InstanceDropdown.vue";
 import ManageIndexHeader from "@/components/ConfigTemplates/ManageIndexHeader.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import ObjectStoreBadges from "@/components/ObjectStore/ObjectStoreBadges.vue";


### PR DESCRIPTION
Fixes #19597

It seems the issue with the missing name was not triggered by an "empty" (all spaces) name, it was because of an accidentally missing import in https://github.com/galaxyproject/galaxy/commit/1736eb17d8f1cf4d3f41dd3210e11d1a8cf7b90e#diff-64f4319290e726be05911b5d40665fccd570d3811bd7121cbab650ab5517ffa7L14

So even a correctly named object store instance would not render the name in the UI in 24.2.

## Before
![image](https://github.com/user-attachments/assets/a293e9bc-802c-4454-973d-d0467a145d68)


## After
![image](https://github.com/user-attachments/assets/805db521-4d6c-4226-8512-cd9efa56d82f)

Using a name composed only of spaces will still look like this:

![image](https://github.com/user-attachments/assets/05f16ff6-8339-42e4-92da-fe0104e572e0)

But at least we can access the edit menu and fix it, so maybe we don't need to trim the name before validating as this is a sufficient fix.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Follow the steps in #19597

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
