### PR TITLE
Client circular dependency check

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -166,6 +166,7 @@
     "babel-jest": "^29.7.0",
     "babel-plugin-transform-import-meta": "^2.2.1",
     "buffer": "^6.0.3",
+    "circular-dependency-plugin": "^5.2.2",
     "cpy-cli": "^5.0.0",
     "css-loader": "^7.1.2",
     "css-minimizer-webpack-plugin": "^5.0.1",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -8,6 +8,7 @@ const { DumpMetaPlugin } = require("dumpmeta-webpack-plugin");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
+const CircularDependencyPlugin = require("circular-dependency-plugin");
 
 const scriptsBase = path.join(__dirname, "src");
 const testsBase = path.join(__dirname, "tests");
@@ -223,6 +224,17 @@ module.exports = (env = {}, argv = {}) => {
         plugins: [
             // this plugin allows using the following keys/globals in scripts (w/o req'ing them first)
             // and webpack will automagically require them in the bundle for you
+            new CircularDependencyPlugin({
+                // exclude detection of files based on a RegExp
+                exclude: /a\.js|node_modules/,
+                // add errors to webpack instead of warnings
+                failOnError: true,
+                // allow import cycles that include an asyncronous import,
+                // e.g. via import(/* webpackMode: "weak" */ './file.js')
+                allowAsyncCycles: false,
+                // set the current working directory for displaying module paths
+                cwd: process.cwd(),
+            }),
             new webpack.ProvidePlugin({
                 $: `${libsBase}/jquery.custom.js`,
                 jQuery: `${libsBase}/jquery.custom.js`,

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -228,7 +228,7 @@ module.exports = (env = {}, argv = {}) => {
                 // exclude detection of files based on a RegExp
                 exclude: /a\.js|node_modules|src\/libs/,
                 // add errors to webpack instead of warnings
-                failOnError: true,
+                failOnError: !!process.env.CIRCULAR_DEPENDENCY_FAIL_ON_ERROR,
                 // allow import cycles that include an asyncronous import,
                 // e.g. via import(/* webpackMode: "weak" */ './file.js')
                 allowAsyncCycles: false,

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -226,7 +226,7 @@ module.exports = (env = {}, argv = {}) => {
             // and webpack will automagically require them in the bundle for you
             new CircularDependencyPlugin({
                 // exclude detection of files based on a RegExp
-                exclude: /a\.js|node_modules/,
+                exclude: /a\.js|node_modules|src\/libs/,
                 // add errors to webpack instead of warnings
                 failOnError: true,
                 // allow import cycles that include an asyncronous import,

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -224,17 +224,6 @@ module.exports = (env = {}, argv = {}) => {
         plugins: [
             // this plugin allows using the following keys/globals in scripts (w/o req'ing them first)
             // and webpack will automagically require them in the bundle for you
-            new CircularDependencyPlugin({
-                // exclude detection of files based on a RegExp
-                exclude: /a\.js|node_modules|src\/libs/,
-                // add errors to webpack instead of warnings
-                failOnError: !!process.env.CIRCULAR_DEPENDENCY_FAIL_ON_ERROR,
-                // allow import cycles that include an asyncronous import,
-                // e.g. via import(/* webpackMode: "weak" */ './file.js')
-                allowAsyncCycles: false,
-                // set the current working directory for displaying module paths
-                cwd: process.cwd(),
-            }),
             new webpack.ProvidePlugin({
                 $: `${libsBase}/jquery.custom.js`,
                 jQuery: `${libsBase}/jquery.custom.js`,
@@ -313,6 +302,23 @@ module.exports = (env = {}, argv = {}) => {
             ],
         },
     };
+
+    // Only include CircularDependencyPlugin in development mode
+    if (targetEnv === "development") {
+        buildconfig.plugins.push(
+            new CircularDependencyPlugin({
+                // exclude detection of files based on a RegExp
+                exclude: /a\.js|node_modules|src\/libs/,
+                // add errors to webpack instead of warnings
+                failOnError: !!process.env.CIRCULAR_DEPENDENCY_FAIL_ON_ERROR,
+                // allow import cycles that include an asyncronous import,
+                // e.g. via import(/* webpackMode: "weak" */ './file.js')
+                allowAsyncCycles: false,
+                // set the current working directory for displaying module paths
+                cwd: process.cwd(),
+            })
+        );
+    }
 
     if (process.env.GXY_BUILD_SOURCEMAPS) {
         buildconfig.devtool = "eval-cheap-module-source-map";

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4390,6 +4390,11 @@ ci-info@^3.2.0:
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz"
   integrity sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==
 
+circular-dependency-plugin@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/circular-dependency-plugin/-/circular-dependency-plugin-5.2.2.tgz#39e836079db1d3cf2f988dc48c5188a44058b600"
+  integrity sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ==
+
 circular-json@^0.5.0:
   version "0.5.9"
   resolved "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz"


### PR DESCRIPTION
Adds circular dependency detection.  Ignores `node_modules`, `src/libs`.

The plugin only runs in `development` mode, and additionally it only fails a build when the env var `CIRCULAR_DEPENDENCY_FAIL_ON_ERROR` is set.  Otherwise it will simply helpfully print out all the warnings.  Once we've got them sorted, we can flip this to default `fail`

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
