### PR TITLE
[24.2] Don't fail startup on conflicting data table definition

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -428,6 +428,7 @@ class MinimalGalaxyApplication(BasicSharedApp, HaltableContainer, SentryClientMi
                 config_filename=self.config.shed_tool_data_table_config,
                 tool_data_path=self.tool_data_tables.tool_data_path,
                 from_shed_config=from_shed_config,
+                fail_on_exception=False,  # Don't stop booting just cause admin installed a tool with conflicting data tables
             )
         except OSError as exc:
             # Missing shed_tool_data_table_config is okay if it's the default


### PR DESCRIPTION
While I'm all for failing hard on configuration issues, this one is almost unpredictable, as rebooting a galaxy instance will fail if being unlucky enough to install the wrong combination of tools with data tables. And it won't fail during installation, but at any point a restart is necessary, making it not obvious what caused this and when to expect this.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
