### PR TITLE
[24.2] Reduce default framework tool test timeout to 60 seconds

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -532,7 +532,7 @@
     <datatype extension="juicer_medium_tabix.gz" type="galaxy.datatypes.interval:JuicerMediumTabix" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="bed_tabix.gz" type="galaxy.datatypes.interval:BedTabix" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="gff_tabix.gz" type="galaxy.datatypes.interval:GffTabix" mimetype="application/octet-stream" display_in_upload="true"/>
-    <datatype extension="bgzip" type="galaxy.datatypes.binary:Binary" subclass="true" display_in_upload="true"/>
+    <datatype extension="bgzip" type="galaxy.datatypes.binary:CompressedArchive" subclass="true" display_in_upload="true"/>
     <datatype extension="vcf_bgzip" type="galaxy.datatypes.tabular:VcfGz" display_in_upload="true">
       <display file="igv/vcf.xml"/>
       <converter file="vcf_bgzip_to_tabix_converter.xml" target_datatype="tabix"/>

--- a/lib/galaxy/datatypes/converters/interval_to_tabix_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_tabix_converter.xml
@@ -40,13 +40,8 @@
     </outputs>
     <tests>
         <test>
-            <param name="input1" ftype="bed" value="droPer1.bed"/>
-            <param name="bgzip" ftype="bgzip" value="droPer1.bed.gz"/>
-            <output name="output1" ftype="tabix">
-                <assert_contents>
-                    <has_size value="133"/>
-                </assert_contents>
-            </output>
+            <param name="input1" ftype="bed" value="droPer1.bed" />
+            <param name="bgzip" ftype="bgzip" value="droPer1.bed.gz" />
             <assert_command>
                 <has_text text="-p bed"/>
             </assert_command>
@@ -55,13 +50,8 @@
             </assert_stdout>
         </test>
         <test>
-            <param name="input1" ftype="encodepeak" value="encode.broad.peak"/>
-            <param name="bgzip" ftype="bgzip" value="encode.broad.peak.gz"/>
-            <output name="output1" ftype="tabix">
-                <assert_contents>
-                    <has_size value="110" delta="10"/>
-                </assert_contents>
-            </output>
+            <param name="input1" ftype="encodepeak" value="encode.broad.peak" />
+            <param name="bgzip" ftype="bgzip" value="encode.broad.peak.gz" />
             <assert_command>
                 <has_text text="-p" negate="true"/>
             </assert_command>
@@ -70,13 +60,8 @@
             </assert_stdout>
         </test>
         <test>
-            <param name="input1" ftype="gff" value="gff_filter_by_feature_count_out2.gff"/>
-            <param name="bgzip" ftype="bgzip" value="gff_filter_by_feature_count_out2.gff.gz"/>
-            <output name="output1" ftype="tabix">
-                <assert_contents>
-                    <has_size value="120"/>
-                </assert_contents>
-            </output>
+            <param name="input1" ftype="gff" value="gff_filter_by_feature_count_out2.gff" />
+            <param name="bgzip" ftype="bgzip" value="gff_filter_by_feature_count_out2.gff.gz" />
             <assert_command>
                 <has_text text="-p gff"/>
             </assert_command>
@@ -85,13 +70,8 @@
             </assert_stdout>
         </test>
         <test>
-            <param name="input1" ftype="interval" value="2.interval"/>
-            <param name="bgzip" ftype="bgzip" value="2.interval.gz"/>
-            <output name="output1" ftype="tabix">
-                <assert_contents>
-                    <has_size value="247"/>
-                </assert_contents>
-            </output>
+            <param name="input1" ftype="interval" value="2.interval" />
+            <param name="bgzip" ftype="bgzip" value="2.interval.gz" />
             <assert_command>
                 <has_text text="-p" negate="true"/>
             </assert_command>
@@ -100,13 +80,8 @@
             </assert_stdout>
         </test>
         <test>
-            <param name="input1" ftype="vcf" value="vcf_to_maf_in.vcf"/>
-            <param name="bgzip" ftype="bgzip" value="vcf_to_maf_in.vcf.gz"/>
-            <output name="output1" ftype="tabix">
-                <assert_contents>
-                    <has_size value="143"/>
-                </assert_contents>
-            </output>
+            <param name="input1" ftype="vcf" value="vcf_to_maf_in.vcf" />
+            <param name="bgzip" ftype="bgzip" value="vcf_to_maf_in.vcf.gz" />
             <assert_command>
                 <has_text text="-p vcf"/>
             </assert_command>
@@ -115,16 +90,14 @@
             </assert_stdout>
         </test>
         <test>
