### PR TITLE
Jest Cleanup (Part 5)

### DIFF
--- a/client/src/components/Collections/common/CollectionCreatorFooterButtons.vue
+++ b/client/src/components/Collections/common/CollectionCreatorFooterButtons.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { BButton } from "bootstrap-vue";
+
 import localize from "@/utils/localization";
 
 interface Props {

--- a/client/src/components/Workflow/Editor/Comments/WorkflowComment.test.ts
+++ b/client/src/components/Workflow/Editor/Comments/WorkflowComment.test.ts
@@ -1,6 +1,7 @@
 import { createTestingPinia } from "@pinia/testing";
 import { mount, shallowMount } from "@vue/test-utils";
 import { setActivePinia } from "pinia";
+import { suppressErrorForCustomIcons } from "tests/jest/helpers";
 import { nextTick } from "vue";
 
 import { type LazyUndoRedoAction, type UndoRedoAction } from "@/stores/undoRedoStore";
@@ -48,6 +49,8 @@ function getStyleProperty(element: Element, property: string) {
 
     return style.substring(startIndex, endIndex).trim();
 }
+
+suppressErrorForCustomIcons();
 
 describe("WorkflowComment", () => {
     const comment = {

--- a/client/src/components/admin/Notifications/BroadcastForm.test.ts
+++ b/client/src/components/admin/Notifications/BroadcastForm.test.ts
@@ -1,3 +1,5 @@
+import "@/composables/__mocks__/filter";
+
 import { createTestingPinia } from "@pinia/testing";
 import { getLocalVue } from "@tests/jest/helpers";
 import { mount, type Wrapper } from "@vue/test-utils";

--- a/client/src/composables/__mocks__/filter.ts
+++ b/client/src/composables/__mocks__/filter.ts
@@ -8,6 +8,5 @@ jest.mock("@/composables/filter", () => ({
 }));
 
 export const useFilterObjectArray: typeof UseFilterObjectArray = (array): Ref<any[]> => {
-    console.debug("USING MOCKED useFilterObjectArray");
     return computed(() => toValue(array));
 };

--- a/client/tests/jest/helpers.js
+++ b/client/tests/jest/helpers.js
@@ -292,10 +292,22 @@ export function suppressDebugConsole() {
 }
 
 export function suppressBootstrapVueWarnings() {
+    const originalWarn = console.warn;
     jest.spyOn(console, "warn").mockImplementation(
         jest.fn((msg) => {
             if (msg.indexOf("BootstrapVue warn") < 0) {
-                console.warn(msg);
+                originalWarn(msg);
+            }
+        })
+    );
+}
+
+export function suppressErrorForCustomIcons() {
+    const originalError = console.error;
+    jest.spyOn(console, "error").mockImplementation(
+        jest.fn((msg) => {
+            if (msg.indexOf("Could not find one or more icon(s)") < 0) {
+                originalError(msg);
             }
         })
     );


### PR DESCRIPTION
There were regressions - we really need to solve to https://github.com/galaxyproject/galaxy/issues/19200 so we can enable failing on unexpected console output. 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
