### PR TITLE
Various styling improvements to Workflow Run and Invocation views

### DIFF
--- a/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
+++ b/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { faFolder } from "@fortawesome/free-regular-svg-icons";
 import { faCaretDown, faEye, faPlus, faSpinner, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton, BButtonGroup, BDropdown, BDropdownItem } from "bootstrap-vue";
@@ -59,8 +60,13 @@ function createCollectionType(colType: string) {
                 v-b-tooltip.hover.bottom
                 :pressed="props.currentField === index"
                 :title="v.tooltip"
+                :style="v.icon === faFolder && v.multiple ? 'padding-bottom: 2px' : ''"
                 @click="emit('set-current-field', index)">
-                <FontAwesomeIcon :icon="['far', v.icon]" />
+                <span v-if="v.icon === faFolder && v.multiple" style="position: relative; display: inline-block">
+                    <FontAwesomeIcon :icon="faFolder" size="sm" style="position: absolute; left: 2px" />
+                    <FontAwesomeIcon :icon="faFolder" size="sm" />
+                </span>
+                <FontAwesomeIcon v-else :icon="v.icon" />
             </BButton>
             <BButton
                 v-if="props.canBrowse && !props.workflowRun"

--- a/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
+++ b/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
@@ -60,11 +60,11 @@ function createCollectionType(colType: string) {
                 v-b-tooltip.hover.bottom
                 :pressed="props.currentField === index"
                 :title="v.tooltip"
-                :style="v.icon === faFolder && v.multiple ? 'padding-bottom: 2px' : ''"
+                :style="v.icon === faFolder && v.multiple ? 'padding: 2px' : ''"
                 @click="emit('set-current-field', index)">
-                <span v-if="v.icon === faFolder && v.multiple" style="position: relative; display: inline-block">
-                    <FontAwesomeIcon :icon="faFolder" size="sm" style="position: absolute; left: 2px" />
-                    <FontAwesomeIcon :icon="faFolder" size="sm" />
+                <span v-if="v.icon === faFolder && v.multiple" class="fa-stack" style="height: unset">
+                    <FontAwesomeIcon :icon="faFolder" class="fa-stack-1x" />
+                    <FontAwesomeIcon :icon="faFolder" class="fa-stack-1x" style="transform: translate(0.2em, -0.2em)" />
                 </span>
                 <FontAwesomeIcon v-else :icon="v.icon" />
             </BButton>

--- a/client/src/components/Form/Elements/FormData/variants.ts
+++ b/client/src/components/Form/Elements/FormData/variants.ts
@@ -1,7 +1,10 @@
+import { faCopy, faFile, faFolder } from "@fortawesome/free-regular-svg-icons";
+import type { IconDefinition } from "font-awesome-6";
+
 /** Data input variations interface */
 export interface VariantInterface {
     batch: string;
-    icon: string;
+    icon: IconDefinition;
     library?: boolean;
     multiple: boolean;
     src: string;
@@ -19,7 +22,7 @@ export const VARIANTS: Record<string, Array<VariantInterface>> = {
     data: [
         {
             src: SOURCE.DATASET,
-            icon: "fa-file",
+            icon: faFile,
             tooltip: "Single dataset",
             library: true,
             multiple: false,
@@ -27,14 +30,14 @@ export const VARIANTS: Record<string, Array<VariantInterface>> = {
         },
         {
             src: SOURCE.DATASET,
-            icon: "fa-copy",
+            icon: faCopy,
             tooltip: "Multiple datasets",
             multiple: true,
             batch: BATCH.LINKED,
         },
         {
             src: SOURCE.COLLECTION,
-            icon: "fa-folder",
+            icon: faFolder,
             tooltip: "Dataset collection",
             multiple: false,
             batch: BATCH.LINKED,
@@ -43,7 +46,7 @@ export const VARIANTS: Record<string, Array<VariantInterface>> = {
     data_multiple: [
         {
             src: SOURCE.DATASET,
-            icon: "fa-copy",
+            icon: faCopy,
             tooltip: "Multiple datasets",
             library: true,
             multiple: true,
@@ -51,7 +54,7 @@ export const VARIANTS: Record<string, Array<VariantInterface>> = {
         },
         {
             src: SOURCE.COLLECTION,
-            icon: "fa-folder",
+            icon: faFolder,
             tooltip: "Dataset collection",
             multiple: true,
             batch: BATCH.DISABLED,
@@ -60,7 +63,7 @@ export const VARIANTS: Record<string, Array<VariantInterface>> = {
     data_collection: [
         {
             src: SOURCE.COLLECTION,
-            icon: "fa-folder",
+            icon: faFolder,
             tooltip: "Dataset collection",
             multiple: false,
             batch: BATCH.DISABLED,
@@ -69,7 +72,7 @@ export const VARIANTS: Record<string, Array<VariantInterface>> = {
     workflow_data: [
         {
             src: SOURCE.DATASET,
-            icon: "fa-file",
+            icon: faFile,
             tooltip: "Single dataset",
             multiple: false,
             batch: BATCH.DISABLED,
@@ -78,7 +81,7 @@ export const VARIANTS: Record<string, Array<VariantInterface>> = {
     workflow_data_multiple: [
         {
             src: SOURCE.DATASET,
-            icon: "fa-copy",
+            icon: faCopy,
             tooltip: "Multiple datasets",
             multiple: true,
             batch: BATCH.DISABLED,
@@ -87,7 +90,7 @@ export const VARIANTS: Record<string, Array<VariantInterface>> = {
     workflow_data_collection: [
         {
             src: SOURCE.COLLECTION,
-            icon: "fa-folder",
+            icon: faFolder,
             tooltip: "Dataset collection",
             multiple: false,
             batch: BATCH.DISABLED,
@@ -96,14 +99,14 @@ export const VARIANTS: Record<string, Array<VariantInterface>> = {
     module_data: [
         {
             src: SOURCE.DATASET,
-            icon: "fa-file",
+            icon: faFile,
             tooltip: "Single dataset",
             multiple: false,
             batch: BATCH.DISABLED,
         },
         {
             src: SOURCE.DATASET,
-            icon: "fa-copy",
+            icon: faCopy,
             tooltip: "Multiple datasets",
             multiple: true,
             batch: BATCH.ENABLED,
@@ -112,14 +115,14 @@ export const VARIANTS: Record<string, Array<VariantInterface>> = {
     module_data_collection: [
         {
             src: SOURCE.COLLECTION,
-            icon: "fa-folder",
+            icon: faFolder,
             tooltip: "Dataset collection",
             multiple: false,
             batch: BATCH.DISABLED,
         },
         {
             src: SOURCE.COLLECTION,
-            icon: "fa-folder",
+            icon: faFolder,
             tooltip: "Multiple collections",
             multiple: true,
             batch: BATCH.ENABLED,

--- a/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
+++ b/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
@@ -263,13 +263,6 @@ function stepClicked(nodeId: number | null) {
     }
 }
 
-.graph-steps-aside {
-    overflow-y: scroll;
-    &.steps-fixed-height {
-        max-height: 60vh;
-    }
-}
-
 .invocation-graph {
     &:deep(.workflow-overview),
     &:deep(.zoom-control) {

--- a/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
+++ b/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
@@ -216,10 +216,16 @@ function stepClicked(nodeId: number | null) {
                             v-if="activeNodeId !== null"
                             title="Scroll to Step"
                             size="sm"
+                            variant="link"
                             @click="scrollStepToView()">
                             <FontAwesomeIcon :icon="faArrowDown" />
                         </BButton>
-                        <BButton v-if="activeNodeId !== null" title="Hide Step" size="sm" @click="activeNodeId = null">
+                        <BButton
+                            v-if="activeNodeId !== null"
+                            title="Hide Step"
+                            size="sm"
+                            variant="link"
+                            @click="activeNodeId = null">
                             <FontAwesomeIcon :icon="faTimes" />
                         </BButton>
                     </div>

--- a/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
+++ b/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
@@ -184,6 +184,7 @@ function stepClicked(nodeId: number | null) {
             <div class="d-flex">
                 <div class="position-relative w-100">
                     <BCard no-body>
+                        <div v-if="activeNodeId !== null" class="overlay overlay-left" />
                         <WorkflowGraph
                             ref="workflowGraph"
                             class="invocation-graph"
@@ -197,6 +198,7 @@ function stepClicked(nodeId: number | null) {
                             is-invocation
                             readonly
                             @stepClicked="stepClicked" />
+                        <div v-if="activeNodeId !== null" class="overlay overlay-right" />
                     </BCard>
                 </div>
             </div>
@@ -245,6 +247,19 @@ function stepClicked(nodeId: number | null) {
 .portlet-header {
     &:hover {
         opacity: 0.8;
+    }
+}
+
+.overlay {
+    bottom: 0;
+    width: 1.5rem;
+    background: rgba(200, 200, 200, 0.2);
+    &.overlay-left {
+        z-index: 1;
+    }
+    &.overlay-right {
+        left: auto;
+        right: 0;
     }
 }
 

--- a/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
+++ b/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
@@ -204,7 +204,7 @@ function stepClicked(nodeId: number | null) {
             </div>
             <BCard v-if="activeNodeId !== null" ref="stepCard" class="mt-2" no-body>
                 <BCardHeader
-                    class="d-flex justify-content-between align-items-center px-3 py-2"
+                    class="d-flex justify-content-between align-items-center px-3 py-1"
                     :class="activeNodeId !== null ? steps[activeNodeId]?.headerClass : ''">
                     <WorkflowInvocationStepHeader
                         class="w-100 pr-2"

--- a/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
+++ b/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
@@ -218,7 +218,7 @@ function stepClicked(nodeId: number | null) {
                         </BButton>
                     </div>
                 </BCardHeader>
-                <BCardBody>
+                <BCardBody body-class="p-2">
                     <WorkflowInvocationStep
                         ref="loadedJobInfo"
                         :key="activeNodeId"

--- a/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
+++ b/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
@@ -253,7 +253,8 @@ function stepClicked(nodeId: number | null) {
 .overlay {
     bottom: 0;
     width: 1.5rem;
-    background: rgba(200, 200, 200, 0.2);
+    background: $gray-200;
+    opacity: 0.5;
     &.overlay-left {
         z-index: 1;
     }

--- a/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
+++ b/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
@@ -64,6 +64,7 @@ const initialLoading = ref(true);
 const errored = ref(false);
 const errorMessage = ref("");
 const pollTimeout = ref<any>(null);
+const showSideOverlay = ref(false);
 const stepCard = ref<BCard | null>(null);
 const loadedJobInfo = ref<typeof WorkflowInvocationStep | null>(null);
 const workflowGraph = ref<InstanceType<typeof WorkflowGraph> | null>(null);
@@ -182,9 +183,13 @@ function stepClicked(nodeId: number | null) {
         </div>
         <div v-else-if="steps && datatypesMapper">
             <div class="d-flex">
-                <div class="position-relative w-100">
+                <!-- eslint-disable-next-line vuejs-accessibility/mouse-events-have-key-events, vuejs-accessibility/no-static-element-interactions -->
+                <div
+                    class="position-relative w-100"
+                    @mouseover="showSideOverlay = true"
+                    @mouseleave="showSideOverlay = false">
                     <BCard no-body>
-                        <div v-if="activeNodeId !== null" class="overlay overlay-left" />
+                        <div v-if="activeNodeId !== null && showSideOverlay" class="overlay overlay-left" />
                         <WorkflowGraph
                             ref="workflowGraph"
                             class="invocation-graph"
@@ -198,7 +203,7 @@ function stepClicked(nodeId: number | null) {
                             is-invocation
                             readonly
                             @stepClicked="stepClicked" />
-                        <div v-if="activeNodeId !== null" class="overlay overlay-right" />
+                        <div v-if="activeNodeId !== null && showSideOverlay" class="overlay overlay-right" />
                     </BCard>
                 </div>
             </div>

--- a/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
+++ b/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
@@ -200,39 +200,26 @@ function stepClicked(nodeId: number | null) {
                     </BCard>
                 </div>
             </div>
-            <BCard ref="stepCard" class="mt-2" no-body>
+            <BCard v-if="activeNodeId !== null" ref="stepCard" class="mt-2" no-body>
                 <BCardHeader
                     class="d-flex justify-content-between align-items-center px-3 py-2"
                     :class="activeNodeId !== null ? steps[activeNodeId]?.headerClass : ''">
                     <WorkflowInvocationStepHeader
-                        v-if="activeNodeId !== null"
                         class="w-100 pr-2"
                         :workflow-step="activeStepFor(activeNodeId)"
                         :graph-step="steps[activeNodeId]"
                         :invocation-step="props.invocation.steps[activeNodeId]" />
-                    <span v-else>No Step Selected</span>
                     <div class="d-flex flex-gapx-1">
-                        <BButton
-                            v-if="activeNodeId !== null"
-                            title="Scroll to Step"
-                            size="sm"
-                            variant="link"
-                            @click="scrollStepToView()">
+                        <BButton title="Scroll to Step" size="sm" variant="link" @click="scrollStepToView()">
                             <FontAwesomeIcon :icon="faArrowDown" />
                         </BButton>
-                        <BButton
-                            v-if="activeNodeId !== null"
-                            title="Hide Step"
-                            size="sm"
-                            variant="link"
-                            @click="activeNodeId = null">
+                        <BButton title="Hide Step" size="sm" variant="link" @click="activeNodeId = null">
                             <FontAwesomeIcon :icon="faTimes" />
                         </BButton>
                     </div>
                 </BCardHeader>
                 <BCardBody>
                     <WorkflowInvocationStep
-                        v-if="activeNodeId !== null"
                         ref="loadedJobInfo"
                         :key="activeNodeId"
                         :invocation="props.invocation"
@@ -241,9 +228,9 @@ function stepClicked(nodeId: number | null) {
                         in-graph-view
                         :graph-step="steps[activeNodeId]"
                         expanded />
-                    <BAlert v-else show>Click on a step in the invocation to view its details here.</BAlert>
                 </BCardBody>
             </BCard>
+            <BAlert v-else class="mt-2" show>Click on a step in the workflow graph above to view its details.</BAlert>
         </div>
     </div>
 </template>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.vue
@@ -41,13 +41,13 @@ function dataInputStepLabel(key: number, input: HasSrc) {
         </BTab>
         <BTab v-if="Object.keys(invocation.outputs).length" title="Outputs" lazy>
             <div v-for="(output, key) in invocation.outputs" :key="output.id">
-                <b>{{ key }}:</b>
+                <b>{{ key }}</b>
                 <GenericHistoryItem :item-id="output.id" :item-src="output.src" />
             </div>
         </BTab>
         <BTab v-if="Object.keys(invocation.output_collections).length" title="Output Collections" lazy>
             <div v-for="(output, key) in invocation.output_collections" :key="output.id">
-                <b>{{ key }}:</b>
+                <b>{{ key }}</b>
                 <GenericHistoryItem :item-id="output.id" :item-src="output.src" />
             </div>
         </BTab>


### PR DESCRIPTION
### Add icon for multiple collections to `FormDataContextButtons`:
| Before | After |
| ---- | ---- |
| ![firefox_teNq5s3Xhc](https://github.com/user-attachments/assets/6d2cdbc7-57fd-480b-a0bd-387438873739) | ![firefox_C7RIOiYim5](https://github.com/user-attachments/assets/8466f576-9b16-4fe6-a550-56a68e32572a) |

### Change `WorkflowInvocationStepHeader` buttons to `link` variant:
| Before | After |
| ---- | ---- |
| ![firefox_m1s6IKYu8C](https://github.com/user-attachments/assets/23de8d1e-84aa-4cbb-9658-342d334fd194) | ![firefox_UzegorT3j6](https://github.com/user-attachments/assets/69cb7b40-2754-4f67-b628-3b1f5c1e1e07) |

### If no step is activated, show just an alert instead of an alert in a card:
| Before | After |
| ---- | ---- |
| ![firefox_M8iJMpcTeD](https://github.com/user-attachments/assets/9f059029-acf3-4f4b-8b52-45cba84b3b02) | ![firefox_mVDO89fa5B](https://github.com/user-attachments/assets/2dd1eba7-a8bf-48fa-ab64-125371246d24) |

### Reduce padding in currently viewed step card:
| Before | After |
| ---- | ---- |
| ![firefox_sPQD5yyUbv](https://github.com/user-attachments/assets/81563aeb-ad75-4f91-8d3b-4909b031d07d) | ![firefox_ZZLFGvUu81](https://github.com/user-attachments/assets/4afe66d2-1a85-46f0-ab11-7f5970dd8de5) |

### Add side overlays to invocation graph for easier scrolling:

https://github.com/user-attachments/assets/881cbcc2-c10b-481a-943d-9cad5ae615bf

### Make currently viewed step header shorter:
| Before | After |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/0e9bacf7-ee04-4eef-b8a9-8290ba9421e8) | ![image](https://github.com/user-attachments/assets/87b086d9-e16a-4df5-b799-4e7945386d53) |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
