### PR TITLE
Implement galaxy-job-config-init.

### DIFF
--- a/lib/galaxy/config/jobs/__init__.py
+++ b/lib/galaxy/config/jobs/__init__.py
@@ -1,0 +1,15 @@
+from .generate import (
+    build_job_config,
+    summary_markdown,
+)
+from .types import (
+    CliConfigArgs,
+    ConfigArgs,
+)
+
+__all__ = (
+    "build_job_config",
+    "CliConfigArgs",
+    "ConfigArgs",
+    "summary_markdown",
+)

--- a/lib/galaxy/config/jobs/arg_parsing.py
+++ b/lib/galaxy/config/jobs/arg_parsing.py
@@ -1,0 +1,68 @@
+import argparse
+from typing import List
+
+from .types import (
+    ConfigArgs,
+    Runner,
+)
+
+DESCRIPTION = "Generate job configuration YAML."
+
+HELP_GALAXY_VERSION = "Generate job config YAML for this version of Galaxy."
+HELP_RUNNER = "Galaxy runner (e.g. DRM) to target (defaults to 'local' requiring no external resource manager)."
+HELP_TPV = "Enable shared TPV database."
+HELP_DOCKER = "Enable Docker."
+HELP_DOCKER_CMD = "Command used to launch docker (defaults to 'docker')."
+HELP_DOCKER_HOST = "Docker host."
+HELP_DOCKER_SUDO = "Use sudo with Docker."
+HELP_DOCKER_SUDO_CMD = "Docker sudo command."
+HELP_DOCKER_RUN_EXTRA_ARGUMENTS = "Extra arguments for Docker run."
+HELP_DOCKER_EXTRA_VOLUME = "Extra Docker volumes."
+HELP_SINGULARITY = "Enable Singularity."
+HELP_SINGULARITY_CMD = "Command used to execute singularity (defaults to 'singularity')."
+HELP_SINGULARITY_SUDO = "Use sudo with Singularity."
+HELP_SINGULARITY_SUDO_CMD = "Singularity sudo command."
+HELP_SINGULARITY_EXTRA_VOLUME = "Extra Singularity volumes."
+
+
+def config_args(argv: List[str]):
+    parser = argparser()
+    args = parser.parse_args(argv)
+    config_args = ConfigArgs(
+        galaxy_version=args.galaxy_version,
+        runner=Runner(args.runner) if args.runner else None,
+        tpv=args.tpv,
+        docker=args.docker,
+        docker_cmd=args.docker_cmd,
+        docker_host=args.docker_host,
+        docker_sudo=args.docker_sudo,
+        docker_sudo_cmd=args.docker_sudo_cmd,
+        docker_run_extra_arguments=args.docker_run_extra_arguments,
+        docker_extra_volume=args.docker_extra_volume,
+        singularity=args.singularity,
+        singularity_cmd=args.singularity_cmd,
+        singularity_sudo=args.singularity_sudo,
+        singularity_sudo_cmd=args.singularity_sudo_cmd,
+        singularity_extra_volume=args.singularity_extra_volume,
+    )
+    return config_args
+
+
+def argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument("--galaxy-version", type=str, help=HELP_GALAXY_VERSION)
+    parser.add_argument("--runner", type=str, choices=[e.value for e in Runner], help=HELP_RUNNER)
+    parser.add_argument("--tpv", action="store_true", help=HELP_TPV)
+    parser.add_argument("--docker", action="store_true", help=HELP_DOCKER)
+    parser.add_argument("--docker-cmd", type=str, help=HELP_DOCKER_CMD)
+    parser.add_argument("--docker-host", type=str, help=HELP_DOCKER_HOST)
+    parser.add_argument("--docker-sudo", action="store_true", help=HELP_DOCKER_SUDO)
+    parser.add_argument("--docker-sudo-cmd", type=str, help=HELP_DOCKER_SUDO_CMD)
+    parser.add_argument("--docker-run-extra-arguments", type=str, help=HELP_DOCKER_RUN_EXTRA_ARGUMENTS)
+    parser.add_argument("--docker-extra-volume", type=str, nargs="*", help=HELP_DOCKER_EXTRA_VOLUME)
+    parser.add_argument("--singularity", action="store_true", help=HELP_SINGULARITY)
+    parser.add_argument("--singularity-cmd", type=str, help=HELP_SINGULARITY_CMD)
+    parser.add_argument("--singularity-sudo", action="store_true", help=HELP_SINGULARITY_SUDO)
+    parser.add_argument("--singularity-sudo-cmd", type=str, help=HELP_SINGULARITY_SUDO_CMD)
+    parser.add_argument("--singularity-extra-volume", type=str, nargs="*", help=HELP_SINGULARITY_EXTRA_VOLUME)
+    return parser

