### PR TITLE
[24.2] Backport #19810: Fix workflow param tests not updating param type.

### DIFF
--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -921,7 +921,9 @@ steps:
         self.assert_workflow_has_changes_and_save()
 
     def switch_param_type(self, element, param_type):
-        self.action_chains().move_to_element(element).click().send_keys(param_type).send_keys(Keys.ENTER).perform()
+        self.action_chains().move_to_element(element).click().pause(1).send_keys(param_type).pause(1).send_keys(
+            Keys.ENTER
+        ).perform()
 
     @selenium_test
     def test_editor_invalid_tool_state(self):


### PR DESCRIPTION
Backport of #19810.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
