### PR TITLE
Fix remaining typing errors in Form Element

### DIFF
--- a/client/src/components/Form/Elements/FormOptionalText.vue
+++ b/client/src/components/Form/Elements/FormOptionalText.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script>
-import FormText from "./FormText";
+import FormText from "./FormText.vue";
 
 export default {
     components: {

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -42,12 +42,12 @@ interface FormElementProps {
     id?: string;
     type: FormParameterTypes | undefined;
     value: FormParameterValue;
-    title?: string;
+    title: string | undefined;
     refreshOnChange?: boolean;
-    help?: string;
+    help: string | undefined;
     helpFormat?: string;
-    error?: string;
-    warning?: string;
+    error: string | undefined;
+    warning: string | undefined;
     disabled?: boolean;
     loading?: boolean;
     attributes?: FormParameterAttributes;

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -182,7 +182,11 @@ const nonMdHelp = computed(() =>
 );
 const showNonMdHelp = computed(() => Boolean(nonMdHelp.value) && (!props.workflowRun || props.type !== "boolean"));
 
-const currentValue = computed({
+// TODO: Replace nay cast with template casts
+// the any cast is a work around for vue 2
+// once upgraded to vue 3, remove this `any`,
+// and use type casts in the template
+const currentValue = computed<any>({
     get() {
         return props.value ?? props.attributes.value;
     },
@@ -190,6 +194,12 @@ const currentValue = computed({
         setValue(val);
     },
 });
+
+// TODO: Remove
+// the any cast is a work around for vue 2
+// once upgraded to vue 3, remove this computed,
+// and use type casts in the template
+const attributeOptions = computed<any>(() => props.attributes.options);
 
 /**
  * Instead of just using `props.title`, we check `attrs.label` and `attrs.name`:
@@ -412,7 +422,7 @@ function onAlert(value: string | undefined) {
                     v-model="currentValue"
                     :data="props.attributes.data"
                     :display="props.attributes.display"
-                    :options="props.attributes.options"
+                    :options="attributeOptions"
                     :optional="props.attributes.optional"
                     :multiple="props.attributes.multiple" />
                 <FormDataUri v-else-if="isUriDataField" :id="props.id" :multiple="props.attributes.multiple" />
@@ -425,7 +435,7 @@ function onAlert(value: string | undefined) {
                     :flavor="props.attributes.flavor"
                     :multiple="props.attributes.multiple"
                     :optional="props.attributes.optional"
-                    :options="props.attributes.options"
+                    :options="attributeOptions"
                     :tag="props.attributes.tag"
                     :user-defined-title="userDefinedTitle"
                     :type="formDataField"
@@ -437,7 +447,7 @@ function onAlert(value: string | undefined) {
                     v-else-if="props.type === 'drill_down'"
                     :id="props.id"
                     v-model="currentValue"
-                    :options="props.attributes.options ?? []"
+                    :options="attributeOptions"
                     :multiple="props.attributes.multiple" />
                 <FormColor v-else-if="props.type === 'color'" :id="props.id" v-model="currentValue" />
                 <FormDirectory v-else-if="props.type === 'directory_uri'" v-model="currentValue" />

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -5,7 +5,7 @@ import { faArrowsAltH, faExclamation, faTimes } from "@fortawesome/free-solid-sv
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { sanitize } from "dompurify";
 import type { ComputedRef } from "vue";
-import { computed, ref, useAttrs } from "vue";
+import { computed, ref } from "vue";
 
 import { linkify } from "@/utils/utils";
 
@@ -40,8 +40,8 @@ const TYPE_TO_PLACEHOLDER: Record<string, string> = {
 
 interface FormElementProps {
     id?: string;
-    type?: FormParameterTypes;
-    value?: FormParameterValue;
+    type: FormParameterTypes | undefined;
+    value: FormParameterValue;
     title?: string;
     refreshOnChange?: boolean;
     help?: string;
@@ -79,6 +79,7 @@ const props = withDefaults(defineProps<FormElementProps>(), {
     helpFormat: "html",
     workflowBuildingMode: false,
     workflowRun: false,
+    attributes: () => ({}),
 });
 
 const emit = defineEmits<{
@@ -88,22 +89,16 @@ const emit = defineEmits<{
 
 library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSquareUp);
 
-/** TODO: remove attrs computed.
- useAttrs is *not* reactive, and does not play nice with type safety.
- It is present for compatibility with the legacy "FormParameter" component,
- but should be removed as soon as that component is removed.
- */
-const attrs: ComputedRef<FormParameterAttributes> = computed(() => props.attributes || useAttrs());
-const collapsibleValue: ComputedRef<FormParameterValue> = computed(() => attrs.value["collapsible_value"]);
-const defaultValue: ComputedRef<FormParameterValue> = computed(() => attrs.value["default_value"]);
+const collapsibleValue: ComputedRef<FormParameterValue> = computed(() => props.attributes.collapsible_value);
+const defaultValue: ComputedRef<FormParameterValue> = computed(() => props.attributes.default_value);
 const connectedValue: FormParameterValue = { __class__: "ConnectedValue" };
 
 const computedPlaceholder = computed(() => {
     if (!props.workflowRun) {
         return "";
     }
-    if (props.attributes?.placeholder || !props.type) {
-        return props.attributes?.placeholder;
+    if (props.attributes.placeholder || !props.type) {
+        return props.attributes.placeholder;
     }
     return `please provide ${props.type in TYPE_TO_PLACEHOLDER ? TYPE_TO_PLACEHOLDER[props.type] : "a value"}${
         isOptional.value ? " (optional)" : ""
@@ -122,7 +117,7 @@ const connected = ref(false);
 const collapsed = ref(false);
 
 const collapsible = computed(() => !props.disabled && collapsibleValue.value !== undefined);
-const connectable = computed(() => collapsible.value && Boolean(attrs.value["connectable"]));
+const connectable = computed(() => collapsible.value && Boolean(props.attributes.connectable));
 
 // Determines whether to expand or collapse the input
 {
@@ -161,19 +156,19 @@ function onConnect() {
     }
 }
 
-const isHidden = computed(() => attrs.value["hidden"]);
+const isHidden = computed(() => props.attributes.hidden);
 const elementId = computed(() => `form-element-${props.id}`);
 const hasAlert = computed(() => alerts.value.length > 0);
-const showPreview = computed(() => (collapsed.value && attrs.value["collapsible_preview"]) || props.disabled);
+const showPreview = computed(() => (collapsed.value && props.attributes.collapsible_preview) || props.disabled);
 const showField = computed(() => !collapsed.value && !props.disabled);
 const formDataField = computed(() =>
     props.type && ["data", "data_collection"].includes(props.type) ? (props.type as "data" | "data_collection") : null
 );
 const isUriDataField = computed(() => formDataField.value && isDataUri(props.value));
 
-const previewText = computed(() => attrs.value["text_value"]);
+const previewText = computed(() => props.attributes.text_value);
 const helpText = computed(() => {
-    const helpArgument = attrs.value["argument"];
+    const helpArgument = props.attributes.argument;
     if (helpArgument && !props.help?.includes(`(${helpArgument})`)) {
         return `${props.help} (${helpArgument})`;
     } else {
@@ -189,7 +184,7 @@ const showNonMdHelp = computed(() => Boolean(nonMdHelp.value) && (!props.workflo
 
 const currentValue = computed({
     get() {
-        return props.value;
+        return props.value ?? props.attributes.value;
     },
     set(val) {
         setValue(val);
@@ -204,8 +199,8 @@ const currentValue = computed({
  * to the step index + 1.
  */
 const userDefinedTitle = computed(() => {
-    const label = parseInt(attrs.value.label);
-    const name = parseInt(attrs.value.name);
+    const label = parseInt(props.attributes.label ?? "");
+    const name = parseInt(props.attributes.name ?? "");
     if (isNaN(label) || isNaN(name) || name !== label - 1) {
         return props.title;
     }
@@ -242,9 +237,9 @@ const isEmpty = computed(() => {
     return false;
 });
 
-const isRequired = computed(() => attrs.value["optional"] === false);
+const isRequired = computed(() => props.attributes.optional === false);
 const isRequiredType = computed(() => props.type !== "boolean");
-const isOptional = computed(() => !isRequired.value && attrs.value["optional"] !== undefined);
+const isOptional = computed(() => !isRequired.value && props.attributes.optional !== undefined);
 const formAlert = ref<string>();
 const alerts = computed(() => {
     return [formAlert.value, props.error, props.warning]
@@ -340,7 +335,7 @@ function onAlert(value: string | undefined) {
                 :has-alert="hasAlert"
                 :is-empty="isEmpty"
                 :is-optional="isOptional"
-                :extensions="attrs.extensions">
+                :extensions="props.attributes.extensions">
                 <template v-slot:badges>
                     <slot name="workflow-run-form-title-badges" />
                 </template>
@@ -362,79 +357,79 @@ function onAlert(value: string | undefined) {
                     <span v-if="Boolean(nonMdHelp)" class="text-muted" v-html="nonMdHelp" />
                 </div>
                 <FormBoolean v-else-if="props.type === 'boolean'" :id="props.id" v-model="currentValue" />
-                <FormHidden v-else-if="isHiddenType" :id="props.id" v-model="currentValue" :info="attrs['info']" />
+                <FormHidden
+                    v-else-if="isHiddenType"
+                    :id="props.id"
+                    v-model="currentValue"
+                    :info="props.attributes.info" />
                 <FormNumber
                     v-else-if="props.type === 'integer' || props.type === 'float'"
                     :id="props.id"
                     v-model="currentValue"
-                    :max="attrs.max"
-                    :min="attrs.min"
+                    :max="props.attributes.max"
+                    :min="props.attributes.min"
                     :placeholder="computedPlaceholder"
                     :optional="isOptional"
                     :show-state="props.workflowRun"
                     :type="props.type ?? 'float'"
                     :workflow-building-mode="workflowBuildingMode" />
                 <FormOptionalText
-                    v-else-if="props.type === 'select' && attrs.is_workflow && attrs.optional"
+                    v-else-if="props.type === 'select' && props.attributes.is_workflow && props.attributes.optional"
                     :id="props.id"
                     v-model="currentValue"
-                    :readonly="attrs.readonly"
-                    :area="attrs.area"
+                    :readonly="props.attributes.readonly"
+                    :area="props.attributes.area"
                     :placeholder="computedPlaceholder"
-                    :multiple="attrs.multiple"
-                    :datalist="attrs.datalist"
+                    :multiple="props.attributes.multiple"
+                    :datalist="props.attributes.datalist"
                     :type="props.type" />
                 <FormText
                     v-else-if="
                         ['text', 'password'].includes(props.type ?? '') ||
-                        (attrs.is_workflow &&
+                        (props.attributes.is_workflow &&
                             ['data_column', 'drill_down', 'genomebuild', 'group_tag', 'select'].includes(
                                 props.type ?? ''
                             ))
                     "
                     :id="props.id"
                     v-model="currentValue"
-                    :readonly="attrs.readonly"
-                    :area="attrs.area"
+                    :readonly="props.attributes.readonly"
+                    :area="props.attributes.area"
                     :placeholder="computedPlaceholder"
                     :optional="isOptional"
                     :show-state="props.workflowRun"
-                    :color="attrs.color"
-                    :multiple="attrs.multiple"
-                    :cls="attrs.cls"
-                    :datalist="attrs.datalist"
+                    :color="props.attributes.color"
+                    :multiple="props.attributes.multiple"
+                    :cls="props.attributes.cls"
+                    :datalist="props.attributes.datalist"
                     :type="props.type" />
                 <FormSelection
                     v-else-if="
-                        (props.type === undefined && attrs.options) ||
+                        (props.type === undefined && props.attributes.options) ||
                         ['data_column', 'genomebuild', 'group_tag', 'select'].includes(props.type ?? '')
                     "
                     :id="props.id"
                     v-model="currentValue"
-                    :data="attrs.data"
-                    :display="attrs.display"
-                    :options="attrs.options"
-                    :optional="attrs.optional"
-                    :multiple="attrs.multiple" />
-                <FormDataUri
-                    v-else-if="isUriDataField"
-                    :id="props.id"
-                    :value="attrs.value"
-                    :multiple="attrs.multiple" />
+                    :data="props.attributes.data"
+                    :display="props.attributes.display"
+                    :options="props.attributes.options"
+                    :optional="props.attributes.optional"
+                    :multiple="props.attributes.multiple" />
+                <FormDataUri v-else-if="isUriDataField" :id="props.id" :multiple="props.attributes.multiple" />
                 <FormData
                     v-else-if="formDataField"
                     :id="props.id"
                     v-model="currentValue"
                     :loading="loading"
-                    :extensions="attrs.extensions"
-                    :flavor="attrs.flavor"
-                    :multiple="attrs.multiple"
-                    :optional="attrs.optional"
-                    :options="attrs.options"
-                    :tag="attrs.tag"
+                    :extensions="props.attributes.extensions"
+                    :flavor="props.attributes.flavor"
+                    :multiple="props.attributes.multiple"
+                    :optional="props.attributes.optional"
+                    :options="props.attributes.options"
+                    :tag="props.attributes.tag"
                     :user-defined-title="userDefinedTitle"
                     :type="formDataField"
-                    :collection-types="attrs.collection_types"
+                    :collection-types="props.attributes.collection_types"
                     :workflow-run="props.workflowRun"
                     @alert="onAlert"
                     @focus="addTempFocus" />
@@ -442,17 +437,20 @@ function onAlert(value: string | undefined) {
                     v-else-if="props.type === 'drill_down'"
                     :id="props.id"
                     v-model="currentValue"
-                    :options="attrs.options"
-                    :multiple="attrs.multiple" />
+                    :options="props.attributes.options ?? []"
+                    :multiple="props.attributes.multiple" />
                 <FormColor v-else-if="props.type === 'color'" :id="props.id" v-model="currentValue" />
                 <FormDirectory v-else-if="props.type === 'directory_uri'" v-model="currentValue" />
                 <FormUpload v-else-if="props.type === 'upload'" v-model="currentValue" />
-                <FormRulesEdit v-else-if="props.type == 'rules'" v-model="currentValue" :target="attrs.target" />
+                <FormRulesEdit
+                    v-else-if="props.type == 'rules'"
+                    v-model="currentValue"
+                    :target="props.attributes.target" />
                 <FormTags
                     v-else-if="props.type === 'tags'"
                     v-model="currentValue"
                     :placeholder="props.attributes?.placeholder" />
-                <FormInput v-else :id="props.id" v-model="currentValue" :area="attrs['area']" />
+                <FormInput v-else :id="props.id" v-model="currentValue" :area="props.attributes.area" />
             </div>
 
             <div v-if="showPreview" class="ui-form-preview pt-1 pl-2 mt-1">{{ previewText }}</div>

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -40,14 +40,14 @@ const TYPE_TO_PLACEHOLDER: Record<string, string> = {
 
 interface FormElementProps {
     id?: string;
-    type: FormParameterTypes | undefined;
+    type?: FormParameterTypes;
     value: FormParameterValue;
-    title: string | undefined;
+    title?: string;
     refreshOnChange?: boolean;
-    help: string | undefined;
+    help?: string;
     helpFormat?: string;
-    error: string | undefined;
-    warning: string | undefined;
+    error?: string;
+    warning?: string;
     disabled?: boolean;
     loading?: boolean;
     attributes?: FormParameterAttributes;
@@ -80,6 +80,11 @@ const props = withDefaults(defineProps<FormElementProps>(), {
     workflowBuildingMode: false,
     workflowRun: false,
     attributes: () => ({}),
+    type: undefined,
+    title: undefined,
+    help: undefined,
+    error: undefined,
+    warning: undefined,
 });
 
 const emit = defineEmits<{

--- a/client/src/components/Form/parameterTypes.d.ts
+++ b/client/src/components/Form/parameterTypes.d.ts
@@ -1,7 +1,15 @@
 import type { CollectionType } from "@/components/History/adapters/buildCollectionModal";
 
 // TODO: stricter types
-export type FormParameterValue = string | number | boolean | undefined | FormParameterClass | FormParameterDataField;
+export type FormParameterValue =
+    | string
+    | number
+    | boolean
+    | undefined
+    | null
+    | string[]
+    | FormParameterClass
+    | FormParameterDataField;
 export type FormParameterAttributes = {
     value?: FormParameterValue;
     collapsible_value?: FormParameterValue;

--- a/client/src/components/Form/parameterTypes.d.ts
+++ b/client/src/components/Form/parameterTypes.d.ts
@@ -1,7 +1,46 @@
+import type { CollectionType } from "@/components/History/adapters/buildCollectionModal";
+
 // TODO: stricter types
-export type FormParameterValue = any;
+export type FormParameterValue = string | number | boolean | undefined | FormParameterClass | FormParameterDataField;
 export type FormParameterAttributes = {
-    [attribute: string]: any;
+    value?: FormParameterValue;
+    collapsible_value?: FormParameterValue;
+    default_value?: FormParameterValue;
+    placeholder?: string;
+    hidden?: boolean;
+    collapsible_preview?: boolean;
+    text_value?: string;
+    argument?: string;
+    label?: string;
+    name?: string;
+    titleonly?: boolean;
+    optional?: boolean;
+    extensions?: string[];
+    info?: string;
+    min?: string | number;
+    max?: string | number;
+    is_workflow?: boolean;
+    readonly?: boolean;
+    area?: boolean;
+    multiple?: boolean;
+    datalist?: { value: string; label?: string }[];
+    color?: string;
+    cls?: string;
+    options?: Option[] | Record<string, DataOption[]>;
+    data?: Option[];
+    display?: string;
+    target?: Record<string, any>;
+    collection_types?: CollectionType[];
+    tag?: string;
+    connectable?: boolean;
+    flavor?: string;
+};
+
+export type FormParameterClassName = "ConnectedValue" | "RuntimeValue";
+export type FormParameterClass = { __class__: FormParameterClassName };
+
+export type FormParameterDataField = {
+    src: string;
 };
 
 export type FormParameterTypes =

--- a/client/src/components/Workflow/Editor/Forms/FormConditional.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormConditional.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
+import type { FormParameterValue } from "@/components/Form/parameterTypes";
 import type { Step } from "@/stores/workflowStepStore";
 
 import FormElement from "@/components/Form/FormElement.vue";
@@ -16,7 +17,7 @@ const conditionalDefined = computed(() => {
     return Boolean(props.step.when);
 });
 
-function onSkipBoolean(value: boolean) {
+function onSkipBoolean(value: FormParameterValue) {
     if (props.step.when && value === false) {
         emit("onUpdateStep", props.step.id, { when: undefined });
     } else if (value === true && !props.step.when) {

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -73,6 +73,7 @@ import { storeToRefs } from "pinia";
 import { computed, ref, toRef, watch } from "vue";
 
 import type { DatatypesMapperModel } from "@/components/Datatypes/model";
+import type { FormParameterValue } from "@/components/Form/parameterTypes";
 import WorkflowIcons from "@/components/Workflow/icons";
 import { useWorkflowStores } from "@/composables/workflowStores";
 import { useRefreshFromStore } from "@/stores/refreshFromStore";
@@ -115,10 +116,10 @@ const nodeIcon = computed(() => WorkflowIcons[type.value]);
 const formDisplayId = computed(() => stepId.value.toString());
 const isSubworkflow = computed(() => type.value === "subworkflow");
 
-function onAnnotation(newAnnotation: string) {
+function onAnnotation(newAnnotation: FormParameterValue, _id: string) {
     emit("onAnnotation", stepId.value, newAnnotation);
 }
-function onLabel(newLabel: string) {
+function onLabel(newLabel: FormParameterValue, _id: string) {
     emit("onLabel", stepId.value, newLabel);
 }
 function onEditSubworkflow() {

--- a/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
@@ -13,6 +13,7 @@
 import type { Ref } from "vue";
 import { computed, ref } from "vue";
 
+import type { FormParameterValue } from "@/components/Form/parameterTypes";
 import { useStepActions } from "@/components/Workflow/Editor/Actions/stepActions";
 import { useWorkflowStores } from "@/composables/workflowStores";
 import type { Step } from "@/stores/workflowStepStore";
@@ -49,7 +50,7 @@ const label = computed(() => {
 
 const { setOutputLabel } = useStepActions(stepStore, undoRedoStore, stateStore, connectionStore);
 
-function onInput(newLabel: string | undefined | null) {
+function onInput(newLabel: FormParameterValue) {
     if (newLabel === undefined || newLabel === null) {
         // form got activated or we set a workflow output through the checkbox
         // shouldn't change status of error label or result in deleting the label
@@ -68,17 +69,17 @@ function onInput(newLabel: string | undefined | null) {
         return;
     }
 
-    const existingWorkflowOutput = stepStore.workflowOutputs[newLabel];
+    const existingWorkflowOutput = stepStore.workflowOutputs[newLabel as string];
     if (!existingWorkflowOutput) {
         // got a new label that isn't in use yet
         const newWorkflowOutputs = [...(props.step.workflow_outputs || [])].filter(
             (workflowOutput) => workflowOutput.output_name !== props.name
         );
         newWorkflowOutputs.push({
-            label: newLabel,
+            label: newLabel as string,
             output_name: props.name,
         });
-        setOutputLabel(props.step, newWorkflowOutputs, oldLabel, newLabel);
+        setOutputLabel(props.step, newWorkflowOutputs, oldLabel, newLabel as string);
         error.value = undefined;
     } else if (existingWorkflowOutput.stepId !== props.step.id) {
         error.value = `Duplicate output label '${newLabel}' will be ignored.`;


### PR DESCRIPTION
fixes the remaining typescript errors in FormElement.
Removed `attrs` computed, since mentioned legacy component has been removed.

Uses two explicit any, as a work-around for template types not being available in vue 2.
Added TODO comments for these.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