--- a/lib/galaxy/config/jobs/generate.py
+++ b/lib/galaxy/config/jobs/generate.py
@@ -1,0 +1,460 @@
+import os
+from dataclasses import dataclass
+from textwrap import indent
+from typing import (
+    Dict,
+    Iterable,
+    List,
+    Optional,
+)
+
+import yaml
+
+from galaxy.util.container_volumes import DockerVolume
+from .arg_parsing import config_args
+from .templates import render
+from .types import (
+    ConfigArgs,
+    Runner,
+)
+
+TEMPLATE = """
+runners:
+  local:
+    load: galaxy.jobs.runners.local:LocalJobRunner
+    # modify the number of threads working on local jobs here
+    # workers: 4
+{{ additional_runners }}
+handling:
+  assign:
+    - db-skip-locked
+
+execution:
+  default: {{ default_environment }}
+  environments:{{ local_environment }}{{ additional_environments }}
+tools:
+  - class: local
+    environment: local
+"""
+
+DRMAA_RUNNER_TEMPLATE = """
+  drmaa:
+    load: galaxy.jobs.runners.drmaa:DRMAAJobRunner
+    # modify below to specify a specific drmaa shared library
+    # drmaa_library_path: /sge/lib/libdrmaa.so
+"""
+
+SLURM_RUNNER_TEMPLATE = """
+  slurm:
+    load: galaxy.jobs.runners.slurm:SlurmJobRunner
+    # modify below to specify a specific drmaa shared library for slurm
+    # drmaa_library_path: /usr/lib/slurm-drmaa/lib/libdrmaa.so.1
+"""
+
+CONDOR_RUNNER_TEMPLATE = """
+  condor:
+    load: galaxy.jobs.runners.condor:CondorJobRunner
+"""
+
+K8S_RUNNER_TEMPLATE = """
+  k8s:
+    load: galaxy.jobs.runners.kubernetes:KubernetesJobRunner
+"""
+
+DRMAA_ENVIRONMENT_TEMPLATE = """
+    drmaa:
+      runner: drmaa
+      native_specification: "" """
+
+SLURM_ENVIRONMENT_TEMPLATE = """
+    # Information on connecting Galaxy to SLURM can be found at:
+    # https://training.galaxyproject.org/training-material/topics/admin/tutorials/connect-to-compute-cluster/tutorial.html
+    slurm:
+      runner: slurm
+      native_specification: "" """
+
+CONDOR_ENVIRONMENT_TEMPLATE = """
+    condor:
+      runner: condor
+      # universe: "vanilla"
+      # Additional/override query ClassAd params can be specified here"""
+
+K8S_ENVIRONMENT_TEMPLATE = """
+    k8s:
+      runner: k8s"""
+
+
+COMMON_ENVIRONMENT_TEMPLATE = """
+{%- if docker_config.enabled %}
+docker_enabled: true
+{%- if docker_config.sudo %}
+docker_sudo: {{ docker_config.sudo }}
+docker_sudo_cmd: {{ docker_config.sudo_cmd }}
+{%- endif %}
+docker_cmd: {{ docker_config.docker_cmd }}
+{%- if docker_config.host %}
+docker_host: {{ docker_config.host }}
+{%- endif %}
+docker_volumes: {{ docker_config.volumes }}
+{%- if docker_config.run_extra_arguments %}
+docker_run_extra_arguments: {{ docker_config.run_extra_arguments }}
+{%- endif %}
+{%- endif -%}
+{%- if singularity_config.enabled %}
+singularity_enabled: true
+{%- if singularity_config.sudo %}
+singularity_sudo: {{ singularity_config.sudo }}
+singularity_sudo_cmd: {{ singularity_config.sudo_cmd }}
+{%- endif %}
+singularity_cmd: {{ singularity_config.singularity_cmd }}
+singularity_volumes: {{ singularity_config.volumes }}
+## May need to setup addition environment variables to get singularity working based on examples @
+## https://training.galaxyproject.org/training-material/topics/admin/tutorials/connect-to-compute-cluster/tutorial.html
+# env:
+# - name: LC_ALL
+#   value: C
+# - name: APPTAINER_CACHEDIR
+#   value: /tmp/singularity
+# - name: APPTAINER_TMPDIR
+#   value: /tmp
+{%- endif -%}"""
+
+
+TPV_ENVIRONMENT_24_2_TEMPLATE = """
+    # Information on configuring TPV and leveraging the shared TPV Galaxy database for tools can be found at @
+    # https://training.galaxyproject.org/training-material/topics/admin/tutorials/job-destinations/tutorial.html
+    tpv:
+      runner: dynamic
+      type: python
+      function: map_tool_to_destination
+      rules_module: tpv.rules
+      tpv_config_files:
+      - https://gxy.io/tpv/db.yml
+      - {{ cwd }}/tpv.yml  # TODO: create this file and setup a TPV destination
+##  tpv.yml should contain something like:
+# global:
+#   default_inherits: default
+# destinations:
+"""
+
+TPV_ENVIRONMENT_25_0_TEMPLATE = """
+    # Information on configuring TPV and leveraging the shared TPV Galaxy database for tools can be found at @
+    # https://training.galaxyproject.org/training-material/topics/admin/tutorials/job-destinations/tutorial.html
+    tpv:
+      runner: dynamic_tpv
+      tpv_configs:
+      - https://gxy.io/tpv/db.yml
+      - destinations:"""
+
+TPV_DESTINATION_SLURM = """
+tpvdb_slurm:"""
+
+TPV_DESTINATION_LOCAL = """
+tpvdb_local:"""
+
+TPV_DESTINATION_K8S = """
+tpvdb_k8s:
+  runner: k8s"""
+
+TPV_DESTINATION_DRMAA = """
+tpvdb_drmaa:
+  runner: drmaa
+  params:
+    # adapt {cores} and {mem} to your DRM here - likely using native_specification
+    native_specification: ""
+"""
+
+TPV_DESTINATION_CONDOR = """
+tpvdb_condor:
+  runner: condor
+  params:
+    request_cpus: "{cores}"
+    # universe: "vanilla"
+    # Additional/override query ClassAd params can be specified here
+"""
+
+
+# class that lets Planemo computed stuff be taken into account when deciding how containers
+# are mounted (ensuring test data and tools are in the final containers tools run in).
+@dataclass
+class DevelopmentContext:
+    test_data_dir: Optional[str]
+    all_tool_paths: List[str]
+
+
+@dataclass
+class DockerConfig:
+    enabled: bool
+    host: Optional[str]
+    volumes: str
+    sudo: bool
+    sudo_cmd: str
+    docker_cmd: str
+    run_extra_arguments: str
+
+
+@dataclass
+class SingularityConfig:
+    enabled: bool
+    volumes: str
+    sudo: bool
+    sudo_cmd: str
+    singularity_cmd: str
+
+
+def to_docker_config(dev_context: DevelopmentContext, config: ConfigArgs) -> DockerConfig:
+    enabled = bool(config.docker)
+    host = config.docker_host
+    sudo = config.docker_sudo or False
+    sudo_cmd = str(config.docker_sudo_cmd or "sudo")
+    docker_cmd = str(config.docker_cmd or "docker")
+    run_extra_arguments = str(config.docker_run_extra_arguments or "")
+
+    volumes = list(config.docker_extra_volume or [])
+    if dev_context.test_data_dir:
+        volumes.append(f"{dev_context.test_data_dir}:ro")
+
+    docker_volumes_str = "$defaults"
+    if volumes:
+        # exclude tool directories, these are mounted :ro by $defaults
+        all_tool_dirs = {os.path.dirname(tool_path) for tool_path in dev_context.all_tool_paths}
+        extra_volumes_str = ",".join(str(v) for v in create_docker_volumes(volumes) if v.path not in all_tool_dirs)
+        docker_volumes_str = f"{docker_volumes_str},{extra_volumes_str}"
+
+    return DockerConfig(
+        enabled=enabled,
+        host=host,
+        volumes=docker_volumes_str,
+        sudo=sudo,
+        sudo_cmd=sudo_cmd,
+        docker_cmd=docker_cmd,
+        run_extra_arguments=run_extra_arguments,
+    )
+
+
+def to_singularity_config(dev_context: DevelopmentContext, config: ConfigArgs) -> SingularityConfig:
+    enabled = bool(config.singularity)
+    sudo = config.singularity_sudo or False
+    sudo_cmd = str(config.singularity_sudo_cmd or "sudo")
+    singularity_cmd = str(config.singularity_cmd or "singularity")
+
+    volumes = list(config.singularity_extra_volume or [])
+    if dev_context.test_data_dir:
+        volumes.append(f"{dev_context.test_data_dir}:ro")
+
+    singularity_volumes_str = "$defaults"
+    if volumes:
+        # exclude tool directories, these are mounted :ro by $defaults
+        all_tool_dirs = {os.path.dirname(tool_path) for tool_path in dev_context.all_tool_paths}
+        extra_volumes_str = ",".join(str(v) for v in create_docker_volumes(volumes) if v.path not in all_tool_dirs)
+        singularity_volumes_str = f"{singularity_volumes_str},{extra_volumes_str}"
+
+    return SingularityConfig(
+        enabled=enabled,
+        sudo=sudo,
+        sudo_cmd=sudo_cmd,
+        volumes=singularity_volumes_str,
+        singularity_cmd=singularity_cmd,
+    )
+
+
+def build_job_config(
+    config: ConfigArgs,
+    dev_context: Optional[DevelopmentContext] = None,
+) -> str:
+    dev_context = dev_context or DevelopmentContext(None, [])
+    runner = config.runner
+    tpv = config.tpv
+    galaxy_version = config.galaxy_version or "25.0"
+    docker_config = to_docker_config(dev_context, config)
+    singularity_config = to_singularity_config(dev_context, config)
+    environment_docker_stuff = render(
+        COMMON_ENVIRONMENT_TEMPLATE,
+        docker_config=docker_config,
+        singularity_config=singularity_config,
+    )
+    additional_runners = ""
+    additional_environments = ""
+    default_environment = "local"
+    local_environment = f"""
+    local:
+      runner: local{ indent(environment_docker_stuff, " " * 6) }
+"""
+    tpv_runner_destination_template = TPV_DESTINATION_LOCAL
+    if runner == Runner.SLURM:
+        additional_runners += SLURM_RUNNER_TEMPLATE
+        default_environment = "slurm"
+        additional_environments += SLURM_ENVIRONMENT_TEMPLATE + indent(environment_docker_stuff, " " * 6)
+        tpv_runner_destination_template = TPV_DESTINATION_SLURM
+    elif runner == Runner.K8S:
+        additional_runners += K8S_RUNNER_TEMPLATE
+        additional_environments += K8S_ENVIRONMENT_TEMPLATE + indent(environment_docker_stuff, " " * 6)
+        default_environment = "k8s"
+        tpv_runner_destination_template = TPV_DESTINATION_K8S
+    elif runner == Runner.DRMAA:
+        additional_runners += DRMAA_RUNNER_TEMPLATE
+        additional_environments += DRMAA_ENVIRONMENT_TEMPLATE + indent(environment_docker_stuff, " " * 6)
+        default_environment = "drmaa"
+        tpv_runner_destination_template = TPV_DESTINATION_DRMAA
+    elif runner == Runner.CONDOR:
+        additional_runners += CONDOR_RUNNER_TEMPLATE
+        additional_environments += CONDOR_ENVIRONMENT_TEMPLATE + indent(environment_docker_stuff, " " * 6)
+        default_environment = "condor"
+        tpv_runner_destination_template = TPV_DESTINATION_CONDOR
+
+    if config.tpv:
+        if galaxy_version < "25.0":
+            tpv_environment = render(TPV_ENVIRONMENT_24_2_TEMPLATE, cwd=os.getcwd())
+            if not environment_docker_stuff and tpv_runner_destination_template.endswith(":"):
+                environment_extras = " {}"
+            else:
+                environment_extras = indent(environment_docker_stuff, "#     ")
+
+            tpv_environment += indent(tpv_runner_destination_template, "#   ") + environment_extras
+        else:
+            if not environment_docker_stuff and tpv_runner_destination_template.endswith(":"):
+                environment_extras = " {}"
+            else:
+                environment_extras = indent(environment_docker_stuff, " " * 12)
+            tpv_environment = (
+                TPV_ENVIRONMENT_25_0_TEMPLATE + indent(tpv_runner_destination_template, " " * 10) + environment_extras
+            )
+        if additional_environments:
+            additional_environments += "\n"
+        additional_environments += tpv_environment
+
+    if tpv:
+        default_environment = "tpv"
+
+    config_str = render(
+        TEMPLATE,
+        additional_runners=additional_runners,
+        additional_environments=additional_environments,
+        local_environment=local_environment,
+        default_environment=default_environment,
+    )
+    yaml.safe_load(config_str)  # try loading it just to assure we're building valid YAML
+    return config_str
+
+
+def create_docker_volumes(paths: Iterable[str]) -> Iterable[DockerVolume]:
+    """
+    Creates string of the format "host_path:target_path:mode" and deduplicates overlapping mounts.
+    """
+    docker_volumes: Dict[str, DockerVolume] = {}
+    for path in paths:
+        docker_volume = DockerVolume.from_str(path)
+        if docker_volume.path in docker_volumes:
+            # volume has been specified already, make sure we use "rw" if any of the modes are "rw"
+            if docker_volume.mode == "rw" or docker_volumes[docker_volume.path].mode == "rw":
+                docker_volumes[docker_volume.path].mode = "rw"
+        else:
+            docker_volumes[docker_volume.path] = docker_volume
+    return docker_volumes.values()
+
+
+def summarize(cli: str):
+    planemo_cli = cli.replace("--", "DOUBLE_DASH").replace("-", "_").replace("DOUBLE_DASH", "--")
+    as_argv = [x for x in cli.split() if x]
+    config = config_args(as_argv)
+    return f"""
+
+```
+galaxy-job-config-init {cli}
+```
+
+-or-
+
+```
+planemo job_config_init {planemo_cli}
+```
+
+generate the follow job configuration YAML file:
+
+```yaml{ build_job_config(config) }
+```
+"""
+
+
+def summary_markdown():
+    extra = ""
+    markdown = f"""# Job Configuration Examples
+
+This page provides examples of Galaxy job configuration files generated by the `galaxy-job-config-init` command.
+
+## Without Shared TPV Database ()
+
+### Local Runner and No Containers
+
+{ summarize(f" {extra}") }
+
+### Local Runner and Docker
+
+{ summarize(f"--docker {extra}") }
+
+### Local Runner and Singularity
+
+{ summarize(f"--singularity {extra}") }
+
+### SLURM Runner and No Containers
+
+{ summarize(f"--runner slurm {extra}") }
+
+### DRMAA Runner and No Containers
+
+{ summarize(f"--runner drmaa {extra}") }
+
+### Condor Runner and No Containers
+
+{ summarize(f"--runner condor {extra}") }
+
+### K8S Runner and Docker
+
+{ summarize(f"--runner k8s --docker {extra}") }
+
+### SLURM Runner and Singularity
+
+{ summarize(f"--runner slurm {extra} --singularity") }
+
+## With TPV in 25.0+
+
+### Local Runner and No Containers
+
+{ summarize(f"--tpv {extra}") }
+
+### Local Runner and Docker
+
+{ summarize(f"--docker --tpv {extra}") }
+
+### Local Runner and Singularity
+
+{ summarize(f"--singularity --tpv {extra}") }
+
+### SLURM Runner and No Containers
+
+{ summarize(f"--runner slurm --tpv {extra}") }
+
+### DRMAA Runner and No Containers
+
+{ summarize(f"--runner drmaa --tpv {extra}") }
+
+### Condor Runner and No Containers
+
+{ summarize(f"--runner condor --tpv {extra}") }
+
+### K8S Runner and Docker
+
+{ summarize(f"--runner k8s --docker --tpv {extra}") }
+
+## With Legacy TPV in 24.2
+
+### Local Runner and No Containers
+
+{ summarize(f"--tpv --galaxy-version 24.2 {extra}") }
+
+### SLURM Runner and Singularity
+
+{ summarize(f"--runner slurm --tpv --singularity  --galaxy-version 24.2 {extra}") }
+
+"""
+    return markdown

