### PR TITLE
Add kepler.gl visualization

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -37,6 +37,7 @@ const INSTALL_PLUGIN_BUILD_IDS = [
     "cytoscape",
     "h5web",
     "heatmap",
+    "kepler",
     "ngl",
     "msa",
     "openlayers",

--- a/config/plugins/visualizations/kepler/config/kepler.xml
+++ b/config/plugins/visualizations/kepler/config/kepler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Kepler" embeddable="true">
+<visualization name="Kepler.gl" embeddable="true">
     <description>Geospatial analysis tool for large-scale data sets</description>
     <data_sources>
         <data_source>
@@ -14,7 +14,7 @@
         <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>
     </params>
     <requirements>
-        <requirement type="npm" version="0.0.0" package="@galaxyproject/kepler"/>
+        <requirement type="npm" version="0.0.1" package="@galaxyproject/kepler"/>
     </requirements>
     <entry_point entry_point_type="script" src="dist/index.js" />
 </visualization>

--- a/config/plugins/visualizations/kepler/config/kepler.xml
+++ b/config/plugins/visualizations/kepler/config/kepler.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE visualization SYSTEM "../../visualization.dtd">
+<visualization name="Kepler" embeddable="true">
+    <description>Geospatial analysis tool for large-scale data sets</description>
+    <data_sources>
+        <data_source>
+            <model_class>HistoryDatasetAssociation</model_class>
+            <test test_attr="ext" result_type="datatype">csv</test>
+            <test test_attr="ext" result_type="datatype">geojson</test>
+            <to_param param_attr="id">dataset_id</to_param>
+        </data_source>
+    </data_sources>
+    <params>
+        <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>
+    </params>
+    <requirements>
+        <requirement type="npm" version="0.0.0" package="@galaxyproject/kepler"/>
+    </requirements>
+    <entry_point entry_point_type="script" src="dist/index.js" />
+</visualization>

--- a/config/plugins/visualizations/kepler/static/logo.svg
+++ b/config/plugins/visualizations/kepler/static/logo.svg
@@ -1,0 +1,5 @@
+<svg width="300" height="300" viewBox="0 0 300 300" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="300" height="300" fill="white"/>
+<rect x="25" y="150" width="117.851" height="117.851" transform="rotate(-45 25 150)" fill="#535C6C"/>
+<rect x="108.333" y="150" width="117.851" height="117.851" transform="rotate(-45 108.333 150)" fill="#1FBAD6"/>
+</svg>


### PR DESCRIPTION
Adds Kepler.gl for geojson and location csv files.

Test data available at:
http://cdn.jsdelivr.net/gh/galaxyproject/galaxy-test-data/geolocation.geojson
http://cdn.jsdelivr.net/gh/galaxyproject/galaxy-test-data/geolocation.csv

![kepler](https://github.com/user-attachments/assets/69b5cf42-63b3-4fd0-b3d9-475958f416fc)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
