### PR TITLE
[24.2] Fix various job concurrency limit issues

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1727,7 +1727,9 @@ class MinimalJobWrapper(HasResourceParameters):
     def enqueue(self):
         job = self.get_job()
         # Change to queued state before handing to worker thread so the runner won't pick it up again
-        if not self.queue_with_limit(job, self.job_destination):
+        if self.is_task:
+            self.change_state(model.Job.states.QUEUED, flush=False, job=job)
+        elif not self.queue_with_limit(job, self.job_destination):
             return False
         # Set object store after job destination so can leverage parameters...
         self._set_object_store_ids(job)

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -451,9 +451,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
             job = job_wrapper.get_job()
             # Set the job destination here (unlike other runners) because there are likely additional job destination
             # params from the Pulsar client.
-            # Flush with change_state.
-            job_wrapper.set_job_destination(job_destination, external_id=external_job_id, flush=False, job=job)
-            job_wrapper.change_state(model.Job.states.QUEUED, job=job)
+            job_wrapper.set_job_destination(job_destination, external_id=external_job_id, flush=True, job=job)
         except Exception:
             job_wrapper.fail("failure running job", exception=True)
             log.exception("failure running job %d", job_wrapper.job_id)

--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -138,16 +138,8 @@ class SlurmJobRunner(DRMAAJobRunner):
                         ajs.job_wrapper.get_id_tag(),
                         ajs.job_id,
                     )
-                    ajs.job_wrapper.change_state(
-                        model.Job.states.QUEUED, info="Job was resubmitted due to node failure"
-                    )
-                    try:
-                        self.queue_job(ajs.job_wrapper)
-                        return
-                    except Exception:
-                        ajs.fail_message = (
-                            "This job failed due to a cluster node failure, and an attempt to resubmit the job failed."
-                        )
+                    self.mark_as_resubmitted(ajs, info="Job was resubmitted due to node failure")
+                    return
                 elif slurm_state == "OUT_OF_MEMORY":
                     log.info(
                         "(%s/%s) Job hit memory limit (SLURM state: OUT_OF_MEMORY)",

--- a/test/unit/app/jobs/test_queue_limit.py
+++ b/test/unit/app/jobs/test_queue_limit.py
@@ -1,0 +1,133 @@
+from typing import Optional
+from unittest.mock import Mock
+
+from galaxy.jobs import (
+    JobConfigurationLimits,
+    MinimalJobWrapper,
+)
+from galaxy.model import (
+    GalaxySession,
+    Job,
+)
+from galaxy.model.unittest_utils import GalaxyDataTestApp
+from galaxy.model.unittest_utils.data_app import GalaxyDataTestConfig
+
+
+class MockJobConfig:
+
+    def __init__(self) -> None:
+        self.limits = JobConfigurationLimits()
+
+    def get_destinations(self, tag):
+        return [create_mock_destination()]
+
+
+class GalaxyJobConfigApp(GalaxyDataTestApp):
+
+    def __init__(self, config: Optional[GalaxyDataTestConfig] = None, **kwd):
+        super().__init__(config, **kwd)
+        self.job_config = MockJobConfig()
+
+
+def create_mock_app():
+    return GalaxyJobConfigApp()
+
+
+def create_job_wrapper(app: GalaxyJobConfigApp, user_id=None, session_id=None):
+    if session_id:
+        session = GalaxySession(id=session_id)
+        app.model.session.add(session)
+        app.model.session.commit()
+    job = create_mock_job(app, user_id, session_id)
+    job_wrapper = MinimalJobWrapper(job, app)  # type: ignore[arg-type]
+    return job_wrapper
+
+
+def create_mock_job(app: GalaxyJobConfigApp, user_id=None, session_id=None, state="new"):
+    """Creates a mock job object."""
+    job = Job()
+    job.user_id = user_id
+    job.session_id = session_id
+    job.state = state
+    app.model.session.add(job)
+    app.model.session.commit()
+    return job
+
+
+def create_mock_destination():
+    """Creates a mock job destination."""
+    job_destination_mock = Mock()
+    job_destination_mock.id = "one"
+    job_destination_mock.params = {}
+    job_destination_mock.runner = "test_runner"
+    job_destination_mock.tags = ["one", "two"]
+    return job_destination_mock
+
+
+def test_registered_user_limit():
+    app = create_mock_app()
+    job_wrapper = create_job_wrapper(app, user_id=1)
+    job = job_wrapper.get_job()
+    job_destination_mock = create_mock_destination()
+
+    for _ in range(2):
+        create_mock_job(app, user_id=1, state="running")
+
+    # Test below limit
+    job_wrapper.app.job_config.limits.registered_user_concurrent_jobs = 3
+    result = job_wrapper.queue_with_limit(job, job_destination_mock)
+    assert result is True
+
+    # Test at limit
+    result = job_wrapper.queue_with_limit(job, job_destination_mock)
+    assert result is False
+
+
+def test_anonymous_user_limit():
+    app = create_mock_app()
+    job_wrapper = create_job_wrapper(app, session_id=1)
+    job = job_wrapper.get_job()
+    job_destination_mock = create_mock_destination()
+
+    create_mock_job(app, session_id=1, state="running")
+
+    # Test below limit
+    app.job_config.limits.anonymous_user_concurrent_jobs = 2
+    result = job_wrapper.queue_with_limit(job, job_destination_mock)
+    assert result is True
+
+    # Test at limit
+    result = job_wrapper.queue_with_limit(job, job_destination_mock)
+    assert result is False
+
+
+def test_destination_total_limit():
+    app = create_mock_app()
+    job_wrapper = create_job_wrapper(app, user_id=1)
+    job = job_wrapper.get_job()
+    job_destination_mock = create_mock_destination()
+
+    # Test below limit
+    app.job_config.limits.destination_total_concurrent_jobs["one"] = 1
+    result = job_wrapper.queue_with_limit(job, job_destination_mock)
+    assert result is True
+
+    # Test at limit
+    result = job_wrapper.queue_with_limit(job, job_destination_mock)
+    assert result is False
+
+
+def test_destination_tag_limit():
+    app = create_mock_app()
+    job_wrapper = create_job_wrapper(app, user_id=1)
+    job = job_wrapper.get_job()
+    job_destination_mock = create_mock_destination()
+
+    # Test below limit
+    app.job_config.limits.destination_total_concurrent_jobs["two"] = 1
+    result = job_wrapper.queue_with_limit(job, job_destination_mock)
+    assert result is True
+
+    # Test at limit
+    result = job_wrapper.queue_with_limit(job, job_destination_mock)
+    assert result is False


### PR DESCRIPTION
I've added an additional check in job_wrapper.enqueue that only updates jobs below the limit. This should be multi-process / multi-thread safe.
The queries are essentially the same queries that are done in `JobHandler.__check_user_jobs`, `JobHandler.__check_destination_jobs` etc, but now it's all in in a single update statement.

I suppose performance might be a concern, however we still run through the (cached) checks before we decide to queue the job, so I think the cost is likely minimal. By integrating the limit check in the query i think it should become very unlikely that jobs can bypass limits in a multi handler scenario.

[c088f9c](https://github.com/galaxyproject/galaxy/pull/19824/commits/c088f9c08a01eba33c77825a4844f5e32b136fb5) fixes a bug where a resubmitted job would cause the cached user_job_count_per_destination / user_job_count values to start at 0.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