--- a/lib/galaxy/config/jobs/script.py
+++ b/lib/galaxy/config/jobs/script.py
@@ -1,0 +1,14 @@
+import sys
+
+from .arg_parsing import config_args
+from .generate import build_job_config
+
+
+def main(argv=None):
+    argv = argv or sys.argv[1:]
+    config_str = build_job_config(config_args(argv))
+    print(config_str)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/galaxy/config/jobs/script_summary.py
+++ b/lib/galaxy/config/jobs/script_summary.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+# how to use this from Galaxy root & venv
+# PYTHONPATH=lib python lib/galaxy/config/jobs/script_summary.py
+import argparse
+
+from galaxy.config.jobs.generate import summary_markdown
+
+DESCRIPTION = """Generate summary of galaxy-job-config-init example outputs.
+
+These will be generated in markdown format along with the CLI that would generate
+them. It would be pretty impossible to test all possible combination but this script
+can be used to visually inspect possible generated configurations for manual review.
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.parse_args()
+
+    markdown_output = summary_markdown()
+    print(markdown_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/galaxy/config/jobs/templates.py
+++ b/lib/galaxy/config/jobs/templates.py
@@ -1,0 +1,10 @@
+"""Templating abstraction around jinja2 for galaxy.config.jobs."""
+
+from jinja2 import Template
+
+
+def render(template_str: str, **kwds):
+    """Use jinja2 to render specified template."""
+    template = Template(template_str)
+    contents = template.render(**kwds)
+    return contents

--- a/lib/galaxy/config/jobs/types.py
+++ b/lib/galaxy/config/jobs/types.py
@@ -1,0 +1,77 @@
+import enum
+from dataclasses import dataclass
+from typing import (
+    List,
+    Optional,
+)
+
+from typing_extensions import (
+    NotRequired,
+    TypedDict,
+    Unpack,
+)
+
+
+class Runner(enum.StrEnum):
+    LOCAL = "local"
+    SLURM = "slurm"
+    DRMAA = "drmaa"
+    K8S = "k8s"
+    CONDOR = "condor"
+
+
+class CliConfigArgs(TypedDict, total=False):
+    galaxy_version: NotRequired[Optional[str]]
+    runner: NotRequired[Optional[Runner]]
+    tpv: NotRequired[bool]
+    docker: NotRequired[Optional[bool]]
+    docker_cmd: NotRequired[Optional[str]]
+    docker_host: NotRequired[Optional[str]]
+    docker_sudo: NotRequired[Optional[bool]]
+    docker_sudo_cmd: NotRequired[Optional[str]]
+    docker_run_extra_arguments: NotRequired[Optional[str]]
+    docker_extra_volume: NotRequired[Optional[List[str]]]
+    singularity: NotRequired[Optional[bool]]
+    singularity_cmd: NotRequired[Optional[str]]
+    singularity_sudo: NotRequired[Optional[bool]]
+    singularity_sudo_cmd: NotRequired[Optional[str]]
+    singularity_extra_volume: NotRequired[Optional[List[str]]]
+
+
+@dataclass
+class ConfigArgs:
+    galaxy_version: Optional[str] = None
+    runner: Optional[Runner] = None
+    tpv: Optional[bool] = None
+    docker: Optional[bool] = None
+    docker_cmd: Optional[str] = None
+    docker_host: Optional[str] = None
+    docker_sudo: Optional[bool] = None
+    docker_sudo_cmd: Optional[str] = None
+    docker_run_extra_arguments: Optional[str] = None
+    docker_extra_volume: Optional[List[str]] = None
+    singularity: Optional[bool] = None
+    singularity_cmd: Optional[str] = None
+    singularity_sudo: Optional[bool] = None
+    singularity_sudo_cmd: Optional[str] = None
+    singularity_extra_volume: Optional[List[str]] = None
+
+    @staticmethod
+    def from_dict(**data: Unpack[CliConfigArgs]) -> "ConfigArgs":
+        return ConfigArgs(
+            runner=data.get("runner", Runner.LOCAL),
+            tpv=data.get("tpv", None),
+            galaxy_version=data.get("galaxy_version", None),
+            docker=data.get("docker", None),
+            docker_cmd=data.get("docker_cmd", None),
+            docker_host=data.get("docker_host", None),
+            docker_sudo=data.get("docker_sudo", None),
+            docker_sudo_cmd=data.get("docker_sudo_cmd", None),
+            docker_run_extra_arguments=data.get("docker_run_extra_arguments", None),
+            docker_extra_volume=data.get("docker_extra_volume", None),
+            singularity=data.get("singularity", None),
+            singularity_cmd=data.get("singularity_cmd", None),
+            singularity_sudo=data.get("singularity_sudo", None),
+            singularity_sudo_cmd=data.get("singularity_sudo_cmd", None),
+            singularity_extra_volume=data.get("singularity_extra_volume", []),
+        )

--- a/lib/galaxy/tool_util/deps/container_volumes.py
+++ b/lib/galaxy/tool_util/deps/container_volumes.py
@@ -1,70 +1,11 @@
-import shlex
-from abc import (
-    ABCMeta,
-    abstractmethod,
+"""Shadow galaxy.util.container_volumes for backward compatibility."""
+
+from galaxy.util.container_volumes import (
+    ContainerVolume,
+    DockerVolume,
 )
-from typing import Optional
 
-
-class ContainerVolume(metaclass=ABCMeta):
-    valid_modes = frozenset({"ro", "rw", "z", "Z"})
-
-    def __init__(self, path: str, host_path: Optional[str] = None, mode: Optional[str] = None):
-        self.path = path
-        self.host_path = host_path
-        self.mode = mode
-        if mode and not self.mode_is_valid:
-            raise ValueError(f"Invalid container volume mode: {mode}")
-
-    @abstractmethod
-    def from_str(cls, as_str: str) -> "ContainerVolume":
-        """Classmethod to convert from this container type's string representation.
-
-        :param  as_str: string representation of volume
-        :type   as_str: str
-        """
-
-    @abstractmethod
-    def __str__(self) -> str:
-        """Return this container type's string representation of the volume."""
-
-    @property
-    def mode_is_valid(self) -> bool:
-        return self.mode in self.valid_modes
-
-
-class DockerVolume(ContainerVolume):
-    @classmethod
-    def from_str(cls, as_str: str) -> "DockerVolume":
-        """Construct an instance from a string as would be passed to `docker run --volume`.
-
-        A string in the format ``<host_path>:<mode>`` is supported for legacy purposes even though it is not valid
-        Docker volume syntax.
-        """
-        if not as_str:
-            raise ValueError(f"Failed to parse Docker volume from {as_str}")
-        parts = as_str.split(":", 2)
-        kwds = dict(host_path=parts[0])
-        if len(parts) == 1:
-            # auto-generated volume
-            kwds["path"] = kwds["host_path"]
-        elif len(parts) == 2:
-            # /host_path:mode is not (or is no longer?) valid Docker volume syntax
-            if all(mode_part in DockerVolume.valid_modes for mode_part in parts[1].split(",")):
-                kwds["mode"] = parts[1]
-                kwds["path"] = kwds["host_path"]
-            else:
-                kwds["path"] = parts[1]
-        elif len(parts) == 3:
-            kwds["path"] = parts[1]
-            kwds["mode"] = parts[2]
-        return cls(**kwds)
-
-    def __str__(self) -> str:
-        volume_str = ":".join(x for x in (self.host_path, self.path, self.mode) if x is not None)
-        if "$" not in volume_str:
-            volume_for_cmd_line = shlex.quote(volume_str)
-        else:
-            # e.g. $_GALAXY_JOB_TMP_DIR:$_GALAXY_JOB_TMP_DIR:rw so don't single quote.
-            volume_for_cmd_line = f'"{volume_str}"'
-        return volume_for_cmd_line
+__all__ = (
+    "ContainerVolume",
+    "DockerVolume",
+)

