### PR TITLE
Allow different AI providers (as long as they are openai compatible)

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5431,30 +5431,30 @@
 :Type: int
 
 
-~~~~~~~~~~~~~~~~
-``ai_api_base_url``
-~~~~~~~~~~~~~~~~
-
-:Description:
-    The base url of your AI providers API. Defaults to OpenAI
-:Default: ``https://api.openai.com/v1``
-:Type: str
-
-
-
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 ``ai_api_key``
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 :Description:
-    API key to use for the AI wizzard. Should be your Openai/Deepinfra/Groq api key
+    API key for an AI provider. AI provider is Openai By default
+    (https://openai.com/) to enable the wizard (or more?)
 :Default: ``None``
 :Type: str
 
 
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
+``ai_api_base_url``
+~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    AI API base URL. Needs to be OpenAI compatible, defaults to OpenAI
+:Default: ``None``
+:Type: str
+
+
+~~~~~~~~~~~~
 ``ai_model``
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 :Description:
     AI model to enable the wizard.

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5431,23 +5431,33 @@
 :Type: int
 
 
+~~~~~~~~~~~~~~~~
+``ai_api_base_url``
+~~~~~~~~~~~~~~~~
+
+:Description:
+    The base url of your AI providers API. Defaults to OpenAI
+:Default: ``https://api.openai.com/v1``
+:Type: str
+
+
+
 ~~~~~~~~~~~~~~~~~~
-``openai_api_key``
+``ai_api_key``
 ~~~~~~~~~~~~~~~~~~
 
 :Description:
-    API key for OpenAI (https://openai.com/) to enable the wizard (or
-    more?)
+    API key to use for the AI wizzard. Should be your Openai/Deepinfra/Groq api key
 :Default: ``None``
 :Type: str
 
 
 ~~~~~~~~~~~~~~~~
-``openai_model``
+``ai_model``
 ~~~~~~~~~~~~~~~~
 
 :Description:
-    OpenAI model to enable the wizard.
+    AI model to enable the wizard.
 :Default: ``gpt-4o``
 :Type: str
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -1107,7 +1107,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         self._process_celery_config()
 
         # load in the chat_prompts if openai api key is configured
-        if self.openai_api_key:
+        if self.ai_api_key:
             self._load_chat_prompts()
 
         self.pretty_datetime_format = expand_pretty_datetime_format(self.pretty_datetime_format)

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2934,12 +2934,15 @@ galaxy:
   # as threshold (above threshold: regular select fields will be used)
   #select_type_workflow_threshold: -1
 
-  # API key for OpenAI (https://openai.com/) to enable the wizard (or
+  # API key for an AI provider. AI provider is Openai By default (https://openai.com/) to enable the wizard (or
   # more?)
-  #openai_api_key: null
+  # ai_api_key: null
 
-  # OpenAI model to enable the wizard.
-  #openai_model: gpt-4o
+  # AI model to enable the wizard.
+  # ai_model: gpt-4o
+
+  # AI API base URL. Needs to be OpenAI compatible, defaults to OpenAI
+  # ai_api_base_url: null
 
   # Allow the display of tool recommendations in workflow editor and
   # after tool execution. If it is enabled and set to true, please

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1,21 +1,21 @@
 # Galaxy is configured by default to be usable in a single-user development
 # environment.  To tune the application for a multi-user production
 # environment, see the documentation at:
-#
+# 
 #  https://docs.galaxyproject.org/en/master/admin/production.html
-#
+# 
 # Throughout this sample configuration file, except where stated otherwise,
 # uncommented values override the default if left unset, whereas commented
 # values are set to the default value.  Relative paths are relative to the root
 # Galaxy directory.
-#
+# 
 # Examples of many of these options are explained in more detail in the Galaxy
 # Community Hub.
-#
+# 
 #   https://galaxyproject.org/admin/config
-#
+# 
 # Config hackers are encouraged to check there before asking for help.
-#
+# 
 # Configuration for Gravity process manager.
 # ``uwsgi:`` section will be ignored if Galaxy is started via Gravity commands (e.g ``./run.sh``, ``galaxy`` or ``galaxyctl``).
 gravity:
@@ -189,9 +189,9 @@ gravity:
     # Public-facing port of the proxy
     # port: 4002
 
-    # Routes file to monitor.
-    # Should be set to the same path as ``interactivetools_map`` in the ``galaxy:`` section. This is ignored if
-    # ``interactivetools_map is set``.
+    # Database to monitor.
+    # Should be set to the same value as ``interactivetools_map`` (or ``interactivetoolsproxy_map``) in the ``galaxy:`` section. This is
+    # ignored if either ``interactivetools_map`` or ``interactivetoolsproxy_map`` are set.
     # sessions: database/interactivetools_map.sqlite
 
     # Include verbose messages in gx-it-proxy
@@ -2934,15 +2934,15 @@ galaxy:
   # as threshold (above threshold: regular select fields will be used)
   #select_type_workflow_threshold: -1
 
-  # API key for an AI provider. AI provider is Openai By default (https://openai.com/) to enable the wizard (or
-  # more?)
-  # ai_api_key: null
-
-  # AI model to enable the wizard.
-  # ai_model: gpt-4o
+  # API key for an AI provider. AI provider is Openai By default
+  # (https://openai.com/) to enable the wizard (or more?)
+  #ai_api_key: null
 
   # AI API base URL. Needs to be OpenAI compatible, defaults to OpenAI
-  # ai_api_base_url: null
+  #ai_api_base_url: null
+
+  # AI model to enable the wizard.
+  #ai_model: gpt-4o
 
   # Allow the display of tool recommendations in workflow editor and
   # after tool execution. If it is enabled and set to true, please

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -4026,18 +4026,24 @@ mapping:
           use -1 (default) in order to always use the regular select fields,
           use any other positive number as threshold (above threshold: regular select fields will be used)
 
-      openai_api_key:
+      ai_api_key:
         type: str
         required: false
         desc: |
-          API key for OpenAI (https://openai.com/) to enable the wizard (or more?)
+          API key for an AI provider. AI provider is Openai By default (https://openai.com/) to enable the wizard (or more?)
 
-      openai_model:
+      ai_api_base_url:
+        type: str
+        required: false
+        desc: |
+          AI API base URL. Needs to be OpenAI compatible, defaults to OpenAI
+
+      ai_model:
         type: str
         default: gpt-4o
         required: false
         desc: |
-          OpenAI model to enable the wizard.
+          AI model to enable the wizard.
 
       enable_tool_recommendations:
         type: bool

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -4029,6 +4029,7 @@ mapping:
       ai_api_key:
         type: str
         required: false
+        deprecated_alias: openai_api_key
         desc: |
           API key for an AI provider. AI provider is Openai By default (https://openai.com/) to enable the wizard (or more?)
 
@@ -4042,6 +4043,7 @@ mapping:
         type: str
         default: gpt-4o
         required: false
+        deprecated_alias: openai_model
         desc: |
           AI model to enable the wizard.
 

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -229,7 +229,7 @@ class ConfigSerializer(base.ModelSerializer):
             "fixed_delegated_auth": _defaults_to(False),
             "help_forum_api_url": _use_config,
             "enable_help_forum_tool_panel_integration": _use_config,
-            "llm_api_configured": lambda item, key, **context: bool(item.openai_api_key),
+            "llm_api_configured": lambda item, key, **context: bool(item.ai_api_key),
         }
 
 

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -101,9 +101,11 @@ class ChatAPI:
         """Ensure OpenAI is available and configured with an API key."""
         if openai is None:
             raise ConfigurationError("OpenAI is not installed. Please install openai to use this feature.")
-        if self.config.openai_api_key is None:
+        if self.config.ai_api_key is None:
             raise ConfigurationError("OpenAI is not configured for this instance.")
-        openai.api_key = self.config.openai_api_key
+        openai.api_key = self.config.ai_api_key
+        if self.config.ai_api_base_url is not None:
+            openai.base_url = self.config.ai_api_base_url
 
     def _get_system_prompt(self) -> str:
         """Get the system prompt for OpenAI."""
@@ -121,7 +123,7 @@ class ChatAPI:
         """Send a chat request to OpenAI and handle exceptions."""
         try:
             return openai.chat.completions.create(
-                model=self.config.openai_model,
+                model=self.config.ai_model,
                 messages=messages,
             )
         except Exception as e:


### PR DESCRIPTION
This PR allows configuring the backend used for AI calls. As long as the provider is OpenAI compatible this will work, allowing the use of models from other commercial providers like deepinfra or groq, but also locally and self hosted models via ollama or proxies like litellm. 

## How to test the changes?
The easiest way is to test with Ollama locally, or setting up an account with groq / deepinfra. I used a local ollama host the following way: 
1. Install Ollama on the host
2. Install a model into Ollama (YOU WILL NEED SIGNIFICANT VRAM FOR THIS) 
`ollama pull deepseek-r1:14b`
3. Ensure Ollama can run the model:
`ollama run deepseek-r1:14b`
4. Configure galaxy to use the local ollama instance
    ai_api_key: "doesntmatter"
    ai_model: deepseek-r1:14b
    ai_api_base_url: http://localhost:11434/v1/ 
5. fire up galaxy and enjoy. 

Other providers that will straight away work are: deepinfra (you need an API key). But here is a good model:
ai_model: meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8
ai_api_base_url: https://api.deepinfra.com/v1/

Or groq (you will need an API key):
ai_model: meta-llama/llama-4-maverick-17b-128e-instruct
ai_api_base_url: https://api.groq.com/openai/v1/

## License
[x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
