### PR TITLE
[24.2] Lazy-load invocation step jobs as needed

### DIFF
--- a/client/src/components/JobInformation/JobDetails.vue
+++ b/client/src/components/JobInformation/JobDetails.vue
@@ -1,6 +1,7 @@
 <template>
     <b-card>
         <JobInformation :job_id="id" :include-times="true">
+            <!-- only needed for admin job component -->
             <tr v-if="hasTraceback">
                 <td>Traceback</td>
                 <td>


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/19876

We now only load the data for the job we're looking at. This makes a huge difference for large map over steps.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
