### PR TITLE
Refactor Object Store Selection Modals UI

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -176,6 +176,7 @@ export type HDAObject = components["schemas"]["HDAObject"];
 export type DatasetCollectionAttributes = components["schemas"]["DatasetCollectionAttributesResult"];
 
 export type ConcreteObjectStoreModel = components["schemas"]["ConcreteObjectStoreModel"];
+export type UserConcreteObjectStoreModel = components["schemas"]["UserConcreteObjectStoreModel"];
 
 export interface SelectableObjectStore extends ConcreteObjectStoreModel {
     object_store_id: string;

--- a/client/src/components/ConfigTemplates/SourceOptionCard.vue
+++ b/client/src/components/ConfigTemplates/SourceOptionCard.vue
@@ -7,7 +7,6 @@ import type { UserConcreteObjectStoreModel } from "@/api";
 import type { FileSourceTemplateSummary } from "@/api/fileSources";
 import type { ObjectStoreTemplateSummary } from "@/api/objectStores.templates";
 import type { CardAttributes } from "@/components/Common/GCard.types";
-import { markup } from "@/components/ObjectStore/configurationMarkdown";
 import { QuotaSourceUsageProvider } from "@/components/User/DiskUsage/Quota/QuotaUsageProvider.js";
 
 import GButton from "@/components/BaseComponents/GButton.vue";
@@ -76,8 +75,6 @@ const quotaSourceLabel = computed(() => {
     return "";
 });
 
-const description = markup(props.sourceOption.description ?? "", true) ?? undefined;
-
 const primaryActions = computed<CardAttributes[]>(() => [
     {
         id: "select",
@@ -96,7 +93,8 @@ const primaryActions = computed<CardAttributes[]>(() => [
         :id="uniqueId"
         :data-source-option-card-id="uniqueId"
         :title="props.sourceOption.name ?? ''"
-        :description="description"
+        full-description
+        :description="props.sourceOption.description ?? ''"
         :primary-actions="primaryActions"
         :grid-view="props.gridView"
         :selected="props.selected">

--- a/client/src/components/ConfigTemplates/SourceOptionCard.vue
+++ b/client/src/components/ConfigTemplates/SourceOptionCard.vue
@@ -50,7 +50,7 @@ const uniqueId = computed(() => {
     } else if ("object_store_id" in props.sourceOption && props.sourceOption.object_store_id) {
         return props.sourceOption.object_store_id;
     } else {
-        return Math.random().toString(36).substring(7);
+        return undefined;
     }
 });
 const buttonTitle = computed(() => {

--- a/client/src/components/ConfigTemplates/SourceOptionCard.vue
+++ b/client/src/components/ConfigTemplates/SourceOptionCard.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import type { IconDefinition } from "font-awesome-6";
+import { computed } from "vue";
 
+import type { ConcreteObjectStoreModel } from "@/api";
 import type { FileSourceTemplateSummary } from "@/api/fileSources";
 import type { ObjectStoreTemplateSummary } from "@/api/objectStores.templates";
 import type { CardAttributes } from "@/components/Common/GCard.types";
@@ -10,6 +12,8 @@ import { markup } from "@/components/ObjectStore/configurationMarkdown";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GCard from "@/components/Common/GCard.vue";
 
+type SourceOption = FileSourceTemplateSummary | ObjectStoreTemplateSummary | ConcreteObjectStoreModel;
+
 type OptionType = {
     icon: IconDefinition;
     title: string;
@@ -17,26 +21,55 @@ type OptionType = {
 
 interface Props {
     /** The source option to display */
-    sourceOption: FileSourceTemplateSummary | ObjectStoreTemplateSummary;
+    sourceOption: SourceOption;
     /** The route to navigate to when the user selects this option */
-    selectRoute: string;
+    selectRoute?: string;
     /** The type of the source option */
-    optionType: OptionType;
+    optionType?: OptionType;
     /** Whether to display the card in a grid view */
     gridView?: boolean;
+    /** Whether the card is selected */
+    selected?: boolean;
+    /** The title of the submit button */
+    submitButtonTooltip?: string;
+    /** Whether to show the selection mode */
+    selectionMode?: boolean;
 }
 
 const props = defineProps<Props>();
+
+const emit = defineEmits<{
+    (e: "select", sourceOption: SourceOption): void;
+}>();
+
+const uniqueId = computed(() =>
+    "id" in props.sourceOption ? props.sourceOption.id : Math.random().toString(36).substring(7)
+);
+const buttonTitle = computed(() => {
+    if (props.selectionMode) {
+        return props.selected ? "Selected" : "Select as Default";
+    }
+
+    return props.submitButtonTooltip ?? "Select";
+});
+const buttonTooltip = computed(() => {
+    if (props.selectionMode) {
+        return props.selected ? "This is the preferred option" : "Select this option as the preferred one";
+    }
+
+    return props.submitButtonTooltip ?? "Select this option to create a new instance";
+});
 
 const description = markup(props.sourceOption.description ?? "", true) ?? undefined;
 
 const primaryActions: CardAttributes[] = [
     {
         id: "select",
-        label: "Select",
-        title: "Select this option to create a new instance",
+        label: buttonTitle.value,
+        title: buttonTooltip.value,
         variant: "outline-primary",
         to: props.selectRoute,
+        handler: () => emit("select", props.sourceOption),
         visible: true,
     },
 ];
@@ -44,11 +77,12 @@ const primaryActions: CardAttributes[] = [
 
 <template>
     <GCard
-        :id="props.sourceOption.id"
+        :id="uniqueId"
         :title="props.sourceOption.name ?? ''"
         :description="description"
         :primary-actions="primaryActions"
-        :grid-view="props.gridView">
+        :grid-view="props.gridView"
+        :selected="props.selected">
         <template v-slot:titleActions>
             <GButton
                 tooltip

--- a/client/src/components/ConfigTemplates/SourceOptionCard.vue
+++ b/client/src/components/ConfigTemplates/SourceOptionCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BSpinner } from "bootstrap-vue";
 import type { IconDefinition } from "font-awesome-6";
 import { computed } from "vue";
 
@@ -8,9 +9,11 @@ import type { FileSourceTemplateSummary } from "@/api/fileSources";
 import type { ObjectStoreTemplateSummary } from "@/api/objectStores.templates";
 import type { CardAttributes } from "@/components/Common/GCard.types";
 import { markup } from "@/components/ObjectStore/configurationMarkdown";
+import { QuotaSourceUsageProvider } from "@/components/User/DiskUsage/Quota/QuotaUsageProvider.js";
 
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GCard from "@/components/Common/GCard.vue";
+import QuotaUsageBar from "@/components/User/DiskUsage/Quota/QuotaUsageBar.vue";
 
 type SourceOption = FileSourceTemplateSummary | ObjectStoreTemplateSummary | UserConcreteObjectStoreModel;
 
@@ -65,6 +68,13 @@ const buttonTooltip = computed(() => {
 
     return props.submitButtonTooltip ?? "Select this option to create a new instance";
 });
+const quotaSourceLabel = computed(() => {
+    if ("quota" in props.sourceOption && props.sourceOption.quota.enabled) {
+        return props.sourceOption.quota.source;
+    }
+
+    return "";
+});
 
 const description = markup(props.sourceOption.description ?? "", true) ?? undefined;
 
@@ -106,6 +116,16 @@ const primaryActions: CardAttributes[] = [
 
         <template v-slot:extra-actions>
             <slot name="badges" />
+        </template>
+
+        <template v-if="'quota' in props.sourceOption && props.sourceOption.quota.enabled" v-slot:description>
+            <QuotaSourceUsageProvider
+                ref="quotaUsageProvider"
+                v-slot="{ result: quotaUsage, loading: isLoadingUsage }"
+                :quota-source-label="quotaSourceLabel">
+                <BSpinner v-if="isLoadingUsage" />
+                <QuotaUsageBar v-else-if="quotaUsage" :quota-usage="quotaUsage" :embedded="true" />
+            </QuotaSourceUsageProvider>
         </template>
     </GCard>
 </template>

--- a/client/src/components/ConfigTemplates/SourceOptionCard.vue
+++ b/client/src/components/ConfigTemplates/SourceOptionCard.vue
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import type { IconDefinition } from "font-awesome-6";
 import { computed } from "vue";
 
-import type { ConcreteObjectStoreModel } from "@/api";
+import type { UserConcreteObjectStoreModel } from "@/api";
 import type { FileSourceTemplateSummary } from "@/api/fileSources";
 import type { ObjectStoreTemplateSummary } from "@/api/objectStores.templates";
 import type { CardAttributes } from "@/components/Common/GCard.types";
@@ -12,7 +12,7 @@ import { markup } from "@/components/ObjectStore/configurationMarkdown";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GCard from "@/components/Common/GCard.vue";
 
-type SourceOption = FileSourceTemplateSummary | ObjectStoreTemplateSummary | ConcreteObjectStoreModel;
+type SourceOption = FileSourceTemplateSummary | ObjectStoreTemplateSummary | UserConcreteObjectStoreModel;
 
 type OptionType = {
     icon: IconDefinition;
@@ -42,9 +42,15 @@ const emit = defineEmits<{
     (e: "select", sourceOption: SourceOption): void;
 }>();
 
-const uniqueId = computed(() =>
-    "id" in props.sourceOption ? props.sourceOption.id : Math.random().toString(36).substring(7)
-);
+const uniqueId = computed(() => {
+    if ("id" in props.sourceOption) {
+        return props.sourceOption.id;
+    } else if ("object_store_id" in props.sourceOption && props.sourceOption.object_store_id) {
+        return props.sourceOption.object_store_id;
+    } else {
+        return Math.random().toString(36).substring(7);
+    }
+});
 const buttonTitle = computed(() => {
     if (props.selectionMode) {
         return props.selected ? "Selected" : "Select as Default";
@@ -78,6 +84,7 @@ const primaryActions: CardAttributes[] = [
 <template>
     <GCard
         :id="uniqueId"
+        :data-source-option-card-id="uniqueId"
         :title="props.sourceOption.name ?? ''"
         :description="description"
         :primary-actions="primaryActions"

--- a/client/src/components/ConfigTemplates/SourceOptionCard.vue
+++ b/client/src/components/ConfigTemplates/SourceOptionCard.vue
@@ -102,6 +102,7 @@ const primaryActions: CardAttributes[] = [
         :selected="props.selected">
         <template v-slot:titleActions>
             <GButton
+                v-if="props.optionType?.icon"
                 tooltip
                 transparent
                 inline
@@ -110,7 +111,7 @@ const primaryActions: CardAttributes[] = [
                 size="large"
                 :title="props.optionType?.title"
                 class="inline-icon-button">
-                <FontAwesomeIcon :icon="props.optionType?.icon" />
+                <FontAwesomeIcon :icon="props.optionType.icon" />
             </GButton>
         </template>
 

--- a/client/src/components/ConfigTemplates/SourceOptionCard.vue
+++ b/client/src/components/ConfigTemplates/SourceOptionCard.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BSpinner } from "bootstrap-vue";
 import type { IconDefinition } from "font-awesome-6";
 import { computed } from "vue";
 
@@ -13,6 +12,7 @@ import { QuotaSourceUsageProvider } from "@/components/User/DiskUsage/Quota/Quot
 
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GCard from "@/components/Common/GCard.vue";
+import LoadingSpan from "@/components/LoadingSpan.vue";
 import QuotaUsageBar from "@/components/User/DiskUsage/Quota/QuotaUsageBar.vue";
 
 type SourceOption = FileSourceTemplateSummary | ObjectStoreTemplateSummary | UserConcreteObjectStoreModel;
@@ -56,14 +56,14 @@ const uniqueId = computed(() => {
 });
 const buttonTitle = computed(() => {
     if (props.selectionMode) {
-        return props.selected ? "Selected" : "Select as Default";
+        return props.selected ? "Current preferred option" : "Select as the preferred one";
     }
 
     return props.submitButtonTooltip ?? "Select";
 });
 const buttonTooltip = computed(() => {
     if (props.selectionMode) {
-        return props.selected ? "This is the preferred option" : "Select this option as the preferred one";
+        return props.selected ? "Current preferred option" : "Select as the preferred one";
     }
 
     return props.submitButtonTooltip ?? "Select this option to create a new instance";
@@ -78,7 +78,7 @@ const quotaSourceLabel = computed(() => {
 
 const description = markup(props.sourceOption.description ?? "", true) ?? undefined;
 
-const primaryActions: CardAttributes[] = [
+const primaryActions = computed<CardAttributes[]>(() => [
     {
         id: "select",
         label: buttonTitle.value,
@@ -86,9 +86,9 @@ const primaryActions: CardAttributes[] = [
         variant: "outline-primary",
         to: props.selectRoute,
         handler: () => emit("select", props.sourceOption),
-        visible: true,
+        visible: !props.selected,
     },
-];
+]);
 </script>
 
 <template>
@@ -119,12 +119,13 @@ const primaryActions: CardAttributes[] = [
             <slot name="badges" />
         </template>
 
-        <template v-if="'quota' in props.sourceOption && props.sourceOption.quota.enabled" v-slot:description>
+        <template v-if="'quota' in props.sourceOption && props.sourceOption.quota.enabled" v-slot:tags>
             <QuotaSourceUsageProvider
                 ref="quotaUsageProvider"
                 v-slot="{ result: quotaUsage, loading: isLoadingUsage }"
+                class="w-100"
                 :quota-source-label="quotaSourceLabel">
-                <BSpinner v-if="isLoadingUsage" />
+                <LoadingSpan v-if="isLoadingUsage" message="Loading usage" />
                 <QuotaUsageBar v-else-if="quotaUsage" :quota-usage="quotaUsage" :embedded="true" />
             </QuotaSourceUsageProvider>
         </template>

--- a/client/src/components/Dataset/DatasetStorage/RelocateLink.vue
+++ b/client/src/components/Dataset/DatasetStorage/RelocateLink.vue
@@ -20,10 +20,10 @@ const props = defineProps<RelocateLinkProps>();
 const showModal = ref(false);
 
 const store = useObjectStoreStore();
-const { isLoaded, selectableObjectStores } = storeToRefs(store);
+const { loading, selectableObjectStores } = storeToRefs(store);
 
 const currentObjectStore = computed<ConcreteObjectStoreModel | null>(() => {
-    const isLoadedVal = isLoaded.value;
+    const isLoadedVal = !loading.value;
     const objectStores = selectableObjectStores.value;
     const currentObjectStoreId = props.datasetStorageDetails.object_store_id;
 
@@ -40,7 +40,7 @@ const currentObjectStore = computed<ConcreteObjectStoreModel | null>(() => {
 });
 
 const validTargets = computed<SelectableObjectStore[]>(() => {
-    const isLoadedVal = isLoaded.value;
+    const isLoadedVal = !loading.value;
     const objectStores = selectableObjectStores.value;
     const currentObjectStoreId = props.datasetStorageDetails.object_store_id;
 

--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -125,7 +125,6 @@ async function reloadContents() {
 }
 
 function onUpdatePreferredObjectStoreId(preferredObjectStoreId: string | null) {
-    showPreferredObjectStoreModal.value = false;
     // ideally this would be pushed back to the history object somehow
     // and tracked there... but for now this is only component using
     // this information.

--- a/client/src/components/History/CurrentHistory/HistoryDetails.vue
+++ b/client/src/components/History/CurrentHistory/HistoryDetails.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import type { HistorySummary } from "@/api";
+import { useConfig } from "@/composables/config";
 import { useHistoryStore } from "@/stores/historyStore";
 
 import type { DetailsLayoutSummarized } from "../Layout/types";
 
 import HistoryIndicators from "../HistoryIndicators.vue";
+import StorageLocationIndicator from "./StorageLocationIndicator.vue";
 import DetailsLayout from "@/components/History/Layout/DetailsLayout.vue";
 
 interface Props {
@@ -24,6 +26,8 @@ function onSave(newDetails: HistorySummary) {
     const id = props.history.id;
     historyStore.updateHistory({ ...newDetails, id });
 }
+
+const { config } = useConfig();
 </script>
 
 <template>
@@ -38,5 +42,7 @@ function onSave(newDetails: HistorySummary) {
         <template v-if="summarized" v-slot:update-time>
             <HistoryIndicators :history="history" detailed-time />
         </template>
+
+        <StorageLocationIndicator v-if="config && config.object_store_allows_id_selection" :history="history" />
     </DetailsLayout>
 </template>

--- a/client/src/components/History/CurrentHistory/SelectPreferredStore.test.ts
+++ b/client/src/components/History/CurrentHistory/SelectPreferredStore.test.ts
@@ -3,7 +3,6 @@ import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import flushPromises from "flush-promises";
 import { getLocalVue } from "tests/jest/helpers";
-import { h } from "vue";
 
 import { useServerMock } from "@/api/client/__mocks__";
 import { ROOT_COMPONENT } from "@/utils/navigation/schema";
@@ -25,15 +24,40 @@ const TEST_HISTORY = {
     preferred_object_store_id: null,
 };
 
-async function mountComponent() {
+async function mountComponent(preferredObjectStoreId: string | null = null) {
     server.use(
         http.get("/api/configuration", ({ response }) => {
             return response(200).json({});
         })
     );
+
+    server.use(
+        http.get("/api/users/{user_id}/usage/{label}", ({ response }) => {
+            return response(200).json({
+                total_disk_usage: 0,
+            });
+        })
+    );
+
     const wrapper = mount(SelectPreferredStore as object, {
-        propsData: { userPreferredObjectStoreId: null, history: TEST_HISTORY },
+        propsData: {
+            preferredObjectStoreId: preferredObjectStoreId,
+            history: TEST_HISTORY,
+            showModal: true,
+        },
         localVue,
+        stubs: {
+            BModal: {
+                template: `
+                    <div>
+                        <slot></slot>
+                        <div class="modal-footer">
+                            <button class="btn btn-primary" @click="$emit('ok')">OK</button>
+                        </div>
+                    </div>
+                `,
+            },
+        },
     });
 
     await flushPromises();
@@ -42,13 +66,6 @@ async function mountComponent() {
 }
 
 const PREFERENCES = ROOT_COMPONENT.preferences;
-
-// bootstrap vue will try to match targets to actual HTML elements in DOM but there
-// may be no DOM for jest tests, just stub out an alternative minimal implementation.
-jest.mock("@/components/ObjectStore/ObjectStoreSelectButtonPopover.vue", () => ({
-    name: "ObjectStoreSelectButtonPopover",
-    render: () => h("div", "Mocked Popover"),
-}));
 
 describe("SelectPreferredStore.vue", () => {
     let axiosMock: MockAdapter;
@@ -62,7 +79,7 @@ describe("SelectPreferredStore.vue", () => {
     });
 
     it("updates object store to default on selection null", async () => {
-        const wrapper = await mountComponent();
+        const wrapper = await mountComponent("object_store_1");
         const els = wrapper.findAll(PREFERENCES.object_store_selection.option_cards.selector);
         expect(els.length).toBe(3);
         const galaxyDefaultOption = wrapper.find(
@@ -76,6 +93,12 @@ describe("SelectPreferredStore.vue", () => {
         await flushPromises();
         const errorEl = wrapper.find(".object-store-selection-error");
         expect(errorEl.exists()).toBeFalsy();
+
+        const okButton = wrapper.find(".btn-primary");
+        await okButton.trigger("click");
+
+        await flushPromises();
+
         const emitted = wrapper.emitted();
         expect(emitted["updated"]?.[0]?.[0]).toEqual(null);
     });
@@ -98,6 +121,12 @@ describe("SelectPreferredStore.vue", () => {
         await flushPromises();
         const errorEl = wrapper.find(".object-store-selection-error");
         expect(errorEl.exists()).toBeFalsy();
+
+        const okButton = wrapper.find(".btn-primary");
+        await okButton.trigger("click");
+
+        await flushPromises();
+
         const emitted = wrapper.emitted();
         expect(emitted["updated"]?.[0]?.[0]).toEqual("object_store_2");
     });

--- a/client/src/components/History/CurrentHistory/SelectPreferredStore.test.ts
+++ b/client/src/components/History/CurrentHistory/SelectPreferredStore.test.ts
@@ -63,10 +63,10 @@ describe("SelectPreferredStore.vue", () => {
 
     it("updates object store to default on selection null", async () => {
         const wrapper = await mountComponent();
-        const els = wrapper.findAll(PREFERENCES.object_store_selection.option_buttons.selector);
+        const els = wrapper.findAll(PREFERENCES.object_store_selection.option_cards.selector);
         expect(els.length).toBe(3);
         const galaxyDefaultOption = wrapper.find(
-            PREFERENCES.object_store_selection.option_button({ object_store_id: "__null__" }).selector
+            PREFERENCES.object_store_selection.option_card_select({ object_store_id: "__null__" }).selector
         );
         expect(galaxyDefaultOption.exists()).toBeTruthy();
         axiosMock
@@ -82,10 +82,10 @@ describe("SelectPreferredStore.vue", () => {
 
     it("updates object store to on non-null selection", async () => {
         const wrapper = await mountComponent();
-        const els = wrapper.findAll(PREFERENCES.object_store_selection.option_buttons.selector);
+        const els = wrapper.findAll(PREFERENCES.object_store_selection.option_cards.selector);
         expect(els.length).toBe(3);
         const galaxyDefaultOption = wrapper.find(
-            PREFERENCES.object_store_selection.option_button({ object_store_id: "object_store_2" }).selector
+            PREFERENCES.object_store_selection.option_card_select({ object_store_id: "object_store_2" }).selector
         );
         expect(galaxyDefaultOption.exists()).toBeTruthy();
         axiosMock

--- a/client/src/components/History/CurrentHistory/SelectPreferredStore.vue
+++ b/client/src/components/History/CurrentHistory/SelectPreferredStore.vue
@@ -145,6 +145,7 @@ defineExpose({
         :title="storageLocationTitle"
         title-tag="h2"
         title-class="h-sm"
+        cancel-variant="outline-primary"
         @ok="modalOk"
         @cancel="reset"
         @close="reset">

--- a/client/src/components/History/CurrentHistory/SelectPreferredStore.vue
+++ b/client/src/components/History/CurrentHistory/SelectPreferredStore.vue
@@ -142,6 +142,8 @@ defineExpose({
 <template>
     <BModal
         v-model="modalShown"
+        scrollable
+        centered
         :title="storageLocationTitle"
         title-tag="h2"
         title-class="h-sm"

--- a/client/src/components/History/CurrentHistory/SelectPreferredStore.vue
+++ b/client/src/components/History/CurrentHistory/SelectPreferredStore.vue
@@ -36,7 +36,7 @@ const props = defineProps({
 
 const { confirm } = useConfirmDialog();
 
-const error = ref<string | null>(null);
+const error = ref();
 
 const newDatasetsDescription = "New dataset outputs from tools and workflows executed in this history";
 const galaxySelectionDefaultTitle = "Use Galaxy Defaults";
@@ -124,17 +124,15 @@ function selectionChanged(preferredObjectStoreId: string | null, isPrivate: bool
 }
 
 async function modalOk(event: BvModalEvent) {
-    if (currentSelectedStoreId.value !== props.preferredObjectStoreId) {
-        event?.preventDefault();
+    event?.preventDefault();
 
-        try {
-            await handleSubmit(currentSelectedStoreId.value, currentSelectedStorePrivate.value);
-            reset();
-        } catch (_e) {
-            // pass
-        }
-    } else {
+    try {
+        await handleSubmit(currentSelectedStoreId.value, currentSelectedStorePrivate.value);
+
         reset();
+        emit("close");
+    } catch (_e) {
+        // pass
     }
 }
 
@@ -142,25 +140,30 @@ function reset() {
     currentSelectedStoreId.value = props.preferredObjectStoreId;
     currentSelectedStorePrivate.value = false;
     error.value = null;
-    emit("close");
 }
 </script>
 
 <template>
     <BModal
         :visible="props.showModal"
-        scrollable
         centered
+        scrollable
+        size="lg"
         :title="storageLocationTitle"
-        title-tag="h2"
         title-class="h-sm"
+        title-tag="h3"
+        ok-title="Change Storage Location"
         cancel-variant="outline-primary"
-        @ok="modalOk"
+        :ok-disabled="currentSelectedStoreId === props.preferredObjectStoreId"
+        :no-close-on-backdrop="currentSelectedStoreId !== props.preferredObjectStoreId"
+        :no-close-on-esc="currentSelectedStoreId !== props.preferredObjectStoreId"
         @cancel="reset"
-        @close="reset">
+        @change="emit('close')"
+        @close="reset"
+        @ok="modalOk">
         <SelectObjectStore
             :show-sub-setting="props.showSubSetting"
-            :parent-error="error || undefined"
+            :parent-error="error"
             :for-what="newDatasetsDescription"
             :selected-object-store-id="currentSelectedStoreId"
             :default-option-title="defaultOptionTitle"

--- a/client/src/components/History/CurrentHistory/SelectPreferredStore.vue
+++ b/client/src/components/History/CurrentHistory/SelectPreferredStore.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import axios from "axios";
-import { computed, ref } from "vue";
+import { BModal, type BvModalEvent } from "bootstrap-vue";
+import { computed, type PropType, ref } from "vue";
 
 import { getPermissions, isHistoryPrivate, makePrivate, type PermissionsResponse } from "@/components/History/services";
+import { useStorageLocationConfiguration } from "@/composables/storageLocation";
 import { prependPath } from "@/utils/redirect";
 import { errorMessageAsString } from "@/utils/simple-error";
 
@@ -10,17 +12,24 @@ import SelectObjectStore from "@/components/ObjectStore/SelectObjectStore.vue";
 
 const props = defineProps({
     userPreferredObjectStoreId: {
-        type: String,
+        type: String as PropType<string | null>,
+        default: null,
+    },
+    preferredObjectStoreId: {
+        type: String as PropType<string | null>,
         default: null,
     },
     history: {
         type: Object,
         required: true,
     },
+    showSubSetting: {
+        type: Boolean,
+        default: false,
+    },
 });
 
 const error = ref<string | null>(null);
-const selectedObjectStoreId = ref(props.history.preferred_object_store_id);
 
 const newDatasetsDescription = "New dataset outputs from tools and workflows executed in this history";
 const galaxySelectionDefaultTitle = "Use Galaxy Defaults";
@@ -37,6 +46,7 @@ const defaultOptionTitle = computed(() => {
         return galaxySelectionDefaultTitle;
     }
 });
+
 const defaultOptionDescription = computed(() => {
     if (props.userPreferredObjectStoreId) {
         return userSelectionDefaultDescription;
@@ -54,6 +64,7 @@ async function handleSubmit(preferredObjectStoreId: string | null, isPrivate: bo
         const { data } = await getPermissions(props.history.id);
         const permissionResponse = data as PermissionsResponse;
         const historyPrivate = await isHistoryPrivate(permissionResponse);
+
         if (!historyPrivate) {
             if (
                 confirm(
@@ -64,6 +75,7 @@ async function handleSubmit(preferredObjectStoreId: string | null, isPrivate: bo
                     await makePrivate(props.history.id, permissionResponse);
                 } catch {
                     error.value = "Failed to update default permissions for history.";
+                    throw new Error();
                 }
             }
         }
@@ -71,21 +83,78 @@ async function handleSubmit(preferredObjectStoreId: string | null, isPrivate: bo
 
     const payload = { preferred_object_store_id: preferredObjectStoreId };
     const url = prependPath(`api/histories/${props.history.id}`);
+
     try {
         await axios.put(url, payload);
+        emit("updated", preferredObjectStoreId);
     } catch (e) {
         error.value = errorMessageAsString(e);
+        throw new Error();
     }
-    selectedObjectStoreId.value = preferredObjectStoreId;
-    emit("updated", preferredObjectStoreId);
 }
+
+const { isOnlyPreference } = useStorageLocationConfiguration();
+
+const storageLocationTitle = computed(() => {
+    if (isOnlyPreference.value) {
+        return "History Preferred Storage Location";
+    } else {
+        return "History Storage Location";
+    }
+});
+
+const modalShown = ref(false);
+
+function showModal() {
+    modalShown.value = true;
+}
+
+const currentSelectedStoreId = ref<string | null>(props.preferredObjectStoreId);
+const currentSelectedStorePrivate = ref(false);
+
+function selectionChanged(preferredObjectStoreId: string | null, isPrivate: boolean) {
+    currentSelectedStoreId.value = preferredObjectStoreId;
+    currentSelectedStorePrivate.value = isPrivate;
+}
+
+async function modalOk(event: BvModalEvent) {
+    if (currentSelectedStoreId.value !== props.preferredObjectStoreId) {
+        event.preventDefault();
+        try {
+            await handleSubmit(currentSelectedStoreId.value, currentSelectedStorePrivate.value);
+            modalShown.value = false;
+        } catch (_e) {
+            // pass
+        }
+    }
+}
+
+function reset() {
+    currentSelectedStoreId.value = props.preferredObjectStoreId;
+    currentSelectedStorePrivate.value = false;
+}
+
+defineExpose({
+    showModal,
+});
 </script>
+
 <template>
-    <SelectObjectStore
-        :parent-error="error || undefined"
-        :for-what="newDatasetsDescription"
-        :selected-object-store-id="selectedObjectStoreId"
-        :default-option-title="defaultOptionTitle"
-        :default-option-description="defaultOptionDescription"
-        @onSubmit="handleSubmit" />
+    <BModal
+        v-model="modalShown"
+        :title="storageLocationTitle"
+        title-tag="h2"
+        title-class="h-sm"
+        @ok="modalOk"
+        @cancel="reset"
+        @close="reset">
+        <SelectObjectStore
+            :show-sub-setting="props.showSubSetting"
+            :parent-error="error || undefined"
+            :for-what="newDatasetsDescription"
+            :selected-object-store-id="currentSelectedStoreId"
+            :default-option-title="defaultOptionTitle"
+            :default-option-description="defaultOptionDescription"
+            @onSubmit="selectionChanged" />
+    </BModal>
 </template>

--- a/client/src/components/History/CurrentHistory/StorageLocationIndicator.vue
+++ b/client/src/components/History/CurrentHistory/StorageLocationIndicator.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { faHdd } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BButton } from "bootstrap-vue";
+import { storeToRefs } from "pinia";
+import { computed, ref } from "vue";
+
+import type { HistorySummary } from "@/api";
+import { useSync } from "@/composables/sync";
+import { useObjectStoreStore } from "@/stores/objectStoreStore";
+import { useUserStore } from "@/stores/userStore";
+
+import SelectPreferredStore from "./SelectPreferredStore.vue";
+
+const props = defineProps<{
+    history: HistorySummary;
+}>();
+
+const preferredObjectStoreId = ref<string | null>(null);
+
+useSync(() => props.history.preferred_object_store_id, preferredObjectStoreId);
+
+const objectStoreStore = useObjectStoreStore();
+
+const { currentUser, isAnonymous } = storeToRefs(useUserStore());
+const userPreferredObjectStoreId = computed(() => {
+    const user = currentUser.value;
+    if (user && "preferred_object_store_id" in user) {
+        return user.preferred_object_store_id ?? null;
+    } else {
+        return null;
+    }
+});
+
+function onUpdatePreferredObjectStoreId(id: string | null) {
+    preferredObjectStoreId.value = id;
+}
+
+const selectPreferredStore = ref<InstanceType<typeof SelectPreferredStore>>();
+const storageLocationButtonTitle = computed(() => {
+    if (!isAnonymous.value) {
+        return "View and select storage location";
+    } else {
+        return "Log in to view and select storage location";
+    }
+});
+</script>
+
+<template>
+    <div class="storage-location-indicator">
+        <BButton
+            class="ui-link"
+            :title="storageLocationButtonTitle"
+            :disabled="isAnonymous"
+            @click="selectPreferredStore?.showModal()">
+            <FontAwesomeIcon :icon="faHdd" />
+            {{ objectStoreStore.getObjectStoreNameById(preferredObjectStoreId) ?? "Default Storage" }}
+        </BButton>
+
+        <SelectPreferredStore
+            ref="selectPreferredStore"
+            show-sub-setting
+            :user-preferred-object-store-id="userPreferredObjectStoreId"
+            :preferred-object-store-id="preferredObjectStoreId"
+            :history="history"
+            @updated="onUpdatePreferredObjectStoreId" />
+    </div>
+</template>
+
+<style lang="scss" scoped>
+.storage-location-indicator {
+    margin: 0.5rem 0;
+}
+</style>

--- a/client/src/components/History/CurrentHistory/StorageLocationIndicator.vue
+++ b/client/src/components/History/CurrentHistory/StorageLocationIndicator.vue
@@ -49,6 +49,7 @@ const storageLocationButtonTitle = computed(() => {
 <template>
     <div class="storage-location-indicator">
         <BButton
+            v-b-tooltip.hover.noninteractive
             class="ui-link"
             :title="storageLocationButtonTitle"
             :disabled="isAnonymous"

--- a/client/src/components/History/CurrentHistory/StorageLocationIndicator.vue
+++ b/client/src/components/History/CurrentHistory/StorageLocationIndicator.vue
@@ -36,7 +36,8 @@ function onUpdatePreferredObjectStoreId(id: string | null) {
     preferredObjectStoreId.value = id;
 }
 
-const selectPreferredStore = ref<InstanceType<typeof SelectPreferredStore>>();
+const showSelectPreferredStore = ref(false);
+
 const storageLocationButtonTitle = computed(() => {
     if (!isAnonymous.value) {
         return "View and select storage location";
@@ -44,6 +45,10 @@ const storageLocationButtonTitle = computed(() => {
         return "Log in to view and select storage location";
     }
 });
+
+function toggleSelectPreferredStore() {
+    showSelectPreferredStore.value = !showSelectPreferredStore.value;
+}
 </script>
 
 <template>
@@ -53,17 +58,18 @@ const storageLocationButtonTitle = computed(() => {
             class="ui-link"
             :title="storageLocationButtonTitle"
             :disabled="isAnonymous"
-            @click="selectPreferredStore?.showModal()">
+            @click="toggleSelectPreferredStore">
             <FontAwesomeIcon :icon="faHdd" />
             {{ objectStoreStore.getObjectStoreNameById(preferredObjectStoreId) ?? "Default Storage" }}
         </BButton>
 
         <SelectPreferredStore
-            ref="selectPreferredStore"
+            :show-modal.sync="showSelectPreferredStore"
             show-sub-setting
             :user-preferred-object-store-id="userPreferredObjectStoreId"
             :preferred-object-store-id="preferredObjectStoreId"
             :history="history"
+            @close="toggleSelectPreferredStore"
             @updated="onUpdatePreferredObjectStoreId" />
     </div>
 </template>

--- a/client/src/components/History/Layout/DetailsLayout.vue
+++ b/client/src/components/History/Layout/DetailsLayout.vue
@@ -235,6 +235,8 @@ function selectText() {
                 <span v-localize>Cancel</span>
             </BButton>
         </div>
+
+        <slot></slot>
     </section>
 </template>
 

--- a/client/src/components/ObjectStore/SelectObjectStore.vue
+++ b/client/src/components/ObjectStore/SelectObjectStore.vue
@@ -22,9 +22,8 @@ interface SelectObjectStoreProps {
 const props = defineProps<SelectObjectStoreProps>();
 
 const { isOnlyPreference } = useStorageLocationConfiguration();
-
-const objectStoreStore = useObjectStoreStore();
-const { isLoading, loadErrorMessage, selectableObjectStores } = storeToRefs(objectStoreStore);
+const store = useObjectStoreStore();
+const { loading, loadErrorMessage, selectableObjectStores } = storeToRefs(store);
 
 const selectableAndVisibleObjectStores = computed(() => {
     const allSelectableObjectStores = selectableObjectStores.value;
@@ -77,7 +76,7 @@ const defaultObjectStore: UserConcreteObjectStoreModel = {
 
 <template>
     <div>
-        <LoadingSpan v-if="isLoading" message="Loading Galaxy storage information" />
+        <LoadingSpan v-if="loading" message="Loading Galaxy storage information" />
         <div v-else>
             <span v-if="isOnlyPreference" v-localize>
                 Select a preferred Galaxy storage for new datasets. Depending on the job and workflow execution

--- a/client/src/components/ObjectStore/SelectObjectStore.vue
+++ b/client/src/components/ObjectStore/SelectObjectStore.vue
@@ -4,6 +4,7 @@ import { storeToRefs } from "pinia";
 import { computed } from "vue";
 
 import type { UserConcreteObjectStoreModel } from "@/api";
+import { useStorageLocationConfiguration } from "@/composables/storageLocation";
 import { useObjectStoreStore } from "@/stores/objectStoreStore";
 
 import SourceOptionCard from "@/components/ConfigTemplates/SourceOptionCard.vue";
@@ -20,8 +21,10 @@ interface SelectObjectStoreProps {
 
 const props = defineProps<SelectObjectStoreProps>();
 
-const store = useObjectStoreStore();
-const { isLoading, loadErrorMessage, selectableObjectStores } = storeToRefs(store);
+const { isOnlyPreference } = useStorageLocationConfiguration();
+
+const objectStoreStore = useObjectStoreStore();
+const { isLoading, loadErrorMessage, selectableObjectStores } = storeToRefs(objectStoreStore);
 
 const selectableAndVisibleObjectStores = computed(() => {
     const allSelectableObjectStores = selectableObjectStores.value;
@@ -76,7 +79,7 @@ const defaultObjectStore: UserConcreteObjectStoreModel = {
     <div>
         <LoadingSpan v-if="isLoading" message="Loading Galaxy storage information" />
         <div v-else>
-            <span v-localize>
+            <span v-if="isOnlyPreference" v-localize>
                 Select a preferred Galaxy storage for new datasets. Depending on the job and workflow execution
                 configuration of this Galaxy a different Galaxy storage may be ultimately used. After a dataset is
                 created, click on the info icon in the history panel to view information about where it is stored. If it

--- a/client/src/components/ObjectStore/SelectObjectStore.vue
+++ b/client/src/components/ObjectStore/SelectObjectStore.vue
@@ -43,8 +43,13 @@ const error = computed(() => {
 });
 
 async function handleSubmit(preferredObjectStore: UserConcreteObjectStoreModel) {
-    const id: string | null = (preferredObjectStore ? preferredObjectStore.object_store_id : null) as string | null;
+    let id = preferredObjectStore?.object_store_id ?? null;
     const isPrivate: boolean = preferredObjectStore ? preferredObjectStore.private : false;
+
+    if (id === "__null__") {
+        id = null;
+    }
+
     emit("onSubmit", id, isPrivate);
 }
 

--- a/client/src/components/ObjectStore/SelectObjectStore.vue
+++ b/client/src/components/ObjectStore/SelectObjectStore.vue
@@ -3,7 +3,7 @@ import { BAlert } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed } from "vue";
 
-import type { ConcreteObjectStoreModel } from "@/api";
+import type { UserConcreteObjectStoreModel } from "@/api";
 import { useObjectStoreStore } from "@/stores/objectStoreStore";
 
 import SourceOptionCard from "@/components/ConfigTemplates/SourceOptionCard.vue";
@@ -42,19 +42,28 @@ const error = computed(() => {
     return props.parentError || loadErrorMessage.value;
 });
 
-async function handleSubmit(preferredObjectStore: ConcreteObjectStoreModel) {
+async function handleSubmit(preferredObjectStore: UserConcreteObjectStoreModel) {
     const id: string | null = (preferredObjectStore ? preferredObjectStore.object_store_id : null) as string | null;
     const isPrivate: boolean = preferredObjectStore ? preferredObjectStore.private : false;
     emit("onSubmit", id, isPrivate);
 }
 
-const defaultObjectStore: ConcreteObjectStoreModel = {
-    object_store_id: null,
+const defaultObjectStore: UserConcreteObjectStoreModel = {
+    object_store_id: "__null__",
     name: props.defaultOptionTitle,
     description: props.defaultOptionDescription,
     badges: [],
     private: false,
     quota: { enabled: true, source: null },
+    active: false,
+    hidden: false,
+    purged: false,
+    secrets: [],
+    template_id: "",
+    template_version: 0,
+    type: "disk",
+    uuid: "",
+    variables: null,
 };
 </script>
 

--- a/client/src/components/ObjectStore/SelectObjectStore.vue
+++ b/client/src/components/ObjectStore/SelectObjectStore.vue
@@ -11,15 +11,18 @@ import SourceOptionCard from "@/components/ConfigTemplates/SourceOptionCard.vue"
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import ObjectStoreBadges from "@/components/ObjectStore/ObjectStoreBadges.vue";
 
-interface SelectObjectStoreProps {
-    selectedObjectStoreId?: String | null;
-    defaultOptionTitle: string;
+interface Props {
     defaultOptionDescription: string;
+    defaultOptionTitle: string;
     forWhat: string;
-    parentError?: String | null;
+    parentError?: string;
+    selectedObjectStoreId?: string | null;
 }
 
-const props = defineProps<SelectObjectStoreProps>();
+const props = withDefaults(defineProps<Props>(), {
+    selectedObjectStoreId: null,
+    parentError: undefined,
+});
 
 const { isOnlyPreference } = useStorageLocationConfiguration();
 const store = useObjectStoreStore();
@@ -46,7 +49,7 @@ const error = computed(() => {
 
 async function handleSubmit(preferredObjectStore: UserConcreteObjectStoreModel) {
     let id = preferredObjectStore?.object_store_id ?? null;
-    const isPrivate: boolean = preferredObjectStore ? preferredObjectStore.private : false;
+    const isPrivate = preferredObjectStore ? preferredObjectStore.private : false;
 
     if (id === "__null__") {
         id = null;
@@ -61,7 +64,7 @@ const defaultObjectStore: UserConcreteObjectStoreModel = {
     description: props.defaultOptionDescription,
     badges: [],
     private: false,
-    quota: { enabled: true, source: null },
+    quota: { enabled: false },
     active: false,
     hidden: false,
     purged: false,
@@ -79,10 +82,7 @@ const defaultObjectStore: UserConcreteObjectStoreModel = {
         <LoadingSpan v-if="loading" message="Loading Galaxy storage information" />
         <div v-else>
             <span v-if="isOnlyPreference" v-localize>
-                Select a preferred Galaxy storage for new datasets. Depending on the job and workflow execution
-                configuration of this Galaxy a different Galaxy storage may be ultimately used. After a dataset is
-                created, click on the info icon in the history panel to view information about where it is stored. If it
-                is not stored in the place you want, contact Galaxy administrator for more information.
+                {{ props.forWhat }}
             </span>
 
             <BAlert v-if="error" variant="danger" class="object-store-selection-error" show>

--- a/client/src/components/ObjectStore/SelectObjectStore.vue
+++ b/client/src/components/ObjectStore/SelectObjectStore.vue
@@ -1,20 +1,19 @@
 <script setup lang="ts">
+import { BAlert } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
-import { computed, ref } from "vue";
+import { computed } from "vue";
 
 import type { ConcreteObjectStoreModel } from "@/api";
-import { useStorageLocationConfiguration } from "@/composables/storageLocation";
 import { useObjectStoreStore } from "@/stores/objectStoreStore";
 
-import ObjectStoreSelectButton from "./ObjectStoreSelectButton.vue";
-import ObjectStoreSelectButtonDescribePopover from "./ObjectStoreSelectButtonDescribePopover.vue";
-import ObjectStoreSelectButtonPopover from "./ObjectStoreSelectButtonPopover.vue";
+import SourceOptionCard from "@/components/ConfigTemplates/SourceOptionCard.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
+import ObjectStoreBadges from "@/components/ObjectStore/ObjectStoreBadges.vue";
 
 interface SelectObjectStoreProps {
     selectedObjectStoreId?: String | null;
     defaultOptionTitle: string;
-    defaultOptionDescription: String;
+    defaultOptionDescription: string;
     forWhat: string;
     parentError?: String | null;
 }
@@ -23,7 +22,6 @@ const props = defineProps<SelectObjectStoreProps>();
 
 const store = useObjectStoreStore();
 const { isLoading, loadErrorMessage, selectableObjectStores } = storeToRefs(store);
-const { isOnlyPreference } = useStorageLocationConfiguration();
 
 const selectableAndVisibleObjectStores = computed(() => {
     const allSelectableObjectStores = selectableObjectStores.value;
@@ -36,22 +34,6 @@ const selectableAndVisibleObjectStores = computed(() => {
     }
 });
 
-const loadingObjectStoreInfoMessage = ref("Loading Galaxy storage information");
-const whyIsSelectionPreferredText = ref(`
-Select a preferred Galaxy storage for new datasets. Depending on the job and workflow execution configuration of
-this Galaxy a different Galaxy storage may be ultimately used. After a dataset is created,
-click on the info icon in the history panel to view information about where it is stored. If it
-is not stored in the place you want, contact Galaxy administrator for more information.
-`);
-
-function variant(objectStoreId: string | null) {
-    if (props.selectedObjectStoreId == objectStoreId) {
-        return "outline-primary";
-    } else {
-        return "outline-info";
-    }
-}
-
 const emit = defineEmits<{
     (e: "onSubmit", id: string | null, isPrivate: boolean): void;
 }>();
@@ -60,57 +42,58 @@ const error = computed(() => {
     return props.parentError || loadErrorMessage.value;
 });
 
-async function handleSubmit(preferredObjectStore: ConcreteObjectStoreModel | null) {
+async function handleSubmit(preferredObjectStore: ConcreteObjectStoreModel) {
     const id: string | null = (preferredObjectStore ? preferredObjectStore.object_store_id : null) as string | null;
     const isPrivate: boolean = preferredObjectStore ? preferredObjectStore.private : false;
     emit("onSubmit", id, isPrivate);
 }
+
+const defaultObjectStore: ConcreteObjectStoreModel = {
+    object_store_id: null,
+    name: props.defaultOptionTitle,
+    description: props.defaultOptionDescription,
+    badges: [],
+    private: false,
+    quota: { enabled: true, source: null },
+};
 </script>
 
 <template>
     <div>
-        <LoadingSpan v-if="isLoading" :message="loadingObjectStoreInfoMessage" />
+        <LoadingSpan v-if="isLoading" message="Loading Galaxy storage information" />
         <div v-else>
-            <b-alert v-if="error" variant="danger" class="object-store-selection-error" show>
+            <span v-localize>
+                Select a preferred Galaxy storage for new datasets. Depending on the job and workflow execution
+                configuration of this Galaxy a different Galaxy storage may be ultimately used. After a dataset is
+                created, click on the info icon in the history panel to view information about where it is stored. If it
+                is not stored in the place you want, contact Galaxy administrator for more information.
+            </span>
+
+            <BAlert v-if="error" variant="danger" class="object-store-selection-error" show>
                 {{ error }}
-            </b-alert>
-            <b-row align-h="center">
-                <b-col cols="7">
-                    <b-button-group vertical size="lg" style="width: 100%">
-                        <b-button
-                            id="no-preferred-object-store-button"
-                            :variant="variant(null)"
-                            class="preferred-object-store-select-button"
-                            data-object-store-id="__null__"
-                            @click="handleSubmit(null)"
-                            ><i v-localize>{{ defaultOptionTitle }}</i></b-button
-                        >
-                        <ObjectStoreSelectButton
-                            v-for="objectStore in selectableAndVisibleObjectStores"
-                            :key="objectStore.object_store_id"
-                            id-prefix="preferred"
-                            :object-store="objectStore"
-                            :variant="variant(objectStore.object_store_id ?? null)"
-                            class="preferred-object-store-select-button"
-                            @click="handleSubmit(objectStore)" />
-                    </b-button-group>
-                </b-col>
-                <b-col v-if="isOnlyPreference" cols="5">
-                    <p v-localize style="float: right">
-                        {{ whyIsSelectionPreferredText }}
-                    </p>
-                </b-col>
-            </b-row>
-            <ObjectStoreSelectButtonPopover target="no-preferred-object-store-button" :title="defaultOptionTitle">
-                <span v-localize>{{ defaultOptionDescription }}</span>
-            </ObjectStoreSelectButtonPopover>
-            <ObjectStoreSelectButtonDescribePopover
-                v-for="objectStore in selectableAndVisibleObjectStores"
-                :key="objectStore.object_store_id"
-                id-prefix="preferred"
-                :what="forWhat"
-                :object-store="objectStore">
-            </ObjectStoreSelectButtonDescribePopover>
+            </BAlert>
+
+            <div class="d-flex flex-wrap">
+                <SourceOptionCard
+                    :source-option="defaultObjectStore"
+                    selection-mode
+                    :selected="props.selectedObjectStoreId == null"
+                    @select="handleSubmit(defaultObjectStore)" />
+
+                <SourceOptionCard
+                    v-for="objectStore in selectableAndVisibleObjectStores"
+                    :key="objectStore.object_store_id"
+                    :source-option="objectStore"
+                    show-badges
+                    selection-mode
+                    submit-button-title="Select this storage location as the preferred storage location"
+                    :selected="props.selectedObjectStoreId == objectStore.object_store_id"
+                    @select="handleSubmit(objectStore)">
+                    <template v-slot:badges>
+                        <ObjectStoreBadges :badges="objectStore.badges" size="lg" />
+                    </template>
+                </SourceOptionCard>
+            </div>
         </div>
     </div>
 </template>

--- a/client/src/components/ObjectStore/mockServices.ts
+++ b/client/src/components/ObjectStore/mockServices.ts
@@ -6,6 +6,7 @@ jest.mock("@/api/objectStores");
 
 const OBJECT_STORES = [
     {
+        id: "object_store_1",
         object_store_id: "object_store_1",
         badges: [],
         quota: { enabled: false },
@@ -13,6 +14,7 @@ const OBJECT_STORES = [
         name: "Object Store 1",
     },
     {
+        id: "object_store_2",
         object_store_id: "object_store_2",
         badges: [],
         quota: { enabled: false },

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -1,4 +1,7 @@
 <script setup>
+import { faHdd } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BModal } from "bootstrap-vue";
 import Heading from "components/Common/Heading";
 import FormMessage from "components/Form/FormMessage";
 import ToolFooter from "components/Tool/ToolFooter";
@@ -145,25 +148,26 @@ const showHelpForum = computed(() => isConfigLoaded.value && config.value.enable
                     size="sm"
                     class="float-right tool-storage"
                     @click="onShowObjectStoreSelect">
-                    <span class="fa fa-hdd" />
+                    <FontAwesomeIcon :icon="faHdd" />
                 </b-button>
                 <ToolTargetPreferredObjectStorePopover
                     v-if="allowObjectStoreSelection"
                     :tool-preferred-object-store-id="toolPreferredObjectStoreId"
                     :user="currentUser" />
-                <b-modal
+                <BModal
                     v-model="showPreferredObjectStoreModal"
                     :title="storageLocationModalTitle"
                     scrollable
                     centered
                     modal-class="tool-preferred-object-store-modal"
                     title-tag="h3"
-                    size="sm"
-                    hide-footer>
+                    size="lg"
+                    ok-only
+                    ok-title="Close">
                     <ToolSelectPreferredObjectStore
                         :tool-preferred-object-store-id="toolPreferredObjectStoreId"
                         @updated="onUpdatePreferredObjectStoreId" />
-                </b-modal>
+                </BModal>
             </b-button-group>
             <slot name="buttons" />
         </template>

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -3,7 +3,6 @@ import Heading from "components/Common/Heading";
 import FormMessage from "components/Form/FormMessage";
 import ToolFooter from "components/Tool/ToolFooter";
 import ToolHelp from "components/Tool/ToolHelp";
-import { getAppRoot } from "onload/loadConfig";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 
@@ -104,7 +103,6 @@ const storageLocationModalTitle = computed(() => {
     }
 });
 
-const root = computed(() => getAppRoot());
 const showPreferredObjectStoreModal = ref(false);
 const toolPreferredObjectStoreId = ref(props.preferredObjectStoreId);
 
@@ -113,7 +111,6 @@ function onShowObjectStoreSelect() {
 }
 
 function onUpdatePreferredObjectStoreId(selectedToolPreferredObjectStoreId) {
-    showPreferredObjectStoreModal.value = false;
     toolPreferredObjectStoreId.value = selectedToolPreferredObjectStoreId;
     emit("updatePreferredObjectStoreId", selectedToolPreferredObjectStoreId);
 }
@@ -157,13 +154,14 @@ const showHelpForum = computed(() => isConfigLoaded.value && config.value.enable
                 <b-modal
                     v-model="showPreferredObjectStoreModal"
                     :title="storageLocationModalTitle"
+                    scrollable
+                    centered
                     modal-class="tool-preferred-object-store-modal"
                     title-tag="h3"
                     size="sm"
                     hide-footer>
                     <ToolSelectPreferredObjectStore
                         :tool-preferred-object-store-id="toolPreferredObjectStoreId"
-                        :root="root"
                         @updated="onUpdatePreferredObjectStoreId" />
                 </b-modal>
             </b-button-group>

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -155,6 +155,7 @@ const showHelpForum = computed(() => isConfigLoaded.value && config.value.enable
                     :tool-preferred-object-store-id="toolPreferredObjectStoreId"
                     :user="currentUser" />
                 <BModal
+                    id="modal-select-preferred-object-store"
                     v-model="showPreferredObjectStoreModal"
                     :title="storageLocationModalTitle"
                     scrollable

--- a/client/src/components/Tool/ToolSelectPreferredObjectStore.test.js
+++ b/client/src/components/Tool/ToolSelectPreferredObjectStore.test.js
@@ -31,10 +31,10 @@ describe("ToolSelectPreferredObjectStore.vue", () => {
         const wrapper = mountComponent();
 
         await flushPromises();
-        const els = wrapper.findAll(PREFERENCES.object_store_selection.option_buttons.selector);
+        const els = wrapper.findAll(PREFERENCES.object_store_selection.option_cards.selector);
         expect(els.length).toBe(3);
         const galaxyDefaultOption = wrapper.find(
-            PREFERENCES.object_store_selection.option_button({ object_store_id: "__null__" }).selector
+            PREFERENCES.object_store_selection.option_card_select({ object_store_id: "__null__" }).selector
         );
         expect(galaxyDefaultOption.exists()).toBeTruthy();
         await galaxyDefaultOption.trigger("click");

--- a/client/src/components/Tool/ToolSelectPreferredObjectStore.test.ts
+++ b/client/src/components/Tool/ToolSelectPreferredObjectStore.test.ts
@@ -1,23 +1,22 @@
 import "tests/jest/mockHelpPopovers";
 
+import { getLocalVue } from "@tests/jest/helpers";
 import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
-import { getLocalVue } from "tests/jest/helpers";
 import { setupMockConfig } from "tests/jest/mockConfig";
 
 import { setupSelectableMock } from "@/components/ObjectStore/mockServices";
-import { ROOT_COMPONENT } from "@/utils/navigation";
+import { ROOT_COMPONENT } from "@/utils/navigation/schema";
 
 import ToolSelectPreferredObjectStore from "./ToolSelectPreferredObjectStore.vue";
 
 setupSelectableMock();
+setupMockConfig({});
 
 const localVue = getLocalVue(true);
 
-setupMockConfig({});
-
 function mountComponent() {
-    const wrapper = mount(ToolSelectPreferredObjectStore, {
+    const wrapper = mount(ToolSelectPreferredObjectStore as object, {
         propsData: { toolPreferredObjectStoreId: null },
         localVue,
     });
@@ -27,21 +26,33 @@ function mountComponent() {
 const PREFERENCES = ROOT_COMPONENT.preferences;
 
 describe("ToolSelectPreferredObjectStore.vue", () => {
-    it("updates object store to default on selection null", async () => {
+    it("update preferred object store on selection", async () => {
         const wrapper = mountComponent();
 
         await flushPromises();
         const els = wrapper.findAll(PREFERENCES.object_store_selection.option_cards.selector);
         expect(els.length).toBe(3);
+
         const galaxyDefaultOption = wrapper.find(
-            PREFERENCES.object_store_selection.option_card_select({ object_store_id: "__null__" }).selector
+            PREFERENCES.object_store_selection.option_card({ object_store_id: "__null__" }).selector
         );
+
         expect(galaxyDefaultOption.exists()).toBeTruthy();
-        await galaxyDefaultOption.trigger("click");
+
+        const objectStoreOptionButton = wrapper.find(
+            ROOT_COMPONENT.preferences.object_store_selection.option_card_select({ object_store_id: "object_store_1" })
+                .selector
+        );
+
+        expect(objectStoreOptionButton.exists()).toBeTruthy();
+
+        await objectStoreOptionButton.trigger("click");
         await flushPromises();
+
         const errorEl = wrapper.find(".object-store-selection-error");
         expect(errorEl.exists()).toBeFalsy();
+
         const emitted = wrapper.emitted();
-        expect(emitted["updated"][0][0]).toEqual(null);
+        expect(emitted["updated"]?.[0]?.[1]).toBeFalsy();
     });
 });

--- a/client/src/components/Tool/ToolSelectPreferredObjectStore.vue
+++ b/client/src/components/Tool/ToolSelectPreferredObjectStore.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { ref } from "vue";
-
 import SelectObjectStore from "@/components/ObjectStore/SelectObjectStore.vue";
 
 interface ToolSelectProps {
@@ -11,7 +9,6 @@ const props = withDefaults(defineProps<ToolSelectProps>(), {
     toolPreferredObjectStoreId: null,
 });
 
-const selectedObjectStoreId = ref<String | null>(props.toolPreferredObjectStoreId);
 const newDatasetsDescription = "The default Galaxy storage for the outputs of this tool";
 const defaultOptionTitle = "Use Defaults";
 const defaultOptionDescription =
@@ -22,7 +19,6 @@ const emit = defineEmits<{
 }>();
 
 async function handleSubmit(preferredObjectStoreId: string | null) {
-    selectedObjectStoreId.value = preferredObjectStoreId;
     emit("updated", preferredObjectStoreId);
 }
 </script>
@@ -30,7 +26,7 @@ async function handleSubmit(preferredObjectStoreId: string | null) {
 <template>
     <SelectObjectStore
         :for-what="newDatasetsDescription"
-        :selected-object-store-id="selectedObjectStoreId"
+        :selected-object-store-id="props.toolPreferredObjectStoreId"
         :default-option-title="defaultOptionTitle"
         :default-option-description="defaultOptionDescription"
         @onSubmit="handleSubmit" />

--- a/client/src/components/Tool/ToolSelectPreferredObjectStore.vue
+++ b/client/src/components/Tool/ToolSelectPreferredObjectStore.vue
@@ -1,22 +1,20 @@
 <script setup lang="ts">
 import SelectObjectStore from "@/components/ObjectStore/SelectObjectStore.vue";
 
-interface ToolSelectProps {
-    toolPreferredObjectStoreId?: String | null;
+interface Props {
+    toolPreferredObjectStoreId?: string | null;
 }
 
-const props = withDefaults(defineProps<ToolSelectProps>(), {
-    toolPreferredObjectStoreId: null,
-});
+const props = defineProps<Props>();
+
+const emit = defineEmits<{
+    (e: "updated", id: string | null): void;
+}>();
 
 const newDatasetsDescription = "The default Galaxy storage for the outputs of this tool";
 const defaultOptionTitle = "Use Defaults";
 const defaultOptionDescription =
     "If the history has a default set, that will be used. If instead, you've set an option in your user preferences - that will be assumed to be your default selection. Finally, the Galaxy configuration will be used.";
-
-const emit = defineEmits<{
-    (e: "updated", id: string | null): void;
-}>();
 
 async function handleSubmit(preferredObjectStoreId: string | null) {
     emit("updated", preferredObjectStoreId);

--- a/client/src/components/User/UserPreferredObjectStore.vue
+++ b/client/src/components/User/UserPreferredObjectStore.vue
@@ -75,11 +75,12 @@ async function handleSubmit(preferred: string | null) {
                 scrollable
                 centered
                 :title="title"
-                hide-footer
                 static
                 size="lg"
-                title-tag="h2"
+                title-tag="h3"
                 dialog-class="modal-select-preferred-object-store"
+                ok-only
+                ok-title="Close"
                 @hidden="resetModal">
                 <SelectObjectStore
                     :parent-error="error"

--- a/client/src/components/User/UserPreferredObjectStore.vue
+++ b/client/src/components/User/UserPreferredObjectStore.vue
@@ -72,6 +72,7 @@ async function handleSubmit(preferred: string | null) {
             <BModal
                 id="modal-select-preferred-object-store"
                 ref="modal"
+                scrollable
                 centered
                 :title="title"
                 hide-footer

--- a/client/src/components/User/UserPreferredObjectStore.vue
+++ b/client/src/components/User/UserPreferredObjectStore.vue
@@ -1,114 +1,102 @@
+<script setup lang="ts">
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import axios from "axios";
+import { BModal, BRow } from "bootstrap-vue";
+import { faHdd } from "font-awesome-6";
+import { storeToRefs } from "pinia";
+import { computed, ref } from "vue";
+
+import { useConfigStore } from "@/stores/configurationStore";
+import { prependPath } from "@/utils/redirect";
+import { errorMessageAsString } from "@/utils/simple-error";
+
+import SelectObjectStore from "@/components/ObjectStore/SelectObjectStore.vue";
+
+interface Props {
+    preferredObjectStoreId?: string;
+}
+
+const { isLoaded: isConfigLoaded, config } = storeToRefs(useConfigStore());
+
+const props = defineProps<Props>();
+
+const error = ref();
+const selectedObjectStoreId = ref(props.preferredObjectStoreId as string | null);
+
+const title = computed(() => {
+    return `${preferredOrEmptyString.value} Galaxy Storage`;
+});
+const preferredOrEmptyString = computed(() => {
+    if (isConfigLoaded && config.value?.object_store_always_respect_user_selection) {
+        return "";
+    } else {
+        return "Preferred";
+    }
+});
+
+function resetModal() {
+    error.value = null;
+}
+
+async function handleSubmit(preferred: string | null) {
+    const payload = { preferred_object_store_id: preferred };
+    const url = prependPath("api/users/current");
+
+    try {
+        await axios.put(url, payload);
+
+        selectedObjectStoreId.value = preferred;
+    } catch (e) {
+        error.value = errorMessageAsString(e);
+    }
+}
+</script>
+
 <template>
     <BRow class="ml-3 mb-1">
-        <i class="pref-icon pt-1 fa fa-lg fa-hdd" />
+        <FontAwesomeIcon :icon="faHdd" class="pt-1 mr-auto" size="lg" />
+
         <div class="pref-content pr-1">
             <a
                 id="select-preferred-object-store"
                 v-b-modal.modal-select-preferred-object-store
                 class="preferred-storage"
-                href="javascript:void(0)"
-                ><b v-localize>{{ title }}</b></a
-            >
+                href="javascript:void(0)">
+                <b v-localize>{{ title }}</b>
+            </a>
+
             <div v-localize class="form-text text-muted">
                 Select a {{ preferredOrEmptyString }} Galaxy storage for the outputs of new jobs.
             </div>
+
             <BModal
                 id="modal-select-preferred-object-store"
                 ref="modal"
-                v-model="showModal"
                 centered
                 :title="title"
-                :title-tag="titleTag"
                 hide-footer
                 static
-                :size="modalSize"
-                @show="resetModal"
+                size="lg"
+                title-tag="h2"
+                dialog-class="modal-select-preferred-object-store"
                 @hidden="resetModal">
                 <SelectObjectStore
                     :parent-error="error"
-                    :for-what="newDatasetsDescription"
                     :selected-object-store-id="selectedObjectStoreId"
-                    :default-option-title="galaxySelectionDefaultTitle"
-                    :default-option-description="galaxySelectionDefaultDescription"
+                    for-what="New dataset outputs from tools and workflows"
+                    default-option-title="Galaxy Defaults"
+                    default-option-description="Selecting this will reset Galaxy to default behaviors configured by your Galaxy administrator."
                     @onSubmit="handleSubmit" />
             </BModal>
         </div>
     </BRow>
 </template>
 
-<script>
-import axios from "axios";
-import { BModal, BRow, VBModal } from "bootstrap-vue";
-import SelectObjectStore from "components/ObjectStore/SelectObjectStore";
-import { mapState } from "pinia";
-import { prependPath } from "utils/redirect";
-import { errorMessageAsString } from "utils/simple-error";
-import Vue from "vue";
-
-import { useConfigStore } from "@/stores/configurationStore";
-
-Vue.use(VBModal);
-
-export default {
-    components: {
-        BModal,
-        BRow,
-        SelectObjectStore,
-    },
-    props: {
-        userId: {
-            type: String,
-            required: true,
-        },
-        preferredObjectStoreId: {
-            type: String,
-            default: null,
-        },
-    },
-    data() {
-        return {
-            error: null,
-            popoverPlacement: "left",
-            newDatasetsDescription: "New dataset outputs from tools and workflows",
-            titleTag: "h3",
-            modalSize: "sm",
-            showModal: false,
-            selectedObjectStoreId: this.preferredObjectStoreId,
-            galaxySelectionDefaultTitle: "Use Galaxy Defaults",
-            galaxySelectionDefaultDescription:
-                "Selecting this will reset Galaxy to default behaviors configured by your Galaxy administrator.",
-        };
-    },
-    computed: {
-        ...mapState(useConfigStore, ["config"]),
-        preferredOrEmptyString() {
-            if (this.config?.object_store_always_respect_user_selection) {
-                return "";
-            } else {
-                return "Preferred";
-            }
-        },
-        title() {
-            return `${this.preferredOrEmptyString} Galaxy Storage`;
-        },
-    },
-    methods: {
-        resetModal() {},
-        async handleSubmit(preferredObjectStoreId) {
-            const payload = { preferred_object_store_id: preferredObjectStoreId };
-            const url = prependPath("api/users/current");
-            try {
-                await axios.put(url, payload);
-            } catch (e) {
-                this.error = errorMessageAsString(e);
-            }
-            this.selectedObjectStoreId = preferredObjectStoreId;
-            this.showModal = false;
-        },
-    },
-};
-</script>
-
-<style scoped>
+<style>
 @import "user-styles.scss";
+
+.modal-select-preferred-object-store {
+    width: inherit;
+    max-width: 800px;
+}
 </style>

--- a/client/src/components/Workflow/Run/WorkflowSelectPreferredObjectStore.test.js
+++ b/client/src/components/Workflow/Run/WorkflowSelectPreferredObjectStore.test.js
@@ -29,11 +29,11 @@ describe("WorkflowSelectPreferredObjectStore.vue", () => {
     it("updates object store to default on selection null", async () => {
         const wrapper = mountComponent();
         await flushPromises();
-        const els = wrapper.findAll(PREFERENCES.object_store_selection.option_buttons.selector);
+        const els = wrapper.findAll(PREFERENCES.object_store_selection.option_cards.selector);
         expect(els.length).toBe(3);
 
         const galaxyDefaultOption = wrapper.find(
-            PREFERENCES.object_store_selection.option_button({ object_store_id: "__null__" }).selector
+            PREFERENCES.object_store_selection.option_card_select({ object_store_id: "__null__" }).selector
         );
         expect(galaxyDefaultOption.exists()).toBeTruthy();
         await galaxyDefaultOption.trigger("click");

--- a/client/src/components/Workflow/Run/WorkflowSelectPreferredObjectStore.test.ts
+++ b/client/src/components/Workflow/Run/WorkflowSelectPreferredObjectStore.test.ts
@@ -1,12 +1,12 @@
 import "tests/jest/mockHelpPopovers";
 
+import { getLocalVue } from "@tests/jest/helpers";
 import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
-import { getLocalVue } from "tests/jest/helpers";
 import { setupMockConfig } from "tests/jest/mockConfig";
 
 import { setupSelectableMock } from "@/components/ObjectStore/mockServices";
-import { ROOT_COMPONENT } from "@/utils/navigation";
+import { ROOT_COMPONENT } from "@/utils/navigation/schema";
 
 import WorkflowSelectPreferredObjectStore from "./WorkflowSelectPreferredObjectStore.vue";
 
@@ -16,7 +16,7 @@ setupMockConfig({});
 const localVue = getLocalVue(true);
 
 function mountComponent() {
-    const wrapper = mount(WorkflowSelectPreferredObjectStore, {
+    const wrapper = mount(WorkflowSelectPreferredObjectStore as object, {
         propsData: { invocationPreferredObjectStoreId: null },
         localVue,
     });
@@ -26,21 +26,33 @@ function mountComponent() {
 const PREFERENCES = ROOT_COMPONENT.preferences;
 
 describe("WorkflowSelectPreferredObjectStore.vue", () => {
-    it("updates object store to default on selection null", async () => {
+    it("update preferred object store on selection", async () => {
         const wrapper = mountComponent();
+
         await flushPromises();
         const els = wrapper.findAll(PREFERENCES.object_store_selection.option_cards.selector);
         expect(els.length).toBe(3);
 
         const galaxyDefaultOption = wrapper.find(
-            PREFERENCES.object_store_selection.option_card_select({ object_store_id: "__null__" }).selector
+            PREFERENCES.object_store_selection.option_card({ object_store_id: "__null__" }).selector
         );
+
         expect(galaxyDefaultOption.exists()).toBeTruthy();
-        await galaxyDefaultOption.trigger("click");
+
+        const objectStoreOptionButton = wrapper.find(
+            ROOT_COMPONENT.preferences.object_store_selection.option_card_select({ object_store_id: "object_store_1" })
+                .selector
+        );
+
+        expect(objectStoreOptionButton.exists()).toBeTruthy();
+
+        await objectStoreOptionButton.trigger("click");
         await flushPromises();
+
         const errorEl = wrapper.find(".object-store-selection-error");
         expect(errorEl.exists()).toBeFalsy();
+
         const emitted = wrapper.emitted();
-        expect(emitted["updated"][0][0]).toEqual(null);
+        expect(emitted["updated"]?.[0]?.[1]).toBeFalsy();
     });
 });

--- a/client/src/components/Workflow/Run/WorkflowSelectPreferredObjectStore.vue
+++ b/client/src/components/Workflow/Run/WorkflowSelectPreferredObjectStore.vue
@@ -1,28 +1,22 @@
 <script setup lang="ts">
-import { ref } from "vue";
-
 import SelectObjectStore from "@/components/ObjectStore/SelectObjectStore.vue";
 
 interface Props {
-    invocationPreferredObjectStoreId?: String | null;
+    invocationPreferredObjectStoreId?: string | null;
 }
 
-const props = withDefaults(defineProps<Props>(), {
-    invocationPreferredObjectStoreId: null,
-});
+const props = defineProps<Props>();
 
 const emit = defineEmits<{
     (e: "updated", id: string | null): void;
 }>();
 
-const selectedObjectStoreId = ref<String | null>(props.invocationPreferredObjectStoreId);
 const newDatasetsDescription = "The default Galaxy storage for the outputs of this workflow invocation";
 const defaultOptionTitle = "Use Defaults";
 const defaultOptionDescription =
     "If the history has a preference set, that will be used. If instead, you've set an option in your user preferences - that will be assumed to be your default selection. Finally, the Galaxy configuration will be used.";
 
 async function handleSubmit(preferredObjectStoreId: string | null) {
-    selectedObjectStoreId.value = preferredObjectStoreId;
     emit("updated", preferredObjectStoreId);
 }
 </script>
@@ -30,7 +24,7 @@ async function handleSubmit(preferredObjectStoreId: string | null) {
 <template>
     <SelectObjectStore
         :for-what="newDatasetsDescription"
-        :selected-object-store-id="selectedObjectStoreId"
+        :selected-object-store-id="props.invocationPreferredObjectStoreId"
         :default-option-title="defaultOptionTitle"
         :default-option-description="defaultOptionDescription"
         @onSubmit="handleSubmit" />

--- a/client/src/components/Workflow/Run/WorkflowStorageConfiguration.vue
+++ b/client/src/components/Workflow/Run/WorkflowStorageConfiguration.vue
@@ -13,7 +13,15 @@
             :title-suffix="suffixPrimary"
             :invocation-preferred-object-store-id="selectedObjectStoreId">
         </WorkflowTargetPreferredObjectStorePopover>
-        <b-modal v-model="showPreferredObjectStoreModal" :title="primaryModalTitle" v-bind="modalProps" hide-footer>
+        <b-modal
+            v-model="showPreferredObjectStoreModal"
+            :title="primaryModalTitle"
+            v-bind="modalProps"
+            size="lg"
+            scrollable
+            centered
+            ok-only
+            ok-title="Close">
             <WorkflowSelectPreferredObjectStore
                 :invocation-preferred-object-store-id="selectedObjectStoreId"
                 @updated="onUpdate" />
@@ -37,7 +45,11 @@
             v-model="showIntermediatePreferredObjectStoreModal"
             :title="intermediateModalTitle"
             v-bind="modalProps"
-            hide-footer>
+            size="lg"
+            scrollable
+            centered
+            ok-only
+            ok-title="Close">
             <WorkflowSelectPreferredObjectStore
                 :invocation-preferred-object-store-id="selectedIntermediateObjectStoreId"
                 @updated="onUpdateIntermediate" />
@@ -122,12 +134,10 @@ export default {
         async onUpdate(preferredObjectStoreId) {
             this.selectedObjectStoreId = preferredObjectStoreId;
             this.$emit("updated", preferredObjectStoreId, false);
-            this.showPreferredObjectStoreModal = false;
         },
         async onUpdateIntermediate(preferredObjectStoreId) {
             this.selectedIntermediateObjectStoreId = preferredObjectStoreId;
             this.$emit("updated", preferredObjectStoreId, true);
-            this.showIntermediatePreferredObjectStoreModal = false;
         },
     },
 };

--- a/client/src/composables/sync.ts
+++ b/client/src/composables/sync.ts
@@ -1,0 +1,11 @@
+import { type MaybeRefOrGetter, toValue } from "@vueuse/core";
+import { type Ref, watch } from "vue";
+
+/** One-way sync source ref, computed or getter function to target ref */
+export function useSync<T>(source: MaybeRefOrGetter<T>, target: Ref<T>) {
+    watch(
+        () => toValue(source),
+        (value) => (target.value = value),
+        { immediate: true }
+    );
+}

--- a/client/src/stores/objectStoreStore.ts
+++ b/client/src/stores/objectStoreStore.ts
@@ -54,7 +54,7 @@ export const useObjectStoreStore = defineStore("objectStoreStore", () => {
      * reloading it from the server.
      * @param objectStore The object store to add or update
      */
-    function addOrUpdateObjectStore(objectStore: ConcreteObjectStoreModel) {
+    function addOrUpdateObjectStore(objectStore: UserConcreteObjectStoreModel) {
         if (selectableObjectStores.value) {
             const index = selectableObjectStores.value.findIndex(
                 (store) => store.object_store_id === objectStore.object_store_id

--- a/client/src/stores/objectStoreStore.ts
+++ b/client/src/stores/objectStoreStore.ts
@@ -1,22 +1,22 @@
 import { defineStore } from "pinia";
 import { computed, ref, set } from "vue";
 
-import type { ConcreteObjectStoreModel } from "@/api";
+import type { UserConcreteObjectStoreModel } from "@/api";
 import { getSelectableObjectStores } from "@/api/objectStores";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 export const useObjectStoreStore = defineStore("objectStoreStore", () => {
-    const selectableObjectStores = ref<ConcreteObjectStoreModel[] | null>(null);
+    const selectableObjectStores = ref<UserConcreteObjectStoreModel[]>();
     const loadErrorMessage = ref<string | null>(null);
     const isLoading = ref(false);
-    const isLoaded = computed(() => selectableObjectStores.value != null);
+    const isLoaded = computed(() => selectableObjectStores.value);
 
     async function loadObjectStores() {
         if (!isLoaded.value && !isLoading.value) {
             isLoading.value = true;
             try {
                 const data = await getSelectableObjectStores();
-                selectableObjectStores.value = data;
+                selectableObjectStores.value = data as UserConcreteObjectStoreModel[];
             } catch (err) {
                 const errorMessage = `Error loading Galaxy object stores: ${errorMessageAsString(err)}`;
                 loadErrorMessage.value = errorMessage;

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -85,8 +85,10 @@ preferences:
 
   object_store_selection:
     selectors:
-      option_buttons: '.preferred-object-store-select-button'
-      option_button: '.preferred-object-store-select-button[data-object-store-id="${object_store_id}"]'
+      modal: '#modal-select-preferred-object-store'
+      option_cards: '.source-option-card'
+      option_card: '.source-option-card[data-source-option-card-id="${object_store_id}"]'
+      option_card_select: '.source-option-card[data-source-option-card-id="${object_store_id}"] .source-option-card-select-button'
 
 object_store_instances:
   index:

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -86,9 +86,9 @@ preferences:
   object_store_selection:
     selectors:
       modal: '#modal-select-preferred-object-store'
-      option_cards: '.source-option-card'
-      option_card: '.source-option-card[data-source-option-card-id="${object_store_id}"]'
-      option_card_select: '.source-option-card[data-source-option-card-id="${object_store_id}"] .source-option-card-select-button'
+      option_cards: '[id^="g-card-"][data-source-option-card-id]'
+      option_card: '#g-card-${object_store_id}'
+      option_card_select: '#g-card-action-select-${object_store_id}'
 
 object_store_instances:
   index:

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -89,6 +89,7 @@ preferences:
       option_cards: '[id^="g-card-"][data-source-option-card-id]'
       option_card: '#g-card-${object_store_id}'
       option_card_select: '#g-card-action-select-${object_store_id}'
+      confirm_button: '#modal-select-preferred-object-store .btn-primary'
 
 object_store_instances:
   index:

--- a/client/src/utils/navigation/schema.ts
+++ b/client/src/utils/navigation/schema.ts
@@ -31,8 +31,10 @@ interface Rootmasthead extends Component {
     logged_out_only: SelectorTemplate;
 }
 interface Rootpreferencesobject_store_selection extends Component {
-    option_buttons: SelectorTemplate;
-    option_button: SelectorTemplate;
+    modal: SelectorTemplate;
+    option_cards: SelectorTemplate;
+    option_card: SelectorTemplate;
+    option_card_select: SelectorTemplate;
 }
 interface Rootpreferences extends Component {
     sign_out: SelectorTemplate;

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1830,8 +1830,6 @@ class NavigatesGalaxy(HasDriver):
         button = selection_component.option_card_select(object_store_id=storage_id)
         if button:
             button.wait_for_and_click()
-        if self.find_element_by_selector(".btn-primary"):
-            self.find_element_by_selector(".btn-primary").click()
         if not selection_component.confirm_button.is_absent:
             selection_component.confirm_button.wait_for_and_click()
         selection_component.option_cards.wait_for_absent_or_hidden()

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1828,7 +1828,7 @@ class NavigatesGalaxy(HasDriver):
         selection_component = self.components.preferences.object_store_selection
         selection_component.option_cards.wait_for_present()
         button = selection_component.option_card_select(object_store_id=storage_id)
-        if button:
+        if not button.is_absent:
             button.wait_for_and_click()
         if not selection_component.confirm_button.is_absent:
             selection_component.confirm_button.wait_for_and_click()

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1828,7 +1828,7 @@ class NavigatesGalaxy(HasDriver):
         selection_component = self.components.preferences.object_store_selection
         selection_component.option_cards.wait_for_present()
         button = selection_component.option_card_select(object_store_id=storage_id)
-        if not button.is_absent and button.is_clickable:
+        if button:
             button.wait_for_and_click()
         if self.find_element_by_selector(".btn-primary"):
             self.find_element_by_selector(".btn-primary").click()

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1826,10 +1826,12 @@ class NavigatesGalaxy(HasDriver):
 
     def select_storage(self, storage_id: str) -> None:
         selection_component = self.components.preferences.object_store_selection
-        selection_component.option_buttons.wait_for_present()
-        button = selection_component.option_button(object_store_id=storage_id)
+        selection_component.option_cards.wait_for_present()
+        button = selection_component.option_card_select(object_store_id=storage_id)
         button.wait_for_and_click()
-        selection_component.option_buttons.wait_for_absent_or_hidden()
+        if self.find_element_by_selector(".btn-primary"):
+            self.find_element_by_selector(".btn-primary").click()
+        selection_component.option_cards.wait_for_absent_or_hidden()
 
     def create_page_and_edit(self, name=None, slug=None, screenshot_name=None):
         name = self.create_page(name=name, slug=slug, screenshot_name=screenshot_name)

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1828,9 +1828,12 @@ class NavigatesGalaxy(HasDriver):
         selection_component = self.components.preferences.object_store_selection
         selection_component.option_cards.wait_for_present()
         button = selection_component.option_card_select(object_store_id=storage_id)
-        button.wait_for_and_click()
+        if not button.is_absent and button.is_clickable:
+            button.wait_for_and_click()
         if self.find_element_by_selector(".btn-primary"):
             self.find_element_by_selector(".btn-primary").click()
+        if not selection_component.confirm_button.is_absent:
+            selection_component.confirm_button.wait_for_and_click()
         selection_component.option_cards.wait_for_absent_or_hidden()
 
     def create_page_and_edit(self, name=None, slug=None, screenshot_name=None):


### PR DESCRIPTION
This pull request introduces a redesign of the Object Store Selection modals for User Preferred, Current History, Tool form and Workflow run form, aiming to enhance user experience through a consistent and modernised interface.

Required: #19521

https://github.com/user-attachments/assets/e85fca15-8c1b-4683-83bd-eb53fb2a28f7

|Before|After|
|--|--|
|<img width="960" alt="image" src="https://github.com/user-attachments/assets/65b1fabd-642a-479c-b6ac-04a249103e5c" />|<img width="960" alt="image" src="https://github.com/user-attachments/assets/978a63e6-e988-421a-a11c-37dd389e53a0" />|
|<img width="960" alt="image" src="https://github.com/user-attachments/assets/fdb6c7d8-5a2a-4ee2-899c-ce219c7cf117" />|<img width="960" alt="image" src="https://github.com/user-attachments/assets/382d59b8-c3c0-4508-abc3-762a81815140" />|
|<img width="960" alt="image" src="https://github.com/user-attachments/assets/c51a6357-4ae1-43fb-bbc1-ac59c21a8943" />|<img width="960" alt="image" src="https://github.com/user-attachments/assets/0e6faaeb-cac8-4a5f-ae98-39a1d890c185" />|
|<img width="960" alt="image" src="https://github.com/user-attachments/assets/4fcf4e35-870d-4bcd-91f6-5264cbe107e4" />|<img width="960" alt="image" src="https://github.com/user-attachments/assets/f23951f8-52e6-493f-b884-8513dd0a4e2f" />|

Key Changes:

- Enhanced Selection Interface using the `SourceOptionCard`
- Update types and improve the logic
- Use a consistent object store selection for every use case

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  a1. Go to `User Preferences`
  a2. Click on `Preferred Storage Location`

  b1. Go to the tool run form
  b2. Select the storage icon at the top of the form toolbar

  c1. Go to the workflow run form
  c2. Click on the storage icon at the top of the page

  d1. In the current history panel, click on the storage icon on top

 
## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
