### PR TITLE
Fix `keyedCache` never allowing multiple fetches

### DIFF
--- a/client/src/composables/keyedCache.ts
+++ b/client/src/composables/keyedCache.ts
@@ -69,7 +69,7 @@ export function useKeyedCache<T>(
 
     const isLoadingItem = computed(() => {
         return (id: string) => {
-            return loadingRequests.value[id] ?? false;
+            return Boolean(loadingRequests.value[id]);
         };
     });
 


### PR DESCRIPTION
We just weren't deleting the existing promises.

Fixes https://github.com/galaxyproject/galaxy/issues/20003 which was happening again.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
