### PR TITLE
Add Breadcrumb Heading Component

### DIFF
--- a/client/src/components/Common/BreadcrumbHeading.vue
+++ b/client/src/components/Common/BreadcrumbHeading.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { RouterLink } from "vue-router";
+
+import localize from "@/utils/localization";
+
+import Heading from "@/components/Common/Heading.vue";
+
+interface BreadcrumbItem {
+    title: string;
+    to?: string;
+    superText?: string;
+}
+
+interface Props {
+    items: BreadcrumbItem[];
+}
+
+const props = defineProps<Props>();
+</script>
+
+<template>
+    <div class="breadcrumb-heading">
+        <Heading h1 separator inline size="xl" class="breadcrumb-heading-header">
+            <template v-for="(item, index) in props.items">
+                <RouterLink v-if="item.to" :key="index" :to="item.to">
+                    {{ localize(item.title) }}
+                </RouterLink>
+                <span v-else :key="'else-' + index">
+                    {{ localize(item.title) }}
+                </span>
+
+                <template v-if="item.superText">
+                    <sup :key="'sup-' + index" class="breadcrumb-heading-header-beta">
+                        {{ localize(item.superText) }}
+                    </sup>
+                </template>
+
+                <template v-if="index < items.length - 1"> / </template>
+            </template>
+        </Heading>
+
+        <slot />
+    </div>
+</template>
+
+<style scoped lang="scss">
+.breadcrumb-heading {
+    display: flex;
+
+    .breadcrumb-heading-header {
+        flex-grow: 1;
+        margin-bottom: 0.5rem;
+
+        .breadcrumb-heading-header-beta {
+            color: #717273;
+        }
+    }
+}
+</style>

--- a/client/src/components/User/DiskUsage/Management/StorageManager.vue
+++ b/client/src/components/User/DiskUsage/Management/StorageManager.vue
@@ -18,7 +18,6 @@ interface ModalDialog {
 }
 
 const breadcrumbItems = [
-    { title: "User Preferences", to: "/user" },
     { title: "Storage Dashboard", to: "StorageDashboard" },
     { title: "Manage your account storage", superText: "(Beta)" },
 ];

--- a/client/src/components/User/DiskUsage/Management/StorageManager.vue
+++ b/client/src/components/User/DiskUsage/Management/StorageManager.vue
@@ -11,10 +11,17 @@ import type { CleanableItem, CleanupOperation, CleanupResult } from "./Cleanup/m
 import CleanupOperationSummary from "./Cleanup/CleanupOperationSummary.vue";
 import CleanupResultDialog from "./Cleanup/CleanupResultDialog.vue";
 import ReviewCleanupDialog from "./Cleanup/ReviewCleanupDialog.vue";
+import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 
 interface ModalDialog {
     openModal: () => void;
 }
+
+const breadcrumbItems = [
+    { title: "User Preferences", to: "/user" },
+    { title: "Storage Dashboard", to: "StorageDashboard" },
+    { title: "Manage your account storage", superText: "(Beta)" },
+];
 
 const { config } = useConfig();
 const { cleanupCategories } = useCleanupCategories();
