### PR TITLE
Log controller exceptions

### DIFF
--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -195,7 +195,7 @@ class WebApplication(base.WebApplication):
             )
 
     def handle_controller_exception(self, e, trans, method, **kwargs):
-        log.exception(f"Encountered exception in controller method: {method}")
+        log.debug(f"Encountered exception in controller method: {method}", exc_info=True)
         if isinstance(e, TypeError):
             method_signature = inspect.signature(method)
             required_parameters = {

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -195,6 +195,7 @@ class WebApplication(base.WebApplication):
             )
 
     def handle_controller_exception(self, e, trans, method, **kwargs):
+        log.exception(f"Encountered exception in controller method: {method}")
         if isinstance(e, TypeError):
             method_signature = inspect.signature(method)
             required_parameters = {


### PR DESCRIPTION
I've been complaining about "missing errors" in the logs for a good while now, I think this may be the cause of it.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Start Galaxy prior to this PR
  2. Install ucsc_wigtobigwig
  3. Upload 1.wig from test-data, do not set a dbkey
  4. Run ucsc_wigtobigwig on 1.wig
  5. Observe 400 response in browser and access log but no additional details:
      ```
      uvicorn.access INFO 2025-04-09 15:26:01,360 [pN:main.1,p:1248908,tN:MainThread] 127.0.0.1:55364 - "POST /api/tools HTTP/1.1" 400
      ```
  6. Apply PR
  7. Run ucsc_wigtobigwig
  8. Observe traceback in addition to 400 access log:
      ```pytb
      Traceback (most recent call last):
        File "/home/nate/work/galaxy/lib/galaxy/web/framework/decorators.py", line 346, in decorator
          rval = func(self, trans, *args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/nate/work/galaxy/lib/galaxy/webapps/galaxy/api/tools.py", line 666, in create
          return self.service._create(trans, payload, **kwd)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/nate/work/galaxy/lib/galaxy/webapps/galaxy/services/tools.py", line 174, in _create
          vars = tool.handle_input(
                 ^^^^^^^^^^^^^^^^^^
        File "/home/nate/work/galaxy/lib/galaxy/tools/__init__.py", line 2169, in handle_input
          self.handle_incoming_errors(all_errors)
        File "/home/nate/work/galaxy/lib/galaxy/tools/__init__.py", line 2219, in handle_incoming_errors
          raise exceptions.RequestParameterInvalidException(
      galaxy.exceptions.RequestParameterInvalidException: Parameter 'input1': Unspecified genome build, click the pencil icon in the history item to set the genome build
      uvicorn.access INFO 2025-04-09 15:51:07,062 [pN:main.1,p:1303302,tN:MainThread] 127.0.0.1:49006 - "POST /api/tools HTTP/1.1" 400
      ```

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