-            <param name="input1" ftype="gtf" value="cufflinks_out1.gtf"/>
-            <param name="bgzip" ftype="bgzip" value="cufflinks_out1.gtf.gz"/>
-            <output name="output1" ftype="tabix">
-                <assert_contents>
-                    <has_size value="125"/>
-                </assert_contents>
-            </output>
+            <param name="input1" ftype="gtf" value="cufflinks_out1.gtf" />
+            <param name="bgzip" ftype="bgzip" value="cufflinks_out1.gtf.gz" />
             <assert_command>
-                <has_text text="-p gff"/>
+                <has_text text="-p gff" />
             </assert_command>
+            <assert_stdout>
+                <has_line line="test_chromosome" />
+            </assert_stdout>
         </test>
     </tests>
     <help>

--- a/lib/galaxy/datatypes/converters/neostorezip_to_neostore_converter.xml
+++ b/lib/galaxy/datatypes/converters/neostorezip_to_neostore_converter.xml
@@ -15,7 +15,9 @@
   <tests>
     <test>
       <!-- TODO mock test? $output1 should be the html primary file? -->
-      <param name="input1" ftype="neostore.zip" value="neostore.zip"/>
+      <param name="input1" value="" ftype="neostore.zip">
+        <composite_data value="neostore.zip" />
+      </param>
       <output name="output1" ftype="neostore">
         <assert_contents>
           <has_n_lines n="2"/>

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -66,6 +66,7 @@ FRAMEWORK_DATATYPES_CONF = os.path.join(FRAMEWORK_TOOLS_DIR, "sample_datatypes_c
 MIGRATED_TOOL_PANEL_CONFIG = "config/migrated_tools_conf.xml"
 INSTALLED_TOOL_PANEL_CONFIGS = [os.environ.get("GALAXY_TEST_SHED_TOOL_CONF", "config/shed_tool_conf.xml")]
 DEFAULT_LOCALES = "en"
+DEFAULT_TOOL_TEST_WAIT: int = int(os.environ.get("GALAXY_TEST_DEFAULT_WAIT", 60))
 
 log = logging.getLogger("test_driver")
 
@@ -961,12 +962,17 @@ class GalaxyTestDriver(TestDriver):
             "keep_outputs_dir": None,
         }
         galaxy_interactor = GalaxyInteractorApi(**galaxy_interactor_kwds)
+        # Cut down default timeout to 60 seconds within tests run via
+        # GalaxyTestDriver. Does not affect tests run via galaxy-tool-util,
+        # which use a much longer timeout.
+        maxseconds = kwd.pop("maxseconds", DEFAULT_TOOL_TEST_WAIT)
         verify_tool(
             tool_id=tool_id,
             test_index=index,
             galaxy_interactor=galaxy_interactor,
             resource_parameters=resource_parameters,
             test_data_resolver=TestDataResolver(),
+            maxseconds=maxseconds,
             **kwd,
         )
 

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -863,6 +863,7 @@ class GalaxyTestDriver(TestDriver):
         self.allow_tool_conf_override = allow_tool_conf_override
         self.default_tool_conf = default_tool_conf
         self.datatypes_conf_override = datatypes_conf_override
