### PR TITLE
[24.2] Fix default ordering of items sorted by name

### DIFF
--- a/client/src/components/Grid/configs/adminForms.ts
+++ b/client/src/components/Grid/configs/adminForms.ts
@@ -147,7 +147,7 @@ const gridConfig: GridConfig = {
     getData: getData,
     plural: "Forms",
     sortBy: "name",
-    sortDesc: true,
+    sortDesc: false,
     sortKeys: ["name", "update_time"],
     title: "Forms",
 };

--- a/client/src/components/Grid/configs/adminGroups.ts
+++ b/client/src/components/Grid/configs/adminGroups.ts
@@ -188,7 +188,7 @@ const gridConfig: GridConfig = {
     getData: getData,
     plural: "Groups",
     sortBy: "name",
-    sortDesc: true,
+    sortDesc: false,
     sortKeys: ["name", "update_time"],
     title: "Groups",
 };

--- a/client/src/components/Grid/configs/adminQuotas.ts
+++ b/client/src/components/Grid/configs/adminQuotas.ts
@@ -225,7 +225,7 @@ const gridConfig: GridConfig = {
     getData: getData,
     plural: "Quotas",
     sortBy: "name",
-    sortDesc: true,
+    sortDesc: false,
     sortKeys: ["name", "description", "update_time"],
     title: "Quotas",
 };

--- a/client/src/components/Grid/configs/adminRoles.ts
+++ b/client/src/components/Grid/configs/adminRoles.ts
@@ -199,7 +199,7 @@ const gridConfig: GridConfig = {
     getData: getData,
     plural: "Roles",
     sortBy: "name",
-    sortDesc: true,
+    sortDesc: false,
     sortKeys: ["description", "name", "update_time"],
     title: "Roles",
 };

--- a/client/src/components/Grid/configs/adminUsers.ts
+++ b/client/src/components/Grid/configs/adminUsers.ts
@@ -366,7 +366,7 @@ const gridConfig: GridConfig = {
     getData: getData,
     plural: "Users",
     sortBy: "email",
-    sortDesc: true,
+    sortDesc: false,
     sortKeys: ["active", "create_time", "disk_usage", "email", "external", "last_login", "username"],
     title: "Users",
 };

--- a/lib/galaxy/web/framework/helpers/grids.py
+++ b/lib/galaxy/web/framework/helpers/grids.py
@@ -86,7 +86,7 @@ class GridData:
 
         # Process sort arguments.
         sort_by = kwargs.get("sort_by", self.default_sort_key)
-        sort_desc = string_as_bool(kwargs.get("sort_desc", True))
+        sort_desc = string_as_bool(kwargs.get("sort_desc", False))
         for column in self.columns:
             if column.key == sort_by:
                 query = column.sort(trans, query, not sort_desc, column_name=sort_by)


### PR DESCRIPTION
Fixes #19633

The edit in `grids.py` ensures the endpoint returns the correct ordering (this does not affect how the items are displayed on the client)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
