### PR TITLE
[24.0] Check if index exists before creating

### DIFF
--- a/lib/galaxy/model/migrations/alembic/versions_gxy/2dc3386d091f_add_indexes_for_workflow_comment_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/2dc3386d091f_add_indexes_for_workflow_comment_.py
@@ -10,6 +10,7 @@ from galaxy.model.database_object_names import build_index_name
 from galaxy.model.migrations.util import (
     create_index,
     drop_index,
+    index_exists,
 )
 
 # revision identifiers, used by Alembic.
@@ -32,7 +33,8 @@ workflow_comment_parent_comment_index_name = build_index_name(
 
 def upgrade():
     create_index(workflow_step_parent_comment_index_name, workflow_step_table_name, [parent_comment_id_column_name])
-    create_index(workflow_comment_workflow_id_index_name, workflow_comment_table_name, [workflow_id_column_name])
+    if not index_exists(workflow_comment_workflow_id_index_name, workflow_comment_table_name, False):
+        create_index(workflow_comment_workflow_id_index_name, workflow_comment_table_name, [workflow_id_column_name])
     create_index(
         workflow_comment_parent_comment_index_name, workflow_comment_table_name, [parent_comment_id_column_name]
     )


### PR DESCRIPTION
This fixes a bug that prevents migrating from 23.2 to 24.0 and up in the rare case that the database was initialized by starting galaxy versioned < 24.0. The error happens when the migration script tries to create the `ix_workflow_comment_workflow_id` index, which already exists. Here, we check for the index existence before creating it.

Here's what happened. The `WorkflowComment` was added in #16612, with the index specified in the model, but not in the migration script. As a result, if galaxy was started on a blank database, the database was initialized with an index; however, if the migration was applied to an existing database (which was the typical case), the index was NOT created). 

Later, the index was explicitly added in #17700 (3 indexes were added in the migration script, but only 2 were added to the model, because one already existed). This migration worked fine for most cases, except for databases that had been initialized with galaxy version 23.2 (with the index in the model) - which broke on their migration to 24.0.

The error caused by this bug was most recently reported on Galaxy Help https://help.galaxyproject.org/t/error-when-upgrading-database/15058 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
