### PR TITLE
Relax job status check in test_delete_user_cancel_all_jobs

### DIFF
--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -171,9 +171,9 @@ class TestUsersApi(ApiTestCase):
             # Delete user will cancel all jobs
             self._delete(f"users/{user_id}", admin=True)
 
-            # Get the job state again (this time as admin), it should be deleting
+            # Get the job state again (this time as admin), it should be deleting or deleted
             job_response = self._get(f"jobs/{job_id}", admin=True).json()
-            assert job_response["state"] == "deleting", job_response
+            assert job_response["state"] in ["deleting", "deleted"], job_response
 
     @requires_new_user
     def test_information(self):


### PR DESCRIPTION
In some cases, it seems the job status may be updated quickly enough from "deleting" to "deleted".

```
FAILED lib/galaxy_test/api/test_users.py::TestUsersApi::test_delete_user_cancel_all_jobs - AssertionError: {'command_line': None, 'command_version': None, 'copied_from_job_id': None, 'create_time': '2025-02-19T12:24:45.916221', ...}
assert 'deleted' == 'deleting'
  - deleting
  + deleted
```

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
