### PR TITLE
[24.2] Do not reorder options in FormSelect component when multiselect disabled

### DIFF
--- a/client/src/components/Form/Elements/FormData/types.ts
+++ b/client/src/components/Form/Elements/FormData/types.ts
@@ -9,3 +9,7 @@ export type DataOption = {
     src: string;
     tags: Array<string>;
 };
+
+export function isDataOption(item: object): item is DataOption {
+    return !!item && "src" in item;
+}

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -64,7 +64,7 @@ const filteredOptions = useFilterObjectArray(() => props.options, filter, ["labe
 const optionReorderThreshold = 8;
 
 const reorderedOptions = computed(() => {
-    if (filteredOptions.value.length <= optionReorderThreshold) {
+    if (!props.multiple || filteredOptions.value.length <= optionReorderThreshold) {
         return filteredOptions.value;
     } else {
         const selectedOptions: SelectOption[] = [];

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -114,6 +114,10 @@ const selectedLabel: ComputedRef<string> = computed(() => {
  */
 const selectedValues = computed(() => (Array.isArray(props.value) ? props.value : [props.value]));
 
+const selectedIds = computed(() => {
+    return selectedValues.value.map((v) => (isValueWithId(v) ? v.id : undefined)).filter((v) => v !== undefined);
+});
+
 /**
  * Tracks current value and emits changes
  */
@@ -163,8 +167,19 @@ function isValueWithTags(item: SelectValue): item is ValueWithTags {
     return item !== null && typeof item === "object" && (item as ValueWithTags).tags !== undefined;
 }
 
+function isValueWithId(item: SelectValue): item is { id: string } {
+    return !!item && typeof item === "object" && (item as { id: string }).id !== undefined;
+}
+
 function onSearchChange(search: string): void {
     filter.value = search;
+}
+
+function isSelected(item: SelectValue): boolean {
+    if (isValueWithId(item)) {
+        return selectedIds.value.includes(item.id);
+    }
+    return selectedValues.value.includes(item);
 }
 </script>
 
@@ -200,7 +215,7 @@ function onSearchChange(search: string): void {
                             :value="option.value.tags"
                             disabled />
                     </div>
-                    <FontAwesomeIcon v-if="selectedValues.includes(option.value)" :icon="faCheckSquare" />
+                    <FontAwesomeIcon v-if="isSelected(option.value)" :icon="faCheckSquare" />
                     <FontAwesomeIcon v-else :icon="faSquare" />
                 </div>
             </template>

--- a/client/src/style/scss/multiselect.scss
+++ b/client/src/style/scss/multiselect.scss
@@ -47,7 +47,7 @@
         }
 
         &.multiselect__option--highlight {
-            background: $brand-danger;
+            background: $brand-success;
 
             &::after {
                 background: unset;

--- a/client/src/style/scss/multiselect.scss
+++ b/client/src/style/scss/multiselect.scss
@@ -47,7 +47,7 @@
         }
 
         &.multiselect__option--highlight {
-            background: $brand-success;
+            background: darken($brand-secondary, 40%);
 
             &::after {
                 background: unset;


### PR DESCRIPTION
Fix #19804

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
