### PR TITLE
[24.2] Skip ``data_meta`` filter in run form

### DIFF
--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -190,6 +190,9 @@ class DataMetaFilter(Filter):
 
     def filter_options(self, options: Sequence[ParameterOption], trans, other_values):
         options = list(options)
+        if trans.workflow_building_mode is workflow_building_modes.USE_HISTORY:
+            # We're in the run form, can't possibly apply a data_meta filter.
+            return options
 
         def _add_meta(meta_value, m):
             if isinstance(m, list):

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -6841,6 +6841,27 @@ steps:
             hda2 = self.dataset_populator.get_history_dataset_details(history_id, hid=2)
             assert hda2["validated_state"] == "invalid"
 
+    @skip_without_tool("dbkey_filter_input")
+    def test_value_restriction_with_data_meta_filter(self):
+        workflow_id = self.workflow_populator.upload_yaml_workflow(
+            """
+class: GalaxyWorkflow
+inputs:
+  select_text:
+     type: text
+     restrictOnConnections: true
+steps:
+  select:
+    tool_id: dbkey_filter_input
+    in:
+      index: select_text
+"""
+        )
+        with self.dataset_populator.test_history() as history_id:
+            run_workflow = self._download_workflow(workflow_id, style="run", history_id=history_id)
+        options = run_workflow["steps"][0]["inputs"][0]["options"]
+        assert len(options) >= 1
+
     def test_value_restriction_with_select_and_text_param(self):
         workflow_id = self.workflow_populator.upload_yaml_workflow(
             """


### PR DESCRIPTION
So that `Attempt restriction based on connections` works for tools like lofreq_call that uses a dbkey filter to restrict the data table (https://github.com/galaxyproject/tools-iuc/blob/ed3c07cc67bacb7c1c5a929d5f427536a35db5ca/tools/lofreq/macros.xml#L36).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
