### PR TITLE
Augments popper wrapper, add click and escape handler

### DIFF
--- a/client/src/components/Popper/Popper.vue
+++ b/client/src/components/Popper/Popper.vue
@@ -3,7 +3,7 @@
         <span v-if="!referenceEl" ref="reference">
             <slot name="reference" />
         </span>
-        <div v-show="visible" ref="popper" class="popper-element mt-1" :class="`popper-element-${mode}`">
+        <div v-show="!disabled && visible" ref="popper" class="popper-element" :class="`popper-element-${mode}`">
             <div v-if="arrow" class="popper-arrow" data-popper-arrow />
             <div v-if="title" class="popper-header px-2 py-1 rounded-top d-flex justify-content-between">
                 <span class="px-1">{{ title }}</span>
@@ -22,7 +22,7 @@ import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { type Placement } from "@popperjs/core";
 import type { PropType } from "vue";
-import { ref, watch } from "vue";
+import { ref } from "vue";
 
 import { type Trigger, usePopper } from "./usePopper";
 
@@ -39,22 +39,13 @@ const props = defineProps({
 });
 
 const reference = props.referenceEl ? ref(props.referenceEl) : ref();
+
 const popper = ref();
 
 const { visible } = usePopper(reference, popper, {
     placement: props.placement,
     trigger: props.trigger,
 });
-
-watch(
-    () => [visible.value, props.disabled],
-    () => {
-        if (props.disabled && visible.value) {
-            visible.value = false;
-        }
-    },
-    { flush: "sync" }
-);
 
 defineExpose({
     visible,
@@ -82,20 +73,12 @@ defineExpose({
     color: $brand-light;
     max-width: 12rem;
     opacity: 0.95;
-    .popper-arrow:before {
-        background: $brand-dark;
-        border: popper-border($brand-dark);
-    }
 }
 
 .popper-element-light {
     background: $white;
     border: popper-border($border-color);
     color: $brand-dark;
-    .popper-arrow:before {
-        background: $white;
-        border: popper-border($border-color);
-    }
 }
 
 .popper-element-primary-title {
@@ -106,63 +89,46 @@ defineExpose({
         background: $brand-primary;
         color: $white;
     }
-    .popper-arrow:before {
-        background: $brand-primary;
-        border: popper-border($border-color);
-    }
 }
 
-/** Arrow positioning and border handling */
-.popper-arrow,
-.popper-arrow:before {
-    height: 9px;
-    width: 9px;
+/** Triangle Arrow */
+.popper-arrow {
     position: absolute;
-    content: "";
-    transform: rotate(45deg);
+    width: 0;
+    height: 0;
+    border-style: solid;
 }
 
-.popper-element[data-popper-placement^="top"] {
-    > .popper-arrow {
-        bottom: 0px;
-    }
-    > .popper-arrow:before {
-        bottom: -5px;
-        border-top: none;
-        border-left: none;
-    }
+/** Arrow positioning based on placement */
+.popper-element[data-popper-placement^="top"] > .popper-arrow {
+    bottom: -14px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 7px;
+    border-color: $brand-dark transparent transparent transparent;
 }
 
-.popper-element[data-popper-placement^="right"] {
-    > .popper-arrow {
-        left: 0px;
-    }
-    > .popper-arrow:before {
-        left: -5px;
-        border-top: none;
-        border-right: none;
-    }
+.popper-element[data-popper-placement^="bottom"] > .popper-arrow {
+    top: -14px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 7px;
+    border-color: transparent transparent $brand-dark transparent;
 }
 
-.popper-element[data-popper-placement^="bottom"] {
-    > .popper-arrow {
-        top: 0px;
-    }
-    > .popper-arrow:before {
-        top: -5px;
-        border-bottom: none;
-        border-right: none;
-    }
+.popper-element[data-popper-placement^="left"] > .popper-arrow {
+    right: -14px;
+    top: 50%;
+    transform: translateY(-50%);
+    border-width: 7px;
+    border-color: transparent transparent transparent $brand-dark;
 }
 
-.popper-element[data-popper-placement^="left"] {
-    > .popper-arrow {
-        right: 0px;
-    }
-    > .popper-arrow:before {
-        right: -5px;
-        border-bottom: none;
-        border-left: none;
-    }
+.popper-element[data-popper-placement^="right"] > .popper-arrow {
+    left: -14px;
+    top: 50%;
+    transform: translateY(-50%);
+    border-width: 7px;
+    border-color: transparent $brand-dark transparent transparent;
 }
 </style>

--- a/client/src/components/Popper/usePopper.test.js
+++ b/client/src/components/Popper/usePopper.test.js
@@ -45,6 +45,14 @@ describe("usePopper", () => {
         createTestComponent();
         expect(createPopper).toHaveBeenCalledWith(referenceElement, popperElement, {
             placement: "bottom",
+            modifiers: [
+                {
+                    name: "offset",
+                    options: {
+                        offset: [0, 5],
+                    },
+                },
+            ],
             strategy: "absolute",
         });
     });

--- a/client/src/components/Popper/usePopper.ts
+++ b/client/src/components/Popper/usePopper.ts
@@ -16,8 +16,20 @@ export function usePopper(
 
     const doOpen = () => (visible.value = true);
     const doClose = () => (visible.value = false);
-    const doCloseForDocument = (e: Event) => {
+    const doCloseDocument = (e: Event) => {
         if (!reference.value?.contains(e.target as Node) && !popper.value?.contains(e.target as Node)) {
+            visible.value = false;
+        }
+    };
+    const doCloseElement = (event: Event) => {
+        const target = event.target as Element;
+        if (target && target.closest(".popper-close")) {
+            doClose();
+        }
+    };
+    const doCloseEscape = (event: Event) => {
+        const keyboardEvent = event as KeyboardEvent;
+        if (keyboardEvent.key === "Escape") {
             visible.value = false;
         }
     };
@@ -31,12 +43,22 @@ export function usePopper(
         instance.value = createPopper(reference.value, popper.value, {
             placement: options.placement ?? "bottom",
             strategy: "absolute",
+            modifiers: [
+                {
+                    name: "offset",
+                    options: {
+                        offset: [0, 5],
+                    },
+                },
+            ],
         });
 
         const trigger = options.trigger ?? defaultTrigger;
         if (trigger === "click") {
             addEventListener(reference.value, "click", doOpen);
-            addEventListener(document, "click", doCloseForDocument);
+            addEventListener(popper.value, "click", doCloseElement);
+            addEventListener(document, "click", doCloseDocument);
+            addEventListener(document, "keydown", doCloseEscape);
         } else if (trigger === "hover") {
             addEventListener(reference.value, "mouseover", doOpen);
             addEventListener(reference.value, "mouseout", doClose);


### PR DESCRIPTION
This PR augments the popper wrapper by adding click and escape handlers. It also replaces the arrow, previously the arrow sometimes overlapped, see e.g.

Before:
<img width="245" alt="Screenshot 2025-02-27 at 12 23 34 PM" src="https://github.com/user-attachments/assets/6c314813-896d-4156-8a25-9b958fae1572" />

After:
<img width="245" alt="Screenshot 2025-02-27 at 12 23 27 PM" src="https://github.com/user-attachments/assets/3fd10815-15be-4809-a74f-3115f6846375" />

This PR has been extracted from: #19226.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
