### PR TITLE
Unwind more client dependencies at top of stack. 

### DIFF
--- a/client/src/app/galaxy.js
+++ b/client/src/app/galaxy.js
@@ -1,10 +1,10 @@
-import { getGalaxyInstance } from "app";
 import Backbone from "backbone";
 import $ from "jquery";
 import _ from "underscore";
 import { create, dialog } from "utils/data";
 import { _getUserLocale, _setUserLocale, localize } from "utils/localization";
 
+import { getGalaxyInstance } from "./singleton";
 import userModel from "./user-model";
 
 // ============================================================================

--- a/client/src/app/galaxy.js
+++ b/client/src/app/galaxy.js
@@ -55,8 +55,19 @@ GalaxyApp.prototype._init = function (options, bootstrapped) {
     /* These shouldn't probably be here, but they need to be right now for
      * compatibility with external plugins */
     this.data = {};
-    this.data.create = create;
-    this.data.dialog = dialog;
+
+    const galaxy = this;
+
+    const createWithGalaxyProvided = (...args) => {
+        return create(galaxy, ...args);
+    };
+
+    const dialogWithGalaxyProvided = (...args) => {
+        return dialog(galaxy, ...args);
+    };
+
+    this.data.create = createWithGalaxyProvided;
+    this.data.dialog = dialogWithGalaxyProvided;
 
     return this;
 };

--- a/client/src/app/monitor.js
+++ b/client/src/app/monitor.js
@@ -2,10 +2,11 @@
 // pass through the singleton accessors. All future code should access galaxy
 // through getGalaxyInstance, and rarely with setGalaxyInstance
 
-import { getGalaxyInstance, setGalaxyInstance } from "app";
 import config from "config";
 import { getAppRoot } from "onload/loadConfig";
 import { serverPath } from "utils/serverPath";
+
+import { getGalaxyInstance, setGalaxyInstance } from "./singleton";
 
 const galaxyStub = {
     root: getAppRoot(),

--- a/client/src/components/FilesDialog/FilesInput.vue
+++ b/client/src/components/FilesDialog/FilesInput.vue
@@ -3,7 +3,7 @@ import { BFormInput } from "bootstrap-vue";
 import { computed } from "vue";
 
 import { type FileSourceBrowsingMode, type FilterFileSourcesOptions } from "@/api/remoteFiles";
-import { filesDialog } from "@/utils/data";
+import { filesDialog } from "@/utils/dataModals";
 
 import { type SelectionItem } from "../SelectionDialog/selectionTypes";
 

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -14,7 +14,7 @@ import { useHistoryStore } from "@/stores/historyStore";
 import { useUserStore } from "@/stores/userStore";
 import { type Alias, getOperatorForAlias } from "@/utils/filtering";
 import { setItemDragstart } from "@/utils/setDrag";
-import { startWatchingHistory } from "@/watch/watchHistory";
+import { startWatchingHistory } from "@/watch/watchHistoryProvided";
 
 import { useHistoryDragDrop } from "../../../composables/historyDragDrop";
 

--- a/client/src/components/History/adapters/HistoryPanelProxy.js
+++ b/client/src/components/History/adapters/HistoryPanelProxy.js
@@ -6,7 +6,7 @@ import Backbone from "backbone";
 import { createDatasetCollection } from "components/History/model/queries";
 import { useHistoryItemsStore } from "stores/historyItemsStore";
 import { useHistoryStore } from "stores/historyStore";
-import { startWatchingHistory } from "watch/watchHistory";
+import { startWatchingHistory } from "watch/watchHistoryProvided";
 
 import { buildRuleCollectionModal } from "./buildCollectionModal";
 

--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -593,7 +593,7 @@ import _l from "utils/localization";
 import Vue from "vue";
 
 import { errorMessageAsString } from "@/utils/simple-error";
-import { startWatchingHistory } from "@/watch/watchHistory";
+import { startWatchingHistory } from "@/watch/watchHistoryProvided";
 
 import TooltipOnHover from "components/TooltipOnHover.vue";
 

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -122,7 +122,7 @@ import { canMutateHistory } from "@/api";
 import { useConfigStore } from "@/stores/configurationStore";
 import { useHistoryStore } from "@/stores/historyStore";
 import { useUserStore } from "@/stores/userStore";
-import { startWatchingHistory } from "@/watch/watchHistory";
+import { startWatchingHistory } from "@/watch/watchHistoryProvided";
 
 import ToolRecommendation from "../ToolRecommendation";
 import { getToolFormData, submitJob, updateToolFormData } from "./services";

--- a/client/src/components/Upload/CompositeRow.vue
+++ b/client/src/components/Upload/CompositeRow.vue
@@ -3,7 +3,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCheck, faEdit, faExclamation, faFolderOpen, faLaptop } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BDropdown, BDropdownItem } from "bootstrap-vue";
-import { filesDialog } from "utils/data";
+import { filesDialog } from "utils/dataModals";
 import { bytesToString } from "utils/utils";
 import { computed, ref } from "vue";
 

