### PR TITLE
Use discriminated unions in object stores and file source template configs

### DIFF
--- a/lib/galaxy/files/templates/models.py
+++ b/lib/galaxy/files/templates/models.py
@@ -2,13 +2,19 @@ from typing import (
     Any,
     Dict,
     List,
-    Literal,
     Optional,
     Type,
     Union,
 )
 
-from pydantic import RootModel
+from pydantic import (
+    Field,
+    RootModel,
+)
+from typing_extensions import (
+    Annotated,
+    Literal,
+)
 
 from galaxy.util.config_templates import (
     ConfiguredOAuth2Sources,
@@ -213,27 +219,34 @@ class eLabFTWFileSourceConfiguration(StrictModel):  # noqa
     writable: bool = True
 
 
-FileSourceTemplateConfiguration = Union[
-    PosixFileSourceTemplateConfiguration,
-    S3FSFileSourceTemplateConfiguration,
-    FtpFileSourceTemplateConfiguration,
-    AzureFileSourceTemplateConfiguration,
-    OnedataFileSourceTemplateConfiguration,
-    WebdavFileSourceTemplateConfiguration,
-    DropboxFileSourceTemplateConfiguration,
-    GoogleDriveFileSourceTemplateConfiguration,
-    eLabFTWFileSourceTemplateConfiguration,
+FileSourceTemplateConfiguration = Annotated[
+    Union[
+        PosixFileSourceTemplateConfiguration,
+        S3FSFileSourceTemplateConfiguration,
+        FtpFileSourceTemplateConfiguration,
+        AzureFileSourceTemplateConfiguration,
+        OnedataFileSourceTemplateConfiguration,
+        WebdavFileSourceTemplateConfiguration,
+        DropboxFileSourceTemplateConfiguration,
+        GoogleDriveFileSourceTemplateConfiguration,
+        eLabFTWFileSourceTemplateConfiguration,
+    ],
+    Field(discriminator="type"),
 ]
-FileSourceConfiguration = Union[
-    PosixFileSourceConfiguration,
-    S3FSFileSourceConfiguration,
-    FtpFileSourceConfiguration,
-    AzureFileSourceConfiguration,
-    OnedataFileSourceConfiguration,
-    WebdavFileSourceConfiguration,
-    DropboxFileSourceConfiguration,
-    GoogleDriveFileSourceConfiguration,
-    eLabFTWFileSourceConfiguration,
+
+FileSourceConfiguration = Annotated[
+    Union[
+        PosixFileSourceConfiguration,
+        S3FSFileSourceConfiguration,
+        FtpFileSourceConfiguration,
+        AzureFileSourceConfiguration,
+        OnedataFileSourceConfiguration,
+        WebdavFileSourceConfiguration,
+        DropboxFileSourceConfiguration,
+        GoogleDriveFileSourceConfiguration,
+        eLabFTWFileSourceConfiguration,
+    ],
+    Field(discriminator="type"),
 ]
 
 

--- a/lib/galaxy/objectstore/templates/models.py
+++ b/lib/galaxy/objectstore/templates/models.py
@@ -7,8 +7,14 @@ from typing import (
     Union,
 )
 
-from pydantic import RootModel
-from typing_extensions import Literal
+from pydantic import (
+    Field,
+    RootModel,
+)
+from typing_extensions import (
+    Annotated,
+    Literal,
+)
 
 from galaxy.objectstore.badges import (
     BadgeDict,
@@ -314,21 +320,28 @@ class OnedataObjectStoreConfiguration(StrictModel):
     badges: BadgeList = None
 
 
-ObjectStoreTemplateConfiguration = Union[
-    AwsS3ObjectStoreTemplateConfiguration,
-    Boto3ObjectStoreTemplateConfiguration,
-    GenericS3ObjectStoreTemplateConfiguration,
-    DiskObjectStoreTemplateConfiguration,
-    AzureObjectStoreTemplateConfiguration,
-    OnedataObjectStoreTemplateConfiguration,
+ObjectStoreTemplateConfiguration = Annotated[
+    Union[
+        AwsS3ObjectStoreTemplateConfiguration,
+        Boto3ObjectStoreTemplateConfiguration,
+        GenericS3ObjectStoreTemplateConfiguration,
+        DiskObjectStoreTemplateConfiguration,
+        AzureObjectStoreTemplateConfiguration,
+        OnedataObjectStoreTemplateConfiguration,
+    ],
+    Field(discriminator="type"),
 ]
-ObjectStoreConfiguration = Union[
-    AwsS3ObjectStoreConfiguration,
-    Boto3ObjectStoreConfiguration,
-    DiskObjectStoreConfiguration,
-    AzureObjectStoreConfiguration,
-    GenericS3ObjectStoreConfiguration,
-    OnedataObjectStoreConfiguration,
+
+ObjectStoreConfiguration = Annotated[
+    Union[
+        AwsS3ObjectStoreConfiguration,
+        Boto3ObjectStoreConfiguration,
+        DiskObjectStoreConfiguration,
+        AzureObjectStoreConfiguration,
+        GenericS3ObjectStoreConfiguration,
+        OnedataObjectStoreConfiguration,
+    ],
+    Field(discriminator="type"),
 ]
 
 


### PR DESCRIPTION
It is the recommended way by Pydantic. Discriminated unions are both more performant and more predictable than untagged unions, as they allow you to control which member of the union to validate against.

https://docs.pydantic.dev/latest/concepts/unions/

Extracted from #19619 for easier review

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
