### PR TITLE
Drop old galaxy_session records

### DIFF
--- a/doc/source/admin/useful_scripts.rst
+++ b/doc/source/admin/useful_scripts.rst
@@ -36,3 +36,22 @@ To safely delete unused histories and their associated records, please use the `
       -h, --help         show this help message and exit
       --batch BATCH      batch size
       --created CREATED  most recent created date/time in ISO format (for example, March 11, 1952 is represented as '1952-03-11')
+
+
+Deleting old galaxy_session records
+-----------------------------------
+
+Each time Galaxy is accessed, a galaxy_session record is created, even when the user is annonymous. Over time, Galaxy accumulates such records. Deleting such records will declutter the database and free up space. 
+
+To safely delete such records, please use the galaxy-delete-sessions script. By default, a galaxy_session record should be at least a month old to be considered safe to delete (which is determinded by the value of its ``update_time`` field). 
+
+.. code-block:: console
+
+    $ python  $GALAXY_ROOT/lib/galaxy/model/scripts/delete_galaxy_sessions.py
+    usage: delete_galaxy_sessions.py [-h] [--updated UPDATED]
+    
+    Remove old galaxy_session records from database.
+    
+    options:
+      -h, --help         show this help message and exit
+      --updated UPDATED  most recent `updated` date/time in ISO format (for example, March 11, 1952 is represented as '1952-03-11'

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2439,9 +2439,6 @@ class MinimalJobWrapper(HasResourceParameters):
             return None
         return f'{self.version_command_line or ""}{self.command_line}'
 
-    def get_session_id(self):
-        return self.session_id
-
     def get_env_setup_clause(self):
         if self.app.config.environment_setup_file is None:
             return ""
@@ -2982,9 +2979,6 @@ class TaskWrapper(JobWrapper):
 
     def get_command_line(self):
         return self.command_line
-
-    def get_session_id(self):
-        return self.session_id
 
     def get_output_file_id(self, file):
         # There is no permanent output file for tasks.

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1731,9 +1731,6 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
         """
         return self.external_output_metadata
 
-    def get_session_id(self):
-        return self.session_id
-
     def get_user_id(self):
         return self.user_id
 
@@ -2463,11 +2460,6 @@ class Task(Base, JobLike, RepresentById):
         """
         # TODO: Merge into get_runner_external_id.
         return self.task_runner_external_id
-
-    def get_session_id(self):
-        # The Job's galaxy session is equal to the Job's session, so the
-        # Job's session is the same as the Task's session.
-        return self.get_job().get_session_id()
 
     def set_id(self, id):
         # This is defined in the SQL Alchemy's mapper and not here.

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1516,7 +1516,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     tool_stderr: Mapped[Optional[str]] = mapped_column(TEXT)
     exit_code: Mapped[Optional[int]]
     traceback: Mapped[Optional[str]] = mapped_column(TEXT)
-    session_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_session.id"), index=True)
+    session_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_session.id", ondelete="SET NULL"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     job_runner_name: Mapped[Optional[str]] = mapped_column(String(255))
     job_runner_external_id: Mapped[Optional[str]] = mapped_column(String(255), index=True)
@@ -7763,7 +7763,7 @@ class Event(Base, RepresentById):
     history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
     message: Mapped[Optional[str]] = mapped_column(TrimmedString(1024))
-    session_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_session.id"), index=True)
+    session_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_session.id", ondelete="SET NULL"), index=True)
     tool_id: Mapped[Optional[str]] = mapped_column(String(255))
 
     history: Mapped[Optional["History"]] = relationship()
@@ -7822,7 +7822,7 @@ class GalaxySessionToHistoryAssociation(Base, RepresentById):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
-    session_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_session.id"), index=True)
+    session_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_session.id", ondelete="CASCADE"), index=True)
     history_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history.id"), index=True)
     galaxy_session: Mapped[Optional["GalaxySession"]] = relationship(back_populates="histories")
     history: Mapped[Optional["History"]] = relationship(back_populates="galaxy_sessions")
@@ -11587,7 +11587,7 @@ class UserAction(Base, RepresentById):
     id: Mapped[int] = mapped_column(primary_key=True)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_user.id"), index=True)
-    session_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_session.id"), index=True)
+    session_id: Mapped[Optional[int]] = mapped_column(ForeignKey("galaxy_session.id", ondelete="SET NULL"), index=True)
     action: Mapped[Optional[str]] = mapped_column(Unicode(255))
     context: Mapped[Optional[str]] = mapped_column(Unicode(512))
     params: Mapped[Optional[str]] = mapped_column(Unicode(1024))

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/0c681a59dce1_add_on_delete_to_fkey_on_event_session_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/0c681a59dce1_add_on_delete_to_fkey_on_event_session_.py
@@ -1,0 +1,40 @@
+"""Add on-delete to fkey on event.session_id
+
+Revision ID: 0c681a59dce1
+Revises: 24feca8a6a5a
+Create Date: 2025-03-22 11:49:53.739419
+
+"""
+
+from galaxy.model.database_object_names import build_foreign_key_name
+from galaxy.model.migrations.util import (
+    create_foreign_key,
+    drop_constraint,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "0c681a59dce1"
+down_revision = "24feca8a6a5a"
+branch_labels = None
+depends_on = None
+
+session_table = "galaxy_session"
+job_table = "event"
+session_id_column = "session_id"
+
+job_session_fk = build_foreign_key_name(job_table, session_id_column)
+fkey_args = (job_session_fk, job_table, session_table, [session_id_column], ["id"])
+
+
+def upgrade():
+    with transaction():
+        drop_constraint(job_session_fk, job_table)
+        create_foreign_key(*fkey_args, ondelete="SET NULL")
+
+
+def downgrade():
+    pass
+    with transaction():
+        drop_constraint(job_session_fk, job_table)
+        create_foreign_key(*fkey_args)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/24feca8a6a5a_add_on_delete_to_fkey_on_user_action_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/24feca8a6a5a_add_on_delete_to_fkey_on_user_action_.py
@@ -1,0 +1,40 @@
+"""Add on-delete to fkey on user_action.session_id
+
+Revision ID: 24feca8a6a5a
+Revises: cde5d2db77e7
+Create Date: 2025-03-22 11:47:02.069491
+
+"""
+
+from galaxy.model.database_object_names import build_foreign_key_name
+from galaxy.model.migrations.util import (
+    create_foreign_key,
+    drop_constraint,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "24feca8a6a5a"
+down_revision = "cde5d2db77e7"
+branch_labels = None
+depends_on = None
+
+session_table = "galaxy_session"
+job_table = "user_action"
+session_id_column = "session_id"
+
+job_session_fk = build_foreign_key_name(job_table, session_id_column)
+fkey_args = (job_session_fk, job_table, session_table, [session_id_column], ["id"])
+
+
+def upgrade():
+    with transaction():
+        drop_constraint(job_session_fk, job_table)
+        create_foreign_key(*fkey_args, ondelete="SET NULL")
+
+
+def downgrade():
+    pass
+    with transaction():
+        drop_constraint(job_session_fk, job_table)
+        create_foreign_key(*fkey_args)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/caeee878d7cd_add_on_delete_to_fkey_on_galaxy_session_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/caeee878d7cd_add_on_delete_to_fkey_on_galaxy_session_.py
@@ -1,0 +1,40 @@
+"""Add on-delete to fkey on galaxy_session_to_history.session_id
+
+Revision ID: caeee878d7cd
+Revises: 0c681a59dce1
+Create Date: 2025-03-22 11:53:01.514335
+
+"""
+
+from galaxy.model.database_object_names import build_foreign_key_name
+from galaxy.model.migrations.util import (
+    create_foreign_key,
+    drop_constraint,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "caeee878d7cd"
+down_revision = "0c681a59dce1"
+branch_labels = None
+depends_on = None
+
+session_table = "galaxy_session"
+job_table = "galaxy_session_to_history"
+session_id_column = "session_id"
+
+job_session_fk = build_foreign_key_name(job_table, session_id_column)
+fkey_args = (job_session_fk, job_table, session_table, [session_id_column], ["id"])
+
+
+def upgrade():
+    with transaction():
+        drop_constraint(job_session_fk, job_table)
+        create_foreign_key(*fkey_args, ondelete="CASCADE")
+
+
+def downgrade():
+    pass
+    with transaction():
+        drop_constraint(job_session_fk, job_table)
+        create_foreign_key(*fkey_args)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/cde5d2db77e7_add_on_delete_to_fkey_on_job_session_id.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/cde5d2db77e7_add_on_delete_to_fkey_on_job_session_id.py
@@ -1,0 +1,40 @@
+"""Add on-delete to fkey on job.session_id
+
+Revision ID: cde5d2db77e7
+Revises: b964490175fd
+Create Date: 2025-03-21 18:18:07.287968
+
+"""
+
+from galaxy.model.database_object_names import build_foreign_key_name
+from galaxy.model.migrations.util import (
+    create_foreign_key,
+    drop_constraint,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "cde5d2db77e7"
+down_revision = "b964490175fd"
+branch_labels = None
+depends_on = None
+
+session_table = "galaxy_session"
+job_table = "job"
+session_id_column = "session_id"
+
+job_session_fk = build_foreign_key_name(job_table, session_id_column)
+fkey_args = (job_session_fk, job_table, session_table, [session_id_column], ["id"])
+
+
+def upgrade():
+    with transaction():
+        drop_constraint(job_session_fk, job_table)
+        create_foreign_key(*fkey_args, ondelete="SET NULL")
+
+
+def downgrade():
+    pass
+    with transaction():
+        drop_constraint(job_session_fk, job_table)
+        create_foreign_key(*fkey_args)

--- a/lib/galaxy/model/scripts/delete_galaxy_sessions.py
+++ b/lib/galaxy/model/scripts/delete_galaxy_sessions.py
@@ -1,0 +1,53 @@
+import argparse
+import datetime
+import os
+import sys
+
+from sqlalchemy import (
+    create_engine,
+    text,
+)
+
+sys.path.insert(
+    1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir, os.pardir, "lib"))
+)
+
+from galaxy.model.orm.scripts import get_config
+
+DESCRIPTION = """Remove old galaxy_session records from database."""
+
+
+def main():
+    args = _get_parser().parse_args()
+    config = get_config(sys.argv, use_argparse=False, cwd=os.getcwd())
+    engine = create_engine(config["db_url"])
+    run(engine=engine, max_update_time=args.updated)
+
+
+def _get_parser():
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument(
+        "--updated",
+        type=datetime.datetime.fromisoformat,
+        help="most recent `updated` date/time in ISO format  (for example, March 11, 1952 is represented as '1952-03-11')",
+    )
+    return parser
+
+
+def run(engine, max_update_time=None):
+    max_update_time = max_update_time or _get_default_max_update_time()
+    """ Delete galaxy_session records which were updated prior to `max_update_time`."""
+    stmt = text("DELETE FROM galaxy_session WHERE update_time < :update_time")
+    params = {"update_time": max_update_time}
+    with engine.begin() as conn:
+        conn.execute(stmt, params)
+
+
+def _get_default_max_update_time():
+    """By default, do not delete galaxy_sessions updated less than a month ago."""
+    today = datetime.date.today()
+    return today.replace(month=today.month - 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -705,7 +705,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                         elif history:
                             user = history.user
                             regenerate_kwds["user"] = user
-                            if user is None:
+                            if user is None and history.galaxy_sessions[0]:
                                 regenerate_kwds["session_id"] = history.galaxy_sessions[0].galaxy_session.id
                             else:
                                 regenerate_kwds["session_id"] = None

--- a/lib/galaxy/tools/actions/model_operations.py
+++ b/lib/galaxy/tools/actions/model_operations.py
@@ -115,7 +115,7 @@ class ModelOperationToolAction(DefaultToolAction):
         #
         # Create job.
         #
-        job, galaxy_session = self._new_job_for_session(trans, tool, history)
+        job, _ = self._new_job_for_session(trans, tool, history)
         self._produce_outputs(
             trans,
             tool,

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -907,7 +907,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
         return history
 
     def set_history(self, history):
-        if history and not history.deleted:
+        if history and not history.deleted and self.galaxy_session:
             self.galaxy_session.current_history = history
         self.sa_session.add(self.galaxy_session)
         self.sa_session.commit()

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -921,6 +921,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
         Gets or creates a default history and associates it with the current
         session.
         """
+        assert self.galaxy_session
 
         # Just return the current history if one exists and is not deleted.
         history = self.galaxy_session.current_history

--- a/packages/data/setup.cfg
+++ b/packages/data/setup.cfg
@@ -70,6 +70,7 @@ console_scripts =
         galaxy-load-objects = galaxy.model.store.load_objects:main
         galaxy-manage-db = galaxy.model.orm.scripts:manage_db
         galaxy-prune-histories = galaxy.model.scripts:prune_history_table
+        galaxy-delete-sessions = galaxy.model.scripts:delete_galaxy_sessions
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Ref #13992

Is 1 month a safe cut off for deleting old sessions? If so, main has 173M session records that are more than 2 months old (checked against updated_time; if checked against last_action value, then 151M). 

This introduces some minor duplication (see the history pruning script, as well as admin documentation). I'll refactor as needed when adding more such scripts (as per #13992).

**A note on prev_session_id:**
The `galaxy_session.prev_session_id` field should be defined as a self-referencing foreign key, but it is not. Instead, it's an integer field which allows null values.  Adding a foreign key constraint is trivial; however, the migration process would have to include fixing existing data by setting to null any existing values that do not correspond to an existing galaxy_session record. For databases like main, which contains 173M galaxy_session records, this process requires special handling, and the migration may take a long time. In this case it seems to be not worth the effort. 

UPDATE: we do need the previous session id to be available; however, it is not accessed from the code base and, from a practical standpoint, a foreign key constraint is not needed.

To do:
- [x] Check code base for potential problems when session record has been deleted
- [x] Add cascading for: deleting GalaxySessionToHistoryAssociation records, setting to null references on job, event, user_action, galaxy_session (self ref) (model + db migrations)
- [x] Add script to delete session records (also handle references to prev session in galaxy_session table, which is not a foreign key)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Upgrade database to enable ondelete behavior
  2. Check galaxy_session records in your current local database
  3. Run script with some cutoff date, verify database that records have been deleted
  4. Run script without setting a date, verify database that records older than one month have been deleted.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
