### PR TITLE
[24.2] Fix tabular metadata setting on pulsar with remote metadata

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1758,6 +1758,7 @@ class MinimalJobWrapper(HasResourceParameters):
             self.change_state(model.Job.states.QUEUED, flush=False, job=job)
         elif not self.queue_with_limit(job, self.job_destination):
             return False
+        job.update_output_states(self.app.application_stack.supports_skip_locked())
         # Set object store after job destination so can leverage parameters...
         self._set_object_store_ids(job)
         # Now that we have the object store id, check if we are over the limit

--- a/test/functional/tools/metadata_column_names.xml
+++ b/test/functional/tools/metadata_column_names.xml
@@ -32,6 +32,7 @@
             <param name="input" value="2.tabular" />
             <output name="output">
                 <metadata name="column_names" value="First,2.tabular"/>
+                <metadata name="column_types" value="int,int,float"/>
             </output>
             <output_collection name="paired_output" type="paired">
                 <element name="forward" ftype="tabular" value="2.tabular">

--- a/test/integration/test_pulsar_embedded.py
+++ b/test/integration/test_pulsar_embedded.py
@@ -41,5 +41,6 @@ test_tools = integration_util.integration_tool_runner(
         "composite_output_tests",
         "detect_errors",
         "tool_directory_copy",
+        "metadata_columns",
     ]
 )


### PR DESCRIPTION
We debugged some weird workflow failures that involved the Filter1 tool, which requires `input.metadata.column_types` to be accurate. if the tool that produced the input ran on pulsar the Filter1 job would fail.

Broken in https://github.com/galaxyproject/galaxy/pull/19824

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
