### PR TITLE
Clarify is_active method usage for Python Social Auth in Galaxy

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1243,7 +1243,10 @@ ON CONFLICT
         }
 
     def is_active(self):
-        return self.active
+        # This is ONLY used for python social auth (PSA) - it is not used for
+        # authentication in Galaxy, and `user_is_active` checks the attribute directly.
+        # PSA uses this to determine login flow, but ours is the exact same for active and inactive users.
+        return True
 
     def is_authenticated(self):
         # TODO: is required for python social auth (PSA); however, a user authentication is relative to the backend.


### PR DESCRIPTION
And always return `True`, because that is the case for everything related to PSA.

As discussed in the dev meeting, this is a landmine.  Using a proxy object or something explicitly for PSA is another possible approach.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
