### PR TITLE
Add Tapis auth support

### DIFF
--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -45,6 +45,7 @@ BACKENDS = {
     "azure": "social_core.backends.azuread_tenant.AzureADV2TenantOAuth2",
     "egi_checkin": "social_core.backends.egi_checkin.EGICheckinOpenIdConnect",
     "oidc": "social_core.backends.open_id_connect.OpenIdConnectAuth",
+    "tapis": "galaxy.authnz.tapis.TapisOAuth2",
 }
 
 BACKENDS_NAME = {
@@ -55,6 +56,7 @@ BACKENDS_NAME = {
     "azure": "azuread-v2-tenant-oauth2",
     "egi_checkin": "egi-checkin",
     "oidc": "oidc",
+    "tapis": "tapis",
 }
 
 AUTH_PIPELINE = (

--- a/lib/galaxy/authnz/tapis.py
+++ b/lib/galaxy/authnz/tapis.py
@@ -31,7 +31,6 @@ class TapisOAuth2(BaseOAuth2):
     USE_BASIC_AUTH = True
 
     EXTRA_DATA = [
-        ("expires_in", "expires_in"),
         ("refresh_token", "refresh_token"),
     ]
 

--- a/lib/galaxy/authnz/tapis.py
+++ b/lib/galaxy/authnz/tapis.py
@@ -28,9 +28,12 @@ class TapisOAuth2(BaseOAuth2):
         Extract user details from the Tapis API response.
         TODO: verify and adjust the field names as provided by Tapis.
         """
+        # For TACC Tapis, we use username@tacc.utexas.edu as the email, but this may vary by deployment
+        # TODO: Allow config override of canonical identifier for username/email
+        TAPIS_DOMAIN_OVERRIDE = "tacc.utexas.edu"
         return {
             "username": response.get("username"),
-            "email": response.get("email"),
+            "email": f"{response.get('username')}@{TAPIS_DOMAIN_OVERRIDE}",
             # There is no fullname, we have first/last in Tapis, so we can construct it from the first and last names if available
             "fullname": response.get("full_name"),
         }

--- a/lib/galaxy/authnz/tapis.py
+++ b/lib/galaxy/authnz/tapis.py
@@ -31,7 +31,7 @@ class TapisOAuth2(BaseOAuth2):
     USE_BASIC_AUTH = True
 
     EXTRA_DATA = [
-        ("expires_in", "expires"),
+        ("expires_in", "expires_in"),
         ("refresh_token", "refresh_token"),
     ]
 

--- a/lib/galaxy/authnz/tapis.py
+++ b/lib/galaxy/authnz/tapis.py
@@ -92,7 +92,8 @@ class TapisOAuth2(BaseOAuth2):
         self.process_error(response)
         result = response.get("result")
         token = result.get("access_token")
-        return self.do_auth(token, response=response, *args, **kwargs)
+        # ignore B026, we keep the same signature as the base class
+        return self.do_auth(token, response=response, *args, **kwargs)  # noqa: B026
 
     def restructure_response(self, response):
         # For compatibility we pull several keys up to the top to match the expected payload

--- a/lib/galaxy/authnz/tapis.py
+++ b/lib/galaxy/authnz/tapis.py
@@ -31,11 +31,10 @@ class TapisOAuth2(BaseOAuth2):
         # For TACC Tapis, we use username@tacc.utexas.edu as the email, but this may vary by deployment
         # TODO: Allow config override of canonical identifier for username/email
         TAPIS_DOMAIN_OVERRIDE = "tacc.utexas.edu"
+        username = response.get("username")
         return {
-            "username": response.get("username"),
-            "email": f"{response.get('username')}@{TAPIS_DOMAIN_OVERRIDE}",
-            # There is no fullname, we have first/last in Tapis, so we can construct it from the first and last names if available
-            "fullname": response.get("full_name"),
+            "username": username,
+            "email": f"{username}@{TAPIS_DOMAIN_OVERRIDE}",
         }
 
     def user_data(self, access_token, *args, **kwargs):

--- a/lib/galaxy/authnz/tapis.py
+++ b/lib/galaxy/authnz/tapis.py
@@ -1,4 +1,5 @@
 from social_core.backends.oauth import BaseOAuth2
+from social_core.utils import handle_http_errors
 
 
 class TapisOAuth2(BaseOAuth2):
@@ -6,16 +7,21 @@ class TapisOAuth2(BaseOAuth2):
     # TODO: parameterize tenant
     AUTHORIZATION_URL = "https://cfde.tapis.io/v3/oauth2/authorize"
     ACCESS_TOKEN_URL = "https://cfde.tapis.io/v3/oauth2/tokens"
+    USERINFO_URL = "https://cfde.tapis.io/v3/oauth2/userinfo"
+
     ACCESS_TOKEN_METHOD = "POST"
     REDIRECT_STATE = False  # Don't include state parameter since tapis validates redirect_uri and state invalidates it?
 
     RESPONSE_TYPE = "code"
+    USE_BASIC_AUTH = True
 
     # What extra data do we need?
     EXTRA_DATA = [
         ("expires_in", "expires"),
         ("refresh_token", "refresh_token"),
     ]
+
+    # Response for token needs to be something like: requests.post(url, data=data, auth=(client_id, res.client_key))
 
     def get_user_details(self, response):
         """
@@ -30,11 +36,69 @@ class TapisOAuth2(BaseOAuth2):
 
     def user_data(self, access_token, *args, **kwargs):
         """
-        If Tapis provides an endpoint for user profile info we need, we can
-        fetch it here. Otherwise, return an empty dict.
+        Fetch user profile data from Tapis API.
+
+        This uses the access token to retrieve the user's profile information
+        from the Tapis API endpoint.
         """
-        # For example:
-        # url = 'https://tacc.tapis.io/v3/profile'
-        # response = self.get_json(url, params={'access_token': access_token})
-        # return response
-        return {}  # Modify this if you have a user data endpoint
+        # Set up the authorization header with the access token
+        headers = {"X-Tapis-Token": f"{access_token.get('access_token', '')}"}
+
+        # Make the request to the profile endpoint
+        response = self.get_json(self.USERINFO_URL, headers=headers)
+
+        # If the response is in a nested structure, extract the user data
+        # This may need adjustment based on the actual Tapis API response structure
+        if response and isinstance(response, dict):
+            # If the result is nested inside a 'result' key, extract it
+            user_data = response.get("result", response)
+            return user_data
+
+        return response
+
+    @handle_http_errors
+    def auth_complete(self, *args, **kwargs):
+        """Completes login process, must return user instance"""
+        self.process_error(self.data)
+        state = self.validate_state()
+        data, params = None, None
+        if self.ACCESS_TOKEN_METHOD == "GET":
+            params = self.auth_complete_params(state)
+        else:
+            data = self.auth_complete_params(state)
+
+        response = self.request_access_token(
+            self.access_token_url(),
+            data=data,
+            params=params,
+            headers=self.auth_headers(),
+            auth=self.auth_complete_credentials(),
+            method=self.ACCESS_TOKEN_METHOD,
+        )
+        self.process_error(response)
+        result = response.get("result")
+        token = result.get("access_token")
+        return self.do_auth(token, response=response, *args, **kwargs)
+
+    def restructure_response(self, response):
+        # For compatibility we pull several keys up to the top to match the expected payload
+        if "access_token" in response.get("result", {}).get("access_token", {}):
+            response["access_token"] = response["result"]["access_token"]["access_token"]
+
+        if "id_token" in response.get("result", {}).get("access_token", {}):
+            response["id_token"] = response["result"]["access_token"]["id_token"]
+
+        if "refresh_token" in response.get("result", {}):
+            response["refresh_token"] = response["result"]["refresh_token"]
+        return response
+
+    @handle_http_errors
+    def do_auth(self, access_token, *args, **kwargs):
+        """Finish the auth process once the access_token was retrieved"""
+        data = self.user_data(access_token, *args, **kwargs)
+        response = kwargs.get("response") or {}
+        response.update(data or {})
+        # Restructure response to pop access_token, id_token, and refresh_token up.
+        response = self.restructure_response(response)
+        kwargs.update({"response": response, "backend": self})
+        return self.strategy.authenticate(*args, **kwargs)

--- a/lib/galaxy/authnz/tapis.py
+++ b/lib/galaxy/authnz/tapis.py
@@ -7,6 +7,7 @@ class TapisOAuth2(BaseOAuth2):
     AUTHORIZATION_URL = "https://cfde.tapis.io/v3/oauth2/authorize"
     ACCESS_TOKEN_URL = "https://cfde.tapis.io/v3/oauth2/tokens"
     ACCESS_TOKEN_METHOD = "POST"
+    REDIRECT_STATE = False  # Don't include state parameter since tapis validates redirect_uri and state invalidates it?
 
     RESPONSE_TYPE = "code"
 

--- a/lib/galaxy/authnz/tapis.py
+++ b/lib/galaxy/authnz/tapis.py
@@ -30,7 +30,8 @@ class TapisOAuth2(BaseOAuth2):
     RESPONSE_TYPE = "code"
     USE_BASIC_AUTH = True
 
-    EXTRA_DATA = [
+    # Upstream this is initialized to None, but it is expected this will be a list of tuples
+    EXTRA_DATA = [  # type: ignore[assignment]
         ("refresh_token", "refresh_token"),
     ]
 

--- a/lib/galaxy/authnz/tapis.py
+++ b/lib/galaxy/authnz/tapis.py
@@ -1,0 +1,39 @@
+from social_core.backends.oauth import BaseOAuth2
+
+
+class TapisOAuth2(BaseOAuth2):
+    name = "tapis"
+    # TODO: parameterize tenant
+    AUTHORIZATION_URL = "https://cfde.tapis.io/v3/oauth2/authorize"
+    ACCESS_TOKEN_URL = "https://cfde.tapis.io/v3/oauth2/tokens"
+    ACCESS_TOKEN_METHOD = "POST"
+
+    RESPONSE_TYPE = "code"
+
+    # What extra data do we need?
+    EXTRA_DATA = [
+        ("expires_in", "expires"),
+        ("refresh_token", "refresh_token"),
+    ]
+
+    def get_user_details(self, response):
+        """
+        Extract user details from the Tapis API response.
+        TODO: verify and adjust the field names as provided by Tapis.
+        """
+        return {
+            "username": response.get("username"),
+            "email": response.get("email"),
+            "fullname": response.get("full_name"),
+        }
+
+    def user_data(self, access_token, *args, **kwargs):
+        """
+        If Tapis provides an endpoint for user profile info we need, we can
+        fetch it here. Otherwise, return an empty dict.
+        """
+        # For example:
+        # url = 'https://tacc.tapis.io/v3/profile'
+        # response = self.get_json(url, params={'access_token': access_token})
+        # return response
+        return {}  # Modify this if you have a user data endpoint

--- a/lib/galaxy/authnz/tapis.py
+++ b/lib/galaxy/authnz/tapis.py
@@ -31,6 +31,7 @@ class TapisOAuth2(BaseOAuth2):
         return {
             "username": response.get("username"),
             "email": response.get("email"),
+            # There is no fullname, we have first/last in Tapis, so we can construct it from the first and last names if available
             "fullname": response.get("full_name"),
         }
 

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -96,7 +96,13 @@ class OIDC(JSAppLauncher):
     @web.expose
     def callback(self, trans, provider, idphint=None, **kwargs):
         user = trans.user.username if trans.user is not None else "anonymous"
-        login_next = url_for(trans.get_cookie(name=LOGIN_NEXT_COOKIE_NAME) or "/")
+        login_next_cookie = trans.get_cookie(name=LOGIN_NEXT_COOKIE_NAME)
+        if login_next_cookie and login_next_cookie != "None":
+            # This cookie can sometimes be set to a literal string 'None', which we don't want to use as a redirect.
+            login_next = url_for(login_next_cookie)
+        else:
+            # Fallback to default redirect if no login_next cookie is found.
+            login_next = url_for("/")
         if not bool(kwargs):
             log.error(f"OIDC callback received no data for provider `{provider}` and user `{user}`")
             return trans.show_error_message(


### PR DESCRIPTION
Adds a Tapis psa backend.  We use this to take advantage of TACC Auth for the CFDE deployment.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
