### PR TITLE
Migrate from Prism to Monaco for ToolSource display.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,6 @@
   ],
   "resolutions": {
     "chokidar": "3.5.3",
-    "prismjs": "1.29.0",
     "vue": "2.7.16",
     "vue-loader": "15.11.1"
   },
@@ -112,7 +111,6 @@
     "vue-infinite-scroll": "^2.0.2",
     "vue-multiselect": "^2.1.7",
     "vue-observe-visibility": "^1.0.0",
-    "vue-prismjs": "^1.2.0",
     "vue-router": "^3.6.5",
     "vue-rx": "^6.2.0",
     "vue-virtual-scroll-list": "^2.3.5",

--- a/client/package.json
+++ b/client/package.json
@@ -39,6 +39,7 @@
     "@handsontable/vue": "^2.0.0",
     "@hirez_io/observer-spy": "^2.1.2",
     "@johmun/vue-tags-input": "^2.1.0",
+    "@monaco-editor/loader": "^1.5.0",
     "@popperjs/core": "^2.11.8",
     "@sentry/browser": "^7.74.1",
     "@sentry/vue": "^7.114.0",

--- a/client/src/components/Tool/ToolSource.vue
+++ b/client/src/components/Tool/ToolSource.vue
@@ -10,12 +10,14 @@ import Alert from "components/Alert";
 import LoadingSpan from "components/LoadingSpan";
 import { ToolSourceProvider } from "components/providers/ToolSourceProvider";
 
