### PR TITLE
[24.1] Initialize dictionary used to set connection execution options

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -123,6 +123,7 @@ class ItemGrabber:
         self.self_handler_tags = self_handler_tags
         self.max_grab = max_grab
         self.handler_tags = handler_tags
+        self._grab_conn_opts = {}
         self._grab_query = None
         self._supports_returning = self.app.application_stack.supports_returning()
 


### PR DESCRIPTION
Fix bug introduced in 09fee6aaad34fe34e6c2c76daab35bf89b95a681

Thanks to @luke-c-sargent for spotting the bug and finding its root cause!

We need that to be initialized to a dictionary because it is accessed here: https://github.com/galaxyproject/galaxy/blob/release_24.1/lib/galaxy/jobs/handler.py#L158

Related: #19651

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
