### PR TITLE
Decrease sentry_sdk.errors log level to INFO

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -124,6 +124,10 @@ LOGGING_CONFIG_DEFAULT: Dict[str, Any] = {
             "level": "INFO",
             "qualname": "celery.utils.functional",
         },
+        "sentry_sdk.errors": {
+            "level": "INFO",
+            "qualname": "sentry_sdk.errors",
+        },
     },
     "filters": {
         "stack": {


### PR DESCRIPTION
sentry_sdk must've added a bunch of debug logging because each request is now generating log messages like:

```
sentry_sdk.errors DEBUG 2025-04-02 14:30:58,764 [pN:main.1,p:1253439,tN:MainThread] [ASGI] Created transaction (continuing trace): <Transaction(name='https://127.0.0.1:8080/api/datasets/c0ffee', op='http.server', trace_id='aa4b3b1de8364a1da6dff126f5d9e729', span_id='0059c3cad468e583', parent_span_id=None, sampled=None, source=<TransactionSource.URL: 'url'>, origin='auto.http.starlette')>
sentry_sdk.errors DEBUG 2025-04-02 14:30:58,764 [pN:main.1,p:1253439,tN:MainThread] [ASGI] Set transaction name and source on transaction: 'https://127.0.0.1:8080/api/datasets/c0ffee' / 'url'
sentry_sdk.errors DEBUG 2025-04-02 14:30:58,764 [pN:main.1,p:1253439,tN:MainThread] [Tracing] Discarding <http.server> transaction <https://127.0.0.1:8080/api/datasets/c0ffee> because it's not included in the random sample (sampling rate = 0.2)
sentry_sdk.errors DEBUG 2025-04-02 14:30:58,764 [pN:main.1,p:1253439,tN:MainThread] [ASGI] Started transaction: <Transaction(name='https://127.0.0.1:8080/api/datasets/c0ffee', op='http.server', trace_id='aa4b3b1de8364a1da6dff126f5d9e729', span_id='0059c3cad468e583', parent_span_id=None, sampled=False, source=<TransactionSource.URL: 'url'>, origin='auto.http.starlette')>
sentry_sdk.errors DEBUG 2025-04-02 14:30:58,765 [pN:main.1,p:1253439,tN:MainThread] [FastAPI] Set transaction name and source on scope: /api/datasets/{dataset_id} / route
uvicorn.access INFO 2025-04-02 14:30:58,799 [pN:main.1,p:1253439,tN:MainThread] 173.13.209.137:0 - "GET /api/datasets/c0ffee HTTP/1.0" 200
sentry_sdk.errors DEBUG 2025-04-02 14:30:58,801 [pN:main.1,p:1253439,tN:MainThread] Discarding transaction because sampled = False
```