### PR TITLE
Show workflow help (and readme?) in run form

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -16454,6 +16454,11 @@ export interface components {
              */
             email_hash: string | null;
             /**
+             * Help
+             * @description The detailed help text for how to use the workflow and debug problems with it.
+             */
+            help: string | null;
+            /**
              * Hidden
              * @description TODO
              */
@@ -16512,6 +16517,11 @@ export interface components {
              * @description Whether this workflow is currently publicly available to all users.
              */
             published: boolean;
+            /**
+             * Readme
+             * @description The detailed markdown readme of the workflow.
+             */
+            readme: string | null;
             /**
              * Show in Tool Panel
              * @description Whether to display this workflow in the Tools Panel.

--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -63,7 +63,11 @@ const showRightPanel = ref<"help" | "graph" | null>(!showPanels.value && props.m
 const showGraph = computed(() => showRightPanel.value === "graph");
 const showHelp = computed(() => showRightPanel.value === "help");
 
-const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true, removeNewlinesAfterList: true });
+const { renderMarkdown } = useMarkdown({
+    openLinksInNewPage: true,
+    removeNewlinesAfterList: true,
+    increaseHeadingLevelBy: 2,
+});
 
 const { changingCurrentHistory } = storeToRefs(useHistoryStore());
 

--- a/client/src/components/Workflow/WorkflowAnnotation.vue
+++ b/client/src/components/Workflow/WorkflowAnnotation.vue
@@ -4,13 +4,15 @@ import { faExclamation, faHdd } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BBadge } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
-import { computed } from "vue";
+import { computed, ref } from "vue";
 
 import { isRegisteredUser } from "@/api";
+import { useMarkdown } from "@/composables/markdown";
 import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
 import { useHistoryStore } from "@/stores/historyStore";
 import { useUserStore } from "@/stores/userStore";
 
+import Heading from "../Common/Heading.vue";
 import TextSummary from "../Common/TextSummary.vue";
 import SwitchToHistoryLink from "../History/SwitchToHistoryLink.vue";
 import StatelessTags from "../TagsMultiselect/StatelessTags.vue";
@@ -56,6 +58,14 @@ const timeElapsed = computed(() => {
 const workflowTags = computed(() => {
     return workflow.value?.tags || [];
 });
+
+const readmeShown = ref(false);
+
+const { renderMarkdown } = useMarkdown({
+    openLinksInNewPage: true,
+    removeNewlinesAfterList: true,
+    increaseHeadingLevelBy: 1,
+});
 </script>
 
 <template>
@@ -94,7 +104,20 @@ const workflowTags = computed(() => {
         <div v-if="props.showDetails">
             <TextSummary v-if="description" class="my-1" :description="description" one-line-summary component="span" />
             <StatelessTags v-if="workflowTags.length" :value="workflowTags" :disabled="true" />
-            <hr class="mb-0 mt-2" />
+            <div v-if="workflow.readme" class="mt-2">
+                <Heading
+                    h2
+                    separator
+                    bold
+                    size="sm"
+                    :collapse="readmeShown ? 'open' : 'closed'"
+                    @click="readmeShown = !readmeShown">
+                    <span v-localize>Readme</span>
+                </Heading>
+                <!-- eslint-disable-next-line vue/no-v-html -->
+                <p v-if="readmeShown" v-html="renderMarkdown(workflow.readme)" />
+            </div>
+            <hr v-if="!workflow.readme" class="mb-0 mt-2" />
         </div>
     </div>
 </template>

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1090,6 +1090,7 @@ class WorkflowContentsManager(UsesAnnotations):
         return {
             "id": trans.app.security.encode_id(stored.id),
             "workflow_id": trans.app.security.encode_id(workflow.id),
+            "help": workflow.help,
             "history_id": trans.app.security.encode_id(history.id) if history else None,
             "name": stored.name,
             "owner": stored.user.username,

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -258,6 +258,16 @@ class StoredWorkflowDetailed(StoredWorkflowSummary):
         title="Email Hash",
         description="The hash of the email of the creator of this workflow",
     )
+    readme: Optional[str] = Field(
+        ...,
+        title="Readme",
+        description="The detailed markdown readme of the workflow.",
+    )
+    help: Optional[str] = Field(
+        ...,
+        title="Help",
+        description="The detailed help text for how to use the workflow and debug problems with it.",
+    )
     slug: Optional[str] = Field(
         ...,
         title="Slug",


### PR DESCRIPTION
Builds on https://github.com/galaxyproject/galaxy/pull/19591 and https://github.com/galaxyproject/galaxy/pull/19294

https://github.com/user-attachments/assets/d7952977-c1cf-4a13-a483-47dbc59d57ac

We add the `workflow.help` to the workflow run model to show the help.

Additionally, to show the readme in the run form as well i also added the `help` and `readme` properties to `StoredWorkflowDetailed`, and then simply used `useWorkflowInstance` to render the readme in `WorkflowAnnotation`. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
