### PR TITLE
[24.2] Raise ``MessageException`` when using data provider on incompatible data

### DIFF
--- a/lib/galaxy/visualization/data_providers/genome.py
+++ b/lib/galaxy/visualization/data_providers/genome.py
@@ -4,6 +4,7 @@ Data providers for genome visualizations.
 
 import abc
 import itertools
+import logging
 import math
 import os
 import random
@@ -43,6 +44,8 @@ from galaxy.exceptions import MessageException
 from galaxy.model import DatasetInstance
 from galaxy.visualization.data_providers.basic import BaseDataProvider
 from galaxy.visualization.data_providers.cigar import get_ref_based_read_seq_and_cigar
+
+log = logging.getLogger(__name__)
 
 IntWebParam = Union[str, int]
 
@@ -234,7 +237,12 @@ class GenomeDataProvider(BaseDataProvider):
         start, end = int(start), int(end)
         with self.open_data_file() as data_file:
             iterator = self.get_iterator(data_file, chrom, start, end, **kwargs)
-            data = self.process_data(iterator, start_val, max_vals, start=start, end=end, **kwargs)
+            try:
+                data = self.process_data(iterator, start_val, max_vals, start=start, end=end, **kwargs)
+            except ValueError as e:
+                err_msg = f"Could not return data, error was '{e}'"
+                log.warning(err_msg, exc_info=True)
+                raise MessageException(err_msg)
         return data
 
     def get_genome_data(self, chroms_info, **kwargs):


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/19637

This seems like fairly legacy stuff, otherwise I would have added more specific checks in the actual data provider and said which column is at fault. Anyways, better than an uncaught exception.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
