### PR TITLE
Remove ``num_unique_values`` tiff metadata element

### DIFF
--- a/lib/galaxy/datatypes/images.py
+++ b/lib/galaxy/datatypes/images.py
@@ -80,14 +80,6 @@ class Image(data.Data):
     )
 
     MetadataElement(
-        name="num_unique_values",
-        desc="Number of unique values in the image data (e.g., should be 2 for binary images)",
-        readonly=True,
-        visible=True,
-        optional=True,
-    )
-
-    MetadataElement(
         name="width",
         desc="Width of the image (in pixels)",
         readonly=True,
@@ -167,7 +159,6 @@ class Image(data.Data):
                     dataset.metadata.height = im.size[0]
                     dataset.metadata.depth = 0
                     dataset.metadata.frames = getattr(im, "n_frames", 0)
-                    dataset.metadata.num_unique_values = sum(val > 0 for val in im.histogram())
 
                     # Peek into a small 2x2 section of the image data
                     im_peek_arr = np.array(im.crop((0, 0, min((2, im.size[1])), min((2, im.size[0])))))
@@ -242,7 +233,6 @@ class Tiff(Image):
                         "channels",
                         "depth",
                         "frames",
-                        "num_unique_values",
                     ]
                 }
                 for page in tif.series:
@@ -257,13 +247,6 @@ class Tiff(Image):
                     metadata["channels"].append(Tiff._get_axis_size(page.shape, axes, "C"))
                     metadata["depth"].append(Tiff._get_axis_size(page.shape, axes, "Z"))
                     metadata["frames"].append(Tiff._get_axis_size(page.shape, axes, "T"))
-
-                    # Determine the metadata values that require reading the image data
-                    try:
-                        im_arr = page.asarray()
-                        metadata["num_unique_values"].append(len(np.unique(im_arr)))
-                    except ValueError:  # Occurs if the compression of the TIFF file is unsupported
-                        pass
 
                 # Populate the metadata fields based on the values determined above
                 for key, values in metadata.items():

--- a/test/unit/data/datatypes/test_images.py
+++ b/test/unit/data/datatypes/test_images.py
@@ -51,7 +51,6 @@ def __assert_empty_metadata(metadata):
     for key in (
         "axes",
         "dtype",
-        "num_unique_values",
         "width",
         "height",
         "channels",
@@ -68,8 +67,6 @@ test_tiff_axes_zcyx = __create_test(Tiff, "im6_uint8.tif", "axes", "ZCYX")
 test_tiff_dtype_uint8 = __create_test(Tiff, "im6_uint8.tif", "dtype", "uint8")
 test_tiff_dtype_uint16 = __create_test(Tiff, "im8_uint16.tif", "dtype", "uint16")
 test_tiff_dtype_float64 = __create_test(Tiff, "im4_float.tif", "dtype", "float64")
-test_tiff_num_unique_values_2 = __create_test(Tiff, "im3_b.tif", "num_unique_values", 2)
-test_tiff_num_unique_values_618 = __create_test(Tiff, "im4_float.tif", "num_unique_values", 618)
 test_tiff_width_16 = __create_test(Tiff, "im7_uint8.tif", "width", 16)  # axes: ZYX
 test_tiff_width_32 = __create_test(Tiff, "im3_b.tif", "width", 32)  # axes: YXS
 test_tiff_height_8 = __create_test(Tiff, "im7_uint8.tif", "height", 8)  # axes: ZYX
@@ -99,15 +96,11 @@ def test_tiff_unsupported_compression(metadata):
     assert metadata.depth == 0
     assert metadata.frames == 0
 
-    # The other fields should be missing
-    assert getattr(metadata, "num_unique_values", None) is None
-
 
 @__test(Tiff, "im9_multipage.tif")
 def test_tiff_multipage(metadata):
     assert metadata.axes == ["YXS", "YX"]
     assert metadata.dtype == ["uint8", "uint16"]
-    assert metadata.num_unique_values == [2, 255]
     assert metadata.width == [32, 256]
     assert metadata.height == [32, 256]
     assert metadata.channels == [3, 0]
@@ -120,8 +113,6 @@ def test_tiff_multipage(metadata):
 test_png_axes_yx = __create_test(Image, "im1_uint8.png", "axes", "YX")
 test_png_axes_yxc = __create_test(Image, "im3_a.png", "axes", "YXC")
 test_png_dtype_uint8 = __create_test(Image, "im1_uint8.png", "dtype", "uint8")
-test_png_num_unique_values_1 = __create_test(Image, "im2_a.png", "num_unique_values", 1)
-test_png_num_unique_values_2 = __create_test(Image, "im2_b.png", "num_unique_values", 2)
 test_png_width_32 = __create_test(Image, "im2_b.png", "width", 32)
 test_png_height_32 = __create_test(Image, "im2_b.png", "height", 32)
 test_png_channels_0 = __create_test(Image, "im1_uint8.png", "channels", 0)


### PR DESCRIPTION
This was added in https://github.com/galaxyproject/galaxy/pull/18951 but its memory consumption scales with input size. On a 5.5GB TIFF file this consumed a peak of 18GB of memory.

A working and more memory efficient implentation would be
```
import rasterio
import numpy as np
from collections import Counter

def count_unique_values_rasterio(file_path):
    counter = Counter()

    with rasterio.open(file_path) as src:
        for _, window in src.block_windows(1):  # Read in small windows
            data = src.read(1, window=window)  # Read only the small chunk
            unique, counts = np.unique(data, return_counts=True)
            counter.update(dict(zip(unique, counts)))

    return len(counter)
```

However this seems to be a property mostly useful for test assertions (do correct me if I'm wrong @kostrykin), as such I would not compute this for every tiff dataset, and instead handle it in the client test code.
Considering that the rasterio wheel is 22MB in size and I haven't found any use in the current test framework I think it's better to remove this for now and add it when necessary.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
