### PR TITLE
[24.0] Fix user preferences secret (without vault) lost on save

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -962,6 +962,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
         extra_user_pref_data = dict()
         extra_pref_keys = self._get_extra_user_preferences(trans)
         user_vault = UserVaultWrapper(trans.app.vault, user)
+        current_extra_user_pref_data = json.loads(user.preferences.get("extra_user_preferences", "{}"))
         if extra_pref_keys is not None:
             for key in extra_pref_keys:
                 key_prefix = f"{key}|"
@@ -974,8 +975,17 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
                             input = matching_input[0]
                             if input.get("required") and payload[item] == "":
                                 raise exceptions.ObjectAttributeMissingException("Please fill the required field")
-                            if not (input.get("type") == "secret" and payload[item] == "__SECRET_PLACEHOLDER__"):
-                                if input.get("store") == "vault":
+                            input_type = input.get("type")
+                            is_secret_value_unchanged = (
+                                input_type == "secret" and payload[item] == "__SECRET_PLACEHOLDER__"
+                            )
+                            is_stored_in_vault = input.get("store") == "vault"
+                            if is_secret_value_unchanged:
+                                if not is_stored_in_vault:
+                                    # If the value is unchanged, keep the current value
+                                    extra_user_pref_data[item] = current_extra_user_pref_data.get(item, "")
+                            else:
+                                if is_stored_in_vault:
                                     user_vault.write_secret(f"preferences/{keys[0]}/{keys[1]}", str(payload[item]))
                                 else:
                                     extra_user_pref_data[item] = payload[item]

--- a/test/integration/user_preferences_extra_conf.yml
+++ b/test/integration/user_preferences_extra_conf.yml
@@ -21,3 +21,15 @@ preferences:
               type: secret
               store: vault
               required: True
+
+    non_vault_test_section:
+        description: For testing Settings
+        inputs:
+            - name: user
+              label: User
+              type: text
+              required: True
+            - name: pass
+              label: Pass
+              type: secret # It's a secret but not stored in vault
+              required: True


### PR DESCRIPTION
Fixes #19587

It seems the use of `type: secret` in user preferences fields was meant to be combined with `store: vault` and was not working correctly when the value is stored in the user preferences like `type: password` do.
This fix will maintain the secret value stored in user preferences when it was not changed in the UI.

Includes an integration test that will fail without the fix.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
