### PR TITLE
[24.2] Use materialized datasets in pulsar job runner

### DIFF
--- a/lib/galaxy/job_execution/compute_environment.py
+++ b/lib/galaxy/job_execution/compute_environment.py
@@ -8,6 +8,7 @@ from typing import (
     Dict,
 )
 
+from galaxy.job_execution.datasets import DeferrableObjectsT
 from galaxy.job_execution.setup import JobIO
 from galaxy.model import Job
 
@@ -21,6 +22,9 @@ class ComputeEnvironment(metaclass=ABCMeta):
     """Definition of the job as it will be run on the (potentially) remote
     compute server.
     """
+
+    def __init__(self):
+        self.materialized_objects: Dict[str, DeferrableObjectsT] = {}
 
     @abstractmethod
     def output_names(self):

--- a/lib/galaxy/job_execution/datasets.py
+++ b/lib/galaxy/job_execution/datasets.py
@@ -7,6 +7,15 @@ from abc import (
     ABCMeta,
     abstractmethod,
 )
+from typing import Union
+
+from galaxy.model import (
+    DatasetCollectionElement,
+    DatasetInstance,
+    HistoryDatasetCollectionAssociation,
+)
+
+DeferrableObjectsT = Union[DatasetInstance, HistoryDatasetCollectionAssociation, DatasetCollectionElement]
 
 
 def dataset_path_rewrites(dataset_paths):

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -365,7 +365,9 @@ class PulsarJobRunner(AsynchronousJobRunner):
                 output_names = compute_environment.output_names()
 
                 client_inputs_list = []
-                for input_dataset_wrapper in job_wrapper.job_io.get_input_paths():
+                for input_dataset_wrapper in job_wrapper.job_io.get_input_paths(
+                    compute_environment.materialized_objects
+                ):
                     # str here to resolve false_path if set on a DatasetPath object.
                     path = str(input_dataset_wrapper)
                     object_store_ref = {

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -13,7 +13,6 @@ from typing import (
     List,
     Optional,
     TYPE_CHECKING,
-    Union,
 )
 
 from packaging.version import Version
@@ -21,6 +20,7 @@ from packaging.version import Version
 from galaxy import model
 from galaxy.authnz.util import provider_name_to_backend
 from galaxy.job_execution.compute_environment import ComputeEnvironment
+from galaxy.job_execution.datasets import DeferrableObjectsT
 from galaxy.job_execution.setup import ensure_configs_directory
 from galaxy.model.deferred import (
     materialize_collection_input,
@@ -117,11 +117,6 @@ def global_tool_logs(func, config_file: str, action_str: str, tool: "Tool"):
         ) from e
 
 
-DeferrableObjectsT = Union[
-    model.DatasetInstance, model.HistoryDatasetCollectionAssociation, model.DatasetCollectionElement
-]
-
-
 class ToolEvaluator:
     """An abstraction linking together a tool and a job runtime to evaluate
     tool inputs in an isolated, testable manner.
@@ -168,6 +163,7 @@ class ToolEvaluator:
 
         # materialize deferred datasets
         materialized_objects = self._materialize_objects(deferred_objects, self.local_working_directory)
+        self.compute_environment.materialized_objects = materialized_objects
 
         # replace materialized objects back into tool input parameters
         self._replaced_deferred_objects(inp_data, incoming, materialized_objects)

--- a/test/integration/test_pulsar_embedded.py
+++ b/test/integration/test_pulsar_embedded.py
@@ -23,6 +23,8 @@ instance = integration_util.integration_module_instance(EmbeddedPulsarIntegratio
 
 test_tools = integration_util.integration_tool_runner(
     [
+        "cat_default",
+        "collection_nested_default",
         "collection_creates_dynamic_nested_from_json",
         "composite",
         "simple_constructs",


### PR DESCRIPTION
We were already materializing the datasets in the ToolEvaluator class, just to then not be using the materialized datasets.
Not doing materialization in remote pulsar yet, but at least this will not just fail the job.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
