### PR TITLE
Revise consistently failing edam tool panel view test.

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1695,6 +1695,14 @@ class NavigatesGalaxy(HasDriver):
 
         self.sleep_for(self.wait_types.UX_RENDER)
 
+    def swap_to_tool_panel(self, panel_id: str) -> None:
+        tool_panel = self.components.tool_panel
+        tool_panel.views_button.wait_for_and_click()
+        tool_panel.views_menu_item(panel_id=panel_id).wait_for_and_click()
+
+    def swap_to_tool_panel_edam_operations(self) -> None:
+        self.swap_to_tool_panel("ontology:edam_operations")
+
     def tool_open(self, tool_id, outer=False):
         self.open_toolbox()
 

--- a/lib/galaxy_test/selenium/test_edam_tool_panel_views.py
+++ b/lib/galaxy_test/selenium/test_edam_tool_panel_views.py
@@ -1,22 +1,21 @@
-from galaxy.selenium.navigates_galaxy import retry_during_transitions
 from .framework import (
+    retry_assertion_during_transitions,
     selenium_test,
-    SeleniumIntegrationTestCase,
+    SeleniumTestCase,
 )
 
 
-class TestEdamToolPanelViewsSeleniumIntegration(SeleniumIntegrationTestCase):
+class TestEdamToolPanelViewsSelenium(SeleniumTestCase):
     ensure_registered = True  # to test workflow editor
 
     @selenium_test
     def test_basic_navigation(self):
-        tool_panel = self.components.tool_panel
-        tool_panel.views_button.wait_for_and_click()
-        tool_panel.views_menu_item(panel_id="ontology:edam_operations").wait_for_and_click()
+        self.swap_to_tool_panel_edam_operations()
         self._assert_displaying_edam_operations()
 
         # reload page and ensure the edam operations are still being displayed.
         self.home()
+        tool_panel = self.components.tool_panel
         tool_panel.views_button.wait_for_visible()
         self._assert_displaying_edam_operations()
         self.screenshot("tool_panel_view_edam_landing")
@@ -31,7 +30,7 @@ class TestEdamToolPanelViewsSeleniumIntegration(SeleniumIntegrationTestCase):
         self._assert_displaying_edam_operations()
         self.screenshot("tool_panel_view_edam_workflow_editor")
 
-    @retry_during_transitions
+    @retry_assertion_during_transitions
     def _assert_displaying_edam_operations(self):
         tool_panel = self.components.tool_panel
         tool_panel.toolbox.wait_for_visible()


### PR DESCRIPTION
The tool panel view renders the default view before switching to the EDAM I think, so retrying the assertion instead of just retrying any DOM click failures should allow that to stabilize. The UI flicker seems to be a regression though - but this test didn't prevent that so now it has to test something else.

Also I think the EDAM stuff is just on by default now so this doesn't need to be an integration test - as such moved it to the vanilla Selenium tests.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
