### PR TITLE
[24.2] Remove unused/deprecated Cloud Authorization preference

### DIFF
--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -49,12 +49,6 @@
             description="Manage your notification settings."
             to="/user/notifications/preferences" />
         <UserPreferencesElement
-            id="edit-preferences-cloud-auth"
-            icon="fa-cloud"
-            title="Manage Cloud Authorization"
-            description="Add or modify the configuration that grants Galaxy to access your cloud-based resources."
-            to="/user/cloud_auth" />
-        <UserPreferencesElement
             v-if="isConfigLoaded && config.enable_oidc && !config.fixed_delegated_auth"
             id="manage-third-party-identities"
             icon="fa-id-card-o"


### PR DESCRIPTION
Fixes #19575. Deletes the UserPreferencesElement for managing cloud authorization from the user preferences.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
