### PR TITLE
Cleanup SCSS to prevent mass re-imports. 

### DIFF
--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -455,4 +455,52 @@ function onAlert(value: string | undefined) {
 
 <style lang="scss" scoped>
 @import "./_form-elements.scss";
+@import "base.scss";
+
+// Workflow Run Form
+.workflow-run-element {
+    // when a temporary focus is applied to the element
+    &.temp-focus {
+        border: solid 3px $brand-primary;
+    }
+    &:not(.temp-focus) {
+        border: solid 1px $portlet-bg-color;
+        box-shadow: 0 0 5px $portlet-bg-color;
+    }
+
+    .ui-form-title {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+
+        // inherit the border radius from the parent .alert class
+        border-top-left-radius: inherit;
+        border-top-right-radius: inherit;
+
+        &:deep(.form-element-header-badge) {
+            display: flex;
+            align-items: center;
+            font-weight: normal;
+            font-size: 100%;
+            padding-left: $spacer;
+            padding-right: $spacer;
+
+            &.populated {
+                background-color: $state-success-bg;
+            }
+            &.unpopulated {
+                background-color: $state-info-bg;
+            }
+        }
+    }
+    .form-element-content {
+        display: flex;
+        flex-direction: column;
+        row-gap: 0.25rem;
+
+        .ui-form-info {
+            order: -1;
+        }
+    }
+}
 </style>

--- a/client/src/components/Form/_form-elements.scss
+++ b/client/src/components/Form/_form-elements.scss
@@ -1,6 +1,4 @@
-@import "theme/blue.scss";
 @import "base.scss";
-@import "~@fortawesome/fontawesome-free/scss/_variables";
 
 .ui-form-element {
     margin-top: $margin-v * 0.25;

--- a/client/src/components/Form/_form-elements.scss
+++ b/client/src/components/Form/_form-elements.scss
@@ -1,57 +1,11 @@
-@import "base.scss";
+@import "theme/blue.scss";
+@import "~@fortawesome/fontawesome-free/scss/_variables";
 
 .ui-form-element {
     margin-top: $margin-v * 0.25;
     margin-bottom: $margin-v * 0.5;
     overflow: visible;
     clear: both;
-
-    // Workflow Run Form
-    &.workflow-run-element {
-        // when a temporary focus is applied to the element
-        &.temp-focus {
-            border: solid 3px $brand-primary;
-        }
-        &:not(.temp-focus) {
-            border: solid 1px $portlet-bg-color;
-            box-shadow: 0 0 5px $portlet-bg-color;
-        }
-
-        .ui-form-title {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-
-            // inherit the border radius from the parent .alert class
-            border-top-left-radius: inherit;
-            border-top-right-radius: inherit;
-
-            &:deep(.form-element-header-badge) {
-                display: flex;
-                align-items: center;
-                font-weight: normal;
-                font-size: 100%;
-                padding-left: $spacer;
-                padding-right: $spacer;
-
-                &.populated {
-                    background-color: map-get($galaxy-state-bg, "ok");
-                }
-                &.unpopulated {
-                    background-color: $state-info-bg;
-                }
-            }
-        }
-        .form-element-content {
-            display: flex;
-            flex-direction: column;
-            row-gap: 0.25rem;
-
-            .ui-form-info {
-                order: -1;
-            }
-        }
-    }
 
     .ui-form-title {
         word-wrap: break-word;


### PR DESCRIPTION
These are imported as part of base.scss.

The relevant change is in https://github.com/galaxyproject/galaxy/commit/0b262c05a12d797b2c871adfc53d3a1d0a4196e6#diff-f93bafd11ed7133c2cb9ab50021a3d29e5ce689d4292d758daa2ae6353d213ae.

Are there downsides to importing all of base.scss in here? I cannot get my downstream branch in #19377 to compile at all when I use components that import _form-elements.scss now 😢. Can we get away with a lighter import than was done 0b262c05a12d797b2c871adfc53d3a1d0a4196e6? 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
