### PR TITLE
Adds a trimInputs prop to FormGeneric to trim string values on submit.

### DIFF
--- a/client/src/components/Form/FormGeneric.vue
+++ b/client/src/components/Form/FormGeneric.vue
@@ -72,6 +72,10 @@ export default {
             type: String,
             default: null,
         },
+        trimInputs: {
+            type: Boolean,
+            default: false,
+        },
     },
     data() {
         return {
@@ -103,7 +107,18 @@ export default {
             window.location = withPrefix(this.cancelRedirect);
         },
         onSubmit() {
-            submitData(this.url, this.formData).then((response) => {
+            const formData = { ...this.formData };
+
+            if (this.trimInputs) {
+                // Trim string values in form data
+                Object.keys(formData).forEach((key) => {
+                    if (typeof formData[key] === "string") {
+                        formData[key] = formData[key].trim();
+                    }
+                });
+            }
+
+            submitData(this.url, formData).then((response) => {
                 let params = {};
                 if (response.id) {
                     params.id = response.id;

--- a/client/src/components/User/UserPreferencesForm.vue
+++ b/client/src/components/User/UserPreferencesForm.vue
@@ -1,5 +1,5 @@
 <template>
-    <FormGeneric v-bind="formConfig" />
+    <FormGeneric v-bind="formConfig" :trim-inputs="true" />
 </template>
 <script>
 import FormGeneric from "components/Form/FormGeneric";


### PR DESCRIPTION
This addresses a minor issue noticed during live planning. We only need this functionality in one place (user preferences forms) and drilling props through the entire component hierarchy to handle it locally would add unnecessary complexity. This provides a clean, centralized solution for client-side form data cleanup.

Again, currently only used in user preferences forms -- no change elsewehere.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