--- a/lib/galaxy/util/container_volumes.py
+++ b/lib/galaxy/util/container_volumes.py
@@ -1,0 +1,70 @@
+import shlex
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
+from typing import Optional
+
+
+class ContainerVolume(metaclass=ABCMeta):
+    valid_modes = frozenset({"ro", "rw", "z", "Z"})
+
+    def __init__(self, path: str, host_path: Optional[str] = None, mode: Optional[str] = None):
+        self.path = path
+        self.host_path = host_path
+        self.mode = mode
+        if mode and not self.mode_is_valid:
+            raise ValueError(f"Invalid container volume mode: {mode}")
+
+    @abstractmethod
+    def from_str(cls, as_str: str) -> "ContainerVolume":
+        """Classmethod to convert from this container type's string representation.
+
+        :param  as_str: string representation of volume
+        :type   as_str: str
+        """
+
+    @abstractmethod
+    def __str__(self) -> str:
+        """Return this container type's string representation of the volume."""
+
+    @property
+    def mode_is_valid(self) -> bool:
+        return self.mode in self.valid_modes
+
+
+class DockerVolume(ContainerVolume):
+    @classmethod
+    def from_str(cls, as_str: str) -> "DockerVolume":
+        """Construct an instance from a string as would be passed to `docker run --volume`.
+
+        A string in the format ``<host_path>:<mode>`` is supported for legacy purposes even though it is not valid
+        Docker volume syntax.
+        """
+        if not as_str:
+            raise ValueError(f"Failed to parse Docker volume from {as_str}")
+        parts = as_str.split(":", 2)
+        kwds = dict(host_path=parts[0])
+        if len(parts) == 1:
+            # auto-generated volume
+            kwds["path"] = kwds["host_path"]
+        elif len(parts) == 2:
+            # /host_path:mode is not (or is no longer?) valid Docker volume syntax
+            if all(mode_part in DockerVolume.valid_modes for mode_part in parts[1].split(",")):
+                kwds["mode"] = parts[1]
+                kwds["path"] = kwds["host_path"]
+            else:
+                kwds["path"] = parts[1]
+        elif len(parts) == 3:
+            kwds["path"] = parts[1]
+            kwds["mode"] = parts[2]
+        return cls(**kwds)
+
+    def __str__(self) -> str:
+        volume_str = ":".join(x for x in (self.host_path, self.path, self.mode) if x is not None)
+        if "$" not in volume_str:
+            volume_for_cmd_line = shlex.quote(volume_str)
+        else:
+            # e.g. $_GALAXY_JOB_TMP_DIR:$_GALAXY_JOB_TMP_DIR:rw so don't single quote.
+            volume_for_cmd_line = f'"{volume_str}"'
+        return volume_for_cmd_line

