### PR TITLE
Add share button for invocations

### DIFF
--- a/client/src/api/histories.ts
+++ b/client/src/api/histories.ts
@@ -1,3 +1,9 @@
-import { type components } from "@/api";
+import { type AnyHistory, type components } from "@/api";
+
+type HistoryDetailed = components["schemas"]["HistoryDetailed"];
 
 export type HistoryContentsResult = components["schemas"]["HistoryContentsResult"];
+
+export function hasImportable(entry?: AnyHistory): entry is HistoryDetailed {
+    return entry !== undefined && "importable" in entry;
+}

--- a/client/src/components/Workflow/WorkflowAnnotation.vue
+++ b/client/src/components/Workflow/WorkflowAnnotation.vue
@@ -3,14 +3,11 @@ import { faClock } from "@fortawesome/free-regular-svg-icons";
 import { faExclamation, faHdd } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BBadge } from "bootstrap-vue";
-import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 
-import { isRegisteredUser } from "@/api";
 import { useMarkdown } from "@/composables/markdown";
 import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
 import { useHistoryStore } from "@/stores/historyStore";
-import { useUserStore } from "@/stores/userStore";
 
 import Heading from "../Common/Heading.vue";
 import TextSummary from "../Common/TextSummary.vue";
@@ -32,16 +29,7 @@ const props = withDefaults(defineProps<Props>(), {
     invocationUpdateTime: undefined,
 });
 