@@ -50,11 +57,8 @@ async function onConfirmCleanupSelected(selectedItems: CleanableItem[]) {
 </script>
 
 <template>
-    <b-container fluid>
-        <b-link to="StorageDashboard">{{ localize("Back to Dashboard") }}</b-link>
-        <h2 class="text-center my-3">
-            <b>{{ localize("Manage your account storage") }}</b> <sup class="text-beta">(Beta)</sup>
-        </h2>
+    <div>
+        <BreadcrumbHeading :items="breadcrumbItems" />
 
         <b-row class="justify-content-md-center">
             <b-alert show dismissible variant="warning">
@@ -96,11 +100,5 @@ async function onConfirmCleanupSelected(selectedItems: CleanableItem[]) {
             @onConfirmCleanupSelectedItems="onConfirmCleanupSelected" />
 
         <CleanupResultDialog ref="resultModal" :result="cleanupResult" />
-    </b-container>
+    </div>
 </template>
-
-<style lang="css" scoped>
-.text-beta {
-    color: #717273;
-}
-</style>

--- a/client/src/components/User/DiskUsage/StorageDashboard.vue
+++ b/client/src/components/User/DiskUsage/StorageDashboard.vue
@@ -40,7 +40,7 @@ const texts = reactive({
     },
 });
 
-const breadcrumbItems = [{ title: "User Preferences", to: "/user" }, { title: texts.title }];
+const breadcrumbItems = [{ title: texts.title }];
 
 function goToStorageManager() {
     router.push({ name: "StorageManager" });

--- a/client/src/components/User/DiskUsage/StorageDashboard.vue
+++ b/client/src/components/User/DiskUsage/StorageDashboard.vue
@@ -5,6 +5,8 @@ import { useRouter } from "vue-router/composables";
 import localize from "@/utils/localization";
 
 import DiskUsageSummary from "./DiskUsageSummary.vue";
+import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
+import Heading from "@/components/Common/Heading.vue";
 import IconCard from "@/components/IconCard.vue";
 
 const router = useRouter();
@@ -38,6 +40,8 @@ const texts = reactive({
     },
 });
 
+const breadcrumbItems = [{ title: "User Preferences", to: "/user" }, { title: texts.title }];
+
 function goToStorageManager() {
     router.push({ name: "StorageManager" });
 }
@@ -53,13 +57,14 @@ function goToObjectStoresOverview() {
 
 <template>
     <div>
-        <header class="main-header">
-            <h1 class="text-center my-3">
-                <b>{{ texts.title }}</b>
-            </h1>
-            <h2 class="text-center my-3 h-sm">{{ texts.subtitle }}</h2>
-        </header>
+        <BreadcrumbHeading :items="breadcrumbItems" />
+
+        <Heading h2 size="sm">
+            {{ texts.subtitle }}
+        </Heading>
+
         <DiskUsageSummary class="m-3" />
+
         <IconCard
             class="mx-auto mb-3"
             data-description="free space card"

--- a/client/src/components/User/DiskUsage/Visualizations/OverviewPage.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/OverviewPage.vue
@@ -1,19 +1,23 @@
 <script setup lang="ts">
-import localize from "@/utils/localization";
-
-import Heading from "@/components/Common/Heading.vue";
+import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 
 interface Props {
     title: string;
 }
 
-defineProps<Props>();
+const props = defineProps<Props>();
+
+const breadcrumbItems = [
+    { title: "User Preferences", to: "/user" },
+    { title: "Storage Dashboard", to: "StorageDashboard" },
+    { title: props.title },
+];
 </script>
 
 <template>
-    <div class="mx-3">
-        <router-link :to="{ name: 'StorageDashboard' }">{{ localize("Back to Dashboard") }}</router-link>
-        <Heading h1 bold class="my-3">{{ localize(title) }}</Heading>
+    <div>
+        <BreadcrumbHeading :items="breadcrumbItems" />
+
         <slot />
     </div>
 </template>

--- a/client/src/components/User/DiskUsage/Visualizations/OverviewPage.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/OverviewPage.vue
@@ -7,11 +7,7 @@ interface Props {
 
 const props = defineProps<Props>();
 
-const breadcrumbItems = [
-    { title: "User Preferences", to: "/user" },
-    { title: "Storage Dashboard", to: "StorageDashboard" },
-    { title: props.title },
-];
+const breadcrumbItems = [{ title: "Storage Dashboard", to: "StorageDashboard" }, { title: props.title }];
 </script>
 
 <template>

--- a/client/src/components/Workflow/List/WorkflowList.vue
+++ b/client/src/components/Workflow/List/WorkflowList.vue
@@ -18,6 +18,7 @@ import { rethrowSimple } from "@/utils/simple-error";
 import type { SelectedWorkflow } from "./types";
 
 import WorkflowCardList from "./WorkflowCardList.vue";
+import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 import FilterMenu from "@/components/Common/FilterMenu.vue";
 import Heading from "@/components/Common/Heading.vue";
 import ListHeader from "@/components/Common/ListHeader.vue";
@@ -35,6 +36,8 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
     activeList: "my",
 });
+
+const breadcrumbItems = [{ title: "Workflows" }];
 
 const router = useRouter();
 const userStore = useUserStore();
@@ -352,11 +355,9 @@ onMounted(() => {
 <template>
     <div id="workflows-list" class="workflows-list">
         <div id="workflows-list-header" class="workflows-list-header mb-2">
-            <div class="d-flex flex-gapx-1">
-                <Heading h1 separator inline size="xl" class="flex-grow-1 mb-2">Workflows</Heading>
-
+            <BreadcrumbHeading :items="breadcrumbItems">
                 <WorkflowListActions />
-            </div>
+            </BreadcrumbHeading>
 
             <BNav pills justified class="mb-2">
                 <BNavItem id="my" :active="activeList === 'my'" :disabled="userStore.isAnonymous" to="/workflows/list">


### PR DESCRIPTION
This pull request adds a `BreadcrumbHeading` component, enhancing user navigation by displaying the current page's hierarchical path. It replaces headers in `StorageManager`, `StorageDashboard`, and `Visualizations/OverviewPage` with this new component. Future PRs will extend its use to additional components.

|Before|After|
|--------|-------|
|![image](https://github.com/user-attachments/assets/b131f005-3b44-4ddc-b028-db6987c5c404)|![image](https://github.com/user-attachments/assets/3cbb96c0-eb88-430a-9b61-90b4d4d5e232)|
|![image](https://github.com/user-attachments/assets/26d49934-94a1-471e-b671-0cb31b06498c)|![image](https://github.com/user-attachments/assets/80f1b186-23c6-4b36-9e6c-aad9d9571f37)|
|![image](https://github.com/user-attachments/assets/c96d826c-6e29-4386-9e42-c39e1db530df)|![image](https://github.com/user-attachments/assets/b32fdd51-da79-4e90-9231-8c2a80a1adeb)|
|![image](https://github.com/user-attachments/assets/e7b708a1-4fd9-47d8-b246-c24346ff7837)|![image](https://github.com/user-attachments/assets/b386da3d-f61f-4fe4-865b-84bcc8c48d53)|

Key Changes:
- Addition of the `BreadcrumbHeading` component to display breadcrumb-style headings.
- Included a default slot within the component for header action buttons
![image](https://github.com/user-attachments/assets/4cea01a1-7bdb-42a7-a986-69ea840be8a5)
- Replace existing headings in `StorageManager`, `StorageDashboard`, and `Visualizations/OverviewPage` for consistent and improved user experience.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Verify that the BreadcrumbHeading displays correctly and functions as expected in the updated components.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
