### PR TITLE
Pass host url to visualizations

### DIFF
--- a/config/plugins/visualizations/annotate_image/src/script.js
+++ b/config/plugins/visualizations/annotate_image/src/script.js
@@ -467,6 +467,6 @@ const { root, visualization_config } = JSON.parse(document.getElementById("app")
 
 const datasetId = visualization_config.dataset_id;
 
-const downloadUrl = window.location.origin + root + "api/datasets/" + datasetId + "/display";
+const downloadUrl = root + "api/datasets/" + datasetId + "/display";
 
 render(downloadUrl);

--- a/config/plugins/visualizations/common/templates/script_entry_point.mako
+++ b/config/plugins/visualizations/common/templates/script_entry_point.mako
@@ -16,7 +16,7 @@
     <%
         from markupsafe import escape
         data_incoming = {
-            "root": trans.request.host_url + h.url_for("/"),
+            "root": host_url + h.url_for("/"),
             "visualization_id": visualization_id,
             "visualization_name": visualization_name,
             "visualization_plugin": visualization_plugin,

--- a/config/plugins/visualizations/common/templates/script_entry_point.mako
+++ b/config/plugins/visualizations/common/templates/script_entry_point.mako
@@ -16,7 +16,7 @@
     <%
         from markupsafe import escape
         data_incoming = {
-            "root": h.url_for("/"),
+            "root": trans.request.host_url + h.url_for("/"),
             "visualization_id": visualization_id,
             "visualization_name": visualization_name,
             "visualization_plugin": visualization_plugin,

--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -331,7 +331,13 @@ class MockTrans:
         self.security = self.app.security
         self.history = history
 
-        self.request: Any = Bunch(headers={}, is_body_readable=False, host="request.host", url_path="mock/url/path")
+        self.request: Any = Bunch(
+            headers={},
+            is_body_readable=False,
+            host="request.host",
+            host_url="request.host_url",
+            url_path="mock/url/path",
+        )
         self.response: Any = Bunch(headers={}, set_content_type=lambda i: None)
 
     @property

--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -441,7 +441,7 @@ class MockTemplateHelpers:
         pass
 
     def dumps(*kwargs):
-        return {}
+        return kwargs
 
     def js(*js_files):
         pass

--- a/lib/galaxy/visualization/plugins/plugin.py
+++ b/lib/galaxy/visualization/plugins/plugin.py
@@ -264,6 +264,7 @@ class ScriptVisualizationPlugin(VisualizationPlugin):
         template.
         """
         render_vars["embedded"] = self._parse_embedded(embedded)
+        render_vars["host_url"] = trans.request.host_url
         render_vars["static_url"] = url_for(f"/{self.static_path}/")
         render_vars.update(vars={})
         render_vars.update({"script_attributes": self.config["entry_point"]["attr"]})

--- a/test/unit/app/visualizations/plugins/test_VisualizationsRegistry.py
+++ b/test/unit/app/visualizations/plugins/test_VisualizationsRegistry.py
@@ -3,6 +3,7 @@ Test lib/galaxy/visualization/plugins/registry.
 """
 
 import os
+import re
 
 from galaxy.app_unittest_utils import galaxy_mock
 from galaxy.util import (
@@ -171,7 +172,8 @@ class TestVisualizationsRegistry(VisualizationsBase_TestCase):
         response = script_entry.render(trans=trans, embedded=True)
         assert '<script type="module" src="mysrc">' in response
         assert '<link rel="stylesheet" href="mycss">' in response
-        assert "<div id=\"mycontainer\" data-incoming='{}'></div>" in response
+        assert re.search(r'<div id="mycontainer" data-incoming=\'.*?\'></div>', response)
+        assert "'root': 'request.host_url/'" in response
         mock_app_dir.remove()
 
 


### PR DESCRIPTION
Some third-party visualization plugins, such as h5web, require dataset URLs to be fully qualified and will reject incomplete or relative URLs. This PR ensures that the generated visualization dataset URLs always include the host name, making them fully qualified and compatible with such plugins. This approach is already implemented in the [VisualizationWrapper.vue](https://github.com/galaxyproject/galaxy/blob/dev/client/src/components/Visualizations/VisualizationWrapper.vue#L42) component. Providing the host name explicitly is significantly more robust than relying on the visualization to infer it via window.location.origin, which may be unavailable or incorrect in certain contexts or embedded environments.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. Upload the h5 file from http://cdn.jsdelivr.net/gh/galaxyproject/galaxy-test-data/hdf5.h5
  2. Visualize the dataset using h5web
  3. Notice how the message: `Failed to construct 'URL': Invalid URL` is shown for DS1 and DS2

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
