### PR TITLE
[24.2] Bump up max_peek_size to 50MB

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -172,7 +172,7 @@ def _get_max_peek_size(data):
 
     max_peek_size = DEFAULT_MAX_PEEK_SIZE  # 1 MB
     if isinstance(data.datatype, text.Html):
-        max_peek_size = 10000000  # 10 MB for html
+        max_peek_size = 50000000  # 50 MB for html
     elif isinstance(data.datatype, binary.Binary):
         max_peek_size = 100000  # 100 KB for binary
     return max_peek_size


### PR DESCRIPTION
Fixes the display of a 17MB html file.

The file is served by nginx in production, and even without nginx we just stream the file. We may crash the browser tab, but I think 50MB is fine for modern browsers, and maybe we shouldn't be in the business of deciding what's too large anyway.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
