### PR TITLE
[24.2] Restrict job cache to terminal jobs (and other fixes)

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -9,6 +9,7 @@ from typing import (
     Any,
     cast,
     Dict,
+    Iterable,
     List,
     Optional,
     Union,
@@ -96,7 +97,7 @@ from galaxy.util.search import (
 log = logging.getLogger(__name__)
 
 JobStateT = str
-JobStatesT = Union[JobStateT, List[JobStateT]]
+JobStatesT = Union[JobStateT, Iterable[JobStateT]]
 
 
 STDOUT_LOCATION = "outputs/tool_stdout"
@@ -380,7 +381,7 @@ class JobSearch:
         tool_version: Optional[str],
         param: ToolStateJobInstancePopulatedT,
         param_dump: ToolStateDumpedToJsonInternalT,
-        job_state: Optional[JobStatesT] = "ok",
+        job_state: Optional[Union[JobStatesT, JobStatesT]] = (Job.states.OK, Job.states.SKIPPED),
     ):
         """Search for jobs producing same results using the 'inputs' part of a tool POST."""
         user = trans.user

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -382,7 +382,7 @@ class JobSearch:
         tool_version: Optional[str],
         param: ToolStateJobInstancePopulatedT,
         param_dump: ToolStateDumpedToJsonInternalT,
-        job_state: Optional[Union[JobStatesT, JobStatesT]] = (Job.states.OK, Job.states.SKIPPED),
+        job_state: Optional[JobStatesT] = (Job.states.OK, Job.states.SKIPPED),
     ):
         """Search for jobs producing same results using the 'inputs' part of a tool POST."""
         user = trans.user

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -447,7 +447,11 @@ class JobSearch:
                 current_case = param_dump
                 for p in path:
                     current_case = current_case[p]
-                src = current_case["src"]
+                src = current_case.get("src")
+                if src is None:
+                    # just a parameter named id.
+                    # same workaround as in populate_input_data_input_id
+                    return key, value
                 value = job_input_ids[src][value]
                 return key, value
             return key, value

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1945,7 +1945,6 @@ class Tool(UsesDictVisibleKeys):
                     tool_version=self.version,
                     param=param,
                     param_dump=param_dump,
-                    job_state=None,
                 )
             else:
                 completed_jobs[i] = None

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -546,6 +546,7 @@ class DefaultToolAction(ToolAction):
                         if output_dataset.name == name:
                             create_datasets = False
                             completed_data = output_dataset.dataset
+                            ext = completed_data.extension
                             dataset = output_dataset.dataset.dataset
                             break
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -2179,6 +2179,7 @@ class BaseWorkflowPopulator(BasePopulator):
         invocations: int = 1,
         raw_yaml: bool = False,
         use_cached_job: bool = False,
+        copy_inputs_to_history: bool = False,
     ):
         """High-level wrapper around workflow API, etc. to invoke format 2 workflows."""
         workflow_populator = self
@@ -2221,6 +2222,8 @@ class BaseWorkflowPopulator(BasePopulator):
         )
         if use_cached_job:
             workflow_request["use_cached_job"] = True
+        if copy_inputs_to_history:
+            workflow_request["copy_inputs_to_history"] = True
         workflow_request["inputs"] = json.dumps(label_map)
         workflow_request["inputs_by"] = "name"
         if parameters:

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -2178,6 +2178,7 @@ class BaseWorkflowPopulator(BasePopulator):
         round_trip_format_conversion: bool = False,
         invocations: int = 1,
         raw_yaml: bool = False,
+        use_cached_job: bool = False,
     ):
         """High-level wrapper around workflow API, etc. to invoke format 2 workflows."""
         workflow_populator = self
@@ -2218,6 +2219,8 @@ class BaseWorkflowPopulator(BasePopulator):
             history=f"hist_id={history_id}",
             workflow_id=workflow_id,
         )
+        if use_cached_job:
+            workflow_request["use_cached_job"] = True
         workflow_request["inputs"] = json.dumps(label_map)
         workflow_request["inputs_by"] = "name"
         if parameters:


### PR DESCRIPTION
Also
- fixes picking up skipped jobs at all (https://github.com/galaxyproject/galaxy/commit/fd3d3dbc5bd052a2cf7284458b2e0da9a1679284)
- fixes jobs that produced null datasets to not pick up the extension from format_source (5fa648aa92e4eef4dc1ebf42b50816bcba995024)
- fixes the job cache input check if there is a parameter called `id` (https://github.com/galaxyproject/galaxy/pull/19978/commits/af57b326bdfdd1164a1b2253a013e07cac563c7d)

By not copying non-terminal jobs we fix https://github.com/galaxyproject/galaxy/pull/19976#discussion_r2036836846.
We should eventually restore that functionality (you can do cool stuff with it!), but that would need more tests.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
