### PR TITLE
[24.0] Drop unused alembic-utils from galaxy-data package requirements

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -5,11 +5,13 @@ on:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   schedule:
     # Run at midnight UTC every Tuesday
     - cron: '0 0 * * 2'

--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -4,10 +4,12 @@ on:
     paths-ignore:
       - 'client/**'
       - 'doc/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'client/**'
       - 'doc/**'
+      - 'packages/**'
   schedule:
     # Run at midnight UTC every Tuesday
     - cron: '0 0 * * 2'

--- a/.github/workflows/cwl_conformance.yaml
+++ b/.github/workflows/cwl_conformance.yaml
@@ -4,10 +4,12 @@ on:
     paths-ignore:
       - 'client/**'
       - 'doc/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'client/**'
       - 'doc/**'
+      - 'packages/**'
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
 concurrency:

--- a/.github/workflows/db_indexes.yaml
+++ b/.github/workflows/db_indexes.yaml
@@ -5,11 +5,13 @@ on:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,10 +4,12 @@ on:
     paths-ignore:
       - 'client/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'client/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -4,10 +4,12 @@ on:
     paths-ignore:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
 env:
   YARN_INSTALL_OPTS: --frozen-lockfile
 concurrency:

--- a/.github/workflows/framework.yaml
+++ b/.github/workflows/framework.yaml
@@ -5,11 +5,13 @@ on:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   schedule:
     # Run at midnight UTC every Tuesday
     - cron: '0 0 * * 2'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -5,11 +5,13 @@ on:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   schedule:
     # Run at midnight UTC every Tuesday
     - cron: '0 0 * * 2'

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -3,9 +3,11 @@ on:
   push:
     paths-ignore:
       - 'doc/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'doc/**'
+      - 'packages/**'
   schedule:
     # Run at midnight UTC every Tuesday
     - cron: '0 0 * * 2'

--- a/.github/workflows/lint_openapi_schema.yml
+++ b/.github/workflows/lint_openapi_schema.yml
@@ -5,11 +5,13 @@ on:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -5,11 +5,13 @@ on:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/osx_startup.yaml
+++ b/.github/workflows/osx_startup.yaml
@@ -4,10 +4,12 @@ on:
     paths-ignore:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -5,11 +5,13 @@ on:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   schedule:
     # Run at midnight UTC every Tuesday
     - cron: '0 0 * * 2'

--- a/.github/workflows/publish_artifacts.yaml
+++ b/.github/workflows/publish_artifacts.yaml
@@ -1,7 +1,7 @@
 name: Publish release artifacts
 on:
-    release:
-      types: [released, prereleased]
+  release:
+    types: [released, prereleased]
 jobs:
   build-and-publish:
     if: github.repository_owner == 'galaxyproject'

--- a/.github/workflows/reports_startup.yaml
+++ b/.github/workflows/reports_startup.yaml
@@ -3,9 +3,11 @@ on:
   push:
     paths-ignore:
       - 'doc/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'doc/**'
+      - 'packages/**'
 env:
   YARN_INSTALL_OPTS: --frozen-lockfile
 concurrency:

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -3,9 +3,11 @@ on:
   push:
     paths-ignore:
       - 'doc/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'doc/**'
+      - 'packages/**'
   schedule:
     # Run at midnight UTC every Tuesday
     - cron: '0 0 * * 2'

--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -4,10 +4,12 @@ on:
     paths-ignore:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   TOOL_SHED_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/toolshed?client_encoding=utf8'

--- a/.github/workflows/unit-postgres.yaml
+++ b/.github/workflows/unit-postgres.yaml
@@ -5,11 +5,13 @@ on:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/postgres?client_encoding=utf8'  # using postgres as the db
 concurrency:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -5,11 +5,13 @@ on:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -101,7 +101,7 @@ class CondaContext(installable.InstallableContext):
     def __init__(
         self,
         conda_prefix: Optional[str] = None,
-        conda_exec: Optional[str] = None,
+        conda_exec: Optional[Union[str, List[str]]] = None,
         shell_exec: Optional[Callable[..., int]] = None,
         debug: bool = False,
         ensure_channels: Union[str, List[str]] = "",
@@ -204,11 +204,12 @@ class CondaContext(installable.InstallableContext):
 
     def is_conda_installed(self) -> bool:
         """
-        Check if conda_exec exists
+        Check if conda_info() works
         """
-        if os.path.exists(self.conda_exec):
+        try:
+            self.conda_info()
             return True
-        else:
+        except Exception:
             return False
 
     def can_install_conda(self) -> bool:
@@ -218,6 +219,7 @@ class CondaContext(installable.InstallableContext):
         If conda_exec equals conda_prefix/bin/conda, we can install conda if either conda_prefix
         does not exist or is empty.
         """
+        assert isinstance(self.conda_exec, str), "conda_exec is not a str"
         conda_exec = os.path.abspath(self.conda_exec)
         conda_prefix_plus_exec = os.path.abspath(os.path.join(self.conda_prefix, "bin/conda"))
         if conda_exec == conda_prefix_plus_exec:

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -42,13 +42,13 @@ from ..container_classes import (
 )
 from ..docker_util import build_docker_images_command
 from ..mulled.mulled_build import (
-    DEFAULT_CHANNELS,
     ensure_installed,
     InvolucroContext,
     mull_targets,
 )
 from ..mulled.mulled_build_tool import requirements_to_mulled_targets
 from ..mulled.util import (
+    DEFAULT_CHANNELS,
     default_mulled_conda_channels_from_env,
     mulled_tags_for,
     split_tag,

--- a/lib/galaxy/tool_util/deps/dependencies.py
+++ b/lib/galaxy/tool_util/deps/dependencies.py
@@ -12,7 +12,7 @@ from galaxy.tool_util.deps.requirements import (
     ToolRequirements,
 )
 from galaxy.util import bunch
-from .mulled.mulled_build import DEFAULT_CHANNELS
+from .mulled.util import DEFAULT_CHANNELS
 
 
 class AppInfo:

--- a/lib/galaxy/tool_util/deps/installable.py
+++ b/lib/galaxy/tool_util/deps/installable.py
@@ -34,7 +34,7 @@ class InstallableContext(metaclass=abc.ABCMeta):
         """Return parent path of the location the installable will be created within."""
 
 
-def ensure_installed(installable_context, install_func, auto_init):
+def ensure_installed(installable_context: InstallableContext, install_func, auto_init):
     """Make sure target is installed - handle multiple processes potentially attempting installation."""
     parent_path = installable_context.parent_path
     desc = installable_context.installable_description

--- a/lib/galaxy/tool_util/deps/mulled/get_tests.py
+++ b/lib/galaxy/tool_util/deps/mulled/get_tests.py
@@ -25,12 +25,17 @@ except ImportError:
     Template = None  # type: ignore[assignment,misc]
     UndefinedError = Exception  # type: ignore[assignment,misc]
 
+from galaxy.tool_util.deps.conda_util import (
+    best_search_result,
+    CondaTarget,
+)
 from galaxy.util import (
     check_github_api_response_rate_limit,
     unicodify,
 )
 from galaxy.util.commands import argv_to_str
 from .util import (
+    CondaInDockerContext,
     get_files_from_conda_package,
     MULLED_SOCKET_TIMEOUT,
     split_container_name,
@@ -291,20 +296,19 @@ def hashed_test_search(
     targets = concatenated_targets.split(",")
     packages = [target.split("=") for target in targets]
 
+    conda_context = CondaInDockerContext(ensure_channels=[anaconda_channel])
     containers = []
-    for package in packages:
-        r = requests.get(f"https://anaconda.org/bioconda/{package[0]}/files", timeout=MULLED_SOCKET_TIMEOUT)
-        r.raise_for_status()
-        p = "-".join(package)
-        for line in r.text.split("\n"):
-            # include only linux-64 builds since that is hardcoded in get_anaconda_url and the only target for container builds
-            if p in line and "linux-64" in line:
-                build = line.split(p)[1].split(".tar.bz2")[0]
-                if build == "":
-                    containers.append(f"{package[0]}:{package[1]}")
-                else:
-                    containers.append(f"{package[0]}:{package[1]}-{build}")
-                break
+    for package_name, package_version in packages:
+        conda_target = CondaTarget(package_name, package_version)
+        # include only linux-64 builds since that is hardcoded in get_anaconda_url and the only target for container builds
+        hit, exact = best_search_result(conda_target, conda_context, platform="linux-64")
+        if not hit or not exact:
+            raise Exception(f"Could not find {conda_target}")
+        build = hit["build"]
+        if build:
+            containers.append(f"{package_name}:{package_version}--{build}")
+        else:
+            containers.append(f"{package_name}:{package_version}")
 
     for container in containers:
         tests = main_test_search(container, recipes_path, deep, anaconda_channel, github_repo)

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -33,7 +33,6 @@ from galaxy.tool_util.deps.conda_util import (
     CondaContext,
     CondaTarget,
 )
-from galaxy.tool_util.deps.docker_util import command_list as docker_command_list
 from galaxy.util import (
     commands,
     download_to_file,
@@ -45,8 +44,10 @@ from ._cli import arg_parser
 from .util import (
     build_target,
     conda_build_target_str,
+    CONDA_IMAGE,
+    CondaInDockerContext,
     create_repository,
-    default_mulled_conda_channels_from_env,
+    DEFAULT_CHANNELS,
     get_files_from_conda_package,
     PrintProgress,
     quay_repository,
@@ -62,14 +63,12 @@ DEFAULT_BASE_IMAGE = os.environ.get("DEFAULT_BASE_IMAGE", "quay.io/bioconda/base
 DEFAULT_EXTENDED_BASE_IMAGE = os.environ.get(
     "DEFAULT_EXTENDED_BASE_IMAGE", "quay.io/bioconda/base-glibc-debian-bash:latest"
 )
-DEFAULT_CHANNELS = default_mulled_conda_channels_from_env() or ["conda-forge", "bioconda"]
 DEFAULT_REPOSITORY_TEMPLATE = "quay.io/${namespace}/${image}"
 DEFAULT_BINDS = ["build/dist:/usr/local/"]
 DEFAULT_WORKING_DIR = "/source/"
 IS_OS_X = _platform == "darwin"
 INVOLUCRO_VERSION = "1.1.2"
 DEST_BASE_IMAGE = os.environ.get("DEST_BASE_IMAGE", None)
-CONDA_IMAGE = os.environ.get("CONDA_IMAGE", None)
 
 SINGULARITY_TEMPLATE = """Bootstrap: docker
 From: %(base_image)s
@@ -360,34 +359,6 @@ def mull_targets(
 def context_from_args(args):
     verbose = "2" if not args.verbose else "3"
     return InvolucroContext(involucro_bin=args.involucro_path, verbose=verbose)
-
-
-class CondaInDockerContext(CondaContext):
-    def __init__(
-        self,
-        conda_prefix=None,
-        conda_exec=None,
-        shell_exec=None,
-        debug=False,
-        ensure_channels=DEFAULT_CHANNELS,
-        condarc_override=None,
-    ):
-        if not conda_exec:
-            conda_image = CONDA_IMAGE or "continuumio/miniconda3:latest"
-            binds = []
-            for channel in ensure_channels:
-                if channel.startswith("file://"):
-                    bind_path = channel[7:]
-                    binds.extend(["-v", f"{bind_path}:{bind_path}"])
-            conda_exec = docker_command_list("run", binds + [conda_image, "conda"])
-        super().__init__(
-            conda_prefix=conda_prefix,
-            conda_exec=conda_exec,
-            shell_exec=shell_exec,
-            debug=debug,
-            ensure_channels=ensure_channels,
-            condarc_override=condarc_override,
-        )
 
 
 class InvolucroContext(installable.InstallableContext):

--- a/lib/galaxy/tool_util/deps/mulled/util.py
+++ b/lib/galaxy/tool_util/deps/mulled/util.py
@@ -9,6 +9,7 @@ import sys
 import threading
 from typing import (
     Any,
+    Callable,
     Dict,
     Iterable,
     List,
@@ -24,7 +25,11 @@ from conda_package_streaming.url import stream_conda_info as stream_conda_info_f
 from packaging.version import Version
 from requests import Session
 
-from galaxy.tool_util.deps.conda_util import CondaTarget
+from galaxy.tool_util.deps.conda_util import (
+    CondaContext,
+    CondaTarget,
+)
+from galaxy.tool_util.deps.docker_util import command_list as docker_command_list
 from galaxy.tool_util.version import (
     LegacyVersion,
     parse_version,
@@ -41,6 +46,7 @@ MULLED_SOCKET_TIMEOUT = 12
 QUAY_VERSIONS_CACHE_EXPIRY = 300
 NAMESPACE_HAS_REPO_NAME_KEY = "galaxy.tool_util.deps.container_resolvers.mulled.util:namespace_repo_names"
 TAG_CACHE_KEY = "galaxy.tool_util.deps.container_resolvers.mulled.util:tag_cache"
+CONDA_IMAGE = os.environ.get("CONDA_IMAGE", "quay.io/condaforge/miniforge3:latest")
 
 
 class PARSED_TAG(NamedTuple):
@@ -55,6 +61,36 @@ def default_mulled_conda_channels_from_env() -> Optional[List[str]]:
         return os.environ["DEFAULT_MULLED_CONDA_CHANNELS"].split(",")
     else:
         return None
+
+
+DEFAULT_CHANNELS = default_mulled_conda_channels_from_env() or ["conda-forge", "bioconda"]
+
+
+class CondaInDockerContext(CondaContext):
+    def __init__(
+        self,
+        conda_prefix: Optional[str] = None,
+        conda_exec: Optional[Union[str, List[str]]] = None,
+        shell_exec: Optional[Callable[..., int]] = None,
+        debug: bool = False,
+        ensure_channels: Union[str, List[str]] = DEFAULT_CHANNELS,
+        condarc_override: Optional[str] = None,
+    ):
+        if not conda_exec:
+            binds = []
+            for channel in ensure_channels:
+                if channel.startswith("file://"):
+                    bind_path = channel[7:]
+                    binds.extend(["-v", f"{bind_path}:{bind_path}"])
+            conda_exec = docker_command_list("run", binds + [CONDA_IMAGE, "conda"])
+        super().__init__(
+            conda_prefix=conda_prefix,
+            conda_exec=conda_exec,
+            shell_exec=shell_exec,
+            debug=debug,
+            ensure_channels=ensure_channels,
+            condarc_override=condarc_override,
+        )
 
 
 def create_repository(namespace: str, repo_name: str, oauth_token: str) -> None:
@@ -436,7 +472,10 @@ image_name = v1_image_name  # deprecated
 
 __all__ = (
     "build_target",
+    "CONDA_IMAGE",
     "conda_build_target_str",
+    "CondaInDockerContext",
+    "DEFAULT_CHANNELS",
     "get_files_from_conda_package",
     "image_name",
     "mulled_tags_for",

--- a/packages/data/setup.cfg
+++ b/packages/data/setup.cfg
@@ -37,7 +37,6 @@ install_requires =
     galaxy-tool-util
     galaxy-util[template]
     alembic
-    alembic-utils
     bdbag>=1.6.3
     bx-python
     dnspython

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -5,13 +5,13 @@ import pytest
 from galaxy.tool_util.deps.mulled.mulled_build import (
     base_image_for_targets,
     build_target,
-    CondaInDockerContext,
     DEFAULT_BASE_IMAGE,
     DEFAULT_EXTENDED_BASE_IMAGE,
     InvolucroContext,
     mull_targets,
     target_str_to_targets,
 )
+from galaxy.tool_util.deps.mulled.util import CondaInDockerContext
 from ..util import external_dependency_management
 
 


### PR DESCRIPTION
Last use removed in https://github.com/galaxyproject/galaxy/pull/15876 .

Also:
- Ignore changes to `packages/` in most CI workflows.
- Use `best_search_result()` function instead of parsing anaconda.org web pages. Fix `test/unit/tool_util/mulled/test_get_tests.py::test_hashed_test_search` mulled unit test.
- Add type annotation to `CondaInDockerContext` and fix ensuing issues.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
