### PR TITLE
Update webdav user file source template help text

### DIFF
--- a/lib/galaxy/files/templates/examples/production_webdav.yml
+++ b/lib/galaxy/files/templates/examples/production_webdav.yml
@@ -12,10 +12,10 @@
         The domain of the WebDAV server you are connecting to. This should be the full URL
         including the protocol (http or https) and the domain name.
     root:
-      label: WebDAV server Path (should end with /remote.php/webdav, e.g. /a/sub/path/remote.php/webdav)
+      label: WebDAV server Path (e.g., /a/sub/path/remote.php/webdav, /remote.php/dav/files/username)
       type: string
       help: |
-        The full server path to the WebDAV service. Ensure the path includes /remote.php/webdav.
+        The full server path to the WebDAV service.
     login:
       label: Username
       type: string


### PR DESCRIPTION
Testers complained that the help text was confusing. So, I slightly modified it to what we see nowadays when adding Nextcloud (as an example) as a user file source. 