### PR TITLE
[24.2] Fix private role name performance issue

### DIFF
--- a/lib/galaxy/files/__init__.py
+++ b/lib/galaxy/files/__init__.py
@@ -396,7 +396,11 @@ class ProvidesFileSourcesUserContext(FileSourcesUserContext, FileSourceDictifiab
     def role_names(self) -> Set[str]:
         """The set of role names of this user."""
         user = self.trans.user
-        return {ura.role.name for ura in user.roles} if user else set()
+        role_names = set()
+        if user:
+            role_names = {ura.role.name for ura in user.roles}
+            role_names.add(user.email)  # User's private role may have a generic name, so add user's email explicitly.
+        return role_names
 
     @property
     def group_names(self) -> Set[str]:

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -11,6 +11,7 @@ from typing import (
     Generic,
     List,
     Optional,
+    Set,
     Type,
     TypeVar,
 )
@@ -36,6 +37,7 @@ from galaxy.model import (
     HistoryDatasetAssociation,
 )
 from galaxy.model.base import transaction
+from galaxy.model.db.role import get_private_role_user_emails_dict
 from galaxy.schema.tasks import (
     ComputeDatasetHashTaskRequest,
     PurgeDatasetsTaskRequest,
@@ -451,16 +453,24 @@ class DatasetAssociationManager(
             library_dataset = None
             dataset = dataset_assoc.dataset
 
+        private_role_emails = get_private_role_user_emails_dict(self.session())
+
         # Omit duplicated roles by converting to set
         access_roles = set(dataset.get_access_roles(self.app.security_agent))
         manage_roles = set(dataset.get_manage_permissions_roles(self.app.security_agent))
 
-        access_dataset_role_list = [
-            (access_role.name, self.app.security.encode_id(access_role.id)) for access_role in access_roles
-        ]
-        manage_dataset_role_list = [
-            (manage_role.name, self.app.security.encode_id(manage_role.id)) for manage_role in manage_roles
-        ]
+        def make_tuples(roles: Set):
+            tuples = []
+            for role in roles:
+                # use role name for non-private roles, and user.email from private rules
+                displayed_name = private_role_emails.get(role.id, role.name)
+                role_tuple = (displayed_name, self.app.security.encode_id(role.id))
+                tuples.append(role_tuple)
+            return tuples
+
+        access_dataset_role_list = make_tuples(access_roles)
+        manage_dataset_role_list = make_tuples(manage_roles)
+
         rval = dict(access_dataset_roles=access_dataset_role_list, manage_dataset_roles=manage_dataset_role_list)
         if library_dataset is not None:
             modify_roles = set(
@@ -468,9 +478,7 @@ class DatasetAssociationManager(
                     library_dataset, self.app.security_agent.permitted_actions.LIBRARY_MODIFY
                 )
             )
-            modify_item_role_list = [
-                (modify_role.name, self.app.security.encode_id(modify_role.id)) for modify_role in modify_roles
-            ]
+            modify_item_role_list = make_tuples(modify_roles)
             rval["modify_item_roles"] = modify_item_role_list
         return rval
 

--- a/lib/galaxy/managers/folders.py
+++ b/lib/galaxy/managers/folders.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import (
     List,
     Optional,
+    Set,
     Tuple,
     Union,
 )
@@ -49,6 +50,7 @@ from galaxy.model import (
     LibraryFolderPermissions,
 )
 from galaxy.model.base import transaction
+from galaxy.model.db.role import get_private_role_user_emails_dict
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.schema.schema import LibraryFolderContentsIndexQueryPayload
 from galaxy.security import RBACAgent
@@ -295,6 +297,8 @@ class FolderManager:
         :returns:   dict of current roles for all available permission types
         :rtype:     dictionary
         """
+        private_role_emails = get_private_role_user_emails_dict(trans.sa_session)
+
         # Omit duplicated roles by converting to set
         modify_roles = set(
             trans.app.security_agent.get_roles_for_action(
@@ -312,17 +316,19 @@ class FolderManager:
             )
         )
 
-        modify_folder_role_list = [
-            (modify_role.name, trans.security.encode_id(modify_role.id)) for modify_role in modify_roles
-        ]
-        manage_folder_role_list = [
-            (manage_role.name, trans.security.encode_id(manage_role.id)) for manage_role in manage_roles
-        ]
-        add_library_item_role_list = [(add_role.name, trans.security.encode_id(add_role.id)) for add_role in add_roles]
+        def make_tuples(roles: Set):
+            tuples = []
+            for role in roles:
+                # use role name for non-private roles, and user.email from private rules
+                displayed_name = private_role_emails.get(role.id, role.name)
+                role_tuple = (displayed_name, trans.security.encode_id(role.id))
+                tuples.append(role_tuple)
+            return tuples
+
         return dict(
-            modify_folder_role_list=modify_folder_role_list,
-            manage_folder_role_list=manage_folder_role_list,
-            add_library_item_role_list=add_library_item_role_list,
+            modify_folder_role_list=make_tuples(modify_roles),
+            manage_folder_role_list=make_tuples(manage_roles),
+            add_library_item_role_list=make_tuples(add_roles),
         )
 
     def can_add_item(self, trans, folder):

--- a/lib/galaxy/managers/libraries.py
+++ b/lib/galaxy/managers/libraries.py
@@ -30,6 +30,7 @@ from galaxy.model.db.library import (
     get_library_ids,
     get_library_permissions_by_role,
 )
+from galaxy.model.db.role import get_private_role_user_emails_dict
 from galaxy.util import (
     pretty_print_time_interval,
     unicodify,
@@ -277,26 +278,26 @@ class LibraryManager:
         :rtype:     dictionary
         :returns:   dict of current roles for all available permission types
         """
-        access_library_role_list = [
-            (access_role.name, trans.security.encode_id(access_role.id))
-            for access_role in self.get_access_roles(trans, library)
-        ]
-        modify_library_role_list = [
-            (modify_role.name, trans.security.encode_id(modify_role.id))
-            for modify_role in self.get_modify_roles(trans, library)
-        ]
-        manage_library_role_list = [
-            (manage_role.name, trans.security.encode_id(manage_role.id))
-            for manage_role in self.get_manage_roles(trans, library)
-        ]
-        add_library_item_role_list = [
-            (add_role.name, trans.security.encode_id(add_role.id)) for add_role in self.get_add_roles(trans, library)
-        ]
+        private_role_emails = get_private_role_user_emails_dict(trans.sa_session)
+        access_roles = self.get_access_roles(trans, library)
+        modify_roles = self.get_modify_roles(trans, library)
+        manage_roles = self.get_manage_roles(trans, library)
+        add_roles = self.get_add_roles(trans, library)
+
+        def make_tuples(roles: Set):
+            tuples = []
+            for role in roles:
+                # use role name for non-private roles, and user.email from private rules
+                displayed_name = private_role_emails.get(role.id, role.name)
+                role_tuple = (displayed_name, trans.security.encode_id(role.id))
+                tuples.append(role_tuple)
+            return tuples
+
         return dict(
-            access_library_role_list=access_library_role_list,
-            modify_library_role_list=modify_library_role_list,
-            manage_library_role_list=manage_library_role_list,
-            add_library_item_role_list=add_library_item_role_list,
+            access_library_role_list=make_tuples(access_roles),
+            modify_library_role_list=make_tuples(modify_roles),
+            manage_library_role_list=make_tuples(manage_roles),
+            add_library_item_role_list=make_tuples(add_roles),
         )
 
     def get_access_roles(self, trans, library: Library) -> Set[Role]:

--- a/lib/galaxy/managers/roles.py
+++ b/lib/galaxy/managers/roles.py
@@ -84,11 +84,7 @@ class RoleManager(base.ModelManager[model.Role]):
         user_ids = role_definition_model.user_ids or []
         group_ids = role_definition_model.group_ids or []
 
-        stmt = (
-            select(Role)
-            .where(Role.name == name)  # type:ignore[arg-type,comparison-overlap]  # Role.name is a SA hybrid property
-            .limit(1)
-        )
+        stmt = select(Role).where(Role.name == name).limit(1)
         if trans.sa_session.scalars(stmt).first():
             raise Conflict(f"A role with that name already exists [{name}]")
 

--- a/lib/galaxy/managers/roles.py
+++ b/lib/galaxy/managers/roles.py
@@ -5,10 +5,7 @@ Manager and Serializer for Roles.
 import logging
 from typing import List
 
-from sqlalchemy import (
-    false,
-    select,
-)
+from sqlalchemy import select
 from sqlalchemy.exc import (
     MultipleResultsFound,
     NoResultFound,
@@ -26,6 +23,7 @@ from galaxy.managers import base
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.model import Role
 from galaxy.model.base import transaction
+from galaxy.model.db.role import get_displayable_roles
 from galaxy.schema.schema import RoleDefinitionModel
 from galaxy.util import unicodify
 
@@ -71,12 +69,7 @@ class RoleManager(base.ModelManager[model.Role]):
         return role
 
     def list_displayable_roles(self, trans: ProvidesUserContext) -> List[Role]:
-        roles = []
-        stmt = select(Role).where(Role.deleted == false())
-        for role in trans.sa_session.scalars(stmt):
-            if trans.user_is_admin or trans.app.security_agent.ok_to_display(trans.user, role):
-                roles.append(role)
-        return roles
+        return get_displayable_roles(trans.sa_session, trans.user, trans.user_is_admin, trans.app.security_agent)
 
     def create_role(self, trans: ProvidesUserContext, role_definition_model: RoleDefinitionModel) -> model.Role:
         name = role_definition_model.name

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -112,7 +112,6 @@ from sqlalchemy.ext.associationproxy import (
     association_proxy,
     AssociationProxy,
 )
-from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.orderinglist import ordering_list
 from sqlalchemy.orm import (
     aliased,
@@ -3836,7 +3835,7 @@ class Role(Base, Dictifiable, RepresentById):
     id: Mapped[int] = mapped_column(primary_key=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
-    _name: Mapped[str] = mapped_column("name", String(255), index=True)
+    name: Mapped[str] = mapped_column(String(255), index=True)
     description: Mapped[Optional[str]] = mapped_column(TEXT)
     type: Mapped[Optional[str]] = mapped_column(String(40), index=True)
     deleted: Mapped[Optional[bool]] = mapped_column(index=True, default=False)
@@ -3858,19 +3857,6 @@ class Role(Base, Dictifiable, RepresentById):
     @staticmethod
     def default_name(role_type):
         return f"{role_type.value} role"
-
-    @hybrid_property
-    def name(self):
-        if self.type == Role.types.PRIVATE:
-            user_assocs = self.users
-            assert len(user_assocs) == 1, f"Did not find exactly one user for private role {self}"
-            return user_assocs[0].user.email
-        else:
-            return self._name
-
-    @name.setter  # type:ignore[no-redef]  # property setter
-    def name(self, name):
-        self._name = name
 
     def __init__(self, name=None, description=None, type=types.SYSTEM, deleted=False):
         self.name = name or Role.default_name(type)

--- a/lib/galaxy/model/db/role.py
+++ b/lib/galaxy/model/db/role.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from sqlalchemy import (
     and_,
     false,
@@ -6,6 +8,7 @@ from sqlalchemy import (
 
 from galaxy.model import (
     Role,
+    User,
     UserRoleAssociation,
 )
 from galaxy.model.scoped_session import galaxy_scoped_session
@@ -50,3 +53,10 @@ def get_displayable_roles(session, trans_user, user_is_admin, security_agent):
         if user_is_admin or security_agent.ok_to_display(trans_user, role):
             roles.append(role)
     return roles
+
+
+def get_private_role_user_emails_dict(session) -> Dict[int, str]:
+    """Return a mapping of private role ids to user emails."""
+    stmt = select(UserRoleAssociation.role_id, User.email).join(Role).join(User).where(Role.type == Role.types.PRIVATE)
+    roleid_email_tuples = session.execute(stmt).all()
+    return dict(roleid_email_tuples)

--- a/lib/galaxy/model/db/role.py
+++ b/lib/galaxy/model/db/role.py
@@ -41,3 +41,12 @@ def get_private_user_role(user, session):
 def get_roles_by_ids(session: galaxy_scoped_session, role_ids):
     stmt = select(Role).where(Role.id.in_(role_ids))
     return session.scalars(stmt).all()
+
+
+def get_displayable_roles(session, trans_user, user_is_admin, security_agent):
+    roles = []
+    stmt = select(Role).where(Role.deleted == false())
+    for role in session.scalars(stmt):
+        if user_is_admin or security_agent.ok_to_display(trans_user, role):
+            roles.append(role)
+    return roles

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -27,6 +27,7 @@ from galaxy.managers import (
     roles,
 )
 from galaxy.model.base import transaction
+from galaxy.model.db.role import get_private_role_user_emails_dict
 from galaxy.structured_app import StructuredApp
 from galaxy.tools.actions import upload_common
 from galaxy.tools.parameters import populate_state
@@ -150,10 +151,12 @@ class LibraryDatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin,
                 page_limit = 10
             query = kwd.get("q", None)
             roles, total_roles = trans.app.security_agent.get_valid_roles(trans, dataset, query, page, page_limit)
+            private_role_emails = get_private_role_user_emails_dict(trans.sa_session)
             return_roles = []
             for role in roles:
                 role_id = trans.security.encode_id(role.id)
-                return_roles.append(dict(id=role_id, name=role.name, type=role.type))
+                displayed_name = private_role_emails.get(role.id, role.name)
+                return_roles.append(dict(id=role_id, name=displayed_name, type=role.type))
             return dict(roles=return_roles, page=page, page_limit=page_limit, total=total_roles)
         else:
             raise exceptions.RequestParameterInvalidException(

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -166,7 +166,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             role_tuples = []
             for role in trans.app.security_agent.get_legitimate_roles(trans, data.dataset, "root"):
                 displayed_name = private_role_emails.get(role.id, role.name)
-                role_tuples.add((displayed_name, trans.security.encode_id(role.id)))
+                role_tuples.append((displayed_name, trans.security.encode_id(role.id)))
 
             data_metadata = list(data.metadata.spec.items())
             converters_collection = [(key, value.name) for key, value in data.get_converter_types().items()]

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -30,6 +30,7 @@ from galaxy.managers.hdas import (
 )
 from galaxy.managers.histories import HistoryManager
 from galaxy.model.base import transaction
+from galaxy.model.db.role import get_private_role_user_emails_dict
 from galaxy.model.item_attrs import (
     UsesAnnotations,
     UsesItemRatings,
@@ -160,10 +161,13 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                 if dtype_value.is_datatype_change_allowed()
             ]
             ldatatypes.sort()
-            all_roles = [
-                (r.name, trans.security.encode_id(r.id))
-                for r in trans.app.security_agent.get_legitimate_roles(trans, data.dataset, "root")
-            ]
+
+            private_role_emails = get_private_role_user_emails_dict(trans.sa_session)
+            role_tuples = []
+            for role in trans.app.security_agent.get_legitimate_roles(trans, data.dataset, "root"):
+                displayed_name = private_role_emails.get(role.id, role.name)
+                role_tuples.add((displayed_name, trans.security.encode_id(role.id)))
+
             data_metadata = list(data.metadata.spec.items())
             converters_collection = [(key, value.name) for key, value in data.get_converter_types().items()]
             can_manage_dataset = trans.app.security_agent.can_manage_dataset(
@@ -273,7 +277,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                                 "name": index,
                                 "label": action.action,
                                 "help": help_text,
-                                "options": all_roles,
+                                "options": role_tuples,
                                 "value": in_roles.get(action.action),
                                 "readonly": not can_manage_dataset,
                             }

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -12,6 +12,7 @@ from galaxy.managers import histories
 from galaxy.managers.sharable import SlugBuilder
 from galaxy.model import Role
 from galaxy.model.base import transaction
+from galaxy.model.db.role import get_private_role_user_emails_dict
 from galaxy.model.item_attrs import (
     UsesAnnotations,
     UsesItemRatings,
@@ -134,13 +135,20 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
         history = self.history_manager.get_owned(self.decode_id(history_id), trans.user, current_history=trans.history)
         if trans.request.method == "GET":
             inputs = []
-            all_roles = trans.user.all_roles()
+            all_roles = set(trans.user.all_roles())
+            private_role_emails = get_private_role_user_emails_dict(trans.sa_session)
             current_actions = history.default_permissions
             for action_key, action in trans.app.model.Dataset.permitted_actions.items():
                 in_roles = set()
                 for a in current_actions:
                     if a.action == action.action:
                         in_roles.add(a.role)
+
+                role_tuples = []
+                for role in all_roles:
+                    displayed_name = private_role_emails.get(role.id, role.name)
+                    role_tuples.append((displayed_name, trans.security.encode_id(role.id)))
+
                 inputs.append(
                     {
                         "type": "select",
@@ -150,7 +158,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
                         "name": action_key,
                         "label": action.action,
                         "help": action.description,
-                        "options": [(role.name, trans.security.encode_id(role.id)) for role in set(all_roles)],
+                        "options": role_tuples,
                         "value": [trans.security.encode_id(role.id) for role in in_roles],
                     }
                 )

--- a/lib/galaxy/webapps/galaxy/services/libraries.py
+++ b/lib/galaxy/webapps/galaxy/services/libraries.py
@@ -16,6 +16,7 @@ from galaxy.managers.folders import FolderManager
 from galaxy.managers.libraries import LibraryManager
 from galaxy.managers.roles import RoleManager
 from galaxy.model import Role
+from galaxy.model.db.role import get_private_role_user_emails_dict
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     BasicRoleModel,
@@ -170,9 +171,11 @@ class LibrariesService(ServiceBase, ConsumesModelStores):
                 trans, library, query, page, page_limit, is_library_access
             )
 
+            private_role_emails = get_private_role_user_emails_dict(trans.sa_session)
             return_roles = []
             for role in roles:
-                return_roles.append(BasicRoleModel(id=role.id, name=role.name, type=role.type))
+                displayed_name = private_role_emails.get(role.id, role.name)
+                return_roles.append(BasicRoleModel(id=role.id, name=displayed_name, type=role.type))
             return LibraryAvailablePermissions.model_construct(
                 roles=return_roles, page=page, page_limit=page_limit, total=total_roles
             )

--- a/lib/galaxy/webapps/galaxy/services/roles.py
+++ b/lib/galaxy/webapps/galaxy/services/roles.py
@@ -21,8 +21,10 @@ def role_to_model(role, displayed_name: Optional[str] = None):
     item = role.to_dict(view="element")
     role_id = Security.security.encode_id(role.id)
     item["url"] = url_for("role", id=role_id)
+    # If displayed_name provided, use that value in place of Role.name. It is
+    # used to disambiguate generic role names like "private role".
     if displayed_name:
-        item["displayed_name"] = displayed_name
+        item["name"] = displayed_name
     return RoleModelResponse(**item)
 
 

--- a/lib/galaxy/webapps/galaxy/services/roles.py
+++ b/lib/galaxy/webapps/galaxy/services/roles.py
@@ -1,5 +1,8 @@
+from typing import Optional
+
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.roles import RoleManager
+from galaxy.model.db.role import get_private_role_user_emails_dict
 from galaxy.schema.fields import (
     DecodedDatabaseIdField,
     Security,
@@ -14,10 +17,12 @@ from galaxy.webapps.base.controller import url_for
 from galaxy.webapps.galaxy.services.base import ServiceBase
 
 
-def role_to_model(role):
+def role_to_model(role, displayed_name: Optional[str] = None):
     item = role.to_dict(view="element")
     role_id = Security.security.encode_id(role.id)
     item["url"] = url_for("role", id=role_id)
+    if displayed_name:
+        item["displayed_name"] = displayed_name
     return RoleModelResponse(**item)
 
 
@@ -33,7 +38,12 @@ class RolesService(ServiceBase):
 
     def get_index(self, trans: ProvidesUserContext) -> RoleListResponse:
         roles = self.role_manager.list_displayable_roles(trans)
-        return RoleListResponse(root=[role_to_model(r) for r in roles])
+        private_role_emails = get_private_role_user_emails_dict(trans.sa_session)
+        data = []
+        for role in roles:
+            displayed_name = private_role_emails.get(role.id, role.name)
+            data.append(role_to_model(role, displayed_name))
+        return RoleListResponse(root=data)
 
     def show(self, trans: ProvidesUserContext, id: DecodedDatabaseIdField) -> RoleModelResponse:
         role = self.role_manager.get(trans, id)

--- a/test/unit/data/model/conftest.py
+++ b/test/unit/data/model/conftest.py
@@ -439,7 +439,7 @@ def make_user_and_role(session, make_user, make_role, make_user_role_association
 
     def f(**kwd):
         user = make_user(**kwd)
-        private_role = make_role(type=m.Role.types.PRIVATE)
+        private_role = make_role(type=m.Role.types.PRIVATE, name=m.Role.default_name(m.Role.types.PRIVATE))
         make_user_role_association(user, private_role)
         return user, private_role
 

--- a/test/unit/data/model/db/test_role.py
+++ b/test/unit/data/model/db/test_role.py
@@ -2,6 +2,7 @@ from galaxy.model import Role
 from galaxy.model.db.role import (
     get_displayable_roles,
     get_npns_roles,
+    get_private_role_user_emails_dict,
     get_private_user_role,
     get_roles_by_ids,
 )
@@ -159,3 +160,19 @@ def test_get_displayable_roles(session, make_role, make_user_and_role):
     assert roles[0].name == "private role"
     assert roles[1].name == "private role"
     assert roles[2].name == "admin-role-1"
+
+
+def test_get_private_role_user_emails_dict(session, make_role, make_user_and_role):
+    # make users with private roles
+    user1, private_role1 = make_user_and_role(email="user1@example.com")
+    user2, private_role2 = make_user_and_role(email="user2@example.com")
+    user3, private_role3 = make_user_and_role(email="user3@example.com")
+    # make 2 non-private roles
+    make_role(type="admin", name="admin-role-1", description="Description of admin-role1")
+    make_role(type="admin", name="admin-role-2", description="Description of admin-role2")
+
+    data = get_private_role_user_emails_dict(session)
+    assert len(data) == 3  # only private role mappings are returned
+    assert data[private_role1.id] == "user1@example.com"
+    assert data[private_role2.id] == "user2@example.com"
+    assert data[private_role3.id] == "user3@example.com"

--- a/test/unit/data/model/db/test_security.py
+++ b/test/unit/data/model/db/test_security.py
@@ -13,7 +13,6 @@ from . import have_same_elements
 def test_private_user_role_assoc_not_affected_by_setting_user_roles(session, make_user_and_role):
     # Create user with a private role
     user, private_role = make_user_and_role()
-    assert user.email == private_role.name
     verify_user_associations(user, [], [private_role])  # the only existing association is with the private role
 
     # Delete user roles
@@ -25,7 +24,6 @@ def test_private_user_role_assoc_not_affected_by_setting_user_roles(session, mak
 def test_private_user_role_assoc_not_affected_by_setting_role_users(session, make_user_and_role):
     # Create user with a private role
     user, private_role = make_user_and_role()
-    assert user.email == private_role.name
     verify_user_associations(user, [], [private_role])  # the only existing association is with the private role
 
     # Update role users

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -461,7 +461,7 @@ class TestMappings(BaseModelTestCase):
         def check_private_role(private_role, email):
             assert private_role.type == model.Role.types.PRIVATE
             assert len(private_role.users) == 1
-            assert private_role.name == email
+            assert private_role.name == model.Role.default_name(model.Role.types.PRIVATE)
 
         email = "rule_user_1@example.com"
         u = model.User(email=email, password="password")


### PR DESCRIPTION
Fixes #19654 

The gist of the issue: https://github.com/galaxyproject/galaxy/issues/19654#issuecomment-2672981287

TODO:
- [x] Add fix for notifications (select roles)

### Solution:

Intercept Role data after it has been retrieved from the database but before it's been sent with the Response. Make one call to the database retrieving a mapping of private role IDs to associated user emails, load into a set and use to augment the Role data as needed, replacing names of private roles with corresponding emails, or adding them as an additional field.

Note: there's much duplication here, but to get rid of it we'd have to touch many places (fastapi controllers, services, legacy controllers, managers), and that kind of refactoring should be done on the dev branch. I've tried to change only what's necessary to fix the bug.

### Discarded approaches:

- Set the private role's description field to "Private role for [user' current email]" at runtime. (That field is null by default in newer versions and "private role for [user email]" in older versions.) The value is not persisted and is derived from the associated user's current email.
Reason for discarding:  breaks logic on the client that assumes a private role name to contain a user's email.
(also applies for using any new non-mapped field, like "displayed_name')
- A relationship mapping added to the Role model definition that eagerly loads associated user's email. 
Reasons  for discarding: https://github.com/galaxyproject/galaxy/pull/19679#issuecomment-2688364283
- Use limit + pagination.
Reason  for discarding: requires major changes on the client (role names displayed in dropdowns, etc.)

### Performance
I've tested this locally on 40K users+roles+associations. The roles api endpoint on the release branch is indeed unusable (as reported in the linked issue), whereas this branch is fine.



## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
 - Try to edit permissions for libraries, library datasets, datasets, histories; and in the admin: role permissions, group permissions (on create and edit): observe that role names are displayed as names for non-private roles and emails of associated users for private roles - both in the drop downs and the selected values. 
 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
