### PR TITLE
Job cache allow different names when possible

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -541,20 +541,7 @@ class JobHandlerQueue(BaseJobHandlerQueue):
                 # Some of these states will only happen when using the in-memory job queue
                 if job.copied_from_job_id:
                     copied_from_job = self.sa_session.query(model.Job).get(job.copied_from_job_id)
-                    job.numeric_metrics = copied_from_job.numeric_metrics
-                    job.text_metrics = copied_from_job.text_metrics
-                    job.dependencies = copied_from_job.dependencies
-                    job.state = copied_from_job.state
-                    job.job_stderr = copied_from_job.job_stderr
-                    job.job_stdout = copied_from_job.job_stdout
-                    job.tool_stderr = copied_from_job.tool_stderr
-                    job.tool_stdout = copied_from_job.tool_stdout
-                    job.command_line = copied_from_job.command_line
-                    job.traceback = copied_from_job.traceback
-                    job.tool_version = copied_from_job.tool_version
-                    job.exit_code = copied_from_job.exit_code
-                    job.job_runner_name = copied_from_job.job_runner_name
-                    job.job_runner_external_id = copied_from_job.job_runner_external_id
+                    job.copy_from_job(copied_from_job)
                     continue
                 job_state = self.__check_job_state(job)
                 if job_state == JOB_WAIT:

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -297,7 +297,9 @@ class BaseJobRunner:
 
         # Prepare the job
         try:
