### PR TITLE
Fix job resubmission integration test

### DIFF
--- a/test/integration/resubmission_default_job_conf.yml
+++ b/test/integration/resubmission_default_job_conf.yml
@@ -15,7 +15,7 @@ execution:
     initial_destination:
       runner: dynamic
       type: python
-      function: initial_destination
+      function: initial_target_environment
 
     fail_first_try:
       runner: first_failure_runner

--- a/test/integration/test_job_resubmission.py
+++ b/test/integration/test_job_resubmission.py
@@ -7,7 +7,7 @@ from galaxy_test.driver import integration_util
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 JOB_RESUBMISSION_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_job_conf.yml")
-JOB_RESUBMISSION_DEFAULT_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_default_job_conf.xml")
+JOB_RESUBMISSION_DEFAULT_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_default_job_conf.yml")
 JOB_RESUBMISSION_DYNAMIC_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_dynamic_job_conf.xml")
 JOB_RESUBMISSION_SMALL_MEMORY_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_small_memory_job_conf.xml")
 JOB_RESUBMISSION_SMALL_MEMORY_RESUBMISSION_TO_LARGE_JOB_CONFIG_FILE = os.path.join(


### PR DESCRIPTION
test referred to a non-existent job-config file and jobconf referred to wrong function

xref https://github.com/galaxyproject/galaxy/pull/7854

Is there a way to make our testing framework more strict, i.e. just fail if loading of a config file fails. Currently we just have 

```
galaxy.jobs WARNING 2025-03-06 12:33:05,981 [pN:main,p:8946,tN:MainThread] Job configuration "/home/berntm/projects/galaxyproject/galaxy/test/integration/resubmission_default_job_conf.xml" does not exist, using default job configuration
```


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
