### PR TITLE
Restore Visualization insertion options in Reports Editor

### DIFF
--- a/client/src/components/Markdown/Editor/Configurations/ConfigureVitessce.test.js
+++ b/client/src/components/Markdown/Editor/Configurations/ConfigureVitessce.test.js
@@ -31,12 +31,10 @@ function mountComponent(content = {}) {
         propsData: {
             name: "vitessce-view",
             content: JSON.stringify(content),
-            labels: [],
         },
         stubs: {
             ConfigureSelector: true,
             ConfigureHeader: true,
-            Heading: true,
         },
     });
 }
@@ -52,20 +50,19 @@ describe("ConfigureVitessce.vue", () => {
             stubs: {
                 ConfigureSelector: true,
                 ConfigureHeader: true,
-                Heading: true,
             },
         });
         expect(wrapper.text()).toContain("Failed to parse:");
         expect(wrapper.findComponent({ name: "BAlert" }).exists()).toBe(true);
     });
 
-    it("shows warning alert if no datasets are found", () => {
+    it("shows warning alert if no URL-like fields are found", () => {
         const wrapper = mountComponent({});
-        expect(wrapper.text()).toContain("No datasets found");
+        expect(wrapper.text()).toContain("No URL-like fields found.");
         expect(wrapper.findComponent({ name: "BAlert" }).exists()).toBe(true);
     });
 
-    it("renders ConfigureHeader and ConfigureSelector for each dataset/file", () => {
+    it("renders ConfigureHeader and ConfigureSelector for each URL field", () => {
         const wrapper = mountComponent({
             datasets: [
                 {
@@ -74,12 +71,12 @@ describe("ConfigureVitessce.vue", () => {
                     files: [
                         {
                             fileType: "obs",
-                            url: "some_url_1",
+                            url: "https://example.com/obs",
                             options: { obsType: "cell", obsIndex: "cell_id" },
                         },
                         {
                             fileType: "var",
-                            url: "some_url_2",
+                            url: "https://example.com/var",
                             options: { obsType: "gene" },
                         },
                     ],
@@ -90,7 +87,7 @@ describe("ConfigureVitessce.vue", () => {
                     files: [
                         {
                             fileType: "spatial",
-                            url: "some_url_3",
+                            url: "https://example.com/spatial",
                         },
                     ],
                 },
@@ -112,7 +109,7 @@ describe("ConfigureVitessce.vue", () => {
                 {
                     name: "Dataset 1",
                     uid: "ds1",
-                    files: [{ fileType: "obs", url: "url" }],
+                    files: [{ fileType: "obs", url: "https://example.com/obs" }],
                 },
             ],
         });

--- a/client/src/components/Markdown/MarkdownDialog.vue
+++ b/client/src/components/Markdown/MarkdownDialog.vue
@@ -74,6 +74,7 @@ const selectorConfig = {
 };
 
 const selectedShow = ref(false);
+const visualizationShow = ref(false);
 const workflowShow = ref(false);
 const historyShow = ref(false);
 const jobShow = ref(false);
@@ -121,6 +122,11 @@ function onWorkflow(response: ObjectReference) {
     emit("onInsert", `${props.argumentName}(workflow_id=${response.id})`);
 }
 
+function onVisualization(response: unknown) {
+    visualizationShow.value = false;
+    emit("onInsert", `visualization(visualization_id=${props.argumentName}, history_dataset_id=${response})`);
+}
+
 function onOk(selectedLabel: WorkflowLabel | undefined) {
     const argumentType = props.argumentType ?? "";
     const defaultLabelType: string =
@@ -157,6 +163,12 @@ function onOk(selectedLabel: WorkflowLabel | undefined) {
         } else {
             invocationShow.value = true;
         }
+    } else if (props.argumentType == "visualization_id") {
+        if (hasLabels.value) {
+            emit("onInsert", `visualization(visualization_id=${props.argumentName}, ${labelType}="${labelText}")`);
+        } else {
+            visualizationShow.value = true;
+        }
     }
 }
 
@@ -164,6 +176,7 @@ function onCancel() {
     dataCollectionShow.value = false;
     selectedShow.value = false;
     workflowShow.value = false;
+    visualizationShow.value = false;
     jobShow.value = false;
     invocationShow.value = false;
     dataShow.value = false;
@@ -198,6 +211,12 @@ if (props.argumentType == "workflow_id") {
     } else {
         jobShow.value = true;
     }
+} else if (props.argumentType == "visualization_id") {
+    if (hasLabels.value) {
+        selectedShow.value = true;
+    } else {
+        visualizationShow.value = true;
+    }
 }
 </script>
 
@@ -210,6 +229,12 @@ if (props.argumentType == "workflow_id") {
             :labels="effectiveLabels"
             :label-title="selectedLabelTitle"
             @onOk="onOk"
+            @onCancel="onCancel" />
+        <DataDialog
+            v-else-if="visualizationShow && currentHistoryId !== null"
+            :history="currentHistoryId"
+            format="id"
+            @onOk="onVisualization"
             @onCancel="onCancel" />
         <DataDialog
             v-else-if="dataShow && currentHistoryId !== null"

--- a/client/src/components/Markdown/MarkdownEditor.vue
+++ b/client/src/components/Markdown/MarkdownEditor.vue
@@ -8,6 +8,7 @@
                     </div>
                     <div>
                         <b-form-radio-group
+                            v-if="!hasLabels"
                             v-model="editor"
                             v-b-tooltip.hover.bottom
                             button-variant="outline-primary"
@@ -47,7 +48,7 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faQuestion } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 import type { WorkflowLabel } from "./Editor/types";
 
@@ -57,7 +58,7 @@ import MarkdownHelp from "@/components/Markdown/MarkdownHelp.vue";
 
 library.add(faQuestion);
 
-defineProps<{
+const props = defineProps<{
     markdownText: string;
     mode: "report" | "page";
     labels?: Array<WorkflowLabel>;
@@ -66,6 +67,8 @@ defineProps<{
 }>();
 
 const showHelpModal = ref<boolean>(false);
+
+const hasLabels = computed(() => props.labels !== undefined);
 
 const editor = ref("text");
 const editorOptions = ref([

--- a/client/src/components/Markdown/Utilities/requirements.yml
+++ b/client/src/components/Markdown/Utilities/requirements.yml
@@ -11,6 +11,7 @@ history_dataset_id:
   - history_dataset_link
   - history_dataset_name
   - history_dataset_peek
+  - visualization
 history_id:
   - history_link
 invocation_id:


### PR DESCRIPTION
Requires: #20043, and follows-up on the discussion in: #19898. This PR restores the list of visualizations in the Workflow Reports Toolbox and ensures visualizations can be embedded using the Galaxy Markdown format:

```galaxy
visualization(visualization_id=NAME, history_dataset_id=ID)
```

Additionally, this PR restricts usage to the text-based markdown editor for reports, ensuring that only Galaxy Markdown is inserted into the reports editor—excluding any JSON content. This change preserves existing functionality. Further layout and interface improvements will be evaluated and decided upon in upcoming discussions.

![reports](https://github.com/user-attachments/assets/f9937d7e-3c81-45a7-8088-41777cc033c5)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
