### PR TITLE
Update test_create_dataset_in_subfolder to check for the dataset presence

### DIFF
--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -1,5 +1,4 @@
 import unittest
-from datetime import datetime
 
 from galaxy.model.unittest_utils.store_fixtures import (
     one_ld_library_model_store_dict,
@@ -423,18 +422,18 @@ class TestLibrariesApi(ApiTestCase):
         print(subfolder_response.json())
         subfolder_id = subfolder_response.json()["id"]
         history_id = self.dataset_populator.new_history()
-        hda_id = self.dataset_populator.new_dataset(history_id, content="1 2 3 sub")["id"]
+        expected_dataset_name = "test_dataset_in_subfolder"
+        hda_id = self.dataset_populator.new_dataset(history_id, name=expected_dataset_name, content="1 2 3 sub")["id"]
         payload = {"from_hda_id": hda_id}
         create_response = self._post(f"folders/{subfolder_id}/contents", payload, json=True)
         self._assert_status_code_is(create_response, 200)
         self._assert_has_keys(create_response.json(), "name", "id")
-        dataset_update_time = datetime.fromisoformat(create_response.json()["update_time"])
-        container_fetch_response = self.galaxy_interactor.get(f"folders/{folder_id}/contents")
-        container_update_time = datetime.fromisoformat(
-            container_fetch_response.json()["folder_contents"][0]["update_time"]
-        )
-        # Assert that the update time of the dataset is approximately the same as the update time of the container
-        assert abs((dataset_update_time - container_update_time).total_seconds()) < 1
+
+        folder_response = self.galaxy_interactor.get(f"folders/{subfolder_id}/contents")
+        self._assert_status_code_is(folder_response, 200)
+        folder_contents = folder_response.json()["folder_contents"]
+        assert len(folder_contents) == 1
+        assert folder_contents[0]["name"] == expected_dataset_name
 
     def _patch_library_dataset(self, library_dataset_id, data):
         create_response = self._patch(f"libraries/datasets/{library_dataset_id}", data=data, json=True)

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime
 
 from galaxy.model.unittest_utils.store_fixtures import (
     one_ld_library_model_store_dict,
@@ -427,10 +428,13 @@ class TestLibrariesApi(ApiTestCase):
         create_response = self._post(f"folders/{subfolder_id}/contents", payload, json=True)
         self._assert_status_code_is(create_response, 200)
         self._assert_has_keys(create_response.json(), "name", "id")
-        dataset_update_time = create_response.json()["update_time"]
+        dataset_update_time = datetime.fromisoformat(create_response.json()["update_time"])
         container_fetch_response = self.galaxy_interactor.get(f"folders/{folder_id}/contents")
-        container_update_time = container_fetch_response.json()["folder_contents"][0]["update_time"]
-        assert dataset_update_time == container_update_time, container_fetch_response
+        container_update_time = datetime.fromisoformat(
+            container_fetch_response.json()["folder_contents"][0]["update_time"]
+        )
+        # Assert that the update time of the dataset is approximately the same as the update time of the container
+        assert abs((dataset_update_time - container_update_time).total_seconds()) < 1
 
     def _patch_library_dataset(self, library_dataset_id, data):
         create_response = self._patch(f"libraries/datasets/{library_dataset_id}", data=data, json=True)


### PR DESCRIPTION
To avoid flakiness due to slight time differences on slow systems like CI.

```
FAILED lib/galaxy_test/api/test_libraries.py::TestLibrariesApi::test_create_dataset_in_subfolder - AssertionError: <Response [200]>
assert '2025-02-19T12:18:15.550553' == '2025-02-19T12:18:15.522299'
  - 2025-02-19T12:18:15.522299
  ?                      ^^^^^
  + 2025-02-19T12:18:15.550553
  ?                      ^^^^^
```

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
