### PR TITLE
[24.1] Backport parts of #19659

### DIFF
--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -781,9 +781,19 @@ class DynamicOptions:
                 by_dbkey.update(table_entries)
             for data_table_entry in by_dbkey.values():
                 field_entry = []
+                if hda := data_table_entry.get("__hda__"):
+                    field_entry.append(hda)
+                missing_columns = False
                 for column_key in self.tool_data_table.columns.keys():
+                    if column_key not in data_table_entry:
+                        # currrent data table definition (as in self.tool_data_table)
+                        # may not match against the data manager bundle.
+                        # Breaking here fixes https://github.com/galaxyproject/galaxy/issues/18749.
+                        missing_columns = True
+                        break
                     field_entry.append(data_table_entry[column_key])
-                fields.append(field_entry)
+                if not missing_columns:
+                    fields.append(field_entry)
         return fields
 
     @staticmethod


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/18749

I have the bakta problem on my 24.1 instance as well. Not sure if any other commits of https://github.com/galaxyproject/galaxy/pull/19659 need backporting ..

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
