### PR TITLE
[24.2] Fix validation of required floats specified as empty strings in tool XML.

### DIFF
--- a/lib/galaxy/tool_util/parameters/factory.py
+++ b/lib/galaxy/tool_util/parameters/factory.py
@@ -138,6 +138,9 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
                 float_value = float(value)
             elif optional:
                 float_value = None
+            elif value == "" or value is None:
+                # See note above for matching integer handling.
+                float_value = None
             else:
                 raise ParameterDefinitionError()
             static_validator_models = static_validators(input_source.parse_validators())

--- a/test/functional/tools/float_default.xml
+++ b/test/functional/tools/float_default.xml
@@ -1,0 +1,33 @@
+<tool id="float_default" name="Test float default" version="0.1.0">
+    <command><![CDATA[
+echo ${float($input1) + float($input2) + float($input3)} > '$out_file1'
+    ]]></command>
+    <inputs>
+        <param name="input1" type="float" value="0.0" label="Float with default 0.0" />
+        <param name="input2" type="float" value="" label="Float with default empty string" />
+        <!-- Not needed any more to have `value=""` when there is no good default -->
+        <param name="input3" type="float" label="Float with no default value" />
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input1" value="1.0" />
+            <param name="input2" value="2.0" />
+            <param name="input3" value="3.0" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="6.0" />
+                </assert_contents>
+            </output>
+        </test>
+        <!-- Test that it fails if a non-optional float param is not set -->
+        <test expect_failure="true">
+            <param name="input1" value="1.0" />
+            <param name="input2" value="2.0" />
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -231,6 +231,7 @@
   <tool file="expect_num_outputs.xml" />
   <tool file="text_repeat.xml" />
   <tool file="integer_default.xml" />
+  <tool file="float_default.xml" />
   <tool file="all_output_types.xml" />
   <tool file="multiple_versions_v01.xml" />
   <tool file="multiple_versions_v01galaxy6.xml" />


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/19678.

To exhibit the problem run the following test with the new tool included here and without the fix. It fails to validate the tool that should be fine.

```
pytest test/unit/tool_util/test_parameter_test_cases.py
```

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
