### PR TITLE
Fix Tours and add tooltips to history items

### DIFF
--- a/client/src/components/ActivityBar/ActivityItem.vue
+++ b/client/src/components/ActivityBar/ActivityItem.vue
@@ -68,9 +68,9 @@ const meta = computed(() => store.metaForId(props.id));
     <Popper :placement="tooltipPlacement">
         <template v-slot:reference>
             <b-nav-item
-                :id="`activity-${id}`"
                 class="activity-item my-1 p-2"
                 :class="{ 'nav-item-active': isActive }"
+                :link-attrs="{ id: `activity-${id}` }"
                 :link-classes="`variant-${props.variant}`"
                 :aria-label="localize(title)"
                 :disabled="meta?.disabled"

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -395,6 +395,7 @@ function unexpandedClick(event: Event) {
                 <span class="align-self-start btn-group">
                     <BButton
                         v-if="item.sub_items?.length && !isSubItem"
+                        v-b-tooltip.hover
                         title="Show converted items"
                         tabindex="0"
                         class="display-btn px-1 align-items-center"

--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { BDropdown } from "bootstrap-vue";
+import { BButton, BDropdown } from "bootstrap-vue";
 import { computed, type Ref, ref } from "vue";
 
 import { prependPath } from "@/utils/redirect";
@@ -76,8 +76,9 @@ function onDisplay($event: MouseEvent) {
 <template>
     <span class="align-self-start btn-group align-items-baseline">
         <!-- Special case for collections -->
-        <b-button
+        <BButton
             v-if="isCollection && canShowCollectionDetails"
+            v-b-tooltip.hover
             class="collection-job-details-btn px-1"
             title="Show Details"
             size="sm"
@@ -85,10 +86,11 @@ function onDisplay($event: MouseEvent) {
             :href="showCollectionDetailsUrl"
             @click.prevent.stop="emit('showCollectionInfo')">
             <icon icon="info-circle" />
-        </b-button>
+        </BButton>
         <!-- Common for all content items -->
-        <b-button
+        <BButton
             v-if="isDataset"
+            v-b-tooltip.hover
             :disabled="displayDisabled"
             :title="displayButtonTitle"
             tabindex="0"
@@ -98,9 +100,10 @@ function onDisplay($event: MouseEvent) {
             :href="displayUrl"
             @click.prevent.stop="onDisplay($event)">
             <icon icon="eye" />
-        </b-button>
-        <b-button
+        </BButton>
+        <BButton
             v-if="writable && isHistoryItem"
+            v-b-tooltip.hover
             :disabled="editDisabled"
             :title="editButtonTitle"
             tabindex="0"
@@ -110,9 +113,10 @@ function onDisplay($event: MouseEvent) {
             :href="editUrl"
             @click.prevent.stop="emit('edit')">
             <icon icon="pen" />
-        </b-button>
-        <b-button
+        </BButton>
+        <BButton
             v-if="writable && isHistoryItem && !isDeleted"
+            v-b-tooltip.hover
             :tabindex="isDataset ? '0' : '-1'"
             class="delete-btn px-1"
             title="Delete"
@@ -133,9 +137,10 @@ function onDisplay($event: MouseEvent) {
                     Collection and elements
                 </b-dropdown-item>
             </BDropdown>
-        </b-button>
-        <b-button
+        </BButton>
+        <BButton
             v-if="writable && isHistoryItem && isDeleted"
+            v-b-tooltip.hover
             tabindex="0"
             class="undelete-btn px-1"
             title="Undelete"
@@ -143,9 +148,10 @@ function onDisplay($event: MouseEvent) {
             variant="link"
             @click.stop="emit('undelete')">
             <icon icon="trash-restore" />
-        </b-button>
-        <b-button
+        </BButton>
+        <BButton
             v-if="writable && isHistoryItem && !isVisible"
+            v-b-tooltip.hover
             tabindex="0"
             class="unhide-btn px-1"
             title="Unhide"
@@ -153,7 +159,7 @@ function onDisplay($event: MouseEvent) {
             variant="link"
             @click.stop="emit('unhide')">
             <icon icon="eye-slash" />
-        </b-button>
+        </BButton>
     </span>
 </template>
 

--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -101,6 +101,7 @@ function onHighlight() {
             <div class="btn-group float-left">
                 <BButton
                     v-if="showError"
+                    v-b-tooltip.hover
                     class="px-1"
                     title="Error"
                     size="sm"
@@ -114,6 +115,7 @@ function onHighlight() {
 
                 <BButton
                     v-if="showDownloads"
+                    v-b-tooltip.hover
                     class="px-1"
                     title="Copy Link"
                     size="sm"
@@ -124,6 +126,7 @@ function onHighlight() {
 
                 <BButton
                     v-if="showInfo"
+                    v-b-tooltip.hover
                     class="params-btn px-1"
                     title="Dataset Details"
                     size="sm"
@@ -135,6 +138,7 @@ function onHighlight() {
 
                 <BButton
                     v-if="writable && showRerun"
+                    v-b-tooltip.hover
                     class="rerun-btn px-1"
                     title="Run Job Again"
                     size="sm"
@@ -146,6 +150,7 @@ function onHighlight() {
 
                 <BButton
                     v-if="showVisualizations"
+                    v-b-tooltip.hover
                     class="visualize-btn px-1"
                     title="Visualize"
                     size="sm"
@@ -157,6 +162,7 @@ function onHighlight() {
 
                 <BButton
                     v-if="showHighlight"
+                    v-b-tooltip.hover
                     class="highlight-btn px-1"
                     title="Show Related Items"
                     size="sm"

--- a/client/src/components/History/Content/Dataset/DatasetDownload.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDownload.vue
@@ -39,7 +39,7 @@ function onDownload(resource: string, extension = "") {
 <template>
     <BDropdown
         v-if="hasMetaFiles"
-        v-b-tooltip.top.hover
+        v-b-tooltip.hover
         dropup
         no-caret
         no-flip
@@ -69,6 +69,7 @@ function onDownload(resource: string, extension = "") {
 
     <BButton
         v-else
+        v-b-tooltip.hover
         class="download-btn px-1"
         title="Download"
         size="sm"

--- a/client/src/components/History/CurrentHistory/HistoryOperations/DefaultOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/DefaultOperations.vue
@@ -52,10 +52,12 @@ async function runOperation(operation: () => Promise<unknown>) {
 <template>
     <section>
         <BDropdown
+            v-b-tooltip.hover
             no-caret
             size="sm"
             variant="link"
             class="rounded-0"
+            title="Operations"
             toggle-class="text-decoration-none rounded-0"
             data-description="history action menu">
             <template v-slot:button-content>

--- a/client/src/components/History/CurrentHistory/HistoryOperations/HistoryOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/HistoryOperations.vue
@@ -36,6 +36,7 @@ function onUpdateOperationStatus(updateTime: number) {
         <nav v-if="editable" class="content-operations d-flex justify-content-between bg-secondary">
             <BButtonGroup>
                 <BButton
+                    v-b-tooltip.hover
                     title="Select Items"
                     class="show-history-content-selectors-btn rounded-0"
                     size="sm"
@@ -47,6 +48,7 @@ function onUpdateOperationStatus(updateTime: number) {
                 </BButton>
 
                 <BButton
+                    v-b-tooltip.hover
                     title="Collapse Items"
                     class="rounded-0"
                     size="sm"
@@ -69,6 +71,7 @@ function onUpdateOperationStatus(updateTime: number) {
         </nav>
         <nav v-else-if="isMultiViewItem" class="content-operations bg-secondary">
             <BButton
+                v-b-tooltip.hover
                 title="Collapse Items"
                 class="rounded-0"
                 size="sm"

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionStatus.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionStatus.vue
@@ -24,8 +24,14 @@ function resetSelection() {
 
 <template>
     <BButtonGroup size="sm">
-        <BButton v-if="hasSelection" variant="link" data-test-id="clear-btn" @click="resetSelection">
-            <span class="fa fa-fw fa-times" title="Clear selection" />
+        <BButton
+            v-if="hasSelection"
+            v-b-tooltip.hover
+            title="Clear selection"
+            variant="link"
+            data-test-id="clear-btn"
+            @click="resetSelection">
+            <span class="fa fa-fw fa-times" />
         </BButton>
 
         <BButton v-else variant="link" data-test-id="select-all-btn" @click="selectAll">

--- a/client/src/components/Tour/Tour.vue
+++ b/client/src/components/Tour/Tour.vue
@@ -5,31 +5,31 @@
             v-else-if="loginRequired(currentUser)"
             id="tour-requirement-unment"
             v-model="showRequirementDialog"
+            title="Requires Login"
+            title-class="h3"
             static
-            ok-only
-            hide-header>
-            <b-alert show variant="danger"> You must log in to Galaxy to use this tour. </b-alert>
+            ok-only>
+            You must log in to Galaxy to use this tour.
         </b-modal>
         <b-modal
             v-else-if="adminRequired(currentUser)"
             id="tour-requirement-unment"
             v-model="showRequirementDialog"
+            title="Requires Admin"
+            title-class="h3"
             static
-            ok-only
-            hide-header>
-            <b-alert show variant="danger"> You must be an admin user to use this tour. </b-alert>
+            ok-only>
+            You must be an admin user to use this tour.
         </b-modal>
         <b-modal
             v-else-if="newHistoryRequired(currentHistory)"
             id="tour-requirement-unment"
             v-model="showRequirementDialog"
-            static
-            ok-only
-            hide-header>
-            <b-alert show variant="danger">
-                This tour is designed to run on a new history, please create a new history before running it.
-                <a @click.prevent="createNewHistory()">Click here</a> to create a new history.
-            </b-alert>
+            title="Requires New History"
+            title-class="h3"
+            ok-title="Create New History"
+            @ok="createNewHistory()">
+            This tour is designed to run on a new history, please create a new history before running it.
         </b-modal>
         <TourStep
             v-else-if="currentStep"
@@ -140,8 +140,8 @@ export default {
                 const nextStep = this.steps[nextIndex];
                 if (nextStep.onBefore) {
                     await nextStep.onBefore();
-                    // automatically continues to next step if enabled
-                    if (this.isPlaying) {
+                    // automatically continues to next step if enabled, unless its the last one
+                    if (this.isPlaying && nextIndex !== this.numberOfSteps - 1) {
                         setTimeout(() => {
                             if (this.isPlaying) {
                                 this.next();

--- a/client/src/components/Tour/Tour.vue
+++ b/client/src/components/Tour/Tour.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="d-flex flex-column">
-        <div v-if="historiesLoading">computing tour requirements...</div>
+        <div v-if="historiesLoading">Evaluating requirements...</div>
         <b-modal
             v-else-if="errorMessage"
             id="tour-failed"
@@ -39,7 +39,7 @@
             This tour is designed to run on a new history, please create a new history before running it.
         </b-modal>
         <TourStep
-            v-else-if="currentStep"
+            v-else-if="currentHistory && currentStep && currentUser"
             :key="currentIndex"
             :step="currentStep"
             :is-playing="isPlaying"
@@ -92,11 +92,11 @@ export default {
         numberOfSteps() {
             return this.steps.length;
         },
+        isFirst() {
+            return this.currentIndex === 0;
+        },
         isLast() {
             return this.currentIndex === this.steps.length - 1;
-        },
-        hasBegun() {
-            return this.currentIndex >= 1;
         },
     },
     beforeDestroy() {
@@ -118,21 +118,22 @@ export default {
             }
         },
         loginRequired(user) {
-            return !this.hasBegun && this.requirements.indexOf("logged_in") >= 0 && user.isAnonymous;
+            return this.isFirst && this.requirements.indexOf("logged_in") >= 0 && user.isAnonymous;
         },
         adminRequired(user) {
-            return !this.hasBegun && this.requirements.indexOf("admin") >= 0 && !user.is_admin;
+            return this.isFirst && this.requirements.indexOf("admin") >= 0 && !user.is_admin;
         },
         newHistoryRequired(history) {
-            if (this.hasBegun) {
-                return false;
-            }
-            const hasNewHistoryRequirement = this.requirements.indexOf("new_history") >= 0;
-            if (!hasNewHistoryRequirement) {
-                return false;
-            } else if (history && history.size != 0) {
-                // TODO: better estimate for whether the history is new.
-                return true;
+            if (this.isFirst) {
+                const hasNewHistoryRequirement = this.requirements.indexOf("new_history") >= 0;
+                if (!hasNewHistoryRequirement) {
+                    return false;
+                } else if (history && history.size != 0) {
+                    // TODO: better estimate for whether the history is new.
+                    return true;
+                } else {
+                    return false;
+                }
             } else {
                 return false;
             }

--- a/client/src/components/Tour/Tour.vue
+++ b/client/src/components/Tour/Tour.vue
@@ -12,7 +12,7 @@
         </b-modal>
         <b-modal
             v-else-if="loginRequired(currentUser)"
-            id="tour-requirement-unment"
+            id="tour-requirement"
             v-model="showModal"
             title="Requires Login"
             title-class="h3"
@@ -21,7 +21,7 @@
         </b-modal>
         <b-modal
             v-else-if="adminRequired(currentUser)"
-            id="tour-requirement-unment"
+            id="tour-requirement"
             v-model="showModal"
             title="Requires Admin"
             title-class="h3"
@@ -30,7 +30,7 @@
         </b-modal>
         <b-modal
             v-else-if="newHistoryRequired(currentHistory)"
-            id="tour-requirement-unment"
+            id="tour-requirement"
             v-model="showModal"
             title="Requires New History"
             title-class="h3"

--- a/client/src/components/Tour/TourList.vue
+++ b/client/src/components/Tour/TourList.vue
@@ -17,7 +17,7 @@
                         <span
                             v-for="(tag, index) in tour.tags"
                             :key="index"
-                            class="badge badge-primary text-capitalize">
+                            class="badge badge-primary text-capitalize mr-1">
                             {{ tag }}
                         </span>
                     </li>

--- a/client/src/components/Tour/runTour.js
+++ b/client/src/components/Tour/runTour.js
@@ -21,7 +21,7 @@ function getElement(selector) {
         try {
             return document.querySelector(selector);
         } catch (error) {
-            throw Error(`Tour - Invalid selector. ${selector}`);
+            throw Error(`Invalid selector. ${selector}`);
         }
     }
 }
@@ -39,8 +39,7 @@ function waitForElement(selector, resolve, reject, tries) {
                 waitForElement(selector, resolve, reject, tries - 1);
             }, delay);
         } else {
-            console.error("Tour - Element not found.", selector);
-            reject();
+            throw Error("Element not found.", selector);
         }
     } else {
         resolve();
@@ -55,7 +54,7 @@ function doClick(targets) {
             if (el) {
                 el.click();
             } else {
-                console.error("Tour - Click target not found.", selector);
+                throw Error("Click target not found.", selector);
             }
         });
     }
@@ -70,7 +69,7 @@ function doInsert(selector, value) {
             const event = new Event("input");
             el.dispatchEvent(event);
         } else {
-            console.error("Tour - Insert target not found.", selector);
+            throw Error("Insert target not found.", selector);
         }
     }
 }

--- a/client/src/components/Tour/runTour.js
+++ b/client/src/components/Tour/runTour.js
@@ -98,7 +98,7 @@ export async function runTour(tourId, tourData = null) {
             element: step.element,
             title: step.title,
             content: step.content,
-            onBefore: () => {
+            onBefore: async () => {
                 return new Promise((resolve, reject) => {
                     // wait for element before continuing tour
                     waitForElement(step.element, resolve, reject, attempts);

--- a/client/src/components/Tour/runTour.js
+++ b/client/src/components/Tour/runTour.js
@@ -30,7 +30,9 @@ function getElement(selector) {
 function waitForElement(selector, resolve, reject, tries) {
     if (selector) {
         const el = getElement(selector);
-        if (el) {
+        const rect = el?.getBoundingClientRect();
+        const isVisible = !!(rect && rect.width > 0 && rect.height > 0);
+        if (el && isVisible) {
             resolve();
         } else if (tries > 0) {
             setTimeout(() => {

--- a/config/plugins/tours/core.windows.yaml
+++ b/config/plugins/tours/core.windows.yaml
@@ -89,3 +89,6 @@ steps:
     - component: history_panel.item(hid=2,state=ok).display_button
       intro: "View the second dataset in a window as well."
       postclick: true
+
+    - title: "Enjoy your Galaxy Window Manager"
+      intro: "Thanks for taking this tour! Happy research with Galaxy!"

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -2262,7 +2262,7 @@ class NavigatesGalaxy(HasDriver):
     @retry_during_transitions
     def _tour_wait_for_and_click_element(self, selector):
         element = self.tour_wait_for_clickable_element(selector)
-        element.click()
+        self.driver.execute_script("arguments[0].click();", element)
 
     @retry_during_transitions
     def wait_for_and_click_selector(self, selector):


### PR DESCRIPTION
This PR fixes issues with tours that currently do not work properly. Specifically, the upload modal was not displaying during tours. This has been resolved by adjusting the activity bar click target. Additionally, error handling has been improved, and target element visibility is now validated.

This PR also updates the tour requirements modal. Instead of displaying an error message, the modal now provides options to either cancel or create a new history. Requirement conditions have been adjusted to prevent flickering at tour start. Finally, the tours have been modified to ensure the final step remains visible.

This PR also adds tool tips to history items.

![tooltips](https://github.com/user-attachments/assets/f69f6c65-529e-494e-ad40-b933a20ae051)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