--- a/client/src/components/Upload/DefaultBox.vue
+++ b/client/src/components/Upload/DefaultBox.vue
@@ -7,7 +7,7 @@ import Vue, { computed, type Ref, ref } from "vue";
 import type { HDASummary } from "@/api";
 import { monitorUploadedHistoryItems } from "@/composables/monitorUploadedHistoryItems";
 import type { DbKey, ExtensionDetails } from "@/composables/uploadConfigurations";
-import { filesDialog } from "@/utils/data";
+import { filesDialog } from "@/utils/dataModals";
 import { UploadQueue } from "@/utils/upload-queue.js";
 
 import type { CollectionType } from "../History/adapters/buildCollectionModal";

--- a/client/src/components/Upload/RulesInput.vue
+++ b/client/src/components/Upload/RulesInput.vue
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { getGalaxyInstance } from "app";
 import { BAlert, BButton } from "bootstrap-vue";
 import { getRemoteEntries, getRemoteEntriesAt } from "components/Upload/utils";
-import { filesDialog } from "utils/data";
+import { filesDialog } from "utils/dataModals";
 import { urlData } from "utils/url";
 import { computed, ref } from "vue";
 

--- a/client/src/components/Workflow/Run/WorkflowRunSuccess.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunSuccess.vue
@@ -4,7 +4,7 @@ import { onMounted } from "vue";
 import type { WorkflowInvocation } from "@/api/invocations";
 import { useHistoryStore } from "@/stores/historyStore";
 import Webhooks from "@/utils/webhooks";
-import { startWatchingHistory } from "@/watch/watchHistory";
+import { startWatchingHistory } from "@/watch/watchHistoryProvided";
 
 import GridInvocation from "@/components/Grid/GridInvocation.vue";
 import WorkflowInvocationState from "@/components/WorkflowInvocationState/WorkflowInvocationState.vue";

