### PR TITLE
[24.0] Fix mulled tests

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/invfile.lua
+++ b/lib/galaxy/tool_util/deps/mulled/invfile.lua
@@ -88,13 +88,14 @@ inv.task('build')
     .using(conda_image)
         .withHostConfig({binds = bind_args})
         .run('/bin/sh', '-c', preinstall
+            .. conda_bin .. ' create --quiet --yes -p /usr/local/env --copy  && '
             .. conda_bin .. ' install '
             .. channel_args .. ' '
             .. target_args
-            .. ' --strict-channel-priority -p /usr/local --copy --yes '
+            .. ' --strict-channel-priority -p /usr/local/env --copy --yes '
             .. verbose
             .. postinstall)
-    .wrap('build/dist')
+    .wrap('build/dist/env')
         .at('/usr/local')
         .inImage(destination_base_image)
         .as(repo)

--- a/lib/galaxy/tool_util/deps/mulled/mulled_search.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_search.py
@@ -148,7 +148,8 @@ class CondaSearch:
             elif header_found:
                 lines_fields.append(line.split())
         return [
-            {"package": line_fields[0], "version": line_fields[1], "build": line_fields[2]} for line_fields in lines_fields
+            {"package": line_fields[0], "version": line_fields[1], "build": line_fields[2]}
+            for line_fields in lines_fields
         ]
 
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_search.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_search.py
@@ -5,6 +5,10 @@ import json
 import logging
 import sys
 import tempfile
+from typing import (
+    Dict,
+    List,
+)
 
 import requests
 
@@ -123,7 +127,7 @@ class CondaSearch:
     def __init__(self, channel):
         self.channel = channel
 
-    def get_json(self, search_string):
+    def get_json(self, search_string) -> List[Dict[str, str]]:
         """
         Function takes search_string variable and returns results from the bioconda channel in JSON format
 
@@ -136,8 +140,15 @@ class CondaSearch:
         except Exception as e:
             logging.info(f"Search failed with: {e}")
             return []
+        header_found = False
+        lines_fields: List[List[str]] = []
+        for line in raw_out.splitlines():
+            if line.startswith("#"):
+                header_found = True
+            elif header_found:
+                lines_fields.append(line.split())
         return [
-            {"package": n.split()[0], "version": n.split()[1], "build": n.split()[2]} for n in raw_out.split("\n")[2:-1]
+            {"package": line_fields[0], "version": line_fields[1], "build": line_fields[2]} for line_fields in lines_fields
         ]
 
 

--- a/test/unit/tool_util/mulled/test_mulled_search.py
+++ b/test/unit/tool_util/mulled/test_mulled_search.py
@@ -25,10 +25,10 @@ def test_quay_search():
 @skip_unless_executable("conda")
 def test_conda_search():
     t = CondaSearch("bioconda")
-    search1 = t.get_json("asdfasdf")
-    search2 = t.get_json("bioconductor-gosemsim")
-    assert search1 == []
-    assert all(r["package"] == "bioconductor-gosemsim" for r in search2)
+    search = t.get_json("asdfasdf")
+    assert search == []
+    search = t.get_json("bioconductor-gosemsim")
+    assert all(r["package"] == "bioconductor-gosemsim" for r in search)
 
 
 @external_dependency_management


### PR DESCRIPTION
- Fix `CondaSearch.get_json()` to skip all header lines. Fix new `test_conda_search` failure.
- Backport https://github.com/galaxyproject/galaxy/pull/19545

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
