### PR TITLE
Allow embedding vitessce visualizations

### DIFF
--- a/config/plugins/visualizations/vitessce/config/vitessce.xml
+++ b/config/plugins/visualizations/vitessce/config/vitessce.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Vitessce">
+<visualization name="Vitessce" embeddable="true">
     <description>Visual integration tool for exploration of experiments</description>
     <data_sources>
         <data_source>


### PR DESCRIPTION
Seems to work fine AFAICT. It's not super useful without expanding to full width/height.

<img width="1436" alt="Screenshot 2025-03-26 at 13 02 31" src="https://github.com/user-attachments/assets/621196c2-5de1-40b4-8e3d-5cf4ad036465" />

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
