### PR TITLE
Refactor tool panel handling, resolve transiently failing jest test

### DIFF
--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -66,7 +66,7 @@ const query = computed({
     },
 });
 
-const { currentPanel, currentPanelView } = storeToRefs(toolStore);
+const { currentPanelView, currentToolSections } = storeToRefs(toolStore);
 const hasResults = computed(() => results.value.length > 0);
 const queryTooShort = computed(() => query.value && query.value.length < 3);
 const queryFinished = computed(() => query.value && queryPending.value != true);
@@ -99,7 +99,7 @@ const localSectionsById = computed(() => {
     const validToolIdsInCurrentView = Object.keys(localToolsById.value);
 
     // Looking within each `ToolSection`, and filtering on child elements
-    const sectionEntries = getValidToolsInEachSection(validToolIdsInCurrentView, currentPanel.value);
+    const sectionEntries = getValidToolsInEachSection(validToolIdsInCurrentView, currentToolSections.value);
 
     // Looking at each item in the panel now (not within each child)
     return getValidPanelItems(

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -30,7 +30,6 @@ const emit = defineEmits<{
 
 const props = defineProps({
     workflow: { type: Boolean, default: false },
-    panelView: { type: String, required: true },
     showAdvanced: { type: Boolean, default: false, required: true },
     panelQuery: { type: String, required: true },
     dataManagers: { type: Array, default: null },
@@ -196,7 +195,7 @@ function onToggle() {
         <div class="unified-panel-controls">
             <ToolSearch
                 :enable-advanced="!props.workflow"
-                :current-panel-view="props.panelView || ''"
+                :current-panel-view="currentPanelView"
                 :placeholder="localize('search tools')"
                 :show-advanced.sync="propShowAdvanced"
                 :tools-list="toolsList"

--- a/client/src/components/Panels/ToolPanel.test.ts
+++ b/client/src/components/Panels/ToolPanel.test.ts
@@ -70,7 +70,7 @@ describe("ToolPanel", () => {
      *                              mock an error for the default view as well
      * @returns wrapper
      */
-    async function createWrapper(errorView = "", failDefault = false) {
+    async function createWrapper(errorView: string = "", failDefault: boolean = false) {
         const axiosMock = new MockAdapter(axios);
         axiosMock
             .onGet(`/api/tools?in_panel=False`)
@@ -113,22 +113,21 @@ describe("ToolPanel", () => {
 
         await flushPromises();
 
-        return { wrapper };
+        return wrapper;
     }
 
     it("test navigation of tool panel views menu", async () => {
-        const { wrapper } = await createWrapper();
+        const wrapper = await createWrapper();
         // there is a panel view selector initially collapsed
-        expect(wrapper.find(".panel-view-selector").exists()).toBe(true);
-        expect(wrapper.find(".dropdown-menu.show").exists()).toBe(false);
+        expect(wrapper.find(".panel-view-selector").exists()).toBeTruthy();
 
         // Test: starts up with a default panel view, click to open menu
         expect(wrapper.find("#toolbox-heading").text()).toBe(viewsList[DEFAULT_VIEW_ID]!.name);
         await wrapper.find("#toolbox-heading").trigger("click");
         await flushPromises();
 
-        const dropdownMenu = wrapper.find(".dropdown-menu.show");
-        expect(dropdownMenu.exists()).toBe(true);
+        const dropdownMenu = wrapper.find(".dropdown-menu");
+        expect(dropdownMenu.exists()).toBeTruthy();
 
         // Test: check if the dropdown menu has all the panel views
         const dropdownItems = dropdownMenu.findAll(".dropdown-item");
@@ -166,10 +165,8 @@ describe("ToolPanel", () => {
 
     it("initializes non default current panel view correctly", async () => {
         const { viewKey, view } = storeNonDefaultView();
-
-        const { wrapper } = await createWrapper();
-
-        // starts up with a non default panel view
+        const wrapper = await createWrapper();
+        expect(wrapper.find(".alert").exists()).toBeFalsy();
         expect(wrapper.find("#toolbox-heading").text()).toBe(view!.name);
         const toolStore = useToolStore();
         expect(toolStore.currentPanelView).toBe(viewKey);
@@ -177,28 +174,18 @@ describe("ToolPanel", () => {
 
     it("changes panel to default if current panel view throws error", async () => {
         const { viewKey, view } = storeNonDefaultView();
-
-        const { wrapper } = await createWrapper(viewKey);
-
-        // does not initialize non default panel view, and changes to default
+        const wrapper = await createWrapper(viewKey);
         expect(wrapper.find("#toolbox-heading").text()).not.toBe(view!.name);
         expect(wrapper.find("#toolbox-heading").text()).toBe(viewsList[DEFAULT_VIEW_ID]!.name);
         const toolStore = useToolStore();
         expect(toolStore.currentPanelView).toBe(DEFAULT_VIEW_ID);
-
-        // toolbox loaded
         expect(wrapper.find('[data-description="panel toolbox"]').exists()).toBe(true);
     });
 
     it("simply shows error if even default panel view throws error", async () => {
         const { viewKey } = storeNonDefaultView();
-
-        const { wrapper } = await createWrapper(viewKey, true);
-
-        // toolbox not loaded
-        expect(wrapper.find('[data-description="panel toolbox"]').exists()).toBe(false);
-
-        // error message shown
+        const wrapper = await createWrapper(viewKey, true);
+        expect(wrapper.find('[data-description="panel toolbox"]').exists()).toBeFalsy();
         expect(wrapper.find('[data-description="tool panel error message"]').text()).toBe(PANEL_VIEW_ERR_MSG);
     });
 });

--- a/client/src/components/Panels/ToolPanel.vue
+++ b/client/src/components/Panels/ToolPanel.vue
@@ -32,7 +32,8 @@ const emit = defineEmits<{
     (e: "onInsertWorkflowSteps", workflowId: string, workflowStepCount: number | undefined): void;
 }>();
 
-const { currentPanel, currentPanelView, isPanelPopulated, loading, panel, panels } = storeToRefs(toolStore);
+const { currentPanelView, currentToolSections, isPanelPopulated, loading, panels, toolSections } =
+    storeToRefs(toolStore);
 
 const errorMessage = ref("");
 const panelName = ref("");
@@ -129,7 +130,7 @@ watch(
     () => currentPanelView.value,
     async (newVal) => {
         query.value = "";
-        if ((!newVal || !panel.value[newVal]) && panelsFetched.value) {
+        if ((!newVal || !toolSections.value[newVal]) && panelsFetched.value) {
             await initializePanel();
         }
     }
@@ -202,7 +203,7 @@ initializePanel();
             </b-badge>
         </div>
     </div>
-    <b-alert v-else-if="currentPanel" class="m-2" variant="info" show>
+    <b-alert v-else-if="currentToolSections" class="m-2" variant="info" show>
         <LoadingSpan message="Loading Toolbox" />
     </b-alert>
 </template>

--- a/client/src/components/Panels/ToolPanel.vue
+++ b/client/src/components/Panels/ToolPanel.vue
@@ -199,7 +199,6 @@ initializeToolPanel();
             :data-managers="dataManagers"
             :module-sections="moduleSections"
             :use-search-worker="useSearchWorker"
-            @updatePanelView="updatePanelView"
             @onInsertTool="onInsertTool"
             @onInsertModule="onInsertModule"
             @onInsertWorkflow="onInsertWorkflow"

--- a/client/src/components/Panels/ToolPanel.vue
+++ b/client/src/components/Panels/ToolPanel.vue
@@ -103,7 +103,7 @@ async function initializeTools() {
         await toolStore.fetchTools();
         await toolStore.initCurrentPanelView(defaultPanelView.value);
     } catch (error: any) {
-        console.error("ToolPanel - Intialize error:", error);
+        console.error(`ToolPanel::initializeTools - ${error}`);
         errorMessage.value = errorMessageAsString(error);
         rethrowSimple(error);
     }

--- a/client/src/components/Panels/ToolPanel.vue
+++ b/client/src/components/Panels/ToolPanel.vue
@@ -194,7 +194,6 @@ initializeToolPanel();
             v-if="isPanelPopulated"
             :workflow="props.workflow"
             :panel-query.sync="query"
-            :panel-view="currentPanelView"
             :show-advanced.sync="showAdvanced"
             :data-managers="dataManagers"
             :module-sections="moduleSections"

--- a/client/src/components/Panels/ToolPanel.vue
+++ b/client/src/components/Panels/ToolPanel.vue
@@ -32,7 +32,7 @@ const emit = defineEmits<{
     (e: "onInsertWorkflowSteps", workflowId: string, workflowStepCount: number | undefined): void;
 }>();
 
-const { currentPanel, currentPanelView, defaultPanelView, isPanelPopulated, loading, panel, panelViews } =
+const { currentPanel, currentPanelView, defaultPanelView, isPanelPopulated, loading, panel, panels } =
     storeToRefs(toolStore);
 
 const errorMessage = ref("");
@@ -46,10 +46,10 @@ const panelIcon = computed(() => {
         return "search";
     } else if (
         currentPanelView.value !== "default" &&
-        panelViews.value &&
-        typeof panelViews.value[currentPanelView.value]?.view_type === "string"
+        panels.value &&
+        typeof panels.value[currentPanelView.value]?.view_type === "string"
     ) {
-        const viewType = panelViews.value[currentPanelView.value]?.view_type;
+        const viewType = panels.value[currentPanelView.value]?.view_type;
         return viewType ? types_to_icons[viewType] : null;
     } else {
         return null;
@@ -76,12 +76,8 @@ const toolPanelHeader = computed(() => {
         return localize("Advanced Tool Search");
     } else if (loading.value && panelName.value) {
         return localize(panelName.value);
-    } else if (
-        currentPanelView.value !== "default" &&
-        panelViews.value &&
-        panelViews.value[currentPanelView.value]?.name
-    ) {
-        return localize(panelViews.value[currentPanelView.value]?.name);
+    } else if (currentPanelView.value !== "default" && panels.value && panels.value[currentPanelView.value]?.name) {
+        return localize(panels.value[currentPanelView.value]?.name);
     } else {
         return localize("Tools");
     }
@@ -89,7 +85,7 @@ const toolPanelHeader = computed(() => {
 
 async function initializeToolPanel() {
     try {
-        await toolStore.fetchPanelViews();
+        await toolStore.fetchPanels();
         await initializeTools();
     } catch (error) {
         console.error(`ToolPanel::initializeToolPanel - ${error}`);
@@ -102,7 +98,7 @@ async function initializeToolPanel() {
 async function initializeTools() {
     try {
         await toolStore.fetchTools();
-        await toolStore.initCurrentPanelView(defaultPanelView.value);
+        await toolStore.initCurrentPanel(defaultPanelView.value);
     } catch (error: any) {
         console.error(`ToolPanel::initializeTools - ${error}`);
         errorMessage.value = errorMessageAsString(error);
@@ -111,8 +107,8 @@ async function initializeTools() {
 }
 
 async function updatePanelView(panelView: string) {
-    panelName.value = panelViews.value[panelView]?.name || "";
-    await toolStore.setCurrentPanelView(panelView);
+    panelName.value = panels.value[panelView]?.name || "";
+    await toolStore.setCurrentPanel(panelView);
     panelName.value = "";
 }
 
@@ -158,8 +154,8 @@ initializeToolPanel();
         <div unselectable="on">
             <div class="unified-panel-header-inner mx-3 my-2 d-flex justify-content-between">
                 <PanelViewMenu
-                    v-if="panelViews && Object.keys(panelViews).length > 1"
-                    :panel-views="panelViews"
+                    v-if="panels && Object.keys(panels).length > 1"
+                    :panel-views="panels"
                     :current-panel-view="currentPanelView"
                     :show-advanced.sync="showAdvanced"
                     :store-loading="loading"

--- a/client/src/components/Toolshed/RepositoryDetails/Index.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/Index.vue
@@ -26,7 +26,7 @@ const props = defineProps({
 const services = new Services();
 
 const { config } = useConfig(true);
-const { panel, fetchPanel } = useToolStore();
+const { toolSections, fetchToolSections } = useToolStore();
 
 const repositoryWatcher = useResourceWatcher(loadInstalledRepositories, {
     shortPollingInterval: 2000,
@@ -64,9 +64,7 @@ const isActionBusy = computed(() => (item) => {
 
 onMounted(() => {
     load();
-    if (!panel["default"]) {
-        fetchPanel("default");
-    }
+    fetchToolSections("default");
     startWatchingRepository();
 });
 
@@ -268,7 +266,7 @@ function stopWatchingRepository() {
                         :toolshed-url="toolshedUrl"
                         :changeset-revision="selectedChangeset"
                         :requires-panel="selectedRequiresPanel"
-                        :current-panel="panel['default']"
+                        :current-panel="toolSections['default']"
                         :tool-dynamic-configs="config.tool_dynamic_configs"
                         @hide="onHide"
                         @ok="onInstallRepository" />

--- a/client/src/stores/toolStore.ts
+++ b/client/src/stores/toolStore.ts
@@ -144,9 +144,11 @@ export const useToolStore = defineStore("toolStore", () => {
 
     async function fetchToolSections(panelView: string) {
         try {
-            loading.value = true;
-            const { data } = await axios.get(`${getAppRoot()}api/tool_panels/${panelView}`);
-            saveToolSections(panelView, data);
+            if (!toolSections.value[panelView]) {
+                loading.value = true;
+                const { data } = await axios.get(`${getAppRoot()}api/tool_panels/${panelView}`);
+                saveToolSections(panelView, data);
+            }
         } catch (e) {
             rethrowSimple(e);
         } finally {
@@ -229,9 +231,7 @@ export const useToolStore = defineStore("toolStore", () => {
 
     async function setPanel(panelView: string) {
         try {
-            if (!toolSections.value[panelView]) {
-                await fetchToolSections(panelView);
-            }
+            await fetchToolSections(panelView);
             currentPanelView.value = panelView;
         } catch (e) {
             rethrowSimple(e);

--- a/client/src/stores/toolStore.ts
+++ b/client/src/stores/toolStore.ts
@@ -21,7 +21,7 @@ export interface FilterSettings {
     help?: string;
 }
 
-export interface PanelView {
+export interface Panel {
     id: string;
     model_class: string;
     name: string;
@@ -78,7 +78,7 @@ export const useToolStore = defineStore("toolStore", () => {
     const defaultPanelView: Ref<string> = ref("");
     const loading = ref(false);
     const panel = ref<Record<string, Record<string, Tool | ToolSection>>>({});
-    const panelViews = ref<Record<string, PanelView>>({});
+    const panels = ref<Record<string, Panel>>({});
     const searchWorker = ref<Worker | undefined>(undefined);
     const toolsById = shallowRef<Record<string, Tool>>({});
     const toolResults = ref<Record<string, string[]>>({});
@@ -150,7 +150,7 @@ export const useToolStore = defineStore("toolStore", () => {
         try {
             loading.value = true;
             const { data } = await axios.get(`${getAppRoot()}api/tool_panels/${panelView}`);
-            savePanelView(panelView, data);
+            savePanel(panelView, data);
         } catch (e) {
             rethrowSimple(e);
         } finally {
@@ -158,12 +158,12 @@ export const useToolStore = defineStore("toolStore", () => {
         }
     }
 
-    async function fetchPanelViews() {
+    async function fetchPanels() {
         try {
-            if (!defaultPanelView.value || Object.keys(panelViews.value).length === 0) {
+            if (!defaultPanelView.value || Object.keys(panels.value).length === 0) {
                 const { data } = await axios.get(`${getAppRoot()}api/tool_panels`);
                 defaultPanelView.value = data.default_panel_view;
-                panelViews.value = data.views;
+                panels.value = data.views;
             }
         } catch (e) {
             rethrowSimple(e);
@@ -203,7 +203,7 @@ export const useToolStore = defineStore("toolStore", () => {
         }
     }
 
-    async function initCurrentPanelView(siteDefaultPanelView: string) {
+    async function initCurrentPanel(siteDefaultPanelView: string) {
         try {
             if (!isPanelPopulated.value) {
                 loading.value = true;
@@ -212,11 +212,11 @@ export const useToolStore = defineStore("toolStore", () => {
                     throw new Error("No valid panel view found.");
                 }
                 const { data } = await axios.get(`${getAppRoot()}api/tool_panels/${currentPanelView.value}`);
-                savePanelView(currentPanelView.value, data);
+                savePanel(currentPanelView.value, data);
             }
         } catch (e) {
             if (currentPanelView.value !== siteDefaultPanelView) {
-                await setCurrentPanelView(siteDefaultPanelView);
+                await setCurrentPanel(siteDefaultPanelView);
             } else {
                 rethrowSimple(e);
             }
@@ -232,7 +232,7 @@ export const useToolStore = defineStore("toolStore", () => {
         }, {} as Record<string, Tool>);
     }
 
-    function savePanelView(panelView: string, newPanel: { [id: string]: ToolSection | Tool }) {
+    function savePanel(panelView: string, newPanel: { [id: string]: ToolSection | Tool }) {
         Vue.set(panel.value, panelView, newPanel);
     }
 
@@ -244,12 +244,12 @@ export const useToolStore = defineStore("toolStore", () => {
         Vue.set(toolResults.value, whooshQuery, toolsData);
     }
 
-    async function setCurrentPanelView(panelView: string) {
+    async function setCurrentPanel(panelView: string) {
         try {
             if (!panel.value[panelView]) {
                 loading.value = true;
                 const { data } = await axios.get(`${getAppRoot()}api/tool_panels/${panelView}`);
-                savePanelView(panelView, data);
+                savePanel(panelView, data);
             }
             currentPanelView.value = panelView;
         } catch (e) {
@@ -264,24 +264,24 @@ export const useToolStore = defineStore("toolStore", () => {
         currentPanelView,
         defaultPanelView,
         fetchPanel,
-        fetchPanelViews,
+        fetchPanels,
         fetchToolForId,
         fetchTools,
-        initCurrentPanelView,
+        initCurrentPanel,
         isPanelPopulated,
         loading,
         getToolForId,
         getToolNameById,
         getToolsById,
         panel,
-        panelViews,
+        panels,
         saveAllTools,
-        savePanelView,
+        savePanel,
         saveToolForId,
         saveToolResults,
         searchWorker,
         sectionDatalist,
-        setCurrentPanelView,
+        setCurrentPanel,
         toolsById,
     };
 });

--- a/client/src/stores/toolStore.ts
+++ b/client/src/stores/toolStore.ts
@@ -219,7 +219,6 @@ export const useToolStore = defineStore("toolStore", () => {
                 loading.value = false;
             } catch (e) {
                 loading.value = false;
-
                 if (currentPanelView.value !== siteDefaultPanelView) {
                     // If the stored panelView failed to load, try the default panel for this site.
                     await setCurrentPanelView(siteDefaultPanelView);

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -379,6 +379,7 @@ edit_collection_attributes:
 
 tool_panel:
   selectors:
+    edam_title: '[title="Apply analytical methods to existing data of a specific type."]'
     tool_box: '[data-description="panel toolbox"]'
     tool_link: 'a[href$$="tool_runner?tool_id=${tool_id}"]'
     outer_tool_link: '.toolTitle a[href$$="tool_runner?tool_id=${tool_id}"]'
@@ -389,6 +390,7 @@ tool_panel:
     views_button: '.tool-panel-dropdown'
     views_menu_item: '[data-panel-id="${panel_id}"]'
     panel_labels: '.tool-panel-label'
+
 
 multi_history_panel:
   selectors:

--- a/test/integration_selenium/test_edam_tool_panel_views.py
+++ b/test/integration_selenium/test_edam_tool_panel_views.py
@@ -13,7 +13,6 @@ class TestEdamToolPanelViewsSeleniumIntegration(SeleniumIntegrationTestCase):
         tool_panel = self.components.tool_panel
         tool_panel.views_button.wait_for_and_click()
         tool_panel.views_menu_item(panel_id="ontology:edam_operations").wait_for_and_click()
-        self.sleep_for(self.wait_types.UX_RENDER)
         self._assert_displaying_edam_operations()
 
         # reload page and ensure the edam operations are still being displayed.
@@ -36,6 +35,7 @@ class TestEdamToolPanelViewsSeleniumIntegration(SeleniumIntegrationTestCase):
     def _assert_displaying_edam_operations(self):
         tool_panel = self.components.tool_panel
         tool_panel.toolbox.wait_for_visible()
+        tool_panel.edam_title.wait_for_visible()
         labels = tool_panel.panel_labels.all()
         assert len(labels) > 0
         label0 = labels[0]


### PR DESCRIPTION
Follow-up #19732. This PR refactors the tool store by implementing explicit request conditions and improving ordering. It removes the use of the unspecific loading flag, which previously led to skipped requests due to race conditions. Requests are now handled with specific conditions, preventing silent failures.

The PR also addresses the intermittent failure of the Jest test.

In order to resolve the transiently failing Selenium test, we probably need to adjust the local Storage handling. This will be done in a separate follow-up PR.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