+        self.maxseconds = getattr(config_object, "maxseconds", DEFAULT_TOOL_TEST_WAIT)
 
     def setup(self, config_object=None):
         """Setup a Galaxy server for functional test (if needed).
@@ -965,7 +966,7 @@ class GalaxyTestDriver(TestDriver):
         # Cut down default timeout to 60 seconds within tests run via
         # GalaxyTestDriver. Does not affect tests run via galaxy-tool-util,
         # which use a much longer timeout.
-        maxseconds = kwd.pop("maxseconds", DEFAULT_TOOL_TEST_WAIT)
+        maxseconds = kwd.pop("maxseconds", self.maxseconds)
         verify_tool(
             tool_id=tool_id,
             test_index=index,

--- a/test/integration/resubmission_pulsar_job_conf.xml
+++ b/test/integration/resubmission_pulsar_job_conf.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0"?>
-<!-- 
+<!--
     Variant of resubmission_job_conf for testing Pulsar resubmission.
 -->
 <job_conf>
     <plugins>
         <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="1"/>
-        <plugin id="pulsar_rest" type="runner" load="galaxy.jobs.runners.pulsar:PulsarRESTJobRunner"/>
+        <plugin id="pulsar_rest" type="runner" load="galaxy.jobs.runners.pulsar:PulsarRESTJobRunner">
+            <param id="transport_timeout">10</param>
+        </plugin>
     </plugins>
 
     <destinations default="initial_pulsar">

--- a/test/integration/test_job_resubmission.py
+++ b/test/integration/test_job_resubmission.py
@@ -27,16 +27,21 @@ JOB_RESUBMISSION_PULSAR_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubm
 
 class _BaseResubmissionIntegrationTestCase(integration_util.IntegrationTestCase):
     framework_tool_and_types = True
+    maxseconds = 60
 
     def _assert_job_passes(self, tool_id="exit_code_oom", resource_parameters=None, history_id=None):
         resource_parameters = resource_parameters or {}
-        self._run_tool_test(tool_id, resource_parameters=resource_parameters, test_history=history_id)
+        self._run_tool_test(
+            tool_id, resource_parameters=resource_parameters, test_history=history_id, maxseconds=self.maxseconds
+        )
 
     def _assert_job_fails(self, tool_id="exit_code_oom", resource_parameters=None, history_id=None):
         resource_parameters = resource_parameters or {}
         exception_thrown = False
         try:
-            self._run_tool_test(tool_id, resource_parameters=resource_parameters, test_history=history_id)
+            self._run_tool_test(
+                tool_id, resource_parameters=resource_parameters, test_history=history_id, maxseconds=self.maxseconds
+            )
         except Exception:
             exception_thrown = True
 
@@ -271,6 +276,10 @@ class TestJobResubmissionToolDetectedErrorResubmitsIntegration(_BaseResubmission
 
 # Verify that a failure to connect to pulsar can trigger a resubmit
 class TestJobResubmissionPulsarIntegration(_BaseResubmissionIntegrationTestCase):
+
+    # It takes a little longer to hit the timeout error for pulsar connections
+    maxseconds = 120
+
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)

--- a/test/integration/test_job_resubmission.py
+++ b/test/integration/test_job_resubmission.py
@@ -27,7 +27,6 @@ JOB_RESUBMISSION_PULSAR_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubm
 
 class _BaseResubmissionIntegrationTestCase(integration_util.IntegrationTestCase):
     framework_tool_and_types = True
-    maxseconds = 60
 
     def _assert_job_passes(self, tool_id="exit_code_oom", resource_parameters=None, history_id=None):
         resource_parameters = resource_parameters or {}
@@ -272,10 +271,6 @@ class TestJobResubmissionToolDetectedErrorResubmitsIntegration(_BaseResubmission
 
 # Verify that a failure to connect to pulsar can trigger a resubmit
 class TestJobResubmissionPulsarIntegration(_BaseResubmissionIntegrationTestCase):
-
-    # It takes a little longer to hit the timeout error for pulsar connections
-    maxseconds = 120
-
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)

--- a/test/integration/test_job_resubmission.py
+++ b/test/integration/test_job_resubmission.py
@@ -31,17 +31,13 @@ class _BaseResubmissionIntegrationTestCase(integration_util.IntegrationTestCase)
 
     def _assert_job_passes(self, tool_id="exit_code_oom", resource_parameters=None, history_id=None):
         resource_parameters = resource_parameters or {}
-        self._run_tool_test(
-            tool_id, resource_parameters=resource_parameters, test_history=history_id, maxseconds=self.maxseconds
-        )
+        self._run_tool_test(tool_id, resource_parameters=resource_parameters, test_history=history_id)
 
     def _assert_job_fails(self, tool_id="exit_code_oom", resource_parameters=None, history_id=None):
         resource_parameters = resource_parameters or {}
         exception_thrown = False
         try:
-            self._run_tool_test(
-                tool_id, resource_parameters=resource_parameters, test_history=history_id, maxseconds=self.maxseconds
-            )
+            self._run_tool_test(tool_id, resource_parameters=resource_parameters, test_history=history_id)
         except Exception:
             exception_thrown = True
 

--- a/test/unit/app/managers/test_CitationsManager_db.py
+++ b/test/unit/app/managers/test_CitationsManager_db.py
@@ -34,8 +34,7 @@ def test_DoiCache(url_factory):  # noqa: F811
         dois = (("10.1093/bioinformatics/bts252", "Jörg"), ("10.1101/2021.12.24.474111", "Özkurt"))
         for doi, author in dois:
             responses.add(method="GET", url=f"https://doi.org/{doi}", body=author)
-        assert "Jörg" in doi_cache.get_bibtex("10.1093/bioinformatics/bts252")
-        assert "Özkurt" in doi_cache.get_bibtex("10.1101/2021.12.24.474111")
+            assert author in doi_cache.get_bibtex(doi)
         assert not is_cache_empty(db_url, "doi")
         doi_cache._cache.clear()
         assert is_cache_empty(db_url, "doi")


### PR DESCRIPTION
This seems like a reasonable value for tests run via GalaxyTestDriver (integration, api, but not galaxy-tool-util / planemo).
At a minimum we don't burn through our minute quota when tests time out indefinitely, like the rucio tests do currently.

Also fixes neo4j converter test definition and mocks out doi.org requests.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
