### PR TITLE
Make job cache generally available

### DIFF
--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -53,9 +53,7 @@
                         @onValidation="onValidation" />
                 </div>
 
-                <div
-                    v-if="emailAllowed(config, currentUser) || remapAllowed || reuseAllowed(currentUser)"
-                    class="mt-2 mb-4">
+                <div class="mt-2 mb-4">
                     <Heading h2 separator bold size="sm"> Additional Options </Heading>
                     <FormElement
                         v-if="emailAllowed(config, currentUser)"
@@ -72,7 +70,6 @@
                         :help="remapHelp"
                         type="boolean" />
                     <FormElement
-                        v-if="reuseAllowed(currentUser)"
                         id="use_cached_job"
                         v-model="useCachedJobs"
                         title="Attempt to re-use jobs with identical parameters?"
@@ -130,7 +127,6 @@ import { startWatchingHistory } from "@/watch/watchHistory";
 import ToolRecommendation from "../ToolRecommendation";
 import { getToolFormData, submitJob, updateToolFormData } from "./services";
 import ToolCard from "./ToolCard";
-import { allowCachedJobs } from "./utilities";
 
 import FormSelect from "@/components/Form/Elements/FormSelect.vue";
 
@@ -268,9 +264,6 @@ export default {
         ...mapActions(useJobStore, ["saveLatestResponse"]),
         emailAllowed(config, user) {
             return config.server_mail_configured && !user.isAnonymous;
-        },
-        reuseAllowed(user) {
-            return allowCachedJobs(user.preferences);
         },
         onHistoryChange() {
             const Galaxy = getGalaxyInstance();

--- a/client/src/components/Tool/utilities.js
+++ b/client/src/components/Tool/utilities.js
@@ -18,14 +18,3 @@ export function downloadTool(toolId) {
 export function openLink(url) {
     window.open(url);
 }
-
-export function allowCachedJobs(userPreferences) {
-    if (userPreferences && "extra_user_preferences" in userPreferences) {
-        const extra_user_preferences = JSON.parse(userPreferences.extra_user_preferences);
-        const keyCached = "use_cached_job|use_cached_job_checkbox";
-        const hasCachedJobs = keyCached in extra_user_preferences;
-        return hasCachedJobs ? ["true", true].includes(extra_user_preferences[keyCached]) : false;
-    } else {
-        return false;
-    }
-}

--- a/client/src/components/Workflow/Run/WorkflowRunForm.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunForm.vue
@@ -36,7 +36,7 @@
                 <FormDisplay :inputs="historyInputs" @onChange="onHistoryInputs" />
             </template>
         </FormCard>
-        <FormCard v-if="reuseAllowed(currentUser)" title="Job re-use Options">
+        <FormCard title="Job re-use Options">
             <template v-slot:body>
                 <FormElement
                     v-model="useCachedJobs"
@@ -75,7 +75,6 @@ import ButtonSpinner from "components/Common/ButtonSpinner";
 import FormCard from "components/Form/FormCard";
 import FormDisplay from "components/Form/FormDisplay";
 import FormElement from "components/Form/FormElement";
-import { allowCachedJobs } from "components/Tool/utilities";
 import { mapState } from "pinia";
 
 import { useHistoryStore } from "@/stores/historyStore";
@@ -175,9 +174,6 @@ export default {
         },
     },
     methods: {
-        reuseAllowed(user) {
-            return allowCachedJobs(user.preferences);
-        },
         getReplaceParams(inputs) {
             return getReplacements(inputs, this.stepData, this.wpData);
         },

--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -10,7 +10,6 @@ import { useConfig } from "@/composables/config";
 import { usePanels } from "@/composables/usePanels";
 import { provideScopedWorkflowStores } from "@/composables/workflowStores";
 import { useHistoryStore } from "@/stores/historyStore";
-import { useUserStore } from "@/stores/userStore";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import { invokeWorkflow } from "./services";
@@ -47,7 +46,6 @@ const { stateStore } = provideScopedWorkflowStores(props.model.workflowId);
 const { activeNodeId } = storeToRefs(stateStore);
 
 const { config, isConfigLoaded } = useConfig(true);
-const { currentUser } = storeToRefs(useUserStore());
 const { showPanels } = usePanels();
 
 const formData = ref<Record<string, any>>({});

--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -5,7 +5,6 @@ import { BAlert, BButton, BDropdown, BDropdownForm, BFormCheckbox, BOverlay } fr
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 
-import { allowCachedJobs } from "@/components/Tool/utilities";
 import { isWorkflowInput } from "@/components/Workflow/constants";
 import { useConfig } from "@/composables/config";
 import { usePanels } from "@/composables/usePanels";
@@ -132,14 +131,6 @@ function onValidation(validation: [string, string] | null) {
     }
 }
 
-function reuseAllowed(user: any) {
-    return user && allowCachedJobs(user.preferences);
-}
-
-function showRuntimeSettings(user: any) {
-    return props.targetHistory && (props.targetHistory.indexOf("prefer") >= 0 || (user && reuseAllowed(user)));
-}
-
 function onChange(data: any) {
     formData.value = data;
 }
@@ -230,7 +221,6 @@ async function onExecute() {
                         <FontAwesomeIcon :icon="faSitemap" fixed-width />
                     </BButton>
                     <BDropdown
-                        v-if="showRuntimeSettings(currentUser)"
                         id="dropdown-form"
                         ref="dropdown"
                         v-b-tooltip.hover.noninteractive
@@ -247,7 +237,6 @@ async function onExecute() {
                                 Send results to a new history
                             </BFormCheckbox>
                             <BFormCheckbox
-                                v-if="reuseAllowed(currentUser)"
                                 v-model="useCachedJobs"
                                 title="This may skip executing jobs that you have already run.">
                                 Attempt to re-use jobs with identical parameters?

--- a/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
+++ b/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
@@ -40,16 +40,6 @@ preferences:
               type: text
               required: False
 
-    use_cached_job:
-        description: Do you want to be able to re-use previously run jobs ?
-        inputs:
-            - name: use_cached_job_checkbox
-              label: Do you want to be able to re-use  equivalent jobs ?
-              type: boolean
-              checked: false
-              value: false
-              help: If you select yes, you will be able to select for each tool and workflow run if you would like to use this feature.
-
     localization:
         description: Localization
         inputs:


### PR DESCRIPTION
Remove cached job reuse *preference* functionality from ToolForm and related components

Closes #19796 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
