### PR TITLE
Cleanup circular dependencies around utils.ts.

### DIFF
--- a/client/src/app/utils.test.ts
+++ b/client/src/app/utils.test.ts
@@ -1,0 +1,15 @@
+import { getFullAppUrl } from "./utils";
+
+describe("test app utils", () => {
+    describe("test getFullAppUrl", () => {
+        it("should return the full app url", () => {
+            const appUrl = getFullAppUrl();
+            expect(appUrl).toBe("http://localhost/");
+        });
+
+        it("should return the full app url", () => {
+            const appUrl = getFullAppUrl("home");
+            expect(appUrl).toBe("http://localhost/home");
+        });
+    });
+});

--- a/client/src/app/utils.ts
+++ b/client/src/app/utils.ts
@@ -1,0 +1,16 @@
+import { getAppRoot } from "@/onload/loadConfig";
+
+/**
+ * Get the full URL path of the app
+ *
+ * @param path Path to append to the URL path
+ * @returns Full URL path of the app
+ */
+export function getFullAppUrl(path: string = ""): string {
+    const protocol = window.location.protocol;
+    const hostname = window.location.hostname;
+    const port = window.location.port ? `:${window.location.port}` : "";
+    const appRoot = getAppRoot();
+
+    return `${protocol}//${hostname}${port}${appRoot}${path}`;
+}

--- a/client/src/components/Sharing/Embeds/WorkflowEmbed.vue
+++ b/client/src/components/Sharing/Embeds/WorkflowEmbed.vue
@@ -6,8 +6,8 @@ import { useDebounce } from "@vueuse/core";
 import { BButton, BFormCheckbox, BFormInput, BInputGroup, BInputGroupAppend } from "bootstrap-vue";
 import { computed, reactive, ref } from "vue";
 
+import { getFullAppUrl } from "@/app/utils";
 import { copy } from "@/utils/clipboard";
-import { getFullAppUrl } from "@/utils/utils";
 
 import ZoomControl from "@/components/Workflow/Editor/ZoomControl.vue";
 import WorkflowPublished from "@/components/Workflow/Published/WorkflowPublished.vue";

--- a/client/src/components/Sharing/SharingPage.vue
+++ b/client/src/components/Sharing/SharingPage.vue
@@ -6,10 +6,10 @@ import { BFormCheckbox } from "bootstrap-vue";
 import { computed, nextTick, reactive, ref, watch } from "vue";
 
 import { getGalaxyInstance } from "@/app";
+import { getFullAppUrl } from "@/app/utils";
 import { useToast } from "@/composables/toast";
 import { getAppRoot } from "@/onload/loadConfig";
 import { errorMessageAsString } from "@/utils/simple-error";
-import { getFullAppUrl } from "@/utils/utils";
 
 import type { Item, ShareOption } from "./item";
 

--- a/client/src/components/Workflow/List/useWorkflowActions.ts
+++ b/client/src/components/Workflow/List/useWorkflowActions.ts
@@ -1,6 +1,7 @@
 import { computed, type Ref, ref } from "vue";
 
 import type { AnyWorkflow } from "@/api/workflows";
+import { getFullAppUrl } from "@/app/utils";
 import {
     copyWorkflow as copyWorkflowService,
     deleteWorkflow as deleteWorkflowService,
@@ -10,7 +11,6 @@ import { useConfirmDialog } from "@/composables/confirmDialog";
 import { useToast } from "@/composables/toast";
 import { copy } from "@/utils/clipboard";
 import { withPrefix } from "@/utils/redirect";
-import { getFullAppUrl } from "@/utils/utils";
 
 export function useWorkflowActions(workflow: Ref<AnyWorkflow>, refreshCallback: () => void) {
     const toast = useToast();

--- a/client/src/components/Workflow/Published/WorkflowInformation.vue
+++ b/client/src/components/Workflow/Published/WorkflowInformation.vue
@@ -6,8 +6,8 @@ import { computed } from "vue";
 import { RouterLink } from "vue-router";
 
 import { type StoredWorkflowDetailed } from "@/api/workflows";
+import { getFullAppUrl } from "@/app/utils";
 import { useUserStore } from "@/stores/userStore";
-import { getFullAppUrl } from "@/utils/utils";
 
 import Heading from "@/components/Common/Heading.vue";
 import CopyToClipboard from "@/components/CopyToClipboard.vue";

--- a/client/src/legacy/grid/grid-view.js
+++ b/client/src/legacy/grid/grid-view.js
@@ -7,10 +7,10 @@ import Backbone from "backbone";
 jQuery.ajaxSettings.traditional = true;
 
 // dependencies
-import Utils from "utils/utils";
 import GridModel from "legacy/grid/grid-model";
 import Templates from "legacy/grid/grid-template";
 import PopupMenu from "./popup-menu";
+import { setWindowTitle } from "./utils";
 import { init_refresh_on_change } from "onload/globalInits/init_refresh_on_change";
 
 var $ = jQuery;
@@ -95,7 +95,7 @@ export default Backbone.View.extend({
         var options = this.grid.attributes;
 
         if (this.allow_title_display && options.title) {
-            Utils.setWindowTitle(options.title);
+            setWindowTitle(options.title);
         }
         // handle refresh requests
         this.handle_refresh(options.refresh_frames);

--- a/client/src/legacy/grid/utils.ts
+++ b/client/src/legacy/grid/utils.ts
@@ -1,0 +1,11 @@
+import { getGalaxyInstance } from "@/app";
+import _l from "@/utils/localization";
+
+export function setWindowTitle(title: string): void {
+    const Galaxy = getGalaxyInstance();
+    if (title) {
+        window.document.title = `Galaxy ${Galaxy.config.brand ? ` | ${Galaxy.config.brand}` : ""} | ${_l(title)}`;
+    } else {
+        window.document.title = `Galaxy ${Galaxy.config.brand ? ` | ${Galaxy.config.brand}` : ""}`;
+    }
+}

--- a/client/src/utils/utils.test.js
+++ b/client/src/utils/utils.test.js
@@ -101,16 +101,4 @@ describe("test utils", () => {
             ]);
         });
     });
