### PR TITLE
Generate correct types for Dataset source transformations on backend.

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -296,10 +296,7 @@ export function canMutateHistory(history: AnyHistory): boolean {
 
 export type DatasetHash = components["schemas"]["DatasetHash"];
 
-export type DatasetTransform = {
-    action: "to_posix_lines" | "spaces_to_tabs" | "datatype_groom";
-    datatype_ext: "bam" | "qname_sorted.bam" | "qname_input_sorted.bam" | "isa-tab" | "isa-json";
-};
+export type DatasetTransform = components["schemas"]["DatasetSourceTransform"];
 
 /**
  * Base type for all exceptions returned by the API.

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -8093,7 +8093,7 @@ export interface components {
              * Transform
              * @description The transformations applied to the dataset source.
              */
-            transform?: unknown[] | null;
+            transform?: components["schemas"]["DatasetSourceTransform"][] | null;
         };
         /** DatasetSourceId */
         DatasetSourceId: {
@@ -8108,6 +8108,24 @@ export interface components {
              */
             src: components["schemas"]["DatasetSourceType"];
         };
+        /** DatasetSourceTransform */
+        DatasetSourceTransform: {
+            /**
+             * Action
+             * @description Action that was applied to dataset source content to transform it into the dataset
+             */
+            action: components["schemas"]["DatasetSourceTransformActionType"];
+            /**
+             * Datatype Extension
+             * @description If action is 'datatype_groom', this is the datatype that was used to find and run the grooming code as part of the transform action.
+             */
+            datatype_ext?: string | null;
+        };
+        /**
+         * DatasetSourceTransformActionType
+         * @enum {string}
+         */
+        DatasetSourceTransformActionType: "to_posix_lines" | "spaces_to_tabs" | "datatype_groom";
         /**
          * DatasetSourceType
          * @enum {string}

--- a/client/src/components/DatasetInformation/DatasetSourceTransform.vue
+++ b/client/src/components/DatasetInformation/DatasetSourceTransform.vue
@@ -18,13 +18,13 @@ const TRANSFORM_ACTION_DESCRIPTIONS = {
     },
 };
 
-const DATATYPE_GROOMING_DESCRIPTIONS = {
-    bam: "The supplied BAM was coordinate-sorted using pysam.",
-    "qname_sorted.bam": "The supplied BAM was 'queryname' sorted using pysam.",
-    "qname_input_sorted.bam": "The supplied BAM was 'queryname' sorted using pysam.",
-    "isa-tab": "The supplied compressed file was converted to an ISA-TAB composite dataset.",
-    "isa-json": "The supplied compressed file was converted to an ISA-JSON composite dataset.",
-};
+const DATATYPE_GROOMING_DESCRIPTIONS = new Map<string, string>([
+    ["bam", "The supplied BAM was coordinate-sorted using pysam."],
+    ["qname_sorted.bam", "The supplied BAM was 'queryname' sorted using pysam."],
+    ["qname_input_sorted.bam", "The supplied BAM was 'queryname' sorted using pysam."],
+    ["isa-tab", "The supplied compressed file was converted to an ISA-TAB composite dataset."],
+    ["isa-json", "The supplied compressed file was converted to an ISA-JSON composite dataset."],
+]);
 
 const UNKNOWN_ACTION_DESCRIPTION = {
     short: "Unknown action.",
@@ -51,9 +51,9 @@ function actionShortDescription(transformAction: DatasetTransform) {
 
 function actionLongDescription(transformAction: DatasetTransform) {
     let longDescription = actionDescription(transformAction).long || "";
-
-    if (transformAction.action == "datatype_groom") {
-        const datatypeDescription = DATATYPE_GROOMING_DESCRIPTIONS[transformAction.datatype_ext];
+    const datatypeExt = transformAction.datatype_ext;
+    if (transformAction.action == "datatype_groom" && datatypeExt && DATATYPE_GROOMING_DESCRIPTIONS.has(datatypeExt)) {
+        const datatypeDescription: string | undefined = DATATYPE_GROOMING_DESCRIPTIONS.get(datatypeExt);
 
         if (datatypeDescription) {
             longDescription += " " + datatypeDescription;

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -134,6 +134,7 @@ from sqlalchemy.sql import exists
 from sqlalchemy.sql.expression import FromClause
 from typing_extensions import (
     Literal,
+    NotRequired,
     Protocol,
     TypeAlias,
     TypedDict,
@@ -178,6 +179,7 @@ from galaxy.schema.invocation import (
 )
 from galaxy.schema.schema import (
     DatasetCollectionPopulatedState,
+    DatasetSourceTransformActionTypeLiteral,
     DatasetState,
     DatasetValidatedState,
     InvocationsStateCounts,
@@ -264,7 +266,10 @@ CONFIGURATION_TEMPLATE_DEFINITION_TYPE = Dict[str, Any]
 
 
 class TransformAction(TypedDict):
-    action: str
+    action: DatasetSourceTransformActionTypeLiteral
+    datatype_ext: NotRequired[
+        str
+    ]  # if action == 'datatype_groom', this is the datatype ext that was used to groom the dataset.
 
 
 TRANSFORM_ACTIONS = List[TransformAction]

--- a/lib/galaxy/model/dereference.py
+++ b/lib/galaxy/model/dereference.py
@@ -35,7 +35,7 @@ def dereference_to_model(sa_session, user, history, data_request_uri: DataReques
     hda.dataset.sources = [dataset_source]
     transform: List[TransformAction] = []
     if data_request_uri.space_to_tab:
-        transform.append({"action": "space_to_tab"})
+        transform.append({"action": "spaces_to_tabs"})
     elif data_request_uri.to_posix_lines:
         transform.append({"action": "to_posix_lines"})
     if len(transform) > 0:

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -122,6 +122,17 @@ class DatasetCollectionPopulatedState(str, Enum):
     FAILED = "failed"  # some problem populating state, won't be populated
 
 
+# we use TypedDicts in the model layer and I don't know how to type with that enum
+# in the dict - it doesn't have the enum value magic that pydantic has.
+DatasetSourceTransformActionTypeLiteral = Literal["to_posix_lines", "spaces_to_tabs", "datatype_groom"]
+
+
+class DatasetSourceTransformActionType(str, Enum):
+    TO_POSIX_LINES = "to_posix_lines"
+    SPACES_TO_TABLES = "spaces_to_tabs"
+    DATATYPE_GROOM = "datatype_groom"
+
+
 # Generic and common Field annotations that can be reused across models
 
 RelativeUrlField = Annotated[
@@ -742,6 +753,29 @@ class DatasetHash(Model):
     )
 
 
+HdaLddaField = Field(
+    DatasetSourceType.hda,
+    title="HDA or LDDA",
+    description="Whether this dataset belongs to a history (HDA) or a library (LDDA).",
+)
+
+DatasetSourceTransformActionField: DatasetSourceTransformActionType = Field(
+    ...,
+    title="Action",
+    description="Action that was applied to dataset source content to transform it into the dataset",
+)
+DatasetSourceTransformActionDatatypeExtField: Optional[str] = Field(
+    None,
+    title="Datatype Extension",
+    description="If action is 'datatype_groom', this is the datatype that was used to find and run the grooming code as part of the transform action.",
+)
+
+
+class DatasetSourceTransform(Model):
+    action: DatasetSourceTransformActionType = DatasetSourceTransformActionField
+    datatype_ext: Optional[str] = DatasetSourceTransformActionDatatypeExtField
+
+
 class DatasetSource(Model):
     id: EncodedDatabaseIdField = Field(
         ...,
@@ -753,7 +787,7 @@ class DatasetSource(Model):
         Optional[str], Field(None, title="Extra Files Path", description="The path to the extra files.")
     ]
     transform: Annotated[
-        Optional[List[Any]],  # TODO: type this
+        Optional[List[DatasetSourceTransform]],
         Field(
             None,
             title="Transform",

--- a/test/unit/data/test_dereference.py
+++ b/test/unit/data/test_dereference.py
@@ -54,4 +54,4 @@ def test_dereference_to_posix():
     hda = dereference_to_model(sa_session, user, history, uri_request)
     assert hda.name == "foobar.txt"
     assert hda.dataset.sources[0].source_uri == TEST_BASE64_URI
-    assert hda.dataset.sources[0].transform[0]["action"] == "space_to_tab"
+    assert hda.dataset.sources[0].transform[0]["action"] == "spaces_to_tabs"


### PR DESCRIPTION
This should cleanup vue-tsc errors generated because of the unknown action types in dataset sources.

I think someone used the groomer messages I wrote for various datatypes to use an enum when defining the ``datatype_ext`` field on the frontend (the stub in api/index.ts this is replacing) - but I don't think that is appropriate. Galaxy deployers can deploy custom datatypes and custom groomers - so I think a string is a more appropriate type (we have enough references to datatype extensions that some sort of string alias would make sense potentially, but not this enum IMO). The enumeration was groomers we had nice little messages for - not the realm of what is or should be possible.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
