### PR TITLE
[23.1] Do not print OIDC access tokens to the logs

### DIFF
--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -80,7 +80,6 @@ class CustosAuthnz(IdentityProvider):
         # do not refresh tokens if they didn't reach their half lifetime
         if int(id_token_decoded["iat"]) + int(id_token_decoded["exp"]) > 2 * int(time.time()):
             return False
-        log.info(custos_authnz_token.access_token)
         oauth2_session = self._create_oauth2_session()
         token_endpoint = self.config["token_endpoint"]
         if self.config.get("iam_client_secret"):


### PR DESCRIPTION
I found OIDC tokens in the logs. I think we all agree that it is not good practice to print secrets to the logs, so let's not print OIDC tokens to the logs when Custos auth refreshes tokens.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows:
  1. Exercising faith so that you can believe that removing a `log.info()` statement does the job.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
