### PR TITLE
[24.2] Fix dynamic filter option access when building command line

### DIFF
--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -42,6 +42,7 @@ from galaxy.util import (
     string_as_bool,
 )
 from galaxy.util.template import fill_template
+from galaxy.work.context import WorkRequestContext
 from . import validation
 from .cancelable_request import request
 
@@ -188,9 +189,9 @@ class DataMetaFilter(Filter):
     def get_dependency_name(self):
         return self.ref_name
 
-    def filter_options(self, options: Sequence[ParameterOption], trans, other_values):
+    def filter_options(self, options: Sequence[ParameterOption], trans: Optional[WorkRequestContext], other_values):
         options = list(options)
-        if trans.workflow_building_mode is workflow_building_modes.USE_HISTORY:
+        if trans and trans.workflow_building_mode is workflow_building_modes.USE_HISTORY:
             # We're in the run form, can't possibly apply a data_meta filter.
             return options
 

--- a/test/functional/tools/dbkey_filter_input.xml
+++ b/test/functional/tools/dbkey_filter_input.xml
@@ -2,7 +2,7 @@
     <description>Filter (single) input on a dbkey</description>
     <command><![CDATA[
        cat '$inputs' > '$output' &&
-       echo $index
+       echo $index.fields.value
     ]]></command>
     <inputs>
         <param name="inputs" type="data" format="txt" label="Inputs" help="" />


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/19975, broken in https://github.com/galaxyproject/galaxy/commit/0f72943993d046ffd8465938ad5eab934791bb25


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
