### PR TITLE
Fix Selenium workflow tests not updating param type properly. 

### DIFF
--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -921,7 +921,9 @@ steps:
         self.assert_workflow_has_changes_and_save()
 
     def switch_param_type(self, element, param_type):
-        self.action_chains().move_to_element(element).click().send_keys(param_type).send_keys(Keys.ENTER).perform()
+        self.action_chains().move_to_element(element).click().pause(1).send_keys(param_type).pause(1).send_keys(
+            Keys.ENTER
+        ).perform()
 
     @selenium_test
     def test_editor_invalid_tool_state(self):


### PR DESCRIPTION
I was able to fix a console error with #19808 but I don't think in retrospect it was the true cause of the test failure. I don't know if want to merge #19808 to clean up the console or wait until the it causes some user seeable issue. This I think should fix the workflow Selenium tests that are failing. I think what is happening is the Enter handler is being executed and before the select value has been updated - easy enough to imagine that being an issue with widgets like this.

A more robust fix for this would be to also check the value is updated in the form after the option is selected and then the value is reflect in the editor UI.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
