### PR TITLE
[24.2] Backport of workflow landing sidebar toggle fix.

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -89,7 +89,7 @@ const emit = defineEmits<{
 }>();
 
 // activities from store
-const { activities } = storeToRefs(activityStore);
+const { activities, isSideBarOpen } = storeToRefs(activityStore);
 
 // drag references
 const dragTarget: Ref<EventTarget | null> = ref(null);

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -112,8 +112,6 @@ function isActiveSideBar(menuKey: string) {
     return activityStore.toggledSideBar === menuKey;
 }
 
-const isSideBarOpen = computed(() => activityStore.toggledSideBar !== "");
-
 /**
  * Checks if an activity that has a panel should have the `is-active` prop
  */

--- a/client/src/components/Landing/WorkflowLanding.vue
+++ b/client/src/components/Landing/WorkflowLanding.vue
@@ -45,7 +45,6 @@ watch(
         } else if (currentUser.value) {
             let claim;
             let claimError;
-            activityStore.toggleSideBar("");
             activityStore.closeSideBar();
             if (props.public) {
                 const { data, error } = await GalaxyApi().GET("/api/workflow_landings/{uuid}", {

--- a/client/src/components/Landing/WorkflowLanding.vue
+++ b/client/src/components/Landing/WorkflowLanding.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import { BAlert } from "bootstrap-vue";
-import { onMounted, ref } from "vue";
+import { storeToRefs } from "pinia";
 
-import { GalaxyApi } from "@/api";
 import { useActivityStore } from "@/stores/activityStore";
-import { errorMessageAsString } from "@/utils/simple-error";
+import { useWorkflowLandingStore } from "@/stores/workflowLandingStore";
 
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import WorkflowRun from "@/components/Workflow/Run/WorkflowRun.vue";
@@ -20,63 +19,34 @@ const props = withDefaults(defineProps<Props>(), {
     public: false,
 });
 
-const workflowId = ref<string | null>(null);
-const errorMessage = ref<string | null>(null);
-const requestState = ref<Record<string, never> | null>(null);
-const instance = ref<boolean>(false);
+const store = useWorkflowLandingStore();
+const { claimWorkflow } = store;
+const { claimState } = storeToRefs(store);
 
 const activityStore = useActivityStore("default");
 
-onMounted(async() => {
-    let claim;
-    let claimError;
-    if (props.public) {
-        const { data, error } = await GalaxyApi().GET("/api/workflow_landings/{uuid}", {
-            params: {
-                path: { uuid: props.uuid },
-            },
-        });
-        claim = data;
-        claimError = error;
-    } else {
-        const { data, error } = await GalaxyApi().POST("/api/workflow_landings/{uuid}/claim", {
-            params: {
-                path: { uuid: props.uuid },
-            },
-            body: {
-                client_secret: props.secret,
-            },
-        });
-        claim = data;
-        claimError = error;
-    }
-    if (claim) {
-        workflowId.value = claim.workflow_id;
-        instance.value = claim.workflow_target_type === "workflow";
-        requestState.value = claim.request_state;
-    } else {
-        errorMessage.value = errorMessageAsString(claimError);
-    }
+// Start claim immediately
+claimWorkflow(props.uuid, props.public, props.secret).then(() => {
     activityStore.closeSideBar();
 });
 </script>
 
 <template>
     <div>
-        <div v-if="errorMessage">
+        <div v-if="claimState.errorMessage">
             <BAlert variant="danger" show>
-                {{ errorMessage }}
+                {{ claimState.errorMessage }}
             </BAlert>
         </div>
-        <div v-else-if="!workflowId">
+        <div v-else-if="!claimState.workflowId">
             <LoadingSpan message="Loading workflow parameters" />
         </div>
         <div v-else>
             <WorkflowRun
-                :workflow-id="workflowId"
+                :workflow-id="claimState.workflowId"
                 :prefer-simple-form="true"
-                :request-state="requestState"
-                :instance="instance" />
+                :request-state="claimState.requestState"
+                :instance="claimState.instance" />
         </div>
     </div>
 </template>

--- a/client/src/components/Landing/WorkflowLanding.vue
+++ b/client/src/components/Landing/WorkflowLanding.vue
@@ -5,6 +5,7 @@ import { ref, watch } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { GalaxyApi } from "@/api";
+import { useActivityStore } from "@/stores/activityStore";
 import { useUserStore } from "@/stores/userStore";
 import { errorMessageAsString } from "@/utils/simple-error";
 
@@ -32,6 +33,8 @@ const router = useRouter();
 userStore.loadUser(false);
 const { isAnonymous, currentUser } = storeToRefs(userStore);
 
+const activityStore = useActivityStore("default");
+
 watch(
     currentUser,
     async () => {
@@ -42,6 +45,8 @@ watch(
         } else if (currentUser.value) {
             let claim;
             let claimError;
+            activityStore.toggleSideBar("");
+            activityStore.closeSideBar();
             if (props.public) {
                 const { data, error } = await GalaxyApi().GET("/api/workflow_landings/{uuid}", {
                     params: {

--- a/client/src/components/Landing/WorkflowLanding.vue
+++ b/client/src/components/Landing/WorkflowLanding.vue
@@ -1,12 +1,9 @@
 <script setup lang="ts">
 import { BAlert } from "bootstrap-vue";
-import { storeToRefs } from "pinia";
-import { ref, watch } from "vue";
-import { useRouter } from "vue-router/composables";
+import { onMounted, ref } from "vue";
 
 import { GalaxyApi } from "@/api";
 import { useActivityStore } from "@/stores/activityStore";
-import { useUserStore } from "@/stores/userStore";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import LoadingSpan from "@/components/LoadingSpan.vue";
@@ -27,56 +24,41 @@ const workflowId = ref<string | null>(null);
 const errorMessage = ref<string | null>(null);
 const requestState = ref<Record<string, never> | null>(null);
 const instance = ref<boolean>(false);
-const userStore = useUserStore();
-const router = useRouter();
-
-userStore.loadUser(false);
-const { isAnonymous, currentUser } = storeToRefs(userStore);
 
 const activityStore = useActivityStore("default");
 
-watch(
-    currentUser,
-    async () => {
-        if (isAnonymous.value) {
-            router.push(
-                `/login/start?redirect=/workflow_landings/${props.uuid}?public=${props.public}&client_secret=${props.secret}`
-            );
-        } else if (currentUser.value) {
-            let claim;
-            let claimError;
-            activityStore.closeSideBar();
-            if (props.public) {
-                const { data, error } = await GalaxyApi().GET("/api/workflow_landings/{uuid}", {
-                    params: {
-                        path: { uuid: props.uuid },
-                    },
-                });
-                claim = data;
-                claimError = error;
-            } else {
-                const { data, error } = await GalaxyApi().POST("/api/workflow_landings/{uuid}/claim", {
-                    params: {
-                        path: { uuid: props.uuid },
-                    },
-                    body: {
-                        client_secret: props.secret,
-                    },
-                });
-                claim = data;
-                claimError = error;
-            }
-            if (claim) {
-                workflowId.value = claim.workflow_id;
-                instance.value = claim.workflow_target_type === "workflow";
-                requestState.value = claim.request_state;
-            } else {
-                errorMessage.value = errorMessageAsString(claimError);
-            }
-        }
-    },
-    { immediate: true }
-);
+onMounted(async() => {
+    let claim;
+    let claimError;
+    if (props.public) {
+        const { data, error } = await GalaxyApi().GET("/api/workflow_landings/{uuid}", {
+            params: {
+                path: { uuid: props.uuid },
+            },
+        });
+        claim = data;
+        claimError = error;
+    } else {
+        const { data, error } = await GalaxyApi().POST("/api/workflow_landings/{uuid}/claim", {
+            params: {
+                path: { uuid: props.uuid },
+            },
+            body: {
+                client_secret: props.secret,
+            },
+        });
+        claim = data;
+        claimError = error;
+    }
+    if (claim) {
+        workflowId.value = claim.workflow_id;
+        instance.value = claim.workflow_target_type === "workflow";
+        requestState.value = claim.request_state;
+    } else {
+        errorMessage.value = errorMessageAsString(claimError);
+    }
+    activityStore.closeSideBar();
+});
 </script>
 
 <template>

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -523,6 +523,22 @@ export function getRouter(Galaxy) {
                             public: route.query.public.toLowerCase() === "true",
                             secret: route.query.client_secret,
                         }),
+                        beforeEnter: async (to, from, next) => {
+                            const userStore = useUserStore();
+                            await userStore.loadUser(false);
+                            if (userStore.isAnonymous) {
+                                next({
+                                    path: "/login/start",
+                                    query: {
+                                        redirect: `/workflow_landings/${to.params.uuid}?public=${to.query.public}&client_secret=${to.query.client_secret}`,
+                                    },
+                                });
+                                return;
+                            }
+                            // const activityStore = useActivityStore("default");
+                            // activityStore.closeSideBar();
+                            next();
+                        },
                     },
                     {
                         path: "user",

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -54,6 +54,7 @@ import AdminRoutes from "entry/analysis/routes/admin-routes";
 import LibraryRoutes from "entry/analysis/routes/library-routes";
 import StorageDashboardRoutes from "entry/analysis/routes/storageDashboardRoutes";
 import { getAppRoot } from "onload/loadConfig";
+import { PiniaVuePlugin } from "pinia";
 import Vue from "vue";
 import VueRouter from "vue-router";
 
@@ -62,6 +63,7 @@ import CreateFileSourceInstance from "@/components/FileSources/Instances/CreateI
 import GridHistory from "@/components/Grid/GridHistory";
 import GridPage from "@/components/Grid/GridPage";
 import CreateObjectStoreInstance from "@/components/ObjectStore/Instances/CreateInstance";
+import { useActivityStore } from "@/stores/activityStore";
 import { parseBool } from "@/utils/utils";
 
 import { patchRouterPush } from "./router-push";
@@ -87,6 +89,8 @@ import WorkflowPublished from "@/components/Workflow/Published/WorkflowPublished
 import WorkflowInvocationState from "@/components/WorkflowInvocationState/WorkflowInvocationState.vue";
 
 Vue.use(VueRouter);
+// Load Pinia
+// Vue.use(PiniaVuePlugin);
 
 // patches $router.push() to trigger an event and hide duplication warnings
 patchRouterPush(VueRouter);
@@ -518,6 +522,16 @@ export function getRouter(Galaxy) {
                     {
                         path: "workflow_landings/:uuid",
                         component: WorkflowLanding,
+                        // On this route, we close any open activity panel
+                        beforeEnter: (to, from, next) => {
+                            // We currently only use the default activity store for routing concerns.
+                            const activityStore = useActivityStore("default");
+                            // Toggle the sidebar to close
+                            console.debug("Closing activity panel");
+                            activityStore.toggleSideBar("");
+                            activityStore.closeSideBar();
+                            next();
+                        },
                         props: (route) => ({
                             uuid: route.params.uuid,
                             public: route.query.public.toLowerCase() === "true",

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -62,6 +62,7 @@ import CreateFileSourceInstance from "@/components/FileSources/Instances/CreateI
 import GridHistory from "@/components/Grid/GridHistory";
 import GridPage from "@/components/Grid/GridPage";
 import CreateObjectStoreInstance from "@/components/ObjectStore/Instances/CreateInstance";
+import { useUserStore } from "@/stores/userStore";
 import { parseBool } from "@/utils/utils";
 
 import { patchRouterPush } from "./router-push";
@@ -535,8 +536,6 @@ export function getRouter(Galaxy) {
                                 });
                                 return;
                             }
-                            // const activityStore = useActivityStore("default");
-                            // activityStore.closeSideBar();
                             next();
                         },
                     },

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -54,7 +54,6 @@ import AdminRoutes from "entry/analysis/routes/admin-routes";
 import LibraryRoutes from "entry/analysis/routes/library-routes";
 import StorageDashboardRoutes from "entry/analysis/routes/storageDashboardRoutes";
 import { getAppRoot } from "onload/loadConfig";
-import { PiniaVuePlugin } from "pinia";
 import Vue from "vue";
 import VueRouter from "vue-router";
 
@@ -63,7 +62,6 @@ import CreateFileSourceInstance from "@/components/FileSources/Instances/CreateI
 import GridHistory from "@/components/Grid/GridHistory";
 import GridPage from "@/components/Grid/GridPage";
 import CreateObjectStoreInstance from "@/components/ObjectStore/Instances/CreateInstance";
-import { useActivityStore } from "@/stores/activityStore";
 import { parseBool } from "@/utils/utils";
 
 import { patchRouterPush } from "./router-push";
@@ -89,8 +87,6 @@ import WorkflowPublished from "@/components/Workflow/Published/WorkflowPublished
 import WorkflowInvocationState from "@/components/WorkflowInvocationState/WorkflowInvocationState.vue";
 
 Vue.use(VueRouter);
-// Load Pinia
-// Vue.use(PiniaVuePlugin);
 
 // patches $router.push() to trigger an event and hide duplication warnings
 patchRouterPush(VueRouter);
@@ -522,16 +518,6 @@ export function getRouter(Galaxy) {
                     {
                         path: "workflow_landings/:uuid",
                         component: WorkflowLanding,
-                        // On this route, we close any open activity panel
-                        beforeEnter: (to, from, next) => {
-                            // We currently only use the default activity store for routing concerns.
-                            const activityStore = useActivityStore("default");
-                            // Toggle the sidebar to close
-                            console.debug("Closing activity panel");
-                            activityStore.toggleSideBar("");
-                            activityStore.closeSideBar();
-                            next();
-                        },
                         props: (route) => ({
                             uuid: route.params.uuid,
                             public: route.query.public.toLowerCase() === "true",

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -62,7 +62,7 @@ import CreateFileSourceInstance from "@/components/FileSources/Instances/CreateI
 import GridHistory from "@/components/Grid/GridHistory";
 import GridPage from "@/components/Grid/GridPage";
 import CreateObjectStoreInstance from "@/components/ObjectStore/Instances/CreateInstance";
-import { useUserStore } from "@/stores/userStore";
+import { requireAuth } from "@/router/guards";
 import { parseBool } from "@/utils/utils";
 
 import { patchRouterPush } from "./router-push";
@@ -524,20 +524,7 @@ export function getRouter(Galaxy) {
                             public: route.query.public.toLowerCase() === "true",
                             secret: route.query.client_secret,
                         }),
-                        beforeEnter: async (to, from, next) => {
-                            const userStore = useUserStore();
-                            await userStore.loadUser(false);
-                            if (userStore.isAnonymous) {
-                                next({
-                                    path: "/login/start",
-                                    query: {
-                                        redirect: `/workflow_landings/${to.params.uuid}?public=${to.query.public}&client_secret=${to.query.client_secret}`,
-                                    },
-                                });
-                                return;
-                            }
-                            next();
-                        },
+                        beforeEnter: requireAuth,
                     },
                     {
                         path: "user",

--- a/client/src/router/guards.ts
+++ b/client/src/router/guards.ts
@@ -1,0 +1,19 @@
+import type { NavigationGuardNext, Route } from "vue-router";
+
+import { useUserStore } from "@/stores/userStore";
+
+export async function requireAuth(to: Route, from: Route, next: NavigationGuardNext) {
+    const userStore = useUserStore();
+    await userStore.loadUser(false);
+
+    if (userStore.isAnonymous) {
+        next({
+            path: "/login/start",
+            query: {
+                redirect: to.fullPath,
+            },
+        });
+        return;
+    }
+    next();
+}

--- a/client/src/stores/activityStore.ts
+++ b/client/src/stores/activityStore.ts
@@ -68,6 +68,10 @@ export const useActivityStore = defineScopedStore("activityStore", (scope) => {
         toggledSideBar.value = toggledSideBar.value === currentOpen ? "" : currentOpen;
     }
 
+    function closeSideBar() {
+        toggledSideBar.value = "closed";
+    }
+
     function overrideDefaultActivities(activities: Activity[]) {
         customDefaultActivities.value = activities;
         sync();
@@ -197,6 +201,8 @@ export const useActivityStore = defineScopedStore("activityStore", (scope) => {
     return {
         toggledSideBar,
         toggleSideBar,
+        closeSideBar,
+        isSideBarOpen,
         activities,
         activityMeta,
         metaForId,

--- a/client/src/stores/activityStore.ts
+++ b/client/src/stores/activityStore.ts
@@ -60,6 +60,7 @@ export const useActivityStore = defineScopedStore("activityStore", (scope) => {
 
     const customDefaultActivities = ref<Activity[] | null>(null);
     const currentDefaultActivities = computed(() => customDefaultActivities.value ?? defaultActivities);
+    const isSideBarOpen = computed(() => toggledSideBar.value !== "" && toggledSideBar.value !== "closed");
 
     const toggledSideBar = useUserLocalStorage(`activity-store-current-side-bar-${scope}`, "tools");
 
@@ -130,7 +131,7 @@ export const useActivityStore = defineScopedStore("activityStore", (scope) => {
         activities.value = newActivities;
 
         // if toggled side-bar does not exist, choose the first option
-        if (toggledSideBar.value !== "") {
+        if (isSideBarOpen.value) {
             const allSideBars = activities.value.flatMap((activity) => {
                 if (activity.panel) {
                     return [activity.id];

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -72,7 +72,6 @@ export const useUserStore = defineStore("userStore", () => {
         if (!loadPromise) {
             loadPromise = new Promise<void>((resolve, reject) => {
                 (async () => {
-                    console.debug("Loading once");
                     try {
                         const user = await getCurrentUser();
 

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -70,30 +70,37 @@ export const useUserStore = defineStore("userStore", () => {
 
     function loadUser(includeHistories = true) {
         if (!loadPromise) {
-            loadPromise = getCurrentUser()
-                .then(async (user) => {
-                    if (isRegisteredUser(user)) {
-                        currentUser.value = user;
-                        currentPreferences.value = processUserPreferences(user);
-                    } else if (isAnonymousUser(user)) {
-                        currentUser.value = user;
-                    } else if (user === null) {
-                        currentUser.value = null;
-                    }
+            loadPromise = new Promise<void>((resolve, reject) => {
+                (async () => {
+                    console.debug("Loading once");
+                    try {
+                        const user = await getCurrentUser();
 
-                    if (includeHistories) {
-                        const historyStore = useHistoryStore();
-                        // load first few histories for user to start pagination
-                        await historyStore.loadHistories();
+                        if (isRegisteredUser(user)) {
+                            currentUser.value = user;
+                            currentPreferences.value = processUserPreferences(user);
+                        } else if (isAnonymousUser(user)) {
+                            currentUser.value = user;
+                        } else if (user === null) {
+                            currentUser.value = null;
+                        }
+                        if (includeHistories) {
+                            const historyStore = useHistoryStore();
+                            await historyStore.loadHistories();
+                        }
+                        resolve(); // Resolve the promise after successful load
+                    } catch (e) {
+                        console.error("Failed to load user", e);
+                        reject(e); // Reject the promise on error
+                    } finally {
+                        //Don't clear the loadPromise, we still want multiple callers to await.
+                        //Instead we must clear it upon $reset
+                        // loadPromise = null;
                     }
-                })
-                .catch((e) => {
-                    console.error("Failed to load user", e);
-                })
-                .finally(() => {
-                    loadPromise = null;
-                });
+                })();
+            });
         }
+        return loadPromise; // Return the shared promise
     }
 
     async function setCurrentTheme(theme: string) {

--- a/client/src/stores/workflowLandingStore.ts
+++ b/client/src/stores/workflowLandingStore.ts
@@ -23,7 +23,6 @@ export const useWorkflowLandingStore = defineStore("workflowLanding", () => {
         let claim;
         let claimError;
 
-        console.debug("Claiming workflow");
         if (isPublic) {
             const { data, error } = await GalaxyApi().GET("/api/workflow_landings/{uuid}", {
                 params: {
@@ -46,7 +45,6 @@ export const useWorkflowLandingStore = defineStore("workflowLanding", () => {
         }
 
         if (claim) {
-            console.debug("CLaim!", claim);
             claimState.value = {
                 workflowId: claim.workflow_id,
                 instance: claim.workflow_target_type === "workflow",
@@ -54,7 +52,6 @@ export const useWorkflowLandingStore = defineStore("workflowLanding", () => {
                 errorMessage: null,
             };
         } else {
-            console.debug("Claim error", claimError);
             claimState.value = {
                 workflowId: null,
                 instance: false,

--- a/client/src/stores/workflowLandingStore.ts
+++ b/client/src/stores/workflowLandingStore.ts
@@ -1,0 +1,71 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+
+import { GalaxyApi } from "@/api";
+import { errorMessageAsString } from "@/utils/simple-error";
+
+interface ClaimState {
+    workflowId: string | null;
+    instance: boolean;
+    requestState: Record<string, never> | null;
+    errorMessage: string | null;
+}
+
+export const useWorkflowLandingStore = defineStore("workflowLanding", () => {
+    const claimState = ref<ClaimState>({
+        workflowId: null,
+        instance: false,
+        requestState: null,
+        errorMessage: null,
+    });
+
+    async function claimWorkflow(uuid: string, isPublic: boolean, secret?: string) {
+        let claim;
+        let claimError;
+
+        console.debug("Claiming workflow");
+        if (isPublic) {
+            const { data, error } = await GalaxyApi().GET("/api/workflow_landings/{uuid}", {
+                params: {
+                    path: { uuid },
+                },
+            });
+            claim = data;
+            claimError = error;
+        } else {
+            const { data, error } = await GalaxyApi().POST("/api/workflow_landings/{uuid}/claim", {
+                params: {
+                    path: { uuid },
+                },
+                body: {
+                    client_secret: secret,
+                },
+            });
+            claim = data;
+            claimError = error;
+        }
+
+        if (claim) {
+            console.debug("CLaim!", claim);
+            claimState.value = {
+                workflowId: claim.workflow_id,
+                instance: claim.workflow_target_type === "workflow",
+                requestState: claim.request_state,
+                errorMessage: null,
+            };
+        } else {
+            console.debug("Claim error", claimError);
+            claimState.value = {
+                workflowId: null,
+                instance: false,
+                requestState: null,
+                errorMessage: errorMessageAsString(claimError),
+            };
+        }
+    }
+
+    return {
+        claimState,
+        claimWorkflow,
+    };
+});


### PR DESCRIPTION
Backporting as requested; bugfix (if we squint?) of not showing wrong/default activity bar when hitting a workflow landing claim. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
