### PR TITLE
Fix ownership check in history contents update route

### DIFF
--- a/client/src/api/datasetCollections.ts
+++ b/client/src/api/datasetCollections.ts
@@ -7,8 +7,8 @@ const DEFAULT_LIMIT = 50;
  * Fetches the details of a collection.
  * @param params.id The ID of the collection (HDCA) to fetch.
  */
-export async function fetchCollectionDetails(params: { id: string }): Promise<HDCADetailed> {
-    const { data, error } = await GalaxyApi().GET("/api/dataset_collections/{id}", {
+export async function fetchCollectionDetails(params: { hdca_id: string }): Promise<HDCADetailed> {
+    const { data, error } = await GalaxyApi().GET("/api/dataset_collections/{hdca_id}", {
         params: { path: params },
     });
 
@@ -22,8 +22,8 @@ export async function fetchCollectionDetails(params: { id: string }): Promise<HD
  * Fetches the details of a collection.
  * @param params.id The ID of the collection (HDCA) to fetch.
  */
-export async function fetchCollectionSummary(params: { id: string }): Promise<HDCASummary> {
-    const { data, error } = await GalaxyApi().GET("/api/dataset_collections/{id}", {
+export async function fetchCollectionSummary(params: { hdca_id: string }): Promise<HDCASummary> {
+    const { data, error } = await GalaxyApi().GET("/api/dataset_collections/{hdca_id}", {
         params: {
             path: params,
             query: { view: "collection" },

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -226,12 +226,30 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /** Returns detailed information about the given collection. */
+        get: operations["show_api_dataset_collections__hdca_id__get"];
         /**
          * Updates the values for the history dataset (HDA) item with the given ``ID``.
          * @description Updates the values for the history content item with the given ``ID``.
          */
         put: operations["dataset_collections__update_collection"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/dataset_collections/{hdca_id}/attributes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Returns `dbkey`/`extension` attributes for all the collection elements. */
+        get: operations["attributes_api_dataset_collections__hdca_id__attributes_get"];
+        put?: never;
         post?: never;
         delete?: never;
         options?: never;
@@ -256,41 +274,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/dataset_collections/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Returns detailed information about the given collection. */
-        get: operations["show_api_dataset_collections__id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/dataset_collections/{id}/attributes": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Returns `dbkey`/`extension` attributes for all the collection elements. */
-        get: operations["attributes_api_dataset_collections__id__attributes_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/dataset_collections/{id}/copy": {
+    "/api/dataset_collections/{hdca_id}/copy": {
         parameters: {
             query?: never;
             header?: never;
@@ -300,14 +284,14 @@ export interface paths {
         get?: never;
         put?: never;
         /** Copy the given collection datasets to a new collection using a new `dbkey` attribute. */
-        post: operations["copy_api_dataset_collections__id__copy_post"];
+        post: operations["copy_api_dataset_collections__hdca_id__copy_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/dataset_collections/{id}/download": {
+    "/api/dataset_collections/{hdca_id}/download": {
         parameters: {
             query?: never;
             header?: never;
@@ -328,7 +312,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/dataset_collections/{id}/prepare_download": {
+    "/api/dataset_collections/{hdca_id}/prepare_download": {
         parameters: {
             query?: never;
             header?: never;
@@ -343,14 +327,14 @@ export interface paths {
          *     returned short term storage object. Progress tracking this file's creation
          *     can be tracked with the short_term_storage API.
          */
-        post: operations["prepare_collection_download_api_dataset_collections__id__prepare_download_post"];
+        post: operations["prepare_collection_download_api_dataset_collections__hdca_id__prepare_download_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/dataset_collections/{id}/suitable_converters": {
+    "/api/dataset_collections/{hdca_id}/suitable_converters": {
         parameters: {
             query?: never;
             header?: never;
@@ -358,7 +342,7 @@ export interface paths {
             cookie?: never;
         };
         /** Returns a list of applicable converters for all datatypes in the given collection. */
-        get: operations["suitable_converters_api_dataset_collections__id__suitable_converters_get"];
+        get: operations["suitable_converters_api_dataset_collections__hdca_id__suitable_converters_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1875,7 +1859,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/histories/{history_id}/contents/dataset_collections/{id}/download": {
+    "/api/histories/{history_id}/contents/dataset_collections/{hdca_id}/download": {
         parameters: {
             query?: never;
             header?: never;
@@ -19371,6 +19355,58 @@ export interface operations {
             };
         };
     };
+    show_api_dataset_collections__hdca_id__get: {
+        parameters: {
+            query?: {
+                /** @description The type of collection instance. Either `history` (default) or `library`. */
+                instance_type?: "history" | "library";
+                /** @description The view of collection instance to return. */
+                view?: string;
+            };
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The ID of the `HDCA`. */
+                hdca_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json":
+                        | components["schemas"]["HDCACustom"]
+                        | components["schemas"]["HDCADetailed"]
+                        | components["schemas"]["HDCASummary"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
     dataset_collections__update_collection: {
         parameters: {
             query?: {
@@ -19409,6 +19445,53 @@ export interface operations {
                         | components["schemas"]["HDCACustom"]
                         | components["schemas"]["HDCADetailed"]
                         | components["schemas"]["HDCASummary"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    attributes_api_dataset_collections__hdca_id__attributes_get: {
+        parameters: {
+            query?: {
+                /** @description The type of collection instance. Either `history` (default) or `library`. */
+                instance_type?: "history" | "library";
+            };
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The ID of the `HDCA`. */
+                hdca_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DatasetCollectionAttributesResult"];
                 };
             };
             /** @description Request Error */
@@ -19484,106 +19567,7 @@ export interface operations {
             };
         };
     };
-    show_api_dataset_collections__id__get: {
-        parameters: {
-            query?: {
-                /** @description The type of collection instance. Either `history` (default) or `library`. */
-                instance_type?: "history" | "library";
-                /** @description The view of collection instance to return. */
-                view?: string;
-            };
-            header?: {
-                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-                "run-as"?: string | null;
-            };
-            path: {
-                /** @description The ID of the `HDCA`. */
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json":
-                        | components["schemas"]["HDCACustom"]
-                        | components["schemas"]["HDCADetailed"]
-                        | components["schemas"]["HDCASummary"];
-                };
-            };
-            /** @description Request Error */
-            "4XX": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MessageExceptionModel"];
-                };
-            };
-            /** @description Server Error */
-            "5XX": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MessageExceptionModel"];
-                };
-            };
-        };
-    };
-    attributes_api_dataset_collections__id__attributes_get: {
-        parameters: {
-            query?: {
-                /** @description The type of collection instance. Either `history` (default) or `library`. */
-                instance_type?: "history" | "library";
-            };
-            header?: {
-                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-                "run-as"?: string | null;
-            };
-            path: {
-                /** @description The ID of the `HDCA`. */
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DatasetCollectionAttributesResult"];
-                };
-            };
-            /** @description Request Error */
-            "4XX": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MessageExceptionModel"];
-                };
-            };
-            /** @description Server Error */
-            "5XX": {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MessageExceptionModel"];
-                };
-            };
-        };
-    };
-    copy_api_dataset_collections__id__copy_post: {
+    copy_api_dataset_collections__hdca_id__copy_post: {
         parameters: {
             query?: never;
             header?: {
@@ -19592,7 +19576,7 @@ export interface operations {
             };
             path: {
                 /** @description The ID of the `HDCA`. */
-                id: string;
+                hdca_id: string;
             };
             cookie?: never;
         };
@@ -19638,7 +19622,7 @@ export interface operations {
             };
             path: {
                 /** @description The ID of the `HDCA`. */
-                id: string;
+                hdca_id: string;
             };
             cookie?: never;
         };
@@ -19671,7 +19655,7 @@ export interface operations {
             };
         };
     };
-    prepare_collection_download_api_dataset_collections__id__prepare_download_post: {
+    prepare_collection_download_api_dataset_collections__hdca_id__prepare_download_post: {
         parameters: {
             query?: never;
             header?: {
@@ -19680,7 +19664,7 @@ export interface operations {
             };
             path: {
                 /** @description The ID of the `HDCA`. */
-                id: string;
+                hdca_id: string;
             };
             cookie?: never;
         };
@@ -19722,7 +19706,7 @@ export interface operations {
             };
         };
     };
-    suitable_converters_api_dataset_collections__id__suitable_converters_get: {
+    suitable_converters_api_dataset_collections__hdca_id__suitable_converters_get: {
         parameters: {
             query?: {
                 /** @description The type of collection instance. Either `history` (default) or `library`. */
@@ -19734,7 +19718,7 @@ export interface operations {
             };
             path: {
                 /** @description The ID of the `HDCA`. */
-                id: string;
+                hdca_id: string;
             };
             cookie?: never;
         };
@@ -24902,7 +24886,7 @@ export interface operations {
             };
             path: {
                 /** @description The ID of the `HDCA`. */
-                id: string;
+                hdca_id: string;
                 /** @description The encoded database identifier of the History. */
                 history_id: string | null;
             };

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -219,6 +219,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/dataset_collections/{hdca_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Updates the values for the history dataset (HDA) item with the given ``ID``.
+         * @description Updates the values for the history content item with the given ``ID``.
+         */
+        put: operations["dataset_collections__update_collection"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/dataset_collections/{hdca_id}/contents/{parent_id}": {
         parameters: {
             query?: never;
@@ -19329,6 +19349,66 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HDCADetailed"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    dataset_collections__update_collection: {
+        parameters: {
+            query?: {
+                /** @description View to be passed to the serializer */
+                view?: string | null;
+                /** @description Comma-separated list of keys to be passed to the serializer */
+                keys?: string | null;
+            };
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The ID of the item (`HDA`/`HDCA`) */
+                hdca_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateHistoryContentsPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json":
+                        | components["schemas"]["HDACustom"]
+                        | components["schemas"]["HDADetailed"]
+                        | components["schemas"]["HDASummary"]
+                        | components["schemas"]["HDAInaccessible"]
+                        | components["schemas"]["HDCACustom"]
+                        | components["schemas"]["HDCADetailed"]
+                        | components["schemas"]["HDCASummary"];
                 };
             };
             /** @description Request Error */

--- a/client/src/components/Collections/common/CollectionEditView.vue
+++ b/client/src/components/Collections/common/CollectionEditView.vue
@@ -121,8 +121,8 @@ async function clickedSave(attribute: string, newValue: any) {
 
     const dbKey = newValue.id as string;
 
-    const { error } = await GalaxyApi().POST("/api/dataset_collections/{id}/copy", {
-        params: { path: { id: props.collectionId } },
+    const { error } = await GalaxyApi().POST("/api/dataset_collections/{hdca_id}/copy", {
+        params: { path: { hdca_id: props.collectionId } },
         body: { dbkey: dbKey },
     });
     if (error) {

--- a/client/src/components/Form/Elements/FormRulesEdit.vue
+++ b/client/src/components/Form/Elements/FormRulesEdit.vue
@@ -40,7 +40,7 @@ async function onEdit() {
         try {
             loading.value = true;
             loadError.value = undefined;
-            const collectionDetails = await fetchCollectionDetails({ id: props.target.id });
+            const collectionDetails = await fetchCollectionDetails({ hdca_id: props.target.id });
             elements.value = collectionDetails;
             modal.value.show();
         } catch (e) {

--- a/client/src/components/Markdown/Sections/Elements/HistoryDatasetCollection/CollectionDisplay.vue
+++ b/client/src/components/Markdown/Sections/Elements/HistoryDatasetCollection/CollectionDisplay.vue
@@ -89,9 +89,9 @@ const onCopyCollection = async (currentHistoryId: string) => {
 };
 
 const getContent = async () => {
-    const { data, error } = await GalaxyApi().GET("/api/dataset_collections/{id}", {
+    const { data, error } = await GalaxyApi().GET("/api/dataset_collections/{hdca_id}", {
         params: {
-            path: { id: props.collectionId },
+            path: { hdca_id: props.collectionId },
         },
     });
     if (error) {

--- a/client/src/components/PageEditor/ObjectPermissions.vue
+++ b/client/src/components/PageEditor/ObjectPermissions.vue
@@ -124,7 +124,7 @@ watch(referencedHistoryDatasetCollectionIds, async () => {
             "Failed to fetch collection information",
             "Some referenced objects may not be listed."
         );
-        fetchCollectionSummary({ id: historyDatasetCollectionId })
+        fetchCollectionSummary({ hdca_id: historyDatasetCollectionId })
             .then((data) => {
                 const historyId = data.history_id;
                 Vue.set(historyDatasetCollectionsToHistories.value, historyDatasetCollectionId, historyId);

--- a/client/src/components/providers/DatasetCollectionProvider.js
+++ b/client/src/components/providers/DatasetCollectionProvider.js
@@ -4,4 +4,7 @@ import { fetchCollectionDetails } from "@/api/datasetCollections";
 
 // There isn't really a good way to know when to stop polling for HDCA updates,
 // but we know the populated_state should at least be ok.
-export default SingleQueryProvider(fetchCollectionDetails, (result) => result.populated_state === "ok");
+export default SingleQueryProvider(
+    (params) => fetchCollectionDetails({ hdca_id: params.id }),
+    (result) => result.populated_state === "ok"
+);

--- a/client/src/composables/useInvocationGraph.ts
+++ b/client/src/composables/useInvocationGraph.ts
@@ -334,7 +334,7 @@ export function useInvocationGraph(
                 set(graphStep, "state", getContentItemState(hda));
                 set(graphStep, "nodeText", `${hda.hid}: <b>${hda.name}</b>`);
             } else {
-                const hdca = await fetchCollectionDetails({ id: inputItem.id });
+                const hdca = await fetchCollectionDetails({ hdca_id: inputItem.id });
                 // TODO: Same type mismatch as above
                 set(graphStep, "state", getContentItemState(hdca));
                 set(graphStep, "nodeText", `${hdca.hid}: <b>${hdca.name}</b>`);

--- a/client/src/stores/collectionAttributesStore.test.ts
+++ b/client/src/stores/collectionAttributesStore.test.ts
@@ -26,7 +26,7 @@ describe("collectionAttributesStore", () => {
         setActivePinia(createPinia());
 
         server.use(
-            http.get("/api/dataset_collections/{id}/attributes", ({ response }) => {
+            http.get("/api/dataset_collections/{hdca_id}/attributes", ({ response }) => {
                 return response(200).json(fetchCollectionAttributesMock());
             })
         );

--- a/client/src/stores/collectionAttributesStore.ts
+++ b/client/src/stores/collectionAttributesStore.ts
@@ -6,8 +6,8 @@ import { rethrowSimple } from "@/utils/simple-error";
 
 export const useCollectionAttributesStore = defineStore("collectionAttributesStore", () => {
     async function fetchAttributes(params: FetchParams): Promise<DatasetCollectionAttributes> {
-        const { data, error } = await GalaxyApi().GET("/api/dataset_collections/{id}/attributes", {
-            params: { path: params },
+        const { data, error } = await GalaxyApi().GET("/api/dataset_collections/{hdca_id}/attributes", {
+            params: { path: { hdca_id: params.id } },
         });
         if (error) {
             rethrowSimple(error);

--- a/client/src/stores/collectionElementsStore.ts
+++ b/client/src/stores/collectionElementsStore.ts
@@ -181,7 +181,7 @@ export const useCollectionElementsStore = defineStore("collectionElementsStore",
     async function fetchCollection(params: { id: string }) {
         set(loadingCollectionElements.value, params.id, true);
         try {
-            const collection = await fetchCollectionDetails({ id: params.id });
+            const collection = await fetchCollectionDetails({ hdca_id: params.id });
             set(storedCollections.value, collection.id, collection);
             return collection;
         } catch (error) {

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -327,7 +327,7 @@ U = TypeVar("U", bound=DatasetInstance)
 class DatasetAssociationManager(
     base.ModelManager[U],
     secured.AccessibleManagerMixin,
-    secured.OwnableManagerMixin,
+    secured.OwnableManagerMixin[U],
     deletable.PurgableManagerMixin,
 ):
     """

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -82,7 +82,7 @@ class HistoryDatasetAssociationNoHistoryException(Exception):
 
 class HDAManager(
     datasets.DatasetAssociationManager[HistoryDatasetAssociation],
-    secured.OwnableManagerMixin,
+    secured.OwnableManagerMixin[HistoryDatasetAssociation],
     annotatable.AnnotatableManagerMixin,
 ):
     """

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -113,7 +113,7 @@ class HDCAManager(
     # .... security and permissions
     def is_owner(self, item: model.HistoryDatasetCollectionAssociation, user: Optional[model.User], **kwargs) -> bool:
         """
-        Use history to see if current user owns HDA.
+        Use history to see if current user owns HDCA.
         """
         history = item.history
         assert history

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -115,7 +115,6 @@ class HDCAManager(
         """
         Use history to see if current user owns HDA.
         """
-        super().is_owner(item, user, **kwargs)
         history = item.history
         assert history
         # allow anonymous user to access current history

--- a/lib/galaxy/managers/secured.py
+++ b/lib/galaxy/managers/secured.py
@@ -4,6 +4,7 @@ Accessible models can be read and copied but not modified or deleted.
 Owned models can be modified and deleted.
 """
 
+import abc
 from typing import (
     Any,
     Generic,
@@ -30,10 +31,11 @@ class AccessibleManagerMixin(Generic[U]):
     # declare what we are using from base ModelManager
     model_class: Type[U]
 
-    def by_id(self, id: int): ...
+    @abc.abstractmethod
+    def by_id(self, id: int) -> U: ...
 
     # don't want to override by_id since consumers will also want to fetch w/o any security checks
-    def is_accessible(self, item, user: Optional[model.User], **kwargs: Any) -> bool:
+    def is_accessible(self, item: U, user: Optional[model.User], **kwargs: Any) -> bool:
         """
         Return True if the item accessible to user.
         """
@@ -50,7 +52,7 @@ class AccessibleManagerMixin(Generic[U]):
         item = self.by_id(id)
         return self.error_unless_accessible(item, user, **kwargs)
 
-    def error_unless_accessible(self, item: U, user: Optional[model.User], **kwargs) -> U:
+    def error_unless_accessible(self, item: U, user: Optional[model.User], **kwargs: Any) -> U:
         """
         Raise an error if the item is NOT accessible to user, otherwise return the item.
 
@@ -74,7 +76,8 @@ class OwnableManagerMixin(Generic[U]):
     # declare what we are using from base ModelManager
     model_class: Type[U]
 
-    def by_id(self, id: int): ...
+    @abc.abstractmethod
+    def by_id(self, id: int) -> U: ...
 
     def is_owner(self, item: U, user: Optional[model.User], **kwargs: Any) -> bool:
         """
@@ -114,7 +117,7 @@ class OwnableManagerMixin(Generic[U]):
         self.error_unless_mutable(item)
         return item
 
-    def error_unless_mutable(self, item: U):
+    def error_unless_mutable(self, item: U) -> None:
         """
         Raise an error if the item is NOT mutable.
 

--- a/lib/galaxy/managers/secured.py
+++ b/lib/galaxy/managers/secured.py
@@ -60,28 +60,6 @@ class AccessibleManagerMixin(Generic[U]):
             return item
         raise exceptions.ItemAccessibilityException(f"{self.model_class.__name__} is not accessible by user")
 
-    # TODO:?? are these even useful?
-    def list_accessible(self, user, **kwargs):
-        """
-        Return a list of items accessible to the user, raising an error if ANY
-        are inaccessible.
-
-        :raises exceptions.ItemAccessibilityException:
-        """
-        raise exceptions.NotImplemented("Abstract interface Method")
-        # NOTE: this will be a large, inefficient list if filters are not passed in kwargs
-        # items = ModelManager.list( self, trans, **kwargs )
-        # return [ self.error_unless_accessible( trans, item, user ) for item in items ]
-
-    def filter_accessible(self, user, **kwargs):
-        """
-        Return a list of items accessible to the user.
-        """
-        raise exceptions.NotImplemented("Abstract interface Method")
-        # NOTE: this will be a large, inefficient list if filters are not  passed in kwargs
-        # items = ModelManager.list( self, trans, **kwargs )
-        # return filter( lambda item: self.is_accessible( trans, item, user ), items )
-
 
 class OwnableManagerMixin(Generic[U]):
     """
@@ -124,24 +102,6 @@ class OwnableManagerMixin(Generic[U]):
         if self.is_owner(item, user, **kwargs):
             return item
         raise exceptions.ItemOwnershipException(f"{self.model_class.__name__} is not owned by user")
-
-    def list_owned(self, user, **kwargs):
-        """
-        Return a list of items owned by the user, raising an error if ANY
-        are not.
-
-        :raises exceptions.ItemAccessibilityException:
-        """
-        raise exceptions.NotImplemented("Abstract interface Method")
-        # just alias to by_user (easier/same thing)
-        # return self.by_user( trans, user, **kwargs )
-
-    def filter_owned(self, user, **kwargs):
-        """
-        Return a list of items owned by the user.
-        """
-        # just alias to list_owned
-        return self.list_owned(user, **kwargs)
 
     def get_mutable(self, id: int, user: Optional[model.User], **kwargs: Any) -> U:
         """

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -61,7 +61,7 @@ U = TypeVar("U", model.History, model.Page, model.StoredWorkflow, model.Visualiz
 
 class SharableModelManager(
     base.ModelManager[U],
-    secured.OwnableManagerMixin,
+    secured.OwnableManagerMixin[U],
     secured.AccessibleManagerMixin,
     annotatable.AnnotatableManagerMixin,
     ratable.RatableManagerMixin,

--- a/lib/galaxy/webapps/galaxy/api/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/api/dataset_collections.py
@@ -68,55 +68,55 @@ class FastAPIDatasetCollections:
         return self.service.create(trans, payload)
 
     @router.post(
-        "/api/dataset_collections/{id}/copy",
+        "/api/dataset_collections/{hdca_id}/copy",
         summary="Copy the given collection datasets to a new collection using a new `dbkey` attribute.",
         status_code=status.HTTP_204_NO_CONTENT,
     )
     def copy(
         self,
-        id: HistoryHDCAIDPathParam,
+        hdca_id: HistoryHDCAIDPathParam,
         trans: ProvidesHistoryContext = DependsOnTrans,
         payload: UpdateCollectionAttributePayload = Body(...),
     ):
-        self.service.copy(trans, id, payload)
+        self.service.copy(trans, hdca_id, payload)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     @router.get(
-        "/api/dataset_collections/{id}/attributes",
+        "/api/dataset_collections/{hdca_id}/attributes",
         summary="Returns `dbkey`/`extension` attributes for all the collection elements.",
     )
     def attributes(
         self,
-        id: HistoryHDCAIDPathParam,
+        hdca_id: HistoryHDCAIDPathParam,
         trans: ProvidesHistoryContext = DependsOnTrans,
         instance_type: DatasetCollectionInstanceType = InstanceTypeQueryParam,
     ) -> DatasetCollectionAttributesResult:
-        return self.service.attributes(trans, id, instance_type)
+        return self.service.attributes(trans, hdca_id, instance_type)
 
     @router.get(
-        "/api/dataset_collections/{id}/suitable_converters",
+        "/api/dataset_collections/{hdca_id}/suitable_converters",
         summary="Returns a list of applicable converters for all datatypes in the given collection.",
     )
     def suitable_converters(
         self,
-        id: HistoryHDCAIDPathParam,
+        hdca_id: HistoryHDCAIDPathParam,
         trans: ProvidesHistoryContext = DependsOnTrans,
         instance_type: DatasetCollectionInstanceType = InstanceTypeQueryParam,
     ) -> SuitableConverters:
-        return self.service.suitable_converters(trans, id, instance_type)
+        return self.service.suitable_converters(trans, hdca_id, instance_type)
 
     @router.get(
-        "/api/dataset_collections/{id}",
+        "/api/dataset_collections/{hdca_id}",
         summary="Returns detailed information about the given collection.",
     )
     def show(
         self,
-        id: HistoryHDCAIDPathParam,
+        hdca_id: HistoryHDCAIDPathParam,
         trans: ProvidesHistoryContext = DependsOnTrans,
         instance_type: DatasetCollectionInstanceType = InstanceTypeQueryParam,
         view: str = ViewTypeQueryParam,
     ) -> AnyHDCA:
-        return self.service.show(trans, id, instance_type, view=view)
+        return self.service.show(trans, hdca_id, instance_type, view=view)
 
     @router.get(
         "/api/dataset_collections/{hdca_id}/contents/{parent_id}",

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -841,6 +841,28 @@ class FastAPIHistoryContents:
         )
 
     @router.put(
+        "/api/dataset_collections/{hdca_id}",
+        summary="Updates the values for the history dataset (HDA) item with the given ``ID``.",
+        operation_id="dataset_collections__update_collection",
+    )
+    def update_collection(
+        self,
+        hdca_id: HistoryItemIDPathParam,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        serialization_params: SerializationParams = Depends(query_serialization_params),
+        payload: UpdateHistoryContentsPayload = Body(...),
+    ) -> AnyHistoryContentItem:
+        """Updates the values for the history content item with the given ``ID``."""
+        return self.service.update(
+            trans,
+            None,
+            hdca_id,
+            payload.model_dump(exclude_unset=True),
+            serialization_params,
+            contents_type=HistoryContentType.dataset_collection,
+        )
+
+    @router.put(
         "/api/histories/{history_id}/contents/{id}",
         summary="Updates the values for the history content item with the given ``ID`` and query specified type. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.",
         deprecated=True,

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -624,14 +624,14 @@ class FastAPIHistoryContents:
         return self.service.index_jobs_summary(trans, params)
 
     @router.get(
-        "/api/histories/{history_id}/contents/dataset_collections/{id}/download",
+        "/api/histories/{history_id}/contents/dataset_collections/{hdca_id}/download",
         summary="Download the content of a dataset collection as a `zip` archive.",
         response_class=StreamingResponse,
         operation_id="history_contents__download_collection",
     )
     def download_dataset_collection_history_content(
         self,
-        id: HistoryHDCAIDPathParam,
+        hdca_id: HistoryHDCAIDPathParam,
         trans: ProvidesHistoryContext = DependsOnTrans,
         history_id: Optional[DecodedDatabaseIdField] = Path(
             description="The encoded database identifier of the History.",
@@ -640,10 +640,10 @@ class FastAPIHistoryContents:
         """Download the content of a history dataset collection as a `zip` archive
         while maintaining approximate collection structure.
         """
-        return self._download_collection(trans, id)
+        return self._download_collection(trans, hdca_id)
 
     @router.get(
-        "/api/dataset_collections/{id}/download",
+        "/api/dataset_collections/{hdca_id}/download",
         summary="Download the content of a dataset collection as a `zip` archive.",
         response_class=StreamingResponse,
         tags=["dataset collections"],
@@ -651,21 +651,21 @@ class FastAPIHistoryContents:
     )
     def download_dataset_collection(
         self,
-        id: HistoryHDCAIDPathParam,
+        hdca_id: HistoryHDCAIDPathParam,
         trans: ProvidesHistoryContext = DependsOnTrans,
     ):
         """Download the content of a history dataset collection as a `zip` archive
         while maintaining approximate collection structure.
         """
-        return self._download_collection(trans, id)
+        return self._download_collection(trans, hdca_id)
 
     @router.post(
-        "/api/histories/{history_id}/contents/dataset_collections/{id}/prepare_download",
+        "/api/histories/{history_id}/contents/dataset_collections/{hdca_id}/prepare_download",
         summary="Prepare an short term storage object that the collection will be downloaded to.",
         include_in_schema=False,
     )
     @router.post(
-        "/api/dataset_collections/{id}/prepare_download",
+        "/api/dataset_collections/{hdca_id}/prepare_download",
         summary="Prepare an short term storage object that the collection will be downloaded to.",
         responses={
             200: {
@@ -677,14 +677,14 @@ class FastAPIHistoryContents:
     )
     def prepare_collection_download(
         self,
-        id: HistoryHDCAIDPathParam,
+        hdca_id: HistoryHDCAIDPathParam,
         trans: ProvidesHistoryContext = DependsOnTrans,
     ) -> AsyncFile:
         """The history dataset collection will be written as a `zip` archive to the
         returned short term storage object. Progress tracking this file's creation
         can be tracked with the short_term_storage API.
         """
-        return self.service.prepare_collection_download(trans, id)
+        return self.service.prepare_collection_download(trans, hdca_id)
 
     @router.post(
         "/api/histories/{history_id}/contents/{type}s",

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -591,12 +591,14 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
             target_history = self.history_manager.get_owned(decoded_id, trans.user, current_history=trans.history)
         else:
             if input_src == "hdca":
-                target_history = self.hdca_manager.get_dataset_collection_instance(
-                    trans, instance_type="history", id=input_id
-                ).history
+                hdca = self.hdca_manager.get_dataset_collection_instance(trans, instance_type="history", id=input_id)
+                assert hdca.history
+                target_history = hdca.history
             elif input_src == "hda":
                 decoded_id = trans.app.security.decode_id(input_id)
-                target_history = self.hda_manager.get_accessible(decoded_id, trans.user).history
+                hda = self.hda_manager.get_accessible(decoded_id, trans.user)
+                assert hda.history
+                target_history = hda.history
                 self.history_manager.error_unless_owner(target_history, trans.user, current_history=trans.history)
             else:
                 raise exceptions.RequestParameterInvalidException("Must run conversion on either hdca or hda.")

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -627,8 +627,14 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
                     any values that were different from the original and, therefore, updated
         """
         if history_id is None:
-            hda = self.hda_manager.get_owned(id, trans.user, current_history=trans.history)
-            history_id = hda.history.id
+            if contents_type == HistoryContentType.dataset:
+                item: Union[HistoryDatasetAssociation, HistoryDatasetCollectionAssociation] = (
+                    self.hda_manager.get_owned(id, trans.user, current_history=trans.history)
+                )
+            else:
+                item = self.hdca_manager.get_owned(id, trans.user, current_history=trans.history)
+            assert item.history
+            history_id = item.history.id
 
         history = self.history_manager.get_mutable(history_id, trans.user, current_history=trans.history)
         if contents_type == HistoryContentType.dataset:

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -832,6 +832,20 @@ class BaseDatasetPopulator(BasePopulator):
         wait_on(_wait_for_purge, "dataset to become purged", timeout=2)
         return self._get(dataset_url)
 
+    def rename_dataset(
+        self,
+        content_id: str,
+        new_name: Optional[str] = None,
+    ):
+        if not new_name:
+            new_name = self.get_random_name()
+        return self.update_dataset(content_id, {"name": new_name})
+
+    def rename_collection(self, content_id: str, new_name: Optional[str] = None):
+        if not new_name:
+            new_name = self.get_random_name()
+        self.update_dataset_collection(content_id, {"name": new_name})
+
     def create_tool_landing(self, payload: CreateToolLandingRequestPayload) -> ToolLandingRequest:
         create_url = "tool_landings"
         json = payload.model_dump(mode="json")
@@ -1532,6 +1546,18 @@ class BaseDatasetPopulator(BasePopulator):
         update_url = f"histories/{history_id}"
         put_response = self._put(update_url, payload, json=True)
         return put_response
+
+    def update_dataset(self, dataset_id: str, update_payload: Dict[str, Any]):
+        update_url = f"datasets/{dataset_id}"
+        put_response = self._put(update_url, update_payload, json=True)
+        api_asserts.assert_status_code_is_ok(put_response)
+        return put_response.json()
+
+    def update_dataset_collection(self, dataset_collection_id: str, update_payload: Dict[str, Any]):
+        update_url = f"dataset_collections/{dataset_collection_id}"
+        put_response = self._put(update_url, update_payload, json=True)
+        api_asserts.assert_status_code_is_ok(put_response)
+        return put_response.json()
 
     def get_histories(self):
         history_index_response = self._get("histories")

--- a/mypy.ini
+++ b/mypy.ini
@@ -22,25 +22,27 @@ platform = linux
 [mypy-galaxy.util.compression_utils]
 disallow_any_generics = True
 disallow_subclassing_any = True
-disallow_untyped_calls = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
+disallow_untyped_calls = True
 disallow_untyped_decorators = True
-warn_unused_ignores = True
+disallow_untyped_defs = True
 warn_return_any = True
-strict_equality = True
 
+[mypy-galaxy.managers.secured]
+disallow_any_generics = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+disallow_untyped_defs = True
+warn_return_any = True
+
+# orange list - still need to enable some of the checks
 [mypy-galaxy.tools.wrappers]
 disallow_any_generics = True
 disallow_subclassing_any = True
 disallow_untyped_calls = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-check_untyped_defs = True
 disallow_untyped_decorators = True
-no_implicit_optional = True
-warn_unused_ignores = True
-strict_equality = True
+disallow_untyped_defs = True
+warn_return_any = False
 warn_unreachable = False
 
 # red list - work on reducing these please!


### PR DESCRIPTION
We'd take the history content id and treat it as an hda id, when it might as well be an hdca id.
Includes more typing (fixes) around the model manager classes.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
