### PR TITLE
Use lower case extension for setting datatype in data discovery

### DIFF
--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -511,6 +511,7 @@ def collect_primary_datasets(job_context: Union[JobContext, SessionlessJobContex
             ext = fields_match.ext
             if ext == "input":
                 ext = input_ext
+            ext = ext.lower()
             dbkey = fields_match.dbkey
             if dbkey == INPUT_DBKEY_TOKEN:
                 dbkey = job_context.input_dbkey

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4673,8 +4673,6 @@ DescribesHash = Union[DatasetSourceHash, DatasetHash]
 
 
 def datatype_for_extension(extension, datatypes_registry=None) -> "Data":
-    if extension is not None:
-        extension = extension.lower()
     if datatypes_registry is None:
         datatypes_registry = _get_datatypes_registry()
     if not extension or extension == "auto" or extension == "_sniff_":

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -362,6 +362,7 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
             designation = fields_match.designation
             visible = fields_match.visible
             ext = ext_override or fields_match.ext
+            ext = ext.lower()
             dbkey = fields_match.dbkey
             extra_files = fields_match.extra_files
             # galaxy.tools.parser.output_collection_def.INPUT_DBKEY_TOKEN

--- a/test/functional/tools/collection_split_on_column.xml
+++ b/test/functional/tools/collection_split_on_column.xml
@@ -1,6 +1,6 @@
 <tool id="collection_split_on_column" name="collection_split_on_column" version="0.1.0">
   <command>
-    mkdir outputs; cd outputs; awk '{ print \$2 > (\$1 ".tabular") }' $input1
+    mkdir outputs; cd outputs; awk '{ print \$2 > (\$1 ".Tabular") }' $input1
   </command>
   <inputs>
     <param name="input1" type="data" label="Input Table" help="Table to split on first column" format="tabular" />

--- a/test/functional/tools/discover_sort_by.xml
+++ b/test/functional/tools/discover_sort_by.xml
@@ -2,7 +2,8 @@
     <command><![CDATA[
 for i in \$(seq 1 10);
 do
-    echo "\$i" > \$i.txt;
+    ## also test that lowercase extension will be used as ext
+    echo "\$i" > \$i.tXt;
 done
 ## create a directory that matches the discovery pattern
 ## but must not be discovered because it's a directory which
@@ -27,44 +28,44 @@ done
   <tests>
     <test expect_num_outputs="4">
       <output_collection name="collection_numeric_name" type="list" count="10">
-        <element name="1">
+        <element name="1" ftype="txt">
           <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
         </element>
-        <element name="2">
+        <element name="2" ftype="txt">
           <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
         </element>
-        <element name="10">
+        <element name="10" ftype="txt">
           <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
         </element>
       </output_collection>
       <output_collection name="collection_rev_numeric_name" type="list" count="10">
-        <element name="10">
+        <element name="10" ftype="txt">
           <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
         </element>
-        <element name="2">
+        <element name="2" ftype="txt">
           <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
         </element>
-        <element name="1">
+        <element name="1" ftype="txt">
           <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
         </element>
       </output_collection>
       <output_collection name="collection_lexical_name" type="list" count="10">
-        <element name="1">
+        <element name="1" ftype="txt">
           <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
         </element>
-        <element name="10">
+        <element name="10" ftype="txt">
           <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
         </element>
-        <element name="2">
+        <element name="2" ftype="txt">
           <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
         </element>
       </output_collection>
       <output name="data_reverse_lexical_name">
         <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
-        <discovered_dataset designation="10">
+        <discovered_dataset designation="10" ftype="txt">
           <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
         </discovered_dataset>
-        <discovered_dataset designation="1">
+        <discovered_dataset designation="1" ftype="txt">
           <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
         </discovered_dataset>
       </output>


### PR DESCRIPTION
I thought that I already did this [here](https://github.com/galaxyproject/galaxy/pull/10803), but apparently it was something else. So, now for real .. with a test. 

When trying to find out what my original change does I found that [`DatasetMatcherFactory.matches_format`](https://github.com/galaxyproject/galaxy/blob/c45f2e5fd01e07fadab8dc98957665b0ddd1d7eb/lib/galaxy/tools/parameters/dataset_matcher.py#L54) and [`DatasetMatcherFactory.matches_any_format`](https://github.com/galaxyproject/galaxy/blob/c45f2e5fd01e07fadab8dc98957665b0ddd1d7eb/lib/galaxy/tools/parameters/dataset_matcher.py#L48) are unused. Should such code be removed?



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
