### PR TITLE
Enhance ListHeader Component for Reusability

### DIFF
--- a/client/src/components/Common/ListHeader.vue
+++ b/client/src/components/Common/ListHeader.vue
@@ -38,7 +38,7 @@ const userStore = useUserStore();
 
 const sortDesc = ref(true);
 const sortBy = ref<SortBy>("update_time");
-const currentListView = computed(() => userStore.currentListViewPreferences[props.listId] || "grid");
+const currentListViewMode = computed(() => userStore.currentListViewPreferences[props.listId] || "grid");
 
 function onSort(newSortBy: SortBy) {
     if (sortBy.value === newSortBy) {
@@ -115,7 +115,7 @@ defineExpose({
                     v-b-tooltip
                     title="Grid view"
                     size="sm"
-                    :pressed="currentListView === 'grid'"
+                    :pressed="currentListViewMode === 'grid'"
                     variant="outline-primary"
                     @click="onToggleView('grid')">
                     <FontAwesomeIcon :icon="faGripVertical" />
@@ -126,7 +126,7 @@ defineExpose({
                     v-b-tooltip
                     title="List view"
                     size="sm"
-                    :pressed="currentListView === 'list'"
+                    :pressed="currentListViewMode === 'list'"
                     variant="outline-primary"
                     @click="onToggleView('list')">
                     <FontAwesomeIcon :icon="faBars" />

--- a/client/src/components/Workflow/List/WorkflowList.vue
+++ b/client/src/components/Workflow/List/WorkflowList.vue
@@ -24,7 +24,6 @@ import TagsSelectionDialog from "@/components/Common/TagsSelectionDialog.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import WorkflowListActions from "@/components/Workflow/List/WorkflowListActions.vue";
 
-type ListView = "grid" | "list";
 type WorkflowsList = Record<string, never>[];
 
 // Interface to match the `Workflow` interface from `WorkflowCard`
@@ -79,7 +78,7 @@ const sharedWithMe = computed(() => props.activeList === "shared_with_me");
 const showDeleted = computed(() => filterText.value.includes("is:deleted"));
 const showBookmarked = computed(() => filterText.value.includes("is:bookmarked"));
 const currentPage = computed(() => Math.floor(offset.value / limit.value) + 1);
-const view = computed(() => (userStore.preferredListViewMode as ListView) || "grid");
+const currentListView = computed(() => userStore.currentListViewPreferences.workflows || "grid");
 const sortDesc = computed(() => (listHeader.value && listHeader.value.sortDesc) ?? true);
 const sortBy = computed(() => (listHeader.value && listHeader.value.sortBy) || "update_time");
 const noItems = computed(() => !loading.value && workflowsLoaded.value.length === 0 && !filterText.value);
@@ -387,7 +386,6 @@ onMounted(() => {
             <FilterMenu
                 id="workflow-list-filter"
                 name="workflows"
-                class="mb-2"
                 :filter-class="workflowFilters"
                 :filter-text.sync="filterText"
                 :loading="loading || overlay"
@@ -402,6 +400,8 @@ onMounted(() => {
 
             <ListHeader
                 ref="listHeader"
+                list-id="workflows"
+                show-sort-options
                 show-view-toggle
                 :show-select-all="!published && !sharedWithMe"
                 :select-all-disabled="loading || overlay || noItems || noResults"
@@ -480,7 +480,7 @@ onMounted(() => {
             <WorkflowCardList
                 :workflows="workflowsLoaded"
                 :published-view="published"
-                :grid-view="view === 'grid'"
+                :grid-view="currentListView === 'grid'"
                 :selected-workflow-ids="selectedWorkflowIds"
                 @select="onSelectWorkflow"
                 @refreshList="load"

--- a/client/src/components/Workflow/List/WorkflowList.vue
+++ b/client/src/components/Workflow/List/WorkflowList.vue
@@ -78,7 +78,7 @@ const sharedWithMe = computed(() => props.activeList === "shared_with_me");
 const showDeleted = computed(() => filterText.value.includes("is:deleted"));
 const showBookmarked = computed(() => filterText.value.includes("is:bookmarked"));
 const currentPage = computed(() => Math.floor(offset.value / limit.value) + 1);
-const currentListView = computed(() => userStore.currentListViewPreferences.workflows || "grid");
+const currentListViewMode = computed(() => userStore.currentListViewPreferences.workflows || "grid");
 const sortDesc = computed(() => (listHeader.value && listHeader.value.sortDesc) ?? true);
 const sortBy = computed(() => (listHeader.value && listHeader.value.sortBy) || "update_time");
 const noItems = computed(() => !loading.value && workflowsLoaded.value.length === 0 && !filterText.value);
@@ -480,7 +480,7 @@ onMounted(() => {
             <WorkflowCardList
                 :workflows="workflowsLoaded"
                 :published-view="published"
-                :grid-view="currentListView === 'grid'"
+                :grid-view="currentListViewMode === 'grid'"
                 :selected-workflow-ids="selectedWorkflowIds"
                 @select="onSelectWorkflow"
                 @refreshList="load"

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -21,13 +21,20 @@ interface Preferences {
     [key: string]: unknown;
 }
 
-type ListViewMode = "grid" | "list";
+export type ListViewMode = "grid" | "list";
+
+type UserListViewPreferences = Record<string, ListViewMode>;
 
 export const useUserStore = defineStore("userStore", () => {
     const currentUser = ref<AnyUser>(null);
     const currentPreferences = ref<Preferences | null>(null);
 
-    const preferredListViewMode = useUserLocalStorage("user-store-preferred-list-view-mode", "grid", currentUser);
+    const currentListViewPreferences = useUserLocalStorage<UserListViewPreferences>(
+        "user-store-list-view-preferences",
+        {},
+        currentUser
+    );
+
     const hasSeenUploadHelp = useUserLocalStorage("user-store-seen-upload-help", false, currentUser);
 
     let loadPromise: Promise<void> | null = null;
@@ -127,8 +134,11 @@ export const useUserStore = defineStore("userStore", () => {
         }
     }
 
-    function setPreferredListViewMode(view: ListViewMode) {
-        preferredListViewMode.value = view;
+    function setListViewPreference(listId: string, view: ListViewMode) {
+        currentListViewPreferences.value = {
+            ...currentListViewPreferences.value,
+            [listId]: view,
+        };
     }
 
     function processUserPreferences(user: RegisteredUser): Preferences {
@@ -148,13 +158,13 @@ export const useUserStore = defineStore("userStore", () => {
         isAnonymous,
         currentTheme,
         currentFavorites,
-        preferredListViewMode,
+        currentListViewPreferences,
         hasSeenUploadHelp,
         loadUser,
         matchesCurrentUsername,
         setCurrentUser,
         setCurrentTheme,
-        setPreferredListViewMode,
+        setListViewPreference,
         addFavoriteTool,
         removeFavoriteTool,
         $reset,


### PR DESCRIPTION
This PR expands `ListHeader` and `userStore` to reuse other list components. 
![image](https://github.com/user-attachments/assets/1e45f527-8fe4-4a9c-9c93-7ff8390e64d7)

Key changes
- Add  `listId` prop to identify lists uniquely, and optional `showSortOptions` prop to show sorting controls  
- Update `userStore` to maintain list-specific view preferences (currently store display mode,  grid or list), replace `preferredListViewMode` with `currentListViewPreferences`, allowing per-list persistence and add `setListViewPreference(listId, view)`
- Refactored `WorkflowList` to use the new list-specific view preferences. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
