### PR TITLE
Add webdavclient3 to conditional-requirements.txt

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -249,6 +249,10 @@ class ConditionalDependencies:
     def check_fs_webdavfs(self):
         return "webdav" in self.file_sources
 
+    def check_webdavclient3(self):
+        # fs.webdavfs dependency for which we need an unreleased version
+        return self.check_fs_webdavfs()
+
     def check_fs_anvilfs(self):
         # pyfilesystem plugin access to terra on anvil
         return "anvil" in self.file_sources

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -18,6 +18,8 @@ openai
 
 # For file sources plugins
 fs.webdavfs>=0.4.2  # type: webdav
+# webdavclient3 on the develop branch contains an important fix for username-based authentification containing the '@' symbol
+webdavclient3 @ git+https://github.com/ezhov-evgeny/webdav-client-python-3@98c23d1abd15efc3db9cfc756429f00041578bc2
 fs.dropboxfs>=1.0  # type: dropbox
 fs.sshfs  # type: ssh
 fs.anvilfs # type: anvil


### PR DESCRIPTION
Unfortunately, we need an unreleased version of webdavclient3, which is a dependency of fs.webdavfs.

The problem that this version is solving is a connection to webdav server with an @ sign in the user name.