### PR TITLE
Enable lazy loading for ace-builds

### DIFF
--- a/client/src/components/Markdown/Editor/CellWrapper.vue
+++ b/client/src/components/Markdown/Editor/CellWrapper.vue
@@ -21,8 +21,8 @@
                 <CellAction
                     :name="name"
                     :show="hover"
-                    :cellIndex="cellIndex"
-                    :cellTotal="cellTotal"
+                    :cell-index="cellIndex"
+                    :cell-total="cellTotal"
                     @clone="$emit('clone')"
                     @configure="$emit('configure')"
                     @delete="$emit('delete')"
@@ -53,8 +53,9 @@ import MarkdownDefault from "../Sections/MarkdownDefault.vue";
 import MarkdownGalaxy from "../Sections/MarkdownGalaxy.vue";
 import CellAction from "./CellAction.vue";
 import CellButton from "./CellButton.vue";
-import CellCode from "./CellCode.vue";
 import ConfigureGalaxy from "./Configurations/ConfigureGalaxy.vue";
+
+const CellCode = () => import("./CellCode.vue");
 
 const VALID_TYPES = ["galaxy", "markdown", "vega", "visualization", "vitessce"];
 

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -28,6 +28,7 @@ const modulesExcludedFromLibs = [
     "vega",
     "vega-embed",
     "vega-lite",
+    "ace-builds",
 ].join("|");
 
 const buildDate = new Date();


### PR DESCRIPTION
Lazy loads the ace-builds package, instead of including it in the main bundle

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
