### PR TITLE
Move some store types out into own file to reduce circular dependencies.

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -9,7 +9,8 @@ import draggable from "vuedraggable";
 
 import { useConfig } from "@/composables/config";
 import { convertDropData } from "@/stores/activitySetup";
-import { type Activity, useActivityStore } from "@/stores/activityStore";
+import { useActivityStore } from "@/stores/activityStore";
+import type { Activity } from "@/stores/activityStoreTypes";
 import { useEventStore } from "@/stores/eventStore";
 import { useUserStore } from "@/stores/userStore";
 

--- a/client/src/components/ActivityBar/ActivityItem.vue
+++ b/client/src/components/ActivityBar/ActivityItem.vue
@@ -6,7 +6,8 @@ import type { Placement } from "@popperjs/core";
 import { computed } from "vue";
 import { useRouter } from "vue-router/composables";
 
-import { type ActivityVariant, useActivityStore } from "@/stores/activityStore";
+import { useActivityStore } from "@/stores/activityStore";
+import type { ActivityVariant } from "@/stores/activityStoreTypes";
 import localize from "@/utils/localization";
 
 import TextShort from "@/components/Common/TextShort.vue";

--- a/client/src/components/ActivityBar/ActivitySettings.vue
+++ b/client/src/components/ActivityBar/ActivitySettings.vue
@@ -5,7 +5,8 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed, type ComputedRef } from "vue";
 import { useRouter } from "vue-router/composables";
 
