### PR TITLE
[24.1] Fix Invenio file source downloads not working with some Invenio instances

### DIFF
--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -347,12 +347,10 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         if is_draft_record:
             file_details_url = self._to_draft_url(file_details_url)
             download_file_content_url = self._to_draft_url(download_file_content_url)
-        file_details = self._get_response(user_context, file_details_url)
-        if not self._can_download_from_api(file_details):
-            # TODO: This is a temporary workaround for the fact that the "content" API
-            # does not support downloading files from S3 or other remote storage classes.
-            # More info: https://inveniordm.docs.cern.ch/reference/file_storage/#remote-files-r
-            download_file_content_url = f"{file_details_url.replace('/api', '')}?download=1"
+        # Downloading through the API is only supported for local files and depends on how
+        # the InvenioRDM instance file storage is configured.
+        # So this is the most reliable way to download files for now it.
+        download_file_content_url = f"{file_details_url.replace('/api', '')}?download=1"
         return download_file_content_url
 
     def _is_api_url(self, url: str) -> bool:
@@ -360,11 +358,6 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
 
     def _to_draft_url(self, url: str) -> str:
         return url.replace("/files/", "/draft/files/")
-
-    def _can_download_from_api(self, file_details: dict) -> bool:
-        # Only files stored locally seems to be fully supported by the API for now
-        # More info: https://inveniordm.docs.cern.ch/reference/file_storage/
-        return file_details["storage_class"] == "L"
 
     def _is_draft_record(self, record_id: str, user_context: OptionalUserContext = None):
         request_url = self._get_draft_record_url(record_id)


### PR DESCRIPTION
The download API endpoint in Invenio works only for files locally managed by the instance and depends on the file storage configuration of the Invenio instance ([docs here](https://inveniordm.docs.cern.ch/reference/file_storage/#remote-files-r)).

This change simplifies the download handling by always using the client route with `?download=1` parameter, which should handle the file download independently of the configuration on the backend.

It also fixes some rare cases we found where the returned `storage_class` is not handled in the expected way, since some of these storage configuration values are still experimental in Invenio.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