--- a/packages/config/setup.cfg
+++ b/packages/config/setup.cfg
@@ -43,6 +43,8 @@ python_requires = >=3.9
 [options.entry_points]
 console_scripts =
         galaxy-config = galaxy.config.script:main
+        galaxy-job-config-init-summary = galaxy.config.jobs.script_summary:main
+        galaxy-job-config-init = galaxy.config.jobs.script:main
 
 [options.packages.find]
 exclude =

--- a/test/unit/config/test_job_config.py
+++ b/test/unit/config/test_job_config.py
@@ -1,0 +1,111 @@
+import yaml
+from typing_extensions import Unpack
+
+from galaxy.config.jobs import (
+    build_job_config,
+    CliConfigArgs,
+    ConfigArgs,
+    summary_markdown,
+)
+from galaxy.config.jobs.types import Runner
+
+
+def test_build_job_config_slurm():
+    config_dict = build_to_yaml(runner=Runner.SLURM)
+    slurm_env = config_dict["execution"]["environments"]["slurm"]
+    assert slurm_env
+    assert slurm_env["runner"] == "slurm"
+    assert "docker_enabled" not in slurm_env
+
+
+def test_build_job_config_slurm_with_docker():
+    config_dict = build_to_yaml(runner=Runner.SLURM, docker=True)
+    slurm_env = config_dict["execution"]["environments"]["slurm"]
+    assert slurm_env
+    assert slurm_env["runner"] == "slurm"
+    assert slurm_env["docker_enabled"] is True
+    assert "docker_sudo" not in slurm_env
+
+
+def test_build_job_config_slurm_with_docker_and_sudo():
+    config_dict = build_to_yaml(runner=Runner.SLURM, docker=True, docker_sudo=True)
+    slurm_env = config_dict["execution"]["environments"]["slurm"]
+    assert config_dict["execution"]["default"] == "slurm"
+    assert slurm_env
+    assert slurm_env["runner"] == "slurm"
+    assert slurm_env["docker_enabled"] is True
+    assert slurm_env["docker_sudo"] is True
+
+
+def test_build_job_config_slurm_with_singularity():
+    config_dict = build_to_yaml(runner=Runner.SLURM, singularity=True)
+    slurm_env = config_dict["execution"]["environments"]["slurm"]
+    assert slurm_env
+    assert slurm_env["runner"] == "slurm"
+    assert slurm_env["singularity_enabled"] is True
+    assert "docker_sudo" not in slurm_env
+
+
+def test_build_job_config_slurm_with_singularity_and_sudo():
+    config_dict = build_to_yaml(runner=Runner.SLURM, singularity=True, singularity_sudo=True)
+    slurm_env = config_dict["execution"]["environments"]["slurm"]
+    assert slurm_env
+    assert slurm_env["runner"] == "slurm"
+    assert slurm_env["singularity_enabled"] is True
+    assert slurm_env["singularity_sudo"] is True
+
+
+def test_build_job_config_drmaa():
+    config_dict = build_to_yaml(runner=Runner.DRMAA)
+    drmaa_env = config_dict["execution"]["environments"]["drmaa"]
+    assert config_dict["execution"]["default"] == "drmaa"
+    assert drmaa_env
+    assert drmaa_env["runner"] == "drmaa"
+
+
+def test_build_job_config_k8s():
+    config_dict = build_to_yaml(runner=Runner.K8S)
+    k8s_env = config_dict["execution"]["environments"]["k8s"]
+    assert config_dict["execution"]["default"] == "k8s"
+    assert k8s_env
+    assert k8s_env["runner"] == "k8s"
+
+
+def test_build_job_config_condor():
+    config_dict = build_to_yaml(runner=Runner.CONDOR)
+    condor_env = config_dict["execution"]["environments"]["condor"]
+    assert config_dict["execution"]["default"] == "condor"
+    assert condor_env
+    assert condor_env["runner"] == "condor"
+
+
+def test_build_job_config_slurm_tpv():
+    config_dict = build_to_yaml(runner=Runner.SLURM, tpv=True, galaxy_version="25.0")
+    slurm_env = config_dict["execution"]["environments"]["slurm"]
+    assert slurm_env
+    assert slurm_env["runner"] == "slurm"
+    assert "docker_enabled" not in slurm_env
+
+    tpv_env = config_dict["execution"]["environments"]["tpv"]
+    assert tpv_env["runner"] == "dynamic_tpv"
+
+
+def test_build_job_config_slurm_tpv_legacy():
+    config_dict = build_to_yaml(runner=Runner.SLURM, tpv=True, galaxy_version="24.2")
+    slurm_env = config_dict["execution"]["environments"]["slurm"]
+    assert slurm_env
+    assert slurm_env["runner"] == "slurm"
+    assert "docker_enabled" not in slurm_env
+
+    tpv_env = config_dict["execution"]["environments"]["tpv"]
+    assert tpv_env["runner"] == "dynamic"
+
+
+def test_summary():
+    print(summary_markdown())
+
+
+def build_to_yaml(**kwds: Unpack[CliConfigArgs]):
+    config = ConfigArgs.from_dict(**kwds)
+    job_config = build_job_config(config)
+    return yaml.safe_load(job_config)


