### PR TITLE
[24.2] xsd: fix format

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -8078,7 +8078,7 @@ favour of a ``has_size`` assertion.</xs:documentation>
   
   <xs:simpleType name="Format">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[0-9a-z.-_]+"/>
+      <xs:pattern value="[0-9a-z._-]+"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="FormatList">


### PR DESCRIPTION
the dash has to be at the end (or quoted) otherwise `.-_` will be interpreted as character range

follow up on: https://github.com/galaxyproject/galaxy/commit/f8478d7aa78450976cff9727106876a9e4db1045


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
