### PR TITLE
[24.2] Fix recording transform action name.

### DIFF
--- a/lib/galaxy/model/dereference.py
+++ b/lib/galaxy/model/dereference.py
@@ -34,7 +34,7 @@ def dereference_to_model(sa_session, user, history, data_request_uri: DataReques
     hda.dataset.sources = [dataset_source]
     transform: List[TransformAction] = []
     if data_request_uri.space_to_tab:
-        transform.append({"action": "space_to_tab"})
+        transform.append({"action": "spaces_to_tabs"})
     elif data_request_uri.to_posix_lines:
         transform.append({"action": "to_posix_lines"})
     if len(transform) > 0:

--- a/test/unit/data/test_dereference.py
+++ b/test/unit/data/test_dereference.py
@@ -54,4 +54,4 @@ def test_dereference_to_posix():
     hda = dereference_to_model(sa_session, user, history, uri_request)
     assert hda.name == "foobar.txt"
     assert hda.dataset.sources[0].source_uri == TEST_BASE64_URI
-    assert hda.dataset.sources[0].transform[0]["action"] == "space_to_tab"
+    assert hda.dataset.sources[0].transform[0]["action"] == "spaces_to_tabs"


### PR DESCRIPTION
This code was added for dereferencing datasets for landing pages. The upload option is space_to_tab, but we've always recorded in the source transform json blob as spaces_to_tabs. I guess the past tense version - it sort of makes sense but anyway we don't want any of these inconsistent values in the database. This bug was caught by type checking the model layer in https://github.com/galaxyproject/galaxy/pull/19666. 

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
