### PR TITLE
Show workflow README in split view next to the form inputs

### DIFF
--- a/client/src/components/Workflow/Run/WorkflowHelpDisplay.vue
+++ b/client/src/components/Workflow/Run/WorkflowHelpDisplay.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { BAlert, BCard } from "bootstrap-vue";
+
+import type { StoredWorkflowDetailed } from "@/api/workflows";
+import { useMarkdown } from "@/composables/markdown";
+
+import LoadingSpan from "@/components/LoadingSpan.vue";
+
+const props = defineProps<{
+    workflow?: StoredWorkflowDetailed;
+    loading?: boolean;
+}>();
+
+const { renderMarkdown } = useMarkdown({
+    openLinksInNewPage: true,
+    removeNewlinesAfterList: true,
+    increaseHeadingLevelBy: 2,
+});
+</script>
+
+<template>
+    <BAlert v-if="props.loading" variant="info" show>
+        <LoadingSpan message="Loading workflow help" />
+    </BAlert>
+    <BCard v-else-if="props.workflow" class="mx-1 flex-grow-1 overflow-auto">
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <p v-if="props.workflow.readme" class="container" v-html="renderMarkdown(props.workflow.readme)" />
+        <template v-if="props.workflow.help">
+            <hr v-if="props.workflow.readme" class="w-100" />
+            <h4 class="text-center">Workflow Help</h4>
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <p class="container" v-html="renderMarkdown(props.workflow.help)" />
+        </template>
+        <div class="py-2 text-center">- End of help -</div>
+    </BCard>
+</template>

--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { faArrowRight, faCog, faInfoCircle, faSitemap } from "@fortawesome/free-solid-svg-icons";
+import { faReadme } from "@fortawesome/free-brands-svg-icons";
+import { faArrowRight, faCog, faSitemap } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BButton, BButtonGroup, BFormCheckbox, BOverlay } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
@@ -247,7 +248,7 @@ async function onExecute() {
                                 variant="link"
                                 :pressed="showHelp"
                                 @click="showRightPanel = showHelp ? null : 'help'">
-                                <FontAwesomeIcon :icon="faInfoCircle" fixed-width />
+                                <FontAwesomeIcon :icon="faReadme" fixed-width />
                             </BButton>
                             <BButton
                                 v-b-tooltip.hover.noninteractive

--- a/client/src/components/Workflow/WorkflowAnnotation.vue
+++ b/client/src/components/Workflow/WorkflowAnnotation.vue
@@ -3,13 +3,11 @@ import { faClock } from "@fortawesome/free-regular-svg-icons";
 import { faExclamation, faHdd } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BBadge } from "bootstrap-vue";
-import { computed, ref } from "vue";
+import { computed } from "vue";
 
-import { useMarkdown } from "@/composables/markdown";
 import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
 import { useHistoryStore } from "@/stores/historyStore";
 
-import Heading from "../Common/Heading.vue";
 import TextSummary from "../Common/TextSummary.vue";
 import SwitchToHistoryLink from "../History/SwitchToHistoryLink.vue";
 import StatelessTags from "../TagsMultiselect/StatelessTags.vue";
@@ -22,6 +20,7 @@ interface Props {
     invocationUpdateTime?: string;
     historyId: string;
     showDetails?: boolean;
+    hideHr?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -44,14 +43,6 @@ const timeElapsed = computed(() => {
 
 const workflowTags = computed(() => {
     return workflow.value?.tags || [];
-});
-
-const readmeShown = ref(false);
-
-const { renderMarkdown } = useMarkdown({
-    openLinksInNewPage: true,
-    removeNewlinesAfterList: true,
-    increaseHeadingLevelBy: 1,
 });
 </script>
 
@@ -91,20 +82,7 @@ const { renderMarkdown } = useMarkdown({
         <div v-if="props.showDetails">
             <TextSummary v-if="description" class="my-1" :description="description" one-line-summary component="span" />
             <StatelessTags v-if="workflowTags.length" :value="workflowTags" :disabled="true" />
-            <div v-if="workflow.readme" class="mt-2">
-                <Heading
-                    h2
-                    separator
-                    bold
-                    size="sm"
-                    :collapse="readmeShown ? 'open' : 'closed'"
-                    @click="readmeShown = !readmeShown">
-                    <span v-localize>Readme</span>
-                </Heading>
-                <!-- eslint-disable-next-line vue/no-v-html -->
-                <p v-if="readmeShown" v-html="renderMarkdown(workflow.readme)" />
-            </div>
-            <hr v-if="!workflow.readme" class="mb-0 mt-2" />
+            <hr v-if="!props.hideHr" class="mb-0 mt-2" />
         </div>
     </div>
 </template>


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20023

As discussed in the Galaxy US team Hackathon UI meeting, it makes sense for the README to be shown on the right side (split view) instead of being placed above the run form.

![firefox_mpbsgmxUqD](https://github.com/user-attachments/assets/3dffb516-384a-410c-b514-9394c52e321b)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
