### PR TITLE
[24.2] Fix duplicate extensions for data inputs

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1060,15 +1060,15 @@ class InputDataModule(InputModule):
         return [dict(name="output", extensions=extensions, optional=optional)]
 
     def get_filter_set(self, connections=None):
-        filter_set = []
+        filter_set = set()  # Use a set to ensure unique extensions
         if connections:
             for oc in connections:
                 for ic in oc.input_step.module.get_data_inputs():
                     if "extensions" in ic and ic["extensions"] != "input" and ic["name"] == oc.input_name:
-                        filter_set += ic["extensions"]
+                        filter_set.update(ic["extensions"])
         if not filter_set:
-            filter_set = ["data"]
-        return ", ".join(filter_set)
+            filter_set = {"data"}
+        return ", ".join(sorted(filter_set))
 
     def get_runtime_inputs(self, step, connections: Optional[Iterable[WorkflowStepConnection]] = None):
         parameter_def = self._parse_state_into_dict()


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/19535 
Fixes https://github.com/galaxyproject/galaxy/issues/19778

| Before 🐞  |
| ---- |
| ![firefox_R1WHeyGWtJ](https://github.com/user-attachments/assets/fa47a81a-47b5-48bb-a5d6-23d62b4662fe) |

| After ✅  |
| ---- |
| ![firefox_zGlSupmWJG](https://github.com/user-attachments/assets/1614f572-ad9e-4e08-89c1-f9ef06cd9dfb) |


If this backend change isn't the best approach, I can instead just make this a frontend/client fix by preventing duplicates directly in `FormData.vue` where we show the extensions. However, I felt it was better to resolve the issue at its source, where the extensions are computed based on the step connections.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
