### PR TITLE
[24.2] Move Workflow Editor save button

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -149,6 +149,7 @@
                             id="workflow-save-button"
                             class="py-1 px-2"
                             variant="link"
+                            :disabled="!hasChanges"
                             :title="saveWorkflowTitle"
                             @click="saveOrCreate">
                             <FontAwesomeIcon :icon="faSave" />

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -129,15 +129,6 @@
                         <span class="editor-title" :title="name"
                             >{{ name }}
                             <i v-if="hasChanges" class="text-muted"> (unsaved changes) </i>
-                            <b-button
-                                v-if="hasChanges"
-                                id="workflow-save-button"
-                                class="py-1 px-2"
-                                variant="link"
-                                :title="saveWorkflowTitle"
-                                @click="saveOrCreate">
-                                <FontAwesomeIcon :icon="faSave" />
-                            </b-button>
                         </span>
                     </span>
 
@@ -153,6 +144,14 @@
                             :variant="undoRedoStore.hasRedo ? 'secondary' : 'muted'"
                             @click="undoRedoStore.redo()">
                             <FontAwesomeIcon icon="fa-arrow-right" />
+                        </b-button>
+                        <b-button
+                            id="workflow-save-button"
+                            class="py-1 px-2"
+                            variant="link"
+                            :title="saveWorkflowTitle"
+                            @click="saveOrCreate">
+                            <FontAwesomeIcon :icon="faSave" />
                         </b-button>
                     </b-button-group>
                 </div>

--- a/client/src/components/Workflow/Editor/modules/activities.ts
+++ b/client/src/components/Workflow/Editor/modules/activities.ts
@@ -98,7 +98,17 @@ export const workflowEditorActivities = [
         optional: true,
     },
     {
-        description: "Save this workflow with a different name and annotation",
+        description: "Save this workflow.",
+        icon: faSave,
+        id: "save-workflow",
+        title: "Save",
+        tooltip: "Save current changes",
+        visible: true,
+        click: true,
+        optional: true,
+    },
+    {
+        description: "Save this workflow with a different name and annotation.",
         icon: farSave,
         id: "save-workflow-as",
         title: "Save as",

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -455,7 +455,6 @@ class TestWithSeleniumMixin(GalaxyTestSeleniumContext, UsesApiTestCaseMixin, Use
         save_button.wait_for_visible()
         assert not save_button.has_class("disabled")
         save_button.wait_for_and_click()
-        save_button.wait_for_absent()
         self.sleep_for(self.wait_types.UX_RENDER)
 
     @retry_assertion_during_transitions

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -44,7 +44,7 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows):
 
         # shouldn't have changes on fresh load
         save_button = self.components.workflow_editor.save_button
-        assert save_button.is_absent
+        save_button.assert_disabled()
 
         self.screenshot("workflow_editor_blank")
 


### PR DESCRIPTION
Fixes #19560

The little "save" icon beside the workflow title has been moved to the top right corner to make it always visible.
In addition, a "Save" activity has been added to the activity bar in case people try to look for the save option there.

![image](https://github.com/user-attachments/assets/26ecb3da-1e20-4ee7-8325-a194e3081bbf)


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