-            job_wrapper.prepare()
+            if job_wrapper.prepare() is False:
+                # job cache
+                return False
             job_wrapper.runner_command_line = self.build_command_line(
                 job_wrapper,
                 include_metadata=include_metadata,

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -497,7 +497,9 @@ class PulsarJobRunner(AsynchronousJobRunner):
             if rewrite_parameters:
                 compute_environment = PulsarComputeEnvironment(client, job_wrapper, remote_job_config)
                 prepare_kwds["compute_environment"] = compute_environment
-            job_wrapper.prepare(**prepare_kwds)
+
+            if job_wrapper.prepare(**prepare_kwds) is False:
+                return command_line, client, remote_job_config, compute_environment, remote_container
             self.__prepare_input_files_locally(job_wrapper)
             remote_metadata = PulsarJobRunner.__remote_metadata(client)
             dependency_resolution = PulsarJobRunner.__dependency_resolution(client)

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -487,7 +487,8 @@ class JobSearch:
                 elif t == "dce":
                     stmt = self._build_stmt_for_dce(stmt, data_conditions, used_ids, k, v)
                 else:
-                    return []
+                    log.error("Unknown input data type %s", t)
+                    return None
 
         stmt = stmt.where(*data_conditions).group_by(model.Job.id, *used_ids).order_by(model.Job.id.desc())
 

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -584,9 +584,9 @@ class JobSearch:
                 job_states = {job_state}
             else:
                 job_states = {*job_state}
-            if wildcard_param_dump.get("__when_value__") is False:
-                job_states = {Job.states.SKIPPED}
-            stmt = stmt.where(Job.state.in_(job_states))
+        if wildcard_param_dump.get("__when_value__") is False:
+            job_states = {Job.states.SKIPPED}
+        stmt = stmt.where(Job.state.in_(job_states))
 
         # exclude jobs with deleted outputs
         stmt = stmt.where(

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -699,29 +699,60 @@ class JobSearch:
         return stmt
 
     def _build_stmt_for_hdca(self, stmt, data_conditions, used_ids, k, v, require_name_match=True):
-        # TODO: clean up join condition, maybe replace by the added data_conditions below ?
+        # Determine depth based on collection_type of the HDCA we're matching against
+        collection_type = self.sa_session.scalar(
+            select(model.DatasetCollection.collection_type)
+            .select_from(model.HistoryDatasetCollectionAssociation)
+            .join(model.DatasetCollection)
+            .where(model.HistoryDatasetCollectionAssociation.id == v)
+        )
+        depth = collection_type.count(":") if collection_type else 0
+
         a = aliased(model.JobToInputDatasetCollectionAssociation)
-        b = aliased(model.HistoryDatasetCollectionAssociation)
-        c = aliased(model.HistoryDatasetCollectionAssociation)
+        hdca_input = aliased(model.HistoryDatasetCollectionAssociation)
+        root_collection = aliased(model.DatasetCollection)
+
+        dce_left = [aliased(model.DatasetCollectionElement) for _ in range(depth + 1)]
+        dce_right = [aliased(model.DatasetCollectionElement) for _ in range(depth + 1)]
+        hda_left = aliased(model.HistoryDatasetAssociation)
+        hda_right = aliased(model.HistoryDatasetAssociation)
+
+        # Start joins from job → input HDCA → its collection → DCE
         stmt = stmt.add_columns(a.dataset_collection_id)
-        stmt = stmt.join(a, a.job_id == model.Job.id).join(b, b.id == a.dataset_collection_id).join(c, b.name == c.name)
+        stmt = stmt.join(a, a.job_id == model.Job.id)
+        stmt = stmt.join(hdca_input, hdca_input.id == a.dataset_collection_id)
+        stmt = stmt.join(root_collection, root_collection.id == hdca_input.collection_id)
+        stmt = stmt.join(dce_left[0], dce_left[0].dataset_collection_id == root_collection.id)
+
+        # Join to target HDCA (v), then to its collection and its first-level DCE
+        hdca_target = aliased(model.HistoryDatasetCollectionAssociation)
+        target_collection = aliased(model.DatasetCollection)
+        stmt = stmt.join(hdca_target, hdca_target.id == v)
+        stmt = stmt.join(target_collection, target_collection.id == hdca_target.collection_id)
+        stmt = stmt.join(dce_right[0], dce_right[0].dataset_collection_id == target_collection.id)
+
+        # Parallel walk the structure
+        for i in range(1, depth + 1):
+            stmt = (
+                stmt.join(dce_left[i], dce_left[i].dataset_collection_id == dce_left[i - 1].child_collection_id)
+                .join(dce_right[i], dce_right[i].dataset_collection_id == dce_right[i - 1].child_collection_id)
+                .filter(dce_left[i].element_identifier == dce_right[i].element_identifier)
+            )
+
+        # Compare leaf-level HDAs
+        leaf_left = dce_left[-1]
+        leaf_right = dce_right[-1]
+        stmt = stmt.outerjoin(hda_left, hda_left.id == leaf_left.hda_id)
+        stmt = stmt.outerjoin(hda_right, hda_right.id == leaf_right.hda_id)
+
         data_conditions.append(
             and_(
                 a.name.in_(k),
-                c.id == v,
-                or_(
-                    and_(b.deleted == false(), b.id == v),
-                    and_(
-                        or_(
-                            c.copied_from_history_dataset_collection_association_id == b.id,
-                            b.copied_from_history_dataset_collection_association_id == c.id,
-                        ),
-                        c.deleted == false(),
-                    ),
-                ),
+                hda_left.dataset_id == hda_right.dataset_id,
             )
         )
-        used_ids.append(a.dataset_collection_id)
+
+        used_ids.append(a.dataset_collection_id)  # input-side HDCA
         return stmt
 
     def _build_stmt_for_dce(self, stmt, data_conditions, used_ids, k, v):

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -724,39 +724,39 @@ class JobSearch:
         return stmt
 
     def _build_stmt_for_dce(self, stmt, data_conditions, used_ids, k, v):
+        dce = self.sa_session.get_one(model.DatasetCollectionElement, v)
+        if dce.child_collection:
+            depth = dce.child_collection.collection_type.count(":") + 1
+        else:
+            depth = 0
         a = aliased(model.JobToInputDatasetCollectionElementAssociation)
-        b = aliased(model.DatasetCollectionElement)
-        c = aliased(model.DatasetCollectionElement)
-        d = aliased(model.HistoryDatasetAssociation)
-        e = aliased(model.HistoryDatasetAssociation)
+        dce_left = [aliased(model.DatasetCollectionElement) for _ in range(depth + 1)]
+        dce_right = [aliased(model.DatasetCollectionElement) for _ in range(depth + 1)]
+        hda_left = aliased(model.HistoryDatasetAssociation)
+        hda_right = aliased(model.HistoryDatasetAssociation)
+
+        # Base joins
         stmt = stmt.add_columns(a.dataset_collection_element_id)
-        stmt = (
-            stmt.join(a, a.job_id == model.Job.id)
-            .join(b, b.id == a.dataset_collection_element_id)
-            .join(
-                c,
-                and_(
-                    c.element_identifier == b.element_identifier,
-                    or_(c.hda_id == b.hda_id, c.child_collection_id == b.child_collection_id),
-                ),
+        stmt = stmt.join(a, a.job_id == model.Job.id)
+        stmt = stmt.join(dce_left[0], dce_left[0].id == a.dataset_collection_element_id)
+        stmt = stmt.join(dce_right[0], dce_right[0].id == v)
+
+        # Parallel walk the collection structure
+        for i in range(1, depth + 1):
+            stmt = (
+                stmt.join(dce_left[i], dce_left[i].dataset_collection_id == dce_left[i - 1].child_collection_id)
+                .join(dce_right[i], dce_right[i].dataset_collection_id == dce_right[i - 1].child_collection_id)
+                .filter(dce_left[i].element_identifier == dce_right[i].element_identifier)
             )
-            .outerjoin(d, d.id == c.hda_id)
-            .outerjoin(e, e.dataset_id == d.dataset_id)
-        )
-        data_conditions.append(
-            and_(
-                a.name.in_(k),
-                or_(
-                    c.child_collection_id == b.child_collection_id,
-                    and_(
-                        c.hda_id == b.hda_id,
-                        d.id == c.hda_id,
-                        e.dataset_id == d.dataset_id,
-                    ),
-                ),
-                c.id == v,
-            )
-        )
+
+        # Compare dataset_ids at the leaf level
+        leaf_left = dce_left[-1]
+        leaf_right = dce_right[-1]
+        stmt = stmt.outerjoin(hda_left, hda_left.id == leaf_left.hda_id)
+        stmt = stmt.outerjoin(hda_right, hda_right.id == leaf_right.hda_id)
+
+        data_conditions.append(and_(a.name.in_(k), hda_left.dataset_id == hda_right.dataset_id))
+
         used_ids.append(a.dataset_collection_element_id)
         return stmt
 

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -48,7 +48,6 @@ from galaxy.job_metrics import (
 )
 from galaxy.managers.collections import DatasetCollectionManager
 from galaxy.managers.context import (
-    ProvidesHistoryContext,
     ProvidesUserContext,
 )
 from galaxy.managers.datasets import DatasetManager
@@ -375,15 +374,15 @@ class JobSearch:
 
     def by_tool_input(
         self,
-        trans: ProvidesHistoryContext,
+        user: User,
         tool_id: str,
         tool_version: Optional[str],
         param: ToolStateJobInstancePopulatedT,
         param_dump: ToolStateDumpedToJsonInternalT,
         job_state: Optional[JobStatesT] = (Job.states.OK, Job.states.SKIPPED),
+        require_name_match: bool = True,
     ):
         """Search for jobs producing same results using the 'inputs' part of a tool POST."""
-        user = trans.user
         input_data = defaultdict(list)
 
         def populate_input_data_input_id(path, key, value):
@@ -425,6 +424,7 @@ class JobSearch:
             job_state=job_state,
             param_dump=param_dump,
             wildcard_param_dump=wildcard_param_dump,
+            require_name_match=require_name_match,
         )
 
     def __search(
@@ -436,6 +436,7 @@ class JobSearch:
         job_state: Optional[JobStatesT],
         param_dump: ToolStateDumpedToJsonInternalT,
         wildcard_param_dump=None,
+        require_name_match: bool = True,
     ):
         search_timer = ExecutionTimer()
 
@@ -476,7 +477,9 @@ class JobSearch:
                 data_types.append(t)
                 identifier = type_values["identifier"]
                 if t == "hda":
-                    stmt = self._build_stmt_for_hda(stmt, data_conditions, used_ids, k, v, identifier)
+                    stmt = self._build_stmt_for_hda(
+                        stmt, data_conditions, used_ids, k, v, identifier, require_name_match=require_name_match
+                    )
                 elif t == "ldda":
                     stmt = self._build_stmt_for_ldda(stmt, data_conditions, used_ids, k, v)
                 elif t == "hdca":
@@ -626,7 +629,7 @@ class JobSearch:
 
         return stmt
 
-    def _build_stmt_for_hda(self, stmt, data_conditions, used_ids, k, v, identifier):
+    def _build_stmt_for_hda(self, stmt, data_conditions, used_ids, k, v, identifier, require_name_match=True):
         a = aliased(model.JobToInputDatasetAssociation)
         b = aliased(model.HistoryDatasetAssociation)
         c = aliased(model.HistoryDatasetAssociation)
@@ -649,7 +652,7 @@ class JobSearch:
                     d.value == json.dumps(identifier),
                 )
             )
