### PR TITLE
Syntactic sugar to ease TPV configuration.

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -54,7 +54,10 @@ class ConditionalDependencies:
                     self.job_runners.append(runner.get("load"))
             environments = job_conf_dict.get("execution", {}).get("environments", {})
             for env in environments.values():
-                if "rules_module" in env:
+                runner = env.get("runner")
+                if runner == "dynamic_tpv":
+                    self.job_rule_modules.append("tpv.rules")
+                elif "rules_module" in env:
                     self.job_rule_modules.append(env.get("rules_module"))
 
         if "job_config" in self.config:

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -459,10 +459,18 @@ class JobConfiguration(ConfiguresHandlers):
         job_metrics = self.app.job_metrics
         execution_dict = job_config_dict.get("execution", {})
         environments = execution_dict.get("environments", [])
-        enviroment_iter = (
+        environments_list = list(
             ((e["id"], e) for e in environments) if isinstance(environments, list) else environments.items()
         )
-        for environment_id, environment_dict in enviroment_iter:
+        for _, environment_dict in environments_list:
+            runner = environment_dict.get("runner")
+            if runner == "dynamic_tpv":
+                environment_dict["runner"] = "dynamic"
+                environment_dict["type"] = "python"
+                environment_dict["function"] = "map_tool_to_destination"
+                environment_dict["rules_module"] = "tpv.rules"
+
+        for environment_id, environment_dict in environments_list:
             metrics = environment_dict.get("metrics")
             if metrics is None:
                 metrics = {"src": "default"}


### PR DESCRIPTION
Setup a special runner type that just fills in all the TPV cruft. Should ease all the TPV documentation and such but my particular interest in the moment is outlined here https://github.com/galaxyproject/total-perspective-vortex/pull/146 - improving the Planemo workflow run story for Galaxy Live. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
