### PR TITLE
[24.2] Sort intersected options

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -132,6 +132,12 @@ INPUT_PARAMETER_TYPES = Literal["text", "integer", "float", "boolean", "color", 
 POSSIBLE_PARAMETER_TYPES: Tuple[INPUT_PARAMETER_TYPES] = get_args(INPUT_PARAMETER_TYPES)
 
 
+class OptionDict(TypedDict):
+    label: str
+    value: str
+    selected: bool
+
+
 class ConditionalStepWhen(BooleanToolParameter):
     pass
 
@@ -1479,7 +1485,7 @@ class InputParameterModule(WorkflowModule):
                                 ].static_options
                             )
 
-            options = None
+            options: Optional[List[OptionDict]] = None
             if static_options and len(static_options) == 1:
                 # If we are connected to a single option, just use it as is so order is preserved cleanly and such.
                 options = [
@@ -1501,6 +1507,7 @@ class InputParameterModule(WorkflowModule):
                     }
                     for value, labels in collapsed_labels.items()
                 ]
+                options.sort(key=lambda x: x["label"])
 
             return options
         except Exception:


### PR DESCRIPTION
Otherwise you're getting a different order every time you load the workflow run form

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
