### PR TITLE
[24.2] Update fs.dropboxfs conditional dependency version to 1.0.3

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -18,7 +18,7 @@ openai
 
 # For file sources plugins
 fs.webdavfs>=0.4.2  # type: webdav
-fs.dropboxfs>=1.0  # type: dropbox
+fs.dropboxfs>=1.0.3  # type: dropbox
 fs.sshfs  # type: ssh
 fs.anvilfs # type: anvil
 fs.googledrivefs # type: googledrive


### PR DESCRIPTION
This is the minimum version of the conditional `fs.dropboxfs` dependency that contains a fix for listing the root directory using "/" (the default used in all file sources).
Otherwise, it will raise the following error: `Specify the root folder as an empty string rather than as "/".`

![image](https://github.com/user-attachments/assets/5a0b8981-4116-4fbd-8568-113bb0c64a4c)



## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
