### PR TITLE
Add better `WorkflowSummary` type

### DIFF
--- a/client/src/api/workflows.ts
+++ b/client/src/api/workflows.ts
@@ -1,17 +1,121 @@
 import { type components } from "@/api/schema";
+import { rethrowSimple } from "@/utils/simple-error";
+
+import { GalaxyApi } from "./client";
 
 export type Creator = components["schemas"]["Person"] | components["schemas"]["galaxy__schema__schema__Organization"];
 export type StoredWorkflowDetailed = components["schemas"]["StoredWorkflowDetailed"];
 
 //TODO: replace with generated schema model when available
-export interface WorkflowSummary {
+export type WorkflowSummary = {
+    model_class: string;
+    id: string;
+    latest_workflow_id: string;
     name: string;
-    owner: string;
-    [key: string]: unknown;
+    create_time: string;
     update_time: string;
-    license?: string;
-    tags?: string[];
-    creator?: {
-        [key: string]: unknown;
-    }[];
+    published: boolean;
+    importable: boolean;
+    deleted: boolean;
+    hidden: boolean;
+    tags: string[];
+    latest_workflow_uuid: string;
+    creator_deleted: boolean;
+    annotations: string[];
+    url: string;
+    owner: string;
+    source_metadata: Record<string, never> | null;
+    number_of_steps?: number;
+    show_in_tool_panel: boolean;
+};
+
+export type AnyWorkflow = WorkflowSummary | StoredWorkflowDetailed;
+
+type SortBy = "create_time" | "update_time" | "name";
+
+interface LoadWorkflowsOptions {
+    sortBy: SortBy;
+    sortDesc: boolean;
+    limit: number;
+    offset: number;
+    filterText: string;
+    showPublished: boolean;
+    skipStepCounts: boolean;
+}
+
+export async function loadWorkflows({
+    sortBy = "update_time",
+    sortDesc = true,
+    limit = 20,
+    offset = 0,
+    filterText = "",
+    showPublished = false,
+    skipStepCounts = true,
+}: LoadWorkflowsOptions): Promise<{ data: WorkflowSummary[]; totalMatches: number }> {
+    const {
+        response,
+        data: workflows,
+        error,
+    } = await GalaxyApi().GET("/api/workflows", {
+        params: {
+            query: {
+                sort_by: sortBy,
+                sort_desc: sortDesc,
+                limit,
+                offset,
+                search: filterText,
+                show_published: showPublished,
+                skip_step_counts: skipStepCounts,
+            },
+        },
+    });
+
+    if (error) {
+        rethrowSimple(error);
+    }
+
+    const totalMatches = parseInt(response.headers.get("Total_matches") || "0", 10) || 0;
+    const data = workflows as unknown as WorkflowSummary[];
+
+    return { data, totalMatches };
+}
+
+export async function getWorkflowInfo(workflowId: string) {
+    const { data, error } = await GalaxyApi().GET("/api/workflows/{workflow_id}", {
+        params: {
+            path: {
+                workflow_id: workflowId,
+            },
+        },
+    });
+
+    if (error) {
+        rethrowSimple(error);
+    }
+
+    return data;
+}
+
+export async function undeleteWorkflow(id: string): Promise<WorkflowSummary> {
+    const { data, error } = await GalaxyApi().POST("/api/workflows/{workflow_id}/undelete", {
+        params: {
+            path: {
+                workflow_id: id,
+            },
+        },
+    });
+
+    if (error) {
+        rethrowSimple(error);
+    }
+
+    return data as WorkflowSummary;
+}
+
+export function hasCreator(entry?: AnyWorkflow): entry is StoredWorkflowDetailed {
+    return entry !== undefined && "creator" in entry && !!entry.creator;
+}
+
+export function hasVersion(entry: AnyWorkflow): entry is StoredWorkflowDetailed {
+    return "version" in entry;
 }

--- a/client/src/components/Panels/WorkflowPanel.vue
+++ b/client/src/components/Panels/WorkflowPanel.vue
@@ -5,7 +5,7 @@ import { useMemoize, watchImmediate } from "@vueuse/core";
 import { BButton } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
 
-import { loadWorkflows, type Workflow } from "@/components/Workflow/workflows.services";
+import { loadWorkflows, type WorkflowSummary } from "@/api/workflows";
 import { useAnimationFrameScroll } from "@/composables/sensors/animationFrameScroll";
 import { useToast } from "@/composables/toast";
 
@@ -35,7 +35,7 @@ const allLoaded = computed(() => totalWorkflowsCount.value <= workflows.value.le
 
 const filterText = ref("");
 
-const workflows = ref<Workflow[]>([]);
+const workflows = ref<WorkflowSummary[]>([]);
 
 const showFavorites = computed({
     get() {

--- a/client/src/components/Workflow/List/WorkflowActions.vue
+++ b/client/src/components/Workflow/List/WorkflowActions.vue
@@ -18,13 +18,13 @@ import { BButton, BButtonGroup, BDropdown, BDropdownItem } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed } from "vue";
 
-import type { StoredWorkflowDetailed } from "@/api/workflows";
+import { type AnyWorkflow, hasVersion } from "@/api/workflows";
 import { useUserStore } from "@/stores/userStore";
 
 import { useWorkflowActions } from "./useWorkflowActions";
 
 interface Props {
-    workflow: StoredWorkflowDetailed;
+    workflow: AnyWorkflow;
     published?: boolean;
     editor?: boolean;
     current?: boolean;
@@ -67,7 +67,7 @@ const sourceType = computed(() => {
 const runPath = computed(
     () =>
         `/workflows/run?id=${props.workflow.id}${
-            props.workflow.version !== undefined ? `&version=${props.workflow.version}` : ""
+            hasVersion(props.workflow) ? `&version=${props.workflow.version}` : ""
         }`
 );
 

--- a/client/src/components/Workflow/List/WorkflowActionsExtend.vue
+++ b/client/src/components/Workflow/List/WorkflowActionsExtend.vue
@@ -14,8 +14,7 @@ import { BButton, BButtonGroup } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed } from "vue";
 
-import type { StoredWorkflowDetailed } from "@/api/workflows";
-import { undeleteWorkflow } from "@/components/Workflow/workflows.services";
+import { type AnyWorkflow, undeleteWorkflow } from "@/api/workflows";
 import { useConfirmDialog } from "@/composables/confirmDialog";
 import { Toast } from "@/composables/toast";
 import { useUserStore } from "@/stores/userStore";
@@ -26,7 +25,7 @@ import AsyncButton from "@/components/Common/AsyncButton.vue";
 import WorkflowRunButton from "@/components/Workflow/WorkflowRunButton.vue";
 
 interface Props {
-    workflow: StoredWorkflowDetailed;
+    workflow: AnyWorkflow;
     published?: boolean;
     editor?: boolean;
     current?: boolean;

--- a/client/src/components/Workflow/List/WorkflowCard.vue
+++ b/client/src/components/Workflow/List/WorkflowCard.vue
@@ -5,7 +5,7 @@ import { BButton, BFormCheckbox, BLink } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 
-import { type StoredWorkflowDetailed } from "@/api/workflows";
+import { type WorkflowSummary } from "@/api/workflows";
 import { updateWorkflow } from "@/components/Workflow/workflows.services";
 import { useUserStore } from "@/stores/userStore";
 
@@ -17,7 +17,7 @@ import WorkflowIndicators from "@/components/Workflow/List/WorkflowIndicators.vu
 import WorkflowInvocationsCount from "@/components/Workflow/WorkflowInvocationsCount.vue";
 
 interface Props {
-    workflow: StoredWorkflowDetailed;
+    workflow: WorkflowSummary;
     gridView?: boolean;
     hideRuns?: boolean;
     filterable?: boolean;

--- a/client/src/components/Workflow/List/WorkflowCardList.vue
+++ b/client/src/components/Workflow/List/WorkflowCardList.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import { BModal } from "bootstrap-vue";
-import { computed, reactive, ref } from "vue";
+import { reactive, ref } from "vue";
 
-import type { StoredWorkflowDetailed } from "@/api/workflows";
-import type { Workflow } from "@/components/Workflow/workflows.services";
+import type { WorkflowSummary } from "@/api/workflows";
 
 import type { SelectedWorkflow } from "./types";
 
@@ -12,7 +11,7 @@ import WorkflowRename from "./WorkflowRename.vue";
 import WorkflowPublished from "@/components/Workflow/Published/WorkflowPublished.vue";
 
 interface Props {
-    workflows: Workflow[];
+    workflows: WorkflowSummary[];
     gridView?: boolean;
     hideRuns?: boolean;
     filterable?: boolean;
@@ -33,17 +32,13 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-    (e: "select", workflow: Workflow): void;
+    (e: "select", workflow: WorkflowSummary): void;
     (e: "tagClick", tag: string): void;
     (e: "refreshList", overlayLoading?: boolean, silent?: boolean): void;
     (e: "updateFilter", key: string, value: any): void;
     (e: "insertWorkflow", id: string, name: string): void;
     (e: "insertWorkflowSteps", id: string, stepCount: number): void;
 }>();
-
-/** `props.workflows` typed as `StoredWorkflowDetailed[]` because that is the type expected by `WorkflowCard` */
-const detailedWorkflows = computed(() => props.workflows as unknown as StoredWorkflowDetailed[]);
-// TODO: Ideally, components like `WorkflowCard` should accept a less specific type, like `Workflow` instead of `StoredWorkflowDetailed`
 
 const modalOptions = reactive({
     rename: {
@@ -75,11 +70,11 @@ function onPreview(id: string) {
 }
 
 // TODO: clean-up types, as soon as better Workflow type is available
-function onInsert(workflow: StoredWorkflowDetailed) {
-    emit("insertWorkflow", (workflow as any).latest_workflow_id, workflow.name);
+function onInsert(workflow: WorkflowSummary) {
+    emit("insertWorkflow", workflow.latest_workflow_id, workflow.name);
 }
 
-function onInsertSteps(workflow: StoredWorkflowDetailed) {
+function onInsertSteps(workflow: WorkflowSummary) {
     emit("insertWorkflowSteps", workflow.id, workflow.number_of_steps as any);
 }
 </script>
@@ -87,7 +82,7 @@ function onInsertSteps(workflow: StoredWorkflowDetailed) {
 <template>
     <div class="workflow-card-list" :class="{ grid: props.gridView }">
         <WorkflowCard
-            v-for="workflow in detailedWorkflows"
+            v-for="workflow in workflows"
             :key="workflow.id"
             :workflow="workflow"
             :selectable="!publishedView && !editorView"

--- a/client/src/components/Workflow/List/WorkflowIndicators.vue
+++ b/client/src/components/Workflow/List/WorkflowIndicators.vue
@@ -14,7 +14,7 @@ import { BBadge, BButton } from "bootstrap-vue";
 import { computed } from "vue";
 import { useRouter } from "vue-router/composables";
 
-import type { Creator, StoredWorkflowDetailed } from "@/api/workflows";
+import { type AnyWorkflow, type Creator, hasCreator } from "@/api/workflows";
 import { useToast } from "@/composables/toast";
 import { useUserStore } from "@/stores/userStore";
 import { copy } from "@/utils/clipboard";
@@ -31,7 +31,7 @@ interface BadgeData {
 }
 
 interface Props {
-    workflow: StoredWorkflowDetailed;
+    workflow: AnyWorkflow;
     publishedView: boolean;
     noEditTime?: boolean;
     filterable?: boolean;
@@ -86,32 +86,37 @@ const sourceTitle = computed(() => {
 });
 
 const creatorBadges = computed<BadgeData[] | undefined>(() => {
-    return props.workflow.creator
-        ?.map((creator: Creator) => {
-            if (!creator.name) {
-                return;
-            }
-            let url: string | undefined;
-            let titleEnd = "Workflow Creator";
+    if (hasCreator(props.workflow)) {
+        return props.workflow.creator
+            ?.map((creator: Creator) => {
+                if (!creator.name) {
+                    return;
+                }
+                let url: string | undefined;
+                let titleEnd = "Workflow Creator";
 
-            if (creator.url && isUrl(creator.url)) {
-                url = creator.url;
-            }
-            const orcidRegex = /^https:\/\/orcid\.org\/\d{4}-\d{4}-\d{4}-\d{3}[0-9X]$/;
-            if (creator.identifier && orcidRegex.test(creator.identifier)) {
-                url = creator.identifier;
-                titleEnd = "ORCID profile";
-            }
+                if (creator.url && isUrl(creator.url)) {
+                    url = creator.url;
+                }
+                const orcidRegex = /^https:\/\/orcid\.org\/\d{4}-\d{4}-\d{4}-\d{3}[0-9X]$/;
+                if (creator.identifier && orcidRegex.test(creator.identifier)) {
+                    url = creator.identifier;
+                    titleEnd = "ORCID profile";
+                }
 
-            return {
-                name: creator.name,
-                url,
-                icon: creator.class === "Organization" ? faBuilding : faUserEdit,
-                title: `${url ? "Click to view " : ""}${titleEnd}`,
-                class: { "cursor-pointer": !!url, "outline-badge": !!url },
-            };
-        })
-        .filter((b) => !!b);
+                return {
+                    name: creator.name,
+                    url,
+                    icon: creator.class === "Organization" ? faBuilding : faUserEdit,
+                    title: `${url ? "Click to view " : ""}${titleEnd}`,
+                    class: { "cursor-pointer": !!url, "outline-badge": !!url },
+                };
+            })
+            .filter((b) => !!b);
+    }
+    {
+        return undefined;
+    }
 });
 
 const { success } = useToast();

--- a/client/src/components/Workflow/List/WorkflowList.vue
+++ b/client/src/components/Workflow/List/WorkflowList.vue
@@ -7,13 +7,12 @@ import { filter } from "underscore";
 import { computed, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router/composables";
 
-import { GalaxyApi } from "@/api";
+import { loadWorkflows, undeleteWorkflow, type WorkflowSummary } from "@/api/workflows";
 import { getWorkflowFilters, helpHtml } from "@/components/Workflow/List/workflowFilters";
-import { deleteWorkflow, undeleteWorkflow, updateWorkflow } from "@/components/Workflow/workflows.services";
+import { deleteWorkflow, updateWorkflow } from "@/components/Workflow/workflows.services";
 import { useConfirmDialog } from "@/composables/confirmDialog";
 import { Toast } from "@/composables/toast";
 import { useUserStore } from "@/stores/userStore";
-import { rethrowSimple } from "@/utils/simple-error";
 
 import type { SelectedWorkflow } from "./types";
 
@@ -26,8 +25,6 @@ import LoginRequired from "@/components/Common/LoginRequired.vue";
 import TagsSelectionDialog from "@/components/Common/TagsSelectionDialog.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import WorkflowListActions from "@/components/Workflow/List/WorkflowListActions.vue";
-
-type WorkflowsList = Record<string, never>[];
 
 interface Props {
     activeList?: "my" | "shared_with_me" | "published";
@@ -54,7 +51,7 @@ const listHeader = ref<any>(null);
 const showBulkAddTagsModal = ref(false);
 const bulkTagsLoading = ref(false);
 const bulkDeleteOrRestoreLoading = ref(false);
-const workflowsLoaded = ref<WorkflowsList>([]);
+const workflowsLoaded = ref<WorkflowSummary[]>([]);
 const selectedWorkflowIds = ref<SelectedWorkflow[]>([]);
 
 const searchPlaceHolder = computed(() => {
@@ -141,23 +138,15 @@ async function load(overlayLoading = false, silent = false) {
     }
 
     try {
-        const { response, data, error } = await GalaxyApi().GET("/api/workflows", {
-            params: {
-                query: {
-                    sort_by: sortBy.value,
-                    sort_desc: sortDesc.value,
-                    limit: limit.value,
-                    offset: offset.value,
-                    search: search?.trim(),
-                    show_published: published.value,
-                    skip_step_counts: true,
-                },
-            },
+        const { data, totalMatches } = await loadWorkflows({
+            sortBy: sortBy.value,
+            sortDesc: sortDesc.value,
+            limit: limit.value,
+            offset: offset.value,
+            filterText: search?.trim(),
+            showPublished: published.value,
+            skipStepCounts: true,
         });
-
-        if (error) {
-            rethrowSimple(error);
-        }
 
         let filteredWorkflows = data;
 
@@ -167,7 +156,7 @@ async function load(overlayLoading = false, silent = false) {
 
         workflowsLoaded.value = filteredWorkflows;
 
-        totalWorkflows.value = parseInt(response.headers.get("Total_matches") || "0", 10) || 0;
+        totalWorkflows.value = totalMatches;
     } catch (e) {
         Toast.error(`Failed to load workflows: ${e}`);
     } finally {

--- a/client/src/components/Workflow/List/useWorkflowActions.ts
+++ b/client/src/components/Workflow/List/useWorkflowActions.ts
@@ -1,6 +1,6 @@
 import { computed, type Ref, ref } from "vue";
 
-import type { StoredWorkflowDetailed } from "@/api/workflows";
+import type { AnyWorkflow } from "@/api/workflows";
 import {
     copyWorkflow as copyWorkflowService,
     deleteWorkflow as deleteWorkflowService,
@@ -12,9 +12,7 @@ import { copy } from "@/utils/clipboard";
 import { withPrefix } from "@/utils/redirect";
 import { getFullAppUrl } from "@/utils/utils";
 
-type Workflow = StoredWorkflowDetailed;
-
-export function useWorkflowActions(workflow: Ref<Workflow>, refreshCallback: () => void) {
+export function useWorkflowActions(workflow: Ref<AnyWorkflow>, refreshCallback: () => void) {
     const toast = useToast();
 
     const bookmarkLoading = ref(false);

--- a/client/src/components/Workflow/Published/WorkflowInformation.vue
+++ b/client/src/components/Workflow/Published/WorkflowInformation.vue
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed } from "vue";
 import { RouterLink } from "vue-router";
 
-import { type WorkflowSummary } from "@/api/workflows";
+import { type StoredWorkflowDetailed } from "@/api/workflows";
 import { useUserStore } from "@/stores/userStore";
 import { getFullAppUrl } from "@/utils/utils";
 
@@ -18,7 +18,7 @@ import UtcDate from "@/components/UtcDate.vue";
 library.add(faBuilding, faUser);
 
 interface Props {
-    workflowInfo: WorkflowSummary;
+    workflowInfo: StoredWorkflowDetailed;
     embedded?: boolean;
 }
 

--- a/client/src/components/Workflow/Published/WorkflowPublished.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublished.vue
@@ -7,9 +7,9 @@ import { type AxiosError } from "axios";
 import { BAlert, BButton, BCard } from "bootstrap-vue";
 import { computed, nextTick, onMounted, ref, watch } from "vue";
 
-import { type StoredWorkflowDetailed, type WorkflowSummary } from "@/api/workflows";
+import { getWorkflowInfo, type StoredWorkflowDetailed } from "@/api/workflows";
 import { fromSimple } from "@/components/Workflow/Editor/modules/model";
-import { getWorkflowFull, getWorkflowInfo } from "@/components/Workflow/workflows.services";
+import { getWorkflowFull } from "@/components/Workflow/workflows.services";
 import { useDatatypesMapper } from "@/composables/datatypesMapper";
 import { provideScopedWorkflowStores } from "@/composables/workflowStores";
 import { useUserStore } from "@/stores/userStore";
@@ -59,7 +59,7 @@ const { stateStore } = provideScopedWorkflowStores(props.id);
 
 const loading = ref(true);
 const errorMessage = ref("");
-const workflowInfo = ref<WorkflowSummary>();
+const workflowInfo = ref<StoredWorkflowDetailed>();
 const workflow = ref<StoredWorkflowDetailed | null>(null);
 
 const hasError = computed(() => !!errorMessage.value);

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -5,7 +5,8 @@ import { RouterLink } from "vue-router";
 import { useRouter } from "vue-router/composables";
 
 import { canMutateHistory } from "@/api";
-import { copyWorkflow, getWorkflowInfo } from "@/components/Workflow/workflows.services";
+import { getWorkflowInfo } from "@/api/workflows";
+import { copyWorkflow } from "@/components/Workflow/workflows.services";
 import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
 import { useHistoryItemsStore } from "@/stores/historyItemsStore";
 import { useHistoryStore } from "@/stores/historyStore";

--- a/client/src/components/Workflow/WorkflowNavigationTitle.vue
+++ b/client/src/components/Workflow/WorkflowNavigationTitle.vue
@@ -8,7 +8,7 @@ import { RouterLink } from "vue-router";
 
 import { isRegisteredUser } from "@/api";
 import type { WorkflowInvocationElementView } from "@/api/invocations";
-import type { StoredWorkflowDetailed } from "@/api/workflows";
+import type { WorkflowSummary } from "@/api/workflows";
 import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
 import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";
@@ -49,7 +49,7 @@ const owned = computed(() => {
 });
 
 const importErrorMessage = ref<string | null>(null);
-const importedWorkflow = ref<StoredWorkflowDetailed | null>(null);
+const importedWorkflow = ref<WorkflowSummary | null>(null);
 const workflowImportedAttempted = ref(false);
 
 async function onImport() {
@@ -58,7 +58,7 @@ async function onImport() {
     }
     try {
         const wf = await copyWorkflow(workflow.value.id, workflow.value.owner);
-        importedWorkflow.value = wf as unknown as StoredWorkflowDetailed;
+        importedWorkflow.value = wf;
     } catch (error) {
         importErrorMessage.value = errorMessageAsString(error, "Failed to import workflow");
     } finally {

--- a/client/src/components/Workflow/workflows.services.ts
+++ b/client/src/components/Workflow/workflows.services.ts
@@ -1,62 +1,15 @@
 import axios from "axios";
 
-import { GalaxyApi } from "@/api";
+import type { WorkflowSummary } from "@/api/workflows";
 import { useUserStore } from "@/stores/userStore";
 import { withPrefix } from "@/utils/redirect";
-import { rethrowSimple } from "@/utils/simple-error";
 
-export type Workflow = Record<string, never>;
-
-type SortBy = "create_time" | "update_time" | "name";
-
-interface LoadWorkflowsOptions {
-    sortBy: SortBy;
-    sortDesc: boolean;
-    limit: number;
-    offset: number;
-    filterText: string;
-    showPublished: boolean;
-    skipStepCounts: boolean;
-}
-
-export async function loadWorkflows({
-    sortBy = "update_time",
-    sortDesc = true,
-    limit = 20,
-    offset = 0,
-    filterText = "",
-    showPublished = false,
-    skipStepCounts = true,
-}: LoadWorkflowsOptions): Promise<{ data: Workflow[]; totalMatches: number }> {
-    const { response, data, error } = await GalaxyApi().GET("/api/workflows", {
-        params: {
-            query: {
-                sort_by: sortBy,
-                sort_desc: sortDesc,
-                limit,
-                offset,
-                search: filterText,
-                show_published: showPublished,
-                skip_step_counts: skipStepCounts,
-            },
-        },
-    });
-
-    if (error) {
-        rethrowSimple(error);
-    }
-
-    const totalMatches = parseInt(response.headers.get("Total_matches") || "0", 10) || 0;
-
-    return { data, totalMatches };
-}
-
-export async function updateWorkflow(id: string, changes: object): Promise<Workflow> {
+export async function updateWorkflow(id: string, changes: object): Promise<WorkflowSummary> {
     const { data } = await axios.put(withPrefix(`/api/workflows/${id}`), changes);
     return data;
 }
 
-export async function copyWorkflow(id: string, currentOwner?: string, version?: string): Promise<Workflow> {
+export async function copyWorkflow(id: string, currentOwner?: string, version?: string): Promise<WorkflowSummary> {
     let path = `/api/workflows/${id}/download`;
     if (version) {
         path += `?version=${version}`;
@@ -74,13 +27,8 @@ export async function copyWorkflow(id: string, currentOwner?: string, version?: 
     return data;
 }
 
-export async function deleteWorkflow(id: string): Promise<Workflow> {
+export async function deleteWorkflow(id: string): Promise<WorkflowSummary> {
     const { data } = await axios.delete(withPrefix(`/api/workflows/${id}`));
-    return data;
-}
-
-export async function undeleteWorkflow(id: string): Promise<Workflow> {
-    const { data } = await axios.post(withPrefix(`/api/workflows/${id}/undelete`));
     return data;
 }
 
@@ -98,10 +46,5 @@ export async function getWorkflowFull(workflowId: string, version?: number) {
         url += `&version=${version}`;
     }
     const { data } = await axios.get(withPrefix(url));
-    return data;
-}
-
-export async function getWorkflowInfo(workflowId: string) {
-    const { data } = await axios.get(withPrefix(`/api/workflows/${workflowId}`));
     return data;
 }

--- a/client/src/stores/workflowStore.ts
+++ b/client/src/stores/workflowStore.ts
@@ -4,9 +4,6 @@ import { computed, ref, set } from "vue";
 import { GalaxyApi } from "@/api";
 import type { StoredWorkflowDetailed } from "@/api/workflows";
 
-// TODO: Define a less specific `Workflow` type here, and unify with the one in `workflows.services.ts`,
-//       instead of using `StoredWorkflowDetailed` directly.
-
 export const useWorkflowStore = defineStore("workflowStore", () => {
     const workflowsByInstanceId = ref<{ [index: string]: StoredWorkflowDetailed }>({});
 


### PR DESCRIPTION
Related to #19777 (?)
Follows up on https://github.com/galaxyproject/galaxy/pull/19294#discussion_r1987153098
Fixes #19681

Creates a `WorkflowSummary` type which we use in cases where `StoredWorkflowDetailed` is not needed (or is rather not the actual return from the backend in fact).

Then also adds the `AnyWorkflow` type to generalize usage:

```
export type AnyWorkflow = WorkflowSummary | StoredWorkflowDetailed;
```

### Moves methods from `workflows.services` to the `client/src/api/workflows.ts` file
I moved some functions that have a typed response from `workflows.services` to `workflows.ts` to make it more uniform with what we do in other places (e.g.: `datasets.ts`).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
