### PR TITLE
Add visualization framework interface to cell-based markdown editor

### DIFF
--- a/client/src/components/Markdown/Editor/CellAction.vue
+++ b/client/src/components/Markdown/Editor/CellAction.vue
@@ -13,7 +13,7 @@
                     <small class="my-1 mx-3 text-info">{{ title }}</small>
                 </span>
                 <CellOption
-                    v-if="name !== 'markdown'"
+                    v-if="['galaxy', 'visualization'].includes(name)"
                     title="Attach Data"
                     description="Select data for this cell"
                     :icon="faPaperclip"

--- a/client/src/components/Markdown/Editor/CellAdd.vue
+++ b/client/src/components/Markdown/Editor/CellAdd.vue
@@ -30,8 +30,9 @@
 <script setup lang="ts">
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { BAlert } from "bootstrap-vue";
-import { computed, ref } from "vue";
+import { computed, onMounted, type Ref, ref } from "vue";
 
+import { getVisualizations } from "./services";
 import cellTemplates from "./templates.yml";
 import type { CellType, TemplateEntry } from "./types";
 
@@ -46,9 +47,11 @@ defineEmits<{
 
 const buttonRef = ref();
 const query = ref("");
+const visualizations: Ref<Array<TemplateEntry>> = ref([]);
 
 const allTemplates = computed(() => {
     const result = { ...(cellTemplates as Record<string, Array<TemplateEntry>>) };
+    result["Visualization"] = visualizations.value;
     return result;
 });
 
@@ -66,6 +69,10 @@ const filteredTemplates = computed(() => {
         }
     });
     return filteredCategories;
+});
+
+onMounted(async () => {
+    visualizations.value = await getVisualizations();
 });
 </script>
 

