### PR TITLE
[24.2] Disable chatgxy wizard for anon users

### DIFF
--- a/client/src/components/DatasetInformation/DatasetError.vue
+++ b/client/src/components/DatasetInformation/DatasetError.vue
@@ -28,7 +28,7 @@ interface Props {
 const props = defineProps<Props>();
 
 const userStore = useUserStore();
-const { currentUser } = storeToRefs(userStore);
+const { currentUser, isAnonymous } = storeToRefs(userStore);
 
 const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true });
 const { config, isConfigLoaded } = useConfig();
@@ -49,7 +49,7 @@ const showForm = computed(() => {
     return noResult || hasError;
 });
 
-const showWizard = computed(() => isConfigLoaded && config.value?.llm_api_configured);
+const showWizard = computed(() => isConfigLoaded && config.value?.llm_api_configured && !isAnonymous.value);
 
 async function getDatasetDetails() {
     datasetLoading.value = true;

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -16,11 +16,13 @@ from galaxy.exceptions import ConfigurationError
 from galaxy.managers.chat import ChatManager
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.jobs import JobManager
+from galaxy.model import User
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import ChatPayload
 from galaxy.webapps.galaxy.api import (
     depends,
     DependsOnTrans,
+    DependsOnUser,
     Router,
 )
 
@@ -57,6 +59,7 @@ class ChatAPI:
         job_id: JobIdPathParam,
         payload: ChatPayload,
         trans: ProvidesUserContext = DependsOnTrans,
+        user: User = DependsOnUser,
     ) -> str:
         """We're off to ask the wizard"""
         # Currently job-based chat exchanges are the only ones supported,
@@ -87,6 +90,7 @@ class ChatAPI:
         job_id: JobIdPathParam,
         feedback: int,
         trans: ProvidesUserContext = DependsOnTrans,
+        user: User = DependsOnUser,
     ) -> Union[int, None]:
         """Provide feedback on the chatbot response."""
         job = self.job_manager.get_accessible_job(trans, job_id)


### PR DESCRIPTION
Retrieving and storing responses requires a user id, and anon's don't have user ids.

Fixes https://github.com/galaxyproject/galaxy/issues/19529

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
