### PR TITLE
Add history sharing and accessibility management view

### DIFF
--- a/client/src/components/Common/PortletSection.vue
+++ b/client/src/components/Common/PortletSection.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import type { IconDefinition } from "font-awesome-6";
+
+const props = defineProps<{
+    icon?: IconDefinition;
+    title?: string;
+}>();
+</script>
+
+<template>
+    <div class="ui-portlet-section">
+        <div class="portlet-header">
+            <span class="portlet-title">
+                <FontAwesomeIcon v-if="props.icon" :icon="props.icon" class="portlet-title-icon mr-1" />
+
+                <b class="portlet-title-text">
+                    <slot name="title">
+                        {{ props.title }}
+                    </slot>
+                </b>
+            </span>
+        </div>
+
+        <div class="portlet-content">
+            <div class="mt-3">
+                <slot />
+            </div>
+        </div>
+    </div>
+</template>

--- a/client/src/components/Dataset/DatasetPermissionsForm.vue
+++ b/client/src/components/Dataset/DatasetPermissionsForm.vue
@@ -45,7 +45,7 @@ watch(props, () => {
             <div class="ui-portlet-section">
                 <div class="portlet-header">
                     <span class="portlet-title">
-                        <FontAwesomeIcon :icnon="faUsers" class="portlet-title-icon mr-1" />
+                        <FontAwesomeIcon :icon="faUsers" class="portlet-title-icon mr-1" />
 
                         <b itemprop="name" class="portlet-title-text">{{ title }}</b>
                     </span>

--- a/client/src/components/Dataset/DatasetPermissionsForm.vue
+++ b/client/src/components/Dataset/DatasetPermissionsForm.vue
@@ -1,16 +1,13 @@
 <script lang="ts" setup>
-import { library } from "@fortawesome/fontawesome-svg-core";
 import { faUsers } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BFormCheckbox } from "bootstrap-vue";
 import { ref, watch } from "vue";
 
+import PortletSection from "../Common/PortletSection.vue";
 import FormGeneric from "@/components/Form/FormGeneric.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 type FormGenericPropsType = InstanceType<typeof FormGeneric>["$props"];
-
-library.add(faUsers);
 
 interface DatasetPermissionsFormProps {
     loading: boolean;
@@ -42,25 +39,15 @@ watch(props, () => {
     <div>
         <LoadingSpan v-if="loading" message="Loading permission information" />
         <div v-else-if="simplePermissions && !selectedAdvancedForm">
-            <div class="ui-portlet-section">
-                <div class="portlet-header">
-                    <span class="portlet-title">
-                        <FontAwesomeIcon :icon="faUsers" class="portlet-title-icon mr-1" />
-
-                        <b itemprop="name" class="portlet-title-text">{{ title }}</b>
-                    </span>
+            <PortletSection :icon="faUsers" :title="title">
+                <div class="mb-3">
+                    <BFormCheckbox v-model="checkedInForm" name="check-button" switch @change="change">
+                        Make new datasets private
+                    </BFormCheckbox>
                 </div>
 
-                <div class="portlet-content">
-                    <div class="mb-3 mt-3">
-                        <BFormCheckbox v-model="checkedInForm" name="check-button" switch @change="change">
-                            Make new datasets private
-                        </BFormCheckbox>
-                    </div>
-
-                    <a href="#" @click="selectedAdvancedForm = true">Show advanced options.</a>
-                </div>
-            </div>
+                <a href="javascript:void(0)" @click="selectedAdvancedForm = true">Show advanced options.</a>
+            </PortletSection>
         </div>
         <div v-else>
             <FormGeneric v-bind="formConfig" />

--- a/client/src/components/Form/FormGeneric.vue
+++ b/client/src/components/Form/FormGeneric.vue
@@ -4,7 +4,7 @@
             <b-alert v-if="config.message" :variant="configMessageVariant(config)" show>
                 {{ config.message }}
             </b-alert>
-            <b-alert v-if="messageText" :variant="messageVariant" show>
+            <b-alert v-if="messageText" :variant="messageVariant" show dismissible @dismissed="messageText = null">
                 {{ messageText }}
             </b-alert>
             <FormCard :title="configTitle(config)" :icon="configIcon(config)">
@@ -13,8 +13,8 @@
                 </template>
             </FormCard>
             <div class="mt-3">
-                <GButton id="submit" color="blue" class="mr-1" @click="onSubmit()">
-                    <span :class="submitIconClass" />{{ submitTitle | l }}
+                <GButton id="submit" color="blue" class="mr-1" :disabled="submitLoading" @click="onSubmit()">
+                    <span :class="submitLoading ? 'fa fa-spinner fa-spin' : submitIconClass" />{{ submitTitle | l }}
                 </GButton>
                 <GButton v-if="cancelRedirect" @click="onCancel()">
                     <span class="mr-1 fa fa-times" />{{ "Cancel" | l }}
@@ -86,6 +86,7 @@ export default {
             messageVariant: null,
             formData: {},
             replaceParams: null,
+            submitLoading: false,
         };
     },
     computed: {
@@ -109,19 +110,22 @@ export default {
         onCancel() {
             window.location = withPrefix(this.cancelRedirect);
         },
-        onSubmit() {
-            const formData = { ...this.formData };
+        async onSubmit() {
+            try {
+                this.submitLoading = true;
 
-            if (this.trimInputs) {
-                // Trim string values in form data
-                Object.keys(formData).forEach((key) => {
-                    if (typeof formData[key] === "string") {
-                        formData[key] = formData[key].trim();
-                    }
-                });
-            }
+                const formData = { ...this.formData };
 
-            submitData(this.url, formData).then((response) => {
+                if (this.trimInputs) {
+                    // Trim string values in form data
+                    Object.keys(formData).forEach((key) => {
+                        if (typeof formData[key] === "string") {
+                            formData[key] = formData[key].trim();
+                        }
+                    });
+                }
+
+                const response = await submitData(this.url, formData);
                 let params = {};
                 if (response.id) {
                     params.id = response.id;
@@ -143,7 +147,11 @@ export default {
                     this.replaceParams = replaceParams;
                     this.showMessage(response.message);
                 }
-            }, this.onError);
+            } catch (error) {
+                this.onError(error);
+            } finally {
+                this.submitLoading = false;
+            }
         },
         onError(error) {
             this.showMessage(error || `Failed to load resource ${this.url}.`, "danger");

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.test.ts
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.test.ts
@@ -19,9 +19,7 @@ const expectedOptions = [
     "Archive History",
     "Extract Workflow",
     "Show Invocations",
-    "Share or Publish",
-    "Set Permissions",
-    "Make Private",
+    "Share & Manage Access",
 ];
 
 // options enabled for logged-out users

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { library } from "@fortawesome/fontawesome-svg-core";
 import {
     faArchive,
     faBars,
@@ -10,14 +9,12 @@ import {
     faFileArchive,
     faFileExport,
     faList,
-    faLock,
     faPlay,
     faPlus,
-    faShareAlt,
     faSpinner,
     faStream,
     faTrash,
-    faUserLock,
+    faUsersCog,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import axios from "axios";
@@ -47,25 +44,6 @@ import { rethrowSimple } from "@/utils/simple-error";
 import CopyModal from "@/components/History/Modals/CopyModal.vue";
 import SelectorModal from "@/components/History/Modals/SelectorModal.vue";
 
-library.add(
-    faArchive,
-    faBars,
-    faBurn,
-    faColumns,
-    faCopy,
-    faExchangeAlt,
-    faFileArchive,
-    faFileExport,
-    faLock,
-    faPlay,
-    faPlus,
-    faShareAlt,
-    faList,
-    faStream,
-    faTrash,
-    faUserLock
-);
-
 interface Props {
     histories: HistorySummary[];
     history: HistorySummary;
@@ -81,7 +59,6 @@ const props = withDefaults(defineProps<Props>(), {
 // modal refs
 const showSwitchModal = ref(false);
 const showDeleteModal = ref(false);
-const showPrivacyModal = ref(false);
 const showCopyModal = ref(false);
 
 const purgeHistory = ref(false);
@@ -294,27 +271,10 @@ async function resumePausedJobs() {
 
                     <BDropdownItem
                         :disabled="isAnonymous || !canEditHistory"
-                        :title="userTitle('Share or Publish this History')"
-                        data-description="share or publish"
+                        :title="userTitle('Share, Publish, or Set Permissions for this History')"
                         @click="$router.push(`/histories/sharing?id=${history.id}`)">
-                        <FontAwesomeIcon fixed-width :icon="faShareAlt" class="mr-1" />
-                        <span v-localize>Share or Publish</span>
-                    </BDropdownItem>
-
-                    <BDropdownItem
-                        :disabled="isAnonymous || !canEditHistory"
-                        :title="userTitle('Set who can View or Edit this History')"
-                        @click="$router.push(`/histories/permissions?id=${history.id}`)">
-                        <FontAwesomeIcon fixed-width :icon="faUserLock" class="mr-1" />
-                        <span v-localize>Set Permissions</span>
-                    </BDropdownItem>
-
-                    <BDropdownItem
-                        :disabled="isAnonymous || !canEditHistory"
-                        :title="userTitle('Make this History Private')"
-                        @click="showPrivacyModal = !showPrivacyModal">
-                        <FontAwesomeIcon fixed-width :icon="faLock" class="mr-1" />
-                        <span v-localize>Make Private</span>
+                        <FontAwesomeIcon fixed-width :icon="faUsersCog" class="mr-1" />
+                        <span v-localize>Share & Manage Access</span>
                     </BDropdownItem>
                 </BDropdown>
             </BButtonGroup>
@@ -330,24 +290,6 @@ async function resumePausedJobs() {
             @selectHistory="historyStore.setCurrentHistory($event.id)" />
 
         <CopyModal :history="history" :show-modal.sync="showCopyModal" />
-
-        <BModal
-            v-model="showPrivacyModal"
-            title="Make History Private"
-            title-tag="h2"
-            @ok="historyStore.secureHistory(history)">
-            <h4>
-                History:
-                <b>
-                    <i>{{ history.name }}</i>
-                </b>
-            </h4>
-            <p v-localize>
-                This will make all the data in this history private (excluding library datasets), and will set
-                permissions such that all new data is created as private. Any datasets within that are currently shared
-                will need to be re-shared or published. Are you sure you want to do this?
-            </p>
-        </BModal>
 
         <BModal
             v-model="showDeleteModal"

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -271,6 +271,7 @@ async function resumePausedJobs() {
 
                     <BDropdownItem
                         :disabled="isAnonymous || !canEditHistory"
+                        data-description="share and manage access"
                         :title="userTitle('Share, Publish, or Set Permissions for this History')"
                         @click="$router.push(`/histories/sharing?id=${history.id}`)">
                         <FontAwesomeIcon fixed-width :icon="faUsersCog" class="mr-1" />

--- a/client/src/components/History/HistoryAccessibility.vue
+++ b/client/src/components/History/HistoryAccessibility.vue
@@ -8,6 +8,7 @@ import { useHistoryStore } from "@/stores/historyStore";
 import localize from "@/utils/localization";
 
 import Heading from "../Common/Heading.vue";
+import PortletSection from "../Common/PortletSection.vue";
 import SharingPage from "../Sharing/SharingPage.vue";
 import HistoryDatasetPermissions from "./HistoryDatasetPermissions.vue";
 import HistoryMakePrivate from "./HistoryMakePrivate.vue";
@@ -57,7 +58,14 @@ function openSharingTab() {
                     </BBadge>
                 </template>
 
-                <SharingPage :id="props.historyId" plural-name="histories" model-class="History" no-heading />
+                <PortletSection :icon="faShareAlt">
+                    <template v-slot:title>
+                        {{ localize("Share or publish history") }}
+                        "{{ historyStore.getHistoryNameById(props.historyId) }}"
+                    </template>
+
+                    <SharingPage :id="props.historyId" plural-name="histories" model-class="History" no-heading />
+                </PortletSection>
             </BTab>
 
             <BTab :lazy="historyPrivacyChanged" @click="historyPrivacyChanged = false">

--- a/client/src/components/History/HistoryAccessibility.vue
+++ b/client/src/components/History/HistoryAccessibility.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { faLock, faShareAlt, faUserLock } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BTab, BTabs } from "bootstrap-vue";
+import { ref } from "vue";
+
+import { useHistoryStore } from "@/stores/historyStore";
+import localize from "@/utils/localization";
+
+import Heading from "../Common/Heading.vue";
+import SharingPage from "../Sharing/SharingPage.vue";
+import HistoryDatasetPermissions from "./HistoryDatasetPermissions.vue";
+import HistoryMakePrivate from "./HistoryMakePrivate.vue";
+
+const props = defineProps<{
+    historyId: string;
+}>();
+
+const historyStore = useHistoryStore();
+
+const tabsLazy = ref(false);
+</script>
+
+<template>
+    <div aria-labelledby="history-sharing-heading">
+        <Heading id="history-sharing-heading" h1 separator inline truncate size="xl">
+            {{ localize("Manage History") }}
+            "{{ historyStore.getHistoryNameById(props.historyId) }}"
+        </Heading>
+
+        <BTabs class="mt-3">
+            <BTab :lazy="tabsLazy" @click="tabsLazy = false">
+                <template v-slot:title>
+                    <FontAwesomeIcon :icon="faShareAlt" class="mr-1" />
+                    {{ localize("Share or Publish") }}
+                </template>
+
+                <SharingPage :id="props.historyId" plural-name="histories" model-class="History" no-heading />
+            </BTab>
+
+            <BTab :lazy="tabsLazy" @click="tabsLazy = false">
+                <template v-slot:title>
+                    <FontAwesomeIcon :icon="faUserLock" class="mr-1" />
+                    {{ localize("Set Permissions") }}
+                </template>
+
+                <HistoryDatasetPermissions :history-id="props.historyId" no-redirect />
+            </BTab>
+
+            <BTab>
+                <template v-slot:title>
+                    <FontAwesomeIcon :icon="faLock" class="mr-1" />
+                    {{ localize("Make Private") }}
+                </template>
+
+                <HistoryMakePrivate :history-id="props.historyId" @change="tabsLazy = true" />
+            </BTab>
+        </BTabs>
+    </div>
+</template>

--- a/client/src/components/History/HistoryAccessibility.vue
+++ b/client/src/components/History/HistoryAccessibility.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { faLock, faShareAlt, faUserLock } from "@fortawesome/free-solid-svg-icons";
+import { faExclamation, faLock, faShareAlt, faUserLock } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BTab, BTabs } from "bootstrap-vue";
+import { BBadge, BTab, BTabs } from "bootstrap-vue";
 import { ref } from "vue";
 
 import { useHistoryStore } from "@/stores/historyStore";
@@ -18,7 +18,21 @@ const props = defineProps<{
 
 const historyStore = useHistoryStore();
 
-const tabsLazy = ref(false);
+/** This boolean is used to trigger lazy loading (refresh) of other tabs when history privacy has changed. */
+const historyPrivacyChanged = ref(false);
+
+/** Once the history is made private, this boolean is used to notify the user if sharing status has also changed or not. */
+const sharingStatusChanged = ref(false);
+
+function historyMadePrivate(hasSharingStatusChanged: boolean) {
+    sharingStatusChanged.value = hasSharingStatusChanged;
+    historyPrivacyChanged.value = true;
+}
+
+function openSharingTab() {
+    historyPrivacyChanged.value = false;
+    sharingStatusChanged.value = false;
+}
 </script>
 
 <template>
@@ -29,16 +43,24 @@ const tabsLazy = ref(false);
         </Heading>
 
         <BTabs class="mt-3">
-            <BTab :lazy="tabsLazy" @click="tabsLazy = false">
+            <BTab :lazy="historyPrivacyChanged" @click="openSharingTab">
                 <template v-slot:title>
                     <FontAwesomeIcon :icon="faShareAlt" class="mr-1" />
                     {{ localize("Share or Publish") }}
+                    <BBadge
+                        v-if="sharingStatusChanged"
+                        v-b-tooltip.hover.noninteractive
+                        class="ml-1"
+                        :title="localize('Sharing status for this history has changed.')"
+                        variant="primary">
+                        <FontAwesomeIcon :icon="faExclamation" />
+                    </BBadge>
                 </template>
 
                 <SharingPage :id="props.historyId" plural-name="histories" model-class="History" no-heading />
             </BTab>
 
-            <BTab :lazy="tabsLazy" @click="tabsLazy = false">
+            <BTab :lazy="historyPrivacyChanged" @click="historyPrivacyChanged = false">
                 <template v-slot:title>
                     <FontAwesomeIcon :icon="faUserLock" class="mr-1" />
                     {{ localize("Set Permissions") }}
@@ -53,7 +75,7 @@ const tabsLazy = ref(false);
                     {{ localize("Make Private") }}
                 </template>
 
-                <HistoryMakePrivate :history-id="props.historyId" @change="tabsLazy = true" />
+                <HistoryMakePrivate :history-id="props.historyId" @history-made-private="historyMadePrivate" />
             </BTab>
         </BTabs>
     </div>

--- a/client/src/components/History/HistoryDatasetPermissions.vue
+++ b/client/src/components/History/HistoryDatasetPermissions.vue
@@ -9,6 +9,7 @@ import DatasetPermissionsForm from "@/components/Dataset/DatasetPermissionsForm.
 
 interface HistoryDatasetPermissionsProps {
     historyId: string;
+    noRedirect?: boolean;
 }
 const props = defineProps<HistoryDatasetPermissionsProps>();
 
@@ -34,7 +35,7 @@ const formConfig = computed(() => {
         title: title,
         url: inputsUrl.value,
         submitTitle: "Save Permissions",
-        redirect: "/histories/list",
+        redirect: props.noRedirect ? undefined : "/histories/list",
     };
 });
 

--- a/client/src/components/History/HistoryMakePrivate.vue
+++ b/client/src/components/History/HistoryMakePrivate.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { faLock } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { computed } from "vue";
+
+import { Toast } from "@/composables/toast";
+import { useHistoryStore } from "@/stores/historyStore";
+import localize from "@/utils/localization";
+import { errorMessageAsString } from "@/utils/simple-error";
+
+import AsyncButton from "../Common/AsyncButton.vue";
+
+const props = defineProps<{
+    historyId: string;
+}>();
+
+const emit = defineEmits(["change"]);
+
+const historyStore = useHistoryStore();
+
+const history = computed(() => historyStore.getHistoryById(props.historyId, true));
+
+async function makeHistoryPrivate() {
+    try {
+        if (!history.value) {
+            throw new Error("History not found");
+        }
+        await historyStore.secureHistory(history.value);
+        Toast.success(
+            localize(
+                "Existing data in this history is now private, as well as any new data created in this history. \
+                Your sharing preferences have also been reset."
+            ),
+            localize("Successfully made history private.")
+        );
+        emit("change");
+    } catch (error) {
+        Toast.error(errorMessageAsString(error), localize("An error occurred while making the history private."));
+    }
+}
+</script>
+
+<template>
+    <div v-if="history" class="ui-portlet-section">
+        <div class="portlet-header">
+            <span class="portlet-title">
+                <FontAwesomeIcon :icon="faLock" class="portlet-title-icon mr-1" />
+
+                <b class="portlet-title-text">
+                    {{ localize("Make history") }}
+                    "{{ history.name }}"
+                    {{ localize("private?") }}
+                </b>
+            </span>
+        </div>
+
+        <div class="portlet-content">
+            <div class="mt-3">
+                <p v-localize>
+                    This will make all the data in this history private (excluding library datasets), and will set
+                    permissions such that all new data is created as private. Any datasets within that are currently
+                    shared will need to be re-shared or published. Are you sure you want to do this?
+                </p>
+
+                <AsyncButton :icon="faLock" variant="primary" :action="makeHistoryPrivate">
+                    {{ localize("Make History Private") }}
+                </AsyncButton>
+            </div>
+        </div>
+    </div>
+</template>

--- a/client/src/components/History/HistoryMakePrivate.vue
+++ b/client/src/components/History/HistoryMakePrivate.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { faLock } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed } from "vue";
 
 import { Toast } from "@/composables/toast";
@@ -9,6 +8,7 @@ import localize from "@/utils/localization";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import AsyncButton from "../Common/AsyncButton.vue";
+import PortletSection from "../Common/PortletSection.vue";
 
 const props = defineProps<{
     historyId: string;
@@ -43,31 +43,21 @@ async function makeHistoryPrivate() {
 </script>
 
 <template>
-    <div v-if="history" class="ui-portlet-section">
-        <div class="portlet-header">
-            <span class="portlet-title">
-                <FontAwesomeIcon :icon="faLock" class="portlet-title-icon mr-1" />
+    <PortletSection :icon="faLock">
+        <template v-slot:title>
+            {{ localize("Make history") }}
+            "{{ historyStore.getHistoryNameById(props.historyId) }}"
+            {{ localize("private?") }}
+        </template>
 
-                <b class="portlet-title-text">
-                    {{ localize("Make history") }}
-                    "{{ history.name }}"
-                    {{ localize("private?") }}
-                </b>
-            </span>
-        </div>
+        <p v-localize>
+            This will make all the data in this history private (excluding library datasets), and will set permissions
+            such that all new data is created as private. Any datasets within that are currently shared will need to be
+            re-shared or published. Are you sure you want to do this?
+        </p>
 
-        <div class="portlet-content">
-            <div class="mt-3">
-                <p v-localize>
-                    This will make all the data in this history private (excluding library datasets), and will set
-                    permissions such that all new data is created as private. Any datasets within that are currently
-                    shared will need to be re-shared or published. Are you sure you want to do this?
-                </p>
-
-                <AsyncButton :icon="faLock" variant="primary" :action="makeHistoryPrivate">
-                    {{ localize("Make History Private") }}
-                </AsyncButton>
-            </div>
-        </div>
-    </div>
+        <AsyncButton :icon="faLock" :disabled="!history" variant="primary" :action="makeHistoryPrivate">
+            {{ localize("Make History Private") }}
+        </AsyncButton>
+    </PortletSection>
 </template>

--- a/client/src/components/History/HistoryMakePrivate.vue
+++ b/client/src/components/History/HistoryMakePrivate.vue
@@ -14,7 +14,9 @@ const props = defineProps<{
     historyId: string;
 }>();
 
-const emit = defineEmits(["change"]);
+const emit = defineEmits<{
+    (e: "history-made-private", sharingStatusChanged: boolean): void;
+}>();
 
 const historyStore = useHistoryStore();
 
@@ -25,7 +27,7 @@ async function makeHistoryPrivate() {
         if (!history.value) {
             throw new Error("History not found");
         }
-        await historyStore.secureHistory(history.value);
+        const { sharingStatusChanged } = await historyStore.secureHistory(history.value);
         Toast.success(
             localize(
                 "Existing data in this history is now private, as well as any new data created in this history. \
@@ -33,7 +35,7 @@ async function makeHistoryPrivate() {
             ),
             localize("Successfully made history private.")
         );
-        emit("change");
+        emit("history-made-private", sharingStatusChanged);
     } catch (error) {
         Toast.error(errorMessageAsString(error), localize("An error occurred while making the history private."));
     }

--- a/client/src/components/Sharing/SharingPage.vue
+++ b/client/src/components/Sharing/SharingPage.vue
@@ -25,6 +25,7 @@ const props = defineProps<{
     id: string;
     pluralName: string;
     modelClass: string;
+    noHeading?: boolean;
 }>();
 
 const errors = ref<string[]>([]);
@@ -223,7 +224,7 @@ const embedable = computed(() => item.value.importable && props.modelClass.toLoc
 
 <template>
     <div class="sharing-page">
-        <Heading h1 size="lg" separator>
+        <Heading v-if="!props.noHeading" h1 size="lg" separator>
             <span>
                 Share or Publish {{ modelClass }} <span v-if="ready">"{{ item.title }}"</span>
             </span>

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -77,6 +77,7 @@ import CreateUserFileSource from "@/components/FileSources/Templates/CreateUserF
 import GridInvocation from "@/components/Grid/GridInvocation.vue";
 import GridVisualization from "@/components/Grid/GridVisualization.vue";
 import HistoryArchiveWizard from "@/components/History/Archiving/HistoryArchiveWizard.vue";
+import HistoryAccessibility from "@/components/History/HistoryAccessibility.vue";
 import HistoryDatasetPermissions from "@/components/History/HistoryDatasetPermissions.vue";
 import NotificationsList from "@/components/Notifications/NotificationsList.vue";
 import EditObjectStoreInstance from "@/components/ObjectStore/Instances/EditInstance.vue";
@@ -273,11 +274,9 @@ export function getRouter(Galaxy) {
                     },
                     {
                         path: "histories/sharing",
-                        component: Sharing,
+                        component: HistoryAccessibility,
                         props: (route) => ({
-                            id: route.query.id,
-                            pluralName: "Histories",
-                            modelClass: "History",
+                            historyId: route.query.id,
                         }),
                     },
                     {

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -369,9 +369,12 @@ export const useHistoryStore = defineStore("historyStore", () => {
         }
     }
 
-    async function secureHistory(history: HistorySummary) {
-        const securedHistory = (await secureHistoryOnServer(history)) as HistorySummaryExtended;
+    async function secureHistory(history: HistorySummary): Promise<{ sharingStatusChanged: boolean }> {
+        const { securedHistory, sharingStatusChanged } = await secureHistoryOnServer(history);
         setHistory(securedHistory);
+        return {
+            sharingStatusChanged,
+        };
     }
 
     async function archiveHistoryById(historyId: string, archiveExportId?: string, purgeHistory = false) {

--- a/client/src/stores/services/history.services.ts
+++ b/client/src/stores/services/history.services.ts
@@ -127,7 +127,12 @@ export async function secureHistoryOnServer(history: AnyHistory) {
     if (response.status !== 200) {
         throw new Error(response.statusText);
     }
-    return await getHistoryByIdFromServer(id);
+    const securedHistory = await getHistoryByIdFromServer(id);
+    return {
+        securedHistory,
+        message: response.data.message as string,
+        sharingStatusChanged: response.data.sharing_status_changed as boolean,
+    };
 }
 
 /**

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1813,7 +1813,7 @@ class NavigatesGalaxy(HasDriver):
         self.use_bootstrap_dropdown(option="export to file", menu="history options")
 
     def click_history_option_sharing(self):
-        self.use_bootstrap_dropdown(option="share or publish", menu="history options")
+        self.use_bootstrap_dropdown(option="share and manage access", menu="history options")
 
     def click_history_option(self, option_label_or_component):
         # Open menu


### PR DESCRIPTION
Fixes #19645 

Adds a new Manage History sharing and accessibility view, located at the same route as the existing Share or Publish history view. It combines the three options: **Share or Publish**, **Set Permissions** and **Make Private** and places them in the same view.

| Before | After |
| ---- | ---- |
| <img src="https://github.com/user-attachments/assets/33d347af-70d6-4ad5-99f8-adc72c4feaca" height="400" /> | <img src="https://github.com/user-attachments/assets/e23c9e57-aa04-4c5c-9e10-42323c611953" height="400" />|

https://github.com/user-attachments/assets/52cdbc28-b776-470d-872f-44ecef6ba168

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
