### PR TITLE
Enhance breadcrumb navigation UX in small screen sizes

### DIFF
--- a/client/src/components/Common/BreadcrumbHeading.vue
+++ b/client/src/components/Common/BreadcrumbHeading.vue
@@ -17,10 +17,16 @@ const props = defineProps<Props>();
     <div class="breadcrumb-heading">
         <Heading h1 separator inline size="xl" class="breadcrumb-heading-header">
             <template v-for="(item, index) in props.items">
-                <RouterLink v-if="item.to" :key="index" :to="item.to">
+                <RouterLink
+                    v-if="item.to"
+                    :key="index"
+                    v-b-tooltip.hover.bottom.noninteractive
+                    :title="`Go back to ${localize(item.title)}`"
+                    :to="item.to"
+                    class="breadcrumb-heading-header-active">
                     {{ localize(item.title) }}
                 </RouterLink>
-                <span v-else :key="'else-' + index">
+                <span v-else :key="'else-' + index" class="breadcrumb-heading-header-inactive">
                     {{ localize(item.title) }}
                 </span>
 
@@ -45,6 +51,21 @@ const props = defineProps<Props>();
     .breadcrumb-heading-header {
         flex-grow: 1;
         margin-bottom: 0.5rem;
+
+        .breadcrumb-heading-header-active {
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+
+            &:hover {
+                cursor: pointer;
+            }
+        }
+
+        .breadcrumb-heading-header-inactive {
+            flex-shrink: 0;
+            margin-left: auto;
+        }
 
         .breadcrumb-heading-header-beta {
             color: #717273;

--- a/client/src/components/Common/BreadcrumbHeading.vue
+++ b/client/src/components/Common/BreadcrumbHeading.vue
@@ -15,7 +15,7 @@ const props = defineProps<Props>();
 
 <template>
     <div class="breadcrumb-heading">
-        <Heading h1 separator inline size="xl" class="breadcrumb-heading-header">
+        <Heading h1 separator inline size="md" class="breadcrumb-heading-header">
             <template v-for="(item, index) in props.items">
                 <RouterLink
                     v-if="item.to"


### PR DESCRIPTION
This PR adds tooltip to breadcrumb links for better context, and improves text overflow handling for long titles in smaller screen sizes.

https://github.com/user-attachments/assets/405e0528-e8fd-41f5-8af4-fb7de9bf9a52

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