-const { workflow } = useWorkflowInstance(props.workflowId);
-
-const { currentUser } = storeToRefs(useUserStore());
-const owned = computed(() => {
-    if (isRegisteredUser(currentUser.value) && workflow.value) {
-        return currentUser.value.username === workflow.value.owner;
-    } else {
-        return false;
-    }
-});
+const { workflow, owned } = useWorkflowInstance(props.workflowId);
 
 const description = computed(() => {
     if (workflow.value?.annotation) {

--- a/client/src/components/Workflow/WorkflowNavigationTitle.vue
+++ b/client/src/components/Workflow/WorkflowNavigationTitle.vue
@@ -6,7 +6,6 @@ import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 import { RouterLink } from "vue-router";
 
-import { isRegisteredUser } from "@/api";
 import type { WorkflowInvocationElementView } from "@/api/invocations";
 import type { WorkflowSummary } from "@/api/workflows";
 import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
@@ -37,16 +36,9 @@ const emit = defineEmits<{
     (e: "on-execute"): void;
 }>();
 
-const { workflow, loading, error } = useWorkflowInstance(props.workflowId);
+const { workflow, loading, error, owned } = useWorkflowInstance(props.workflowId);
 
-const { currentUser, isAnonymous } = storeToRefs(useUserStore());
-const owned = computed(() => {
-    if (isRegisteredUser(currentUser.value) && workflow.value) {
-        return currentUser.value.username === workflow.value.owner;
-    } else {
-        return false;
-    }
-});
+const { isAnonymous } = storeToRefs(useUserStore());
 
 const importErrorMessage = ref<string | null>(null);
 const importedWorkflow = ref<WorkflowSummary | null>(null);

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.test.ts
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.test.ts
@@ -1,0 +1,203 @@
+import { createTestingPinia } from "@pinia/testing";
+import { getFakeRegisteredUser } from "@tests/test-data";
+import { shallowMount, type Wrapper } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import { getLocalVue } from "tests/jest/helpers";
+
+import { useServerMock } from "@/api/client/__mocks__/index";
+import { useUserStore } from "@/stores/userStore";
+
+import WorkflowInvocationShare from "./WorkflowInvocationShare.vue";
+
+// Constants
+const WORKFLOW_OWNER = "test-user";
+const OTHER_USER = "other-user";
+const TEST_WORKFLOW = {
+    id: "workflow-id",
+    name: "workflow-name",
+    owner: WORKFLOW_OWNER,
+    version: 1,
+    importable: false,
+    published: false,
+    users_shared_with: [],
+    title: "workflow-title",
+};
+const SHARED_WORKFLOW_ID = "shared-workflow-id";
+const TEST_HISTORY = {
+    id: "test-history-id",
+    name: "test-history-name",
+    archived: false,
+};
+const TEST_HISTORY_POST_SHARE = {
+    ...TEST_HISTORY,
+    importable: true,
+    published: false,
+    users_shared_with: [],
+    title: "history-title",
+};
+const SHARE_SUCCESS_MSG = "Workflow and history are now shareable.";
+const CLIPBOARD_MSG = "The link to the invocation has been copied to your clipboard.";
+
+const SELECTORS = {
+    SHARE_ICON_BUTTON: "[data-description='share invocation icon button']",
+    MODAL: "[data-description='share invocation modal']",
+};
+
+// Mock the toast composable to track the messages
+const MSG = 0;
+const TYPE = 1;
+const toastMock = jest.fn((message, type: "success" | "info") => {
+    return { message, type };
+});
+jest.mock("@/composables/toast", () => ({
+    Toast: {
+        success: jest.fn().mockImplementation((message) => {
+            toastMock(message, "success");
+        }),
+        info: jest.fn().mockImplementation((message) => {
+            toastMock(message, "info");
+        }),
+    },
+}));
+
+// Mock "@/utils/clipboard"
+const writeText = jest.fn();
+Object.assign(navigator, {
+    clipboard: {
+        writeText,
+    },
+});
+
+// Mock the workflow store to return the sample workflow
+jest.mock("@/stores/workflowStore", () => {
+    const originalModule = jest.requireActual("@/stores/workflowStore");
+    return {
+        ...originalModule,
+        useWorkflowStore: () => ({
+            ...originalModule.useWorkflowStore(),
+            getStoredWorkflowByInstanceId: jest.fn().mockImplementation((workflowId: string) => {
+                return {
+                    ...TEST_WORKFLOW,
+                    id: workflowId === SHARED_WORKFLOW_ID ? SHARED_WORKFLOW_ID : TEST_WORKFLOW.id,
+                    importable: workflowId === SHARED_WORKFLOW_ID,
+                };
+            }),
+        }),
+    };
+});
+
+const { server, http } = useServerMock();
+
+const localVue = getLocalVue();
+
+/**
+ * Mounts the WorkflowInvocationShare component with props/stores adjusted given the parameters
+ * @param ownsWorkflow Whether the user owns the workflow associated with the invocation
+ * @param bothShareable Whether the workflow and history are already shareable
+ * @returns The wrapper object
+ */
+async function mountWorkflowInvocationShare(ownsWorkflow = true, bothShareable = false) {
+    server.use(
+        http.get("/api/histories/{history_id}", ({ response }) => {
+            return response(200).json({
+                ...TEST_HISTORY,
+                importable: bothShareable,
+            });
+        }),
+
+        http.put("/api/workflows/{workflow_id}/enable_link_access", ({ response }) => {
+            return response(200).json({
+                ...TEST_WORKFLOW,
+                importable: true,
+            });
+        }),
+
+        http.put("/api/histories/{history_id}/enable_link_access", ({ response }) => {
+            return response(200).json(TEST_HISTORY_POST_SHARE);
+        })
+    );
+
+    const wrapper = shallowMount(WorkflowInvocationShare as object, {
+        propsData: {
+            invocationId: "invocation-id",
+            workflowId: bothShareable ? SHARED_WORKFLOW_ID : TEST_WORKFLOW.id,
+            historyId: TEST_HISTORY.id,
+        },
+        localVue,
+        pinia: createTestingPinia(),
+    });
+
+    const userStore = useUserStore();
+    userStore.currentUser = getFakeRegisteredUser({
+        username: ownsWorkflow ? WORKFLOW_OWNER : OTHER_USER,
+    });
+
+    await flushPromises();
+
+    return { wrapper };
+}
+
+async function openShareModal(wrapper: Wrapper<Vue>) {
+    await wrapper.find(SELECTORS.SHARE_ICON_BUTTON).trigger("click");
+}
+
+describe("WorkflowInvocationShare", () => {
+    beforeEach(() => {
+        (navigator.clipboard.writeText as jest.Mock).mockResolvedValue(undefined);
+    });
+
+    it("opens the modal with the expected history and workflow information", async () => {
+        const { wrapper } = await mountWorkflowInvocationShare();
+
+        // Initially, the modal is not visible and opens when the button is clicked
+        expect(wrapper.find(SELECTORS.MODAL).attributes("visible")).toBeUndefined();
+        await openShareModal(wrapper);
+        expect(wrapper.find(SELECTORS.MODAL).attributes("visible")).toBe("true");
+
+        expect(wrapper.find(SELECTORS.MODAL).text()).toContain(TEST_WORKFLOW.name);
+        expect(wrapper.find(SELECTORS.MODAL).text()).toContain(TEST_HISTORY.name);
+    });
+
+    it("shares the workflow and history when the share button is clicked, and copies link", async () => {
+        const { wrapper } = await mountWorkflowInvocationShare();
+
+        await openShareModal(wrapper);
+
+        // Click the share button in the modal
+        wrapper.find(SELECTORS.MODAL).vm.$emit("ok");
+        await flushPromises();
+
+        // We have 2 toasts
+        const toasts = toastMock.mock.calls;
+        expect(toasts.length).toBe(2);
+
+        // The first one is the success message for sharing the workflow and history
+        expect(toasts[0]![MSG]).toBe(SHARE_SUCCESS_MSG);
+        expect(toasts[0]![TYPE]).toBe("success");
+
+        // The second one is the copied link message
+        expect(toasts[1]![MSG]).toBe(CLIPBOARD_MSG);
+        expect(toasts[1]![TYPE]).toBe("info");
+    });
+
+    it("renders nothing when the user does not own the workflow", async () => {
+        const { wrapper } = await mountWorkflowInvocationShare(false);
+        expect(wrapper.find(SELECTORS.SHARE_ICON_BUTTON).exists()).toBe(false);
+        expect(wrapper.find(SELECTORS.MODAL).exists()).toBe(false);
+    });
+
+    it("just copies link and does not open modal if both workflow and history are already shareable", async () => {
+        const { wrapper } = await mountWorkflowInvocationShare(true, true);
+
+        // Initially, the modal is not visible and this time remains closed when the button is clicked
+        expect(wrapper.find(SELECTORS.MODAL).attributes("visible")).toBeUndefined();
+        await openShareModal(wrapper);
+        expect(wrapper.find(SELECTORS.MODAL).attributes("visible")).toBeUndefined();
+
+        // Instead we already have a singular toast with the link copied message
+        const toasts = toastMock.mock.calls;
+        expect(toasts.length).toBe(1);
+        expect(toasts[0]![MSG]).toBe(CLIPBOARD_MSG);
+        expect(toasts[0]![TYPE]).toBe("info");
+    });
+});

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
@@ -23,7 +23,7 @@ const props = defineProps<{
 const modalToggle = ref(false);
 
 // Workflow and History refs
-const { workflow, loading: workflowLoading, error: workflowError } = useWorkflowInstance(props.workflowId);
+const { workflow, loading, error, owned } = useWorkflowInstance(props.workflowId);
 const historyStore = useHistoryStore();
 
 /** The link to the invocation. */
@@ -58,7 +58,7 @@ async function makeInvocationShareable() {
 </script>
 
 <template>
-    <div>
+    <div v-if="owned">
         <BButton
             v-b-tooltip.noninteractive.hover
             title="Share Invocation"
@@ -76,11 +76,11 @@ async function makeInvocationShareable() {
             title-tag="h2"
             ok-title="Make Workflow and History Shareable, and Copy Link"
             @ok="makeInvocationShareable">
-            <BAlert v-if="workflowError" variant="danger" show>
-                {{ workflowError }}
+            <BAlert v-if="error" variant="danger" show>
+                {{ error }}
             </BAlert>
 
-            <LoadingSpan v-else-if="workflowLoading" message="Loading details for invocation" />
+            <LoadingSpan v-else-if="loading" message="Loading details for invocation" />
 
             <div v-else-if="!!workflow">
                 <p v-localize>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
@@ -10,6 +10,7 @@ import { Toast } from "@/composables/toast";
 import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
 import { useHistoryStore } from "@/stores/historyStore";
 import { copy } from "@/utils/clipboard";
+import { errorMessageAsString } from "@/utils/simple-error";
 
 import LoadingSpan from "../LoadingSpan.vue";
 
@@ -43,7 +44,10 @@ async function makeInvocationShareable() {
     });
 
     if (workflowShareError || historyShareError) {
-        Toast.error(`${workflowShareError || historyShareError}`, "Failed to make workflow and history shareable.");
+        Toast.error(
+            `${errorMessageAsString(workflowShareError) || errorMessageAsString(historyShareError)}`,
+            "Failed to make workflow and history shareable."
+        );
         return;
     } else {
         Toast.success("Workflow and history are now shareable.");

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
@@ -74,7 +74,7 @@ async function makeInvocationShareable() {
             v-model="modalToggle"
             title="Share Workflow Invocation"
             title-tag="h2"
-            ok-title="Make Workflow and History Shareable, and Copy Link"
+            ok-title="Share"
             @ok="makeInvocationShareable">
             <BAlert v-if="error" variant="danger" show>
                 {{ error }}
@@ -91,9 +91,10 @@ async function makeInvocationShareable() {
                     are accessible via link.
                 </p>
                 <p v-localize>
-                    You can do this by clicking the <i>"Make Workflow and History Shareable, and Copy Link"</i>
-                    button below. This will generate a link that you can share with others, allowing them to view the
-                    invocation.
+                    You can do this by clicking the <i>"Share"</i>
+                    button below. This will
+                    <strong>make the workflow and history shareable</strong>
+                    and generate a link that you can share with others, allowing them to view the invocation.
                 </p>
             </div>
         </BModal>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { faShareAlt } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BAlert, BButton, BModal } from "bootstrap-vue";
+import { computed, ref } from "vue";
+
+import { GalaxyApi } from "@/api";
+import { getFullAppUrl } from "@/app/utils";
+import { Toast } from "@/composables/toast";
+import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
+import { useHistoryStore } from "@/stores/historyStore";
+import { copy } from "@/utils/clipboard";
+
+import LoadingSpan from "../LoadingSpan.vue";
+
+const props = defineProps<{
+    invocationId: string;
+    workflowId: string;
+    historyId: string;
+}>();
+
+const modalToggle = ref(false);
+
+// Workflow and History refs
+const { workflow, loading: workflowLoading, error: workflowError } = useWorkflowInstance(props.workflowId);
+const historyStore = useHistoryStore();
+
+/** The link to the invocation. */
+const invocationLink = computed(() => getFullAppUrl(`workflows/invocations/${props.invocationId}`));
+
+async function makeInvocationShareable() {
+    if (!workflow.value) {
+        return;
+    }
+
+    // Note: Is it worth it to check here if the workflow and history are already shareable?
+
+    const { error: workflowShareError } = await GalaxyApi().PUT("/api/workflows/{workflow_id}/enable_link_access", {
+        params: { path: { workflow_id: workflow.value.id } },
+    });
+    const { error: historyShareError } = await GalaxyApi().PUT("/api/histories/{history_id}/enable_link_access", {
+        params: { path: { history_id: props.historyId } },
+    });
+
+    if (workflowShareError || historyShareError) {
+        Toast.error(`${workflowShareError || historyShareError}`, "Failed to make workflow and history shareable.");
+        return;
+    } else {
+        Toast.success("Workflow and history are now shareable.");
+    }
+
+    copy(invocationLink.value, "The link to the invocation has been copied to your clipboard.");
+}
+</script>
+
+<template>
+    <div>
+        <BButton
+            v-b-tooltip.noninteractive.hover
+            title="Share Invocation"
+            size="sm"
+            class="text-decoration-none"
+            variant="link"
+            :disabled="!workflow"
+            @click="modalToggle = true">
+            <FontAwesomeIcon :icon="faShareAlt" fixed-width />
+        </BButton>
+
+        <BModal
+            v-model="modalToggle"
+            title="Share Workflow Invocation"
+            title-tag="h2"
+            ok-title="Make Workflow and History Shareable, and Copy Link"
+            @ok="makeInvocationShareable">
+            <BAlert v-if="workflowError" variant="danger" show>
+                {{ workflowError }}
+            </BAlert>
+
+            <LoadingSpan v-else-if="workflowLoading" message="Loading details for invocation" />
+
+            <div v-else-if="!!workflow">
+                <p v-localize>
+                    To share this invocation, you need to make sure that the workflow
+                    <strong>"{{ workflow.name }}"</strong>
+                    and history
+                    <strong>"{{ historyStore.getHistoryNameById(props.historyId) }}"</strong>
+                    are accessible via link.
+                </p>
+                <p v-localize>
+                    You can do this by clicking the <i>"Make Workflow and History Shareable, and Copy Link"</i>
+                    button below. This will generate a link that you can share with others, allowing them to view the
+                    invocation.
+                </p>
+            </div>
+        </BModal>
+    </div>
+</template>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
@@ -39,11 +39,11 @@ const invocationLink = computed(() => getFullAppUrl(`workflows/invocations/${pro
 const historyAlreadyShareable = computed(() => {
     // Note: We will mostly have a summarized history object without the importable property
     //       and in that case we still attempt to make it shareable.
-    return !!history.value && hasImportable(history.value) && history.value.importable;
+    return Boolean(history.value && hasImportable(history.value) && history.value.importable);
 });
 
 /** If the workflow is already shareable. */
-const workflowAlreadyShareable = computed(() => !!workflow.value && workflow.value.importable);
+const workflowAlreadyShareable = computed(() => Boolean(workflow.value && workflow.value.importable));
 
 /** If both the workflow and history are already shareable. */
 const historyAndWorkflowAlreadyShareable = computed(
@@ -122,7 +122,7 @@ function shareInvocationButtonClicked() {
 
             <LoadingSpan v-else-if="loading" message="Loading details for invocation" />
 
-            <div v-else-if="!!workflow">
+            <div v-else-if="workflow">
                 <p v-localize>
                     To share this invocation, you need to make sure that the workflow
                     <strong>"{{ workflow.name }}"</strong>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
@@ -102,6 +102,7 @@ function shareInvocationButtonClicked() {
             title="Share Invocation"
             size="sm"
             class="text-decoration-none"
+            data-description="share invocation icon button"
             variant="link"
             :disabled="!workflow"
             @click="shareInvocationButtonClicked">
@@ -113,6 +114,7 @@ function shareInvocationButtonClicked() {
             title="Share Workflow Invocation"
             title-tag="h2"
             ok-title="Share"
+            data-description="share invocation modal"
             @ok="makeInvocationShareable">
             <BAlert v-if="error" variant="danger" show>
                 {{ error }}

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
@@ -15,6 +15,8 @@ import { errorMessageAsString } from "@/utils/simple-error";
 
 import LoadingSpan from "../LoadingSpan.vue";
 
+const CLIPBOARD_MSG = "The link to the invocation has been copied to your clipboard.";
+
 const props = defineProps<{
     invocationId: string;
     workflowId: string;
@@ -42,6 +44,11 @@ const historyAlreadyShareable = computed(() => {
 
 /** If the workflow is already shareable. */
 const workflowAlreadyShareable = computed(() => !!workflow.value && workflow.value.importable);
+
+/** If both the workflow and history are already shareable. */
+const historyAndWorkflowAlreadyShareable = computed(
+    () => historyAlreadyShareable.value && workflowAlreadyShareable.value
+);
 
 async function makeInvocationShareable() {
     if (!workflow.value) {
@@ -76,7 +83,15 @@ async function makeInvocationShareable() {
         Toast.success("Workflow and history are now shareable.");
     }
 
-    copy(invocationLink.value, "The link to the invocation has been copied to your clipboard.");
+    copy(invocationLink.value, CLIPBOARD_MSG);
+}
+
+function shareInvocationButtonClicked() {
+    if (historyAndWorkflowAlreadyShareable.value) {
+        copy(invocationLink.value, CLIPBOARD_MSG);
+    } else {
+        modalToggle.value = true;
+    }
 }
 </script>
 
@@ -89,7 +104,7 @@ async function makeInvocationShareable() {
             class="text-decoration-none"
             variant="link"
             :disabled="!workflow"
-            @click="modalToggle = true">
+            @click="shareInvocationButtonClicked">
             <FontAwesomeIcon :icon="faShareAlt" fixed-width />
         </BButton>
 

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -28,6 +28,7 @@ import WorkflowInvocationExportOptions from "./WorkflowInvocationExportOptions.v
 import WorkflowInvocationInputOutputTabs from "./WorkflowInvocationInputOutputTabs.vue";
 import WorkflowInvocationMetrics from "./WorkflowInvocationMetrics.vue";
 import WorkflowInvocationOverview from "./WorkflowInvocationOverview.vue";
+import WorkflowInvocationShare from "./WorkflowInvocationShare.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 interface Props {
@@ -263,6 +264,10 @@ async function onCancel() {
                     <FontAwesomeIcon :icon="faSquare" fixed-width />
                     Cancel
                 </BButton>
+                <WorkflowInvocationShare
+                    :invocation-id="invocation.id"
+                    :workflow-id="invocation.workflow_id"
+                    :history-id="invocation.history_id" />
             </template>
         </WorkflowNavigationTitle>
         <WorkflowAnnotation

--- a/client/src/composables/useWorkflowInstance.ts
+++ b/client/src/composables/useWorkflowInstance.ts
@@ -1,5 +1,6 @@
 import { computed, ref } from "vue";
 
+import { useUserStore } from "@/stores/userStore";
 import { useWorkflowStore } from "@/stores/workflowStore";
 import { errorMessageAsString } from "@/utils/simple-error";
 
@@ -8,6 +9,9 @@ export function useWorkflowInstance(workflowId: string) {
     const workflow = computed(() => workflowStore.getStoredWorkflowByInstanceId(workflowId));
     const loading = ref(false);
     const error = ref<string | null>(null);
+
+    const userStore = useUserStore();
+    const owned = computed(() => workflow.value && userStore.matchesCurrentUsername(workflow.value.owner));
 
     async function getWorkflowInstance() {
         if (!workflow.value) {
@@ -23,5 +27,5 @@ export function useWorkflowInstance(workflowId: string) {
     }
     getWorkflowInstance();
 
-    return { workflow, loading, error };
+    return { workflow, loading, error, owned };
 }


### PR DESCRIPTION
Adds a button to the header for invocations which opens a modal where the user can click and share both the workflow and history associated with the invocation, and then also copy the link to the invocation to their clipboard.

Fixes https://github.com/galaxyproject/galaxy/issues/19756

https://github.com/user-attachments/assets/608b8bfb-f40a-4e19-8f13-311ea9b81b35

<details>
<summary><h3>Initial Progress-Wizard Implementation:</h3></summary>

This initially used the `GenericWizard` to enforce the user to make their history and workflow both accessible, and then showed them the link they can copy.

https://github.com/user-attachments/assets/4a006c8c-b04d-4d52-b9fa-428a42c73d8d

</details>

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
