### PR TITLE
First steps of bootstrap replacement

### DIFF
--- a/client/src/components/BaseComponents/GButton.vue
+++ b/client/src/components/BaseComponents/GButton.vue
@@ -97,21 +97,20 @@ useAccessibleHover(
 </script>
 
 <template>
-    <!-- TODO: Remove wrapping span in Vue 3 -->
-    <span>
-        <component
-            :is="baseComponent"
-            ref="buttonRef"
-            class="g-button"
-            :class="{ ...variantClasses, ...styleClasses }"
-            :to="props.to"
-            :href="props.href"
-            :title="currentTitle"
-            :aria-describedby="describedBy"
-            v-bind="$attrs"
-            @click="onClick">
-            <slot></slot>
-        </component>
+    <component
+        :is="baseComponent"
+        ref="buttonRef"
+        class="g-button"
+        :class="{ ...variantClasses, ...styleClasses }"
+        :to="props.to"
+        :href="props.href"
+        :title="currentTitle"
+        :aria-describedby="describedBy"
+        v-bind="$attrs"
+        @click="onClick">
+        <slot></slot>
+
+        <!-- TODO: make tooltip a sibling in Vue 3 -->
         <GTooltip
             v-if="props.tooltip"
             :id="tooltipId"
@@ -119,7 +118,7 @@ useAccessibleHover(
             :reference="buttonRef"
             :text="currentTooltip"
             :placement="props.tooltipPlacement" />
-    </span>
+    </component>
 </template>
 
 <style scoped lang="scss">

--- a/client/src/components/BaseComponents/GButton.vue
+++ b/client/src/components/BaseComponents/GButton.vue
@@ -115,10 +115,9 @@ useAccessibleHover(
         class="g-button"
         :class="{ ...variantClasses, ...styleClasses }"
         :to="props.to"
-        :href="props.href"
+        :href="props.to ?? props.href"
         :title="currentTitle"
         :aria-describedby="describedBy"
-        tabindex="0"
         v-bind="$attrs"
         @click="onClick">
         <slot></slot>

--- a/client/src/components/BaseComponents/GButton.vue
+++ b/client/src/components/BaseComponents/GButton.vue
@@ -4,6 +4,7 @@ import { computed, ref } from "vue";
 import { RouterLink } from "vue-router";
 
 import { useAccessibleHover } from "@/composables/accessibleHover";
+import { useResolveElement } from "@/composables/resolveElement";
 import { useUid } from "@/composables/utils/uid";
 
 import { type ComponentColor, type ComponentSize, type ComponentVariantClassList, prefix } from "./componentVariants";
@@ -86,6 +87,7 @@ const currentTitle = computed(() => {
 });
 
 const tooltipId = useUid("g-tooltip");
+
 const describedBy = computed(() => {
     if (props.tooltip) {
         return tooltipId.value;
@@ -94,11 +96,13 @@ const describedBy = computed(() => {
     }
 });
 
-const buttonRef = ref<HTMLElement | null>(null);
+const buttonRef = ref<HTMLElement | InstanceType<typeof RouterLink> | null>(null);
 const tooltipRef = ref<InstanceType<typeof GTooltip>>();
 
+const buttonElementRef = useResolveElement(buttonRef);
+
 useAccessibleHover(
-    buttonRef,
+    buttonElementRef,
     () => {
         tooltipRef.value?.show();
     },
@@ -127,7 +131,7 @@ useAccessibleHover(
             v-if="props.tooltip"
             :id="tooltipId"
             ref="tooltipRef"
-            :reference="buttonRef"
+            :reference="buttonElementRef"
             :text="currentTooltip"
             :placement="props.tooltipPlacement" />
     </component>

--- a/client/src/components/BaseComponents/GButton.vue
+++ b/client/src/components/BaseComponents/GButton.vue
@@ -25,15 +25,18 @@ const props = defineProps<{
     iconOnly?: boolean;
     transparent?: boolean;
     pill?: boolean;
+    pressed?: boolean;
 }>();
 
 const emit = defineEmits<{
     (e: "click", event: PointerEvent): void;
+    (e: "update:pressed", pressed: boolean): void;
 }>();
 
 function onClick(event: PointerEvent) {
     if (!props.disabled) {
         emit("click", event);
+        emit("update:pressed", !props.pressed);
     }
 }
 
@@ -52,6 +55,7 @@ const styleClasses = computed(() => {
         "g-inline": props.inline,
         "g-pill": props.pill,
         "g-transparent": props.transparent,
+        "g-pressed": props.pressed,
     };
 });
 
@@ -114,6 +118,7 @@ useAccessibleHover(
         :href="props.href"
         :title="currentTitle"
         :aria-describedby="describedBy"
+        tabindex="0"
         v-bind="$attrs"
         @click="onClick">
         <slot></slot>
@@ -146,8 +151,16 @@ useAccessibleHover(
         transition: none;
     }
 
+    &:focus {
+        outline: none;
+        box-shadow: 0 0 0 0.2rem rgb(from var(--color-blue-400) r g b / 0.33);
+        z-index: 999;
+    }
+
     &:focus-visible {
+        outline: none;
         box-shadow: 0 0 0 0.2rem var(--color-blue-400);
+        z-index: 999;
     }
 
     // sizes
@@ -173,15 +186,14 @@ useAccessibleHover(
         color: var(--color-grey-800);
 
         &:hover,
-        &:focus,
         &:focus-visible {
             background-color: var(--color-grey-300);
             border-color: var(--color-grey-400);
-        }
 
-        &:active {
-            background-color: var(--color-grey-400);
-            border-color: var(--color-grey-600);
+            &:active {
+                background-color: var(--color-grey-400);
+                border-color: var(--color-grey-600);
+            }
         }
 
         &:focus-visible {
@@ -196,15 +208,14 @@ useAccessibleHover(
             color: var(--color-#{$color}-100);
 
             &:hover,
-            &:focus,
             &:focus-visible {
                 background-color: var(--color-#{$color}-700);
                 border-color: var(--color-#{$color}-700);
-            }
 
-            &:active {
-                background-color: var(--color-#{$color}-600);
-                color: var(--color-#{$color}-100);
+                &:active {
+                    background-color: var(--color-#{$color}-600);
+                    color: var(--color-#{$color}-100);
+                }
             }
 
             &:focus-visible {
@@ -212,14 +223,11 @@ useAccessibleHover(
             }
         }
 
-        &.g-outline.g-#{$color} {
-            background-color: rgb(100% 100% 100% / 0);
+        &.g-outline:not(.g-pressed).g-#{$color} {
             border-color: var(--color-#{$color}-600);
             color: var(--color-#{$color}-600);
 
-            &:hover,
-            &:focus,
-            &:focus-visible {
+            &:hover {
                 background-color: var(--color-#{$color}-600);
                 border-color: var(--color-#{$color}-600);
                 color: var(--color-#{$color}-100);
@@ -233,22 +241,25 @@ useAccessibleHover(
         }
     }
 
+    &.g-outline:not(.g-pressed) {
+        background-color: var(--background-color);
+    }
+
     &.g-disabled {
         background-color: var(--color-grey-100);
         border-color: var(--color-grey-200);
         color: var(--color-grey-500);
 
         &:hover,
-        &:focus,
         &:focus-visible {
             background-color: var(--color-grey-100);
             border-color: var(--color-grey-200);
-        }
 
-        &:active {
-            background-color: var(--color-grey-100);
-            border-color: var(--color-grey-200);
-            color: var(--color-grey-500);
+            &:active {
+                background-color: var(--color-grey-100);
+                border-color: var(--color-grey-200);
+                color: var(--color-grey-500);
+            }
         }
 
         &:focus-visible {
@@ -256,21 +267,21 @@ useAccessibleHover(
         }
 
         &.g-outline {
-            background-color: rgb(100% 100% 100% / 0);
+            background-color: var(--background-color);
             border-color: var(--color-grey-400);
             color: var(--color-grey-400);
 
             &:hover,
             &:focus,
             &:focus-visible {
-                background-color: rgb(100% 100% 100% / 0);
+                background-color: var(--background-color);
                 border-color: var(--color-grey-400);
                 color: var(--color-grey-400);
             }
 
             &:focus-visible {
                 border-color: var(--color-grey-800);
-                background-color: rgb(100% 100% 100% / 0);
+                background-color: var(--background-color);
                 color: var(--color-grey-500);
             }
         }

--- a/client/src/components/BaseComponents/GButton.vue
+++ b/client/src/components/BaseComponents/GButton.vue
@@ -132,6 +132,13 @@ useAccessibleHover(
     text-decoration: none;
     vertical-align: middle;
 
+    transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out,
+        box-shadow 0.15s ease-in-out;
+
+    @media (prefers-reduced-motion) {
+        transition: none;
+    }
+
     &:focus-visible {
         box-shadow: 0 0 0 0.2rem var(--color-blue-400);
     }

--- a/client/src/components/BaseComponents/GButton.vue
+++ b/client/src/components/BaseComponents/GButton.vue
@@ -117,6 +117,7 @@ useAccessibleHover(
         :is="baseComponent"
         ref="buttonRef"
         class="g-button"
+        :data-title="currentTooltip"
         :class="{ ...variantClasses, ...styleClasses }"
         :to="props.to"
         :href="props.to ?? props.href"

--- a/client/src/components/BaseComponents/GButton.vue
+++ b/client/src/components/BaseComponents/GButton.vue
@@ -1,0 +1,163 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { RouterLink } from "vue-router";
+
+import { type ComponentColor, type ComponentSize, type ComponentVariantClassList, prefix } from "./componentVariants";
+
+const props = defineProps<{
+    href?: string;
+    to?: string;
+    color?: ComponentColor;
+    outline?: boolean;
+    disabled?: boolean;
+    title?: string;
+    disabledTitle?: string;
+    size?: ComponentSize;
+}>();
+
+const emit = defineEmits<{
+    (e: "click", event: PointerEvent): void;
+}>();
+
+function onClick(event: PointerEvent) {
+    emit("click", event);
+}
+
+const variantClasses = computed(() => {
+    const classObject = {} as ComponentVariantClassList;
+    classObject[prefix(props.color ?? "grey")] = true;
+    classObject[prefix(props.size ?? "medium")] = true;
+    return classObject;
+});
+
+const styleClasses = computed(() => {
+    return {
+        outline: props.outline,
+    };
+});
+
+const baseComponent = computed(() => {
+    if (props.to) {
+        return RouterLink;
+    } else if (props.href) {
+        return "a" as const;
+    } else {
+        return "button" as const;
+    }
+});
+</script>
+
+<template>
+    <component
+        :is="baseComponent"
+        class="g-button"
+        :class="{ ...variantClasses, ...styleClasses }"
+        :to="props.to"
+        :href="props.href"
+        @click="onClick">
+        <slot></slot>
+    </component>
+</template>
+
+<style scoped lang="scss">
+.g-button {
+    display: inline-block;
+    margin: 0;
+    border: 1px solid;
+    border-radius: var(--spacing);
+    text-decoration: none;
+    vertical-align: middle;
+
+    &:focus-visible {
+        box-shadow: 0 0 0 0.2rem var(--color-blue-400);
+    }
+
+    // sizes
+    &.g-small {
+        font-size: var(--font-size-small);
+        padding: var(--spacing-1) var(--spacing-2);
+    }
+
+    &.g-medium {
+        font-size: var(--font-size-medium);
+        padding: var(--spacing-1) var(--spacing-2);
+    }
+
+    &.g-large {
+        font-size: var(--font-size-large);
+        padding: var(--spacing-2) var(--spacing-3);
+    }
+
+    // colors
+    &.g-grey {
+        background-color: var(--color-grey-200);
+        border-color: var(--color-grey-300);
+        color: var(--color-grey-800);
+
+        &:hover,
+        &:focus,
+        &:focus-visible {
+            background-color: var(--color-grey-300);
+            border-color: var(--color-grey-400);
+        }
+
+        &:active {
+            background-color: var(--color-grey-400);
+            border-color: var(--color-grey-600);
+        }
+
+        &:focus-visible {
+            border-color: var(--color-grey-600);
+        }
+    }
+
+    @each $color in "blue", "green", "red", "yellow", "orange" {
+        &.g-#{$color} {
+            background-color: var(--color-#{$color}-600);
+            border-color: var(--color-#{$color}-600);
+            color: var(--color-#{$color}-100);
+
+            &:hover,
+            &:focus,
+            &:focus-visible {
+                background-color: var(--color-#{$color}-700);
+                border-color: var(--color-#{$color}-700);
+            }
+
+            &:active {
+                background-color: var(--color-#{$color}-600);
+                color: var(--color-#{$color}-100);
+            }
+
+            &:focus-visible {
+                border-color: var(--color-#{$color}-900);
+            }
+        }
+
+        &.outline.g-#{$color} {
+            background-color: rgb(100% 100% 100% / 0);
+            border-color: var(--color-#{$color}-600);
+            color: var(--color-#{$color}-600);
+
+            &:hover,
+            &:focus,
+            &:focus-visible {
+                background-color: var(--color-#{$color}-600);
+                border-color: var(--color-#{$color}-600);
+                color: var(--color-#{$color}-100);
+            }
+
+            &:active {
+                background-color: var(--color-#{$color}-600);
+                color: var(--color-#{$color}-100);
+            }
+
+            &:focus-visible {
+                border-color: var(--color-#{$color}-900);
+                background-color: var(--color-#{$color}-200);
+                color: var(--color-#{$color}-600);
+            }
+        }
+    }
+}
+</style>

--- a/client/src/components/BaseComponents/GButton.vue
+++ b/client/src/components/BaseComponents/GButton.vue
@@ -23,6 +23,7 @@ const props = defineProps<{
     tooltipPlacement?: Placement;
     inline?: boolean;
     iconOnly?: boolean;
+    transparent?: boolean;
     pill?: boolean;
 }>();
 
@@ -50,6 +51,7 @@ const styleClasses = computed(() => {
         "g-icon-only": props.iconOnly,
         "g-inline": props.inline,
         "g-pill": props.pill,
+        "g-transparent": props.transparent,
     };
 });
 
@@ -286,16 +288,27 @@ useAccessibleHover(
     }
 
     &.g-icon-only {
-        border: none;
-        background-color: rgb(100% 100% 100% / 0);
-        padding: var(--spacing-1);
         aspect-ratio: 1;
         display: inline-flex;
         justify-content: center;
 
+        &.g-small,
+        &.g-medium {
+            padding: var(--spacing-1);
+        }
+
+        &.g-large {
+            padding: var(--spacing-2);
+        }
+
         &.g-inline {
             padding: 2px;
         }
+    }
+
+    &.g-transparent {
+        border: none;
+        background-color: rgb(100% 100% 100% / 0);
 
         @each $color in "blue", "green", "red", "yellow", "orange" {
             &.g-#{$color} {

--- a/client/src/components/BaseComponents/GButton.vue
+++ b/client/src/components/BaseComponents/GButton.vue
@@ -21,6 +21,9 @@ const props = defineProps<{
     size?: ComponentSize;
     tooltip?: boolean;
     tooltipPlacement?: Placement;
+    inline?: boolean;
+    iconOnly?: boolean;
+    pill?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -42,8 +45,11 @@ const variantClasses = computed(() => {
 
 const styleClasses = computed(() => {
     return {
-        outline: props.outline,
-        disabled: props.disabled,
+        "g-outline": props.outline,
+        "g-disabled": props.disabled,
+        "g-icon-only": props.iconOnly,
+        "g-inline": props.inline,
+        "g-pill": props.pill,
     };
 });
 
@@ -122,8 +128,6 @@ useAccessibleHover(
 </template>
 
 <style scoped lang="scss">
-// todo: remove bootstrap overrides
-
 .g-button {
     display: inline-block;
     margin: 0;
@@ -131,6 +135,7 @@ useAccessibleHover(
     border-radius: var(--spacing-1);
     text-decoration: none;
     vertical-align: middle;
+    cursor: pointer;
 
     transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out,
         box-shadow 0.15s ease-in-out;
@@ -205,7 +210,7 @@ useAccessibleHover(
             }
         }
 
-        &.outline.g-#{$color} {
+        &.g-outline.g-#{$color} {
             background-color: rgb(100% 100% 100% / 0);
             border-color: var(--color-#{$color}-600);
             color: var(--color-#{$color}-600);
@@ -226,10 +231,7 @@ useAccessibleHover(
         }
     }
 
-    &.disabled {
-        // bootstrap override
-        opacity: 1;
-
+    &.g-disabled {
         background-color: var(--color-grey-100);
         border-color: var(--color-grey-200);
         color: var(--color-grey-500);
@@ -251,7 +253,7 @@ useAccessibleHover(
             border-color: var(--color-grey-500);
         }
 
-        &.outline {
+        &.g-outline {
             background-color: rgb(100% 100% 100% / 0);
             border-color: var(--color-grey-400);
             color: var(--color-grey-400);
@@ -268,6 +270,43 @@ useAccessibleHover(
                 border-color: var(--color-grey-800);
                 background-color: rgb(100% 100% 100% / 0);
                 color: var(--color-grey-500);
+            }
+        }
+    }
+
+    // variants
+    &.g-inline {
+        display: inline;
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+
+    &.g-pill {
+        border-radius: 100rem;
+    }
+
+    &.g-icon-only {
+        border: none;
+        background-color: rgb(100% 100% 100% / 0);
+        padding: var(--spacing-1);
+        aspect-ratio: 1;
+        display: inline-flex;
+        justify-content: center;
+
+        &.g-inline {
+            padding: 2px;
+        }
+
+        @each $color in "blue", "green", "red", "yellow", "orange" {
+            &.g-#{$color} {
+                color: var(--color-#{$color}-600);
+
+                &:hover,
+                &:focus,
+                &:focus-visible {
+                    background-color: var(--color-#{$color}-600);
+                    color: var(--color-#{$color}-100);
+                }
             }
         }
     }

--- a/client/src/components/BaseComponents/GButtonGroup.vue
+++ b/client/src/components/BaseComponents/GButtonGroup.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = defineProps<{
+    vertical?: boolean;
+}>();
+
+const styleClasses = computed(() => {
+    return {
+        "g-vertical": props.vertical,
+    };
+});
+</script>
+
+<template>
+    <div class="g-button-group" :class="styleClasses">
+        <slot></slot>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+.g-button-group {
+    display: inline-flex;
+    gap: 0;
+
+    &:not(.g-vertical) {
+        &:deep(.g-button) {
+            &:not(:nth-child(1 of .g-button)) {
+                border-top-left-radius: 0;
+                border-bottom-left-radius: 0;
+            }
+
+            &:not(:nth-last-child(1 of .g-button)) {
+                border-top-right-radius: 0;
+                border-bottom-right-radius: 0;
+
+                border-right: 0;
+            }
+        }
+    }
+
+    &.g-vertical {
+        flex-direction: column;
+
+        &:deep(.g-button) {
+            &:not(:nth-child(1 of .g-button)) {
+                border-top-left-radius: 0;
+                border-top-right-radius: 0;
+            }
+
+            &:not(:nth-last-child(1 of .g-button)) {
+                border-bottom-left-radius: 0;
+                border-bottom-right-radius: 0;
+
+                border-bottom: 0;
+            }
+        }
+    }
+}
+</style>

--- a/client/src/components/BaseComponents/GTooltip.vue
+++ b/client/src/components/BaseComponents/GTooltip.vue
@@ -97,6 +97,7 @@ defineExpose({
     padding: var(--spacing-1) var(--spacing-2);
     font-size: var(--font-size-small);
     border-radius: var(--spacing-1);
+    pointer-events: none;
 
     &:not(.sr-only) {
         display: block;

--- a/client/src/components/BaseComponents/GTooltip.vue
+++ b/client/src/components/BaseComponents/GTooltip.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { Instance as PopperInstance, Placement } from "@popperjs/core";
 import { createPopper } from "@popperjs/core";
-import flip from "@popperjs/core/lib/modifiers/flip";
 import { watchImmediate } from "@vueuse/core";
 import { ref } from "vue";
 
@@ -30,9 +29,11 @@ watchImmediate(
         assertDefined(tooltip.value);
 
         popperInstance.value = createPopper(props.reference, tooltip.value, {
-            placement: props.placement ?? "auto",
+            placement: props.placement ?? "top",
             modifiers: [
-                flip,
+                {
+                    name: "flip",
+                },
                 {
                     name: "offset",
                     options: {
@@ -43,6 +44,12 @@ watchImmediate(
                     name: "preventOverflow",
                     options: {
                         altBoundary: true,
+                    },
+                },
+                {
+                    name: "arrow",
+                    options: {
+                        padding: 8,
                     },
                 },
             ],
@@ -109,32 +116,33 @@ defineExpose({
         &,
         &::before {
             position: absolute;
-            width: 9px;
-            height: 9px;
+            width: 8px;
+            height: 8px;
             background: inherit;
+            z-index: -1;
         }
 
         &::before {
             visibility: visible;
             content: "";
-            transform: rotate(45deg);
+            transform: translateX(-4px) rotate(45deg);
         }
     }
 
     &[data-popper-placement^="top"] > .g-tooltip-arrow {
-        bottom: -4.5px;
+        bottom: -4px;
     }
 
     &[data-popper-placement^="bottom"] > .g-tooltip-arrow {
-        top: -4.5px;
+        top: -4px;
     }
 
     &[data-popper-placement^="left"] > .g-tooltip-arrow {
-        right: -4.5px;
+        right: -4px;
     }
 
     &[data-popper-placement^="right"] > .g-tooltip-arrow {
-        left: -4.5px;
+        left: -4px;
     }
 }
 </style>

--- a/client/src/components/BaseComponents/GTooltip.vue
+++ b/client/src/components/BaseComponents/GTooltip.vue
@@ -1,0 +1,140 @@
+<script setup lang="ts">
+import type { Instance as PopperInstance, Placement } from "@popperjs/core";
+import { createPopper } from "@popperjs/core";
+import flip from "@popperjs/core/lib/modifiers/flip";
+import { watchImmediate } from "@vueuse/core";
+import { ref } from "vue";
+
+import { assertDefined } from "@/utils/assertions";
+
+const props = defineProps<{
+    id: string;
+    reference: HTMLElement | null;
+    text?: string;
+    placement?: Placement;
+}>();
+
+const tooltip = ref<HTMLDivElement>();
+const popperInstance = ref<PopperInstance | null>(null);
+const isShowing = ref(false);
+
+watchImmediate(
+    () => [props.id, props.reference],
+    () => {
+        popperInstance.value?.destroy();
+
+        if (!props.reference) {
+            console.warn(`no reference defined for tooltip with id ${props.id}`);
+            return;
+        }
+
+        assertDefined(tooltip.value);
+
+        popperInstance.value = createPopper(props.reference, tooltip.value, {
+            placement: props.placement ?? "auto",
+            modifiers: [
+                flip,
+                {
+                    name: "offset",
+                    options: {
+                        offset: [0, 8],
+                    },
+                },
+                {
+                    name: "preventOverflow",
+                    options: {
+                        altBoundary: true,
+                    },
+                },
+            ],
+        });
+    }
+);
+
+function show() {
+    isShowing.value = true;
+
+    popperInstance.value?.setOptions((options) => ({
+        ...options,
+        modifiers: [...(options.modifiers ?? []), { name: "eventListeners", enabled: true }],
+    }));
+
+    popperInstance.value?.update();
+}
+
+function hide() {
+    isShowing.value = false;
+
+    popperInstance.value?.setOptions((options) => ({
+        ...options,
+        modifiers: [...(options.modifiers ?? []), { name: "eventListeners", enabled: false }],
+    }));
+}
+
+defineExpose({
+    show,
+    hide,
+});
+</script>
+
+<template>
+    <div
+        :id="props.id"
+        ref="tooltip"
+        role="tooltip"
+        class="g-tooltip"
+        :class="{ 'sr-only': !isShowing }"
+        :data-show="isShowing">
+        <slot></slot>
+        {{ props.text ?? "" }}
+        <div class="g-tooltip-arrow" data-popper-arrow></div>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+.g-tooltip {
+    background-color: var(--color-blue-800);
+    color: var(--color-grey-100);
+    padding: var(--spacing-1) var(--spacing-2);
+    font-size: var(--font-size-small);
+    border-radius: var(--spacing-1);
+
+    &:not(.sr-only) {
+        display: block;
+    }
+
+    .g-tooltip-arrow {
+        visibility: hidden;
+
+        &,
+        &::before {
+            position: absolute;
+            width: 9px;
+            height: 9px;
+            background: inherit;
+        }
+
+        &::before {
+            visibility: visible;
+            content: "";
+            transform: rotate(45deg);
+        }
+    }
+
+    &[data-popper-placement^="top"] > .g-tooltip-arrow {
+        bottom: -4.5px;
+    }
+
+    &[data-popper-placement^="bottom"] > .g-tooltip-arrow {
+        top: -4.5px;
+    }
+
+    &[data-popper-placement^="left"] > .g-tooltip-arrow {
+        right: -4.5px;
+    }
+
+    &[data-popper-placement^="right"] > .g-tooltip-arrow {
+        left: -4.5px;
+    }
+}
+</style>

--- a/client/src/components/BaseComponents/GTooltip.vue
+++ b/client/src/components/BaseComponents/GTooltip.vue
@@ -105,6 +105,8 @@ defineExpose({
     font-size: var(--font-size-small);
     border-radius: var(--spacing-1);
     pointer-events: none;
+    font-weight: 400;
+    z-index: 9999;
 
     &:not(.sr-only) {
         display: block;

--- a/client/src/components/BaseComponents/GTooltip.vue
+++ b/client/src/components/BaseComponents/GTooltip.vue
@@ -24,7 +24,6 @@ watchImmediate(
         popperInstance.value?.destroy();
 
         if (!props.reference) {
-            console.warn(`no reference defined for tooltip with id ${props.id}`);
             return;
         }
 

--- a/client/src/components/BaseComponents/componentVariants.ts
+++ b/client/src/components/BaseComponents/componentVariants.ts
@@ -1,0 +1,12 @@
+export type ComponentColor = "grey" | "blue" | "green" | "yellow" | "orange" | "red";
+export type ComponentSize = "small" | "medium" | "large";
+
+export type ComponentVariantClassList = {
+    [_key in `g-${ComponentSize}`]?: true;
+} & {
+    [_key in `g-${ComponentColor}`]?: true;
+};
+
+export function prefix<T extends string>(key: T): `g-${T}` {
+    return `g-${key}`;
+}

--- a/client/src/components/Common/BreadcrumbHeading.vue
+++ b/client/src/components/Common/BreadcrumbHeading.vue
@@ -14,8 +14,8 @@ const props = defineProps<Props>();
 </script>
 
 <template>
-    <div class="breadcrumb-heading">
-        <Heading h1 separator inline size="md" class="breadcrumb-heading-header">
+    <div class="breadcrumb-heading mb-2">
+        <Heading h1 separator inline size="md" class="breadcrumb-heading-header mr-2 mb-0">
             <template v-for="(item, index) in props.items">
                 <RouterLink
                     v-if="item.to"
@@ -50,7 +50,6 @@ const props = defineProps<Props>();
 
     .breadcrumb-heading-header {
         flex-grow: 1;
-        margin-bottom: 0.5rem;
 
         .breadcrumb-heading-header-active {
             overflow: hidden;

--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -19,6 +19,7 @@ import { useUserStore } from "@/stores/userStore";
 
 import PreferredStorePopover from "./PreferredStorePopover.vue";
 import SelectPreferredStore from "./SelectPreferredStore.vue";
+import GButton from "@/components/BaseComponents/GButton.vue";
 
 const { isOnlyPreference } = useStorageLocationConfiguration();
 
@@ -147,18 +148,19 @@ onMounted(() => {
 
 <template>
     <div class="history-size my-1 d-flex justify-content-between">
-        <BButton
-            v-b-tooltip.hover
+        <GButton
+            tooltip
             title="History Size"
-            variant="link"
-            size="sm"
-            class="rounded-0 text-decoration-none history-storage-overview-button"
+            transparent
+            size="small"
+            color="blue"
+            class="rounded-0 history-storage-overview-button"
             :disabled="!canManageStorage"
             data-description="storage dashboard button"
             @click="onDashboard">
             <FontAwesomeIcon :icon="faDatabase" />
             <span>{{ niceHistorySize }}</span>
-        </BButton>
+        </GButton>
 
         <BButtonGroup v-if="currentUser">
             <BButton

--- a/client/src/components/History/HistoryView.test.js
+++ b/client/src/components/History/HistoryView.test.js
@@ -112,7 +112,7 @@ describe("History center panel View", () => {
     }
 
     function storageDashboardButtonDisabled(wrapper) {
-        return wrapper.find("[data-description='storage dashboard button']").attributes("disabled");
+        return wrapper.find("[data-description='storage dashboard button']").classes().includes("g-disabled");
     }
 
     it("current user's current history", async () => {

--- a/client/src/components/Workflow/Editor/Tools/ToolBar.vue
+++ b/client/src/components/Workflow/Editor/Tools/ToolBar.vue
@@ -15,7 +15,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { useMagicKeys, whenever } from "@vueuse/core";
-import { BButton, BButtonGroup, BFormInput } from "bootstrap-vue";
+import { BFormInput } from "bootstrap-vue";
 //@ts-ignore deprecated package without types (vue 2, remove this comment on vue 3 migration)
 import { BoxSelect, Workflow } from "lucide-vue";
 import { storeToRefs } from "pinia";
@@ -31,6 +31,8 @@ import { AutoLayoutAction } from "../Actions/stepActions";
 import { useSelectionOperations } from "./useSelectionOperations";
 import { useToolLogic } from "./useToolLogic";
 
+import GButton from "@/components/BaseComponents/GButton.vue";
+import GButtonGroup from "@/components/BaseComponents/GButtonGroup.vue";
 import ColorSelector from "@/components/Workflow/Editor/Comments/ColorSelector.vue";
 
 library.add(
@@ -160,132 +162,153 @@ function autoLayout() {
     <div class="workflow-editor-toolbar">
         <div class="tools">
             <template v-if="toolbarVisible">
-                <BButtonGroup vertical>
-                    <BButton
-                        v-b-tooltip.hover.noninteractive.right
+                <GButtonGroup vertical>
+                    <GButton
+                        tooltip
+                        tooltip-placement="right"
+                        outline
+                        color="blue"
                         class="button"
                         data-tool="pointer"
                         title="Pointer Tool (Ctrl + 1)"
                         :pressed="currentTool === 'pointer'"
-                        variant="outline-primary"
                         @click="onClickPointer">
                         <FontAwesomeIcon icon="fa-mouse-pointer" size="lg" />
-                    </BButton>
-                    <BButton
-                        v-b-tooltip.hover.noninteractive.right
+                    </GButton>
+                    <GButton
+                        tooltip
+                        tooltip-placement="right"
+                        outline
+                        color="blue"
                         class="button"
                         data-tool="toggle_snap"
                         :title="snapButtonTitle"
-                        :pressed.sync="snapActive"
-                        variant="outline-primary">
+                        :pressed.sync="snapActive">
                         <FontAwesomeIcon icon="fa-magnet" size="lg" />
-                    </BButton>
-                </BButtonGroup>
+                    </GButton>
+                </GButtonGroup>
 
-                <BButtonGroup vertical>
-                    <BButton
-                        v-b-tooltip.hover.noninteractive.right
+                <GButtonGroup vertical>
+                    <GButton
+                        tooltip
+                        tooltip-placement="right"
+                        outline
+                        color="blue"
                         class="button font-weight-bold"
                         data-tool="text_comment"
                         title="Text comment (Ctrl + 3)"
                         :pressed="currentTool === 'textComment'"
-                        variant="outline-primary"
                         @click="() => onCommentToolClick('textComment')">
                         <span class="icon-t">T</span>
-                    </BButton>
-                    <BButton
-                        v-b-tooltip.hover.noninteractive.right
+                    </GButton>
+                    <GButton
+                        tooltip
+                        tooltip-placement="right"
+                        outline
+                        color="blue"
                         class="button"
                         data-tool="markdown_comment"
                         title="Markdown comment (Ctrl + 4)"
                         :pressed="currentTool === 'markdownComment'"
-                        variant="outline-primary"
                         @click="() => onCommentToolClick('markdownComment')">
                         <FontAwesomeIcon :icon="['fab', 'markdown']" size="lg" />
-                    </BButton>
-                    <BButton
-                        v-b-tooltip.hover.noninteractive.right
+                    </GButton>
+                    <GButton
+                        tooltip
+                        tooltip-placement="right"
+                        outline
+                        color="blue"
                         class="button"
                         data-tool="frame_comment"
                         title="Frame comment (Ctrl + 5)"
                         :pressed="currentTool === 'frameComment'"
-                        variant="outline-primary"
                         @click="() => onCommentToolClick('frameComment')">
                         <FontAwesomeIcon icon="fa-object-group" size="lg" />
-                    </BButton>
-                </BButtonGroup>
+                    </GButton>
+                </GButtonGroup>
 
-                <BButtonGroup vertical>
-                    <BButton
-                        v-b-tooltip.hover.noninteractive.right
+                <GButtonGroup vertical>
+                    <GButton
+                        tooltip
+                        tooltip-placement="right"
+                        outline
+                        color="blue"
                         title="Freehand Pen (Ctrl + 6)"
                         data-tool="freehand_pen"
                         :pressed="currentTool === 'freehandComment'"
                         class="button"
-                        variant="outline-primary"
                         @click="() => onCommentToolClick('freehandComment')">
                         <FontAwesomeIcon icon="fa-pen" size="lg" />
-                    </BButton>
-                    <BButton
-                        v-b-tooltip.hover.noninteractive.right
+                    </GButton>
+                    <GButton
+                        tooltip
+                        tooltip-placement="right"
+                        outline
+                        color="blue"
                         title="Freehand Eraser (Ctrl + 7)"
                         data-tool="freehand_eraser"
                         :pressed="currentTool === 'freehandEraser'"
                         class="button"
-                        variant="outline-primary"
                         @click="() => onCommentToolClick('freehandEraser')">
                         <FontAwesomeIcon icon="fa-eraser" size="lg" />
-                    </BButton>
-                </BButtonGroup>
+                    </GButton>
+                </GButtonGroup>
 
-                <BButton
-                    v-b-tooltip.hover.noninteractive.right
+                <GButton
+                    tooltip
+                    tooltip-placement="right"
+                    outline
+                    color="blue"
                     title="Box Select (Ctrl + 8)"
                     data-tool="box_select"
                     :pressed="currentTool === 'boxSelect'"
                     class="button"
-                    variant="outline-primary"
                     @click="onClickBoxSelect">
                     <BoxSelect />
-                </BButton>
+                </GButton>
 
-                <BButton
+                <GButton
                     id="auto-layout-button"
-                    v-b-tooltip.hover.noninteractive.right
+                    tooltip
+                    tooltip-placement="right"
+                    outline
+                    color="blue"
                     title="Auto Layout (Ctrl + 9)"
                     data-tool="auto_layout"
                     class="button"
                     variant="outline-primary"
                     @click="autoLayout">
                     <Workflow />
-                </BButton>
+                </GButton>
             </template>
 
-            <BButton
-                v-b-tooltip.hover.noninteractive.right
+            <GButton
+                tooltip
+                tooltip-placement="right"
+                outline
+                color="blue"
                 class="toggle-visibility-button"
                 :title="toggleVisibilityButtonTitle"
-                variant="outline-primary"
                 @click="toolbarVisible = !toolbarVisible">
                 <FontAwesomeIcon v-if="toolbarVisible" icon="fa-chevron-up" />
                 <FontAwesomeIcon v-else icon="fa-chevron-down" />
-            </BButton>
+            </GButton>
         </div>
         <div v-if="toolbarVisible" class="options">
             <div v-if="anySelected" class="selection-options">
                 <span>{{ selectedCountText }}</span>
 
-                <BButtonGroup>
-                    <BButton class="button" title="clear selection" @click="deselectAll">
+                <GButtonGroup>
+                    <GButton class="button" title="clear selection" @click="deselectAll">
                         Clear <FontAwesomeIcon icon="fa-times" />
-                    </BButton>
-                    <BButton class="button" title="duplicate selected" @click="duplicateSelection">
+                    </GButton>
+                    <GButton class="button" title="duplicate selected" @click="duplicateSelection">
                         Duplicate <FontAwesomeIcon icon="fa-clone" />
-                    </BButton>
-                    <BButton class="button" title="delete selected" @click="deleteSelection">
+                    </GButton>
+                    <GButton class="button" title="delete selected" @click="deleteSelection">
                         Delete <FontAwesomeIcon icon="fa-trash" />
-                    </BButton>
-                </BButtonGroup>
+                    </GButton>
+                </GButtonGroup>
             </div>
 
             <div
@@ -309,22 +332,24 @@ function autoLayout() {
             </div>
 
             <div v-if="toolbarStore.currentTool === 'textComment'" class="option buttons">
-                <BButtonGroup>
-                    <BButton
+                <GButtonGroup>
+                    <GButton
                         :pressed.sync="commentOptions.bold"
-                        variant="outline-primary"
+                        outline
+                        color="blue"
                         class="button font-weight-bold"
                         data-option="toggle-bold">
                         Bold
-                    </BButton>
-                    <BButton
+                    </GButton>
+                    <GButton
                         :pressed.sync="commentOptions.italic"
-                        variant="outline-primary"
+                        outline
+                        color="blue"
                         class="button font-italic"
                         data-option="toggle-italic">
                         Italic
-                    </BButton>
-                </BButtonGroup>
+                    </GButton>
+                </GButtonGroup>
             </div>
 
             <div
@@ -382,36 +407,38 @@ function autoLayout() {
             </div>
 
             <div v-if="['freehandComment', 'freehandEraser'].includes(toolbarStore.currentTool)" class="option buttons">
-                <BButton
+                <GButton
                     class="button"
                     data-option="remove-freehand"
                     title="Remove all freehand comments"
                     @click="onRemoveAllFreehand">
                     Remove all
-                </BButton>
+                </GButton>
             </div>
 
             <div v-if="currentTool === 'boxSelect'" class="option buttons">
-                <BButtonGroup>
-                    <BButton
+                <GButtonGroup>
+                    <GButton
                         :pressed="toolbarStore.boxSelectMode === 'add'"
                         class="button"
+                        outline
+                        color="blue"
                         data-option="select-mode-add"
-                        variant="outline-primary"
                         title="add items to selection"
                         @click="toolbarStore.boxSelectMode = 'add'">
                         Add to selection
-                    </BButton>
-                    <BButton
+                    </GButton>
+                    <GButton
                         :pressed="toolbarStore.boxSelectMode === 'remove'"
                         class="button"
+                        outline
+                        color="blue"
                         data-option="select-mode-remove"
-                        variant="outline-primary"
                         title="remove items from selection"
                         @click="toolbarStore.boxSelectMode = 'remove'">
                         Remove from selection
-                    </BButton>
-                </BButtonGroup>
+                    </GButton>
+                </GButtonGroup>
             </div>
         </div>
     </div>
@@ -458,7 +485,9 @@ function autoLayout() {
     .toggle-visibility-button {
         height: 1.5rem;
         display: grid;
-        align-items: center;
+        place-items: center;
+        padding: 0;
+        width: 2.25rem;
     }
 
     .options {

--- a/client/src/components/Workflow/List/WorkflowActionsExtend.vue
+++ b/client/src/components/Workflow/List/WorkflowActionsExtend.vue
@@ -10,7 +10,6 @@ import {
     faUpload,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton, BButtonGroup } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed } from "vue";
 
@@ -21,6 +20,8 @@ import { useUserStore } from "@/stores/userStore";
 
 import { useWorkflowActions } from "./useWorkflowActions";
 
+import GButton from "@/components/BaseComponents/GButton.vue";
+import GButtonGroup from "@/components/BaseComponents/GButtonGroup.vue";
 import AsyncButton from "@/components/Common/AsyncButton.vue";
 import WorkflowRunButton from "@/components/Workflow/WorkflowRunButton.vue";
 
@@ -99,84 +100,90 @@ const { copyPublicLink, copyWorkflow, downloadUrl, importWorkflow } = useWorkflo
 
 <template>
     <div class="workflow-card-actions flex-gapx-1">
-        <BButtonGroup>
+        <GButtonGroup>
             <template v-if="!props.editor && !workflow.deleted">
-                <BButton
+                <GButton
                     v-if="workflow.published"
                     id="workflow-copy-public-button"
-                    v-b-tooltip.hover.noninteractive
-                    size="sm"
+                    tooltip
+                    outline
+                    size="small"
+                    color="blue"
                     title="Copy link to workflow"
-                    variant="outline-primary"
                     @click="copyPublicLink">
                     <FontAwesomeIcon :icon="faLink" fixed-width />
                     <span class="compact-view">Link to Workflow</span>
-                </BButton>
+                </GButton>
 
-                <BButton
+                <GButton
                     v-if="!isAnonymous && !shared"
                     id="workflow-copy-button"
-                    v-b-tooltip.hover.noninteractive
-                    size="sm"
+                    tooltip
+                    outline
+                    size="small"
+                    color="blue"
                     title="Copy"
-                    variant="outline-primary"
                     @click="copyWorkflow">
                     <FontAwesomeIcon :icon="faCopy" fixed-width />
                     <span class="compact-view">Copy</span>
-                </BButton>
+                </GButton>
 
-                <BButton
+                <GButton
                     id="workflow-download-button"
-                    v-b-tooltip.hover.noninteractive
-                    size="sm"
+                    tooltip
+                    outline
+                    size="small"
+                    color="blue"
                     title="Download workflow in .ga format"
-                    variant="outline-primary"
                     :href="downloadUrl">
                     <FontAwesomeIcon :icon="faDownload" fixed-width />
                     <span class="compact-view">Download</span>
-                </BButton>
+                </GButton>
 
-                <BButton
+                <GButton
                     v-if="!isAnonymous && !shared"
                     id="workflow-share-button"
-                    v-b-tooltip.hover.noninteractive
-                    size="sm"
+                    tooltip
+                    outline
+                    size="small"
+                    color="blue"
                     title="Share"
-                    variant="outline-primary"
                     :to="`/workflows/sharing?id=${workflow.id}`">
                     <FontAwesomeIcon :icon="faShareAlt" fixed-width />
                     <span class="compact-view">Share</span>
-                </BButton>
+                </GButton>
             </template>
 
-            <BButton
+            <GButton
                 v-if="workflow.deleted"
                 id="restore-button"
-                v-b-tooltip.hover.noninteractive
-                size="sm"
+                tooltip
+                outline
+                size="small"
+                color="blue"
                 title="Restore"
-                variant="outline-primary"
                 @click="onRestore">
                 <FontAwesomeIcon :icon="faTrashRestore" fixed-width />
                 <span class="compact-view">Restore</span>
-            </BButton>
-        </BButtonGroup>
+            </GButton>
+        </GButtonGroup>
 
-        <div>
+        <div class="d-flex flex-gapx-1 align-items-center">
             <i v-if="props.current" class="mr-2"> current workflow </i>
 
-            <BButton
+            <GButton
                 v-if="!isAnonymous && !shared && !props.current"
-                v-b-tooltip.hover.noninteractive
                 :disabled="workflow.deleted"
-                size="sm"
+                tooltip
+                outline
+                size="small"
+                color="blue"
                 class="workflow-edit-button"
                 :title="editButtonTitle"
-                variant="outline-primary"
                 :to="`/workflows/edit?id=${workflow.id}`">
                 <FontAwesomeIcon :icon="faEdit" fixed-width />
                 Edit
-            </BButton>
+            </GButton>
 
             <AsyncButton
                 v-else-if="!props.current"
@@ -196,27 +203,29 @@ const { copyPublicLink, copyWorkflow, downloadUrl, importWorkflow } = useWorkflo
                 :disabled="isAnonymous || workflow.deleted"
                 :title="runButtonTitle" />
 
-            <BButtonGroup v-if="props.editor && !workflow.deleted">
-                <BButton
-                    v-b-tooltip.hover.noninteractive
-                    size="sm"
+            <GButtonGroup v-if="props.editor && !workflow.deleted">
+                <GButton
+                    tooltip
+                    outline
+                    size="small"
+                    color="blue"
                     title="Copy steps into workflow"
-                    variant="outline-primary"
                     @click="emit('insertSteps')">
                     <FontAwesomeIcon :icon="faCopy" fixed-width />
-                </BButton>
+                </GButton>
 
-                <BButton
+                <GButton
                     v-if="!props.current"
-                    v-b-tooltip.hover.noninteractive
-                    size="sm"
+                    tooltip
+                    outline
+                    size="small"
+                    color="blue"
                     title="Insert as sub-workflow"
-                    variant="primary"
                     @click="emit('insert')">
                     <FontAwesomeIcon :icon="faPlusSquare" fixed-width />
                     <span> Insert </span>
-                </BButton>
-            </BButtonGroup>
+                </GButton>
+            </GButtonGroup>
         </div>
     </div>
 </template>

--- a/client/src/components/Workflow/List/WorkflowCard.vue
+++ b/client/src/components/Workflow/List/WorkflowCard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faPen } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton, BFormCheckbox, BLink } from "bootstrap-vue";
+import { BFormCheckbox, BLink } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 
@@ -9,6 +9,7 @@ import { type WorkflowSummary } from "@/api/workflows";
 import { updateWorkflow } from "@/components/Workflow/workflows.services";
 import { useUserStore } from "@/stores/userStore";
 
+import GButton from "@/components/BaseComponents/GButton.vue";
 import TextSummary from "@/components/Common/TextSummary.vue";
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 import WorkflowActions from "@/components/Workflow/List/WorkflowActions.vue";
@@ -133,17 +134,18 @@ const dropdownOpen = ref(false);
                         {{ workflow.name }}
                     </BLink>
 
-                    <BButton
+                    <GButton
                         v-if="!props.current && !shared && !workflow.deleted"
-                        v-b-tooltip.hover.noninteractive
+                        tooltip
+                        icon-only
+                        color="blue"
                         :data-workflow-rename="workflow.id"
-                        class="inline-icon-button workflow-rename"
-                        variant="link"
-                        size="sm"
+                        class="workflow-rename"
+                        size="small"
                         title="Rename"
                         @click="emit('rename', props.workflow.id, props.workflow.name)">
                         <FontAwesomeIcon :icon="faPen" fixed-width />
-                    </BButton>
+                    </GButton>
                 </span>
 
                 <TextSummary

--- a/client/src/components/Workflow/List/WorkflowCard.vue
+++ b/client/src/components/Workflow/List/WorkflowCard.vue
@@ -138,6 +138,7 @@ const dropdownOpen = ref(false);
                         v-if="!props.current && !shared && !workflow.deleted"
                         tooltip
                         icon-only
+                        transparent
                         color="blue"
                         :data-workflow-rename="workflow.id"
                         class="workflow-rename"

--- a/client/src/components/Workflow/List/WorkflowListActions.vue
+++ b/client/src/components/Workflow/List/WorkflowListActions.vue
@@ -27,37 +27,35 @@ function navigateToOldCreate() {
 </script>
 
 <template>
-    <div id="workflow-list-actions" class="d-flex justify-content-between">
-        <div>
-            <GButton
-                id="workflow-create"
-                size="small"
-                outline
-                tooltip
-                tooltip-placement="bottom"
-                color="blue"
-                title="Create new workflow"
-                disabled-title="Log in to create workflow"
-                :disabled="isAnonymous"
-                @click="navigateToOldCreate">
-                <FontAwesomeIcon :icon="faPlus" />
-                Create
-            </GButton>
+    <div id="workflow-list-actions" class="d-flex align-items-center flex-gapx-1">
+        <GButton
+            id="workflow-create"
+            size="small"
+            outline
+            tooltip
+            tooltip-placement="bottom"
+            color="blue"
+            title="Create new workflow"
+            disabled-title="Log in to create workflow"
+            :disabled="isAnonymous"
+            @click="navigateToOldCreate">
+            <FontAwesomeIcon :icon="faPlus" />
+            Create
+        </GButton>
 
-            <GButton
-                id="workflow-import"
-                outline
-                tooltip
-                tooltip-placement="bottom"
-                size="small"
-                title="Import workflow from URL or file"
-                disabled-title="Log in to import workflow"
-                color="blue"
-                :disabled="isAnonymous"
-                @click="navigateToImport">
-                <FontAwesomeIcon :icon="faUpload" />
-                Import
-            </GButton>
-        </div>
+        <GButton
+            id="workflow-import"
+            outline
+            tooltip
+            tooltip-placement="bottom"
+            size="small"
+            title="Import workflow from URL or file"
+            disabled-title="Log in to import workflow"
+            color="blue"
+            :disabled="isAnonymous"
+            @click="navigateToImport">
+            <FontAwesomeIcon :icon="faUpload" />
+            Import
+        </GButton>
     </div>
 </template>

--- a/client/src/components/Workflow/List/WorkflowListActions.vue
+++ b/client/src/components/Workflow/List/WorkflowListActions.vue
@@ -2,12 +2,12 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faPlus, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
-import { computed } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { useUserStore } from "@/stores/userStore";
+
+import GButton from "@/components/BaseComponents/GButton.vue";
 
 library.add(faPlus, faUpload);
 
@@ -16,21 +16,6 @@ const router = useRouter();
 const userStore = useUserStore();
 
 const { isAnonymous } = storeToRefs(userStore);
-
-const createButtonTitle = computed(() => {
-    if (isAnonymous.value) {
-        return "Log in to create workflow";
-    } else {
-        return "Create new workflow";
-    }
-});
-const importButtonTitle = computed(() => {
-    if (isAnonymous.value) {
-        return "Log in to import workflow";
-    } else {
-        return "Import workflow from URL or file";
-    }
-});
 
 function navigateToImport() {
     router.push("/workflows/import");
@@ -44,29 +29,35 @@ function navigateToOldCreate() {
 <template>
     <div id="workflow-list-actions" class="d-flex justify-content-between">
         <div>
-            <BButton
+            <GButton
                 id="workflow-create"
-                v-b-tooltip.hover.noninteractive
-                size="sm"
-                :title="createButtonTitle"
-                variant="outline-primary"
+                size="small"
+                outline
+                tooltip
+                tooltip-placement="bottom"
+                color="blue"
+                title="Create new workflow"
+                disabled-title="Log in to create workflow"
                 :disabled="isAnonymous"
                 @click="navigateToOldCreate">
                 <FontAwesomeIcon :icon="faPlus" />
                 Create
-            </BButton>
+            </GButton>
 
-            <BButton
+            <GButton
                 id="workflow-import"
-                v-b-tooltip.hover.noninteractive
-                size="sm"
-                :title="importButtonTitle"
-                variant="outline-primary"
+                outline
+                tooltip
+                tooltip-placement="bottom"
+                size="small"
+                title="Import workflow from URL or file"
+                disabled-title="Log in to import workflow"
+                color="blue"
                 :disabled="isAnonymous"
                 @click="navigateToImport">
                 <FontAwesomeIcon :icon="faUpload" />
                 Import
-            </BButton>
+            </GButton>
         </div>
     </div>
 </template>

--- a/client/src/composables/accessibleHover.ts
+++ b/client/src/composables/accessibleHover.ts
@@ -1,0 +1,59 @@
+import { type Ref, ref, watch } from "vue";
+
+export function useAccessibleHover(
+    elementRef: Ref<HTMLElement | null>,
+    onHoverEnter?: () => void,
+    onHoverExit?: () => void
+) {
+    const isHovering = ref(false);
+    let previousElement: HTMLElement | null = null;
+
+    function enter() {
+        if (!isHovering.value) {
+            onHoverEnter?.();
+            isHovering.value = true;
+        }
+    }
+
+    function exit() {
+        if (isHovering.value) {
+            onHoverExit?.();
+            isHovering.value = false;
+        }
+    }
+
+    function keydown(event: KeyboardEvent) {
+        if (event.key === "Escape") {
+            exit();
+        }
+    }
+
+    watch(
+        () => elementRef.value,
+        () => {
+            if (previousElement) {
+                exit();
+                previousElement.removeEventListener("mouseenter", enter);
+                previousElement.removeEventListener("focus", enter);
+                previousElement.removeEventListener("mouseleave", exit);
+                previousElement.removeEventListener("blur", exit);
+                previousElement.removeEventListener("keydown", keydown);
+            }
+
+            if (elementRef.value) {
+                elementRef.value.addEventListener("mouseenter", enter);
+                elementRef.value.addEventListener("focus", enter);
+                elementRef.value.addEventListener("mouseleave", exit);
+                elementRef.value.addEventListener("blur", exit);
+                elementRef.value.addEventListener("keydown", keydown);
+            }
+
+            previousElement = elementRef.value;
+        },
+        {
+            immediate: true,
+        }
+    );
+
+    return isHovering;
+}

--- a/client/src/composables/resolveElement.ts
+++ b/client/src/composables/resolveElement.ts
@@ -1,0 +1,15 @@
+import { computed, type Ref } from "vue";
+
+export function useResolveElement(elementRef: Ref<unknown>) {
+    const resolvedRef = computed(() => {
+        const value = elementRef.value;
+
+        if (typeof value === "object" && value !== null && "$el" in value) {
+            return value.$el as HTMLElement;
+        } else {
+            return value as HTMLElement | null;
+        }
+    });
+
+    return resolvedRef;
+}

--- a/client/src/style/scss/custom_theme_variables.scss
+++ b/client/src/style/scss/custom_theme_variables.scss
@@ -9,7 +9,7 @@ html,
     --color-blue-700: #2c3143;
     --color-blue-600: #25537b;
     --color-blue-500: #197cd2;
-    --color-blue-400: #4593c8;
+    --color-blue-400: #48a1dd;
     --color-blue-300: #80c3ea;
     --color-blue-200: #daecf8;
     --color-blue-100: #f1f9fe;
@@ -63,6 +63,21 @@ html,
     --color-red-300: #f4a3a5;
     --color-red-200: #fdd4d5;
     --color-red-100: #fff3f3;
+
+    // sizes
+    --spacing: 0.25rem;
+    --spacing-1: var(--spacing);
+    --spacing-2: calc(var(--spacing) * 2);
+    --spacing-3: calc(var(--spacing) * 3);
+    --spacing-4: calc(var(--spacing) * 4);
+    --spacing-5: calc(var(--spacing) * 5);
+    --spacing-6: calc(var(--spacing) * 6);
+    --spacing-7: calc(var(--spacing) * 7);
+    --spacing-8: calc(var(--spacing) * 8);
+
+    --font-size-small: 0.75rem;
+    --font-size-base: 0.85rem;
+    --font-size-large: 1rem;
 
     // masthead specific
     --masthead-color: #{$masthead-color};

--- a/client/src/style/scss/custom_theme_variables.scss
+++ b/client/src/style/scss/custom_theme_variables.scss
@@ -1,7 +1,70 @@
+// todo remove import once all color is ported to css
 @import "theme/blue.scss";
 
 html,
 .reset-theme-variables {
+    // main colors
+    --color-blue-900: #040b21;
+    --color-blue-800: #191f33;
+    --color-blue-700: #2c3143;
+    --color-blue-600: #25537b;
+    --color-blue-500: #197cd2;
+    --color-blue-400: #4593c8;
+    --color-blue-300: #80c3ea;
+    --color-blue-200: #daecf8;
+    --color-blue-100: #f1f9fe;
+
+    --color-grey-900: #191919;
+    --color-grey-800: #23262f;
+    --color-grey-700: #35373f;
+    --color-grey-600: #484a52;
+    --color-grey-500: #63656d;
+    --color-grey-400: #8f9199;
+    --color-grey-300: #aab0b4;
+    --color-grey-200: #dee2e6;
+    --color-grey-100: #f8f9fa;
+
+    --color-green-900: #002a1f;
+    --color-green-800: #003f2e;
+    --color-green-700: #006f50;
+    --color-green-600: #25a35b;
+    --color-green-500: #66cc66;
+    --color-green-400: #98e192;
+    --color-green-300: #c8edc8;
+    --color-green-200: #e0f7df;
+    --color-green-100: #f3fbf2;
+
+    --color-yellow-900: #362100;
+    --color-yellow-800: #462b00;
+    --color-yellow-700: #7f5102;
+    --color-yellow-600: #f0aa02;
+    --color-yellow-500: #ffd700;
+    --color-yellow-400: #ffe848;
+    --color-yellow-300: #fff489;
+    --color-yellow-200: #fefbc5;
+    --color-yellow-100: #fefeea;
+
+    --color-orange-900: #391100;
+    --color-orange-800: #461500;
+    --color-orange-700: #9b3a00;
+    --color-orange-600: #fe7e03;
+    --color-orange-500: #ff9b2f;
+    --color-orange-400: #ffae52;
+    --color-orange-300: #ffc985;
+    --color-orange-200: #ffedd5;
+    --color-orange-100: #fffaf1;
+
+    --color-red-900: #430111;
+    --color-red-800: #63021a;
+    --color-red-700: #91081b;
+    --color-red-600: #e31a1e;
+    --color-red-500: #f33b36;
+    --color-red-400: #ff817b;
+    --color-red-300: #f4a3a5;
+    --color-red-200: #fdd4d5;
+    --color-red-100: #fff3f3;
+
+    // masthead specific
     --masthead-color: #{$masthead-color};
     --masthead-text-color: #{$masthead-text-color};
     --masthead-text-hover: #{$masthead-text-hover};

--- a/client/src/style/scss/custom_theme_variables.scss
+++ b/client/src/style/scss/custom_theme_variables.scss
@@ -3,6 +3,8 @@
 
 html,
 .reset-theme-variables {
+    --background-color: #ffffff;
+
     // main colors
     --color-blue-900: #040b21;
     --color-blue-800: #191f33;

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -615,7 +615,7 @@ workflows:
     workflows_list_empty: '#workflow-list-empty'
     workflow_not_found_message: '#no-workflow-found'
     workflow_card: '.workflow-card'
-    workflow_card_button: '.workflow-card[data-workflow-name="${name}"] button[title="${title}"]'
+    workflow_card_button: '.workflow-card[data-workflow-name="${name}"] button[data-title="${title}"]'
     workflow_cards: '#workflow-cards'
     external_link: '.workflow-external-link'
     trs_icon: '.workflow-trs-icon'


### PR DESCRIPTION
This PR is mostly to gather feedback on the discussed bootstrap replacement, as it will heavily shape on how the replacement will look and work moving forward. It includes a base implementation of the button component, which is our most heavily used component from the bootstrap vue library, to illustrate the direction I plan on taking this refactor.

The look of the button component is nearly identical, and the primary goal here to collect feedback on the code structure and direction.

My design goal with this refactor is not achieving a 100% drop in replacement, but still have the components easy to replace while adjusting their interfaces to our use-cases.

### Tooltips

This PR also includes a re-implementation of the bootstrap vue tooltip, which is fully accessible. It can be activated and dismissed via keyboard and works on disabled components.

### Color system

The color system is inspired by tailwind. Each color has a pre-defined set of handpicked gradients, to ensure sufficient contrast and color-uniformity. Additionally partially transparent colors have been removed, as they further reduce contrast, and lead to new, non-palettized colors. Each color has a gradient from 100, lightest, to 900, darkest. example usage: `var(--color-blue-500)`.

### Spacing

Spacing also follows tailwinds example. Instead of defining a arbitrary set of space sizes, all sizes are a multiple of a base size. example usage: `var(--spacing-4)` is 4 times the base spacing.

### Next steps

The next step for the replacement will be replacing all uses of plain (non-grouped) boostrap buttons with this component, and adding additional features required to do so. Mainly an icon-only variant of the button is still missing.

After that further components will be converted, starting with button groups.

Additionally I would like to add a GLink component, as we heavily make use of custom, button-like links.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
