### PR TITLE
HelpText improvements (content, sizing) and WorkflowInvocationHeader tweaks.

### DIFF
--- a/client/src/components/Help/HelpPopover.vue
+++ b/client/src/components/Help/HelpPopover.vue
@@ -12,6 +12,15 @@ defineProps<Props>();
 
 <template>
     <Popper v-if="target" :reference-el="target" mode="light">
-        <HelpTerm :term="term" class="p-2" />
+        <HelpTerm :term="term" class="p-2 help-popover-content" />
     </Popper>
 </template>
+
+<style scoped>
+.help-popover-content {
+    font-size: 1rem; /* Reset to default text size */
+    font-weight: normal;
+    line-height: 1.5;
+    text-transform: none;
+}
+</style>

--- a/client/src/components/Help/HelpPopover.vue
+++ b/client/src/components/Help/HelpPopover.vue
@@ -22,7 +22,7 @@ defineProps<Props>();
 .help-popover-content {
     font-size: $font-size-base;
     font-weight: normal;
-    line-height: 1.5;
+    line-height: $line-height-base;
     text-transform: none;
 }
 </style>

--- a/client/src/components/Help/HelpPopover.vue
+++ b/client/src/components/Help/HelpPopover.vue
@@ -16,9 +16,11 @@ defineProps<Props>();
     </Popper>
 </template>
 
