### PR TITLE
Fix workflow license component typing

### DIFF
--- a/client/src/components/License/LicenseSelector.vue
+++ b/client/src/components/License/LicenseSelector.vue
@@ -22,11 +22,9 @@ type LicenseType = {
     name: string;
 };
 
-interface Props {
-    inputLicense: string | null;
-}
-
-const props = defineProps<Props>();
+const props = defineProps<{
+    inputLicense?: string | null;
+}>();
 
 const emit = defineEmits<{
     (e: "onLicense", license: string | null): void;
@@ -38,10 +36,7 @@ const currentLicense = ref<LicenseType>();
 const licenses = ref<LicenseMetadataModel[] | undefined>([]);
 
 const licenseOptions = computed(() => {
-    const options: LicenseType[] = [];
-
-    options.push(defaultLicense);
-
+    const options: LicenseType[] = [defaultLicense];
     for (const license of licenses.value || []) {
         if (license.licenseId == currentLicense.value?.licenseId || license.recommended) {
             options.push({
@@ -50,7 +45,6 @@ const licenseOptions = computed(() => {
             });
         }
     }
-
     return options;
 });
 
@@ -60,25 +54,19 @@ function onLicense(license: LicenseType) {
 
 async function fetchLicenses() {
     const { error, data } = await GalaxyApi().GET("/api/licenses");
-
     if (error) {
         errorMessage.value = errorMessageAsString(error) || "Unable to fetch licenses.";
     }
-
     licenses.value = data;
-
     licensesLoading.value = false;
 }
 
 async function setCurrentLicense() {
     if (!licenses.value?.length && !licensesLoading.value) {
         licensesLoading.value = true;
-
         await fetchLicenses();
     }
-
     const inputLicense = props.inputLicense;
-
     currentLicense.value = (licenses.value || []).find((l) => l.licenseId == inputLicense) || defaultLicense;
 }
 

--- a/client/src/components/License/LicenseSelector.vue
+++ b/client/src/components/License/LicenseSelector.vue
@@ -23,7 +23,7 @@ type LicenseType = {
 };
 
 interface Props {
-    inputLicense: string;
+    inputLicense: string | null;
 }
 
 const props = defineProps<Props>();


### PR DESCRIPTION
Fixes the following console error in the workflow editor:

```
index.ts:21 [Vue warn]: Invalid prop: type check failed for prop "inputLicense". Expected String, got Null 

found in

---> <LicenseSelector> at src/components/License/LicenseSelector.vue
       <ActivityPanel> at src/components/Panels/ActivityPanel.vue
         <WorkflowAttributes> at src/components/Workflow/Editor/WorkflowAttributes.vue
           <FlexPanel> at src/components/Panels/FlexPanel.vue
             <ActivityBar> at src/components/ActivityBar/ActivityBar.vue
               <Editor> at src/components/Workflow/Editor/Index.vue
                 <WorkflowEditor> at src/entry/analysis/modules/WorkflowEditor.vue
                   <App> at src/entry/analysis/App.vue
                     <Root>
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
