### PR TITLE
[24.2] Fix bug in psa-authnz redirect handling

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -96,7 +96,13 @@ class OIDC(JSAppLauncher):
     @web.expose
     def callback(self, trans, provider, idphint=None, **kwargs):
         user = trans.user.username if trans.user is not None else "anonymous"
-        login_next = url_for(trans.get_cookie(name=LOGIN_NEXT_COOKIE_NAME) or "/")
+        login_next_cookie = trans.get_cookie(name=LOGIN_NEXT_COOKIE_NAME)
+        if login_next_cookie and login_next_cookie != "None":
+            # This cookie can sometimes be set to a literal string 'None', which we don't want to use as a redirect.
+            login_next = url_for(login_next_cookie)
+        else:
+            # Fallback to default redirect if no login_next cookie is found.
+            login_next = url_for("/")
         if not bool(kwargs):
             log.error(f"OIDC callback received no data for provider `{provider}` and user `{user}`")
             return trans.show_error_message(


### PR DESCRIPTION
Fix issue where a literal string 'None' exists for a login redirect cookie.  In this case we defer to the base redirect url.  I want to follow up and figure out the circumstances that can cause this, but it has to be more robust on this end anyway.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
