### PR TITLE
[24.2] Let pysam use extra threads available in job

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -930,11 +930,12 @@ class Bam(BamNative):
             index_file = dataset.metadata.spec[spec_key].param.new_file(
                 dataset=dataset, metadata_tmp_files_dir=metadata_tmp_files_dir
             )
+        extra_threads = int(os.environ.get("GALAXY_SLOTS", 1)) - 1
         if index_flag == "-b":
             # IOError: No such file or directory: '-b' if index_flag is set to -b (pysam 0.15.4)
-            pysam.index("-o", index_file.get_file_name(), dataset.get_file_name())  # type: ignore[attr-defined, unused-ignore]
+            pysam.index("-o", index_file.get_file_name(), f"-@{extra_threads}", dataset.get_file_name())  # type: ignore[attr-defined, unused-ignore]
         else:
-            pysam.index(index_flag, "-o", index_file.get_file_name(), dataset.get_file_name())  # type: ignore[attr-defined, unused-ignore]
+            pysam.index(index_flag, "-o", index_file.get_file_name(), f"-@{extra_threads}", dataset.get_file_name())  # type: ignore[attr-defined, unused-ignore]
         dataset.metadata.bam_index = index_file
 
     def sniff(self, filename: str) -> bool:
@@ -1124,8 +1125,9 @@ class CRAM(Binary):
             return -1, -1
 
     def set_index_file(self, dataset: HasFileName, index_file) -> bool:
+        extra_threads = int(os.environ.get("GALAXY_SLOTS", 1)) - 1
         try:
-            pysam.index("-o", index_file.get_file_name(), dataset.get_file_name())  # type: ignore[attr-defined, unused-ignore]
+            pysam.index("-o", index_file.get_file_name(), f"-@{extra_threads}", dataset.get_file_name())  # type: ignore[attr-defined, unused-ignore]
             return True
         except Exception as exc:
             log.warning("%s, set_index_file Exception: %s", self, exc)


### PR DESCRIPTION
We've got VGP pipelines that need to generate indexes for 2TB files, it would likely make a significant dent if the metadata script used the allocated resources efficiently.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
