### PR TITLE
[24.2] Decode/encode FormDirectory paths to allow spaces (and other characters)

### DIFF
--- a/client/src/components/Form/Elements/FormDirectory.test.js
+++ b/client/src/components/Form/Elements/FormDirectory.test.js
@@ -14,6 +14,28 @@ jest.mock("app");
 
 const { server, http } = useServerMock();
 
+async function init(wrapper, data) {
+    // the file dialog modal should exist
+    const filesDialogComponent = wrapper.findComponent(FilesDialog);
+    expect(filesDialogComponent.exists()).toBe(true);
+    filesDialogComponent.vm.callback({ url: data.url });
+    // HACK to avoid https://github.com/facebook/jest/issues/2549 (URL implementation is not the same as global node)
+    wrapper.vm.pathChunks = data.pathChunks;
+    await flushPromises();
+    await validateLatestEmittedPath(wrapper, data.url);
+}
+
+async function validateLatestEmittedPath(wrapper, expectedPath) {
+    const latestEmitIndex = wrapper.emitted()["input"].length - 1;
+    const latestPath = wrapper.emitted()["input"][latestEmitIndex][0];
+    expect(latestPath).toBe(expectedPath);
+
+    // also manually change prop value to be able to test the value being displayed
+    await wrapper.setProps({ value: latestPath });
+    const fullPathDisplayed = wrapper.find("[data-description='directory full path']");
+    expect(fullPathDisplayed.text()).toBe(`Directory Path: ${expectedPath}`);
+}
+
 describe("DirectoryPathEditableBreadcrumb", () => {
     let wrapper;
     let spyOnUrlSet;
@@ -29,6 +51,11 @@ describe("DirectoryPathEditableBreadcrumb", () => {
     const validPath = "validpath";
     const invalidPath = "./];";
 
+    const testingDataWithSpecialChars = {
+        url: "gxfiles://directory/sub directory/with%20percent",
+        pathChunks: [{ pathChunk: "directory" }, { pathChunk: "sub%20directory" }, { pathChunk: "with%2520percent" }],
+    };
+
     const saveNewChunk = async (path) => {
         // enter a new path chunk
         const input = wrapper.find("#path-input-breadcrumb");
@@ -37,15 +64,6 @@ describe("DirectoryPathEditableBreadcrumb", () => {
 
         input.trigger("keyup.enter");
         return input;
-    };
-    const init = async () => {
-        // the file dialog modal should exist
-        const filesDialogComponent = wrapper.findComponent(FilesDialog);
-        expect(filesDialogComponent.exists()).toBe(true);
-        filesDialogComponent.vm.callback({ url: testingData.url });
-        // HACK to avoid https://github.com/facebook/jest/issues/2549 (URL implementation is not the same as global node)
-        wrapper.vm.pathChunks = testingData.pathChunks;
-        await flushPromises();
     };
 
     beforeEach(async () => {
@@ -67,13 +85,12 @@ describe("DirectoryPathEditableBreadcrumb", () => {
 
         wrapper = mount(FormDirectory, {
             propsData: {
-                callback: () => {},
+                value: null,
             },
             localVue: localVue,
             pinia,
         });
         await flushPromises();
-        await init();
     });
     afterEach(async () => {
         if (wrapper) {
@@ -83,6 +100,7 @@ describe("DirectoryPathEditableBreadcrumb", () => {
     });
 
     it("should render Breadcrumb", async () => {
+        await init(wrapper, testingData);
         // after initial folder is chosen, setUrl() should be called and modal disappear
         expect(spyOnUrlSet).toHaveBeenCalled();
         expect(wrapper.findComponent(FilesDialog).exists()).toBe(false);
@@ -107,6 +125,7 @@ describe("DirectoryPathEditableBreadcrumb", () => {
     });
 
     it("should prevent invalid Paths", async () => {
+        await init(wrapper, testingData);
         // enter a new path chunk
         const input = await saveNewChunk(invalidPath);
         await flushPromises();
@@ -117,6 +136,7 @@ describe("DirectoryPathEditableBreadcrumb", () => {
     });
 
     it("should save and remove new Paths", async () => {
+        await init(wrapper, testingData);
         // enter a new path chunk
         const input = await saveNewChunk(validPath);
 
@@ -129,19 +149,31 @@ describe("DirectoryPathEditableBreadcrumb", () => {
         expect(wrapper.findAll("li.breadcrumb-item").length).toBe(testingData.expectedNumberOfPaths + 1);
         // find newly added chunk
         const addedChunk = wrapper.findAll("li.breadcrumb-item button").wrappers.find((e) => e.text() === validPath);
+
+        await validateLatestEmittedPath(wrapper, `${testingData.url}/${validPath}`);
+
         // remove chunk from the path
         await addedChunk.trigger("click");
         await flushPromises();
         // number of elements should be the same again
         expect(wrapper.findAll("li.breadcrumb-item").length).toBe(testingData.expectedNumberOfPaths);
+
+        await validateLatestEmittedPath(wrapper, testingData.url);
     });
 
     it("should update new path", async () => {
+        await init(wrapper, testingData);
         // enter a new path chunk
         expect(spyOnUpdateURL).toHaveBeenCalled();
         await saveNewChunk(validPath);
         await flushPromises();
 
         expect(spyOnUpdateURL).toHaveBeenCalled();
+    });
+
+    it("should retain special characters in path", async () => {
+        // the init function itself validates that the emits and path display
+        // retain special characters in the url
+        await init(wrapper, testingDataWithSpecialChars);
     });
 });

--- a/client/src/components/Form/Elements/FormDirectory.vue
+++ b/client/src/components/Form/Elements/FormDirectory.vue
@@ -94,6 +94,7 @@ export default {
     methods: {
         removePath(index) {
             this.pathChunks = this.pathChunks.slice(0, index);
+            this.updateURL();
         },
         reset() {
             const data = getDefaultValues();

--- a/client/src/components/Form/Elements/FormDirectory.vue
+++ b/client/src/components/Form/Elements/FormDirectory.vue
@@ -11,7 +11,7 @@
                 :require-writable="true"
                 :is-open="isModalShown" />
         </div>
-        <b-breadcrumb v-if="url">
+        <b-breadcrumb v-if="url" class="mb-0">
             <b-breadcrumb-item title="Select another folder" class="align-items-center" @click="reset">
                 <b-button class="pathname" variant="primary">
                     <FontAwesomeIcon icon="folder-open" /> {{ url.protocol }}</b-button
@@ -38,6 +38,11 @@
                     @keydown.8.capture="removeLastPath" />
             </b-breadcrumb-item>
         </b-breadcrumb>
+
+        <div v-if="value" class="px-2">
+            <span v-localize>Directory Path:</span>
+            <code>{{ value }}</code>
+        </div>
     </div>
 </template>
 
@@ -64,6 +69,12 @@ export default {
     components: {
         FontAwesomeIcon,
         FilesDialog,
+    },
+    props: {
+        value: {
+            type: String,
+            default: null,
+        },
     },
     data() {
         return { ...getDefaultValues(), modalKey: 0, selectText: _l("Select") };

--- a/client/src/components/Form/Elements/FormDirectory.vue
+++ b/client/src/components/Form/Elements/FormDirectory.vue
@@ -39,7 +39,7 @@
             </b-breadcrumb-item>
         </b-breadcrumb>
 
-        <div v-if="value" class="px-2">
+        <div v-if="value" class="px-2" data-description="directory full path">
             <span v-localize>Directory Path:</span>
             <code>{{ value }}</code>
         </div>

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -297,12 +297,7 @@ function onAlert(value: string | undefined) {
                 :options="attrs.options"
                 :optional="attrs.optional"
                 :multiple="attrs.multiple" />
-            <FormDataUri
-                v-else-if="isUriDataField"
-                :id="id"
-                v-model="currentValue"
-                :value="attrs.value"
-                :multiple="attrs.multiple" />
+            <FormDataUri v-else-if="isUriDataField" :id="id" v-model="currentValue" :multiple="attrs.multiple" />
             <FormData
                 v-else-if="['data', 'data_collection'].includes(props.type)"
                 :id="id"


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/19812

https://github.com/user-attachments/assets/0b96b812-9a91-4c89-9d4f-614c7e821de0

Here, note that the problem reported in #19812 of directories with spaces not working as expected is fixed, for e.g.:
```
gxftp://Other Data/Files
```
works fine.

However, the case where a directory name is already "encoded", for e.g.:
```
gxftp://Other%20Data/Files
```

we instead end up creating a directory:
```
OtherX20Data\Files
```
rather than storing in the existing `Other%20Data` directory.

Maybe we ignore this case? Or flag such directory paths as invalid?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
