### PR TITLE
[24.2] Report TestCaseValidation as linter error for 24.2 and above

### DIFF
--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -174,7 +174,7 @@ class TestsCaseValidation(Linter):
         try:
             validation_results = validate_test_cases_for_tool_source(tool_source, use_latest_profile=True)
         except Exception as e:
-            report_foo(
+            lint_log(
                 f"Serious problem parsing tool source or tests - cannot validate test cases. The exception is [{e}]",
                 linter=cls.name(),
             )

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -169,10 +169,7 @@ class TestsCaseValidation(Linter):
     @classmethod
     def lint(cls, tool_source: "ToolSource", lint_ctx: "LintContext"):
         profile = tool_source.parse_profile()
-        if Version(profile) < Version("24.2"):
-            report_foo = lint_ctx.warn
-        else:
-            report_foo = lint_ctx.error
+        lint_log = lint_ctx.warn if Version(profile) < Version("24.2") else lint_ctx.error
 
         try:
             validation_results = validate_test_cases_for_tool_source(tool_source, use_latest_profile=True)
@@ -186,7 +183,7 @@ class TestsCaseValidation(Linter):
             error = validation_result.validation_error
             if error:
                 error_str = _cleanup_pydantic_error(error)
-                report_foo(
+                lint_log(
                     f"Test {test_idx}: failed to validate test parameters against inputs - tests won't run on a modern Galaxy tool profile version. Validation errors are [{error_str}]",
                     linter=cls.name(),
                 )


### PR DESCRIPTION
Tests will not be executed. Linter errors might be easier to spot.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