-        else:
+        elif require_name_match:
             hda_stmt = hda_stmt.where(e.name == c.name)
             name_condition.append(b.name == c.name)
         hda_stmt = (
@@ -694,7 +697,8 @@ class JobSearch:
         used_ids.append(a.ldda_id)
         return stmt
 
-    def _build_stmt_for_hdca(self, stmt, data_conditions, used_ids, k, v):
+    def _build_stmt_for_hdca(self, stmt, data_conditions, used_ids, k, v, require_name_match=True):
+        # TODO: clean up join condition, maybe replace by the added data_conditions below ?
         a = aliased(model.JobToInputDatasetCollectionAssociation)
         b = aliased(model.HistoryDatasetCollectionAssociation)
         c = aliased(model.HistoryDatasetCollectionAssociation)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1619,6 +1619,60 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     def finished(self):
         return self.state in self.finished_states
 
+    def copy_from_job(self, job: "Job", copy_outputs: bool = False):
+        self.copied_from_job_id = job.id
+        self.numeric_metrics = job.numeric_metrics
+        self.text_metrics = job.text_metrics
+        self.dependencies = job.dependencies
+        self.state = job.state
+        self.job_stderr = job.job_stderr
+        self.job_stdout = job.job_stdout
+        self.tool_stderr = job.tool_stderr
+        self.tool_stdout = job.tool_stdout
+        self.command_line = job.command_line
+        self.traceback = job.traceback
+        self.tool_version = job.tool_version
+        self.exit_code = job.exit_code
+        self.job_runner_name = job.job_runner_name
+        self.job_runner_external_id = job.job_runner_external_id
+        if copy_outputs:
+            requires_addition_to_history = False
+            outputs_to_copy = job.io_dicts(exclude_implicit_outputs=True)
+            self_io = self.io_dicts(exclude_implicit_outputs=True)
+            for output_name, out_data in outputs_to_copy.out_data.items():
+                self_output = self_io.out_data[output_name]
+                if isinstance(self_output, HistoryDatasetAssociation) and isinstance(
+                    out_data, HistoryDatasetAssociation
+                ):
+                    self_output.copy_from(out_data, include_metadata=True)
+            for output_name, out_collection in outputs_to_copy.out_collections.items():
+                self_out_collection = self_io.out_collections[output_name]
+                if isinstance(self_out_collection, DatasetCollection) and isinstance(out_collection, DatasetCollection):
+                    # In the context of the job cache this should be unreachable.
+                    # If we have DatasetCollection here, the output was created as part of a map-over job.
+                    # If it is a map-over job, then we were working with element_identifiers instead of names.
+                    # So when we relax the name requirement in the job cache we won't find any additional jobs to consider,
+                    # and we will never get here.
+                    self_out_collection.elements = [
+                        e.copy_to_collection(self_out_collection, element_destination=self.history, flush=False)
+                        for e in out_collection.elements
+                    ]
+                    requires_addition_to_history = True
+                elif isinstance(self_out_collection, HistoryDatasetCollectionAssociation) and isinstance(
+                    out_collection, HistoryDatasetCollectionAssociation
+                ):
+                    out_collection.collection.copy(
+                        destination=self_out_collection, element_destination=self.history, flush=False
+                    )
+                    requires_addition_to_history = True
+                else:
+                    raise NotImplementedError(
+                        f"Don't know how to copy {type(out_collection)} to {type(self_out_collection)}"
+                    )
+            if requires_addition_to_history:
+                assert job.history
+                job.history.add_pending_items()
+
     def io_dicts(self, exclude_implicit_outputs=False) -> IoDicts:
         inp_data: Dict[str, Optional[DatasetInstance]] = {da.name: da.dataset for da in self.input_datasets}
         out_data: Dict[str, DatasetInstance] = {da.name: da.dataset for da in self.output_datasets}

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1636,6 +1636,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
         self.job_runner_name = job.job_runner_name
         self.job_runner_external_id = job.job_runner_external_id
         if copy_outputs:
+            assert self.history
             requires_addition_to_history = False
             outputs_to_copy = job.io_dicts(exclude_implicit_outputs=True)
             self_io = self.io_dicts(exclude_implicit_outputs=True)
@@ -1653,10 +1654,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
                     # If it is a map-over job, then we were working with element_identifiers instead of names.
                     # So when we relax the name requirement in the job cache we won't find any additional jobs to consider,
                     # and we will never get here.
-                    self_out_collection.elements = [
-                        e.copy_to_collection(self_out_collection, element_destination=self.history, flush=False)
-                        for e in out_collection.elements
-                    ]
+                    self_out_collection.replace_elements_with_copies(out_collection.elements, history=self.history)
                     requires_addition_to_history = True
                 elif isinstance(self_out_collection, HistoryDatasetCollectionAssociation) and isinstance(
                     out_collection, HistoryDatasetCollectionAssociation
@@ -6964,6 +6962,28 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
             session.commit()
         return new_collection
 
+    def replace_elements_with_copies(self, replacements: List["DatasetCollectionElement"], history: "History"):
+        assert len(replacements) == len(self.elements)
+        for element, replacement in zip(self.elements, replacements):
+            assert replacement.element_object
+            if replacement.hda:
+                if element.hda:
+                    element.hda.copy_from(replacement.hda, include_metadata=True)
+                else:
+                    element.hda = replacement.hda.copy(copy_hid=False, flush=False)
+                    history.stage_addition(element.hda)
+            if replacement.child_collection:
+                if element.child_collection:
+                    element.child_collection.replace_elements_with_copies(
+                        replacement.child_collection.elements, history=history
+                    )
+                else:
+                    element.child_collection = replacement.child_collection.copy(
+                        flush=False, element_destination=history
+                    )
+            else:
+                raise ValueError("Cannot replace {type(replacement.element_object)}")
+
     def replace_failed_elements(self, replacements):
         stmt = self._build_nested_collection_attributes_stmt(
             return_entities=[DatasetCollectionElement], hda_attributes=["id"]
@@ -7543,7 +7563,10 @@ class DatasetCollectionElement(Base, Dictifiable, Serializable):
 
         self.id = id
         add_object_to_object_session(self, collection)
-        self.collection = collection
+        if collection:
+            self.collection = collection
+            if collection.id:
+                self.dataset_collection_id = collection.id
         self.element_index = element_index
         self.element_identifier = element_identifier or str(element_index)
 
@@ -7579,6 +7602,19 @@ class DatasetCollectionElement(Base, Dictifiable, Serializable):
             return self.child_collection
         else:
             return None
+
+    @element_object.setter
+    def element_object(
+        self, value: Union[HistoryDatasetAssociation, LibraryDatasetDatasetAssociation, DatasetCollection]
+    ):
+        if isinstance(value, HistoryDatasetAssociation):
+            self.hda = value
+        elif isinstance(value, LibraryDatasetDatasetAssociation):
+            self.ldda = value
+        elif isinstance(value, DatasetCollection):
+            self.child_collection = value
+        else:
+            raise AttributeError(f"Unknown element type provided: {type(value)}")
 
     @property
     def dataset_instance(self):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2123,7 +2123,10 @@ class Tool(UsesDictVisibleKeys):
             validate_input(request_context, errors, legacy_non_dce_params, self.inputs)
 
     def completed_jobs(
-        self, trans, use_cached_job: bool, all_params: List[ToolStateJobInstancePopulatedT]
+        self,
+        trans,
+        use_cached_job: bool,
+        all_params: List[ToolStateJobInstancePopulatedT],
     ) -> Dict[int, Optional[Job]]:
         completed_jobs: Dict[int, Optional[Job]] = {}
         for i, param in enumerate(all_params):
@@ -2131,12 +2134,14 @@ class Tool(UsesDictVisibleKeys):
                 tool_id = self.id
                 assert tool_id
                 param_dump: ToolStateDumpedToJsonInternalT = params_to_json_internal(self.inputs, param, self.app)
+                require_name_match = param.get("__when_value__") is not False
                 completed_jobs[i] = self.job_search.by_tool_input(
                     user=trans.user,
                     tool_id=tool_id,
                     tool_version=self.version,
                     param=param,
                     param_dump=param_dump,
+                    require_name_match=require_name_match,
                 )
             else:
                 completed_jobs[i] = None

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2127,12 +2127,12 @@ class Tool(UsesDictVisibleKeys):
     ) -> Dict[int, Optional[Job]]:
         completed_jobs: Dict[int, Optional[Job]] = {}
         for i, param in enumerate(all_params):
-            if use_cached_job:
+            if use_cached_job and trans.user:
                 tool_id = self.id
                 assert tool_id
                 param_dump: ToolStateDumpedToJsonInternalT = params_to_json_internal(self.inputs, param, self.app)
                 completed_jobs[i] = self.job_search.by_tool_input(
-                    trans=trans,
+                    user=trans.user,
                     tool_id=tool_id,
                     tool_version=self.version,
                     param=param,
@@ -2168,6 +2168,8 @@ class Tool(UsesDictVisibleKeys):
         self.handle_incoming_errors(all_errors)
 
         mapping_params = MappingParameters(incoming, all_params)
+        if use_cached_job:
+            mapping_params.param_template["__use_cached_job__"] = use_cached_job
         completed_jobs: Dict[int, Optional[Job]] = self.completed_jobs(trans, use_cached_job, all_params)
         execution_tracker = execute_job(
             trans,

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -140,6 +140,8 @@ class ToolEvaluator:
         self.version_command_line: Optional[str] = None
         self.command_line: Optional[str] = None
         self.interactivetools: List[Dict[str, Any]] = []
+        self.consumes_names = False
+        self.use_cached_job = False
 
     def set_compute_environment(self, compute_environment: ComputeEnvironment, get_special: Optional[Callable] = None):
         """
@@ -151,6 +153,8 @@ class ToolEvaluator:
         job = self.job
         incoming = {p.name: p.value for p in job.parameters}
         incoming = self.tool.params_from_strings(incoming, self.app)
+        if "__use_cached_job__" in incoming:
+            self.use_cached_job = bool(incoming["__use_cached_job__"])
 
         self.file_sources_dict = compute_environment.get_file_sources_dict()
 
@@ -399,6 +403,7 @@ class ToolEvaluator:
                     tool=self.tool,
                     name=input.name,
                     formats=input.formats,
+                    tool_evaluator=self,
                 )
 
             elif isinstance(input, DataToolParameter):
@@ -412,6 +417,7 @@ class ToolEvaluator:
                     compute_environment=self.compute_environment,
                     identifier=element_identifier,
                     formats=input.formats,
+                    tool_evaluator=self,
                 )
             elif isinstance(input, DataCollectionToolParameter):
                 dataset_collection = value
@@ -422,6 +428,7 @@ class ToolEvaluator:
                     compute_environment=self.compute_environment,
                     tool=self.tool,
                     name=input.name,
+                    tool_evaluator=self,
                 )
                 input_values[input.name] = wrapper
             elif isinstance(input, SelectToolParameter):

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -120,6 +120,8 @@ def execute(
         params = execution_slice.param_combination
         if "__data_manager_mode" in mapping_params.param_template:
             params["__data_manager_mode"] = mapping_params.param_template["__data_manager_mode"]
+        if "__use_cached_job__" in mapping_params.param_template:
+            params["__use_cached_job__"] = mapping_params.param_template["__use_cached_job__"]
         if workflow_invocation_uuid:
             params["__workflow_invocation_uuid__"] = workflow_invocation_uuid
         elif "__workflow_invocation_uuid__" in params:

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -515,9 +515,10 @@ class FastAPIJobs:
             return []
         params_dump = [tool.params_to_strings(param, trans.app, nested=True) for param in all_params]
         jobs = []
+        assert trans.user
         for param_dump, param in zip(params_dump, all_params):
             job = self.service.job_search.by_tool_input(
-                trans=trans,
+                user=trans.user,
                 tool_id=tool_id,
                 tool_version=tool.version,
                 param=param,

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2411,6 +2411,8 @@ class ToolModule(WorkflowModule):
         completed_jobs: Dict[int, Optional[Job]] = tool.completed_jobs(trans, use_cached_job, param_combinations)
         try:
             mapping_params = MappingParameters(tool_state.inputs, param_combinations)
+            if use_cached_job:
+                mapping_params.param_template["__use_cached_job__"] = use_cached_job
             max_num_jobs = progress.maximum_jobs_to_schedule_or_none
 
             validate_outputs = False

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2408,7 +2408,11 @@ class ToolModule(WorkflowModule):
             param_combinations.append(execution_state.inputs)
 
         complete = False
-        completed_jobs: Dict[int, Optional[Job]] = tool.completed_jobs(trans, use_cached_job, param_combinations)
+        completed_jobs: Dict[int, Optional[Job]] = tool.completed_jobs(
+            trans,
+            use_cached_job,
+            param_combinations,
+        )
         try:
             mapping_params = MappingParameters(tool_state.inputs, param_combinations)
             if use_cached_job:

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -1058,6 +1058,67 @@ class TestToolsApi(ApiTestCase, TestsTools):
             job_details = self.dataset_populator.get_job_details(copied_job_id, full=True).json()
             assert job_details["copied_from_job_id"] == outputs_one["jobs"][0]["id"]
 
+    @skip_without_tool("collection_creates_list")
+    @requires_new_history
+    def test_run_collection_creates_list_use_cached_job(self):
+        with self.dataset_populator.test_history_for(
+            self.test_run_collection_creates_list_use_cached_job
+        ) as history_id:
+            # Run tool that consumes and produces hdca
+            create_response = self.dataset_collection_populator.create_list_in_history(
+                history_id, contents=["123", "456"], wait=True
+            ).json()
+            hdca = create_response["output_collections"][0]
+            outputs_one = self._run(
+                "collection_creates_list",
+                history_id,
+                inputs={"input1": {"src": "hdca", "id": hdca["id"]}},
+                assert_ok=True,
+                wait_for_job=True,
+            )
+            outputs_two = self._run(
+                "collection_creates_list",
+                history_id,
+                inputs={"input1": {"src": "hdca", "id": hdca["id"]}},
+                assert_ok=True,
+                wait_for_job=True,
+                use_cached_job=True,
+            )
+            copied_job_id = outputs_two["jobs"][0]["id"]
+            job_details = self.dataset_populator.get_job_details(copied_job_id, full=True).json()
+            assert job_details["copied_from_job_id"] == outputs_one["jobs"][0]["id"]
+
+    @skip_without_tool("collection_creates_list")
+    @requires_new_history
+    def test_run_collection_creates_list_use_cached_job_renamed_input(self):
+        with self.dataset_populator.test_history_for(
+            self.test_run_collection_creates_list_use_cached_job
+        ) as history_id:
+            # Run tool that consumes and produces hdca
+            create_response = self.dataset_collection_populator.create_list_in_history(
+                history_id, contents=["123", "456"], wait=True
+            ).json()
+            hdca = create_response["output_collections"][0]
+            outputs_one = self._run(
+                "collection_creates_list",
+                history_id,
+                inputs={"input1": {"src": "hdca", "id": hdca["id"]}},
+                assert_ok=True,
+                wait_for_job=True,
+            )
+            self.dataset_populator.rename_collection(hdca["id"])
+            outputs_two = self._run(
+                "collection_creates_list",
+                history_id,
+                inputs={"input1": {"src": "hdca", "id": hdca["id"]}},
+                assert_ok=True,
+                wait_for_job=True,
+                use_cached_job=True,
+            )
+            copied_job_id = outputs_two["jobs"][0]["id"]
+            job_details = self.dataset_populator.get_job_details(copied_job_id, full=True).json()
+            assert job_details["copied_from_job_id"] == outputs_one["jobs"][0]["id"]
+
     @skip_without_tool("identifier_single")
     @requires_new_history
     def test_run_identifier_single_use_cached_job_renamed_input(self):

--- a/test/unit/app/jobs/test_job_wrapper.py
+++ b/test/unit/app/jobs/test_job_wrapper.py
@@ -116,6 +116,7 @@ class MockEvaluator:
         self.job = job
         self.local_working_directory = local_working_directory
         self.param_dict = {}
+        self.use_cached_job = False
 
     def set_compute_environment(self, *args, **kwds):
         pass


### PR DESCRIPTION
This will do a second pass through the job cache after we've built the job command line and config files. At this point we will know if a tool consumes any dataset names. If it doesn't we can relax the requirement that a valid job to consider must have the same input dataset name.
Considering most tools don't need the dataset name this should increase the number of cases where the job cache can work. 
Also fixes a whole bunch of other issues.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
