### PR TITLE
Mention default values for truevalue and falsevalue

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4315,14 +4315,14 @@ parameter should be checked (or ``true``) by default. Used only when the
         <xs:attribute name="truevalue" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">The parameter value in the Cheetah
-template if the parameter is ``true`` or checked by the user. Used only when the
+template if the parameter is ``true`` or checked by the user (defaults to "true"). Used only when the
 ``type`` attribute value is ``boolean``.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="falsevalue" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">The parameter value in the Cheetah
-template if the parameter is ``false`` or not checked by the user. Used only
+template if the parameter is ``false`` or not checked by the user (defaults to "false"). Used only
 when the ``type`` attribute value is ``boolean``.</xs:documentation>
           </xs:annotation>
         </xs:attribute>


### PR DESCRIPTION
I noticed that the [Galaxy Tool XML docs](https://docs.galaxyproject.org/en/master/dev/schema.html#id49) didn't state what the default values for a boolean parameter in Cheetah were (if truevalue / falsevalue were not specified) so I did a bit of research (in https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tools/parameters/basic.py#L621 and https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tool_util/parser/util.py#L72) and added this note to the docs.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
