### PR TITLE
Remove hgv_sift from tool_conf.xml.sample

### DIFF
--- a/lib/galaxy/config/sample/tool_conf.xml.sample
+++ b/lib/galaxy/config/sample/tool_conf.xml.sample
@@ -125,7 +125,6 @@
     <tool file="maf/vcf_to_maf_customtrack.xml" />
   </section>
   <section id="hgv" name="Phenotype Association">
-    <tool file="phenotype_association/sift.xml" />
     <tool file="phenotype_association/linkToGProfile.xml" />
     <tool file="phenotype_association/linkToDavid.xml" />
     <tool file="phenotype_association/ldtools.xml" />


### PR DESCRIPTION
This depends on data table `sift_db` which likely does not exist (and does not in a default install), so even brand new installs start up with a traceback in the log:

```pytb
galaxy.tool_util.toolbox.base ERROR 2025-04-09 15:28:36,051 [pN:main,p:1272727,tN:MainThread] Error reading tool from path: phenotype_association/sift.xml
Traceback (most recent call last):
  File "/home/nate/work/galaxy/lib/galaxy/tool_util/toolbox/base.py", line 892, in _load_tool_tag_set
    tool = self.load_tool(concrete_path, use_cached=False, tool_cache_data_dir=tool_cache_data_dir)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nate/work/galaxy/lib/galaxy/tool_util/toolbox/base.py", line 1125, in load_tool
    tool = self.create_tool(
           ^^^^^^^^^^^^^^^^^
  File "/home/nate/work/galaxy/lib/galaxy/tools/__init__.py", line 599, in create_tool
    return self._create_tool_from_source(tool_source, config_file=config_file, **kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nate/work/galaxy/lib/galaxy/tools/__init__.py", line 615, in _create_tool_from_source
    return create_tool_from_source(self.app, tool_source, **kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nate/work/galaxy/lib/galaxy/tools/__init__.py", line 411, in create_tool_from_source
    tool = ToolClass(config_file, tool_source, app, **kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nate/work/galaxy/lib/galaxy/tools/__init__.py", line 1053, in __init__
    raise e
  File "/home/nate/work/galaxy/lib/galaxy/tools/__init__.py", line 1050, in __init__
    self.parse(tool_source, guid=guid, dynamic=dynamic)
  File "/home/nate/work/galaxy/lib/galaxy/tools/__init__.py", line 1372, in parse
    self.parse_inputs(self.tool_source)
  File "/home/nate/work/galaxy/lib/galaxy/tools/__init__.py", line 1658, in parse_inputs
    inputs = self.parse_input_elem(page_source, enctypes)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nate/work/galaxy/lib/galaxy/tools/__init__.py", line 1845, in parse_input_elem
    param = self.parse_param_elem(input_source, enctypes, context)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nate/work/galaxy/lib/galaxy/tools/__init__.py", line 1858, in parse_param_elem
    param = ToolParameter.build(self, input_source)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nate/work/galaxy/lib/galaxy/tools/parameters/basic.py", line 360, in build
    return parameter_types[param_type](tool, input_source)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nate/work/galaxy/lib/galaxy/tools/parameters/basic.py", line 2066, in __init__
    super().__init__(tool, input_source, trans)
  File "/home/nate/work/galaxy/lib/galaxy/tools/parameters/basic.py", line 1855, in __init__
    super().__init__(tool, input_source)
  File "/home/nate/work/galaxy/lib/galaxy/tools/parameters/basic.py", line 211, in __init__
    self.validators = validation.to_validators(tool.app if tool else None, input_source.parse_validators())
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nate/work/galaxy/lib/galaxy/tools/parameters/validation.py", line 520, in to_validators
    validators.append(_to_validator(app, validator_model))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nate/work/galaxy/lib/galaxy/tools/parameters/validation.py", line 530, in _to_validator
    tool_data_table = app.tool_data_tables[table_name]
                      ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/nate/work/galaxy/lib/galaxy/tool_util/data/__init__.py", line 947, in __getitem__
    return self.data_tables.__getitem__(key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'sift_db'
```