+import ToolSourceDisplay from "@/components/Tool/ToolSourceDisplay.vue";
+
 export default {
     components: {
         Alert,
         LoadingSpan,
         ToolSourceProvider,
-        ToolSourceDisplay: () => import(/* webpackChunkName: "ToolSourceDisplay" */ "./ToolSourceDisplay.vue"),
+        ToolSourceDisplay,
     },
     props: {
         toolId: {

--- a/client/src/components/Tool/ToolSourceDisplay.vue
+++ b/client/src/components/Tool/ToolSourceDisplay.vue
@@ -1,17 +1,11 @@
 <template>
-    <Prism :language="language" :code="code" :plugins="['normalize-whitespace']"></Prism>
+    <div ref="editorContainer" class="editor-container"></div>
 </template>
 
 <script>
-import "prismjs/themes/prism.css";
-import "prismjs/plugins/normalize-whitespace/prism-normalize-whitespace.js";
-
-import Prism from "vue-prismjs";
+import loader from '@monaco-editor/loader';
 
 export default {
-    components: {
-        Prism,
-    },
     props: {
         language: {
             type: String,
@@ -22,5 +16,52 @@ export default {
             required: true,
         },
     },
+    data() {
+        return {
+            editor: null,
+        };
+    },
+    watch: {
+        code(newValue) {
+            if (this.editor) {
+                this.editor.setValue(newValue);
+            }
+        },
+        language(newValue) {
+            if (this.editor) {
+                monaco.editor.setModelLanguage(this.editor.getModel(), newValue);
+            }
+        }
+    },
+    mounted() {
+        this.initMonaco();
+    },
+    beforeDestroy() {
+        if (this.editor) {
+            this.editor.dispose();
+        }
+    },
+    methods: {
+        initMonaco() {
+            loader.init().then(monaco => {
+                this.editor = monaco.editor.create(this.$refs.editorContainer, {
+                    value: this.code,
+                    language: this.language,
+                    readOnly: true,
+                    minimap: { enabled: false },
+                    scrollBeyondLastLine: false,
+                    automaticLayout: true,
+                    theme: 'vs',
+                });
+            });
+        }
+    }
 };
 </script>
+
+<style scoped>
+.editor-container {
+    width: 100%;
+    height: 600px;
+}
+</style>

--- a/client/src/components/Tool/ToolSourceDisplay.vue
+++ b/client/src/components/Tool/ToolSourceDisplay.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script>
-import loader from '@monaco-editor/loader';
+import loader from "@monaco-editor/loader";
 
 export default {
     props: {
@@ -31,7 +31,7 @@ export default {
             if (this.editor) {
                 this.editor.setModelLanguage(this.editor.getModel(), newValue);
             }
-        }
+        },
     },
     mounted() {
         this.initMonaco();
@@ -43,7 +43,7 @@ export default {
     },
     methods: {
         initMonaco() {
-            loader.init().then(monaco => {
+            loader.init().then((monaco) => {
                 this.editor = monaco.editor.create(this.$refs.editorContainer, {
                     value: this.code,
                     language: this.language,
@@ -51,11 +51,11 @@ export default {
                     minimap: { enabled: false },
                     scrollBeyondLastLine: false,
                     automaticLayout: true,
-                    theme: 'vs',
+                    theme: "vs",
                 });
             });
-        }
-    }
+        },
+    },
 };
 </script>
 

--- a/client/src/components/Tool/ToolSourceDisplay.vue
+++ b/client/src/components/Tool/ToolSourceDisplay.vue
@@ -29,7 +29,7 @@ export default {
         },
         language(newValue) {
             if (this.editor) {
-                monaco.editor.setModelLanguage(this.editor.getModel(), newValue);
+                this.editor.setModelLanguage(this.editor.getModel(), newValue);
             }
         }
     },

--- a/client/src/components/Tool/ToolSourceMenuItem.vue
+++ b/client/src/components/Tool/ToolSourceMenuItem.vue
@@ -27,7 +27,12 @@ const props = defineProps({
         <b-dropdown-item v-b-modal.tool-source-viewer>
             <FontAwesomeIcon icon="far fa-eye" /><span v-localize>View Tool source</span>
         </b-dropdown-item>
-        <b-modal id="tool-source-viewer" modal-class="tool-source-modal" :title="`Tool Source for ${props.toolId}`" size="xl" ok-only ok-title="Close">
+        <b-modal
+            id="tool-source-viewer"
+            modal-class="tool-source-modal"
+            :title="`Tool Source for ${props.toolId}`"
+            ok-only
+            ok-title="Close">
             <ToolSource :tool-id="props.toolId" />
         </b-modal>
     </div>

--- a/client/src/components/Tool/ToolSourceMenuItem.vue
+++ b/client/src/components/Tool/ToolSourceMenuItem.vue
@@ -27,8 +27,17 @@ const props = defineProps({
         <b-dropdown-item v-b-modal.tool-source-viewer>
             <FontAwesomeIcon icon="far fa-eye" /><span v-localize>View Tool source</span>
         </b-dropdown-item>
-        <b-modal id="tool-source-viewer" :title="`Tool Source for ${props.toolId}`" size="lg" ok-only ok-title="Close">
+        <b-modal id="tool-source-viewer" modal-class="tool-source-modal" :title="`Tool Source for ${props.toolId}`" size="xl" ok-only ok-title="Close">
             <ToolSource :tool-id="props.toolId" />
         </b-modal>
     </div>
 </template>
+
+<style lang="scss">
+#tool-source-viewer {
+    .modal-dialog {
+        width: 85%;
+        max-width: 100%;
+    }
+}
+</style>

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -17,7 +17,6 @@ const styleBase = path.join(scriptsBase, "style");
 const modulesExcludedFromLibs = [
     "jspdf",
     "canvg",
-    "prismjs",
     "html2canvas",
     "handsontable",
     "pikaday",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1964,6 +1964,13 @@
   resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-5.3.23.tgz#b662225a8b72482d940143a824b824677666bdae"
   integrity sha512-UnUu2mvVam9CtEMR2+k7eEsbtrYAecmd3SWRrXGDJrAIddnE6Ln+SmihqNMwHRa64VfNkVFSV/mVphvlwky/Bw==
 
+"@monaco-editor/loader@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/loader/-/loader-1.5.0.tgz#dcdbc7fe7e905690fb449bed1c251769f325c55d"
+  integrity sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==
+  dependencies:
+    state-local "^1.0.6"
+
 "@mswjs/interceptors@^0.29.0":
   version "0.29.1"
   resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.29.1.tgz#e77fc58b5188569041d0440b25c9e9ebb1ccd60a"
@@ -11378,6 +11385,11 @@ stacktrace-gps@^3.0.2:
   dependencies:
     source-map "0.5.6"
     stackframe "^1.3.4"
+
+state-local@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/state-local/-/state-local-1.0.7.tgz#da50211d07f05748d53009bee46307a37db386d5"
+  integrity sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==
 
 static-extend@^0.1.1:
   version "0.1.2"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10275,11 +10275,6 @@ pretty@^2.0.0:
     extend-shallow "^2.0.1"
     js-beautify "^1.6.12"
 
-prismjs@1.29.0, prismjs@^1.6.0:
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
-  integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
-
 process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
@@ -12889,13 +12884,6 @@ vue-observe-visibility@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-1.0.0.tgz"
   integrity sha512-s5TFh3s3h3Mhd3jaz3zGzkVHKHnc/0C/gNr30olO99+yw2hl3WBhK3ng3/f9OF+qkW4+l7GkmwfAzDAcY3lCFg==
-
-vue-prismjs@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/vue-prismjs/-/vue-prismjs-1.2.0.tgz"
-  integrity sha512-1mICbMknMiKw4mfM1AU7vkFT3VX4Cq8ySyDU7IBr9tYW1fzxIPkfLoERkRMbQLBc+J74K3FIiuuZ+WfBjO3SCQ==
-  dependencies:
-    prismjs "^1.6.0"
 
 vue-router@^3.6.5:
   version "3.6.5"


### PR DESCRIPTION
Monaco offers a more modern, robust, and feature-rich experience, aligning with our strategy to use it across other areas of the application. This migration not only helps the build process out (my immediate goal), but also sets the stage for future enhancements.

Ripped from the webpack-speed branch, where I was trying to identify and eliminate or adjust large dependencies.  I feel like this thing was problematic in vite, too.


![image](https://github.com/user-attachments/assets/d6a3dc96-f07c-41e6-98e9-126b62e11e50)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
