### PR TITLE
[24.2] Fix conditional dependency path resolution

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -309,7 +309,7 @@ class BaseAppConfiguration(HasDynamicProperties):
 
     def _set_config_base(self, config_kwargs):
         def _set_global_conf():
-            self.config_file = config_kwargs.get("__file__", None)
+            self.config_file = config_kwargs.get("__file__") or config_kwargs.get("config_file")
             self.global_conf = config_kwargs.get("global_conf")
             self.global_conf_parser = configparser.ConfigParser()
             if not self.config_file and self.global_conf and "__file__" in self.global_conf:

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -42,7 +42,7 @@ class ConditionalDependencies:
             self.config = load_app_properties(config_file=self.config_file)
         else:
             self.config = config
-        self.config_object = GalaxyAppConfiguration(config_file=self.config_file, **self.config)
+        self.config_object = GalaxyAppConfiguration(config_file=self.config_file, override_tempdir=False, **self.config)
         self.parse_configs()
         self.get_conditional_requirements()
 

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -42,7 +42,7 @@ class ConditionalDependencies:
             self.config = load_app_properties(config_file=self.config_file)
         else:
             self.config = config
-        self.config_object = GalaxyAppConfiguration(**self.config)
+        self.config_object = GalaxyAppConfiguration(config_file=self.config_file, **self.config)
         self.parse_configs()
         self.get_conditional_requirements()
 


### PR DESCRIPTION
The path resolution logic was not correct. A relative path within galaxy.yml is relative to the config directory. To fix this we now rely on GalaxyAppConfiguration which is what Galaxy uses to determine config values and do path resolution (and also respects things like env vars).

I noticed this when I added a file source and the conditional depdency logic would not attempt to install the correctly defined conditional dependency. I did have `file_sources_config_file` set in my galaxy config. This would have only worked if I left that setting undefined and we correctly joined the path with the config dir or if I had set an absolute path.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
