### PR TITLE
[24.2] Fix dataypes linter: allow auto for output tags

### DIFF
--- a/lib/galaxy/tool_util/linters/datatypes.py
+++ b/lib/galaxy/tool_util/linters/datatypes.py
@@ -78,10 +78,12 @@ class ValidDatatypes(Linter):
         for attrib in ["format", "ftype", "ext"]:
             for elem in tool_xml.findall(f".//*[@{attrib}]"):
                 formats = elem.get(attrib, "").split(",")
+                # Certain elements (e.g. `data`) can only have one format. This
+                # is checked separately by linting against the XSD.
                 if "auto" in formats:
                     if elem.tag == "param":
                         lint_ctx.error(
-                            f"Format [auto] can not be used for tool or tool test inputs",
+                            "Format [auto] can not be used for tool or tool test inputs",
                             linter=cls.name(),
                             node=elem,
                         )

--- a/lib/galaxy/tool_util/linters/datatypes.py
+++ b/lib/galaxy/tool_util/linters/datatypes.py
@@ -78,6 +78,14 @@ class ValidDatatypes(Linter):
         for attrib in ["format", "ftype", "ext"]:
             for elem in tool_xml.findall(f".//*[@{attrib}]"):
                 formats = elem.get(attrib, "").split(",")
+                if "auto" in formats:
+                    if elem.tag == "param":
+                        lint_ctx.error(
+                            f"Format [auto] can not be used for tool or tool test inputs",
+                            linter=cls.name(),
+                            node=elem,
+                        )
+                    continue
                 for format in formats:
                     if format not in datatypes:
                         lint_ctx.error(

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -2029,8 +2029,10 @@ VALID_DATATYPES = """
         <param name="adata" type="data" format="txt"/>
         <param name="bdata" type="data" format="invalid,fasta,custom"/>
         <param name="fdata" type="data" format="fasta.gz"/>
+        <param name="auto_input" type="data" format="auto"/>
     </inputs>
     <outputs>
+        <data name="autoformat" format="auto"/>
         <data name="name" format="another_invalid">
             <change_format>
                 <when input="input_text" value="foo" format="just_another_invalid"/>
@@ -2045,6 +2047,7 @@ VALID_DATATYPES = """
         <test>
             <param name="adata" ftype="txt"/>
             <param name="bdata" ftype="invalid"/>
+            <param name="auto_test_input" ftype="auto"/>
         </test>
     </tests>
 </tool>
@@ -2082,7 +2085,8 @@ def test_valid_datatypes(lint_ctx):
     assert "Unknown datatype [collection_format] used in collection" in lint_ctx.error_messages
     assert "Unknown datatype [invalid] used in param" in lint_ctx.error_messages
     assert "Unknown datatype [invalid] used in discover_datasets" in lint_ctx.error_messages
-    assert len(lint_ctx.error_messages) == 6
+    assert "Format [auto] can not be used for tool or tool test inputs" in lint_ctx.error_messages  # 2x
+    assert len(lint_ctx.error_messages) == 8
 
 
 DATA_MANAGER = """<tool id="test_dm" name="test dm" version="1" tool_type="manage_data">


### PR DESCRIPTION


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
