### PR TITLE
[24.2] Skip slow tests for manage_db, db_dev scripts

### DIFF
--- a/test/unit/app/test_dbscript.py
+++ b/test/unit/app/test_dbscript.py
@@ -41,6 +41,9 @@ ADMIN_CMD = "manage_db.sh"
 DEV_CMD = "scripts/db_dev.sh"
 COMMANDS = [ADMIN_CMD, DEV_CMD]
 
+# Skip all but one due to slow speed. Leave one test as a "smoke test".
+SKIP_REASON = "Slow test: database migration management scripts"
+
 
 @pytest.fixture(scope="session")
 def migrations_dir() -> Traversable:
@@ -99,6 +102,7 @@ def create_alembic_branches(config: Config, gxy_versions_dir: str, tsi_versions_
     )
 
 
+@pytest.mark.skip(SKIP_REASON)
 class TestRevisionCommand:
     def test_revision_cmd(self, config):
         run_command(f"{DEV_CMD} revision --message foo1")
@@ -121,6 +125,7 @@ class TestRevisionCommand:
         assert "the following arguments are required: -m/--message" in completed.stderr
 
 
+@pytest.mark.skip(SKIP_REASON)
 class TestShowCommand:
     def test_show_cmd(self, config):
         alembic.command.revision(config, rev_id="42", head=GXY_BASE_ID)
@@ -146,6 +151,7 @@ class TestShowCommand:
         assert "the following arguments are required: revision" in completed.stderr
 
 
+@pytest.mark.skip(SKIP_REASON)
 class TestHistoryCommand:
     def test_history_cmd(self, config):
         alembic.command.revision(config, rev_id="1", head=GXY_BASE_ID)
@@ -180,6 +186,7 @@ class TestHistoryCommand:
         assert "gxy0 -> 1 (gxy)" in completed.stdout
 
 
+@pytest.mark.skip(SKIP_REASON)
 @pytest.mark.parametrize("command", COMMANDS)
 class TestVersionCommand:
     def test_version_cmd(self, config, command):
@@ -200,6 +207,7 @@ class TestVersionCommand:
         assert "Revises: 1" in completed.stdout
 
 
+@pytest.mark.skip(SKIP_REASON)
 @pytest.mark.parametrize("command", COMMANDS)
 class TestDbVersionCommand:
     def test_dbversion_cmd(self, config, command):
@@ -230,6 +238,7 @@ class TestDbVersionCommand:
 
 @pytest.mark.parametrize("command", COMMANDS)
 class TestUpgradeCommand:
+    @pytest.mark.skip(SKIP_REASON)
     def test_upgrade_cmd(self, config, command):
         alembic.command.revision(config, rev_id="1", head=GXY_BASE_ID)
         alembic.command.revision(config, rev_id="2", head="1")
@@ -271,6 +280,7 @@ class TestUpgradeCommand:
         assert "UPDATE alembic_version SET version_num='2'" in completed.stdout
         assert "UPDATE alembic_version SET version_num='3'" in completed.stdout
 
+    @pytest.mark.skip(SKIP_REASON)
     def test_upgrade_cmd_with_revision_arg(self, config, command):
         alembic.command.revision(config, rev_id="1", head=GXY_BASE_ID)
         alembic.command.revision(config, rev_id="2", head="1")
@@ -283,6 +293,7 @@ class TestUpgradeCommand:
         heads = get_db_heads(config)
         assert heads == ("1",)
 
+    @pytest.mark.skip(SKIP_REASON)
     def test_upgrade_cmd_with_relative_revision_syntax(self, config, command):
         alembic.command.revision(config, rev_id="a", head=GXY_BASE_ID)
         alembic.command.revision(config, rev_id="b", head="a")
@@ -309,6 +320,7 @@ class TestUpgradeCommand:
         heads = get_db_heads(config)
         assert heads == ("d",)
 
+    @pytest.mark.skip(SKIP_REASON)
     def test_repair_arg_available_to_dev_script_only(self, config, command):
         completed = run_command(f"{command} upgrade --repair")
         if command == DEV_CMD:
@@ -318,6 +330,7 @@ class TestUpgradeCommand:
             assert "unrecognized arguments: --repair" in completed.stderr
 
 
+@pytest.mark.skip(SKIP_REASON)
 @pytest.mark.parametrize("command", COMMANDS)
 class TestDowngradeCommand:
     def test_downgrade_cmd(self, config, command):

--- a/test/unit/tool_shed/test_dbscript.py
+++ b/test/unit/tool_shed/test_dbscript.py
@@ -23,6 +23,8 @@ DbUrl = NewType("DbUrl", str)
 BASE_ID = "ts0"
 COMMAND = "manage_toolshed_db.sh"
 
+SKIP_REASON = "Slow test: database migration management scripts"
+
 
 @pytest.fixture(scope="session")
 def migrations_dir():
@@ -70,6 +72,7 @@ def create_alembic_branch(config: Config, versions_dir: str) -> None:
     alembic.command.revision(config, head="base", rev_id=BASE_ID, version_path=versions_dir)
 
 
+@pytest.mark.skip(SKIP_REASON)
 class TestVersionCommand:
     def test_version_cmd(self, config):
         alembic.command.revision(config, rev_id="1", head=BASE_ID)
@@ -89,6 +92,7 @@ class TestVersionCommand:
         assert "Revises: 1" in completed.stdout
 
 
+@pytest.mark.skip(SKIP_REASON)
 class TestDbVersionCommand:
     def test_dbversion_cmd(self, config):
         alembic.command.revision(config, rev_id="1", head=BASE_ID)
@@ -116,6 +120,7 @@ class TestDbVersionCommand:
         assert "Revises: 1" in completed.stdout
 
 
+@pytest.mark.skip(SKIP_REASON)
 class TestUpgradeCommand:
     def test_upgrade_cmd(self, config):
         alembic.command.revision(config, rev_id="1", head=BASE_ID)
@@ -185,6 +190,7 @@ class TestUpgradeCommand:
         assert heads == ("d",)
 
 
+@pytest.mark.skip(SKIP_REASON)
 class TestDowngradeCommand:
     def test_downgrade_cmd(self, config):
         alembic.command.revision(config, rev_id="1", head=BASE_ID)


### PR DESCRIPTION
Fixes #19724

This skips 65 out of 69 tests that test the `manage_db.sh` and `scripts/db_dev.sh` db migration management scripts. I've left one test unmarked (4 test runs due to parametrization) as a smoke test to verify the scripts work. Based on the benchmarks from #19724, these 4 test runs account for 7% of the total `test_dbscript.py` run time (52 seconds of 12 min), so we're still saving around 11 minutes.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
