### PR TITLE
Define simple models for job messages.

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -8966,6 +8966,22 @@ export interface components {
              */
             src: components["schemas"]["DataItemSourceType"];
         };
+        /** ExitCodeJobMessage */
+        ExitCodeJobMessage: {
+            /** Code Desc */
+            code_desc?: string | null;
+            /** Desc */
+            desc: string | null;
+            /** Error Level */
+            error_level: number;
+            /** Exit Code */
+            exit_code: number;
+            /**
+             * Type
+             * @constant
+             */
+            type: "exit_code";
+        };
         /** ExportHistoryArchivePayload */
         ExportHistoryArchivePayload: {
             /**
@@ -14314,6 +14330,20 @@ export interface components {
              */
             source: components["schemas"]["DatasetSourceType"];
         };
+        /** MaxDiscoveredFilesJobMessage */
+        MaxDiscoveredFilesJobMessage: {
+            /** Code Desc */
+            code_desc?: string | null;
+            /** Desc */
+            desc: string | null;
+            /** Error Level */
+            error_level: number;
+            /**
+             * Type
+             * @constant
+             */
+            type: "max_discovered_files";
+        };
         /** MessageExceptionModel */
         MessageExceptionModel: {
             /** Err Code */
@@ -15632,6 +15662,24 @@ export interface components {
             /** Workflow */
             workflow: string;
         };
+        /** RegexJobMessage */
+        RegexJobMessage: {
+            /** Code Desc */
+            code_desc?: string | null;
+            /** Desc */
+            desc: string | null;
+            /** Error Level */
+            error_level: number;
+            /** Match */
+            match: string | null;
+            /** Stream */
+            stream: string | null;
+            /**
+             * Type
+             * @constant
+             */
+            type: "regex";
+        };
         /** ReloadFeedback */
         ReloadFeedback: {
             /** Failed */
@@ -16315,7 +16363,13 @@ export interface components {
              * Job Messages
              * @description List with additional information and possible reasons for a failed job.
              */
-            job_messages?: unknown[] | null;
+            job_messages?:
+                | (
+                      | components["schemas"]["ExitCodeJobMessage"]
+                      | components["schemas"]["RegexJobMessage"]
+                      | components["schemas"]["MaxDiscoveredFilesJobMessage"]
+                  )[]
+                | null;
             /**
              * Job Metrics
              * @description Collections of metrics provided by `JobInstrumenter` plugins on a particular job. Only administrators can see these metrics.

--- a/client/src/components/DatasetInformation/DatasetError.test.ts
+++ b/client/src/components/DatasetInformation/DatasetError.test.ts
@@ -5,6 +5,7 @@ import { createPinia } from "pinia";
 import { getLocalVue } from "tests/jest/helpers";
 
 import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
+import { type components } from "@/api/schema";
 import { useUserStore } from "@/stores/userStore";
 
 import DatasetError from "./DatasetError.vue";
@@ -15,8 +16,26 @@ const DATASET_ID = "dataset_id";
 
 const { server, http } = useServerMock();
 
+type RegexJobMessage = components["schemas"]["RegexJobMessage"];
+
 async function montDatasetError(has_duplicate_inputs = true, has_empty_inputs = true, user_email = "") {
     const pinia = createPinia();
+    const error1: RegexJobMessage = {
+        desc: "message_1",
+        code_desc: null,
+        stream: null,
+        match: null,
+        type: "regex",
+        error_level: 1,
+    };
+    const error2: RegexJobMessage = {
+        desc: "message_2",
+        code_desc: null,
+        stream: null,
+        match: null,
+        type: "regex",
+        error_level: 1,
+    };
 
     server.use(
         http.get("/api/datasets/{dataset_id}", ({ response }) => {
@@ -35,7 +54,7 @@ async function montDatasetError(has_duplicate_inputs = true, has_empty_inputs = 
                 tool_id: "tool_id",
                 tool_stderr: "tool_stderr",
                 job_stderr: "job_stderr",
-                job_messages: [{ desc: "message_1" }, { desc: "message_2" }],
+                job_messages: [error1, error2],
                 user_email,
                 create_time: "2021-01-01T00:00:00",
                 update_time: "2021-01-01T00:00:00",

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2131,7 +2131,7 @@ class MinimalJobWrapper(HasResourceParameters):
                 final_job_state = job.states.ERROR
                 job.job_messages = [
                     {
-                        "type": "internal",
+                        "type": "max_discovered_files",
                         "desc": str(e),
                         "error_level": StdioErrorLevel.FATAL,
                     }

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -20,8 +20,6 @@ import traceback
 from functools import partial
 from pathlib import Path
 from typing import (
-    Any,
-    Dict,
     List,
     Optional,
 )
@@ -63,6 +61,7 @@ from galaxy.objectstore import (
     ObjectStore,
 )
 from galaxy.tool_util.output_checker import (
+    AnyJobMessage,
     check_output,
     DETECTED_JOB_STATE,
 )
@@ -224,7 +223,7 @@ def set_metadata_portable(
 
     export_store = None
     final_job_state = Job.states.OK
-    job_messages: List[Dict[str, Any]] = []
+    job_messages: List[AnyJobMessage] = []
     if extended_metadata_collection:
         tool_dict = metadata_params["tool"]
         stdio_exit_code_dicts, stdio_regex_dicts = tool_dict["stdio_exit_codes"], tool_dict["stdio_regexes"]

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -190,6 +190,7 @@ from galaxy.schema.workflow.comments import WorkflowCommentModel
 from galaxy.security import get_permitted_actions
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.security.validate_user_input import validate_password_str
+from galaxy.tool_util.output_checker import AnyJobMessage
 from galaxy.util import (
     directory_hash_id,
     enum_values,
@@ -572,6 +573,7 @@ def cached_id(galaxy_model_object):
 
 
 class JobLike:
+    job_messages: Mapped[Optional[List[AnyJobMessage]]]
     MAX_NUMERIC = 10 ** (JOB_METRIC_PRECISION - JOB_METRIC_SCALE) - 1
 
     def _init_metrics(self):
@@ -606,7 +608,14 @@ class JobLike:
         # TODO: Make iterable, concatenate with chain
         return self.text_metrics + self.numeric_metrics
 
-    def set_streams(self, tool_stdout, tool_stderr, job_stdout=None, job_stderr=None, job_messages=None):
+    def set_streams(
+        self,
+        tool_stdout,
+        tool_stderr,
+        job_stdout=None,
+        job_stderr=None,
+        job_messages: Optional[List[AnyJobMessage]] = None,
+    ):
         def shrink_and_unicodify(what, stream):
             if stream and len(stream) > galaxy.util.DATABASE_MAX_STRING_SIZE:
                 log.info(
@@ -631,7 +640,7 @@ class JobLike:
             self.job_stderr = None
 
         if job_messages is not None:
-            self.job_messages = job_messages
+            self.job_messages = cast(Optional[List[AnyJobMessage]], job_messages)
 
     def log_str(self):
         extra = ""
@@ -1497,7 +1506,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     copied_from_job_id: Mapped[Optional[int]]
     command_line: Mapped[Optional[str]] = mapped_column(TEXT)
     dependencies: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
-    job_messages: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
+    job_messages: Mapped[Optional[List[AnyJobMessage]]] = mapped_column(MutableJSONType)
     param_filename: Mapped[Optional[str]] = mapped_column(String(1024))
     runner_name: Mapped[Optional[str]] = mapped_column(String(255))
     job_stdout: Mapped[Optional[str]] = mapped_column(TEXT)
@@ -2272,7 +2281,7 @@ class Task(Base, JobLike, RepresentById):
     tool_stdout: Mapped[Optional[str]] = mapped_column(TEXT)
     tool_stderr: Mapped[Optional[str]] = mapped_column(TEXT)
     exit_code: Mapped[Optional[int]]
-    job_messages: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
+    job_messages: Mapped[Optional[List[AnyJobMessage]]] = mapped_column(MutableJSONType)
     info: Mapped[Optional[str]] = mapped_column(TrimmedString(255))
     traceback: Mapped[Optional[str]] = mapped_column(TEXT)
     job_id: Mapped[int] = mapped_column(ForeignKey("job.id"), index=True)

--- a/lib/galaxy/schema/jobs.py
+++ b/lib/galaxy/schema/jobs.py
@@ -23,7 +23,6 @@ from galaxy.schema.schema import (
     DataItemSourceType,
     EncodedDataItemSourceId,
     EncodedJobParameterHistoryItem,
-    JobMetricCollection,
     JobState,
     JobSummary,
     Model,
@@ -247,55 +246,4 @@ class JobDisplayParametersSummary(Model):
         default=...,
         title="Outputs",
         description="Dictionary mapping all the tool outputs (by name) with the corresponding dataset information in a nested format.",
-    )
-
-
-class ShowFullJobResponse(EncodedJobDetails):
-    tool_stdout: Optional[str] = Field(
-        default=None,
-        title="Tool Standard Output",
-        description="The captured standard output of the tool executed by the job.",
-    )
-    tool_stderr: Optional[str] = Field(
-        default=None,
-        title="Tool Standard Error",
-        description="The captured standard error of the tool executed by the job.",
-    )
-    job_stdout: Optional[str] = Field(
-        default=None,
-        title="Job Standard Output",
-        description="The captured standard output of the job execution.",
-    )
-    job_stderr: Optional[str] = Field(
-        default=None,
-        title="Job Standard Error",
-        description="The captured standard error of the job execution.",
-    )
-    stdout: Optional[str] = Field(  # Redundant? it seems to be (tool_stdout + "\n" + job_stdout)
-        default=None,
-        title="Standard Output",
-        description="Combined tool and job standard output streams.",
-    )
-    stderr: Optional[str] = Field(  # Redundant? it seems to be (tool_stderr + "\n" + job_stderr)
-        default=None,
-        title="Standard Error",
-        description="Combined tool and job standard error streams.",
-    )
-    job_messages: Optional[List[Any]] = Field(
-        default=None,
-        title="Job Messages",
-        description="List with additional information and possible reasons for a failed job.",
-    )
-    dependencies: Optional[List[Any]] = Field(
-        default=None,
-        title="Job dependencies",
-        description="The dependencies of the job.",
-    )
-    job_metrics: Optional[JobMetricCollection] = Field(
-        default=None,
-        title="Job Metrics",
-        description=(
-            "Collections of metrics provided by `JobInstrumenter` plugins on a particular job. "
-            "Only administrators can see these metrics."
-        ),
     )


### PR DESCRIPTION
Implements #19676 - first step toward proper typing on the frontend and solving one more vue-tsc error.

## A note about a refactoring and dependencies

I moved the Job schema definition into the API package so it can depend on galaxy-tool-util. For now - us defining models in both galaxy-schema and galaxy-tool-util will mean combined models need to be placed in a package that depends on them both. I think longer term we will need to separate all the galaxy-tool-util models out into their own package and have galaxy-schema depend on that. Maybe I'm wrong though and the right approach is just to place all the models into galaxy-schema and update galaxy-tool-util to depend on that - I just really want galaxy-tool-util to have minimal dependencies and it seems like there is so much unrelated to artifact parsing and execution in galaxy-schema. 

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
