### PR TITLE
[24.2] Fail request explicitly when sqlite provider used on non-sqlite file

### DIFF
--- a/lib/galaxy/datatypes/dataproviders/dataset.py
+++ b/lib/galaxy/datatypes/dataproviders/dataset.py
@@ -14,6 +14,7 @@ from bx import (
     wiggle as bx_wig,
 )
 
+from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.util import sqlite
 from galaxy.util.compression_utils import get_fileobj
 from . import (
@@ -716,7 +717,11 @@ class SQliteDataProvider(base.DataProvider):
 
     def __init__(self, source, query=None, **kwargs):
         self.query = query
-        self.connection = sqlite.connect(source.dataset.get_file_name())
+        datatype = source.datatype
+        file_name = source.dataset.get_file_name()
+        if not datatype.sniff(file_name):
+            raise RequestParameterInvalidException("Dataset is not a SQlite file, cannot fetch data.")
+        self.connection = sqlite.connect(file_name)
         super().__init__(source, **kwargs)
 
     def __iter__(self):


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/19629

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
