### PR TITLE
[24.2] Fix parameter model constructions with leading underscores, fixes converter linting

### DIFF
--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Lint converters
         run: |
           mapfile -t TOOL_ARRAY < tool_list.txt
-          planemo lint --skip citations,stdio,help --report_level warn "${TOOL_ARRAY[@]}"
+          planemo lint --skip CitationsMissing,HelpEmpty,HelpMissing --report_level warn "${TOOL_ARRAY[@]}"
       - name: Run tests
         run: |
           mapfile -t TOOL_ARRAY < tool_list.txt

--- a/lib/galaxy/datatypes/converters/interval_to_tabix_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_tabix_converter.xml
@@ -5,7 +5,7 @@
     </requirements>
     <command><![CDATA[
         ln -s '$bgzip' input.bgz &&
-        tabix 
+        tabix
         #if $input1.is_of_type('bed')
             -p bed
         #elif $input1.is_of_type('vcf')
@@ -23,7 +23,7 @@
         if [ ! -s input.bgz.tbi ]; then
             >&2 echo "The converted tabix index file is empty, meaning the input data is invalid.";
             exit 1;
-        fi 
+        fi
         &&
         tabix -l input.bgz
     ]]></command>
@@ -41,6 +41,7 @@
     <tests>
         <test>
             <param name="input1" ftype="bed" value="droPer1.bed"/>
+            <param name="bgzip" ftype="bgzip" value="droPer1.bed.gz"/>
             <output name="output1" ftype="tabix">
                 <assert_contents>
                     <has_size value="133"/>
@@ -55,6 +56,7 @@
         </test>
         <test>
             <param name="input1" ftype="encodepeak" value="encode.broad.peak"/>
+            <param name="bgzip" ftype="bgzip" value="encode.broad.peak.gz"/>
             <output name="output1" ftype="tabix">
                 <assert_contents>
                     <has_size value="110" delta="10"/>
@@ -69,6 +71,7 @@
         </test>
         <test>
             <param name="input1" ftype="gff" value="gff_filter_by_feature_count_out2.gff"/>
+            <param name="bgzip" ftype="bgzip" value="gff_filter_by_feature_count_out2.gff.gz"/>
             <output name="output1" ftype="tabix">
                 <assert_contents>
                     <has_size value="120"/>
@@ -83,6 +86,7 @@
         </test>
         <test>
             <param name="input1" ftype="interval" value="2.interval"/>
+            <param name="bgzip" ftype="bgzip" value="2.interval.gz"/>
             <output name="output1" ftype="tabix">
                 <assert_contents>
                     <has_size value="247"/>
@@ -97,6 +101,7 @@
         </test>
         <test>
             <param name="input1" ftype="vcf" value="vcf_to_maf_in.vcf"/>
+            <param name="bgzip" ftype="bgzip" value="vcf_to_maf_in.vcf.gz"/>
             <output name="output1" ftype="tabix">
                 <assert_contents>
                     <has_size value="143"/>
@@ -111,6 +116,7 @@
         </test>
         <test>
             <param name="input1" ftype="gtf" value="cufflinks_out1.gtf"/>
+            <param name="bgzip" ftype="bgzip" value="cufflinks_out1.gtf.gz"/>
             <output name="output1" ftype="tabix">
                 <assert_contents>
                     <has_size value="125"/>
@@ -119,7 +125,7 @@
             <assert_command>
                 <has_text text="-p gff"/>
             </assert_command>
-        </test>        
+        </test>
     </tests>
     <help>
     </help>


### PR DESCRIPTION
We'll use an alias if necessary. Also adjusts the lint skips to the new linting classes.
Will require a new galaxy-tool-util release to have an effect in CI.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