--- a/client/src/composables/resourceWatcher.ts
+++ b/client/src/composables/resourceWatcher.ts
@@ -1,4 +1,4 @@
-export type WatchResourceHandler = () => Promise<void>;
+export type WatchResourceHandler<T = unknown> = (app?: T) => Promise<void>;
 
 export interface WatchOptions {
     /**
@@ -29,7 +29,10 @@ const DEFAULT_WATCH_OPTIONS: WatchOptions = {
  * @param watchHandler The handler function that watches the resource by querying the server.
  * @param options Options to customize the polling interval.
  */
-export function useResourceWatcher(watchHandler: WatchResourceHandler, options: WatchOptions = DEFAULT_WATCH_OPTIONS) {
+export function useResourceWatcher<T = unknown>(
+    watchHandler: WatchResourceHandler,
+    options: WatchOptions = DEFAULT_WATCH_OPTIONS
+) {
     const { shortPollingInterval, longPollingInterval, enableBackgroundPolling } = {
         ...DEFAULT_WATCH_OPTIONS,
         ...options,
@@ -41,9 +44,9 @@ export function useResourceWatcher(watchHandler: WatchResourceHandler, options: 
     /**
      * Starts watching the resource by polling the server continuously.
      */
-    function startWatchingResource() {
+    function startWatchingResource(app?: T) {
         stopWatcher();
-        tryWatchResource();
+        tryWatchResource(app);
     }
 
     /**
@@ -60,15 +63,15 @@ export function useResourceWatcher(watchHandler: WatchResourceHandler, options: 
         }
     }
 
-    async function tryWatchResource() {
+    async function tryWatchResource(app?: T) {
         try {
-            await watchHandler();
+            await watchHandler(app);
         } catch (error) {
             console.warn(error);
         } finally {
             if (currentPollingInterval) {
                 watchTimeout = setTimeout(() => {
-                    tryWatchResource();
+                    tryWatchResource(app);
                 }, currentPollingInterval);
             }
         }

--- a/client/src/composables/userLocalStorage.ts
+++ b/client/src/composables/userLocalStorage.ts
@@ -1,37 +1,22 @@
-import { watchImmediate } from "@vueuse/core";
-import { type Ref, ref } from "vue";
+import { type Ref, type UnwrapRef } from "vue";
 
 import { type AnyUser } from "@/api";
 
 import { useHashedUserId } from "./hashedUserId";
 import { useHashedUserId as useHashedUserIdFromStore } from "./hashedUserIdFromUserStore";
-import { syncRefToLocalStorage } from "./persistentRef";
+import { useUserLocalStorageFromHashId } from "./userLocalStorageFromHashedId";
 
 /**
  * Local storage composable specific to current user.
  * @param key
  * @param initialValue
  */
-export function useUserLocalStorage<T>(key: string, initialValue: T, user?: Ref<AnyUser>) {
+export function useUserLocalStorage<T>(key: string, initialValue: T, user?: Ref<AnyUser>): Ref<UnwrapRef<T>> {
     let hashedUserId;
     if (user) {
         hashedUserId = useHashedUserId(user).hashedUserId;
     } else {
         hashedUserId = useHashedUserIdFromStore().hashedUserId;
     }
-
-    const refToSync = ref(initialValue);
-    let hasSynced = false;
-
-    watchImmediate(
-        () => hashedUserId.value,
-        () => {
-            if (hashedUserId.value && !hasSynced) {
-                syncRefToLocalStorage(`${key}-${hashedUserId.value}`, refToSync);
-                hasSynced = true;
-            }
-        }
-    );
-
-    return refToSync;
+    return useUserLocalStorageFromHashId<T>(key, initialValue, hashedUserId);
 }

--- a/client/src/composables/userLocalStorageFromHashedId.ts
+++ b/client/src/composables/userLocalStorageFromHashedId.ts
@@ -1,0 +1,30 @@
+import { watchImmediate } from "@vueuse/core";
+import { type Ref, ref, type UnwrapRef } from "vue";
+
+import { syncRefToLocalStorage } from "./persistentRef";
+
+/**
+ * Local storage composable specific to current user.
+ * @param key
+ * @param initialValue
+ */
+export function useUserLocalStorageFromHashId<T>(
+    key: string,
+    initialValue: T,
+    hashedUserId: Ref<string | null>
+): Ref<UnwrapRef<T>> {
+    const refToSync = ref(initialValue);
+    let hasSynced = false;
+
+    watchImmediate(
+        () => hashedUserId.value,
+        () => {
+            if (hashedUserId.value && !hasSynced) {
+                syncRefToLocalStorage(`${key}-${hashedUserId.value}`, refToSync);
+                hasSynced = true;
+            }
+        }
+    );
+
+    return refToSync;
+}

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -2,7 +2,8 @@ import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 
 import { type AnyUser, isAdminUser, isAnonymousUser, isRegisteredUser, type RegisteredUser } from "@/api";
-import { useUserLocalStorage } from "@/composables/userLocalStorage";
+import { useHashedUserId } from "@/composables/hashedUserId";
+import { useUserLocalStorageFromHashId } from "@/composables/userLocalStorageFromHashedId";
 import { useHistoryStore } from "@/stores/historyStore";
 import {
     addFavoriteToolQuery,
@@ -28,14 +29,15 @@ type UserListViewPreferences = Record<string, ListViewMode>;
 export const useUserStore = defineStore("userStore", () => {
     const currentUser = ref<AnyUser>(null);
     const currentPreferences = ref<Preferences | null>(null);
+    const { hashedUserId } = useHashedUserId(currentUser);
 
-    const currentListViewPreferences = useUserLocalStorage<UserListViewPreferences>(
+    const currentListViewPreferences = useUserLocalStorageFromHashId<UserListViewPreferences>(
         "user-store-list-view-preferences",
         {},
-        currentUser
+        hashedUserId
     );
 
-    const hasSeenUploadHelp = useUserLocalStorage("user-store-seen-upload-help", false, currentUser);
+    const hasSeenUploadHelp = useUserLocalStorageFromHashId("user-store-seen-upload-help", false, hashedUserId);
 
     let loadPromise: Promise<void> | null = null;
 

--- a/client/src/utils/data.js
+++ b/client/src/utils/data.js
@@ -89,6 +89,8 @@ function _mountSelectionDialog(clazz, options) {
  * TODO: This should live somewhere else.
  */
 export function create(options) {
+    const galaxy = getGalaxyInstance();
+
     async function getHistory() {
         if (!options.history_id) {
             return getCurrentGalaxyHistory();
@@ -98,7 +100,7 @@ export function create(options) {
     getHistory().then((history_id) => {
         uploadSubmit({
             success: (response) => {
-                startWatchingHistory();
+                startWatchingHistory(galaxy);
                 if (options.success) {
                     options.success(response);
                 }

--- a/client/src/utils/data.js
+++ b/client/src/utils/data.js
@@ -1,46 +1,19 @@
-import { getGalaxyInstance } from "app";
-import axios from "axios";
-import { FilesDialog } from "components/FilesDialog";
 import { useGlobalUploadModal } from "composables/globalUploadModal";
-import $ from "jquery";
-import { getAppRoot } from "onload/loadConfig";
-import Vue from "vue";
 
 import { uploadPayload } from "@/utils/upload-payload.js";
 import { uploadSubmit } from "@/utils/upload-submit.js";
 import { startWatchingHistory } from "@/watch/watchHistory";
 
-import DataDialog from "components/DataDialog/DataDialog.vue";
-import DatasetCollectionDialog from "components/SelectionDialog/DatasetCollectionDialog.vue";
+import { getCurrentGalaxyHistory, mountSelectionDialog } from "./dataModalUtils";
 
-// This should be moved more centrally (though still hanging off Galaxy for
-// external use?), and populated from the store; just using this as a temporary
-// interface.
-export async function getCurrentGalaxyHistory() {
-    const galaxy = getGalaxyInstance();
-    if (galaxy.currHistoryPanel && galaxy.currHistoryPanel.model.id) {
-        // TODO: use central store for this.
-        return galaxy.currHistoryPanel.model.id;
-    } else {
-        // Otherwise manually fetch the current history json and use that id.
-        return axios
-            .get(`${getAppRoot()}history/current_history_json`)
-            .then((response) => {
-                return response.data.id;
-            })
-            .catch((err) => {
-                console.error("Error fetching current user history:", err);
-                return null;
-            });
-    }
-}
+import DataDialog from "components/DataDialog/DataDialog.vue";
 
 /**
  * Opens a modal dialog for data selection
  * @param {function} callback - Result function called with selection
  */
-export function dialog(callback, options = {}) {
-    getCurrentGalaxyHistory().then((history_id) => {
+export function dialog(galaxy, callback, options = {}) {
+    getCurrentGalaxyHistory(galaxy).then((history_id) => {
         Object.assign(options, {
             callback: callback,
             history: history_id,
@@ -49,48 +22,16 @@ export function dialog(callback, options = {}) {
             const { openGlobalUploadModal } = useGlobalUploadModal();
             openGlobalUploadModal(options);
         } else {
-            _mountSelectionDialog(DataDialog, options);
+            mountSelectionDialog(DataDialog, options);
         }
     });
-}
-
-/**
- * Opens a modal dialog for dataset collection selection
- * @param {function} callback - Result function called with selection
- */
-export function datasetCollectionDialog(callback, options = {}) {
-    getCurrentGalaxyHistory().then((history_id) => {
-        Object.assign(options, {
-            callback: callback,
-            history: history_id,
-        });
-        _mountSelectionDialog(DatasetCollectionDialog, options);
-    });
-}
-
-export function filesDialog(callback, options = {}) {
-    Object.assign(options, {
-        callback: callback,
-    });
-    _mountSelectionDialog(FilesDialog, options);
-}
-
-function _mountSelectionDialog(clazz, options) {
-    const instance = Vue.extend(clazz);
-    const vm = document.createElement("div");
-    $("body").append(vm);
-    new instance({
-        propsData: options,
-    }).$mount(vm);
 }
 
 /**
  * Creates a history dataset by submitting an upload request
  * TODO: This should live somewhere else.
  */
-export function create(options) {
-    const galaxy = getGalaxyInstance();
-
+export function create(galaxy, options) {
     async function getHistory() {
         if (!options.history_id) {
             return getCurrentGalaxyHistory();

--- a/client/src/utils/dataModalUtils.js
+++ b/client/src/utils/dataModalUtils.js
@@ -1,0 +1,34 @@
+import axios from "axios";
+import $ from "jquery";
+import { getAppRoot } from "onload/loadConfig";
+import Vue from "vue";
+
+// This should be moved more centrally (though still hanging off Galaxy for
+// external use?), and populated from the store; just using this as a temporary
+// interface.
+export async function getCurrentGalaxyHistory(galaxy) {
+    if (galaxy.currHistoryPanel && galaxy.currHistoryPanel.model.id) {
+        // TODO: use central store for this.
+        return galaxy.currHistoryPanel.model.id;
+    } else {
+        // Otherwise manually fetch the current history json and use that id.
+        return axios
+            .get(`${getAppRoot()}history/current_history_json`)
+            .then((response) => {
+                return response.data.id;
+            })
+            .catch((err) => {
+                console.error("Error fetching current user history:", err);
+                return null;
+            });
+    }
+}
+
+export function mountSelectionDialog(clazz, options) {
+    const instance = Vue.extend(clazz);
+    const vm = document.createElement("div");
+    $("body").append(vm);
+    new instance({
+        propsData: options,
+    }).$mount(vm);
+}

--- a/client/src/utils/dataModals.js
+++ b/client/src/utils/dataModals.js
@@ -1,0 +1,27 @@
+import { getGalaxyInstance } from "app";
+import { FilesDialog } from "components/FilesDialog";
+
+import { getCurrentGalaxyHistory, mountSelectionDialog } from "./dataModalUtils";
+
+import DatasetCollectionDialog from "components/SelectionDialog/DatasetCollectionDialog.vue";
+
+/**
+ * Opens a modal dialog for dataset collection selection
+ * @param {function} callback - Result function called with selection
+ */
+export function datasetCollectionDialog(callback, options = {}) {
+    getCurrentGalaxyHistory(getGalaxyInstance()).then((history_id) => {
+        Object.assign(options, {
+            callback: callback,
+            history: history_id,
+        });
+        mountSelectionDialog(DatasetCollectionDialog, options);
+    });
+}
+
+export function filesDialog(callback, options = {}) {
+    Object.assign(options, {
+        callback: callback,
+    });
+    mountSelectionDialog(FilesDialog, options);
+}

--- a/client/src/watch/watchHistory.js
+++ b/client/src/watch/watchHistory.js
@@ -5,7 +5,6 @@
  * submitted, delayed only by the throttle period and the request response time.
  */
 
-import { getGalaxyInstance } from "app";
 import { storeToRefs } from "pinia";
 import { useHistoryItemsStore } from "stores/historyItemsStore";
 import { useHistoryStore } from "stores/historyStore";
@@ -18,8 +17,8 @@ import { useDatasetStore } from "@/stores/datasetStore";
 
 const limit = 1000;
 
-const ACTIVE_POLLING_INTERVAL = 3000;
-const INACTIVE_POLLING_INTERVAL = 60000;
+export const ACTIVE_POLLING_INTERVAL = 3000;
+export const INACTIVE_POLLING_INTERVAL = 60000;
 
 // last time the history has changed
 let lastUpdateTime = null;
@@ -34,11 +33,12 @@ const { startWatchingResource: startWatchingHistory } = useResourceWatcher(watch
 
 export { startWatchingHistory };
 
-async function watchHistory() {
+export async function watchHistory(app) {
+    // GalaxyApp
     const { isWatching } = storeToRefs(useHistoryItemsStore());
     try {
         isWatching.value = true;
-        await watchHistoryOnce();
+        await watchHistoryOnce(app);
     } catch (error) {
         // error alerting the user that watch history failed
         console.warn(error);
@@ -46,7 +46,7 @@ async function watchHistory() {
     }
 }
 
-export async function watchHistoryOnce() {
+export async function watchHistoryOnce(app) {
     const historyStore = useHistoryStore();
     const historyItemsStore = useHistoryItemsStore();
     const datasetStore = useDatasetStore();
@@ -91,10 +91,9 @@ export async function watchHistoryOnce() {
         historyItemsStore.saveHistoryItems(historyId, payload);
         collectionElementsStore.saveCollections(payload);
         // trigger changes in legacy handler
-        const Galaxy = getGalaxyInstance();
-        if (Galaxy) {
-            Galaxy.user.fetch({
-                url: `${Galaxy.user.urlRoot()}/${Galaxy.user.id || "current"}`,
+        if (app) {
+            app.user.fetch({
+                url: `${app.user.urlRoot()}/${app.user.id || "current"}`,
             });
         }
     }

--- a/client/src/watch/watchHistoryProvided.js
+++ b/client/src/watch/watchHistoryProvided.js
@@ -1,0 +1,21 @@
+import { getGalaxyInstance } from "app";
+
+import { useResourceWatcher } from "@/composables/resourceWatcher";
+
+import {
+    ACTIVE_POLLING_INTERVAL,
+    INACTIVE_POLLING_INTERVAL,
+    watchHistory as watchHistorySuppliedApp,
+} from "./watchHistory";
+
+function watchHistory() {
+    const app = getGalaxyInstance();
+    return watchHistorySuppliedApp(app);
+}
+
+const { startWatchingResource: startWatchingHistory } = useResourceWatcher(watchHistory, {
+    shortPollingInterval: ACTIVE_POLLING_INTERVAL,
+    longPollingInterval: INACTIVE_POLLING_INTERVAL,
+});
+
+export { startWatchingHistory };


### PR DESCRIPTION
This is 3 or 4 changes depending on how you look at it that are meant to eliminate circular dependencies around the user store, the Galaxy app, and util/data.js. 

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
