### PR TITLE
Improve docs for output filters

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -6249,10 +6249,11 @@ derive collection's type (e.g. ``collection_type``) from.</xs:documentation>
   <xs:complexType name="OutputFilter">
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
-The ``<data>`` tag can contain a ``<filter>`` tag which includes a Python code
+``<data>`` and ``<collection>`` tags can contain one or more ``<filter>`` tags. Each ``<filter>`` tag contains a Python code
 block to be executed to test whether to include this output in the outputs the
-tool ultimately creates. If the code, when executed, returns ``True``,
-the output dataset is retained. In these code blocks the tool parameters appear
+tool ultimately creates. If the code of each of these filters, when executed, returns ``True``,
+the output dataset is retained, i.e. the output is excluded if at least one evaluates to ``False``. 
+In these code blocks the tool parameters appear
 as Python variables and are thus referred to without the $ used for the Cheetah
 template (used in the ``<command>`` tag). Variables that are part of
 conditionals are accessed using a dictionary named after the conditional. Boolean


### PR DESCRIPTION
mention that filters are used in both data and collections (the docs are inlcuded in both and this way it reads a bit better)

also mention that multiple filters can be used

noted by @richard-burhans on matrix

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
