### PR TITLE
Fix MarkdownDialog types

### DIFF
--- a/client/src/components/DataDialog/DataDialog.vue
+++ b/client/src/components/DataDialog/DataDialog.vue
@@ -44,7 +44,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{
     (e: "onCancel"): void;
-    (e: "onOk", results: Array<Record>): void;
+    (e: "onOk", results: unknown): void;
     (e: "onUpload"): void;
 }>();
 

--- a/client/src/components/Markdown/MarkdownDialog.vue
+++ b/client/src/components/Markdown/MarkdownDialog.vue
@@ -121,7 +121,7 @@ async function getHistories() {
     return data;
 }
 
-function onData(response: string) {
+function onData(response: unknown) {
     dataShow.value = false;
     emit("onInsert", `${props.argumentName}(history_dataset_id=${response})`);
 }

--- a/client/src/components/Markdown/MarkdownDialog.vue
+++ b/client/src/components/Markdown/MarkdownDialog.vue
@@ -252,7 +252,7 @@ if (props.argumentType == "workflow_id") {
             @onOk="onOk"
             @onCancel="onCancel" />
         <MarkdownVisualization
-            v-else-if="visualizationShow"
+            v-else-if="visualizationShow && currentHistoryId !== null"
             :argument-name="argumentName"
             :argument-payload="argumentPayload"
             :labels="effectiveLabels"
@@ -260,9 +260,14 @@ if (props.argumentType == "workflow_id") {
             :history="currentHistoryId"
             @onOk="onVisualization"
             @onCancel="onCancel" />
-        <DataDialog v-else-if="dataShow" :history="currentHistoryId" format="id" @onOk="onData" @onCancel="onCancel" />
+        <DataDialog
+            v-else-if="dataShow && currentHistoryId !== null"
+            :history="currentHistoryId"
+            format="id"
+            @onOk="onData"
+            @onCancel="onCancel" />
         <DatasetCollectionDialog
-            v-else-if="dataCollectionShow"
+            v-else-if="dataCollectionShow && currentHistoryId !== null"
             :history="currentHistoryId"
             format="id"
             @onOk="onDataCollection"

--- a/client/src/components/Markdown/MarkdownDialog.vue
+++ b/client/src/components/Markdown/MarkdownDialog.vue
@@ -29,6 +29,7 @@ const props = withDefaults(defineProps<MarkdownDialogProps>(), {
     argumentName: undefined,
     argumentType: undefined,
     argumentPayload: undefined,
+    labels: undefined,
 });
 
 const emit = defineEmits<{


### PR DESCRIPTION
Fixes #19692

This is the easy fix. The real issue is here:

https://github.com/galaxyproject/galaxy/blob/3f01d5b5c3f3323b05a42ac4c43e7fd59afec274/client/src/components/DataDialog/model.js#L36

So the type defined in the event was incorrect:

https://github.com/galaxyproject/galaxy/blob/3f01d5b5c3f3323b05a42ac4c43e7fd59afec274/client/src/components/DataDialog/DataDialog.vue#L47

The values returned depend on the `format` prop so the real type is certainly `unknown`.

We could still try to convert `components/DataDialog/model.js` to Typescript and try to do some Typescript black magic to define the proper type... react to this PR with:
- :+1: if you think this is enough as a fix
- or :rocket: if I should try to convert the file and use forbidden black magic

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