-import { type Activity, useActivityStore } from "@/stores/activityStore";
+import { useActivityStore } from "@/stores/activityStore";
+import type { Activity } from "@/stores/activityStoreTypes";
 
 const props = defineProps<{
     activityBarId: string;

--- a/client/src/components/Workflow/Editor/Actions/stepActions.ts
+++ b/client/src/components/Workflow/Editor/Actions/stepActions.ts
@@ -2,10 +2,11 @@ import { replaceLabel } from "@/components/Markdown/parse";
 import { useToast } from "@/composables/toast";
 import { useRefreshFromStore } from "@/stores/refreshFromStore";
 import { LazyUndoRedoAction, UndoRedoAction, type UndoRedoStore } from "@/stores/undoRedoStore";
-import { type Connection, type WorkflowConnectionStore } from "@/stores/workflowConnectionStore";
+import { type WorkflowConnectionStore } from "@/stores/workflowConnectionStore";
 import { useWorkflowCommentStore } from "@/stores/workflowEditorCommentStore";
 import { type WorkflowStateStore } from "@/stores/workflowEditorStateStore";
 import { type NewStep, type Step, useWorkflowStepStore, type WorkflowStepStore } from "@/stores/workflowStepStore";
+import type { Connection } from "@/stores/workflowStoreTypes";
 import { assertDefined } from "@/utils/assertions";
 
 import { cloneStepWithUniqueLabel, getLabelSet } from "./cloneStep";

--- a/client/src/components/Workflow/Editor/SVGConnection.vue
+++ b/client/src/components/Workflow/Editor/SVGConnection.vue
@@ -3,8 +3,9 @@ import { curveBasis, line } from "d3";
 import { computed, type PropType } from "vue";
 
 import { useWorkflowStores } from "@/composables/workflowStores";
-import { type Connection, getConnectionId } from "@/stores/workflowConnectionStore";
+import { getConnectionId } from "@/stores/workflowConnectionStore";
 import type { TerminalPosition } from "@/stores/workflowEditorStateStore";
+import type { Connection } from "@/stores/workflowStoreTypes";
 
 const props = defineProps({
     id: String,

--- a/client/src/components/Workflow/Editor/WorkflowEdges.vue
+++ b/client/src/components/Workflow/Editor/WorkflowEdges.vue
@@ -3,8 +3,8 @@ import { storeToRefs } from "pinia";
 import { computed, type Ref } from "vue";
 
 import { useWorkflowStores } from "@/composables/workflowStores";
-import type { Connection, OutputTerminal } from "@/stores/workflowConnectionStore";
 import type { TerminalPosition } from "@/stores/workflowEditorStateStore";
+import type { Connection, OutputTerminal } from "@/stores/workflowStoreTypes";
 
 import type { OutputTerminals } from "./modules/terminals";
 

--- a/client/src/components/Workflow/Editor/modules/activities.ts
+++ b/client/src/components/Workflow/Editor/modules/activities.ts
@@ -17,7 +17,8 @@ import { watchImmediate } from "@vueuse/core";
 import { faDiagramNext } from "font-awesome-6";
 import { computed, type Ref } from "vue";
 
-import { type Activity, useActivityStore } from "@/stores/activityStore";
+import { useActivityStore } from "@/stores/activityStore";
+import type { Activity } from "@/stores/activityStoreTypes";
 
 export const workflowEditorActivities = [
     {

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -2,7 +2,7 @@ import EventEmitter from "events";
 
 import { type DatatypesMapperModel } from "@/components/Datatypes/model";
 import { type useWorkflowStores } from "@/composables/workflowStores";
-import { type Connection, type ConnectionId, getConnectionId } from "@/stores/workflowConnectionStore";
+import { getConnectionId } from "@/stores/workflowConnectionStore";
 import {
     type CollectionOutput,
     type DataCollectionStepInput,
@@ -12,6 +12,7 @@ import {
     type ParameterStepInput,
     type TerminalSource,
 } from "@/stores/workflowStepStore";
+import type { Connection, ConnectionId } from "@/stores/workflowStoreTypes";
 import { assertDefined } from "@/utils/assertions";
 
 import {

--- a/client/src/stores/activitySetup.ts
+++ b/client/src/stores/activitySetup.ts
@@ -17,7 +17,7 @@ import {
     faWrench,
 } from "@fortawesome/free-solid-svg-icons";
 
-import { type Activity } from "@/stores/activityStore";
+import { type Activity } from "@/stores/activityStoreTypes";
 import { type EventData } from "@/stores/eventStore";
 
 export const defaultActivities = [

--- a/client/src/stores/activityStore.ts
+++ b/client/src/stores/activityStore.ts
@@ -1,7 +1,6 @@
 /**
  * Stores the Activity Bar state
  */
-import { type IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import { useDebounceFn, watchImmediate } from "@vueuse/core";
 import { computed, type Ref, ref, set } from "vue";
 
@@ -10,37 +9,8 @@ import { useUserLocalStorage } from "@/composables/userLocalStorage";
 import { ensureDefined } from "@/utils/assertions";
 
 import { defaultActivities } from "./activitySetup";
+import type { Activity } from "./activityStoreTypes";
 import { defineScopedStore } from "./scopedStore";
-
-export type ActivityVariant = "primary" | "danger" | "disabled";
-
-export interface Activity {
-    // determine wether an anonymous user can access this activity
-    anonymous?: boolean;
-    // description of the activity
-    description: string;
-    // unique identifier
-    id: string;
-    // icon to be displayed in activity bar
-    icon: IconDefinition;
-    // indicate if this activity can be modified and/or deleted
-    mutable?: boolean;
-    // indicate wether this activity can be disabled by the user
-    optional?: boolean;
-    // specifiy wether this activity utilizes the side panel
-    panel?: boolean;
-    // title to be displayed in the activity bar
-    title: string;
-    // route to be executed upon selecting the activity
-    to?: string | null;
-    // tooltip to be displayed when hovering above the icon
-    tooltip: string;
-    // indicate wether the activity should be visible by default
-    visible?: boolean;
-    // if activity should cause a click event
-    click?: true;
-    variant?: ActivityVariant;
-}
 
 export interface ActivityMeta {
     disabled: boolean;

--- a/client/src/stores/activityStoreTypes.ts
+++ b/client/src/stores/activityStoreTypes.ts
@@ -1,0 +1,31 @@
+import { type IconDefinition } from "@fortawesome/fontawesome-svg-core";
+
+export type ActivityVariant = "primary" | "danger" | "disabled";
+
+export interface Activity {
+    // determine wether an anonymous user can access this activity
+    anonymous?: boolean;
+    // description of the activity
+    description: string;
+    // unique identifier
+    id: string;
+    // icon to be displayed in activity bar
+    icon: IconDefinition;
+    // indicate if this activity can be modified and/or deleted
+    mutable?: boolean;
+    // indicate wether this activity can be disabled by the user
+    optional?: boolean;
+    // specifiy wether this activity utilizes the side panel
+    panel?: boolean;
+    // title to be displayed in the activity bar
+    title: string;
+    // route to be executed upon selecting the activity
+    to?: string | null;
+    // tooltip to be displayed when hovering above the icon
+    tooltip: string;
+    // indicate wether the activity should be visible by default
+    visible?: boolean;
+    // if activity should cause a click event
+    click?: true;
+    variant?: ActivityVariant;
+}

--- a/client/src/stores/workflowConnectionStore.test.ts
+++ b/client/src/stores/workflowConnectionStore.test.ts
@@ -1,13 +1,8 @@
 import { createPinia, setActivePinia } from "pinia";
 
-import {
-    type Connection,
-    getTerminalId,
-    type InputTerminal,
-    type OutputTerminal,
-    useConnectionStore,
-} from "@/stores/workflowConnectionStore";
+import { getTerminalId, useConnectionStore } from "@/stores/workflowConnectionStore";
 import { type NewStep, useWorkflowStepStore } from "@/stores/workflowStepStore";
+import type { Connection, InputTerminal, OutputTerminal } from "@/stores/workflowStoreTypes";
 
 const workflowStepZero: NewStep = {
     input_connections: {},

--- a/client/src/stores/workflowConnectionStore.ts
+++ b/client/src/stores/workflowConnectionStore.ts
@@ -4,44 +4,15 @@ import { useWorkflowStepStore } from "@/stores/workflowStepStore";
 import { pushOrSet } from "@/utils/pushOrSet";
 
 import { defineScopedStore } from "./scopedStore";
-
-interface InvalidConnections {
-    [index: ConnectionId]: string | undefined;
-}
-
-export interface State {
-    connections: Connection[];
-    invalidConnections: InvalidConnections;
-    inputTerminalToOutputTerminals: TerminalToOutputTerminals;
-    terminalToConnection: { [index: string]: Connection[] };
-    stepToConnections: { [index: number]: Connection[] };
-}
-
-export interface Connection {
-    input: InputTerminal;
-    output: OutputTerminal;
-}
-
-export type ConnectionId = `${string}-${string}-${string}-${string}`;
-
-export interface BaseTerminal {
-    stepId: number;
-    name: string;
-    connectorType?: "input" | "output";
-}
-
-export interface InputTerminal extends BaseTerminal {
-    connectorType: "input";
-    input_subworkflow_step_id?: number;
-}
-
-export interface OutputTerminal extends BaseTerminal {
-    connectorType: "output";
-}
-
-interface TerminalToOutputTerminals {
-    [index: string]: OutputTerminal[];
-}
+import type {
+    BaseTerminal,
+    Connection,
+    ConnectionId,
+    InputTerminal,
+    InvalidConnections,
+    OutputTerminal,
+    TerminalToOutputTerminals,
+} from "./workflowStoreTypes";
 
 function updateTerminalToTerminal(connections: Connection[]) {
     const inputTerminalToOutputTerminals: TerminalToOutputTerminals = {};

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -1,11 +1,12 @@
 import { computed, del, ref, set } from "vue";
 
 import { type CollectionTypeDescriptor } from "@/components/Workflow/Editor/modules/collectionTypeDescription";
-import { type Connection, getConnectionId, useConnectionStore } from "@/stores/workflowConnectionStore";
+import { getConnectionId, useConnectionStore } from "@/stores/workflowConnectionStore";
 import { assertDefined } from "@/utils/assertions";
 
 import { defineScopedStore } from "./scopedStore";
 import { useWorkflowStateStore } from "./workflowEditorStateStore";
+import type { Connection } from "./workflowStoreTypes";
 
 interface StepPosition {
     top: number;

--- a/client/src/stores/workflowStoreTypes.ts
+++ b/client/src/stores/workflowStoreTypes.ts
@@ -1,0 +1,37 @@
+export interface TerminalToOutputTerminals {
+    [index: string]: OutputTerminal[];
+}
+
+export interface InvalidConnections {
+    [index: ConnectionId]: string | undefined;
+}
+
+export interface State {
+    connections: Connection[];
+    invalidConnections: InvalidConnections;
+    inputTerminalToOutputTerminals: TerminalToOutputTerminals;
+    terminalToConnection: { [index: string]: Connection[] };
+    stepToConnections: { [index: number]: Connection[] };
+}
+
+export interface Connection {
+    input: InputTerminal;
+    output: OutputTerminal;
+}
+
+export type ConnectionId = `${string}-${string}-${string}-${string}`;
+
+export interface BaseTerminal {
+    stepId: number;
+    name: string;
+    connectorType?: "input" | "output";
+}
+
+export interface InputTerminal extends BaseTerminal {
+    connectorType: "input";
+    input_subworkflow_step_id?: number;
+}
+
+export interface OutputTerminal extends BaseTerminal {
+    connectorType: "output";
+}


### PR DESCRIPTION
Fixes the circular error around activity stores - improves the workflow situation but does not fix it completely. The workflowConnectionStore imports and uses the workflowStepStore unconditionally and vise versa.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