### PR DESCRIPTION
This is a script I want to use in Planemo to rapidly build a functional, production job_conf.yml from command-line arguments (a generalization and modernization of https://github.com/galaxyproject/planemo/blob/master/planemo/galaxy/config.py#L1372).  I want to get it as robust as I can without tweaks so it can be used directly from "planemo run workflow.ga" in many scenarios for production workflow runs.

That is optimistic, so I will also implement a "planemo job_config_init" command to create a file for a workflow project or "Planemo profile" that can be edited by the user and picked up in subsequent workflow runs. But for ``pip install galaxy``, I've included ``galaxy-job-config-init`` as a script here that can be used admins to rapidly prototype job configs using the same code.

It is intractable to test all of these job configurations - so I've implemented the ability to quickly review a bunch of expected common invocations. I've included the resulting Markdown below. I haven't configured a Galaxy to talk to a cluster since before containers existed and before the job conf had even an XML configuration - so I'd love a review and advice from actual admins.

# Job Configuration Examples

This page provides examples of Galaxy job configuration files generated by the `galaxy-job-config-init` command. 

## Without Shared TPV Database ()

### Local Runner and No Containers



```
galaxy-job-config-init  
```

-or-

```
planemo job_config_init  
```

generate the follow job configuration YAML file:

```yaml
runners:
  local:
    load: galaxy.jobs.runners.local:LocalJobRunner
    # modify the number of threads working on local jobs here
    # workers: 4

handling:
  assign:
    - db-skip-locked

execution:
  default: local
  environments:
    local:
      runner: local

tools:
  - class: local
    environment: local
```


### Local Runner and Docker



```
galaxy-job-config-init --docker 
```

-or-

```
planemo job_config_init --docker 
```

generate the follow job configuration YAML file:

```yaml
runners:
  local:
    load: galaxy.jobs.runners.local:LocalJobRunner
    # modify the number of threads working on local jobs here
    # workers: 4

handling:
  assign:
    - db-skip-locked

execution:
  default: local
  environments:
    local:
      runner: local
      docker_enabled: true
      docker_cmd: docker
      docker_volumes: $defaults

tools:
  - class: local
    environment: local
```


### Local Runner and Singularity



```
galaxy-job-config-init --singularity 
```

-or-

```
planemo job_config_init --singularity 
```

generate the follow job configuration YAML file:

```yaml
runners:
  local:
    load: galaxy.jobs.runners.local:LocalJobRunner
    # modify the number of threads working on local jobs here
    # workers: 4

handling:
  assign:
    - db-skip-locked

execution:
  default: local
  environments:
    local:
      runner: local
      singularity_enabled: true
      singularity_cmd: singularity
      singularity_volumes: $defaults
      ## May need to setup addition environment variables to get singularity working based on examples @
      ## https://training.galaxyproject.org/training-material/topics/admin/tutorials/connect-to-compute-cluster/tutorial.html
      # env:
      # - name: LC_ALL
      #   value: C
      # - name: APPTAINER_CACHEDIR
      #   value: /tmp/singularity
      # - name: APPTAINER_TMPDIR
      #   value: /tmp

tools:
  - class: local
    environment: local
```


### SLURM Runner and No Containers



```
galaxy-job-config-init --runner slurm 
```

-or-

```
planemo job_config_init --runner slurm 
```

generate the follow job configuration YAML file:

```yaml
runners:
  local:
    load: galaxy.jobs.runners.local:LocalJobRunner
    # modify the number of threads working on local jobs here
    # workers: 4

  slurm:
    load: galaxy.jobs.runners.slurm:SlurmJobRunner
    # modify below to specify a specific drmaa shared library for slurm
    # drmaa_library_path: /usr/lib/slurm-drmaa/lib/libdrmaa.so.1

handling:
  assign:
    - db-skip-locked

execution:
  default: slurm
  environments:
    local:
      runner: local

    # Information on connecting Galaxy to SLURM can be found at:
    # https://training.galaxyproject.org/training-material/topics/admin/tutorials/connect-to-compute-cluster/tutorial.html
    slurm:
      runner: slurm
      native_specification: "" 
tools:
  - class: local
    environment: local
```


### DRMAA Runner and No Containers



```
galaxy-job-config-init --runner drmaa 
```

-or-

```
planemo job_config_init --runner drmaa 
```

generate the follow job configuration YAML file:

```yaml
runners:
  local:
    load: galaxy.jobs.runners.local:LocalJobRunner
    # modify the number of threads working on local jobs here
    # workers: 4

  drmaa:
    load: galaxy.jobs.runners.drmaa:DRMAAJobRunner
    # modify below to specify a specific drmaa shared library
    # drmaa_library_path: /sge/lib/libdrmaa.so

handling:
  assign:
    - db-skip-locked

execution:
  default: drmaa
  environments:
    local:
      runner: local

    drmaa:
      runner: drmaa
      native_specification: "" 
tools:
  - class: local
    environment: local
```


### Condor Runner and No Containers



```
galaxy-job-config-init --runner condor 
```

-or-

```
planemo job_config_init --runner condor 
```

generate the follow job configuration YAML file:

```yaml
runners:
  local:
    load: galaxy.jobs.runners.local:LocalJobRunner
    # modify the number of threads working on local jobs here
    # workers: 4

  condor:
    load: galaxy.jobs.runners.condor:CondorJobRunner

handling:
  assign:
    - db-skip-locked

execution:
  default: condor
  environments:
    local:
      runner: local

    condor:
      runner: condor
      # universe: "vanilla"
      # Additional/override query ClassAd params can be specified here
tools:
  - class: local
    environment: local
```


### K8S Runner and Docker



```
galaxy-job-config-init --runner k8s --docker 
```

-or-

```
planemo job_config_init --runner k8s --docker 
```

generate the follow job configuration YAML file:

```yaml
runners:
  local:
    load: galaxy.jobs.runners.local:LocalJobRunner
    # modify the number of threads working on local jobs here
    # workers: 4

  k8s:
    load: galaxy.jobs.runners.kubernetes:KubernetesJobRunner

handling:
  assign:
    - db-skip-locked

execution:
  default: k8s
  environments:
    local:
      runner: local
      docker_enabled: true
      docker_cmd: docker
      docker_volumes: $defaults

    k8s:
      runner: k8s
      docker_enabled: true
      docker_cmd: docker
      docker_volumes: $defaults
tools:
  - class: local
    environment: local
```


### SLURM Runner and Singularity



```
galaxy-job-config-init --runner slurm  --singularity
```

-or-

```
planemo job_config_init --runner slurm  --singularity
```

generate the follow job configuration YAML file:

```yaml
runners:
  local:
    load: galaxy.jobs.runners.local:LocalJobRunner
    # modify the number of threads working on local jobs here
    # workers: 4

  slurm:
    load: galaxy.jobs.runners.slurm:SlurmJobRunner
    # modify below to specify a specific drmaa shared library for slurm
    # drmaa_library_path: /usr/lib/slurm-drmaa/lib/libdrmaa.so.1

handling:
  assign:
    - db-skip-locked

execution:
  default: slurm
  environments:
    local:
      runner: local
      singularity_enabled: true
      singularity_cmd: singularity
      singularity_volumes: $defaults
      ## May need to setup addition environment variables to get singularity working based on examples @
      ## https://training.galaxyproject.org/training-material/topics/admin/tutorials/connect-to-compute-cluster/tutorial.html
      # env:
      # - name: LC_ALL
      #   value: C
      # - name: APPTAINER_CACHEDIR
      #   value: /tmp/singularity
      # - name: APPTAINER_TMPDIR
      #   value: /tmp

    # Information on connecting Galaxy to SLURM can be found at:
    # https://training.galaxyproject.org/training-material/topics/admin/tutorials/connect-to-compute-cluster/tutorial.html
    slurm:
      runner: slurm
      native_specification: "" 
      singularity_enabled: true
      singularity_cmd: singularity
      singularity_volumes: $defaults
      ## May need to setup addition environment variables to get singularity working based on examples @
      ## https://training.galaxyproject.org/training-material/topics/admin/tutorials/connect-to-compute-cluster/tutorial.html
      # env:
      # - name: LC_ALL
      #   value: C
      # - name: APPTAINER_CACHEDIR
      #   value: /tmp/singularity
      # - name: APPTAINER_TMPDIR
      #   value: /tmp
tools:
  - class: local
    environment: local
```


## With TPV in 25.0+

### Local Runner and No Containers



```
galaxy-job-config-init --tpv 
```

-or-

```
planemo job_config_init --tpv 
```

generate the follow job configuration YAML file:

```yaml
runners:
  local:
    load: galaxy.jobs.runners.local:LocalJobRunner
    # modify the number of threads working on local jobs here
    # workers: 4

handling:
  assign:
    - db-skip-locked

execution:
  default: tpv
  environments:
    local:
      runner: local

    # Information on configuring TPV and leveraging the shared TPV Galaxy database for tools can be found at @
    # https://training.galaxyproject.org/training-material/topics/admin/tutorials/job-destinations/tutorial.html
    tpv:
      runner: dynamic_tpv
      tpv_configs:
      - https://gxy.io/tpv/db.yml
      - destinations:
          tpvdb_local: {}
tools:
  - class: local
    environment: local
```


### Local Runner and Docker



```
galaxy-job-config-init --docker --tpv 
```

-or-

```
planemo job_config_init --docker --tpv 
```

generate the follow job configuration YAML file:

```yaml
runners:
  local:
    load: galaxy.jobs.runners.local:LocalJobRunner
    # modify the number of threads working on local jobs here
    # workers: 4

handling:
  assign:
    - db-skip-locked

execution:
  default: tpv
  environments:
    local:
      runner: local
      docker_enabled: true
      docker_cmd: docker
      docker_volumes: $defaults

    # Information on configuring TPV and leveraging the shared TPV Galaxy database for tools can be found at @
    # https://training.galaxyproject.org/training-material/topics/admin/tutorials/job-destinations/tutorial.html
    tpv:
      runner: dynamic_tpv
      tpv_configs:
      - https://gxy.io/tpv/db.yml
      - destinations:
          tpvdb_local:
            docker_enabled: true
            docker_cmd: docker
            docker_volumes: $defaults
tools:
  - class: local
    environment: local
```


### Local Runner and Singularity



```
galaxy-job-config-init --singularity --tpv 
```

-or-

```
planemo job_config_init --singularity --tpv 
```

generate the follow job configuration YAML file:

```yaml
runners:
  local:
    load: galaxy.jobs.runners.local:LocalJobRunner
    # modify the number of threads working on local jobs here
    # workers: 4

handling:
  assign:
    - db-skip-locked

execution:
  default: tpv
  environments:
    local:
      runner: local
      singularity_enabled: true
      singularity_cmd: singularity
      singularity_volumes: $defaults
      ## May need to setup addition environment variables to get singularity working based on examples @
      ## https://training.galaxyproject.org/training-material/topics/admin/tutorials/connect-to-compute-cluster/tutorial.html
      # env:
      # - name: LC_ALL
      #   value: C
      # - name: APPTAINER_CACHEDIR
      #   value: /tmp/singularity
      # - name: APPTAINER_TMPDIR
      #   value: /tmp

    # Information on configuring TPV and leveraging the shared TPV Galaxy database for tools can be found at @
    # https://training.galaxyproject.org/training-material/topics/admin/tutorials/job-destinations/tutorial.html
    tpv:
      runner: dynamic_tpv
      tpv_configs:
      - https://gxy.io/tpv/db.yml
      - destinations:
          tpvdb_local:
            singularity_enabled: true
            singularity_cmd: singularity
            singularity_volumes: $defaults
            ## May need to setup addition environment variables to get singularity working based on examples @
            ## https://training.galaxyproject.org/training-material/topics/admin/tutorials/connect-to-compute-cluster/tutorial.html
            # env:
            # - name: LC_ALL
            #   value: C
            # - name: APPTAINER_CACHEDIR
            #   value: /tmp/singularity
            # - name: APPTAINER_TMPDIR
            #   value: /tmp
tools:
  - class: local
    environment: local
```


### SLURM Runner and No Containers



```
galaxy-job-config-init --runner slurm --tpv 
```

-or-

```
planemo job_config_init --runner slurm --tpv 
```

generate the follow job configuration YAML file:

```yaml
runners:
  local:
    load: galaxy.jobs.runners.local:LocalJobRunner
    # modify the number of threads working on local jobs here
    # workers: 4

  slurm:
    load: galaxy.jobs.runners.slurm:SlurmJobRunner
    # modify below to specify a specific drmaa shared library for slurm
    # drmaa_library_path: /usr/lib/slurm-drmaa/lib/libdrmaa.so.1

handling:
  assign:
    - db-skip-locked

execution:
  default: tpv
  environments:
    local:
      runner: local

    # Information on connecting Galaxy to SLURM can be found at:
    # https://training.galaxyproject.org/training-material/topics/admin/tutorials/connect-to-compute-cluster/tutorial.html
    slurm:
      runner: slurm
      native_specification: "" 

    # Information on configuring TPV and leveraging the shared TPV Galaxy database for tools can be found at @
    # https://training.galaxyproject.org/training-material/topics/admin/tutorials/job-destinations/tutorial.html
    tpv:
      runner: dynamic_tpv
      tpv_configs:
      - https://gxy.io/tpv/db.yml
      - destinations:
          tpvdb_slurm: {}
tools:
  - class: local
    environment: local
```


### DRMAA Runner and No Containers



```
galaxy-job-config-init --runner drmaa --tpv 
```

-or-

```
planemo job_config_init --runner drmaa --tpv 
```

generate the follow job configuration YAML file:

```yaml
runners:
  local:
    load: galaxy.jobs.runners.local:LocalJobRunner
    # modify the number of threads working on local jobs here
    # workers: 4

  drmaa:
    load: galaxy.jobs.runners.drmaa:DRMAAJobRunner
    # modify below to specify a specific drmaa shared library
    # drmaa_library_path: /sge/lib/libdrmaa.so

handling:
  assign:
    - db-skip-locked

execution:
  default: tpv
  environments:
    local:
      runner: local

    drmaa:
      runner: drmaa
      native_specification: "" 

    # Information on configuring TPV and leveraging the shared TPV Galaxy database for tools can be found at @
    # https://training.galaxyproject.org/training-material/topics/admin/tutorials/job-destinations/tutorial.html
    tpv:
      runner: dynamic_tpv
      tpv_configs:
      - https://gxy.io/tpv/db.yml
      - destinations:
          tpvdb_drmaa:
            runner: drmaa
            params:
              # adapt {cores} and {mem} to your DRM here - likely using native_specification
              native_specification: ""

tools:
  - class: local
    environment: local
```


### Condor Runner and No Containers



```
galaxy-job-config-init --runner condor --tpv 
```

-or-

```
planemo job_config_init --runner condor --tpv 
```

generate the follow job configuration YAML file:

```yaml
runners:
  local:
    load: galaxy.jobs.runners.local:LocalJobRunner
    # modify the number of threads working on local jobs here
    # workers: 4

  condor:
    load: galaxy.jobs.runners.condor:CondorJobRunner

handling:
  assign:
    - db-skip-locked

execution:
  default: tpv
  environments:
    local:
      runner: local

    condor:
      runner: condor
      # universe: "vanilla"
      # Additional/override query ClassAd params can be specified here

    # Information on configuring TPV and leveraging the shared TPV Galaxy database for tools can be found at @
    # https://training.galaxyproject.org/training-material/topics/admin/tutorials/job-destinations/tutorial.html
    tpv:
      runner: dynamic_tpv
      tpv_configs:
      - https://gxy.io/tpv/db.yml
      - destinations:
          tpvdb_condor:
            runner: condor
            params:
              request_cpus: "{cores}"
              # universe: "vanilla"
              # Additional/override query ClassAd params can be specified here

tools:
  - class: local
    environment: local
```


### K8S Runner and Docker



```
galaxy-job-config-init --runner k8s --docker --tpv 
```

-or-

```
planemo job_config_init --runner k8s --docker --tpv 
```

generate the follow job configuration YAML file:

```yaml
runners:
  local:
    load: galaxy.jobs.runners.local:LocalJobRunner
    # modify the number of threads working on local jobs here
    # workers: 4

  k8s:
    load: galaxy.jobs.runners.kubernetes:KubernetesJobRunner

handling:
  assign:
    - db-skip-locked

execution:
  default: tpv
  environments:
    local:
      runner: local
      docker_enabled: true
      docker_cmd: docker
      docker_volumes: $defaults

    k8s:
      runner: k8s
      docker_enabled: true
      docker_cmd: docker
      docker_volumes: $defaults

    # Information on configuring TPV and leveraging the shared TPV Galaxy database for tools can be found at @
    # https://training.galaxyproject.org/training-material/topics/admin/tutorials/job-destinations/tutorial.html
    tpv:
      runner: dynamic_tpv
      tpv_configs:
      - https://gxy.io/tpv/db.yml
      - destinations:
          tpvdb_k8s:
            runner: k8s
            docker_enabled: true
            docker_cmd: docker
            docker_volumes: $defaults
tools:
  - class: local
    environment: local
```


## With Legacy TPV in 24.2

### Local Runner and No Containers



```
galaxy-job-config-init --tpv --galaxy-version 24.2 
```

-or-

```
planemo job_config_init --tpv --galaxy_version 24.2 
```

generate the follow job configuration YAML file:

```yaml
runners:
  local:
    load: galaxy.jobs.runners.local:LocalJobRunner
    # modify the number of threads working on local jobs here
    # workers: 4

handling:
  assign:
    - db-skip-locked

execution:
  default: tpv
  environments:
    local:
      runner: local

    # Information on configuring TPV and leveraging the shared TPV Galaxy database for tools can be found at @
    # https://training.galaxyproject.org/training-material/topics/admin/tutorials/job-destinations/tutorial.html
    tpv:
      runner: dynamic
      type: python
      function: map_tool_to_destination
      rules_module: tpv.rules
      tpv_config_files:
      - https://https://gxy.io/tpv/db.yml
      - /Users/jxc755/workspace/galaxy/tpv.yml  # TODO: create this file and setup a TPV destination
##  tpv.yml should contain something like:
# global:
#   default_inherits: default
# destinations:
#   tpvdb_local: {}
tools:
  - class: local
    environment: local
```


### SLURM Runner and Singularity



```
galaxy-job-config-init --runner slurm --tpv --singularity  --galaxy-version 24.2 
```

-or-

```
planemo job_config_init --runner slurm --tpv --singularity  --galaxy_version 24.2 
```

generate the follow job configuration YAML file:

```yaml
runners:
  local:
    load: galaxy.jobs.runners.local:LocalJobRunner
    # modify the number of threads working on local jobs here
    # workers: 4

  slurm:
    load: galaxy.jobs.runners.slurm:SlurmJobRunner
    # modify below to specify a specific drmaa shared library for slurm
    # drmaa_library_path: /usr/lib/slurm-drmaa/lib/libdrmaa.so.1

handling:
  assign:
    - db-skip-locked

execution:
  default: tpv
  environments:
    local:
      runner: local
      singularity_enabled: true
      singularity_cmd: singularity
      singularity_volumes: $defaults
      ## May need to setup addition environment variables to get singularity working based on examples @
      ## https://training.galaxyproject.org/training-material/topics/admin/tutorials/connect-to-compute-cluster/tutorial.html
      # env:
      # - name: LC_ALL
      #   value: C
      # - name: APPTAINER_CACHEDIR
      #   value: /tmp/singularity
      # - name: APPTAINER_TMPDIR
      #   value: /tmp

    # Information on connecting Galaxy to SLURM can be found at:
    # https://training.galaxyproject.org/training-material/topics/admin/tutorials/connect-to-compute-cluster/tutorial.html
    slurm:
      runner: slurm
      native_specification: "" 
      singularity_enabled: true
      singularity_cmd: singularity
      singularity_volumes: $defaults
      ## May need to setup addition environment variables to get singularity working based on examples @
      ## https://training.galaxyproject.org/training-material/topics/admin/tutorials/connect-to-compute-cluster/tutorial.html
      # env:
      # - name: LC_ALL
      #   value: C
      # - name: APPTAINER_CACHEDIR
      #   value: /tmp/singularity
      # - name: APPTAINER_TMPDIR
      #   value: /tmp

    # Information on configuring TPV and leveraging the shared TPV Galaxy database for tools can be found at @
    # https://training.galaxyproject.org/training-material/topics/admin/tutorials/job-destinations/tutorial.html
    tpv:
      runner: dynamic
      type: python
      function: map_tool_to_destination
      rules_module: tpv.rules
      tpv_config_files:
      - https://https://gxy.io/tpv/db.yml
      - /Users/jxc755/workspace/galaxy/tpv.yml  # TODO: create this file and setup a TPV destination
##  tpv.yml should contain something like:
# global:
#   default_inherits: default
# destinations:
#   tpvdb_slurm:
#     singularity_enabled: true
#     singularity_cmd: singularity
#     singularity_volumes: $defaults
#     ## May need to setup addition environment variables to get singularity working based on examples @
#     ## https://training.galaxyproject.org/training-material/topics/admin/tutorials/connect-to-compute-cluster/tutorial.html
#     # env:
#     # - name: LC_ALL
#     #   value: C
#     # - name: APPTAINER_CACHEDIR
#     #   value: /tmp/singularity
#     # - name: APPTAINER_TMPDIR
#     #   value: /tmp
tools:
  - class: local
    environment: local
```








## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
