### PR TITLE
Remove unused (define* - compiler macro) imports from TextEditor.vue

### DIFF
--- a/client/src/components/Markdown/Editor/TextEditor.vue
+++ b/client/src/components/Markdown/Editor/TextEditor.vue
@@ -14,7 +14,7 @@
 
 <script setup lang="ts">
 import { debounce } from "lodash";
-import { defineEmits, defineProps, nextTick, ref, watch } from "vue";
+import { nextTick, ref, watch } from "vue";
 
 import MarkdownToolBox from "@/components/Markdown/MarkdownToolBox.vue";
 import FlexPanel from "@/components/Panels/FlexPanel.vue";


### PR DESCRIPTION
Fixes the two new runtime warnings.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
