### PR TITLE
Allow overriding datatypes for planemo lint

### DIFF
--- a/lib/galaxy/tool_util/linters/datatypes.py
+++ b/lib/galaxy/tool_util/linters/datatypes.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from galaxy.tool_util.parser import ToolSource
     from galaxy.util.resources import Traversable
 
-DATATYPES_CONF = resource_path(__name__, "datatypes_conf.xml.sample")
+DATATYPES_CONF = os.getenv('DATATYPES_CONF', resource_path(__package__, "datatypes_conf.xml.sample"))
 
 
 def _parse_datatypes(datatype_conf_path: Union[str, "Traversable"]) -> Set[str]:

--- a/lib/galaxy/tool_util/linters/datatypes.py
+++ b/lib/galaxy/tool_util/linters/datatypes.py
@@ -1,4 +1,5 @@
 import os.path
+from os import getenv
 from typing import (
     Set,
     TYPE_CHECKING,
@@ -18,7 +19,7 @@ if TYPE_CHECKING:
     from galaxy.tool_util.parser import ToolSource
     from galaxy.util.resources import Traversable
 
-DATATYPES_CONF = os.getenv('DATATYPES_CONF', resource_path(__package__, "datatypes_conf.xml.sample"))
+DATATYPES_CONF = getenv("DATATYPES_CONF", resource_path(__package__, "datatypes_conf.xml.sample"))
 
 
 def _parse_datatypes(datatype_conf_path: Union[str, "Traversable"]) -> Set[str]:

--- a/lib/galaxy/tool_util/linters/datatypes.py
+++ b/lib/galaxy/tool_util/linters/datatypes.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from galaxy.tool_util.parser import ToolSource
     from galaxy.util.resources import Traversable
 
-DATATYPES_CONF = getenv("DATATYPES_CONF", resource_path(__package__, "datatypes_conf.xml.sample"))
+DATATYPES_CONF = getenv("DATATYPES_CONF", resource_path(__name__, "datatypes_conf.xml.sample"))
 
 
 def _parse_datatypes(datatype_conf_path: Union[str, "Traversable"]) -> Set[str]:


### PR DESCRIPTION
Allow overriding the datatypes_conf.xml.sample that's added by default by the Python galaxy-tool-util package for non-standard datatype support

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
