### PR TITLE
[24.2] Renew OIDC access tokens using valid refresh tokens

### DIFF
--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -125,7 +125,7 @@ class OIDCAuthnzBase(IdentityProvider):
             return False
         refresh_token_decoded = self._decode_token_no_signature(custos_authnz_token.refresh_token)
         # do not attempt to use refresh token that is already expired
-        if int(refresh_token_decoded["exp"]) > int(time.time()):
+        if int(refresh_token_decoded["exp"]) <= int(time.time()):
             # in the future we might want to log out the user here
             return False
         log.info(custos_authnz_token.access_token)


### PR DESCRIPTION
Method `OIDCAuthnzBase.refresh()` from custos_authnz.py is supposed to not attempt to use refresh tokens that are already expired. However, the comparison of the token's expiration time with the current time is wrong (it always tries to renew access tokens using expired refresh tokens). Fix the comparison so that it works as intended.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
