### PR TITLE
Add basic support for icons in tools

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -4470,6 +4470,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/tools/{tool_id}/icon": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the icon image associated with a tool
+         * @description Returns the icon image associated with a tool.
+         *
+         *     If the tool has no icon defined, a null response is returned.
+         *     If the tool has an icon defined, but the icon file is not found, a 404 response is returned.
+         */
+        get: operations["get_icon_api_tools__tool_id__icon_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/tours": {
         parameters: {
             query?: never;
@@ -32989,6 +33012,56 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    get_icon_api_tools__tool_id__icon_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                tool_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Tool icon image in PNG format */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "image/png": string;
+                };
+            };
+            /** @description Tool icon file not found or not provided by the tool */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "image/png": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "image/png": components["schemas"]["MessageExceptionModel"];
                 };
             };
         };

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -4481,8 +4481,8 @@ export interface paths {
          * Get the icon image associated with a tool
          * @description Returns the icon image associated with a tool.
          *
-         *     If the tool has no icon defined, a null response is returned.
-         *     If the tool has an icon defined, but the icon file is not found, a 404 response is returned.
+         *     The icon image is served with caching headers to allow for efficient
+         *     client-side caching. The icon image is expected to be in PNG format.
          */
         get: operations["get_icon_api_tools__tool_id__icon_get"];
         put?: never;
@@ -33038,6 +33038,13 @@ export interface operations {
                 content: {
                     "image/png": string;
                 };
+            };
+            /** @description Tool icon image has not been modified since the last request */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Tool icon file not found or not provided by the tool */
             404: {

--- a/lib/galaxy/tool_util/parser/cwl.py
+++ b/lib/galaxy/tool_util/parser/cwl.py
@@ -128,6 +128,9 @@ class CwlToolSource(ToolSource):
     def parse_description(self):
         return self.tool_proxy.description()
 
+    def parse_icon(self) -> Optional[str]:
+        return None  # Not implemented
+
     def parse_interactivetool(self):
         return []
 

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -192,8 +192,8 @@ class ToolSource(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def parse_icon(self) -> Optional["ToolIcon"]:
-        """Return icon for tool."""
+    def parse_icon(self) -> Optional[str]:
+        """Return icon path for tool."""
 
     def parse_edam_operations(self) -> List[str]:
         """Parse list of edam operation codes."""
@@ -920,8 +920,3 @@ class DrillDownOptionsDict(TypedDict):
     value: str
     options: List["DrillDownOptionsDict"]
     selected: bool
-
-
-class ToolIcon(TypedDict):
-    src: str
-    alt: str

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -191,6 +191,10 @@ class ToolSource(metaclass=ABCMeta):
         We parse this out as "" if it isn't explicitly declared.
         """
 
+    @abstractmethod
+    def parse_icon(self) -> Optional["ToolIcon"]:
+        """Return icon for tool."""
+
     def parse_edam_operations(self) -> List[str]:
         """Parse list of edam operation codes."""
         return []
@@ -916,3 +920,8 @@ class DrillDownOptionsDict(TypedDict):
     value: str
     options: List["DrillDownOptionsDict"]
     selected: bool
+
+
+class ToolIcon(TypedDict):
+    src: str
+    alt: str

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -53,6 +53,7 @@ from .interface import (
     TestCollectionDefElementDict,
     TestCollectionDefElementObject,
     TestCollectionOutputDef,
+    ToolIcon,
     ToolSource,
     ToolSourceTest,
     ToolSourceTestInput,
@@ -232,6 +233,18 @@ class XmlToolSource(ToolSource):
 
     def parse_description(self) -> str:
         return xml_text(self.root, "description")
+
+    def parse_icon(self) -> Optional[ToolIcon]:
+        icon_elem = self.root.find("icon")
+        if icon_elem is None:
+            return None
+        icon_src = icon_elem.get("src", None)
+        if icon_src is None:
+            return None
+        return ToolIcon(
+            src=icon_src,
+            alt=icon_elem.get("alt", "Tool Icon"),
+        )
 
     def parse_display_interface(self, default):
         return self._get_attribute_as_bool("display_interface", default)

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -235,12 +235,7 @@ class XmlToolSource(ToolSource):
 
     def parse_icon(self) -> Optional[str]:
         icon_elem = self.root.find("icon")
-        if icon_elem is None:
-            return None
-        icon_src = icon_elem.get("src", None)
-        if icon_src is None:
-            return None
-        return icon_src
+        return icon_elem.get("src") if icon_elem is not None else None
 
     def parse_display_interface(self, default):
         return self._get_attribute_as_bool("display_interface", default)

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -53,7 +53,6 @@ from .interface import (
     TestCollectionDefElementDict,
     TestCollectionDefElementObject,
     TestCollectionOutputDef,
-    ToolIcon,
     ToolSource,
     ToolSourceTest,
     ToolSourceTestInput,
@@ -234,17 +233,14 @@ class XmlToolSource(ToolSource):
     def parse_description(self) -> str:
         return xml_text(self.root, "description")
 
-    def parse_icon(self) -> Optional[ToolIcon]:
+    def parse_icon(self) -> Optional[str]:
         icon_elem = self.root.find("icon")
         if icon_elem is None:
             return None
         icon_src = icon_elem.get("src", None)
         if icon_src is None:
             return None
-        return ToolIcon(
-            src=icon_src,
-            alt=icon_elem.get("alt", "Tool Icon"),
-        )
+        return icon_src
 
     def parse_display_interface(self, default):
         return self._get_attribute_as_bool("display_interface", default)

--- a/lib/galaxy/tool_util/parser/yaml.py
+++ b/lib/galaxy/tool_util/parser/yaml.py
@@ -73,6 +73,10 @@ class YamlToolSource(ToolSource):
     def parse_description(self) -> str:
         return self.root_dict.get("description", "")
 
+    def parse_icon(self) -> Optional[str]:
+        icon_elem = self.root_dict.get("icon", {})
+        return icon_elem.get("src") if icon_elem is not None else None
+
     def parse_edam_operations(self) -> List[str]:
         return self.root_dict.get("edam_operations", [])
 

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -122,6 +122,7 @@ the tool menu immediately following the hyperlink for the tool (based on the
 ]]></xs:documentation>
           </xs:annotation>
         </xs:element>
+        <xs:element name="icon" type="Icon" minOccurs="0"/>
         <xs:element name="parallelism" type="Parallelism" minOccurs="0"/>
         <xs:element name="version_command" type="VersionCommand" minOccurs="0"/>
         <xs:element name="action" type="ToolAction" minOccurs="0" maxOccurs="1"/>
@@ -242,6 +243,16 @@ this attribute defined the HTTP request method to use when communicating with an
       </xs:attribute>
     </xs:complexType>
   </xs:element>
+  <xs:complexType name="Icon">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">Icon image associated with the tool. Ideally, this should be a square PNG image with maximum dimensions of 512x512 pixels.</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="src" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Relative path to the icon image. It must be contained within the tool directory.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
   <xs:complexType name="Macros">
     <xs:annotation>
       <xs:documentation xml:lang="en">Frequently, tools may require the same XML

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1321,6 +1321,7 @@ class Tool(UsesDictVisibleKeys):
 
         # Short description of the tool
         self.description = tool_source.parse_description()
+        self.icon = tool_source.parse_icon()
 
         # Versioning for tools
         self.version_string_cmd = None

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -106,6 +106,10 @@ class FetchTools:
     ):
         return self.service.create_fetch(trans, payload, files)
 
+    @router.get("/api/tools/{id}/icon", summary="Get tool icon")
+    def get_icon(self, id: str, trans: ProvidesHistoryContext = DependsOnTrans):
+        return self.service.get_tool_icon(trans=trans, tool_id=id)
+
 
 class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
     """

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -70,6 +70,8 @@ PROTECTED_TOOLS = ["__DATA_FETCH__"]
 # Tool search bypasses the fulltext for the following list of terms
 SEARCH_RESERVED_TERMS_FAVORITES = ["#favs", "#favorites", "#favourites"]
 
+ICON_CACHE_MAX_AGE = 2592000  # 30 days
+
 
 class FormDataApiRoute(APIContentTypeRoute):
     match_content_type = "multipart/form-data"
@@ -169,7 +171,7 @@ class FetchTools:
 
         # Serve the file with caching headers
         response = PNGIconResponse(tool_icon_path)
-        response.headers["Cache-Control"] = "public, max-age=2592000, immutable"
+        response.headers["Cache-Control"] = f"public, max-age={ICON_CACHE_MAX_AGE}, immutable"
         response.headers["ETag"] = etag
         response.headers["Last-Modified"] = last_modified
         return response

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -1,5 +1,9 @@
 import logging
 import os
+from datetime import (
+    datetime,
+    timezone,
+)
 from json import loads
 from typing import (
     Any,
@@ -16,6 +20,7 @@ from fastapi import (
     Response,
     UploadFile,
 )
+from fastapi.responses import FileResponse
 from starlette.datastructures import UploadFile as StarletteUploadFile
 
 from galaxy import (
@@ -34,6 +39,10 @@ from galaxy.schema.fetch_data import (
 )
 from galaxy.tool_util.verify import ToolTestDescriptionDict
 from galaxy.tools.evaluation import global_tool_errors
+from galaxy.util.hash_util import (
+    HashFunctionNameEnum,
+    memory_bound_hexdigest,
+)
 from galaxy.util.zipstream import ZipstreamWrapper
 from galaxy.web import (
     expose_api,
@@ -70,7 +79,7 @@ class JsonApiRoute(APIContentTypeRoute):
     match_content_type = "application/json"
 
 
-class PNGIconResponse(Response):
+class PNGIconResponse(FileResponse):
     media_type = "image/png"
 
 
@@ -120,18 +129,50 @@ class FetchTools:
                 "content": {"image/png": {}},
                 "description": "Tool icon image in PNG format",
             },
+            304: {
+                "description": "Tool icon image has not been modified since the last request",
+            },
             404: {
                 "description": "Tool icon file not found or not provided by the tool",
             },
         },
     )
-    def get_icon(self, tool_id: str, trans: ProvidesHistoryContext = DependsOnTrans):
+    def get_icon(self, request: Request, tool_id: str, trans: ProvidesHistoryContext = DependsOnTrans):
         """Returns the icon image associated with a tool.
 
-        If the tool has no icon defined, a null response is returned.
-        If the tool has an icon defined, but the icon file is not found, a 404 response is returned.
+        The icon image is served with caching headers to allow for efficient
+        client-side caching. The icon image is expected to be in PNG format.
         """
-        return self.service.get_tool_icon(trans=trans, tool_id=tool_id)
+        tool_icon_path = self.service.get_tool_icon_path(trans=trans, tool_id=tool_id)
+        if tool_icon_path is None:
+            raise exceptions.ObjectNotFound(f"Tool icon file not found or not provided by the tool: {tool_id}")
+
+        # Get file modification time
+        file_stat = os.stat(tool_icon_path)
+        last_modified = datetime.fromtimestamp(file_stat.st_mtime, tz=timezone.utc).strftime(
+            "%a, %d %b %Y %H:%M:%S GMT"
+        )
+
+        # Check If-Modified-Since
+        if_modified_since = request.headers.get("If-Modified-Since")
+        if if_modified_since == last_modified:
+            return Response(status_code=304)
+
+        # Generate ETag based on file content
+        file_hash = memory_bound_hexdigest(hash_func_name=HashFunctionNameEnum.md5, path=tool_icon_path)
+        etag = f'"{file_hash}"'
+
+        # Check If-None-Match (ETag)
+        if_none_match = request.headers.get("If-None-Match", "").split(",")
+        if any(etag.strip() == e.strip(' W/"') for e in if_none_match):  # Handle weak ETags
+            return Response(status_code=304)
+
+        # Serve the file with caching headers
+        response = PNGIconResponse(tool_icon_path)
+        response.headers["Cache-Control"] = "public, max-age=2592000, immutable"
+        response.headers["ETag"] = etag
+        response.headers["Last-Modified"] = last_modified
+        return response
 
 
 class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -332,14 +332,14 @@ class ToolsService(ServiceBase):
     def get_tool_icon(self, trans, tool_id, tool_version=None):
         tool = self._get_tool(trans, tool_id, tool_version)
         if tool and tool.icon:
-            icon_src = tool.icon.get("src")
-            if icon_src and tool.tool_dir:
+            icon_file_path = tool.icon
+            if icon_file_path and tool.tool_dir:
                 # Prevent any path traversal attacks. The icon_src must be in the tool's directory.
-                if not safe_contains(tool.tool_dir, icon_src):
+                if not safe_contains(tool.tool_dir, icon_file_path):
                     raise Exception(
                         f"Invalid icon path for tool '{tool_id}'. Path must be within the tool's directory."
                     )
-                file_path = os.path.join(tool.tool_dir, icon_src)
+                file_path = os.path.join(tool.tool_dir, icon_file_path)
                 if not os.path.exists(file_path):
                     raise exceptions.ObjectNotFound(f"Could not find icon for tool '{tool_id}'.")
                 return FileResponse(file_path)

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -11,7 +11,6 @@ from typing import (
     Union,
 )
 
-from fastapi.responses import FileResponse
 from starlette.datastructures import UploadFile
 
 from galaxy import (
@@ -329,7 +328,7 @@ class ToolsService(ServiceBase):
                     detected_versions.append(tool.version)
         return detected_versions
 
-    def get_tool_icon(self, trans, tool_id, tool_version=None):
+    def get_tool_icon_path(self, trans, tool_id, tool_version=None) -> Optional[str]:
         tool = self._get_tool(trans, tool_id, tool_version)
         if tool and tool.icon:
             icon_file_path = tool.icon
@@ -340,7 +339,6 @@ class ToolsService(ServiceBase):
                         f"Invalid icon path for tool '{tool_id}'. Path must be within the tool's directory."
                     )
                 file_path = os.path.join(tool.tool_dir, icon_file_path)
-                if not os.path.exists(file_path):
-                    raise exceptions.ObjectNotFound(f"Could not find icon for tool '{tool_id}'.")
-                return FileResponse(file_path)
+                if os.path.exists(file_path):
+                    return file_path
         return None


### PR DESCRIPTION
You can add a PNG image along with your tool's XML that can be retrieved using a new API endpoint `api/tools/{tool_id}/icon`.

```xml
<tool id="some_tool" name="Some Tool" version="0.1.0">
    <description>Some description</description>
    <icon src="some_tool_logo.png" />
</tool>
```

The image must be placed within the tool's XML directory or subdirectory and the `src` attribute should be the relative path to the image.

I tried to set the `Cache-Control` to cache the images for 24 hours (it could actually be a lot more), but It doesn't seem to work, so something else must be missing.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
