### PR TITLE
[24.2] Do not display default labels obscuring selectable options in a vue-multiselect component

### DIFF
--- a/client/src/components/License/LicenseSelector.vue
+++ b/client/src/components/License/LicenseSelector.vue
@@ -105,8 +105,8 @@ watchImmediate(
             track-by="licenseId"
             :options="licenseOptions"
             label="name"
-            selectLabel=""
-            deselectLabel=""
+            select-label=""
+            deselect-label=""
             placeholder="Select a license"
             @select="onLicense" />
         <License v-if="currentLicense?.licenseId" :license-id="currentLicense.licenseId" />

--- a/client/src/components/License/LicenseSelector.vue
+++ b/client/src/components/License/LicenseSelector.vue
@@ -105,6 +105,8 @@ watchImmediate(
             track-by="licenseId"
             :options="licenseOptions"
             label="name"
+            selectLabel=""
+            deselectLabel=""
             placeholder="Select a license"
             @select="onLicense" />
         <License v-if="currentLicense?.licenseId" :license-id="currentLicense.licenseId" />

--- a/client/src/components/User/CustomBuilds.vue
+++ b/client/src/components/User/CustomBuilds.vue
@@ -33,6 +33,8 @@
                         multiple
                         taggable
                         label="label"
+                        selectLabel=""
+                        deselectLabel=""
                         track-by="value"
                         :searchable="false"
                         :options="installedBuilds">

--- a/client/src/components/User/CustomBuilds.vue
+++ b/client/src/components/User/CustomBuilds.vue
@@ -33,8 +33,8 @@
                         multiple
                         taggable
                         label="label"
-                        selectLabel=""
-                        deselectLabel=""
+                        select-label=""
+                        deselect-label=""
                         track-by="value"
                         :searchable="false"
                         :options="installedBuilds">

--- a/client/src/components/User/ExternalIdentities/ExternalLogin.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalLogin.vue
@@ -240,8 +240,8 @@ function getIdpPreference() {
                             placeholder="Select your institution"
                             :options="cILogonIdps"
                             label="DisplayName"
-                            selectLabel=""
-                            deselectLabel=""
+                            select-label=""
+                            deselect-label=""
                             :allow-empty="false"
                             track-by="EntityID" />
 

--- a/client/src/components/User/ExternalIdentities/ExternalLogin.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalLogin.vue
@@ -198,8 +198,8 @@ function getIdpPreference() {
                             placeholder="Select your institution"
                             :options="cILogonIdps"
                             label="DisplayName"
-                            selectLabel=""
-                            deselectLabel=""
+                            select-label=""
+                            deselect-label=""
                             :allow-empty="false"
                             track-by="EntityID" />
                     </BFormGroup>

--- a/client/src/components/User/ExternalIdentities/ExternalLogin.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalLogin.vue
@@ -198,7 +198,8 @@ function getIdpPreference() {
                             placeholder="Select your institution"
                             :options="cILogonIdps"
                             label="DisplayName"
-                            :deselect-label="null"
+                            selectLabel=""
+                            deselectLabel=""
                             :allow-empty="false"
                             track-by="EntityID" />
                     </BFormGroup>
@@ -239,7 +240,8 @@ function getIdpPreference() {
                             placeholder="Select your institution"
                             :options="cILogonIdps"
                             label="DisplayName"
-                            :deselect-label="null"
+                            selectLabel=""
+                            deselectLabel=""
                             :allow-empty="false"
                             track-by="EntityID" />
 


### PR DESCRIPTION
Fixes #19979

@ahmedhamidawan Is this correct? I'm replacing `:deselect-label="null"`  with `deselectLabel=""` 

There may be up to 9 more other cases - I'll wait for approval or comments of this fix before addressing those.

I think that for the sake of consistency with other drop-down lists (including lists that are not instances of Multiselect and have no such labels), we should hide both default labels regardless of whether the width of the list is bounded or not.
