### PR TITLE
Create rucio.cfg from inside Rucio objectstore

### DIFF
--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -477,9 +477,10 @@ def set_metadata_portable(
                     # Can't happen, but type system doesn't know
                     raise Exception("object_store not built")
                 if not is_deferred and not link_data_only:
-                    object_store_update_actions.append(
-                        partial(push_if_necessary, object_store, dataset, external_filename)
-                    )
+                    if dataset_instance_id not in unnamed_id_to_path:
+                        object_store_update_actions.append(
+                            partial(push_if_necessary, object_store, dataset, external_filename)
+                        )
                     object_store_update_actions.append(partial(reset_external_filename, dataset))
                 object_store_update_actions.append(partial(dataset.set_total_size))
                 object_store_update_actions.append(partial(export_store.add_dataset, dataset))

--- a/lib/galaxy/objectstore/rucio.py
+++ b/lib/galaxy/objectstore/rucio.py
@@ -158,13 +158,16 @@ class RucioBroker:
             self.rucio_config_path = os.path.join(temp_directory, "rucio.cfg")
             key_for_pass = "password"
             with open(self.rucio_config_path, "w") as f:
-                f.write("[client]\n")
-                f.write(f"rucio_host = {self.config['host']}\n")
-                f.write(f"auth_host = {self.config['auth_host']}\n")
-                f.write(f"account = {self.config['account']}\n")
-                f.write(f"auth_type = {self.config['auth_type']}\n")
-                f.write(f"username = {self.config['username']}\n")
-                f.write(f"{key_for_pass} = {self.config[key_for_pass]}\n")
+                f.write(
+                    f"""[client]
+rucio_host = {self.config['host']}
+auth_host = {self.config['auth_host']}
+account = {self.config['account']}
+auth_type = {self.config['auth_type']}
+username = {self.config['username']}
+{key_for_pass} = {self.config[key_for_pass]}
+"""
+                )
         # We may have crossed a forkpool boundary. No harm setting the env var again.
         # Fixes rucio integration tests
         os.environ["RUCIO_CONFIG"] = self.rucio_config_path

--- a/lib/galaxy/objectstore/rucio.py
+++ b/lib/galaxy/objectstore/rucio.py
@@ -138,9 +138,11 @@ def parse_config_xml(config_xml):
 
 
 class RucioBroker:
-    def __init__(self, rucio_config):
+    def __init__(self, rucio_config, config):
         self._temp_file_name = None
+        self.rucio_config_created = False
         self.config = rucio_config
+        self.extra_dirs = config.get("extra_dirs", [])
         self.upload_scheme = rucio_config["upload_scheme"]
         self.upload_rse_name = rucio_config["upload_rse_name"]
         self.scope = rucio_config["scope"]
@@ -151,12 +153,28 @@ class RucioBroker:
         rucio.common.utils.PREFERRED_CHECKSUM = "md5"
 
     def get_rucio_client(self):
+        if not self.rucio_config_created:
+            temp_directory = "/tmp"
+            for extra_dir in self.extra_dirs:
+                if extra_dir["type"] == "temp":
+                    temp_directory = extra_dir["path"]
+            rucio_config_path = os.path.join(temp_directory, "rucio.cfg")
+            with open(rucio_config_path, "w") as f:
+                f.write("[client]\n")
+                f.write(f"rucio_host = {self.config['host']}\n")
+                f.write(f"auth_host = {self.config['auth_host']}\n")
+                f.write(f"account = {self.config['account']}\n")
+                f.write(f"auth_type = {self.config['auth_type']}\n")
+                f.write(f"username = {self.config['username']}\n")
+                f.write(f"password = {self.config['password']}\n")
+            os.environ["RUCIO_CONFIG"] = rucio_config_path
+            self.rucio_config_created = True
         client = Client(
             rucio_host=self.config["host"],
             auth_host=self.config["auth_host"],
             account=self.config["account"],
             auth_type=self.config["auth_type"],
-            creds={"username": self.config["username"], "password": self.config["username"]},
+            creds={"username": self.config["username"], "password": self.config["password"]},
         )
         return client
 
@@ -293,7 +311,7 @@ class RucioObjectStore(CachingConcreteObjectStore):
         self.rucio_config = config_dict.get("rucio") or {}
 
         self.oidc_provider = config_dict.get("oidc_provider", None)
-        self.rucio_broker = RucioBroker(self.rucio_config)
+        self.rucio_broker = RucioBroker(self.rucio_config, self.config)
         cache_dict = config_dict.get("cache") or {}
         self.enable_cache_monitor, self.cache_monitor_interval = enable_cache_monitor(config, config_dict)
 

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -40,8 +40,8 @@ RUCIO_OBJECT_STORE_CONFIG = string.Template(
     <rucio_upload_scheme rse="${rucio_rse}" scheme="file" scope="galaxy"/>
     <rucio_download_scheme rse="${rucio_rse}" scheme="file"/>
     <cache path="${temp_directory}/object_store_cache" size="1000" cache_updated_data="${cache_updated_data}" />
-    <extra_dir type="job_work" path="${temp_directory}/job_working_directory_swift"/>
-    <extra_dir type="temp" path="${temp_directory}/tmp_swift"/>
+    <extra_dir type="job_work" path="${temp_directory}/job_working_directory_rucio"/>
+    <extra_dir type="temp" path="${temp_directory}/tmp_rucio"/>
 </object_store>
 """
 )
@@ -106,6 +106,7 @@ ONEDATA_OBJECT_STORE_CONFIG = string.Template(
 def wait_rucio_ready(container_name):
     timeout = 30
     start_time = time.time()
+    rse = None
     while True:
         try:
             rse = docker_exec(container_name, "rucio", "list-rses").decode("utf-8").strip()
@@ -114,7 +115,7 @@ def wait_rucio_ready(container_name):
         except subprocess.CalledProcessError:
             pass
         if time.time() - start_time >= timeout:
-            raise TimeoutError(rse)
+            raise TimeoutError(f"cannot start Rucio {rse}")
         time.sleep(1)
 
 
@@ -261,22 +262,6 @@ class BaseRucioObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase
         config["metadata_strategy"] = "extended"
         config["outputs_to_working_directory"] = True
         config["retry_metadata_internally"] = False
-        # Rucio client requires a config file to exist on disk. This is ugly,
-        # but we have to live with it for now. An issue is created: https://github.com/rucio/rucio/issues/6410
-        rucio_config_path = os.path.join(temp_directory, "rucio.cfg")
-        env_file = os.path.join(temp_directory, "env_set.sh")
-        with open(env_file, "w") as f:
-            f.write(f"export RUCIO_CONFIG={rucio_config_path}\n")
-        config["environment_setup_file"] = env_file
-        with open(rucio_config_path, "w") as f:
-            f.write("[client]\n")
-            f.write(f"rucio_host = http://{OBJECT_STORE_HOST}:{OBJECT_STORE_PORT}\n")
-            f.write(f"auth_host = http://{OBJECT_STORE_HOST}:{OBJECT_STORE_PORT}\n")
-            f.write(f"account = {OBJECT_STORE_RUCIO_ACCOUNT}\n")
-            f.write("auth_type = userpass\n")
-            f.write(f"username = {OBJECT_STORE_RUCIO_USERNAME}\n")
-            f.write(f"password = {OBJECT_STORE_RUCIO_ACCESS}\n")
-        os.environ["RUCIO_CONFIG"] = rucio_config_path
         with open(config_path, "w") as f:
             f.write(
                 RUCIO_OBJECT_STORE_CONFIG.safe_substitute(
@@ -292,7 +277,6 @@ class BaseRucioObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase
                     }
                 )
             )
-
         config["object_store_config_file"] = config_path
 
     def setUp(self):

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -41,7 +41,7 @@ RUCIO_OBJECT_STORE_CONFIG = string.Template(
     <rucio_download_scheme rse="${rucio_rse}" scheme="file"/>
     <cache path="${temp_directory}/object_store_cache" size="1000" cache_updated_data="${cache_updated_data}" />
     <extra_dir type="job_work" path="${temp_directory}/job_working_directory_rucio"/>
-    <extra_dir type="temp" path="${temp_directory}/tmp_rucio"/>
+    <extra_dir type="temp" path="${temp_directory}"/>
 </object_store>
 """
 )

--- a/test/integration/objectstore/test_rucio_objectstore.py
+++ b/test/integration/objectstore/test_rucio_objectstore.py
@@ -28,7 +28,12 @@ TEST_TOOL_IDS = [
 
 
 class TestRucioObjectStoreIntegration(BaseRucioObjectStoreIntegrationTestCase):
-    pass
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        config["enable_celery_tasks"] = False
+        config["metadata_strategy"] = "directory"
 
 
 instance = integration_util.integration_module_instance(TestRucioObjectStoreIntegration)

--- a/test/integration/objectstore/test_rucio_objectstore.py
+++ b/test/integration/objectstore/test_rucio_objectstore.py
@@ -33,7 +33,6 @@ class TestRucioObjectStoreIntegration(BaseRucioObjectStoreIntegrationTestCase):
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
         config["enable_celery_tasks"] = False
-        config["metadata_strategy"] = "directory"
 
 
 instance = integration_util.integration_module_instance(TestRucioObjectStoreIntegration)


### PR DESCRIPTION
Rucio client library requires rucio.cfg to be present on the system. We create this file now in objectstore to make sure it always gets created.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
