### PR TITLE
Update TypeScript version to 5.7.3

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -203,7 +203,7 @@
     "ts-jest": "^29.2.3",
     "ts-loader": "^9.5.0",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
-    "typescript": "^5.2.2",
+    "typescript": "^5.7.3",
     "vue-loader": "^15.11.1",
     "vue-template-compiler": "^2.7.14",
     "webpack": "^5.89.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -11707,10 +11707,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
-  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+typescript@^5.7.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
+  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Checking if everything works... so far, in my local setup, it seems to work fine.

I don't know if someone else was experiencing constant crashes of the Typescript Language Server when developing. For me, it was working for some minutes and then crashed with:

```
Error: <syntax> TypeScript Server Error (5.2.2)
Debug Failure. False expression.
Error: Debug Failure. False expression.
```

And I need to reload it so it works again. I thought it was VSCode acting up, but updating the Typescript version in my local branch fixed the problem, and I haven't had any issues since then.

Has anyone had the same problem?

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
