### PR TITLE
[24.1] Handle special charater in raw SQL

### DIFF
--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -368,7 +368,7 @@ class ObjectStore(metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def get_quota_source_map(self):
+    def get_quota_source_map(self) -> "QuotaSourceMap":
         """Return QuotaSourceMap describing mapping of object store IDs to quota sources."""
 
     @abc.abstractmethod
@@ -523,7 +523,7 @@ class BaseObjectStore(ObjectStore):
             badges.append({"type": type, "message": message})
         return badges
 
-    def get_quota_source_map(self):
+    def get_quota_source_map(self) -> "QuotaSourceMap":
         # I'd rather keep this abstract... but register_singleton wants it to be instantiable...
         raise NotImplementedError()
 

--- a/scripts/cleanup_datasets/pgcleanup.py
+++ b/scripts/cleanup_datasets/pgcleanup.py
@@ -401,7 +401,8 @@ class RequiresDiskUsageRecalculation:
             statements = calculate_user_disk_usage_statements(user_id, quota_source_map)
 
             for sql, args in statements:
-                sql, _ = re.subn(r"\:([\w]+)", r"%(\1)s", sql)
+                sql = sql.replace("%", "%%")
+                sql = re.sub(r"\:([\w]+)", r"%(\1)s", sql)
                 new_args = {}
                 for key, val in args.items():
                     if isinstance(val, list):


### PR DESCRIPTION
Fix #19880

This statement is executed by SQLAlchemy and also via psycopg in the `pgcleanup.py` script. For psycopg, the `%` character should be replaced with `%%` (ref https://www.psycopg.org/docs/usage.html#passing-parameters-to-sql-queries) SQLAlchemy already takes care of it automatically.

Executing the statement with the double % via SQLAlchemy (which will double them) won't cause any problems.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
