### PR TITLE
[24.2] PulsarJobRunner stop_job method: return early if job.destination_params is None

### DIFF
--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -733,7 +733,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
 
     def stop_job(self, job_wrapper):
         job = job_wrapper.get_job()
-        if not job.job_runner_external_id:
+        if not job.job_runner_external_id or not job.destination_params:
             return
         # if our local job has JobExternalOutputMetadata associated, then our primary job has to have already finished
         client = self.get_client(job.destination_params, job.job_runner_external_id)


### PR DESCRIPTION
Possible fix for https://github.com/galaxyproject/galaxy/issues/19960. Methods called beyond this point cannot handle job.destination_params being None, and are not useful to jobs that have not been scheduled.

This is in response to a job with state: 'deleting', destination_params: None and a non-null job_runner_external_id causing an unhandled exception that stopped all of the job runners on Galaxy Australia.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