--- a/client/src/components/Markdown/Editor/CellCode.vue
+++ b/client/src/components/Markdown/Editor/CellCode.vue
@@ -14,6 +14,10 @@ const props = defineProps({
         type: String,
         default: "github_light_default",
     },
+    maxLines: {
+        type: Number,
+        default: 99999,
+    },
     mode: {
         type: String,
         default: "json",
@@ -44,7 +48,7 @@ async function buildEditor() {
     aceEditor = ace.edit(editor.value, {
         highlightActiveLine: false,
         highlightGutterLine: false,
-        maxLines: 30,
+        maxLines: props.maxLines,
         minLines: 1,
         mode: modePath,
         showPrintMargin: false,

--- a/client/src/components/Markdown/Editor/CellWrapper.vue
+++ b/client/src/components/Markdown/Editor/CellWrapper.vue
@@ -36,6 +36,13 @@
                     :labels="labels"
                     @cancel="$emit('configure')"
                     @change="handleConfigure($event)" />
+                <ConfigureVisualization
+                    v-else-if="name === 'visualization' && configure"
+                    :name="name"
+                    :content="content"
+                    :labels="labels"
+                    @cancel="$emit('configure')"
+                    @change="handleConfigure($event)" />
                 <CellCode
                     :key="name"
                     class="mt-1"
@@ -60,6 +67,7 @@ import type { WorkflowLabel } from "./types";
 import CellAction from "./CellAction.vue";
 import CellButton from "./CellButton.vue";
 import ConfigureGalaxy from "./Configurations/ConfigureGalaxy.vue";
+import ConfigureVisualization from "./Configurations/ConfigureVisualization.vue";
 import SectionWrapper from "@/components/Markdown/Sections/SectionWrapper.vue";
 
 const CellCode = () => import("./CellCode.vue");

--- a/client/src/components/Markdown/Editor/Configurations/ConfigureVisualization.vue
+++ b/client/src/components/Markdown/Editor/Configurations/ConfigureVisualization.vue
@@ -1,0 +1,84 @@
+<template>
+    <b-alert v-if="errorMessage" variant="warning" show>{{ errorMessage }}</b-alert>
+    <MarkdownSelector v-else-if="labels !== undefined" argument-name="Dataset" :labels="labels" @onOk="onLabel" />
+    <DataDialog
+        v-else-if="currentHistoryId !== null"
+        :history="currentHistoryId"
+        format="id"
+        @onOk="onData"
+        @onCancel="$emit('cancel')" />
+    <b-alert v-else v-localize variant="info" show> No history available to choose from. </b-alert>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from "pinia";
+import { type Ref, ref, watch } from "vue";
+
+import type { DatasetLabel, WorkflowLabel } from "@/components/Markdown/Editor/types";
+import { stringify } from "@/components/Markdown/Utilities/stringify";
+import { useHistoryStore } from "@/stores/historyStore";
+
+import DataDialog from "@/components/DataDialog/DataDialog.vue";
+import MarkdownSelector from "@/components/Markdown/MarkdownSelector.vue";
+
+const { currentHistoryId } = storeToRefs(useHistoryStore());
+
+const props = defineProps<{
+    content: string;
+    labels?: Array<WorkflowLabel>;
+}>();
+
+const emit = defineEmits<{
+    (e: "cancel"): void;
+    (e: "change", content: string): void;
+}>();
+
+interface contentType {
+    dataset_id?: string;
+    dataset_label?: DatasetLabel;
+    dataset_url?: string;
+}
+
+const contentObject: Ref<contentType | undefined> = ref();
+const errorMessage = ref("");
+
+function onData(datasetId: any) {
+    if (contentObject.value) {
+        contentObject.value.dataset_id = datasetId;
+        contentObject.value.dataset_label = undefined;
+        contentObject.value.dataset_url = undefined;
+        emit("change", stringify(contentObject.value));
+    }
+}
+
+function onLabel(selectedLabel: any) {
+    if (selectedLabel !== undefined) {
+        const labelType = selectedLabel.type;
+        const label = selectedLabel.label;
+        if (contentObject.value && label && labelType) {
+            contentObject.value.dataset_label = {
+                invocation_id: "",
+                [labelType]: label,
+            };
+            contentObject.value.dataset_id = undefined;
+            contentObject.value.dataset_url = undefined;
+            emit("change", stringify(contentObject.value));
+        }
+    }
+}
+
+function parseContent() {
+    try {
+        contentObject.value = JSON.parse(props.content);
+        errorMessage.value = "";
+    } catch (e) {
+        errorMessage.value = `Failed to parse: ${e}`;
+    }
+}
+
+watch(
+    () => props.content,
+    () => parseContent(),
+    { immediate: true }
+);
+</script>

--- a/client/src/components/Markdown/Editor/services.ts
+++ b/client/src/components/Markdown/Editor/services.ts
@@ -23,7 +23,6 @@ export async function getVisualizations(): Promise<Array<TemplateEntry>> {
                 name: "visualization",
                 configure: true,
                 content: `{ "visualization_name": "${v.name}", "visualization_title": "${v.html}" }`,
-                // "dataset_url": "http://cdn.jsdelivr.net/gh/galaxyproject/galaxy-test-data/newick.nwk"
             },
         }));
     } catch (e) {

--- a/client/src/components/Markdown/Editor/services.ts
+++ b/client/src/components/Markdown/Editor/services.ts
@@ -1,0 +1,32 @@
+import axios from "axios";
+
+import { getAppRoot } from "@/onload";
+import { rethrowSimple } from "@/utils/simple-error";
+
+import type { TemplateEntry } from "./types";
+
+export interface VisualizationType {
+    description: string;
+    html: string;
+    logo?: string;
+    name: string;
+}
+
+export async function getVisualizations(): Promise<Array<TemplateEntry>> {
+    try {
+        const { data } = await axios.get(`${getAppRoot()}api/plugins?embeddable=True`);
+        return data.map((v: VisualizationType) => ({
+            title: v.html,
+            description: v.description || "",
+            logo: v.logo ? `${getAppRoot()}${v.logo}` : undefined,
+            cell: {
+                name: "visualization",
+                configure: true,
+                content: `{ "visualization_name": "${v.name}", "visualization_title": "${v.html}" }`,
+                // "dataset_url": "http://cdn.jsdelivr.net/gh/galaxyproject/galaxy-test-data/newick.nwk"
+            },
+        }));
+    } catch (e) {
+        rethrowSimple("Failed to load Visualizations.");
+    }
+}

--- a/client/src/components/Markdown/Editor/templates.yml
+++ b/client/src/components/Markdown/Editor/templates.yml
@@ -194,3 +194,68 @@ Galaxy:
     cell:
       name: "galaxy"
       content: "generate_galaxy_version()"
+
+Vega:
+  - title: "Bar Diagram"
+    description: "Basic bar diagram"
+    cell:
+      name: "vega"
+      content: |
+        {
+          "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+          "description": "A simple bar chart with embedded data.",
+          "data": {"values": [
+            { "a": "A", "b": 1 },
+            { "a": "B", "b": 2 },
+            { "a": "C", "b": 3 }
+          ]},
+          "mark": "bar",
+          "encoding": {
+            "x": {"field": "a", "type": "nominal", "axis": {"labelAngle": 0}},
+            "y": {"field": "b", "type": "quantitative"}
+          }
+        }
+  - title: "Line Chart"
+    description: "Basic line chart"
+    cell:
+      name: "vega"
+      content: |
+        {
+          "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+          "description": "A simple line chart with embedded data.",
+          "data": {"values": [
+            { "a": "A", "b": 1 },
+            { "a": "B", "b": 2 },
+            { "a": "C", "b": 3 }
+          ]},
+          "mark": "line",
+          "encoding": {
+            "x": {"field": "a", "type": "nominal", "axis": {"labelAngle": 0}},
+            "y": {"field": "b", "type": "quantitative"}
+          }
+        }
+
+Vitessce:
+  - title: "Hello World"
+    description: "A simple vitessce example"
+    cell:
+      name: "vitessce"
+      content: |
+        {
+          "version": "1.0.16",
+          "name": "Example configuration",
+          "description": "",
+          "datasets": [],
+          "initStrategy": "auto",
+          "coordinationSpace": {},
+          "layout": [{
+            "component": "description",
+            "props": {
+                "description": "Hello, world!"
+            },
+            "x": 0,
+            "y": 0,
+            "w": 6,
+            "h": 6
+          }]
+        }

--- a/client/src/components/Markdown/MarkdownEditor.vue
+++ b/client/src/components/Markdown/MarkdownEditor.vue
@@ -68,7 +68,7 @@ defineProps<{
 
 const showHelpModal = ref<boolean>(false);
 
-const editor = ref("text");
+const editor = ref("editor");
 const editorOptions = ref([
     { text: "Editor", value: "editor" },
     { text: "Text", value: "text" },

--- a/client/src/components/Markdown/MarkdownEditor.vue
+++ b/client/src/components/Markdown/MarkdownEditor.vue
@@ -8,7 +8,6 @@
                     </div>
                     <div>
                         <b-form-radio-group
-                            v-if="!labels || labels.length === 0"
                             v-model="editor"
                             v-b-tooltip.hover.bottom
                             button-variant="outline-primary"

--- a/client/src/components/Markdown/MarkdownEditor.vue
+++ b/client/src/components/Markdown/MarkdownEditor.vue
@@ -68,7 +68,7 @@ defineProps<{
 
 const showHelpModal = ref<boolean>(false);
 
-const editor = ref("editor");
+const editor = ref("text");
 const editorOptions = ref([
     { text: "Editor", value: "editor" },
     { text: "Text", value: "text" },

--- a/client/src/components/Markdown/Sections/MarkdownVega.vue
+++ b/client/src/components/Markdown/Sections/MarkdownVega.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { ref, watch } from "vue";
+
+const VegaWrapper = () => import("@/components/Common/VegaWrapper.vue");
+
+const props = defineProps<{
+    content: string;
+}>();
+
+const errorMessage = ref("");
+const spec = ref({});
+
+function render() {
+    try {
+        errorMessage.value = "";
+        spec.value = {
+            ...JSON.parse(props.content),
+            width: "container",
+        };
+    } catch (e: any) {
+        errorMessage.value = String(e);
+        spec.value = {};
+    }
+}
+
+watch(
+    () => props.content,
+    () => {
+        render();
+    },
+    { immediate: true }
+);
+</script>
+
+<template>
+    <div>
+        <b-alert v-if="errorMessage" class="p-2" variant="danger" show>
+            {{ errorMessage }}
+        </b-alert>
+        <VegaWrapper :spec="spec" />
+    </div>
+</template>

--- a/client/src/components/Markdown/Sections/MarkdownVisualization.vue
+++ b/client/src/components/Markdown/Sections/MarkdownVisualization.vue
@@ -82,7 +82,7 @@ function processContent() {
 function processInvocation() {
     if (invocation.value) {
         const inputId = parseInput(invocation.value as Invocation, datasetLabel.value?.input);
-        const outputId = parseOutput(invocation.value, datasetLabel.value?.output);
+        const outputId = parseOutput(invocation.value as Invocation, datasetLabel.value?.output);
         const datasetId = inputId || outputId;
         visualizationConfig.value.dataset_id = datasetId;
     }

--- a/client/src/components/Markdown/Sections/MarkdownVisualization.vue
+++ b/client/src/components/Markdown/Sections/MarkdownVisualization.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import { BAlert } from "bootstrap-vue";
+import { computed, type Ref, ref, watch } from "vue";
+
+import type { DatasetLabel, Invocation } from "@/components/Markdown/Editor/types";
+import { stringify } from "@/components/Markdown/Utilities/stringify";
+import { useInvocationStore } from "@/stores/invocationStore";
+
+import { parseInput, parseOutput } from "../Utilities/parseInvocation";
+
+import LoadingSpan from "@/components/LoadingSpan.vue";
+import VisualizationWrapper from "@/components/Visualizations/VisualizationWrapper.vue";
+
+const props = defineProps<{
+    attribute?: string;
+    content: string;
+    name?: string;
+}>();
+
+const emit = defineEmits(["change"]);
+
+const errorMessage = ref("");
+const visualizationConfig = ref();
+const visualizationKey = ref(0);
+const visualizationName = ref();
+const visualizationTitle = ref("");
+const datasetLabel: Ref<DatasetLabel | undefined> = ref();
+
+const { getInvocationById, getInvocationLoadError, isLoadingInvocation } = useInvocationStore();
+
+const currentContent = ref(props.content);
+
+const invocation = computed(() => invocationId.value && getInvocationById(invocationId.value));
+const invocationId = computed(() => datasetLabel.value?.invocation_id || "");
+const invocationLoading = computed(() => isLoadingInvocation(invocationId.value));
+const invocationLoadError = computed(() => getInvocationLoadError(invocationId.value));
+
+function onChange(incomingData: Record<string, any>) {
+    const newContent = {
+        visualization_name: visualizationName.value,
+        visualization_title: incomingData.visualization_title,
+        dataset_label: datasetLabel.value,
+        ...incomingData.visualization_config,
+    };
+    currentContent.value = stringify(newContent);
+    emit("change", currentContent.value);
+}
+
+function processContent() {
+    try {
+        errorMessage.value = "";
+        const parsedContent = { ...JSON.parse(props.content) };
+
+        datasetLabel.value = parsedContent.dataset_label;
+
+        if (props.attribute) {
+            visualizationConfig.value = {};
+            visualizationConfig.value[props.attribute] = parsedContent;
+        } else {
+            visualizationConfig.value = {
+                dataset_id: parsedContent.dataset_id,
+                dataset_url: parsedContent.dataset_url,
+                settings: parsedContent.settings,
+                tracks: parsedContent.tracks,
+            };
+            visualizationTitle.value = parsedContent.visualization_title || "";
+        }
+        visualizationName.value = props.name || parsedContent.visualization_name;
+        if (!visualizationName.value) {
+            throw new Error("Please add a 'visualization_name` to the dictionary.");
+        }
+        processInvocation();
+        if (currentContent.value !== props.content) {
+            currentContent.value = props.content;
+            visualizationKey.value++;
+        }
+    } catch (e) {
+        errorMessage.value = String(e);
+    }
+}
+
+function processInvocation() {
+    if (invocation.value) {
+        const inputId = parseInput(invocation.value as Invocation, datasetLabel.value?.input);
+        const outputId = parseOutput(invocation.value, datasetLabel.value?.output);
+        const datasetId = inputId || outputId;
+        visualizationConfig.value.dataset_id = datasetId;
+    }
+}
+
+watch(
+    () => props.content,
+    () => processContent(),
+    { immediate: true }
+);
+
+watch(
+    () => invocation.value,
+    () => processInvocation()
+);
+</script>
+
+<template>
+    <div class="markdown-visualization">
+        <BAlert v-if="errorMessage" v-localize class="m-0" variant="danger" show>
+            {{ errorMessage }}
+        </BAlert>
+        <BAlert v-else-if="invocationLoadError" v-localize class="m-0" variant="danger" show>
+            {{ invocationLoadError }}
+        </BAlert>
+        <LoadingSpan v-else-if="invocationLoading" />
+        <VisualizationWrapper
+            v-else-if="visualizationConfig"
+            :key="visualizationKey"
+            class="markdown-visualization"
+            :config="visualizationConfig"
+            :name="visualizationName"
+            :title="visualizationTitle"
+            @change="onChange" />
+    </div>
+</template>
+
+<style>
+.markdown-visualization {
+    min-height: 400px;
+    max-height: 400px;
+}
+</style>

--- a/client/src/components/Markdown/Sections/SectionWrapper.vue
+++ b/client/src/components/Markdown/Sections/SectionWrapper.vue
@@ -1,14 +1,23 @@
 <template>
     <MarkdownDefault v-if="name === 'markdown'" :content="content" />
     <MarkdownGalaxy v-else-if="name === 'galaxy'" :content="content" :labels="labels" />
+    <MarkdownVega v-else-if="name === 'vega'" :content="content" />
+    <MarkdownVisualization v-else-if="name === 'visualization'" :content="content" @change="$emit('change', $event)" />
+    <MarkdownVisualization
+        v-else-if="name === 'vitessce'"
+        attribute="dataset_content"
+        name="vitessce"
+        :content="content" />
     <b-alert v-else variant="danger" show> This cell type `{{ name }}` is not available. </b-alert>
 </template>
 
 <script setup lang="ts">
 import type { WorkflowLabel } from "@/components/Markdown/Editor/types";
 
-import MarkdownDefault from "../Sections/MarkdownDefault.vue";
-import MarkdownGalaxy from "../Sections/MarkdownGalaxy.vue";
+import MarkdownDefault from "./MarkdownDefault.vue";
+import MarkdownGalaxy from "./MarkdownGalaxy.vue";
+import MarkdownVega from "./MarkdownVega.vue";
+import MarkdownVisualization from "./MarkdownVisualization.vue";
 
 defineProps<{
     content: string;

--- a/client/src/components/Markdown/Utilities/stringify.ts
+++ b/client/src/components/Markdown/Utilities/stringify.ts
@@ -1,0 +1,15 @@
+export function stringify<T extends Record<string, any>>(contentObject: T): string {
+    function deepSortObject(obj: any): any {
+        if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
+            return obj;
+        }
+        return Object.keys(obj)
+            .sort()
+            .reduce((acc, key) => {
+                acc[key] = deepSortObject(obj[key]);
+                return acc;
+            }, {} as Record<string, any>);
+    }
+    const sortedObject = deepSortObject(contentObject);
+    return JSON.stringify(sortedObject, null, 4);
+}

--- a/client/src/components/PageDisplay/PageDisplay.vue
+++ b/client/src/components/PageDisplay/PageDisplay.vue
@@ -64,9 +64,6 @@ export default {
         exportUrl() {
             return `${this.dataUrl}.pdf`;
         },
-        editUrl() {
-            return `/pages/editor?id=${this.pageId}`;
-        },
     },
     created() {
         urlData({ url: this.dataUrl }).then((data) => {
@@ -75,7 +72,7 @@ export default {
     },
     methods: {
         onEdit() {
-            window.location = withPrefix(this.editUrl);
+            this.$router.push(`/pages/editor?id=${this.pageId}`);
         },
         stsUrl(config) {
             return `${this.dataUrl}/prepare_download`;

--- a/client/src/components/PageDisplay/PageDisplay.vue
+++ b/client/src/components/PageDisplay/PageDisplay.vue
@@ -22,7 +22,6 @@ import { storeToRefs } from "pinia";
 
 import { useConfig } from "@/composables/config";
 import { useUserStore } from "@/stores/userStore";
-import { withPrefix } from "@/utils/redirect";
 import { urlData } from "@/utils/url";
 
 import PageHtml from "./PageHtml.vue";

--- a/client/src/components/Visualizations/VisualizationWrapper.vue
+++ b/client/src/components/Visualizations/VisualizationWrapper.vue
@@ -30,7 +30,7 @@ async function render() {
             const { data: plugin } = await axios.get(`${getAppRoot()}api/plugins/${props.name}`);
             const pluginPath = `${getAppRoot()}static/plugins/visualizations/${props.name}/static/`;
             const dataIncoming = {
-                root: getAppRoot(),
+                root: window.location.origin + getAppRoot(),
                 visualization_config: props.config,
                 visualization_plugin: plugin,
                 visualization_title: props.title,

--- a/client/src/components/Visualizations/VisualizationWrapper.vue
+++ b/client/src/components/Visualizations/VisualizationWrapper.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+import axios from "axios";
+import { debounce } from "lodash";
+import { onMounted, ref } from "vue";
+
+import { getAppRoot } from "@/onload/loadConfig";
+
+const DELAY = 300;
+
+const props = defineProps<{
+    config: Object;
+    name: String;
+    title: String;
+}>();
+
+const emit = defineEmits(["change"]);
+
+const emitChange = debounce((newValue: string) => {
+    emit("change", newValue);
+}, DELAY);
+
+const errorMessage = ref("");
+const iframeRef = ref<HTMLIFrameElement | null>(null);
+
+async function render() {
+    if (!props.name) {
+        errorMessage.value = "Visualization name is required!";
+    } else {
+        try {
+            const { data: plugin } = await axios.get(`${getAppRoot()}api/plugins/${props.name}`);
+            const pluginPath = `${getAppRoot()}static/plugins/visualizations/${props.name}/static/`;
+            const dataIncoming = {
+                root: getAppRoot(),
+                visualization_config: props.config,
+                visualization_plugin: plugin,
+                visualization_title: props.title,
+            };
+
+            const iframe = iframeRef.value;
+            if (iframe) {
+                // Verify document existence
+                const iframeDocument = iframe.contentDocument;
+                if (!iframeDocument) {
+                    errorMessage.value = "Failed to access iframe document.";
+                    return;
+                }
+
+                // Create the container for the plugin
+                const container = iframeDocument.createElement("div");
+                container.id = "app";
+                container.setAttribute("data-incoming", JSON.stringify(dataIncoming));
+                iframeDocument.body.appendChild(container);
+
+                // Inject the script tag for the plugin
+                if (plugin?.entry_point?.attr?.src) {
+                    const script = iframeDocument.createElement("script");
+                    script.type = "module";
+                    script.src = `${pluginPath}${plugin.entry_point.attr.src}`;
+                    iframeDocument.body.appendChild(script);
+                } else {
+                    const error = iframeDocument.createElement("div");
+                    error.innerHTML = `Unable to locate plugin module for: ${props.name}.`;
+                    iframeDocument.body.appendChild(error);
+                }
+
+                // Add a CSS link to the iframe document
+                if (plugin?.entry_point?.attr?.css) {
+                    const link = iframeDocument.createElement("link");
+                    link.rel = "stylesheet";
+                    link.href = `${pluginPath}${plugin.entry_point.attr.css}`;
+                    iframeDocument.head.appendChild(link);
+                }
+
+                // Add event listener
+                iframe.contentWindow?.addEventListener("message", (event) => {
+                    if (event.data.from === "galaxy-visualization") {
+                        emitChange(event.data);
+                    }
+                });
+
+                // Reset error message
+                errorMessage.value = "";
+            } else {
+                errorMessage.value = "Frame has been invalidated.";
+            }
+        } catch (e) {
+            errorMessage.value = `Visualization '${props.name}' not available: ${e}.`;
+        }
+    }
+}
+
+onMounted(() => render());
+</script>
+
+<template>
+    <div v-if="errorMessage">
+        <b-alert v-if="errorMessage" variant="danger" show>{{ errorMessage }}</b-alert>
+    </div>
+    <iframe v-else ref="iframeRef" title="visualization" class="visualization-wrapper"></iframe>
+</template>
+
+<style>
+.visualization-wrapper {
+    border: none;
+    width: 100%;
+}
+</style>

--- a/config/plugins/visualizations/fits_graph_viewer/config/fits_graph_viewer.xml
+++ b/config/plugins/visualizations/fits_graph_viewer/config/fits_graph_viewer.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="FITS Graph viewer">
+<visualization name="FITS Graph viewer" embeddable="true">
     <description>Basic plugin for fits file table visualization</description>
     <data_sources>
         <data_source>

--- a/config/plugins/visualizations/fits_graph_viewer/src/index.js
+++ b/config/plugins/visualizations/fits_graph_viewer/src/index.js
@@ -1,13 +1,8 @@
-import {init} from 'astrovisjs/dist/astrovis/astrovis';
+import { init } from "astrovisjs/dist/astrovis/astrovis";
 
-document.addEventListener('DOMContentLoaded', () => {
+const incoming = document.getElementById("app").getAttribute("data-incoming") || "{}";
+const { root, visualization_config } = JSON.parse(incoming);
+const dataset_id = visualization_config.dataset_id;
+const file_url = root + "datasets/" + dataset_id + "/display"
 
-    const {root, visualization_config} = JSON.parse(
-        document.getElementById("app")
-            .getAttribute("data-incoming") || "{}");
-
-    const dataset_id = visualization_config.dataset_id;
-    const file_url = root + "datasets/" + dataset_id + "/display"
-
-    init('app', file_url);
-});
+init('app', file_url);

--- a/config/plugins/visualizations/h5web/config/h5web.xml
+++ b/config/plugins/visualizations/h5web/config/h5web.xml
@@ -12,7 +12,7 @@
         <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>
     </params>
     <requirements>
-        <requirement type="npm" version="0.5.0" package="@galaxyproject/h5web"/>
+        <requirement type="npm" version="0.5.1" package="@galaxyproject/h5web"/>
     </requirements>
     <entry_point entry_point_type="script" src="dist/index.js" css="dist/index.css" />
 </visualization>

--- a/config/plugins/visualizations/heatmap/config/heatmap.xml
+++ b/config/plugins/visualizations/heatmap/config/heatmap.xml
@@ -3,7 +3,7 @@
 <visualization name="Heatmap" embeddable="true">
     <description>Renders a heatmap from matrix data provided in 3-column format (x, y, observation).</description>
     <requirements>
-        <requirement type="npm" version="0.0.13" package="@galaxyproject/heatmap"/>
+        <requirement type="npm" version="0.0.14" package="@galaxyproject/heatmap"/>
     </requirements>
     <data_sources>
         <data_source>

--- a/config/plugins/visualizations/tiffviewer/src/script.js
+++ b/config/plugins/visualizations/tiffviewer/src/script.js
@@ -12,7 +12,7 @@ const { root, visualization_config } = JSON.parse(document.getElementById("app")
 
 const datasetId = visualization_config.dataset_id;
 
-const url = window.location.origin + root + "api/datasets/" + datasetId + "/display";
+const url = root + "api/datasets/" + datasetId + "/display";
 
 const rootElement = createRoot(document.getElementById("app"));
 rootElement.render(

--- a/config/plugins/visualizations/vitessce/config/vitessce.xml
+++ b/config/plugins/visualizations/vitessce/config/vitessce.xml
@@ -13,7 +13,7 @@
         <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>
     </params>
     <requirements>
-        <requirement type="npm" version="0.0.0" package="@galaxyproject/vitessce"/>
+        <requirement type="npm" version="0.0.1" package="@galaxyproject/vitessce"/>
     </requirements>
     <entry_point entry_point_type="script" src="dist/index.js" css="dist/index.css" />
 </visualization>

--- a/config/plugins/visualizations/vizarr/config/vizarr.xml
+++ b/config/plugins/visualizations/vizarr/config/vizarr.xml
@@ -3,7 +3,7 @@
 <visualization name="Vizarr Viewer" embeddable="true">
     <description>Basic visualization for Zarr-based images like OME-Zarr</description>
     <requirements>
-        <requirement type="npm" version="0.1.6" package="@galaxyproject/vizarr"/>
+        <requirement type="npm" version="0.1.7" package="@galaxyproject/vizarr"/>
     </requirements>
     <entry_point entry_point_type="script" src="dist/index.js" css="dist/index.css" />
     <data_sources>

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -84,10 +84,12 @@ GALAXY_FENCED_BLOCK = re.compile(r"^```\s*galaxy\s*(.*?)^```", re.MULTILINE ^ re
 
 def process_invocation_ids(f, workflow_markdown: str) -> str:
     """Finds all invocation ids in jsons and applies f to them."""
+
     def replace_match(match):
         original_id = match.group(2)
         new_id = f(original_id)
         return f'{match.group(1)}"{new_id}"'
+
     pattern = r'("invocation_id"\s*:\s*)"([^"]*)"'
     return re.sub(pattern, replace_match, workflow_markdown)
 

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -83,15 +83,15 @@ ENCODED_ID_PATTERN = re.compile(
 )
 
 # Matches blocks of various types
-ANY_FENCED_BLOCK = re.compile(r"^```\s*[^\s]+\n\s*(.*?)^```", re.MULTILINE | re.DOTALL)
 GALAXY_FENCED_BLOCK = re.compile(r"^```\s*galaxy\s*(.*?)^```", re.MULTILINE | re.DOTALL)
+VISUALIZATION_FENCED_BLOCK = re.compile(r"^```\s*visualization+\n\s*(.*?)^```", re.MULTILINE | re.DOTALL)
 
 # Match invocation ids in json blocks
 INVOCATION_ID_JSON_PATTERN = re.compile(r'("invocation_id"\s*:\s*)"([^"]*)"')
 
 
 def process_invocation_ids(f, workflow_markdown: str) -> str:
-    """Finds all invocation ids in JSONs inside ```ANY ... ``` blocks and applies f to them."""
+    """Finds all invocation ids in JSONs inside visualization blocks and applies f to them."""
 
     def replace_invocation_id(match):
         """Replaces only the invocation_id value while preserving the JSON structure."""
@@ -104,7 +104,7 @@ def process_invocation_ids(f, workflow_markdown: str) -> str:
         block_content = block_match.group(0)
         return re.sub(INVOCATION_ID_JSON_PATTERN, replace_invocation_id, block_content)
 
-    return re.sub(ANY_FENCED_BLOCK, process_block, workflow_markdown)
+    return re.sub(VISUALIZATION_FENCED_BLOCK, process_block, workflow_markdown)
 
 
 def ready_galaxy_markdown_for_import(trans, external_galaxy_markdown):

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -89,6 +89,7 @@ GALAXY_FENCED_BLOCK = re.compile(r"^```\s*galaxy\s*(.*?)^```", re.MULTILINE | re
 # Match invocation ids in json blocks
 INVOCATION_ID_JSON_PATTERN = re.compile(r'("invocation_id"\s*:\s*)"([^"]*)"')
 
+
 def process_invocation_ids(f, workflow_markdown: str) -> str:
     """Finds all invocation ids in JSONs inside ```ANY ... ``` blocks and applies f to them."""
 

--- a/test/unit/workflows/test_workflow_markdown.py
+++ b/test/unit/workflows/test_workflow_markdown.py
@@ -137,11 +137,19 @@ def test_populating_invocation_json():
 }
 """
     galaxy_markdown = populate_markdown(workflow_markdown_0)
-    assert '\n```visualization\n{\n    "invocation_id": "44",\n    "other_key": "other_value"\n}\n```\n' in galaxy_markdown
+    assert (
+        '\n```visualization\n{\n    "invocation_id": "44",\n    "other_key": "other_value"\n}\n```\n' in galaxy_markdown
+    )
     galaxy_markdown = populate_markdown(workflow_markdown_1)
-    assert '\n```visualization\n{\n    "nested_structure": {\n        "invocation_id": "44"\n    }\n}\n```\n' in galaxy_markdown
+    assert (
+        '\n```visualization\n{\n    "nested_structure": {\n        "invocation_id": "44"\n    }\n}\n```\n'
+        in galaxy_markdown
+    )
     galaxy_markdown = populate_markdown(workflow_markdown_2)
-    assert '\n```visualization\n{\n    "nested_structure": {\n        "invocation_id": "44"\n    }\n}\n```\n' in galaxy_markdown
+    assert (
+        '\n```visualization\n{\n    "nested_structure": {\n        "invocation_id": "44"\n    }\n}\n```\n'
+        in galaxy_markdown
+    )
     galaxy_markdown = populate_markdown(workflow_markdown_3)
     assert '\n{\n    "invocation_id": ""\n}\n' in galaxy_markdown
 

--- a/test/unit/workflows/test_workflow_markdown.py
+++ b/test/unit/workflows/test_workflow_markdown.py
@@ -101,6 +101,37 @@ history_dataset_as_image(output=output_label)
     assert "```galaxy\nhistory_dataset_as_image(history_dataset_id=563)\n```" in galaxy_markdown
 
 
+def test_populating_invocation_json():
+    workflow_markdown_0 = """
+```any
+{
+    "invocation_id": "",
+    "other_key": "other_value"
+}
+```
+"""
+    workflow_markdown_1 = """
+```any
+{
+    "nested_structure": {
+        "invocation_id": ""
+    }
+}
+```
+"""
+    workflow_markdown_2 = """
+{
+    "invocation_id": ""
+}
+"""
+    galaxy_markdown = populate_markdown(workflow_markdown_0)
+    assert '\n```any\n{\n    "invocation_id": "44",\n    "other_key": "other_value"\n}\n```\n' in galaxy_markdown
+    galaxy_markdown = populate_markdown(workflow_markdown_1)
+    assert '\n```any\n{\n    "nested_structure": {\n        "invocation_id": "44"\n    }\n}\n```\n' in galaxy_markdown
+    galaxy_markdown = populate_markdown(workflow_markdown_2)
+    assert '\n{\n    "invocation_id": ""\n}\n' in galaxy_markdown
+
+
 def populate_markdown(workflow_markdown):
     # Add invocation ids to internal Galaxy markdown
     trans = MockTrans()

--- a/test/unit/workflows/test_workflow_markdown.py
+++ b/test/unit/workflows/test_workflow_markdown.py
@@ -110,6 +110,7 @@ def test_populating_invocation_json():
 }
 ```
 """
+
     workflow_markdown_1 = """
 ```any
 {
@@ -119,7 +120,18 @@ def test_populating_invocation_json():
 }
 ```
 """
+
     workflow_markdown_2 = """
+```any
+{
+    "nested_structure": {
+        "invocation_id": "REPLACE"
+    }
+}
+```
+"""
+
+    workflow_markdown_3 = """
 {
     "invocation_id": ""
 }
@@ -129,6 +141,8 @@ def test_populating_invocation_json():
     galaxy_markdown = populate_markdown(workflow_markdown_1)
     assert '\n```any\n{\n    "nested_structure": {\n        "invocation_id": "44"\n    }\n}\n```\n' in galaxy_markdown
     galaxy_markdown = populate_markdown(workflow_markdown_2)
+    assert '\n```any\n{\n    "nested_structure": {\n        "invocation_id": "44"\n    }\n}\n```\n' in galaxy_markdown
+    galaxy_markdown = populate_markdown(workflow_markdown_3)
     assert '\n{\n    "invocation_id": ""\n}\n' in galaxy_markdown
 
 

--- a/test/unit/workflows/test_workflow_markdown.py
+++ b/test/unit/workflows/test_workflow_markdown.py
@@ -103,7 +103,7 @@ history_dataset_as_image(output=output_label)
 
 def test_populating_invocation_json():
     workflow_markdown_0 = """
-```any
+```visualization
 {
     "invocation_id": "",
     "other_key": "other_value"
@@ -112,7 +112,7 @@ def test_populating_invocation_json():
 """
 
     workflow_markdown_1 = """
-```any
+```visualization
 {
     "nested_structure": {
         "invocation_id": ""
@@ -122,7 +122,7 @@ def test_populating_invocation_json():
 """
 
     workflow_markdown_2 = """
-```any
+```visualization
 {
     "nested_structure": {
         "invocation_id": "REPLACE"
@@ -137,11 +137,11 @@ def test_populating_invocation_json():
 }
 """
     galaxy_markdown = populate_markdown(workflow_markdown_0)
-    assert '\n```any\n{\n    "invocation_id": "44",\n    "other_key": "other_value"\n}\n```\n' in galaxy_markdown
+    assert '\n```visualization\n{\n    "invocation_id": "44",\n    "other_key": "other_value"\n}\n```\n' in galaxy_markdown
     galaxy_markdown = populate_markdown(workflow_markdown_1)
-    assert '\n```any\n{\n    "nested_structure": {\n        "invocation_id": "44"\n    }\n}\n```\n' in galaxy_markdown
+    assert '\n```visualization\n{\n    "nested_structure": {\n        "invocation_id": "44"\n    }\n}\n```\n' in galaxy_markdown
     galaxy_markdown = populate_markdown(workflow_markdown_2)
-    assert '\n```any\n{\n    "nested_structure": {\n        "invocation_id": "44"\n    }\n}\n```\n' in galaxy_markdown
+    assert '\n```visualization\n{\n    "nested_structure": {\n        "invocation_id": "44"\n    }\n}\n```\n' in galaxy_markdown
     galaxy_markdown = populate_markdown(workflow_markdown_3)
     assert '\n{\n    "invocation_id": ""\n}\n' in galaxy_markdown
 


### PR DESCRIPTION
Requires #19835. See discussion regarding visualizations in pages in #19226.

This PR integrates an interface for our new visualization framework into the cell-based Markdown editor. Only fully packaged, standalone visualizations—published as npm packages in accordance with our [new framework](https://galaxyproject.github.io/galaxy-charts)—can be used in pages and reports. This ensures stability, preventing visualizations from breaking due to Galaxy updates or build system limitations. Additionally, this PR enables the cell-based Markdown editor for workflow reports and lays the groundwork for workflow-specific visualizations by integrating Vega and Vitessce cell/block types.

Usage in Pages (with preview):

https://github.com/user-attachments/assets/0773249e-699f-42c0-a1ef-3b534f6c0bb1

Usage in Workflow Reports (without preview):

https://github.com/user-attachments/assets/238d9906-a6e0-43cf-b349-b155d5fcf5ce

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests (https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
