### PR TITLE
[24.0] Apply exec options to connection

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -188,6 +188,7 @@ class ItemGrabber:
             self.setup_query()
 
         with self.app.model.engine.connect() as conn:
+            conn = conn.execution_options(**self._grab_conn_opts)
             with conn.begin() as trans:
                 try:
                     proxy = conn.execute(self._grab_query)


### PR DESCRIPTION
Fix bug introduced in #15496 (execution options were dropped)

Here we directly assign execution options to the connection object (unlike the previous version where they were passed as a dictionary). Note that unlike in SQLAlchemy 2.0, this method does NOT modify the connection in-place, which is why we use the returned value.

FOLLOW-UP: After this is merged, a follow-up PR should handle this:
- [ ] For SQLAlchemy 2.0 (galaxy 24.1): we don't need the copy of the connection: the method modifies the connection in-place ([ref](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection.execution_options))




## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
