### PR TITLE
Use correct `plugin_kind` in user file sources

### DIFF
--- a/lib/galaxy/managers/file_source_instances.py
+++ b/lib/galaxy/managers/file_source_instances.py
@@ -673,13 +673,14 @@ class UserDefinedFileSourcesImpl(UserDefinedFileSources):
 
         as_dicts = []
         for files_source_properties in self._all_user_file_source_properties(user_context):
-            plugin_kind = PluginKind.rfs
+            files_source_type = files_source_properties["type"]
+            plugin_type_class = self._plugin_loader.get_plugin_type_class(files_source_type)
+            plugin_kind = plugin_type_class.plugin_kind
             if include_kind and plugin_kind not in include_kind:
                 continue
             if exclude_kind and plugin_kind in exclude_kind:
                 continue
-            files_source_type = files_source_properties["type"]
-            is_browsable = file_source_type_is_browsable(self._plugin_loader.get_plugin_type_class(files_source_type))
+            is_browsable = file_source_type_is_browsable(plugin_type_class)
             if browsable_only and not is_browsable:
                 continue
             file_source = self._file_source(files_source_properties)


### PR DESCRIPTION
Extracted from #19619 to simplify the review

Forcing every user file source to `rfs` was ok until #19619 
Using the correct `plugin_kind` enables other kinds of file sources like `rdm` to work as they are supposed and not limited to regular file source logic.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
