### PR TITLE
Move `FormBoolean` back to `FormElement` field in workflow run form

### DIFF
--- a/client/src/components/Form/Elements/FormBoolean.vue
+++ b/client/src/components/Form/Elements/FormBoolean.vue
@@ -3,6 +3,7 @@ import { computed } from "vue";
 
 export interface FormBooleanProps {
     value: boolean | string;
+    noLabel?: boolean;
 }
 
 const props = defineProps<FormBooleanProps>();
@@ -24,6 +25,6 @@ const label = computed(() => (currentValue.value ? "Yes" : "No"));
 
 <template>
     <b-form-checkbox v-model="currentValue" class="no-highlight" switch>
-        {{ label }}
+        <span v-if="!props.noLabel">{{ label }}</span>
     </b-form-checkbox>
 </template>

--- a/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
+++ b/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
@@ -106,7 +106,9 @@ function createCollectionType(colType: string) {
             </BDropdownItem>
         </BDropdown>
         <BButton
-            v-else-if="props.showViewCreateOptions"
+            v-else-if="
+                props.showViewCreateOptions && (!props.collectionType || COLLECTION_TYPE_TO_LABEL[props.collectionType])
+            "
             v-b-tooltip.bottom.hover.noninteractive
             class="d-flex flex-gapx-1 align-items-center"
             :title="createTitle"

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -163,9 +163,7 @@ const isHidden = computed(() => attrs.value["hidden"]);
 const elementId = computed(() => `form-element-${props.id}`);
 const hasAlert = computed(() => alerts.value.length > 0);
 const showPreview = computed(() => (collapsed.value && attrs.value["collapsible_preview"]) || props.disabled);
-const showField = computed(
-    () => !collapsed.value && !props.disabled && (!props.workflowRun || props.type !== "boolean")
-);
+const showField = computed(() => !collapsed.value && !props.disabled);
 const formDataField = computed(() =>
     props.type && ["data", "data_collection"].includes(props.type) ? (props.type as "data" | "data_collection") : null
 );
@@ -333,9 +331,6 @@ function onAlert(value: string | undefined) {
                 :is-empty="isEmpty"
                 :is-optional="isOptional"
                 :extensions="attrs.extensions">
-                <template v-slot:form-element>
-                    <FormBoolean v-if="props.type === 'boolean'" :id="props.id" v-model="currentValue" />
-                </template>
                 <template v-slot:action-items>
                     <slot name="workflow-run-form-title-items" />
                 </template>

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -190,7 +190,7 @@ const nonMdHelp = computed(() =>
         ? sanitize(helpText.value!)
         : ""
 );
-const showNonMdHelp = computed(() => !!nonMdHelp.value && (!props.workflowRun || props.type !== "boolean"));
+const showNonMdHelp = computed(() => Boolean(nonMdHelp.value) && (!props.workflowRun || props.type !== "boolean"));
 
 const currentValue = computed({
     get() {
@@ -343,16 +343,13 @@ function onAlert(value: string | undefined) {
 
             <div v-if="showField" class="ui-form-field" :data-label="props.title">
                 <div
-                    v-if="props.type === 'boolean'"
-                    :class="{ 'd-flex align-items-start flex-gapx-1': props.workflowRun && nonMdHelp }">
-                    <FormBoolean
-                        :id="props.id"
-                        v-model="currentValue"
-                        class="mr-2"
-                        :no-label="props.workflowRun && Boolean(nonMdHelp)" />
+                    v-if="props.type === 'boolean' && props.workflowRun"
+                    :class="{ 'd-flex align-items-start flex-gapx-1': Boolean(nonMdHelp) }">
+                    <FormBoolean :id="props.id" v-model="currentValue" class="mr-2" :no-label="Boolean(nonMdHelp)" />
                     <!-- eslint-disable-next-line vue/no-v-html -->
-                    <span v-if="props.workflowRun && nonMdHelp" class="text-muted" v-html="nonMdHelp" />
+                    <span v-if="Boolean(nonMdHelp)" class="text-muted" v-html="nonMdHelp" />
                 </div>
+                <FormBoolean v-else-if="props.type === 'boolean'" :id="props.id" v-model="currentValue" />
                 <FormHidden v-else-if="isHiddenType" :id="props.id" v-model="currentValue" :info="attrs['info']" />
                 <FormNumber
                     v-else-if="props.type === 'integer' || props.type === 'float'"

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -345,7 +345,11 @@ function onAlert(value: string | undefined) {
                 <div
                     v-if="props.type === 'boolean'"
                     :class="{ 'd-flex align-items-start flex-gapx-1': props.workflowRun && nonMdHelp }">
-                    <FormBoolean :id="props.id" v-model="currentValue" class="mr-2" />
+                    <FormBoolean
+                        :id="props.id"
+                        v-model="currentValue"
+                        class="mr-2"
+                        :no-label="props.workflowRun && Boolean(nonMdHelp)" />
                     <!-- eslint-disable-next-line vue/no-v-html -->
                     <span v-if="props.workflowRun && nonMdHelp" class="text-muted" v-html="nonMdHelp" />
                 </div>

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -190,6 +190,7 @@ const nonMdHelp = computed(() =>
         ? sanitize(helpText.value!)
         : ""
 );
+const showNonMdHelp = computed(() => !!nonMdHelp.value && (!props.workflowRun || props.type !== "boolean"));
 
 const currentValue = computed({
     get() {
@@ -341,7 +342,13 @@ function onAlert(value: string | undefined) {
             <FormError v-if="props.workflowRun && hasAlert && !unPopulatedError" :alerts="alerts" has-alert-class />
 
             <div v-if="showField" class="ui-form-field" :data-label="props.title">
-                <FormBoolean v-if="props.type === 'boolean'" :id="props.id" v-model="currentValue" />
+                <div
+                    v-if="props.type === 'boolean'"
+                    :class="{ 'd-flex align-items-start flex-gapx-1': props.workflowRun && nonMdHelp }">
+                    <FormBoolean :id="props.id" v-model="currentValue" class="mr-2" />
+                    <!-- eslint-disable-next-line vue/no-v-html -->
+                    <span v-if="props.workflowRun && nonMdHelp" class="text-muted" v-html="nonMdHelp" />
+                </div>
                 <FormHidden v-else-if="isHiddenType" :id="props.id" v-model="currentValue" :info="attrs['info']" />
                 <FormNumber
                     v-else-if="props.type === 'integer' || props.type === 'float'"
@@ -440,7 +447,7 @@ function onAlert(value: string | undefined) {
 
             <div v-if="showPreview" class="ui-form-preview pt-1 pl-2 mt-1">{{ previewText }}</div>
             <!-- eslint-disable-next-line vue/no-v-html -->
-            <span v-if="nonMdHelp" class="ui-form-info form-text text-muted" v-html="nonMdHelp" />
+            <span v-if="showNonMdHelp" class="ui-form-info form-text text-muted" v-html="nonMdHelp" />
             <span v-else-if="Boolean(helpText) && helpFormat === 'markdown'" class="ui-form-info form-text text-muted">
                 <FormElementHelpMarkdown :content="helpText ?? ''" />
             </span>


### PR DESCRIPTION
As opposed to on the step header where we moved it to in https://github.com/galaxyproject/galaxy/pull/19294/commits/47eb5e8718c9a3a0bbc8f5ce1cf23a3e31d4d285.

It could be confusing for the user to figure out that this is in fact a workflow parameter value like the other string, integer etc. values if the boolean toggle is in the header.

| Before ◀️ |
| ---- |
| ![image](https://github.com/user-attachments/assets/5dda06ec-7a9b-44ce-b1f6-3e0ff2613e7f) |

| Option | After ➡️ |
| ---- | ---- |
| 1 | ![image](https://github.com/user-attachments/assets/cc11201b-2ddc-419d-9348-851acaa839af) |
| 2 (current) | ![image](https://github.com/user-attachments/assets/0b3e79bf-801c-4eaf-a437-850ec9887e2c) |

## Change Yes/No to True/False?

![firefox_nCAT5avy8s](https://github.com/user-attachments/assets/b8af5cab-8d6e-423d-bb04-4328d2208ae9)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
