### PR TITLE
Limit docker run timeout to 60 seconds

### DIFF
--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -4,6 +4,8 @@ import string
 import subprocess
 import time
 
+import pytest
+
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
 
@@ -403,7 +405,10 @@ def docker_run(image, name, *args, detach=True, remove=True, ports=None):
     cmd.append(image)
     cmd.extend(args)
 
-    subprocess.check_call(cmd)
+    try:
+        subprocess.check_call(cmd, timeout=60)
+    except subprocess.TimeoutExpired:
+        pytest.xfail(f"Timeout starting docker container for {image}")
 
 
 def docker_exec(container_name, *args, output=True):


### PR DESCRIPTION
Not sure if that's where we're timing out, but I guess this is a reasonable limit.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
