### PR TITLE
[24.2] Fix anndata metadata setting for data with integer indexes

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1612,7 +1612,10 @@ class Anndata(H5):
                 obs = get_index_value(tmp)
                 # Determine cell labels
                 if obs is not None:
-                    dataset.metadata.obs_names = [n.decode() for n in obs]
+                    # This is super expensive because the number of observations is unbounded.
+                    # https://github.com/galaxyproject/tools-iuc/blob/8341270dd36185ebf59d15282bc79f1215e936a4/tools/anndata/import.xml#L53
+                    # seems to be the only tool to consume this in the IUC. drop and make tool compute this?
+                    dataset.metadata.obs_names = [util.unicodify(n) for n in obs]
                 else:
                     log.warning("Could not determine observation index for %s", self)
 


### PR DESCRIPTION
Fixes the workflow associated with https://training.galaxyproject.org/training-material/topics/imaging/tutorials/multiplex-tissue-imaging-TMA/tutorial.html, which fails for one dataset in toolshed.g2.bx.psu.edu/repos/goeckslab/scimap_mcmicro_to_anndata/scimap_mcmicro_to_anndata/0.17.7+galaxy0

@mtekman do you think we can drop this and have the tools compute `obs_names` as needed ? It seems like that's not a commonly consumed property in tools, and you'd frequently have more than a thousand values in there (17633 in this case), which takes a considerable amount of memory in the database and would typically be cut off by the `max_metadata_value_size` galaxy config setting, which in the worst case means tools work on wrong values. Alternatively we could store these values in a MetadataFile on disk, but I don't think this is more convenient than just adapting the (few?) tools that actually consume this value.

Anyway, this is the conservative fix for now, but I intend to eventually remove anything that can consume unbounded memory or create large values in the database in the metadata process.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
