### PR TITLE
Use fissix also when python3-lib2to3 is not installed

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -65,7 +65,7 @@ email-validator==2.2.0
 exceptiongroup==1.2.2 ; python_full_version < '3.11'
 fastapi-slim==0.115.10
 filelock==3.17.0
-fissix==24.4.24 ; python_full_version >= '3.13'
+fissix==24.4.24
 frozenlist==1.5.0
 fs==2.4.16
 fsspec==2025.2.0

--- a/lib/galaxy/util/template.py
+++ b/lib/galaxy/util/template.py
@@ -12,7 +12,11 @@ from packaging.version import Version
 from galaxy.util.tree_dict import TreeDict
 from . import unicodify
 
-if sys.version_info >= (3, 13):
+try:
+    from lib2to3.refactor import RefactoringTool
+except ImportError:
+    # Either Python 3.13 or Debian(<=12)/Ubuntu(<=24.10) without the
+    # python3-lib2to3 package
     import fissix
     from fissix import (
         fixes as fissix_fixes,
@@ -25,7 +29,7 @@ if sys.version_info >= (3, 13):
     sys.modules["lib2to3.pgen2"] = fissix_pgen2
     sys.modules["lib2to3.refactor"] = fissix_refactor
 
-from lib2to3.refactor import RefactoringTool
+    from lib2to3.refactor import RefactoringTool
 
 from past.translation import myfixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "dparse",
     "edam-ontology",
     "fastapi-slim>=0.111.0",
-    "fissix ; python_version>='3.13'",
+    "fissix",
     "fs",
     "future>=1.0.0",  # Python 3.12 support
     "gravity>=1.0.4",


### PR DESCRIPTION
Fix https://github.com/galaxyproject/ansible-galaxy/issues/223 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
