### PR TITLE
[24.2] Allow tool state changes in refactor actions

### DIFF
--- a/client/src/components/Workflow/workflows.services.ts
+++ b/client/src/components/Workflow/workflows.services.ts
@@ -56,7 +56,7 @@ export async function updateWorkflow(id: string, changes: object): Promise<Workf
     return data;
 }
 
-export async function copyWorkflow(id: string, currentOwner: string, version?: string): Promise<Workflow> {
+export async function copyWorkflow(id: string, currentOwner?: string, version?: string): Promise<Workflow> {
     let path = `/api/workflows/${id}/download`;
     if (version) {
         path += `?version=${version}`;

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1983,7 +1983,7 @@ class WorkflowContentsManager(UsesAnnotations):
             dry_run=refactor_request.dry_run,
         )
 
-        module_injector = WorkflowModuleInjector(trans)
+        module_injector = WorkflowModuleInjector(trans, allow_tool_state_corrections=True)
         refactor_executor = WorkflowRefactorExecutor(raw_workflow_description, workflow, module_injector)
         action_executions = refactor_executor.refactor(refactor_request)
         refactored_workflow, errors = self.update_workflow_from_raw_description(

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -322,9 +322,14 @@ class WorkflowModule:
         the step.
         """
         if inputs := self.get_inputs():
-            return self.state.encode(Bunch(inputs=inputs), self.trans.app, nested=nested)
-        else:
-            return self.state.inputs
+            try:
+                return self.state.encode(Bunch(inputs=inputs), self.trans.app, nested=nested)
+            except ValueError:
+                log.warning("Tool state invalid for workflow module", exc_info=True)
+                # Always preferable to save unmodified and continue, I think ... we're explicit about alterations when retrieving any workflow,
+                # and it is what we do if we don't have the tool installed (assuming this is a tool).
+                pass
+        return self.state.inputs
 
     def get_export_state(self):
         return self.get_state(nested=True)
@@ -2613,7 +2618,7 @@ class WorkflowModuleInjector:
         self.trans = trans
         self.allow_tool_state_corrections = allow_tool_state_corrections
 
-    def inject(self, step: WorkflowStep, step_args=None, steps=None, **kwargs):
+    def inject(self, step: WorkflowStep, step_args=None, steps=None, allow_tool_state_corrections=False, **kwargs):
         """Pre-condition: `step` is an ORM object coming from the database, if
         supplied `step_args` is the representation of the inputs for that step
         supplied via web form.
@@ -2646,7 +2651,12 @@ class WorkflowModuleInjector:
 
             subworkflow = step.subworkflow
             assert subworkflow
-            populate_module_and_state(self.trans, subworkflow, param_map=unjsonified_subworkflow_param_map)
+            populate_module_and_state(
+                self.trans,
+                subworkflow,
+                param_map=unjsonified_subworkflow_param_map,
+                allow_tool_state_corrections=allow_tool_state_corrections,
+            )
 
     def inject_all(self, workflow: Workflow, param_map=None, ignore_tool_missing_exception=False, **kwargs):
         param_map = param_map or {}

--- a/lib/galaxy/workflow/refactor/execute.py
+++ b/lib/galaxy/workflow/refactor/execute.py
@@ -42,19 +42,26 @@ from .schema import (
     UpgradeSubworkflowAction,
     UpgradeToolAction,
 )
-from ..modules import InputParameterModule
+from ..modules import (
+    InputParameterModule,
+    WorkflowModuleInjector,
+)
 
 log = logging.getLogger(__name__)
 
 
 class WorkflowRefactorExecutor:
-    def __init__(self, raw_workflow_description, workflow, module_injector):
+    def __init__(self, raw_workflow_description, workflow, module_injector: WorkflowModuleInjector):
         # we mostly use the ga representation, but there may be cases where the
         # models/modules of existing workflow are more usable.
         self.raw_workflow_description = raw_workflow_description
         self.workflow = workflow
         self.module_injector = module_injector
-        self.module_injector.inject_all(workflow, ignore_tool_missing_exception=True)
+        self.module_injector.inject_all(
+            workflow,
+            ignore_tool_missing_exception=True,
+            allow_tool_state_corrections=module_injector.allow_tool_state_corrections,
+        )
 
     def refactor(self, refactor_request: RefactorActions):
         action_executions = []
@@ -460,18 +467,30 @@ class WorkflowRefactorExecutor:
     def _inject(self, step, execution):
         # compute runtime state, capture upgrade messages that result
         if not hasattr(step, "module"):
-            self.module_injector.inject(step)
+            self.module_injector.inject(step, allow_tool_state_corrections=True)
         self.module_injector.compute_runtime_state(step)
         if getattr(step, "upgrade_messages", None):
             for key, value in step.upgrade_messages.items():
-                message = RefactorActionExecutionMessage(
-                    message=value,
-                    message_type=RefactorActionExecutionMessageTypeEnum.tool_state_adjustment,
-                    input_name=key,
-                    step_label=step.label,
-                    order_index=step.order_index,
-                )
-                execution.messages.append(message)
+                if isinstance(value, dict):
+                    for input_name, message in value.items():
+                        execution.messages.append(
+                            RefactorActionExecutionMessage(
+                                message=message,
+                                message_type=RefactorActionExecutionMessageTypeEnum.tool_state_adjustment,
+                                input_name=input_name,
+                                step_label=step.label,
+                                order_index=step.order_index,
+                            )
+                        )
+                else:
+                    message = RefactorActionExecutionMessage(
+                        message=value,
+                        message_type=RefactorActionExecutionMessageTypeEnum.tool_state_adjustment,
+                        input_name=key,
+                        step_label=step.label,
+                        order_index=step.order_index,
+                    )
+                    execution.messages.append(message)
         if getattr(step.module, "version_changes", None):
             for version_change in step.module.version_changes:
                 message = RefactorActionExecutionMessage(


### PR DESCRIPTION
I think this has always been the intention given the correct tool_state_upgrade messages. Fixes
https://github.com/galaxyproject/planemo/actions/runs/13438714063/job/37547389150 which happened with a tool update that results in an altered tool state.

Note that we're also now more lenient during workflow upload or if a local tool has been altered in a way that invalidates previously saved tool state. Previously a (now) invalid tool state would have resulted in an internal server error and we wouldn't have create a workflow. Now we save the invalid tool state and notify the user when editing or running the workflow:

Editor:
![Screenshot 2025-03-01 at 10 48 10](https://github.com/user-attachments/assets/5de00f1f-b4cf-43b2-85be-e84f4d245631)

Run form:
![Screenshot 2025-03-01 at 13 21 26](https://github.com/user-attachments/assets/e5dfb79d-d6b3-4d05-b49f-778555e0f07f)


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
