### PR TITLE
Split `docker_cmd`

### DIFF
--- a/config/job_conf.yml.interactivetools.podman
+++ b/config/job_conf.yml.interactivetools.podman
@@ -29,7 +29,7 @@ execution:
       #docker_run_extra_arguments:  --userns=keep-id --security-opt label=disable --network slirp4netns:allow_host_loopback=true
 
       # Change to home directory of the galaxy user, not the directory of the galaxy installation
-      docker_cmd: HOME="/home/galaxy"; podman
+      docker_cmd: HOME="/home/galaxy" podman
 
     docker_dispatch:
       runner: dynamic

--- a/lib/galaxy/tool_util/deps/docker_util.py
+++ b/lib/galaxy/tool_util/deps/docker_util.py
@@ -201,7 +201,7 @@ def _docker_prefix(
     command_parts = []
     if sudo:
         command_parts.append(sudo_cmd)
-    command_parts.append(docker_cmd)
+    command_parts.extend(docker_cmd.split())
     if host:
         command_parts.extend(["-H", host])
     return command_parts


### PR DESCRIPTION
for podman IT setups [it seems necessary](https://github.com/galaxyproject/galaxy/blob/a81c573f037b9389ff928864b30cfe46b2232727/config/job_conf.yml.interactivetools.podman#L32) to set an environment variable (`HOME`) for the podman call in the job script (we overwrite `HOME` for the job).

Without this change the Popen call would fail with `no such file or directory: HOME="..."`

We could use `shlex.split(..., posix=False)` if we want (with posix=True the quotes around the env value are removed).

Also fixes the example `podman_cmd` in the example job config. Since it was wrong so far, @sveinugu wanted to double check if it is necessary in his setup.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