-
-    describe("test getFullAppUrl", () => {
-        it("should return the full app url", () => {
-            const appUrl = Utils.getFullAppUrl();
-            expect(appUrl).toBe("http://localhost/");
-        });
-
-        it("should return the full app url", () => {
-            const appUrl = Utils.getFullAppUrl("home");
-            expect(appUrl).toBe("http://localhost/home");
-        });
-    });
 });

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -170,26 +170,6 @@ export function get(options: getOptions): void {
 }
 
 /**
- * Load a CSS file
- *
- * @param url Url of CSS file
- */
-export function cssLoadFile(url: string): void {
-    const fullUrl = getAppRoot() + url;
-    const links = document.head.getElementsByTagName("link");
-
-    if (Array.from(links).find((link) => link.href === fullUrl)) {
-        return;
-    }
-
-    const link = document.createElement("link");
-    link.type = "text/css";
-    link.rel = "stylesheet";
-    link.href = fullUrl;
-    document.head.appendChild(link);
-}
-
-/**
  * Safely merge two dictionaries
  *
  * @param options        Target dictionary
@@ -458,7 +438,6 @@ export function getFullAppUrl(path: string = ""): string {
 }
 
 export default {
-    cssLoadFile,
     get,
     merge,
     bytesToString,

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -5,9 +5,7 @@
 
 import axios, { type AxiosError, type AxiosResponse } from "axios";
 
-import { getGalaxyInstance } from "@/app";
 import { NON_TERMINAL_STATES } from "@/components/WorkflowInvocationState/util";
-import { getAppRoot } from "@/onload/loadConfig";
 import _l from "@/utils/localization";
 
 export function stateIsTerminal(result: Record<string, any>) {
@@ -286,15 +284,6 @@ export function appendScriptStyle(data: Readonly<{ script?: string; styles?: str
     }
 }
 
-export function setWindowTitle(title: string): void {
-    const Galaxy = getGalaxyInstance();
-    if (title) {
-        window.document.title = `Galaxy ${Galaxy.config.brand ? ` | ${Galaxy.config.brand}` : ""} | ${_l(title)}`;
-    } else {
-        window.document.title = `Galaxy ${Galaxy.config.brand ? ` | ${Galaxy.config.brand}` : ""}`;
-    }
-}
-
 /**
  * Calculate a 32 bit FNV-1a hash
  * Found here: https://gist.github.com/vaiorabbit/5657561
@@ -422,21 +411,6 @@ export function hasKeys(object: unknown, keys: string[]) {
     }
 }
 
-/**
- * Get the full URL path of the app
- *
- * @param path Path to append to the URL path
- * @returns Full URL path of the app
- */
-export function getFullAppUrl(path: string = ""): string {
-    const protocol = window.location.protocol;
-    const hostname = window.location.hostname;
-    const port = window.location.port ? `:${window.location.port}` : "";
-    const appRoot = getAppRoot();
-
-    return `${protocol}//${hostname}${port}${appRoot}${path}`;
-}
-
 export default {
     get,
     merge,
@@ -450,9 +424,7 @@ export default {
     clone,
     linkify,
     appendScriptStyle,
-    setWindowTitle,
     waitForElementToBePresent,
     wait,
     mergeObjectListsById,
-    getFullAppUrl,
 };


### PR DESCRIPTION
Noticed a lot of circular dependencies detected in @dannon's work on https://github.com/galaxyproject/galaxy/pull/19851 went through utils.ts and presumably that package should have the simplest dependencies so it seems the place to start in unwinding that. I checked for these things in galaxy visualizations and webhooks and didn't find any references there.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
