### PR TITLE
Implement dataset collection support in workflow landing requests

### DIFF
--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -112,10 +112,11 @@ def purge_datasets(
 def materialize(
     hda_manager: HDAManager,
     request: MaterializeDatasetInstanceTaskRequest,
+    sa_session: galaxy_scoped_session,
     task_user_id: Optional[int] = None,
 ):
     """Materialize datasets using HDAManager."""
-    hda_manager.materialize(request)
+    hda_manager.materialize(request, sa_session())
 
 
 @galaxy_task(action="set metadata for job")

--- a/lib/galaxy/exceptions/utils.py
+++ b/lib/galaxy/exceptions/utils.py
@@ -1,4 +1,44 @@
-from galaxy.exceptions import error_codes
+from typing import (
+    TYPE_CHECKING,
+    Union,
+)
+
+from galaxy.exceptions import (
+    error_codes,
+    MessageException,
+    RequestParameterInvalidException,
+    RequestParameterMissingException,
+)
+from galaxy.util.json import safe_dumps
+
+if TYPE_CHECKING:
+    from fastapi.exceptions import RequestValidationError
+    from pydantic import ValidationError
+
+
+def validation_error_to_message_exception(e: Union["ValidationError", "RequestValidationError"]) -> MessageException:
+    invalid_found = False
+    missing_found = False
+    messages = []
+    clean_validation_errors = []
+    for error in e.errors():
+        messages.append(f"{error['msg']} in {error['loc']}")
+        if error["type"] == "message_exception" and "ctx" in error:
+            return error["ctx"]["exception"]
+        if error["type"] == "missing" or error["type"] == "type_error.none.not_allowed":
+            missing_found = True
+        elif error["type"].startswith("type_error"):
+            invalid_found = True
+        # ctx contains data that can't be serialized, like exception instances
+        error.pop("ctx", None)
+        try:
+            clean_validation_errors.append(safe_dumps(error))
+        except TypeError:
+            pass
+    if missing_found and not invalid_found:
+        return RequestParameterMissingException("\n".join(messages), validation_errors=clean_validation_errors)
+    else:
+        return RequestParameterInvalidException("\n".join(messages), validation_errors=clean_validation_errors)
 
 
 def api_error_to_dict(**kwds):

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -29,6 +29,7 @@ from sqlalchemy import (
     select,
     true,
 )
+from sqlalchemy.orm import Session
 from sqlalchemy.orm.session import object_session
 
 from galaxy import (
@@ -169,13 +170,15 @@ class HDAManager(
             session.commit()
         return hda
 
-    def materialize(self, request: MaterializeDatasetInstanceTaskRequest, in_place: bool = False) -> bool:
+    def materialize(
+        self, request: MaterializeDatasetInstanceTaskRequest, session: Session, in_place: bool = False
+    ) -> bool:
         request_user: RequestUser = request.user
         materializer = materializer_factory(
             True,  # attached...
             object_store=self.app.object_store,
             file_sources=self.app.file_sources,
-            sa_session=self.app.model.session(),
+            sa_session=session,
         )
         user = self.user_manager.by_id(request_user.user_id)
         if request.source == DatasetSourceType.hda:
@@ -188,7 +191,6 @@ class HDAManager(
             history.add_dataset(new_hda, set_hid=True)
         else:
             new_hda.set_total_size()
-        session = self.session()
         session.commit()
         return new_hda.is_ok
 

--- a/lib/galaxy/model/deferred.py
+++ b/lib/galaxy/model/deferred.py
@@ -8,10 +8,7 @@ from typing import (
     Union,
 )
 
-from sqlalchemy.orm import (
-    object_session,
-    Session,
-)
+from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import DetachedInstanceError
 
 from galaxy.datatypes.sniff import (
@@ -30,6 +27,7 @@ from galaxy.model import (
     HistoryDatasetAssociation,
     HistoryDatasetCollectionAssociation,
     LibraryDatasetDatasetAssociation,
+    required_object_session,
 )
 from galaxy.objectstore import (
     ObjectStore,
@@ -131,8 +129,7 @@ class DatasetInstanceMaterializer:
                 # we need a flush...
                 sa_session = self._sa_session
                 if sa_session is None:
-                    sa_session = object_session(dataset_instance)
-                assert sa_session
+                    sa_session = required_object_session(dataset_instance)
                 sa_session.add(materialized_dataset)
                 sa_session.commit()
             object_store_populator.set_dataset_object_store_id(materialized_dataset)
@@ -179,8 +176,7 @@ class DatasetInstanceMaterializer:
         if attached:
             sa_session = self._sa_session
             if sa_session is None:
-                sa_session = object_session(dataset_instance)
-            assert sa_session
+                sa_session = required_object_session(dataset_instance)
             sa_session.add(materialized_dataset_instance)
         if not in_place:
             materialized_dataset_instance.copy_from(

--- a/lib/galaxy/model/dereference.py
+++ b/lib/galaxy/model/dereference.py
@@ -1,17 +1,41 @@
 import os.path
-from typing import List
+from typing import (
+    List,
+    Union,
+)
 
 from galaxy.model import (
+    DatasetCollection,
+    DatasetCollectionElement,
     DatasetSource,
     DatasetSourceHash,
+    History,
     HistoryDatasetAssociation,
+    HistoryDatasetCollectionAssociation,
     TransformAction,
+    User,
 )
-from galaxy.tool_util.parameters import DataRequestUri
+from galaxy.model.scoped_session import galaxy_scoped_session
+from galaxy.tool_util_models.parameters import (
+    CollectionElementCollectionRequestUri,
+    CollectionElementDataRequestUri,
+    DataRequestCollectionUri,
+    DataRequestUri,
+    FileRequestUri,
+)
 
 
-def dereference_to_model(sa_session, user, history, data_request_uri: DataRequestUri) -> HistoryDatasetAssociation:
-    name = data_request_uri.name or os.path.basename(data_request_uri.url)
+def dereference_to_model(
+    sa_session: galaxy_scoped_session,
+    user: User,
+    history: History,
+    data_request_uri: Union[DataRequestUri, FileRequestUri, CollectionElementDataRequestUri],
+    add_to_history=True,
+) -> HistoryDatasetAssociation:
+    if isinstance(data_request_uri, CollectionElementDataRequestUri):
+        name = data_request_uri.identifier
+    else:
+        name = data_request_uri.name or os.path.basename(data_request_uri.url)
     dbkey = data_request_uri.dbkey or "?"
     hda = HistoryDatasetAssociation(
         name=name,
@@ -20,6 +44,7 @@ def dereference_to_model(sa_session, user, history, data_request_uri: DataReques
         history=history,
         create_dataset=True,
         sa_session=sa_session,
+        flush=False,
     )
     hda.state = hda.states.DEFERRED
     dataset_source = DatasetSource()
@@ -43,5 +68,81 @@ def dereference_to_model(sa_session, user, history, data_request_uri: DataReques
 
     sa_session.add(hda)
     sa_session.add(dataset_source)
-    history.add_dataset(hda, genome_build=dbkey, quota=False)
+    if add_to_history:
+        history.add_dataset(hda, genome_build=dbkey, quota=False)
     return hda
+
+
+def derefence_collection_element(
+    sa_session: galaxy_scoped_session,
+    user: User,
+    history: History,
+    element: CollectionElementCollectionRequestUri,
+    parent_dataset_collection: DatasetCollection,
+    element_index: int,
+):
+    child_dataset_collection = DatasetCollection(collection_type=element.collection_type)
+    DatasetCollectionElement(
+        collection=parent_dataset_collection,
+        element=child_dataset_collection,
+        element_identifier=element.identifier,
+        element_index=element_index,
+    )
+    sa_session.add(child_dataset_collection)
+    for index, child_element in enumerate(element.elements):
+        if child_element.class_ == "File":
+            dereference_collection_dataset_element(
+                sa_session, user, history, child_element, child_dataset_collection, element_index=index
+            )
+        elif child_element.class_ == "Collection":
+            derefence_collection_element(
+                sa_session, user, history, child_element, child_dataset_collection, element_index=element_index
+            )
+    child_dataset_collection.populated_state = "ok"
+    child_dataset_collection.element_count = len(element.elements)
+
+
+def dereference_collection_dataset_element(
+    sa_session: galaxy_scoped_session,
+    user: User,
+    history: History,
+    element: CollectionElementDataRequestUri,
+    parent_dataset_collection: DatasetCollection,
+    element_index: int,
+):
+    hda = dereference_to_model(sa_session, user, history, element, add_to_history=False)
+    history.stage_addition(hda)
+    dce = DatasetCollectionElement(
+        collection=parent_dataset_collection,
+        element=hda,
+        element_identifier=element.identifier,
+        element_index=element_index,
+    )
+    parent_dataset_collection.elements.append(dce)
+
+
+def derefence_collection_to_model(
+    sa_session: galaxy_scoped_session,
+    user: User,
+    history: History,
+    data_request_uri: DataRequestCollectionUri,
+    collection_name: str = "Collection",
+) -> HistoryDatasetCollectionAssociation:
+    name = data_request_uri.name or collection_name
+    hdca = HistoryDatasetCollectionAssociation(
+        name=name,
+        history=history,
+    )
+    sa_session.add(hdca)
+    dc = DatasetCollection(collection_type=data_request_uri.collection_type)
+    sa_session.add(dc)
+    hdca.collection = dc
+    for i, element in enumerate(data_request_uri.elements):
+        if element.class_ == "File":
+            dereference_collection_dataset_element(sa_session, user, history, element, dc, element_index=i)
+        elif element.class_ == "Collection":
+            derefence_collection_element(sa_session, user, history, element, dc, i)
+    dc.populated_state = "ok"
+    dc.element_count = len(data_request_uri.elements)
+    history.stage_addition(hdca)
+    return hdca

--- a/lib/galaxy/model/dereference.py
+++ b/lib/galaxy/model/dereference.py
@@ -31,6 +31,7 @@ def dereference_to_model(
     history: History,
     data_request_uri: Union[DataRequestUri, FileRequestUri, CollectionElementDataRequestUri],
     add_to_history=True,
+    visible=True,
 ) -> HistoryDatasetAssociation:
     if isinstance(data_request_uri, CollectionElementDataRequestUri):
         name = data_request_uri.identifier
@@ -44,6 +45,7 @@ def dereference_to_model(
         history=history,
         create_dataset=True,
         sa_session=sa_session,
+        visible=visible,
         flush=False,
     )
     hda.state = hda.states.DEFERRED
@@ -110,7 +112,7 @@ def dereference_collection_dataset_element(
     parent_dataset_collection: DatasetCollection,
     element_index: int,
 ):
-    hda = dereference_to_model(sa_session, user, history, element, add_to_history=False)
+    hda = dereference_to_model(sa_session, user, history, element, add_to_history=False, visible=False)
     history.stage_addition(hda)
     dce = DatasetCollectionElement(
         collection=parent_dataset_collection,

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -2260,11 +2260,13 @@ class DirectoryModelExportStore(ModelExportStore):
     ) -> None:
         self.included_invocations.append(workflow_invocation)
         for input_dataset in workflow_invocation.input_datasets:
-            self.add_dataset(input_dataset.dataset)
+            if input_dataset.dataset:
+                self.add_dataset(input_dataset.dataset)
         for output_dataset in workflow_invocation.output_datasets:
             self.add_dataset(output_dataset.dataset)
         for input_dataset_collection in workflow_invocation.input_dataset_collections:
-            self.export_collection(input_dataset_collection.dataset_collection)
+            if input_dataset_collection.dataset_collection:
+                self.export_collection(input_dataset_collection.dataset_collection)
         for output_dataset_collection in workflow_invocation.output_dataset_collections:
             self.export_collection(output_dataset_collection.dataset_collection)
         for workflow_invocation_step in workflow_invocation.steps:

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -125,7 +125,7 @@ class WorkflowRunCrateProfileBuilder:
 
     def _add_files(self, crate: ROCrate):
         for wfda in self.invocation.input_datasets:
-            if not self.file_entities.get(wfda.dataset.dataset.id):
+            if wfda.dataset and not self.file_entities.get(wfda.dataset.dataset.id):
                 dataset_formal_param = self._add_dataset_formal_parameter(wfda.dataset, crate)
                 crate.mainEntity.append_to("input", dataset_formal_param)
                 properties = {
@@ -135,7 +135,7 @@ class WorkflowRunCrateProfileBuilder:
                 self.create_action.append_to("object", file_entity)
 
         for wfda in self.invocation.output_datasets:
-            if not self.file_entities.get(wfda.dataset.dataset.id):
+            if wfda.dataset and not self.file_entities.get(wfda.dataset.dataset.id):
                 dataset_formal_param = self._add_dataset_formal_parameter(wfda.dataset, crate)
                 crate.mainEntity.append_to("output", dataset_formal_param)
                 properties = {
@@ -190,16 +190,18 @@ class WorkflowRunCrateProfileBuilder:
 
     def _add_collections(self, crate: ROCrate):
         for wfdca in self.invocation.input_dataset_collections:
-            collection_formal_param = self._add_collection_formal_parameter(wfdca.dataset_collection, crate)
-            collection_entity = self._add_collection(wfdca.dataset_collection, crate, collection_formal_param)
-            crate.mainEntity.append_to("input", collection_formal_param)
-            self.create_action.append_to("object", collection_entity)
+            if wfdca.dataset_collection:
+                collection_formal_param = self._add_collection_formal_parameter(wfdca.dataset_collection, crate)
+                collection_entity = self._add_collection(wfdca.dataset_collection, crate, collection_formal_param)
+                crate.mainEntity.append_to("input", collection_formal_param)
+                self.create_action.append_to("object", collection_entity)
 
         for wfdca in self.invocation.output_dataset_collections:
-            collection_formal_param = self._add_collection_formal_parameter(wfdca.dataset_collection, crate)
-            collection_entity = self._add_collection(wfdca.dataset_collection, crate, collection_formal_param)
-            crate.mainEntity.append_to("output", collection_formal_param)
-            self.create_action.append_to("result", collection_entity)
+            if wfdca.dataset_collection:
+                collection_formal_param = self._add_collection_formal_parameter(wfdca.dataset_collection, crate)
+                collection_entity = self._add_collection(wfdca.dataset_collection, crate, collection_formal_param)
+                crate.mainEntity.append_to("output", collection_formal_param)
+                self.create_action.append_to("result", collection_entity)
 
     def _add_workflows(self, crate: ROCrate):
         workflows_directory = self.model_store.workflows_directory

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1644,7 +1644,8 @@ class NavigatesGalaxy(HasDriver):
         workflow_run = self.components.workflow_run
         for label, value in inputs.items():
             input_div_element = workflow_run.input_data_div(label=label).wait_for_visible()
-            self.select_set_value(input_div_element, "{}: ".format(value["hid"]))
+            hid = value.pop("hid")
+            self.select_set_value(input_div_element, f"{hid}: ")
 
     def workflow_run_submit(self):
         self.components.workflow_run.run_workflow.wait_for_and_click()

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -341,30 +341,32 @@ CollectionStrT = Literal["hdca"]
 TestCaseDataSrcT = Literal["File"]
 
 
-class DataRequestHda(StrictModel):
+class LegacyRequestModelAttributes(StrictModel):
+    # Here for bioblend's sake, should be stripped
+    map_over_type: SkipJsonSchema[Optional[str]] = Field(None, exclude=True)
+    hid: SkipJsonSchema[Optional[int]] = Field(None, exclude=True)
+    workflow_step_id: SkipJsonSchema[Optional[str]] = Field(None, exclude=True)
+    label: SkipJsonSchema[Optional[str]] = Field(None, exclude=True)
+
+
+class DataRequestHda(LegacyRequestModelAttributes):
     src: Literal["hda"] = "hda"
     id: StrictStr
-    map_over_type: SkipJsonSchema[Optional[str]] = Field(None, exclude=True)  # Drop this ?
-    hid: SkipJsonSchema[Optional[int]] = Field(None, exclude=True)  # Drop this ?
 
 
-class DataRequestLdda(StrictModel):
+class DataRequestLdda(LegacyRequestModelAttributes):
     src: Literal["ldda"] = "ldda"
     id: StrictStr
-    map_over_type: SkipJsonSchema[Optional[str]] = Field(None, exclude=True)  # Drop this ?
-    hid: SkipJsonSchema[Optional[int]] = Field(None, exclude=True)  # Drop this ?
 
 
-class DataRequestLd(StrictModel):
+class DataRequestLd(LegacyRequestModelAttributes):
     src: Literal["ld"] = Field(deprecated=True)
     id: StrictStr
 
 
-class DataRequestHdca(StrictModel):
+class DataRequestHdca(LegacyRequestModelAttributes):
     src: Literal["hdca"] = "hdca"
     id: StrictStr
-    map_over_type: SkipJsonSchema[Optional[str]] = Field(None, exclude=True)  # Drop this ?
-    hid: SkipJsonSchema[Optional[int]] = Field(None, exclude=True)  # Drop this ?
 
 
 class DatasetHash(StrictModel):

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -36,6 +36,7 @@ from pydantic import (
     Tag,
     TypeAdapter,
 )
+from pydantic.json_schema import SkipJsonSchema
 from typing_extensions import (
     Annotated,
     Literal,
@@ -343,16 +344,22 @@ TestCaseDataSrcT = Literal["File"]
 class DataRequestHda(StrictModel):
     src: Literal["hda"] = "hda"
     id: StrictStr
+    map_over_type: SkipJsonSchema[Optional[str]] = Field(None, exclude=True)  # Drop this ?
+    hid: SkipJsonSchema[Optional[int]] = Field(None, exclude=True)  # Drop this ?
 
 
 class DataRequestLdda(StrictModel):
     src: Literal["ldda"] = "ldda"
     id: StrictStr
+    map_over_type: SkipJsonSchema[Optional[str]] = Field(None, exclude=True)  # Drop this ?
+    hid: SkipJsonSchema[Optional[int]] = Field(None, exclude=True)  # Drop this ?
 
 
 class DataRequestHdca(StrictModel):
     src: Literal["hdca"] = "hdca"
     id: StrictStr
+    map_over_type: SkipJsonSchema[Optional[str]] = Field(None, exclude=True)  # Drop this ?
+    hid: SkipJsonSchema[Optional[int]] = Field(None, exclude=True)  # Drop this ?
 
 
 class DatasetHash(StrictModel):

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -355,6 +355,11 @@ class DataRequestLdda(StrictModel):
     hid: SkipJsonSchema[Optional[int]] = Field(None, exclude=True)  # Drop this ?
 
 
+class DataRequestLd(StrictModel):
+    src: Literal["ld"] = Field(deprecated=True)
+    id: StrictStr
+
+
 class DataRequestHdca(StrictModel):
     src: Literal["hdca"] = "hdca"
     id: StrictStr
@@ -451,12 +456,15 @@ class DataRequestCollectionUri(StrictModel):
     src: None = Field(None, exclude=True)
 
 
-_DataRequest = Annotated[Union[DataRequestHda, DataRequestLdda, DataRequestUri], Field(discriminator="src")]
+_DataRequest = Annotated[
+    Union[DataRequestHda, DataRequestLdda, DataRequestLd, DataRequestUri], Field(discriminator="src")
+]
 DataRequest: Type = cast(Type, _DataRequest)
 
 DataOrCollectionRequest = Union[_DataRequest, FileRequestUri, DataRequestCollectionUri, DataRequestHdca]
 
 DataRequestHda.model_rebuild()
+DataRequestLd.model_rebuild()
 DataRequestLdda.model_rebuild()
 DataRequestUri.model_rebuild()
 DataRequestHdca.model_rebuild()
@@ -480,17 +488,17 @@ MultiDataRequest: Type = union_type([MultiDataInstance, list_type(MultiDataInsta
 
 
 class DataRequestInternalHda(StrictModel):
-    src: Literal["hda"] = "hda"
+    src: Literal["hda"]
     id: StrictInt
 
 
 class DataRequestInternalLdda(StrictModel):
-    src: Literal["ldda"] = "ldda"
+    src: Literal["ldda"]
     id: StrictInt
 
 
 class DataRequestInternalHdca(StrictModel):
-    src: Literal["hdca"] = "hdca"
+    src: Literal["hdca"]
     id: StrictInt
 
 
@@ -498,7 +506,8 @@ DataRequestInternal: Type = cast(
     Type, Annotated[Union[DataRequestInternalHda, DataRequestInternalLdda, DataRequestUri], Field(discriminator="src")]
 )
 DataRequestInternalDereferenced: Type = cast(
-    Type, Annotated[Union[DataRequestInternalHda, DataRequestInternalLdda], Field(discriminator="src")]
+    Type,
+    Annotated[Union[DataRequestInternalHda, DataRequestInternalLdda], Field(discriminator="src")],
 )
 DataJobInternal = DataRequestInternalDereferenced
 

--- a/lib/galaxy/web/framework/decorators.py
+++ b/lib/galaxy/web/framework/decorators.py
@@ -3,10 +3,6 @@ from functools import wraps
 from inspect import getfullargspec
 from json import loads
 from traceback import format_exc
-from typing import (
-    TYPE_CHECKING,
-    Union,
-)
 
 import paste.httpexceptions
 from pydantic import (
@@ -17,19 +13,17 @@ from pydantic import (
 from galaxy.exceptions import (
     error_codes,
     MessageException,
-    RequestParameterInvalidException,
-    RequestParameterMissingException,
 )
-from galaxy.exceptions.utils import api_error_to_dict
+from galaxy.exceptions.utils import (
+    api_error_to_dict,
+    validation_error_to_message_exception,
+)
 from galaxy.util import (
     parse_non_hex_float,
     unicodify,
 )
 from galaxy.util.json import safe_dumps
 from galaxy.web.framework import url_for
-
-if TYPE_CHECKING:
-    from fastapi.exceptions import RequestValidationError
 
 log = logging.getLogger(__name__)
 
@@ -388,31 +382,6 @@ def format_return_as_json(rval, jsonp_callback=None, pretty=False):
     if jsonp_callback:
         json = f"{jsonp_callback}({json});"
     return json
-
-
-def validation_error_to_message_exception(e: Union[ValidationError, "RequestValidationError"]) -> MessageException:
-    invalid_found = False
-    missing_found = False
-    messages = []
-    clean_validation_errors = []
-    for error in e.errors():
-        messages.append(f"{error['msg']} in {error['loc']}")
-        if error["type"] == "message_exception" and "ctx" in error:
-            return error["ctx"]["exception"]
-        if error["type"] == "missing" or error["type"] == "type_error.none.not_allowed":
-            missing_found = True
-        elif error["type"].startswith("type_error"):
-            invalid_found = True
-        # ctx contains data that can't be serialized, like exception instances
-        error.pop("ctx", None)
-        try:
-            clean_validation_errors.append(safe_dumps(error))
-        except TypeError:
-            pass
-    if missing_found and not invalid_found:
-        return RequestParameterMissingException("\n".join(messages), validation_errors=clean_validation_errors)
-    else:
-        return RequestParameterInvalidException("\n".join(messages), validation_errors=clean_validation_errors)
 
 
 def __api_error_dict(trans, **kwds):

--- a/lib/galaxy/webapps/base/api.py
+++ b/lib/galaxy/webapps/base/api.py
@@ -33,10 +33,12 @@ from starlette_context.plugins import (
 )
 
 from galaxy.exceptions import MessageException
-from galaxy.exceptions.utils import api_error_to_dict
+from galaxy.exceptions.utils import (
+    api_error_to_dict,
+    validation_error_to_message_exception,
+)
 from galaxy.util.path import StrPath
 from galaxy.web.framework.base import walk_controller_modules
-from galaxy.web.framework.decorators import validation_error_to_message_exception
 
 if TYPE_CHECKING:
     from starlette.background import BackgroundTask

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -27,6 +27,7 @@ from starlette.responses import (
 from typing_extensions import Annotated
 
 from galaxy import util
+from galaxy.exceptions.utils import validation_error_to_message_exception
 from galaxy.managers.context import ProvidesHistoryContext
 from galaxy.schema import (
     FilterQueryParams,
@@ -59,7 +60,6 @@ from galaxy.schema.schema import (
     UpdateHistoryContentsPayload,
     WriteStoreToPayload,
 )
-from galaxy.web.framework.decorators import validation_error_to_message_exception
 from galaxy.webapps.galaxy.api import (
     depends,
     DependsOnTrans,

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -7203,16 +7203,16 @@ steps:
                 "coolinput": {
                     "batch": True,
                     "values": [
-                        {"id": hda1.get("id"), "hid": hda1.get("hid"), "src": "hda"},
-                        {"id": hda2.get("id"), "hid": hda2.get("hid"), "src": "hda"},
-                        {"id": hda3.get("id"), "hid": hda2.get("hid"), "src": "hda"},
-                        {"id": hda4.get("id"), "hid": hda2.get("hid"), "src": "hda"},
+                        {"id": hda1.get("id"), "src": "hda"},
+                        {"id": hda2.get("id"), "src": "hda"},
+                        {"id": hda3.get("id"), "src": "hda"},
+                        {"id": hda4.get("id"), "src": "hda"},
                     ],
                 }
             }
             parameters = {
                 "1": {
-                    "input": {"batch": False, "values": [{"id": hda1.get("id"), "hid": hda1.get("hid"), "src": "hda"}]},
+                    "input": {"batch": False, "values": [{"id": hda1.get("id"), "src": "hda"}]},
                     "exp": "2",
                 }
             }

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1749,8 +1749,33 @@ steps:
     @skip_without_tool("multi_data_optional")
     def test_run_workflow_with_url_collection(self):
         with self.dataset_populator.test_history() as history_id:
-            workflow_id = self._upload_yaml_workflow(
-                """
+            invocation = self._run_multi_data_workflow(history_id)
+            assert invocation["state"] == "scheduled", invocation
+            invocation_jobs = self.workflow_populator.get_invocation_jobs(invocation["id"])
+            assert len(invocation_jobs) == 1
+            job = invocation_jobs[0]
+            assert job["state"] == "ok"
+            job = self.dataset_populator.get_job_details(job_id=job["id"], full=True).json()
+            assert (
+                self.dataset_populator.get_history_dataset_content(
+                    history_id=history_id, content_id=job["outputs"]["out1"]["id"]
+                ).strip()
+                == "1 2 3"
+            )
+
+    @skip_without_tool("multi_data_optional")
+    def test_run_workflow_with_url_invalid_hash_collection(self):
+        with self.dataset_populator.test_history() as history_id:
+            invocation = self._run_multi_data_workflow(history_id, invalid_hash=True)
+            assert invocation["state"] == "failed", invocation
+            assert invocation["state"] == "failed"
+            assert len(invocation["messages"]) == 1
+            message = invocation["messages"][0]
+            assert message["reason"] == "dataset_failed"
+
+    def _run_multi_data_workflow(self, history_id, invalid_hash=False):
+        workflow_id = self._upload_yaml_workflow(
+            """
 class: GalaxyWorkflow
 inputs:
   input:
@@ -1762,47 +1787,37 @@ steps:
     in:
       input1: input
     """
-            )
-            input_b64_1 = base64.b64encode(b"1 2 3").decode("utf-8")
-            deferred = False
-            hashes_1 = [{"hash_function": "MD5", "hash_value": "5ba48b6e5a7c4d4930fda256f411e55b"}]
-            inputs = {
-                "input": {
-                    "class": "Collection",
-                    "collection_type": "list",
-                    "elements": [
-                        {
-                            "class": "File",
-                            "identifier": "my cool element",
-                            "url": f"base64://{input_b64_1}",
-                            "ext": "txt",
-                            "deferred": deferred,
-                            "hashes": hashes_1,
-                        }
-                    ],
-                },
-            }
-            workflow_request = dict(
-                history=f"hist_id={history_id}",
-            )
-            workflow_request["inputs"] = json.dumps(inputs)
-            workflow_request["inputs_by"] = "name"
-            invocation_id = self.workflow_populator.invoke_workflow_and_wait(
-                workflow_id, request=workflow_request
-            ).json()["id"]
-            invocation = self._invocation_details(workflow_id, invocation_id)
-            assert invocation["state"] == "scheduled", invocation
-            invocation_jobs = self.workflow_populator.get_invocation_jobs(invocation_id)
-            assert len(invocation_jobs) == 1
-            job = invocation_jobs[0]
-            assert job["state"] == "ok"
-            job = self.dataset_populator.get_job_details(job_id=job["id"], full=True).json()
-            assert (
-                self.dataset_populator.get_history_dataset_content(
-                    history_id=history_id, content_id=job["outputs"]["out1"]["id"]
-                ).strip()
-                == "1 2 3"
-            )
+        )
+        input_b64_1 = base64.b64encode(b"1 2 3").decode("utf-8")
+        deferred = False
+        hashes_1 = [
+            {"hash_function": "MD5", "hash_value": "abcdef" if invalid_hash else "5ba48b6e5a7c4d4930fda256f411e55b"}
+        ]
+        inputs = {
+            "input": {
+                "class": "Collection",
+                "collection_type": "list",
+                "elements": [
+                    {
+                        "class": "File",
+                        "identifier": "my cool element",
+                        "url": f"base64://{input_b64_1}",
+                        "ext": "txt",
+                        "deferred": deferred,
+                        "hashes": hashes_1,
+                    }
+                ],
+            },
+        }
+        workflow_request = dict(
+            history=f"hist_id={history_id}",
+        )
+        workflow_request["inputs"] = json.dumps(inputs)
+        workflow_request["inputs_by"] = "name"
+        invocation_id = self.workflow_populator.invoke_workflow_and_wait(
+            workflow_id, request=workflow_request, assert_ok=not invalid_hash
+        ).json()["id"]
+        return self._invocation_details(workflow_id, invocation_id)
 
     @skip_without_tool("collection_paired_default")
     def test_run_workflow_with_url_paired_collection(self):

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -2133,6 +2133,7 @@ class BaseWorkflowPopulator(BasePopulator):
         assert_ok: bool = True,
     ) -> Response:
         invoke_return = self.invoke_workflow(workflow_id, history_id=history_id, inputs=inputs, request=request)
+        assert invoke_return.status_code < 300, invoke_return.json()
         invoke_return.raise_for_status()
         invocation_id = invoke_return.json()["id"]
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -3427,7 +3427,6 @@ def load_data_dict(
                 ).json()
             hdca_output = fetch_response["outputs"][0]
             hdca = dataset_populator.ds_entry(hdca_output)
-            hdca["hid"] = hdca_output["hid"]
             label_map[key] = hdca
             inputs[key] = hdca
             has_uploads = True

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -635,6 +635,22 @@ class RunsWorkflows(GalaxyTestSeleniumContext):
             inputs, _, _ = load_data_dict(
                 history_id, test_data, self.dataset_populator, self.dataset_collection_populator
             )
+            for input_value in inputs.values():
+                if (
+                    isinstance(input_value, dict)
+                    and (src := input_value.get("src"))
+                    and (content_id := input_value.get("id"))
+                ):
+                    if src == "hda":
+                        content_item = self.dataset_populator.get_history_dataset_details(
+                            history_id, content_id=content_id
+                        )
+                        input_value["hid"] = content_item["hid"]
+                    elif src == "hdca":
+                        content_item = self.dataset_populator.get_history_collection_details(
+                            history_id=history_id, content_id=content_id
+                        )
+                        input_value["hid"] = content_item["hid"]
             self.dataset_populator.wait_for_history(history_id)
         else:
             inputs = {}

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -18,11 +18,11 @@ from typing import (
 import pytest
 from rocrate.rocrate import ROCrate
 from sqlalchemy import select
-from sqlalchemy.orm.scoping import scoped_session
 
 from galaxy import model
 from galaxy.model import store
 from galaxy.model.metadata import MetadataTempFile
+from galaxy.model.scoped_session import galaxy_scoped_session as scoped_session
 from galaxy.model.store import SessionlessContext
 from galaxy.model.unittest_utils import GalaxyDataTestApp
 from galaxy.model.unittest_utils.store_fixtures import (

--- a/test/unit/tool_util/test_parameter_convert.py
+++ b/test/unit/tool_util/test_parameter_convert.py
@@ -232,7 +232,7 @@ def test_fill_defaults():
 
 
 def _fake_dereference(input: DataRequestUri) -> DataRequestInternalHda:
-    return DataRequestInternalHda(id=EXAMPLE_ID_1)
+    return DataRequestInternalHda(id=EXAMPLE_ID_1, src="hda")
 
 
 def _fake_decode(input: str) -> int:


### PR DESCRIPTION
Let's us drive complete example requests from https://iwc.galaxyproject.org and enables building up input requests on https://brc-analytics.org, including building up collections with ENA fastq links for the workflows that need these inputs.

- [x] Needs a fix for https://github.com/galaxyproject/galaxy/issues/20049 as well

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
