### PR TITLE
[25.0] More fixes to `FormData` drag and drop and typing

### DIFF
--- a/client/src/components/Form/Elements/FormData/FormData.test.js
+++ b/client/src/components/Form/Elements/FormData/FormData.test.js
@@ -423,7 +423,7 @@ describe("FormData", () => {
         });
         dispatchEvent(wrapper, "dragenter");
         dispatchEvent(wrapper, "drop");
-        expect(wrapper.emitted().alert[0][0]).toEqual(undefined);
+        expect(wrapper.emitted().alert).toBeUndefined();
     });
 
     it("linked and unlinked batch mode handling", async () => {

--- a/client/src/components/Form/Elements/FormData/FormData.test.js
+++ b/client/src/components/Form/Elements/FormData/FormData.test.js
@@ -405,7 +405,7 @@ describe("FormData", () => {
         dispatchEvent(wrapper, "dragenter");
         dispatchEvent(wrapper, "drop");
         expect(wrapper.emitted().alert[0][0]).toEqual(
-            "paired dataset collection is not a valid input for list type dataset collection parameter."
+            "dataset pair dataset collection is not a valid input for list type dataset collection parameter."
         );
     });
 

--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -16,7 +16,10 @@ import {
 import type { CollectionType } from "@/api/datasetCollections";
 import type { HistoryContentType } from "@/api/datasets";
 import { getGalaxyInstance } from "@/app";
-import type { CollectionBuilderType } from "@/components/History/adapters/buildCollectionModal";
+import {
+    COLLECTION_TYPE_TO_LABEL,
+    type CollectionBuilderType,
+} from "@/components/History/adapters/buildCollectionModal";
 import { useDatatypesMapper } from "@/composables/datatypesMapper";
 import { useUid } from "@/composables/utils/uid";
 import { type EventData, useEventStore } from "@/stores/eventStore";
@@ -254,6 +257,7 @@ const usingSimpleSelect = computed(
  */
 function clearHighlighting(timeout = 1000) {
     setTimeout(() => {
+        $emit("alert", undefined);
         currentHighlighting.value = null;
     }, timeout);
 }
@@ -559,7 +563,7 @@ function canAcceptSrc(historyContentType: "dataset" | "dataset_collection", coll
             } else {
                 $emit(
                     "alert",
-                    `${collectionType} dataset collection is not a valid input for ${orList(
+                    `${collectionTypeToText(collectionType)} dataset collection is not a valid input for ${orList(
                         props.collectionTypes
                     )} type dataset collection parameter.`
                 );
@@ -636,7 +640,7 @@ function onDragEnter(evt: DragEvent) {
                     $emit("alert", `${extensions} is not an acceptable format for this parameter.`);
                 } else if (!canAcceptSrc(historyContentType, collectionType)) {
                     highlightingState = "warning";
-                    $emit("alert", `${historyContentType} is not an acceptable input type for this parameter.`);
+                    // `canAcceptSrc` already alerts if false so no need to alert again
                 }
                 // Check if the item is already in the current value
                 const option = toDataOption(item);
@@ -686,7 +690,6 @@ function onDrop(e: DragEvent) {
         } else {
             currentHighlighting.value = "warning";
         }
-        $emit("alert", undefined);
         dragData.value = [];
         clearHighlighting();
     } else if (props.workflowRun && e.dataTransfer?.files?.length) {
@@ -740,8 +743,8 @@ const formatsVisible = ref(false);
 const formatsButtonId = useUid("form-data-formats-");
 
 function collectionTypeToText(collectionType: string): string {
-    if (collectionType == "list:paired") {
-        return "list of pairs";
+    if (COLLECTION_TYPE_TO_LABEL[collectionType]) {
+        return COLLECTION_TYPE_TO_LABEL[collectionType].toLowerCase();
     } else {
         return collectionType;
     }

--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -116,6 +116,13 @@ const keepOptionsUpdate = ref(0);
 const canBrowse = computed(() => variant.value && !!variant.value.find((v) => v.src === SOURCE.DATASET));
 
 /**
+ * A list of valid `src`s for the variant
+ */
+const validSrcs = computed(() => {
+    return variant.value ? variant.value.map((v) => v.src) : [];
+});
+
+/**
  * Provides the currently shown source type
  */
 const currentSource = computed(() => (currentVariant.value ? currentVariant.value.src : null));
@@ -578,7 +585,12 @@ function canAcceptSrc(historyContentType: "dataset" | "dataset_collection", coll
         }
     } else if (historyContentType === "dataset_collection") {
         if (props.type === "data") {
-            // collection can always be mapped over a data input ... in theory.
+            // if this input doesn't accept collections at all, return false
+            if (!validSrcs.value.includes(SOURCE.COLLECTION)) {
+                $emit("alert", "dataset collection is not a valid input for this dataset parameter.");
+                return false;
+            }
+            // otherwise, collection can always be mapped over a data input ... in theory.
             // One day we should also validate the map over model
             return true;
         }

--- a/client/src/components/Form/Elements/FormData/FormDataWorkflowRunTabs.vue
+++ b/client/src/components/Form/Elements/FormData/FormDataWorkflowRunTabs.vue
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { storeToRefs } from "pinia";
 import { computed, nextTick, ref, watch } from "vue";
 
+import type { HDCASummary } from "@/api";
 import type { CollectionBuilderType } from "@/components/History/adapters/buildCollectionModal";
 import { useUploadConfigurations } from "@/composables/uploadConfigurations";
 import { useHistoryStore } from "@/stores/historyStore";
@@ -62,7 +63,7 @@ function addUploadedFiles(value: any[], viewUploads = true) {
     }
 }
 
-function collectionCreated(collection: any) {
+function collectionCreated(collection: HDCASummary) {
     addUploadedFiles([collection], false);
     emit("focus");
 }

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -260,7 +260,11 @@ class DatasetCollectionManager:
             assert isinstance(dataset_collection_instance, model.HistoryDatasetCollectionAssociation)
             if implicit_inputs:
                 for input_name, input_collection in implicit_inputs:
-                    dataset_collection_instance.add_implicit_input_collection(input_name, input_collection)
+                    if isinstance(input_collection, model.HistoryDatasetCollectionAssociation):
+                        # Can also get dragged DatasetCollectionElement's here.
+                        # We only use this for extracting workflows currently,
+                        # but obviously it would be better to track that somehow.
+                        dataset_collection_instance.add_implicit_input_collection(input_name, input_collection)
 
             if implicit_output_name:
                 dataset_collection_instance.implicit_output_name = implicit_output_name

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5459,7 +5459,7 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
     history_id: Mapped[Optional[int]]
     dataset_id: Mapped[Optional[int]]
     hidden_beneath_collection_instance: Mapped[Optional["HistoryDatasetCollectionAssociation"]]
-    tags: Mapped[Optional["HistoryDatasetAssociationTagAssociation"]]
+    tags: Mapped[List["HistoryDatasetAssociationTagAssociation"]]
 
     def __init__(
         self,
@@ -7714,6 +7714,13 @@ class DatasetCollectionElement(Base, Dictifiable, Serializable):
             self.child_collection = value
         else:
             raise AttributeError(f"Unknown element type provided: {type(value)}")
+
+    @property
+    def auto_propagated_tags(self):
+        first_dataset_instance = self.first_dataset_instance()
+        if first_dataset_instance:
+            return [t for t in first_dataset_instance.tags if t.user_tname in AUTO_PROPAGATED_TAGS]
+        return []
 
     @property
     def dataset_instance(self):

--- a/lib/galaxy/model/dataset_collections/matching.py
+++ b/lib/galaxy/model/dataset_collections/matching.py
@@ -32,6 +32,11 @@ class CollectionsToMatch:
         return self.collections.items()
 
 
+def get_child_collection(item):
+    # item could be HDCA or DCE
+    return getattr(item, "child_collection", item.collection)
+
+
 class MatchingCollections:
     """Structure holding the result of matching a list of collections
     together. This class being different than the class above and being
@@ -85,7 +90,7 @@ class MatchingCollections:
     def map_over_action_tuples(self, input_name):
         if input_name not in self.action_tuples:
             collection_instance = self.collections[input_name]
-            self.action_tuples[input_name] = collection_instance.collection.dataset_action_tuples
+            self.action_tuples[input_name] = get_child_collection(collection_instance).dataset_action_tuples
         return self.action_tuples[input_name]
 
     def is_mapped_over(self, input_name):
@@ -100,7 +105,7 @@ class MatchingCollections:
         for input_key, to_match in sorted(collections_to_match.items()):
             hdca = to_match.hdca
             collection_type_description = collection_type_descriptions.for_collection_type(
-                hdca.collection.collection_type
+                get_child_collection(hdca).collection_type
             )
             subcollection_type = to_match.subcollection_type
 

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -321,11 +321,19 @@ class ExecutionTracker:
         log.warning(message, self.tool.id, error)
         self.execution_errors.append(error)
 
+    @staticmethod
+    def label_for_item(item: Union[model.DatasetCollectionElement, model.HistoryDatasetCollectionAssociation]) -> str:
+        if isinstance(item, model.DatasetCollectionElement):
+            assert item.element_identifier is not None
+            return item.element_identifier
+        else:
+            return f"collection {item.hid}"
+
     @property
     def on_text(self) -> Optional[str]:
         collection_info = self.collection_info
         if self._on_text is None and collection_info is not None:
-            collection_names = [f"collection {c.hid}" for c in collection_info.collections.values()]
+            collection_names = [self.label_for_item(c) for c in collection_info.collections.values()]
             self._on_text = on_text_for_names(collection_names)
 
         return self._on_text

--- a/lib/galaxy/tools/parameters/meta.py
+++ b/lib/galaxy/tools/parameters/meta.py
@@ -14,7 +14,10 @@ from galaxy import (
     exceptions,
     util,
 )
-from galaxy.model import HistoryDatasetCollectionAssociation
+from galaxy.model import (
+    DatasetCollectionElement,
+    HistoryDatasetCollectionAssociation,
+)
 from galaxy.model.dataset_collections import (
     matching,
     subcollections,
@@ -28,6 +31,7 @@ from galaxy.util.permutations import (
     state_remove_value,
     state_set_value,
 )
+from galaxy.work.context import WorkRequestContext
 from . import visit_input_values
 from .wrapped import process_key
 from .._types import (
@@ -178,7 +182,9 @@ def expand_flat_parameters_to_nested(incoming_copy: ToolRequestT) -> Dict[str, A
     return nested_dict
 
 
-def expand_meta_parameters(trans, tool, incoming: ToolRequestT, input_format: InputFormatT) -> ExpandedT:
+def expand_meta_parameters(
+    trans: WorkRequestContext, tool, incoming: ToolRequestT, input_format: InputFormatT
+) -> ExpandedT:
     """
     Take in a dictionary of raw incoming parameters and expand to a list
     of expanded incoming parameters (one set of parameters per tool
@@ -327,7 +333,9 @@ def split_inputs_nested(inputs, nested_dict, classifier):
     return (single_inputs_nested, matched_multi_inputs, multiplied_multi_inputs)
 
 
-def __expand_collection_parameter(trans, input_key, incoming_val, collections_to_match, linked=False):
+def __expand_collection_parameter(
+    trans: WorkRequestContext, input_key, incoming_val, collections_to_match, linked=False
+):
     # If subcollectin multirun of data_collection param - value will
     # be "hdca_id|subcollection_type" else it will just be hdca_id
     if "|" in incoming_val:
@@ -335,24 +343,30 @@ def __expand_collection_parameter(trans, input_key, incoming_val, collections_to
     else:
         try:
             src = incoming_val["src"]
-            if src != "hdca":
+            if src not in ("hdca", "dce"):
                 raise exceptions.ToolMetaParameterException(f"Invalid dataset collection source type {src}")
-            encoded_hdc_id = incoming_val["id"]
+            encoded_id = incoming_val["id"]
             subcollection_type = incoming_val.get("map_over_type", None)
         except TypeError:
-            encoded_hdc_id = incoming_val
+            encoded_id = incoming_val
             subcollection_type = None
-    hdc_id = trans.app.security.decode_id(encoded_hdc_id)
-    hdc = trans.sa_session.get(HistoryDatasetCollectionAssociation, hdc_id)
-    if not hdc.collection.populated_optimized:
+    decoded_id = trans.app.security.decode_id(encoded_id)
+    if src == "dce":
+        item = trans.sa_session.get_one(DatasetCollectionElement, decoded_id)
+        collection = item.child_collection
+    else:
+        item = trans.sa_session.get_one(HistoryDatasetCollectionAssociation, decoded_id)
+        collection = item.collection
+    assert collection
+    if not collection.populated_optimized:
         raise exceptions.ToolInputsNotReadyException("An input collection is not populated.")
-    collections_to_match.add(input_key, hdc, subcollection_type=subcollection_type, linked=linked)
+    collections_to_match.add(input_key, item, subcollection_type=subcollection_type, linked=linked)
     if subcollection_type is not None:
-        subcollection_elements = subcollections.split_dataset_collection_instance(hdc, subcollection_type)
+        subcollection_elements = subcollections._split_dataset_collection(collection, subcollection_type)
         return subcollection_elements
     else:
         hdas = []
-        for element in hdc.collection.dataset_elements:
+        for element in collection.dataset_elements:
             hda = element.dataset_instance
             hda.element_identifier = element.element_identifier
             hdas.append(hda)

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -2279,6 +2279,30 @@ class TestToolsApi(ApiTestCase, TestsTools):
         assert len(response_object["jobs"]) == 2
         assert len(response_object["implicit_collections"]) == 1
 
+    @skip_without_tool("cat1")
+    def test_can_map_over_dce_on_non_multiple_data_param(self):
+        with self.dataset_populator.test_history() as history_id:
+            pair_id = self.dataset_collection_populator.create_pair_in_history(
+                history_id, contents=["0", "0"], wait=True
+            ).json()["outputs"][0]["id"]
+            ok_hdca = self.dataset_collection_populator.create_list_from_pairs(history_id, [pair_id])
+            assert ok_hdca.json()["elements"][0]["model_class"] == "DatasetCollectionElement"
+            dce_id = ok_hdca.json()["elements"][0]["id"]
+
+            inputs = {
+                "input1": {
+                    "batch": True,
+                    "values": [{"src": "dce", "id": dce_id, "map_over_type": None}],
+                },
+            }
+            response = self._run_cat1(history_id, inputs=inputs)
+            self._assert_status_code_is(response, 200)
+
+            response_object = response.json()
+            assert len(response_object["outputs"]) == 1
+            assert len(response_object["jobs"]) == 1
+            assert len(response_object["implicit_collections"]) == 1
+
     @skip_without_tool("identifier_source")
     def test_default_identifier_source_map_over(self):
         with self.dataset_populator.test_history() as history_id:


### PR DESCRIPTION
@mvdbeek has pushed a commit that should fix map-over of collection DCEs. Fixes https://github.com/galaxyproject/galaxy/issues/20315

The rest of these changes (from a while ago 😅) are improvements/fixes for drag and drop as a follow up to changes in https://github.com/galaxyproject/galaxy/pull/19866.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
