### PR TITLE
[24.2] Fix RDM token access for user-defined file sources

### DIFF
--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -201,11 +201,8 @@ class RDMFilesSource(BaseFilesSource):
         return effective_props
 
     def get_authorization_token(self, user_context: OptionalUserContext) -> Optional[str]:
-        token = None
-        if user_context:
-            effective_props = self._serialization_props(user_context)
-            token = effective_props.get("token")
-        return token
+        effective_props = self._serialization_props(user_context)
+        return effective_props.get("token")
 
     def get_public_name(self, user_context: OptionalUserContext) -> Optional[str]:
         effective_props = self._serialization_props(user_context)


### PR DESCRIPTION
Fixes #18237 for user-defined file sources

The user context was needed in the old admin-provided file sources to evaluate templated values. However, the user context is no longer required when using user-defined file sources, as the templated values are already resolved when instancing the file source.

Going forward, we're empowering users to manage all their file sources via the system described in https://github.com/galaxyproject/galaxy/pull/18127. This change means the old admin-defined file source system will only be maintained for public resources that don't need user credentials. So, adapting the `Export datasets` tool won't be necessary.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Use the file source template in #19619
  - Make sure you create a draft record in your Invenio-based instance.
  - Try to export a file using the `Export datasets` (tool_id=export_remote) to your draft record.
  - The file is exported successfully

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
