### PR TITLE
Rucio templates

### DIFF
--- a/client/src/api/objectStores.templates.ts
+++ b/client/src/api/objectStores.templates.ts
@@ -39,6 +39,10 @@ export const objectStoreTemplateTypes: ObjectStoreTemplateType = {
         icon: faNetworkWired,
         message: typeMessage("Onedata"),
     },
+    rucio: {
+        icon: faNetworkWired,
+        message: typeMessage("Rucio"),
+    },
 };
 
 export const ObjectStoreValidFilters = {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -14877,7 +14877,7 @@ export interface components {
              * Type
              * @enum {string}
              */
-            type: "aws_s3" | "azure_blob" | "boto3" | "disk" | "generic_s3" | "onedata";
+            type: "aws_s3" | "azure_blob" | "boto3" | "disk" | "generic_s3" | "onedata" | "rucio";
             /** Variables */
             variables?:
                 | (
@@ -17799,7 +17799,7 @@ export interface components {
              * Type
              * @enum {string}
              */
-            type: "aws_s3" | "azure_blob" | "boto3" | "disk" | "generic_s3" | "onedata";
+            type: "aws_s3" | "azure_blob" | "boto3" | "disk" | "generic_s3" | "onedata" | "rucio";
             /**
              * Uuid
              * Format: uuid4

--- a/client/src/components/ObjectStore/ObjectStoreTypeSpan.vue
+++ b/client/src/components/ObjectStore/ObjectStoreTypeSpan.vue
@@ -12,6 +12,7 @@ const MESSAGES = {
     generic_s3:
         "This is a storage location based on the Amazon Simple Storage Service (S3) interface, but likely not stored by Amazon. The AWS interface has become an industry standard and many storage vendors support it and use it to expose object based storage.",
     onedata: "This is a storage location based on the Onedata system.",
+    rucio: "This is a storage location based on the RUCIO system https://rucio.cern.ch/.",
 };
 
 interface Props {

--- a/lib/galaxy/objectstore/examples/rucio_distributed.yml
+++ b/lib/galaxy/objectstore/examples/rucio_distributed.yml
@@ -20,8 +20,8 @@ backends:
     download_schemes:
       - rse: TEST
         scheme: file
-        ignore_checksum: False
+        ignore_checksum: false
     cache:
       path: database/object_store_cache_rucio
       size: 1000
-      cache_updated_data: True
+      cache_updated_data: true

--- a/lib/galaxy/objectstore/examples/rucio_distributed.yml
+++ b/lib/galaxy/objectstore/examples/rucio_distributed.yml
@@ -1,0 +1,27 @@
+type: distributed
+backends:
+  - id: default
+    type: rucio
+    weight: 1
+    allow_selection: true
+    name: Rucio Object Storage
+    description: >
+      This is Galaxy's object store using Rucio
+    upload_rse_name: TEST
+    upload_scheme: file
+    scope: galaxy
+    account: root
+    auth_host: http://127.0.0.1:9000
+    username: rucio
+    password: rucio
+    auth_type: userpass
+    host: http://127.0.0.1:9000
+    register_only: false
+    download_schemes:
+      - rse: TEST
+        scheme: file
+        ignore_checksum: False
+    cache:
+      path: database/object_store_cache_rucio
+      size: 1000
+      cache_updated_data: True

--- a/lib/galaxy/objectstore/rucio.py
+++ b/lib/galaxy/objectstore/rucio.py
@@ -313,7 +313,7 @@ class RucioObjectStore(CachingConcreteObjectStore):
 
     def to_dict(self):
         rval = super().to_dict()
-        rval["rucio"] = self.rucio_config
+        rval.update(self.rucio_config)
         rval["cache"] = self.cache_config
         rval["oidc_providers"] = self.oidc_providers
         rval["enable_cache_monitor"] = self.enable_cache_monitor

--- a/lib/galaxy/objectstore/rucio.py
+++ b/lib/galaxy/objectstore/rucio.py
@@ -75,15 +75,19 @@ def parse_config_xml(config_xml):
         extra_dirs = [{k: e.get(k) for k in attrs} for e in e_xml]
 
         attrs_schemes = ("rse", "scheme", "ignore_checksum")
-        e_xml = config_xml.findall("rucio_download_scheme")
+        e_xml = config_xml.findall("download_scheme")
         rucio_download_schemes = []
         if e_xml:
             rucio_download_schemes = [{k: e.get(k) for k in attrs_schemes} for e in e_xml]
 
-        oidc_provider = config_xml.findtext("oidc_provider", None)
+        oidc_providers = []
+        e_xml = config_xml.findall("oidc_provider")
+        if e_xml:
+            oidc_providers = [e.text for e in e_xml]
+
         enable_cache_mon = string_as_bool(config_xml.findtext("enable_cache_monitor", "False"))
 
-        e_xml = config_xml.findall("rucio_upload_scheme")
+        e_xml = config_xml.findall("upload_scheme")
         if e_xml:
             rucio_upload_rse_name = e_xml[0].get("rse", None)
             rucio_upload_scheme = e_xml[0].get("scheme", None)
@@ -94,20 +98,19 @@ def parse_config_xml(config_xml):
             rucio_upload_scheme = None
             rucio_scope = None
             rucio_register_only = False
-            oidc_provider = None
 
-        e_xml = config_xml.findall("rucio_auth")
+        e_xml = config_xml.findall("auth")
         if not e_xml:
-            _config_xml_error("rucio_auth")
+            _config_xml_error("auth")
         rucio_account = e_xml[0].get("account", None)
         rucio_auth_host = e_xml[0].get("host", None)
         rucio_username = e_xml[0].get("username", None)
         rucio_password = e_xml[0].get("password", None)
         rucio_auth_type = e_xml[0].get("type", "userpass")
 
-        e_xml = config_xml.findall("rucio_connection")
+        e_xml = config_xml.findall("connection")
         if not e_xml:
-            _config_xml_error("rucio_connection")
+            _config_xml_error("connection")
         rucio_host = e_xml[0].get("host", None)
 
         rucio_dict = {
@@ -126,9 +129,9 @@ def parse_config_xml(config_xml):
 
         return {
             "cache": cache_dict,
-            "rucio": rucio_dict,
+            **rucio_dict,
             "extra_dirs": extra_dirs,
-            "oidc_provider": oidc_provider,
+            "oidc_providers": oidc_providers,
             "enable_cache_monitor": enable_cache_mon,
         }
     except Exception:
@@ -255,7 +258,15 @@ username = {self.config['username']}
                 }
             items = [item]
             download_client = self.get_rucio_download_client(auth_token=auth_token)
-            download_client.download_dids(items)
+            res = download_client.download_dids(items)
+            try:
+                os.replace(res[0]["dest_file_paths"][0], dest_path)
+            except Exception as e:
+                if os.path.exists(dest_path):
+                    log.debug(f"File was already downloaded")
+                else:
+                    log.exception(f"Cannot download file: {str(e)}")
+                    return False
         except Exception as e:
             log.exception(f"Cannot download file: {str(e)}")
             return False
@@ -304,15 +315,15 @@ class RucioObjectStore(CachingConcreteObjectStore):
         rval = super().to_dict()
         rval["rucio"] = self.rucio_config
         rval["cache"] = self.cache_config
-        rval["oidc_provider"] = self.oidc_provider
+        rval["oidc_providers"] = self.oidc_providers
         rval["enable_cache_monitor"] = self.enable_cache_monitor
         return rval
 
     def __init__(self, config, config_dict):
         super().__init__(config, config_dict)
-        self.rucio_config = config_dict.get("rucio") or {}
+        self.rucio_config = config_dict or {}
 
-        self.oidc_provider = config_dict.get("oidc_provider", None)
+        self.oidc_providers = config_dict.get("oidc_providers", None)
         self.rucio_broker = RucioBroker(self)
         cache_dict = config_dict.get("cache") or {}
         self.enable_cache_monitor, self.cache_monitor_interval = enable_cache_monitor(config, config_dict)
@@ -324,7 +335,8 @@ class RucioObjectStore(CachingConcreteObjectStore):
         self._initialize()
 
     def _initialize(self):
-        self._ensure_staging_path_writable()
+        if not self.rucio_config["register_only"]:
+            self._ensure_staging_path_writable()
         self._start_cache_monitor_if_needed()
 
     def _pull_into_cache(self, rel_path, **kwargs) -> bool:
@@ -470,9 +482,11 @@ class RucioObjectStore(CachingConcreteObjectStore):
                 user = trans.user
             else:
                 user = arg_user
-            backend = provider_name_to_backend(self.oidc_provider)
-            tokens = user.get_oidc_tokens(backend)
-            return tokens["id"]
+            for oidc_provider in self.oidc_providers:
+                backend = provider_name_to_backend(oidc_provider)
+                tokens = user.get_oidc_tokens(backend)
+                if tokens["id"]:
+                    return tokens["id"]
         except Exception as e:
             log.debug("Failed to get auth token: %s", e)
             return None

--- a/lib/galaxy/objectstore/rucio.py
+++ b/lib/galaxy/objectstore/rucio.py
@@ -263,7 +263,7 @@ username = {self.config['username']}
                 os.replace(res[0]["dest_file_paths"][0], dest_path)
             except Exception as e:
                 if os.path.exists(dest_path):
-                    log.debug(f"File was already downloaded")
+                    log.debug("File was already downloaded")
                 else:
                     log.exception(f"Cannot download file: {str(e)}")
                     return False

--- a/lib/galaxy/objectstore/templates/examples/rucio.yml
+++ b/lib/galaxy/objectstore/templates/examples/rucio.yml
@@ -1,0 +1,42 @@
+- id: rucio
+  version: 0
+  name: Rucio Storage
+  description: |
+    Rucio manages large volumes of data spread across facilities at multiple institutions and organisations.
+    More information on Rucio can be found in [Rucio's official site](https://rucio.cern.ch/). Currently supported only
+    userpass authentication type.
+  variables:
+    rse:
+      label: RSE Name
+      type: string
+      help: |
+        Name of the primary RSE for data upload
+    host:
+      label: Rucio Host
+      type: string
+      help: |
+        URL of Rucio host
+    account:
+      label: Rucio Account
+      type: string
+      help: |
+        Rucio account
+  secrets:
+    username:
+      label: User Name
+      help: |
+        Username
+    userpass:
+      label: User Password
+      help: |
+        Password of the user specified in username
+  configuration:
+    type: rucio
+    upload_rse_name: "{{ variables.rse }}"
+    scope: galaxy
+    account: "{{ variables.account }}"
+    auth_host: "{{ variables.host }}"
+    username: "{{ secrets.username }}"
+    password: "{{ secrets.userpass }}"
+    auth_type: userpass
+    host: "{{ variables.host }}"

--- a/lib/galaxy/objectstore/templates/models.py
+++ b/lib/galaxy/objectstore/templates/models.py
@@ -7,6 +7,15 @@ from typing import (
     Union,
 )
 
+from pydantic import (
+    Field,
+    RootModel,
+)
+from typing_extensions import (
+    Annotated,
+    Literal,
+)
+
 from galaxy.objectstore.badges import (
     BadgeDict,
     StoredBadgeDict,
@@ -27,14 +36,6 @@ from galaxy.util.config_templates import (
     TemplateVariableType,
     TemplateVariableValueType,
     UserDetailsDict,
-)
-from pydantic import (
-    Field,
-    RootModel,
-)
-from typing_extensions import (
-    Annotated,
-    Literal,
 )
 
 ObjectStoreTemplateVariableType = TemplateVariableType
@@ -280,6 +281,7 @@ class OnedataAuthTemplate(StrictModel):
 class OnedataAuth(StrictModel):
     access_token: str
 
+
 class OnedataConnectionTemplate(StrictModel):
     onezone_domain: Union[str, TemplateExpansion]
     disable_tls_certificate_validation: Union[bool, TemplateExpansion] = False
@@ -327,11 +329,11 @@ class RucioObjectStoreTemplateConfiguration(StrictModel):
     auth_host: str
     host: str
     auth_type: str
-    account: str
-    username: str
-    password: str
+    account: Union[str, TemplateExpansion]
+    username: Union[str, TemplateExpansion]
+    password: Union[str, TemplateExpansion]
     badges: BadgeList = None
-    register_only: bool = False
+    register_only: Optional[bool] = False
     template_start: Optional[str] = None
     template_end: Optional[str] = None
 
@@ -342,7 +344,7 @@ class RucioObjectStoreConfiguration(StrictModel):
     upload_rse_name: str
     upload_scheme: Optional[Any] = None
     download_schemes: Optional[Any] = None
-    register_only: bool = False
+    register_only: Optional[bool] = False
     auth_host: str
     host: str
     auth_type: str
@@ -427,12 +429,12 @@ class ObjectStoreTemplateSummaries(RootModel):
 
 
 def template_to_configuration(
-        template: ObjectStoreTemplate,
-        variables: Dict[str, ObjectStoreTemplateVariableValueType],
-        secrets: SecretsDict,
-        user_details: UserDetailsDict,
-        environment: EnvironmentDict,
-        implicit: Optional[ImplicitConfigurationParameters] = None,
+    template: ObjectStoreTemplate,
+    variables: Dict[str, ObjectStoreTemplateVariableValueType],
+    secrets: SecretsDict,
+    user_details: UserDetailsDict,
+    environment: EnvironmentDict,
+    implicit: Optional[ImplicitConfigurationParameters] = None,
 ) -> ObjectStoreConfiguration:
     configuration_template = template.configuration
     populate_default_variables(template.variables, variables)

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -38,7 +38,7 @@ RUCIO_OBJECT_STORE_CONFIG = string.Template(
     upload_rse_name: ${rucio_rse}
     upload_scheme: file
     register_only: false
-    download_schemes: 
+    download_schemes:
     scope: galaxy
     host: http://${host}:${port}
     account: ${rucio_account}

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -39,6 +39,9 @@ RUCIO_OBJECT_STORE_CONFIG = string.Template(
     upload_scheme: file
     register_only: false
     download_schemes:
+      - rse: ${rucio_rse}
+        scheme: file
+        ignore_checksum: false
     scope: galaxy
     host: http://${host}:${port}
     account: ${rucio_account}

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -34,15 +34,22 @@ OBJECT_STORE_CONFIG = string.Template(
 )
 RUCIO_OBJECT_STORE_CONFIG = string.Template(
     """
-<object_store type="rucio">
-    <rucio_auth account="${rucio_account}" host="http://${host}:${port}" username="${rucio_username}" password="${rucio_password}" type="userpass" />
-    <rucio_connection host="http://${host}:${port}"/>
-    <rucio_upload_scheme rse="${rucio_rse}" scheme="file" scope="galaxy"/>
-    <rucio_download_scheme rse="${rucio_rse}" scheme="file"/>
-    <cache path="${temp_directory}/object_store_cache" size="1000" cache_updated_data="${cache_updated_data}" />
-    <extra_dir type="job_work" path="${temp_directory}/job_working_directory_rucio"/>
-    <extra_dir type="temp" path="${temp_directory}"/>
-</object_store>
+    type: rucio
+    upload_rse_name: ${rucio_rse}
+    upload_scheme: file
+    register_only: false
+    download_schemes: 
+    scope: galaxy
+    host: http://${host}:${port}
+    account: ${rucio_account}
+    auth_host: http://${host}:${port}
+    username: ${rucio_username}
+    password: ${rucio_password}
+    auth_type: userpass
+    cache:
+      path: ${temp_directory}/object_store_cache
+      size: 1000
+      cache_updated_data: ${cache_updated_data}
 """
 )
 AZURE_OBJECT_STORE_CONFIG = string.Template(
@@ -257,7 +264,7 @@ class BaseRucioObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase
         temp_directory = cls._test_driver.mkdtemp()
         cls.object_stores_parent = temp_directory
         cls.object_store_cache_path = f"{temp_directory}/object_store_cache"
-        config_path = os.path.join(temp_directory, "object_store_conf.xml")
+        config_path = os.path.join(temp_directory, "object_store_conf.yml")
         config["object_store_store_by"] = "uuid"
         config["metadata_strategy"] = "extended"
         config["outputs_to_working_directory"] = True


### PR DESCRIPTION
Adding Rucio object store templates, addressing https://github.com/galaxyproject/galaxy/issues/18318. Also some refactoring/bug fixes. 

The template only support userpass authentication and limited configuration options. Rucio is huge, so one would have to update/add the template for specific Rucio instance.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
