### PR TITLE
Refactor dependencies for tool output actions.

### DIFF
--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -37,11 +37,11 @@ if TYPE_CHECKING:
         ResourceRequirement,
         ToolRequirements,
     )
+    from galaxy.tool_util.parser.output_actions import ToolOutputActionApp
     from galaxy.tool_util.parser.output_objects import (
         ToolOutput,
         ToolOutputCollection,
     )
-    from galaxy.tools import Tool
 
 
 NOT_IMPLEMENTED_MESSAGE = "Galaxy tool format does not yet support this tool feature."
@@ -338,7 +338,7 @@ class ToolSource(metaclass=ABCMeta):
 
     @abstractmethod
     def parse_outputs(
-        self, tool: Optional["Tool"]
+        self, app: Optional["ToolOutputActionApp"]
     ) -> Tuple[Dict[str, "ToolOutput"], Dict[str, "ToolOutputCollection"]]:
         """Return a pair of output and output collections ordered
         dictionaries for use by Tool.

--- a/lib/galaxy/tool_util/parser/output_objects.py
+++ b/lib/galaxy/tool_util/parser/output_objects.py
@@ -11,7 +11,10 @@ from typing_extensions import TypedDict
 
 from galaxy.util import Element
 from galaxy.util.dictifiable import Dictifiable
-from .output_actions import ToolOutputActionGroup
+from .output_actions import (
+    ToolOutputActionApp,
+    ToolOutputActionGroup,
+)
 from .output_collection_def import (
     dataset_collector_descriptions_from_output_dict,
     DatasetCollectionDescription,
@@ -116,7 +119,6 @@ class ToolOutput(ToolOutputBase):
         self.dataset_collector_descriptions: List[DatasetCollectionDescription] = []
         self.default_identifier_source: Optional[str] = None
         self.count: Optional[int] = None
-        self.tool: Optional[Any]
 
     # Tuple emulation
 
@@ -163,7 +165,7 @@ class ToolOutput(ToolOutputBase):
         )
 
     @staticmethod
-    def from_dict(name: str, output_dict: Dict[str, Any], tool: Optional[object] = None) -> "ToolOutput":
+    def from_dict(name: str, output_dict: Dict[str, Any], app: Optional[ToolOutputActionApp] = None) -> "ToolOutput":
         output = ToolOutput(name)
         output.format = output_dict.get("format", "data")
         output.change_format = []
@@ -174,11 +176,11 @@ class ToolOutput(ToolOutputBase):
         output.label = output_dict.get("label", None)
         output.count = output_dict.get("count", 1)
         output.filters = []
-        output.tool = tool
         output.from_work_dir = output_dict.get("from_work_dir", None)
         output.hidden = output_dict.get("hidden", False)
         # TODO: implement tool output action group fixes
-        output.actions = ToolOutputActionGroup(output, None)
+        if app is not None:
+            output.actions = ToolOutputActionGroup(app, None)
         output.dataset_collector_descriptions = dataset_collector_descriptions_from_output_dict(output_dict)
         return output
 
@@ -189,6 +191,7 @@ class ToolOutput(ToolOutputBase):
 
 class ToolExpressionOutput(ToolOutputBase):
     dict_collection_visible_keys = ("name", "format", "label", "hidden", "output_type")
+    path: Optional[str]
 
     def __init__(self, name, output_type, from_expression, label=None, filters=None, actions=None, hidden=False):
         super().__init__(name, label=label, filters=filters, hidden=hidden)
@@ -205,6 +208,8 @@ class ToolExpressionOutput(ToolOutputBase):
         self.change_format = []
         self.implicit = False
         self.from_work_dir = None
+
+        self.dataset_collector_descriptions = []
 
     def to_model(self) -> ToolOutputModel:
         model_class: Union[
@@ -366,7 +371,7 @@ class ToolOutputCollection(ToolOutputBase):
         )
 
     @staticmethod
-    def from_dict(name, output_dict, tool=None) -> "ToolOutputCollection":
+    def from_dict(name, output_dict, app: Optional[ToolOutputActionApp] = None) -> "ToolOutputCollection":
         structure = ToolOutputCollectionStructure.from_dict(output_dict["structure"])
         rval = ToolOutputCollection(
             name,

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -31,6 +31,7 @@ from galaxy.util import (
     ElementTree,
     string_as_bool,
     string_as_bool_or_none,
+    unicodify,
     XML,
     xml_text,
     xml_to_string,
@@ -62,7 +63,10 @@ from .interface import (
     XmlTestCollectionDefDict,
     XrefDict,
 )
-from .output_actions import ToolOutputActionGroup
+from .output_actions import (
+    ToolOutputActionApp,
+    ToolOutputActionGroup,
+)
 from .output_collection_def import dataset_collector_descriptions_from_elem
 from .output_objects import (
     ChangeFormatModel,
@@ -438,25 +442,25 @@ class XmlToolSource(ToolSource):
 
         return provided_metadata_file
 
-    def parse_outputs(self, tool=None):
+    def parse_outputs(self, app: Optional[ToolOutputActionApp] = None):
         out_elem = self.root.find("outputs")
-        outputs = {}
-        output_collections = {}
+        outputs: Dict[str, ToolOutput] = {}
+        output_collections: Dict[str, ToolOutputCollection] = {}
         if out_elem is None:
             return outputs, output_collections
 
-        data_dict = {}
+        data_dict: Dict[str, ToolOutput] = {}
 
         def _parse(data_elem, **kwds):
-            output_def = self._parse_output(data_elem, tool, **kwds)
+            output_def = self._parse_output(data_elem, app, **kwds)
             data_dict[output_def.name] = output_def
             return output_def
 
         for _ in out_elem.findall("data"):
             _parse(_)
 
-        def _parse_expression(output_elem, **kwds):
-            output_def = self._parse_expression_output(output_elem, tool, **kwds)
+        def _parse_expression(output_elem, app: Optional[ToolOutputActionApp] = None, **kwds):
+            output_def = self._parse_expression_output(output_elem, app, **kwds)
             output_def.filters = output_elem.findall("filter")
             data_dict[output_def.name] = output_def
             return output_def
@@ -527,11 +531,11 @@ class XmlToolSource(ToolSource):
                 if output_type == "data":
                     _parse(out_child)
                 elif output_type == "collection":
-                    out_child.attrib["type"] = out_child.get("collection_type")
-                    out_child.attrib["type_source"] = out_child.get("collection_type_source")
+                    out_child.attrib["type"] = unicodify(out_child.get("collection_type"))
+                    out_child.attrib["type_source"] = unicodify(out_child.get("collection_type_source"))
                     _parse_collection(out_child)
                 else:
-                    _parse_expression(out_child)
+                    _parse_expression(out_child, app)
             else:
                 log.warning(f"Unknown output tag encountered [{out_child.tag}]")
 
@@ -542,7 +546,7 @@ class XmlToolSource(ToolSource):
     def _parse_output(
         self,
         data_elem,
-        tool,
+        app: Optional[ToolOutputActionApp] = None,
         default_format="data",
         default_format_source=None,
         default_metadata_source="",
@@ -565,26 +569,26 @@ class XmlToolSource(ToolSource):
         output.label = xml_text(data_elem, "label", None)
         output.count = int(data_elem.get("count", 1))
         output.filters = data_elem.findall("filter")
-        output.tool = tool
         output.from_work_dir = data_elem.get("from_work_dir", None)
-        if output.from_work_dir and Version(str(getattr(tool, "profile", 0))) < Version("21.09"):
+        profile_version = Version(self.parse_profile())
+        if output.from_work_dir and profile_version < Version("21.09"):
             # We started quoting from_work_dir outputs in 21.09.
             # Prior to quoting, trailing spaces had no effect.
             # This ensures that old tools continue to work.
             output.from_work_dir = output.from_work_dir.strip()
         output.hidden = string_as_bool(data_elem.get("hidden", ""))
-        if tool is not None:
+        if app is not None:
             # poor design here driven entirely by pragmatism in refactoring, ToolOutputActionGroup
             # belongs in galaxy-tool because it uses app heavily. Breaking the output objects
             # into app-aware things and dumb models would be a large project but superior design
             # and decomposition.
-            output.actions = ToolOutputActionGroup(output, data_elem.find("actions"))
+            output.actions = ToolOutputActionGroup(app, data_elem.find("actions"))
         output.dataset_collector_descriptions = dataset_collector_descriptions_from_elem(
             data_elem, legacy=self.legacy_defaults
         )
         return output
 
-    def _parse_expression_output(self, output_elem, tool, **kwds):
+    def _parse_expression_output(self, output_elem, app: Optional[ToolOutputActionApp] = None, **kwds):
         output_type = output_elem.get("type")
         from_expression = output_elem.get("from")
         output = ToolExpressionOutput(
@@ -596,8 +600,8 @@ class XmlToolSource(ToolSource):
         output.label = xml_text(output_elem, "label", None)
 
         output.hidden = string_as_bool(output_elem.get("hidden", ""))
-        output.actions = ToolOutputActionGroup(output, output_elem.find("actions"))
-        output.dataset_collector_descriptions = []
+        if app is not None:
+            output.actions = ToolOutputActionGroup(app, output_elem.find("actions"))
         return output
 
     def parse_stdio(self):

--- a/lib/galaxy/tool_util/parser/yaml.py
+++ b/lib/galaxy/tool_util/parser/yaml.py
@@ -28,6 +28,7 @@ from .interface import (
     ToolSourceTests,
     XrefDict,
 )
+from .output_actions import ToolOutputActionApp
 from .output_collection_def import dataset_collector_descriptions_from_output_dict
 from .output_objects import (
     ToolOutput,
@@ -136,16 +137,16 @@ class YamlToolSource(ToolSource):
         else:
             return None
 
-    def parse_outputs(self, tool):
+    def parse_outputs(self, app: Optional[ToolOutputActionApp]):
         outputs = self.root_dict.get("outputs", {})
         output_defs = []
         output_collection_defs = []
         for name, output_dict in outputs.items():
             output_type = output_dict.get("type", "data")
             if output_type == "data":
-                output_defs.append(self._parse_output(tool, name, output_dict))
+                output_defs.append(self._parse_output(app, name, output_dict))
             elif output_type == "collection":
-                output_collection_defs.append(self._parse_output_collection(tool, name, output_dict))
+                output_collection_defs.append(self._parse_output_collection(app, name, output_dict))
             else:
                 message = f"Unknown output_type [{output_type}] encountered."
                 raise Exception(message)
@@ -158,8 +159,8 @@ class YamlToolSource(ToolSource):
 
         return outputs, output_collections
 
-    def _parse_output(self, tool, name, output_dict):
-        output = ToolOutput.from_dict(name, output_dict, tool=tool)
+    def _parse_output(self, app, name, output_dict):
+        output = ToolOutput.from_dict(name, output_dict, app=app)
         return output
 
     def _parse_output_collection(self, tool, name, output_dict):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1497,7 +1497,7 @@ class Tool(UsesDictVisibleKeys):
         """
         Parse <outputs> elements and fill in self.outputs (keyed by name)
         """
-        self.outputs, self.output_collections = tool_source.parse_outputs(self)
+        self.outputs, self.output_collections = tool_source.parse_outputs(self.app)
 
     # TODO: Include the tool's name in any parsing warnings.
     def parse_stdio(self, tool_source: ToolSource):


### PR DESCRIPTION
Eliminates a Tool import in the parser stuff that shouldn't be there and implements a better design around how tool output actions are implementation regardless of imports and package structure. Also catches a few little bugs (e.g. around null handling) that were found by introducing better typing in these components.

The output action models still need to spun out from the runtime at some point the way we did for parameter validators, etc.. but these changes will aid that.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
