### PR TITLE
Drop old job metrics

### DIFF
--- a/doc/source/admin/useful_scripts.rst
+++ b/doc/source/admin/useful_scripts.rst
@@ -60,6 +60,10 @@ Deleting old job metrics
 
 Galaxy stores job metrics in two tables: `job_metrics_text` and `job_metrics_numeric`.  To free up space and delete old job metrics records, please use the galaxy-delete-job-metrics script.
 
+Warning: these tables store useful data; you should only use this script if you need to reclaim space. 
+
+To view disk usage by table you can use gxadmin, a command line utility for Galaxy admins: `gxadmin query pg-table-size` (Ref: https://github.com/galaxyproject/gxadmin).
+
 .. code-block:: console
 
     $ python  $GALAXY_ROOT/lib/galaxy/model/scripts/delete_job_metrics.py

--- a/doc/source/admin/useful_scripts.rst
+++ b/doc/source/admin/useful_scripts.rst
@@ -37,7 +37,6 @@ To safely delete unused histories and their associated records, please use the `
       --batch BATCH      batch size
       --created CREATED  most recent created date/time in ISO format (for example, March 11, 1952 is represented as '1952-03-11')
 
-
 Deleting old galaxy_session records
 -----------------------------------
 
@@ -55,3 +54,19 @@ To safely delete such records, please use the galaxy-delete-sessions script. By 
     options:
       -h, --help         show this help message and exit
       --updated UPDATED  most recent `updated` date/time in ISO format (for example, March 11, 1952 is represented as '1952-03-11'
+
+Deleting old job metrics
+-------------------------
+
+Galaxy stores job metrics in two tables: `job_metrics_text` and `job_metrics_numeric`.  To free up space and delete old job metrics records, please use the galaxy-delete-job-metrics script.
+
+.. code-block:: console
+
+    $ python  $GALAXY_ROOT/lib/galaxy/model/scripts/delete_job_metrics.py
+    usage: delete_job_metrics.py [-h] --updated UPDATED
+    
+    Remove old job metrics records from database.
+    
+    options:
+      -h, --help         show this help message and exit
+      --updated UPDATED  most recent `updated` date/time in ISO format (for example, March 11, 1952 is represented as '1952-03-11')

--- a/lib/galaxy/model/scripts/delete_job_metrics.py
+++ b/lib/galaxy/model/scripts/delete_job_metrics.py
@@ -16,8 +16,9 @@ from galaxy.model.orm.scripts import get_config
 
 DESCRIPTION = """
 Remove old job metrics records from database.
-Executing this script will permanently delete all text and numeric job metrics up to the supplied `updated` date/time argument."
-You should only do this if you need to reclaim space.
+Executing this script will permanently delete all text and numeric job metrics up to the supplied `updated` date/time argument.
+Warning: the job_metric_numeric and job_metric_text tables store useful data; you should only use this script if you need to reclaim space.
+To view disk usage by table you can use gxadmin, a command line utility for Galaxy admins: `gxadmin query pg-table-size` (Ref: https://github.com/galaxyproject/gxadmin).
 """
 
 

--- a/lib/galaxy/model/scripts/delete_job_metrics.py
+++ b/lib/galaxy/model/scripts/delete_job_metrics.py
@@ -1,0 +1,52 @@
+import argparse
+import datetime
+import os
+import sys
+
+from sqlalchemy import (
+    create_engine,
+    text,
+)
+
+sys.path.insert(
+    1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir, os.pardir, "lib"))
+)
+
+from galaxy.model.orm.scripts import get_config
+
+DESCRIPTION = """Remove old job metrics records from database."""
+
+
+def main():
+    args = _get_parser().parse_args()
+    config = get_config(sys.argv, use_argparse=False, cwd=os.getcwd())
+    engine = create_engine(config["db_url"])
+    run(engine=engine, max_update_time=args.updated)
+
+
+def _get_parser():
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument(
+        "--updated",
+        required=True,
+        type=datetime.datetime.fromisoformat,
+        help="most recent `updated` date/time in ISO format  (for example, March 11, 1952 is represented as '1952-03-11')",
+    )
+    return parser
+
+
+def run(engine, max_update_time):
+    """Delete galaxy_session records which were updated prior to `max_update_time`."""
+    _delete_metrics(engine, max_update_time, "job_metric_text")
+    _delete_metrics(engine, max_update_time, "job_metric_numeric")
+
+
+def _delete_metrics(engine, max_update_time, metrics_table):
+    stmt = text(f"DELETE FROM {metrics_table} USING job j WHERE m.job_id = j.id AND j.update_time < :update_time")
+    params = {"update_time": max_update_time}
+    with engine.begin() as conn:
+        conn.execute(stmt, params)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/galaxy/model/scripts/delete_job_metrics.py
+++ b/lib/galaxy/model/scripts/delete_job_metrics.py
@@ -43,7 +43,7 @@ def run(engine, max_update_time):
     """Delete galaxy_session records which were updated prior to `max_update_time`."""
     confirm = input(
         f"""
-WARNING: Executing this script will permanently delete all text and numeric job metrics up to {max_update_time.strftime("%B %d, %Y")}. 
+WARNING: Executing this script will permanently delete all text and numeric job metrics up to {max_update_time.strftime("%B %d, %Y")}.
 Are your sure you want to proceed? Type "yes" to confirm: """
     )
     if confirm.lower() == "yes":

--- a/packages/data/setup.cfg
+++ b/packages/data/setup.cfg
@@ -71,6 +71,7 @@ console_scripts =
         galaxy-manage-db = galaxy.model.orm.scripts:manage_db
         galaxy-prune-histories = galaxy.model.scripts:prune_history_table
         galaxy-delete-sessions = galaxy.model.scripts:delete_galaxy_sessions
+        galaxy-delete-job-metrics = galaxy.model.scripts:delete_job_metrics
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Ref #13992

This could be slow for a large galaxy. However, running this script will not lock the underlying tables so, at least in theory, should not affect performance. The update-time argument is required (no default value is provided) - after discussing this with @afgane, I think requiring the admin to provide an explicit value is the safer option. 

This one is very simple, but I still think it belongs here (as opposed to gxadmin), because there will be only a few such scripts targeting the [biggest space hogs](https://github.com/galaxyproject/galaxy/issues/13992#issuecomment-1144934750), and grouping them all in one place with unified documentation seems logical and convenient. But if others feel gxadmin is a better fit, I'll add it to gxadmin instead.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