-<style scoped>
+<style scoped lang="scss">
+@import "theme/blue.scss";
+
 .help-popover-content {
-    font-size: 1rem; /* Reset to default text size */
+    font-size: $font-size-base;
     font-weight: normal;
     line-height: 1.5;
     text-transform: none;

--- a/client/src/components/Help/terms.yml
+++ b/client/src/components/Help/terms.yml
@@ -10,13 +10,13 @@ unix:
 
     More information on exit codes can be found on [Wikipedia](https://en.wikipedia.org/wiki/Exit_status).
   stdout: |
-    When an application is executed most of its reporting, diagnostic, and logging messages are printed to a stream of
+    When an application is executed, most of its reporting, diagnostic, and logging messages are printed to a stream of
     data called the "standard output" (often abbreviated as stdout). Error messages are more typically
     printed to an alternative stream called "standard error".
 
     More information on standard output can be found on [Wikipedia](https://en.wikipedia.org/wiki/Standard_streams).
   stderr: |
-    When an application is executed most of its error messages are typically printed to a stream of
+    When an application is executed, most of its error messages are typically printed to a stream of
     data called the "standard error" (often abbreviated as stderr). Other reporting, diagnostic, and
     logging messages are typically printed to an alternative stream called "standard output".
 
@@ -45,18 +45,18 @@ galaxy:
       matches the structure of the provided collection. This matching structure means the output collections
       will have the same element identifiers as the provided collection and they will appear in the same order.
 
-      It is easiest to visualize "mapping over" a collection is in the context of a tool that consumes a dataset
+      It is easiest to visualize "mapping over" a collection in the context of a tool that consumes a dataset
       and produces a dataset, but the semantics apply rather naturally to tools that consume collections or
       produce collections as well.
       
       For instance, consider a tool that consumes a ``paired`` collection and produces an output dataset.
       If a list of paired collections (collection type ``list:paired``) is passed to the tool - it will
-      will produce a flat list (collection type ``list``) of output datasets with the same number of elements
+      produce a flat list (collection type ``list``) of output datasets with the same number of elements
       in the same order as the provided list of ``paired`` collections.
 
       In the case of outputs, consider a tool that takes in a dataset and produces a flat list. If this tool
       is run over a flat list of datasets - that list will be "mapped over" and each element will produce a list.
-      These lists will be gathered together in a nested list structured (collection type ``list:list``) where
+      These lists will be gathered together in a nested list structure (collection type ``list:list``) where
       the outer element count and structure matches that of the input and the inner list for each of those
       is just the outputs of the tool for the corresponding element of the input.
     collectionBuilder:
@@ -86,17 +86,17 @@ galaxy:
       cores: |
         This is how many [cores](https://en.wikipedia.org/wiki/Central_processing_unit) (or distinct central processing units (CPUs)) are
         allocated to run the job for the tool. This value is generally configured for the tool by the Galaxy administrator. This value
-        does not guarantee how many cores the job actually used - the job may have used more and less based on how Galaxy is configured
+        does not guarantee how many cores the job actually used - the job may have used more or less based on how Galaxy is configured
         and how the tool is programmed.
 
       walltime: |
-        This is estimate of the length of time the job ran created by recording the start and stop of the job in the job script
-        created for the tool execution and subtracting these values. 
+        This is an estimate of the length of time the job ran, created by recording the start and stop times of the job in the job script
+        created for the tool execution and subtracting these values.
 
       allocated_core_time: |
         This is the number of cores Galaxy believes is allocated for the job times the estimated walltime for the job. This can be thought
-        of as scaling the runtime/walltime metric by the number of cores allocated - when purchasing compute time per core hour or consuming
-        compute time from a compute center's allocation - this is likely to be a more interesting and useful number than the walltime.
+        of as scaling the runtime/walltime metric by the number of cores allocated. When purchasing compute time per core hour or consuming
+        compute time from a compute center's allocation, this is likely to be a more interesting and useful number than the walltime.
 
     states:
       # upload, waiting, failed, paused, deleting, deleted, stop, stopped, skipped.

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
@@ -418,35 +418,35 @@ const groupByInTitles = computed(() => {
             </BRow>
             <BRow>
                 <BCol v-if="wallclockAggregate && wallclockAggregate.values" class="text-center">
-                    <h2 class="h-l truncate text-center">
+                    <Heading class="h3 truncate text-center">
                         Aggregate
                         <HelpText :for-title="true" uri="galaxy.jobs.metrics.walltime" text="Runtime Time" /> (in
                         {{ timingInTitles }})
-                    </h2>
+                    </Heading>
                     <VegaWrapper :spec="itemToBarChartSpec(wallclockAggregate)" :fill-width="false" />
                 </BCol>
                 <BCol v-if="allocatedCoreTimeAggregate && allocatedCoreTimeAggregate.values" class="text-center">
-                    <h2 class="h-l truncate text-center">
+                    <Heading class="h3 truncate text-center">
                         Aggregate
                         <HelpText
                             :for-title="true"
                             uri="galaxy.jobs.metrics.allocated_core_time"
                             text="Allocated Core Time" />
                         (in {{ timingInTitles }})
-                    </h2>
+                    </Heading>
                     <VegaWrapper :spec="itemToBarChartSpec(allocatedCoreTimeAggregate)" :fill-width="false" />
                 </BCol>
             </BRow>
             <BRow v-for="({ spec, item }, key) in metrics" :key="key">
                 <BCol>
-                    <h2 class="h-l truncate text-center">
+                    <Heading class="h3 truncate text-center">
                         <span v-if="item.helpTerm">
                             <HelpText :for-title="true" :uri="item.helpTerm" :text="`${key}`" />
                         </span>
                         <span v-else>
                             {{ key }}
                         </span>
-                    </h2>
+                    </Heading>
                     <VegaWrapper :spec="spec" />
                 </BCol>
             </BRow>

--- a/client/src/style/scss/theme/blue.scss
+++ b/client/src/style/scss/theme/blue.scss
@@ -90,6 +90,9 @@ $font-family-monospace: Monaco, Menlo, Consolas, "Courier New", monospace;
 $font-family-base: $font-family-sans-serif;
 $font-size-base: 0.85rem; // default 1rem
 
+// Line control
+$line-height-base: 1.5; // default 1.5
+
 // Header font sizes
 $h1-font-size: $font-size-base * 2; // default 2.5
 $h2-font-size: $font-size-base * 1.75; // default 2


### PR DESCRIPTION
Fixes various issues in the Help component definitions.

Also fixes an issue with inherited text size in poppers, and adjusts the workflowinvocationmetrics header sizes.

Closes https://github.com/galaxyproject/galaxy/issues/19826

![image](https://github.com/user-attachments/assets/156aeab6-d072-42a9-80cf-792f99f57aea)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
