### PR TITLE
Use FA Component (w/svg) instead of span+font in RunWorkflow header

### DIFF
--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faSitemap } from "@fortawesome/free-solid-svg-icons";
+import { faCog, faSitemap } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BButton, BDropdown, BDropdownForm, BFormCheckbox, BOverlay } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
@@ -240,7 +240,7 @@ async function onExecute() {
                         variant="link"
                         no-caret>
                         <template v-slot:button-content>
-                            <span class="fa fa-cog" />
+                            <FontAwesomeIcon :icon="faCog" />
                         </template>
                         <BDropdownForm>
                             <BFormCheckbox v-model="sendToNewHistory" class="workflow-run-settings-target">


### PR DESCRIPTION
Example for https://github.com/galaxyproject/galaxy/issues/19782#issuecomment-2751768749, this addresses the entry in the workflow header shown there.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
