### PR TITLE
Move RequiredAppT back into galaxy packages.

### DIFF
--- a/lib/galaxy/structured_app.py
+++ b/lib/galaxy/structured_app.py
@@ -76,6 +76,7 @@ class BasicSharedApp(Container):
     auth_manager: AuthManager
     security_agent: Any
     quota_agent: QuotaAgent
+    tool_data_tables: "ToolDataTableManager"
 
     @property
     def toolbox(self) -> "ToolBox":
@@ -112,7 +113,6 @@ class MinimalManagerApp(MinimalApp):
     genome_builds: GenomeBuilds
     geographical_server_location_name: str
     dataset_collection_manager: "DatasetCollectionManager"
-    tool_data_tables: "ToolDataTableManager"
     history_manager: "HistoryManager"
     hda_manager: "HDAManager"
     workflow_manager: "WorkflowsManager"

--- a/lib/galaxy/tool_shed/tools/data_table_manager.py
+++ b/lib/galaxy/tool_shed/tools/data_table_manager.py
@@ -4,6 +4,7 @@ import shutil
 from typing import (
     List,
     TYPE_CHECKING,
+    Union,
 )
 
 from galaxy.tool_shed.galaxy_install.client import InstallationTarget
@@ -16,14 +17,17 @@ from galaxy.util.tool_shed import xml_util
 
 if TYPE_CHECKING:
     from galaxy.model.tool_shed_install import ToolShedRepository
+    from galaxy.structured_app import BasicSharedApp
     from galaxy.util.path import StrPath
-    from tool_shed.structured_app import RequiredAppT
 
 log = logging.getLogger(__name__)
 
 
+RequiredAppT = Union["BasicSharedApp", InstallationTarget]
+
+
 class BaseShedToolDataTableManager:
-    def __init__(self, app: "RequiredAppT"):
+    def __init__(self, app: RequiredAppT):
         self.app = app
 
     def handle_sample_tool_data_table_conf_file(self, filename: "StrPath", persist: bool = False):

--- a/lib/galaxy/tool_shed/tools/tool_validator.py
+++ b/lib/galaxy/tool_shed/tools/tool_validator.py
@@ -1,7 +1,9 @@
 import logging
-from typing import TYPE_CHECKING
 
-from galaxy.tool_shed.tools.data_table_manager import BaseShedToolDataTableManager
+from galaxy.tool_shed.tools.data_table_manager import (
+    BaseShedToolDataTableManager,
+    RequiredAppT,
+)
 from galaxy.tool_shed.util import (
     basic_util,
     hg_util,
@@ -14,14 +16,11 @@ from galaxy.tools import (
 )
 from galaxy.tools.parameters import dynamic_options
 
-if TYPE_CHECKING:
-    from tool_shed.structured_app import RequiredAppT
-
 log = logging.getLogger(__name__)
 
 
 class ToolValidator:
-    def __init__(self, app: "RequiredAppT"):
+    def __init__(self, app: RequiredAppT):
         self.app = app
         self.stdtm = BaseShedToolDataTableManager(self.app)
 

--- a/lib/galaxy/tool_shed/util/repository_util.py
+++ b/lib/galaxy/tool_shed/util/repository_util.py
@@ -34,7 +34,7 @@ from galaxy.util.tool_shed.tool_shed_registry import Registry
 
 if TYPE_CHECKING:
     from galaxy.tool_shed.galaxy_install.client import InstallationTarget
-    from tool_shed.structured_app import RequiredAppT
+    from galaxy.tool_shed.tools.data_table_manager import RequiredAppT
 
 log = logging.getLogger(__name__)
 

--- a/lib/tool_shed/structured_app.py
+++ b/lib/tool_shed/structured_app.py
@@ -1,12 +1,8 @@
-from typing import (
-    TYPE_CHECKING,
-    Union,
-)
+from typing import TYPE_CHECKING
 
 from galaxy.structured_app import BasicSharedApp
 
 if TYPE_CHECKING:
-    from galaxy.tool_shed.galaxy_install.client import InstallationTarget
     from galaxy.tools.data import ToolDataTableManager
     from tool_shed.managers.model_cache import ModelCache
     from tool_shed.repository_registry import RegistryInterface
@@ -24,6 +20,3 @@ class ToolShedApp(BasicSharedApp):
     security_agent: "CommunityRBACAgent"
     model_cache: "ModelCache"
     tool_data_tables: "ToolDataTableManager"
-
-
-RequiredAppT = Union[ToolShedApp, "InstallationTarget"]


### PR DESCRIPTION
Follow up from #19642. I'm trying to get all the Galaxy type annotations to only use Galaxy code.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
