### PR TITLE
[24.2] Ensure job states are fetched in invocation view

### DIFF
--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -81,11 +81,15 @@ if (props.instance) {
 }
 
 function handleInvocations(incomingInvocations: any) {
-    invocations.value = incomingInvocations;
-    // make sure any new histories are added to historyStore
-    invocations.value.forEach((invocation: any) => {
-        historyStore.getHistoryById(invocation.history_id);
-    });
+    if (incomingInvocations.length === 1) {
+        router.push(`/workflows/invocations/${incomingInvocations[0].id}?success=true`);
+    } else {
+        invocations.value = incomingInvocations;
+        // make sure any new histories are added to historyStore
+        invocations.value.forEach((invocation: any) => {
+            historyStore.getHistoryById(invocation.history_id);
+        });
+    }
 }
 
 function handleSubmissionError(error: string) {

--- a/client/src/components/Workflow/Run/WorkflowRunSuccess.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunSuccess.vue
@@ -2,7 +2,6 @@
 import { onMounted } from "vue";
 
 import type { WorkflowInvocation } from "@/api/invocations";
-import { useHistoryStore } from "@/stores/historyStore";
 import { refreshContentsWrapper } from "@/utils/data";
 import Webhooks from "@/utils/webhooks";
 
@@ -23,18 +22,12 @@ onMounted(() => {
     refreshContentsWrapper();
 });
 
-const historyStore = useHistoryStore();
-
 const targetHistories = props.invocations.reduce((histories, invocation) => {
     if (invocation.history_id && !histories.includes(invocation.history_id)) {
         histories.push(invocation.history_id);
     }
     return histories;
 }, [] as string[]);
-const wasNewHistoryTarget =
-    props.invocations.length > 0 &&
-    !!props.invocations[0]?.history_id &&
-    historyStore.currentHistoryId !== props.invocations[0].history_id;
 </script>
 
 <template>
@@ -51,7 +44,6 @@ const wasNewHistoryTarget =
         <WorkflowInvocationState
             v-else-if="props.invocations.length === 1 && props.invocations[0]"
             :invocation-id="props.invocations[0].id"
-            :new-history-target="wasNewHistoryTarget"
             is-full-page
             success />
         <div id="webhook-view"></div>

--- a/client/src/components/Workflow/WorkflowAnnotation.vue
+++ b/client/src/components/Workflow/WorkflowAnnotation.vue
@@ -23,7 +23,6 @@ interface Props {
     invocationUpdateTime?: string;
     historyId: string;
     showDetails?: boolean;
-    newHistoryTarget?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -73,12 +72,12 @@ const workflowTags = computed(() => {
                     <FontAwesomeIcon :icon="faHdd" />History:
                     <SwitchToHistoryLink :history-id="props.historyId" />
                     <BBadge
-                        v-if="props.newHistoryTarget && useHistoryStore().currentHistoryId !== props.historyId"
+                        v-if="useHistoryStore().currentHistoryId !== props.historyId"
                         v-b-tooltip.hover.noninteractive
                         data-description="new history badge"
                         role="button"
                         variant="info"
-                        title="Results generated in a new history. Click on history name to switch to that history.">
+                        title="Results generated in a different history. Click on history name to switch to that history.">
                         <FontAwesomeIcon :icon="faExclamation" />
                     </BBadge>
                 </span>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.ts
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.ts
@@ -33,6 +33,10 @@ const invocationById = {
         ...invocationData,
         id: "non-terminal-jobs",
     },
+    "non-terminal-populated-state": {
+        ...invocationData,
+        id: "non-terminal-populated-state",
+    },
 };
 
 // Jobs summary constants
@@ -50,6 +54,10 @@ const invocationJobsSummaryById = {
         states: {
             running: 1,
         },
+    },
+    "non-terminal-populated-state": {
+        ...invocationDataJobsSummary,
+        populated_state: "new",
     },
 };
 
@@ -156,6 +164,15 @@ describe("WorkflowInvocationState check invocation and job terminal states", () 
 
     it("determines that job states are not terminal with non-terminal jobs but scheduled invocation", async () => {
         const wrapper = await mountWorkflowInvocationState("non-terminal-jobs");
+        expect(isInvocationAndJobTerminal(wrapper)).toBe(false);
+
+        // Only the jobs summary should be polled, the invocation is initially fetched only since it is in scheduled/terminal state
+        assertInvocationFetched(1);
+        assertJobsSummaryFetched(1);
+    });
+
+    it("determines that job states are not terminal with non-terminal populated state for summary", async () => {
+        const wrapper = await mountWorkflowInvocationState("non-terminal-populated-state");
         expect(isInvocationAndJobTerminal(wrapper)).toBe(false);
 
         // Only the jobs summary should be polled, the invocation is initially fetched only since it is in scheduled/terminal state

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -35,7 +35,6 @@ interface Props {
     isSubworkflow?: boolean;
     isFullPage?: boolean;
     success?: boolean;
-    newHistoryTarget?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -278,8 +277,7 @@ async function onCancel() {
             v-if="props.isFullPage"
             :workflow-id="invocation.workflow_id"
             :invocation-update-time="invocation.update_time"
-            :history-id="invocation.history_id"
-            :new-history-target="props.newHistoryTarget">
+            :history-id="invocation.history_id">
             <template v-slot:middle-content>
                 <div class="progress-bars mx-1">
                     <ProgressBar

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -108,11 +108,16 @@ const invocationSchedulingTerminal = computed(() => {
     );
 });
 const jobStatesTerminal = computed(() => {
+    // If the job states summary is null, we haven't fetched it yet
+    if (jobStatesSummary.value === null) {
+        return false;
+    }
+
     if (invocationSchedulingTerminal.value && jobCount.value === 0) {
-        // no jobs for this invocation (think subworkflow or just inputs)
+        // no jobs for this invocation (think it has just subworkflows/inputs)
         return true;
     }
-    return !!jobStatesSummary.value && isTerminal(jobStatesSummary.value as InvocationJobsSummary);
+    return isTerminal(jobStatesSummary.value);
 });
 const jobStatesSummary = computed(() => {
     const jobsSummary = invocationStore.getInvocationJobsSummaryById(props.invocationId);

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -109,7 +109,8 @@ const invocationSchedulingTerminal = computed(() => {
 });
 const jobStatesTerminal = computed(() => {
     // If the job states summary is null, we haven't fetched it yet
-    if (jobStatesSummary.value === null) {
+    // If the `populated_state` for the summary is `new`, we haven't finished scheduling all jobs
+    if (jobStatesSummary.value === null || jobStatesSummary.value.populated_state === "new") {
         return false;
     }
 

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -664,6 +664,7 @@ export function getRouter(Galaxy) {
                         props: (route) => ({
                             invocationId: route.params.invocationId,
                             isFullPage: true,
+                            success: route.query.success,
                         }),
                     },
                     {


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20003

We weren't checking if the job states summary had been fetched before we had the following check:
```
if (invocationSchedulingTerminal.value && jobCount.value === 0)
```
`jobCount` is always 0 if the states summary hasn't been fetched yet or has `states: {}`; which can happen when the `populated_state === "new"`. Now we check for that and keep polling until we see some other state than `new`.

### (Additional Improvement) Route to Invocation on Run
**For a singular invocation** (excluding cases of batch runs), we now push to the `workflows/invocations/{invocation_id}` route when the workflow is run.
Without this, we would stay on the `workflows/run` route and refreshing would take you back to the run form, instead of the invocation view.

### ~~TODO~~ Done ✅:
- [x] Add tests
(_If problematic (for merge forwards) I can target dev in another PR just for tests? Doesn't seem bad though..._)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
