### PR TITLE
Enhance OpenAI Chat Integration

### DIFF
--- a/lib/galaxy/config/chat_prompts.json
+++ b/lib/galaxy/config/chat_prompts.json
@@ -1,6 +1,6 @@
 {
    "prompts": {
-       "tool_error": "Adopt the persona of a galaxy project expert who is able to easily explain complex error messages to novice users in a serious manner.\nYou will be provided with an errored output from a galaxy tool and should in simple terms explain what the error is.\nIf it is possible to fix the error in the galaxy web interface, suggest a possible solution.\nIf you are unsure totally sure of how to fix the error, state that you are unable to help.\nPlease ensure your response is in well-formatted markdown."
+       "tool_error": "You are a bioinformatics specialist. Your Job is to describe the error of a bioinformatics tool using simple language that is understandable to a novice user. Try to be on the dot with your answer.\nBelow is an output of the error message. Explain \n1. The source of the error\n2. How to fix the error potentially using tools already existing in galaxy. \n\nIf you are not sure what the error is, state politely that it is not clear from the error message and you are not able to help. \n Please ensure your response is in well-formatted markdown."
    }
 }
 

--- a/lib/galaxy/config/chat_prompts.json
+++ b/lib/galaxy/config/chat_prompts.json
@@ -1,6 +1,6 @@
 {
    "prompts": {
-       "tool_error": "You are a bioinformatics specialist. Your Job is to describe the error of a bioinformatics tool using simple language that is understandable to a novice user. Try to be on the dot with your answer.\nBelow is an output of the error message. Explain \n1. The source of the error\n2. How to fix the error potentially using tools already existing in galaxy. \n\nIf you are not sure what the error is, state politely that it is not clear from the error message and you are not able to help. \n Please ensure your response is in well-formatted markdown."
+       "tool_error": "You are a Galaxy Project expert with deep knowledge of common Galaxy tool errors. Your task is to help novice users understand error messages by explaining them in simple, clear terms. When provided with an error output from a Galaxy tool, please do the following:\n\n1. **Explain the Error:** Describe the likely source of the error in plain language.\n2. **Suggest a Fix:** If possible, offer a practical solution using the Galaxy web interface or existing tools.\n3. **Express Uncertainty if Needed:** If the error is ambiguous or if you’re not certain how to resolve it, politely indicate that the error message does not provide enough information to suggest a fix and encourage the user submit a bug report if they need further assistance.\n\nEnsure your response is formatted in clean, well-structured markdown."
    }
 }
 

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -111,20 +111,7 @@ class ChatAPI:
             {"role": "system", "content": self._get_system_prompt()},
             {"role": "user", "content": payload.query},
         ]
-
-        #user_msg = self._get_user_context_message(trans)
-        #if user_msg:
-        #    messages.append({"role": "system", "content": user_msg})
-
         return messages
-
-    def _get_user_context_message(self, trans: ProvidesUserContext) -> str:
-        """Generate a user context message based on the user's information."""
-        user = trans.user
-        if user:
-            log.debug(f"CHATGPTuser: {user.username}")
-            return f"You will address the user as {user.username}"
-        return "You will address the user as Anonymous User"
 
     def _call_openai(self, messages: list):
         """Send a chat request to OpenAI and handle exceptions."""

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -112,9 +112,9 @@ class ChatAPI:
             {"role": "user", "content": payload.query},
         ]
 
-        user_msg = self._get_user_context_message(trans)
-        if user_msg:
-            messages.append({"role": "system", "content": user_msg})
+        #user_msg = self._get_user_context_message(trans)
+        #if user_msg:
+        #    messages.append({"role": "system", "content": user_msg})
 
         return messages
 


### PR DESCRIPTION
This changes the prompt to chatGPT to generate a better support by
1. Structuring the response into the sections: "Cause of the error" and "How to resolve the error using Galaxy" 
2. Removes the username from the response, making the the response feel inline-d into the web page, also it gets rid of responses that look like a letter (starting with "Hi @Username" and ending in "Kind Regards, ..." 
3. Instructing the agent that it is only providing one shot support, removing sentences like "Feel free to reach out if the error persists" For which there is no UI component.

## How to test the changes?
(Select all options that apply)
- [ x ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ x ] Instructions for manual testing are as follows:
  1. cause a job to fail
  2. use the wizard to analyze the error

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
