### PR TITLE
[24.2] Add missing job state history entry for queued state

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1748,8 +1748,12 @@ class MinimalJobWrapper(HasResourceParameters):
 
         result = self.sa_session.execute(update_stmt)
         self.sa_session.commit()
+        state_updated = result.rowcount > 0
+        if state_updated:
+            self.sa_session.refresh(job)
+            job.state_history.append(model.JobStateHistory(job=job))
 
-        return result.rowcount > 0
+        return state_updated
 
     def enqueue(self):
         job = self.get_job()


### PR DESCRIPTION
Broken in https://github.com/galaxyproject/galaxy/pull/19824. We used to add to the job state history in `Job.set_state`.
xref https://github.com/galaxyproject/galaxy/pull/19976#discussion_r2036840795

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
