### PR TITLE
[24.2] Fix masthead webhook click/nav.

### DIFF
--- a/client/src/components/Masthead/Masthead.vue
+++ b/client/src/components/Masthead/Masthead.vue
@@ -58,6 +58,14 @@ function openUrl(url, target = null) {
     }
 }
 
+function extensionTabClick(tab) {
+    if (tab.url) {
+        openUrl(tab.url, tab.target);
+    } else if (typeof tab.onclick === "function") {
+        tab.onclick();
+    }
+}
+
 function onWindowToggle() {
     windowToggle.value = !windowToggle.value;
     props.windowTab.onclick();
@@ -103,7 +111,7 @@ onMounted(() => {
                 :url="tab.url"
                 :tooltip="tab.tooltip"
                 :target="tab.target"
-                @click="tab.onclick ? tab.onclick : undefined" />
+                @click="extensionTabClick(tab)" />
             <MastheadItem
                 id="help"
                 icon="fa-question"


### PR DESCRIPTION
Adds an extensionTabClick function to handle webhook tab clicks in Masthead.  This fixes the scope and context issues introduced in the masthead migration that were preventing webhooks from functioning previously.  Should close #19572

Test as in that ticket -- GTN webhook continued to work because it's not a single injected function (which had the context issues) but a page-level script.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
