### PR TITLE
[24.2] Remove redundant `Create Collection` ok button from collection creator

### DIFF
--- a/client/src/components/Collections/CollectionCreatorModal.vue
+++ b/client/src/components/Collections/CollectionCreatorModal.vue
@@ -242,10 +242,9 @@ function resetModal() {
         :busy="(fromSelection && isFetchingItems) || creatingCollection"
         modal-class="ui-modal collection-creator-modal"
         :hide-footer="!createdCollection && !createCollectionError"
-        :ok-disabled="!!createdCollection || !!createCollectionError"
-        :cancel-title="localize('Exit')"
-        footer-class="d-flex justify-content-between"
-        :ok-title="localize('Create Collection')"
+        ok-only
+        :ok-title="localize('Exit')"
+        ok-variant="secondary"
         @hidden="resetModal">
         <template v-slot:modal-header>
             <Heading class="w-100" size="sm">


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/19540

| Before ◀️  |
| ---- |
| <img width="1229" alt="Screen Shot 2025-02-14 at 11 12 24 AM" src="https://github.com/user-attachments/assets/2f9dff93-7d92-4a35-98fd-73866d73fdb7" /> |



| After ✨  |
| ---- |
| <img width="1229" alt="Screen Shot 2025-02-14 at 11 13 24 AM" src="https://github.com/user-attachments/assets/fec0d41a-71b7-4d32-b918-ff5ce4e5789e" /> |
| _Ignore the extra "Collection created successfully" message, it's not in the actual implementation_ |




## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
