### PR TITLE
Move README to center panel in workflow editor

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -421,6 +421,16 @@ export default {
                 setReadmeHandler.set(readme.value, newReadme);
             }
         }
+        // If we switch to the report, we want to close the readme editor
+        // TODO: Maybe do this for other activities as well? E.g. inputs, tools...
+        watch(
+            () => reportActive.value,
+            (newReportActive) => {
+                if (newReportActive) {
+                    readmeActive.value = false;
+                }
+            }
+        );
 
         const help = ref(null);
         const setHelpHandler = new SetValueActionHandler(

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -1191,7 +1191,8 @@ export default {
     display: flex;
     flex-direction: column;
     flex-grow: 1;
-    overflow: auto;
+    overflow-x: auto;
+    overflow-y: hidden;
     width: 100%;
 }
 </style>

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -59,6 +59,7 @@
                     v-else-if="isActiveSideBar('workflow-best-practices')"
                     :untyped-parameters="parameters"
                     :annotation="annotation"
+                    :readme="readme"
                     :creator="creator"
                     :license="license"
                     :steps="steps"
@@ -405,10 +406,14 @@ export default {
         }
 
         const readme = ref(null);
+        const readmeActive = ref(false);
         const setReadmeHandler = new SetValueActionHandler(
             undoRedoStore,
             (value) => (readme.value = value),
-            showAttributes,
+            (args) => {
+                readmeActive.value = true;
+                showAttributes(args);
+            },
             "modify readme"
         );
         function setReadme(newReadme) {
@@ -574,6 +579,7 @@ export default {
             setAnnotation,
             readme,
             setReadme,
+            readmeActive,
             help,
             setHelp,
             logoUrl,
@@ -625,7 +631,6 @@ export default {
             messageBody: null,
             messageIsError: false,
             version: this.initialVersion,
-            readmeActive: false,
             saveAsName: null,
             saveAsAnnotation: null,
             showSaveAsModal: false,

--- a/client/src/components/Workflow/Editor/Lint.test.js
+++ b/client/src/components/Workflow/Editor/Lint.test.js
@@ -96,6 +96,7 @@ describe("Lint", () => {
                 untypedParameters: getUntypedWorkflowParameters(steps),
                 steps: steps,
                 annotation: "annotation",
+                readme: "readme",
                 license: null,
                 creator: null,
                 datatypesMapper: testDatatypesMapper,

--- a/client/src/components/Workflow/Editor/Lint.vue
+++ b/client/src/components/Workflow/Editor/Lint.vue
@@ -128,6 +128,10 @@ export default {
             type: String,
             default: null,
         },
+        readme: {
+            type: String,
+            default: null,
+        },
         license: {
             type: String,
             default: null,
@@ -180,7 +184,7 @@ export default {
             }
         },
         checkReadme() {
-            return !!this.annotation;
+            return !!this.readme;
         },
         checkLicense() {
             return !!this.license;

--- a/client/src/components/Workflow/Editor/Lint.vue
+++ b/client/src/components/Workflow/Editor/Lint.vue
@@ -20,7 +20,7 @@
             :okay="checkReadme"
             success-message="This workflow has a readme. Ideally, this helps the researchers understand the purpose, limitations, and usage of the workflow."
             :warning-message="bestPracticeWarningReadme"
-            attribute-link="Provider Readme for your Workflow."
+            attribute-link="Provide Readme for your Workflow."
             @onClick="onAttributes('readme')" />
         <LintSection
             :okay="checkCreator"

--- a/client/src/components/Workflow/Editor/ReadmeEditor.vue
+++ b/client/src/components/Workflow/Editor/ReadmeEditor.vue
@@ -64,7 +64,12 @@ watch(
                     <span v-localize>Preview</span>
                 </BButton>
             </BButtonGroup>
-            <BButton size="sm" variant="outline-danger" :disabled="!readmeEdit" @click="emit('exit')">
+            <BButton
+                v-b-tooltip.hover.noninteractive
+                size="sm"
+                variant="outline-danger"
+                title="Return to Workflow"
+                @click="emit('exit')">
                 <FontAwesomeIcon :icon="faTimes" />
                 <span v-localize>Exit</span>
             </BButton>

--- a/client/src/components/Workflow/Editor/ReadmeEditor.vue
+++ b/client/src/components/Workflow/Editor/ReadmeEditor.vue
@@ -15,9 +15,9 @@ const PLACEHOLDER_TEXT = [
 ].join(" ");
 
 const props = defineProps<{
-    readme: string;
-    name: string;
-    logoUrl: string | null;
+    readme?: string;
+    name?: string;
+    logoUrl?: string;
 }>();
 
 const emit = defineEmits<{
@@ -42,7 +42,7 @@ const readmePreviewMarkdown = computed(() => {
 watch(
     () => props.readme,
     (newValue) => {
-        readmeCurrent.value = newValue;
+        readmeCurrent.value = newValue ?? "";
     },
     { immediate: true }
 );

--- a/client/src/components/Workflow/Editor/ReadmeEditor.vue
+++ b/client/src/components/Workflow/Editor/ReadmeEditor.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faEdit, faEye, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton, BButtonGroup, BFormTextarea } from "bootstrap-vue";
+import { BButton, BButtonGroup, BCard, BFormTextarea } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
 
 import Heading from "@/components/Common/Heading.vue";
@@ -74,18 +74,21 @@ watch(
                 <span v-localize>Exit</span>
             </BButton>
         </div>
-        <div v-if="readmeEdit" class="mt-2 d-flex flex-column">
+        <div class="mt-2 d-flex flex-column">
             <BFormTextarea
+                v-if="readmeEdit"
                 id="workflow-readme"
                 v-model="readmeCurrent"
                 size="lg"
-                class="flex-grow-1 workflow-readme-textarea"
+                class="flex-grow-1 workflow-readme-textarea card-body"
                 :state="readmeCurrent.length > 0 ? null : false"
                 no-resize
                 :placeholder="PLACEHOLDER_TEXT"
                 @keyup="emit('update:readmeCurrent', readmeCurrent)" />
+            <BCard v-else class="overflow-auto h-100" body-class="position-absolute">
+                <ToolHelpMarkdown :content="readmePreviewMarkdown" />
+            </BCard>
         </div>
-        <ToolHelpMarkdown v-else class="mt-2 overflow-auto" :content="readmePreviewMarkdown" />
     </div>
 </template>
 

--- a/client/src/components/Workflow/Editor/ReadmeEditor.vue
+++ b/client/src/components/Workflow/Editor/ReadmeEditor.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { faEdit, faEye, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BButton, BButtonGroup, BFormTextarea } from "bootstrap-vue";
+import { computed, ref, watch } from "vue";
+
+import Heading from "@/components/Common/Heading.vue";
+import ToolHelpMarkdown from "@/components/Tool/ToolHelpMarkdown.vue";
+
+const PLACEHOLDER_TEXT = [
+    "The README is a markdown detailed description of what the workflow does.",
+    "It is best to include descriptions of what kinds of data are required.",
+    "Researchers looking for the workflow will see this text.",
+    "Markdown is enabled.",
+].join(" ");
+
+const props = defineProps<{
+    readme: string;
+    name: string;
+    logoUrl: string | null;
+}>();
+
+const emit = defineEmits<{
+    (e: "update:readmeCurrent", readme: string): void;
+    (e: "exit"): void;
+}>();
+
+const readmeEdit = ref(true);
+const readmeCurrent = ref(props.readme || "");
+
+const readmePreviewMarkdown = computed(() => {
+    let content = "";
+    if (props.logoUrl) {
+        content += `![${props.name || "workflow"} logo](${props.logoUrl})\n\n`;
+    }
+    if (readmeCurrent.value) {
+        content += readmeCurrent.value;
+    }
+    return content;
+});
+
+watch(
+    () => props.readme,
+    (newValue) => {
+        readmeCurrent.value = newValue;
+    },
+    { immediate: true }
+);
+</script>
+
+<template>
+    <div class="h-100 d-flex flex-column">
+        <div class="d-flex flex-gapx-1">
+            <Heading h3 separator inline size="sm" class="flex-grow-1 m-0">
+                <span v-localize>Workflow Readme</span>
+            </Heading>
+            <BButtonGroup>
+                <BButton size="sm" variant="outline-primary" :disabled="readmeEdit" @click="readmeEdit = true">
+                    <FontAwesomeIcon :icon="faEdit" />
+                    <span v-localize>Edit</span>
+                </BButton>
+                <BButton size="sm" variant="outline-primary" :disabled="!readmeEdit" @click="readmeEdit = false">
+                    <FontAwesomeIcon :icon="faEye" />
+                    <span v-localize>Preview</span>
+                </BButton>
+            </BButtonGroup>
+            <BButton size="sm" variant="outline-danger" :disabled="!readmeEdit" @click="emit('exit')">
+                <FontAwesomeIcon :icon="faTimes" />
+                <span v-localize>Exit</span>
+            </BButton>
+        </div>
+        <div v-if="readmeEdit" class="mt-2 d-flex flex-column">
+            <BFormTextarea
+                id="workflow-readme"
+                v-model="readmeCurrent"
+                size="lg"
+                class="flex-grow-1"
+                no-resize
+                :placeholder="PLACEHOLDER_TEXT"
+                @keyup="emit('update:readmeCurrent', readmeCurrent)" />
+        </div>
+        <ToolHelpMarkdown v-else class="mt-2 overflow-auto" :content="readmePreviewMarkdown" />
+    </div>
+</template>

--- a/client/src/components/Workflow/Editor/ReadmeEditor.vue
+++ b/client/src/components/Workflow/Editor/ReadmeEditor.vue
@@ -79,7 +79,8 @@ watch(
                 id="workflow-readme"
                 v-model="readmeCurrent"
                 size="lg"
-                class="flex-grow-1"
+                class="flex-grow-1 workflow-readme-textarea"
+                :state="readmeCurrent.length > 0 ? null : false"
                 no-resize
                 :placeholder="PLACEHOLDER_TEXT"
                 @keyup="emit('update:readmeCurrent', readmeCurrent)" />
@@ -87,3 +88,9 @@ watch(
         <ToolHelpMarkdown v-else class="mt-2 overflow-auto" :content="readmePreviewMarkdown" />
     </div>
 </template>
+
+<style scoped>
+.workflow-readme-textarea {
+    font: 14px/1.7 Menlo, Consolas, Monaco, "Andale Mono", monospace;
+}
+</style>

--- a/client/src/components/Workflow/Editor/WorkflowAttributes.vue
+++ b/client/src/components/Workflow/Editor/WorkflowAttributes.vue
@@ -106,6 +106,23 @@
             </div>
         </div>
         <div class="mt-2">
+            <div>
+                <b>Readme</b>
+            </div>
+            <b-button
+                id="workflow-readme"
+                class="w-100"
+                size="sm"
+                :pressed="readmeActive"
+                @click="$emit('update:readme-active', !readmeActive)">
+                {{ readmeActive ? "Hide" : "Show" }} Readme
+            </b-button>
+            <div class="form-text text-muted">
+                A detailed description of what the workflow does. It is best to include descriptions of what kinds of
+                data are required. Researchers looking for the workflow will see this text. Markdown is enabled.
+            </div>
+        </div>
+        <div class="mt-2">
             <b>Help</b>
             <b-textarea id="workflow-help" v-model="helpCurrent" @keyup="$emit('update:helpCurrent', helpCurrent)" />
             <div class="form-text text-muted">
@@ -192,6 +209,10 @@ export default {
         logoUrl: {
             type: String,
             default: null,
+        },
+        readmeActive: {
+            type: Boolean,
+            default: false,
         },
         help: {
             type: String,

--- a/client/src/components/Workflow/Editor/WorkflowAttributes.vue
+++ b/client/src/components/Workflow/Editor/WorkflowAttributes.vue
@@ -121,6 +121,16 @@
                 A detailed description of what the workflow does. It is best to include descriptions of what kinds of
                 data are required. Researchers looking for the workflow will see this text. Markdown is enabled.
             </div>
+            <b-popover
+                custom-class="best-practice-popover"
+                target="workflow-readme"
+                boundary="window"
+                placement="right"
+                :show.sync="showReadmeHightlight"
+                triggers="manual"
+                title="Best Practice"
+                :content="bestPracticeWarningReadme">
+            </b-popover>
         </div>
         <div class="mt-2">
             <b>Help</b>
@@ -153,6 +163,7 @@ import {
     bestPracticeWarningAnnotationLength,
     bestPracticeWarningCreator,
     bestPracticeWarningLicense,
+    bestPracticeWarningReadme,
 } from "./modules/linting";
 import { UntypedParameters } from "./modules/parameters";
 
@@ -235,6 +246,7 @@ export default {
         return {
             bestPracticeWarningCreator: bestPracticeWarningCreator,
             bestPracticeWarningLicense: bestPracticeWarningLicense,
+            bestPracticeWarningReadme: bestPracticeWarningReadme,
             message: null,
             messageVariant: null,
             versionCurrent: this.version,
@@ -245,6 +257,7 @@ export default {
             showAnnotationHightlight: false,
             showLicenseHightlight: false,
             showCreatorHightlight: false,
+            showReadmeHightlight: false,
             doiDescription: `
 Acceptable format:
 <ul>
@@ -336,7 +349,7 @@ Acceptable format:
                     this.showAnnotationHightlight = true;
                     this.showCreatorHightlight = false;
                     this.showLicenseHightlight = false;
-                    // this.showReadmeHightlight = false;
+                    this.showReadmeHightlight = false;
                     setTimeout(() => {
                         this.showAnnotationHightlight = false;
                     }, bestPracticeHighlightTime);
@@ -344,7 +357,7 @@ Acceptable format:
                     this.showAnnotationHightlight = false;
                     this.showCreatorHightlight = true;
                     this.showLicenseHightlight = false;
-                    // this.showReadmeHightlight = false;
+                    this.showReadmeHightlight = false;
                     setTimeout(() => {
                         this.showCreatorHightlight = false;
                     }, bestPracticeHighlightTime);
@@ -352,21 +365,19 @@ Acceptable format:
                     this.showAnnotationHightlight = false;
                     this.showCreatorHightlight = false;
                     this.showLicenseHightlight = true;
-                    // this.showReadmeHightlight = false;
+                    this.showReadmeHightlight = false;
                     setTimeout(() => {
                         this.showLicenseHightlight = false;
                     }, bestPracticeHighlightTime);
+                } else if (newHighlight == "readme") {
+                    this.showAnnotationHighlight = false;
+                    this.showCreatorHightlight = false;
+                    this.showLicenseHightlight = false;
+                    this.showReadmeHightlight = true;
+                    setTimeout(() => {
+                        this.showReadmeHightlight = false;
+                    }, bestPracticeHighlightTime);
                 }
-                // } else if (newHighlight == "readme") {
-                //     this.showAnnotationHighlight = false;
-                //     this.showCreatorHightlight = false;
-                //     this.showLicenseHightlight = false;
-                //     this.showReadmeHightlight = true;
-                //     setTimeout(() => {
-                //         this.showReadmeHightlight = false;
-                //     }, bestPracticeHighlightTime);
-                // }
-                // TODO: Add readme highlight in parent Index.vue
             },
         },
     },

--- a/client/src/components/Workflow/Editor/WorkflowAttributes.vue
+++ b/client/src/components/Workflow/Editor/WorkflowAttributes.vue
@@ -106,20 +106,6 @@
             </div>
         </div>
         <div class="mt-2">
-            <b
-                >Readme
-                <FontAwesomeIcon :icon="faEye" @click="showReadmePreview = true" />
-            </b>
-            <b-textarea
-                id="workflow-readme"
-                v-model="readmeCurrent"
-                @keyup="$emit('update:readmeCurrent', readmeCurrent)" />
-            <div class="form-text text-muted">
-                A detailed description of what the workflow does. It is best to include descriptions of what kinds of
-                data are required. Researchers looking for the workflow will see this text. Markdown is enabled.
-            </div>
-        </div>
-        <div class="mt-2">
             <b>Help</b>
             <b-textarea id="workflow-help" v-model="helpCurrent" @keyup="$emit('update:helpCurrent', helpCurrent)" />
             <div class="form-text text-muted">
@@ -137,16 +123,10 @@
                 An logo image used when generating publication artifacts for your workflow. This is completely optional.
             </div>
         </div>
-        <BModal v-model="showReadmePreview" hide-header centered ok-only>
-            <ToolHelpMarkdown :content="readmePreviewMarkdown" />
-        </BModal>
     </ActivityPanel>
 </template>
 
 <script>
-import { faEye } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BModal } from "bootstrap-vue";
 import { format, parseISO } from "date-fns";
 
 import { Services } from "@/components/Workflow/services";
@@ -164,21 +144,17 @@ import LicenseSelector from "@/components/License/LicenseSelector.vue";
 import ActivityPanel from "@/components/Panels/ActivityPanel.vue";
 import CreatorEditor from "@/components/SchemaOrg/CreatorEditor.vue";
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
-import ToolHelpMarkdown from "@/components/Tool/ToolHelpMarkdown.vue";
 
 const bestPracticeHighlightTime = 10000;
 
 export default {
     name: "WorkflowAttributes",
     components: {
-        FontAwesomeIcon,
         StatelessTags,
         LicenseSelector,
         CreatorEditor,
         ItemListEditor,
         ActivityPanel,
-        BModal,
-        ToolHelpMarkdown,
     },
     props: {
         id: {
@@ -217,10 +193,6 @@ export default {
             type: String,
             default: null,
         },
-        readme: {
-            type: String,
-            default: null,
-        },
         help: {
             type: String,
             default: null,
@@ -248,13 +220,10 @@ export default {
             annotationCurrent: this.annotation,
             nameCurrent: this.name,
             logoUrlCurrent: this.logoUrl,
-            readmeCurrent: this.readme,
             helpCurrent: this.help,
             showAnnotationHightlight: false,
             showLicenseHightlight: false,
             showCreatorHightlight: false,
-            showReadmePreview: false,
-            faEye,
             doiDescription: `
 Acceptable format:
 <ul>
@@ -277,19 +246,6 @@ Acceptable format:
         },
         hasParameters() {
             return this.parameters && this.parameters.parameters.length > 0;
-        },
-        readmePreviewMarkdown() {
-            let content = "";
-            if (this.nameCurrent) {
-                content += `# ${this.nameCurrent}\n\n`;
-            }
-            if (this.logoUrlCurrent) {
-                content += `![${this.nameCurrent || "workflow"} logo](${this.logoUrlCurrent})\n\n`;
-            }
-            if (this.readmeCurrent) {
-                content += this.readmeCurrent;
-            }
-            return content;
         },
         versionOptions() {
             const versions = [];
@@ -343,9 +299,6 @@ Acceptable format:
         name() {
             this.nameCurrent = this.name;
         },
-        readme() {
-            this.readmeCurrent = this.readme;
-        },
         help() {
             this.helpCurrent = this.help;
         },
@@ -362,7 +315,7 @@ Acceptable format:
                     this.showAnnotationHightlight = true;
                     this.showCreatorHightlight = false;
                     this.showLicenseHightlight = false;
-                    this.showReadmeHightlight = false;
+                    // this.showReadmeHightlight = false;
                     setTimeout(() => {
                         this.showAnnotationHightlight = false;
                     }, bestPracticeHighlightTime);
@@ -370,7 +323,7 @@ Acceptable format:
                     this.showAnnotationHightlight = false;
                     this.showCreatorHightlight = true;
                     this.showLicenseHightlight = false;
-                    this.showReadmeHightlight = false;
+                    // this.showReadmeHightlight = false;
                     setTimeout(() => {
                         this.showCreatorHightlight = false;
                     }, bestPracticeHighlightTime);
@@ -378,19 +331,21 @@ Acceptable format:
                     this.showAnnotationHightlight = false;
                     this.showCreatorHightlight = false;
                     this.showLicenseHightlight = true;
-                    this.showReadmeHightlight = false;
+                    // this.showReadmeHightlight = false;
                     setTimeout(() => {
                         this.showLicenseHightlight = false;
                     }, bestPracticeHighlightTime);
-                } else if (newHighlight == "readme") {
-                    this.showAnnotationHighlight = false;
-                    this.showCreatorHightlight = false;
-                    this.showLicenseHightlight = false;
-                    this.showReadmeHightlight = true;
-                    setTimeout(() => {
-                        this.showReadmeHightlight = false;
-                    }, bestPracticeHighlightTime);
                 }
+                // } else if (newHighlight == "readme") {
+                //     this.showAnnotationHighlight = false;
+                //     this.showCreatorHightlight = false;
+                //     this.showLicenseHightlight = false;
+                //     this.showReadmeHightlight = true;
+                //     setTimeout(() => {
+                //         this.showReadmeHightlight = false;
+                //     }, bestPracticeHighlightTime);
+                // }
+                // TODO: Add readme highlight in parent Index.vue
             },
         },
     },

--- a/client/src/components/Workflow/Editor/modules/activities.ts
+++ b/client/src/components/Workflow/Editor/modules/activities.ts
@@ -1,4 +1,3 @@
-import { faReadme } from "@fortawesome/free-brands-svg-icons";
 import { faSave as farSave } from "@fortawesome/free-regular-svg-icons";
 import {
     faDownload,
@@ -65,16 +64,6 @@ export const workflowEditorActivities = [
         description: "Edit the report for this workflow.",
         tooltip: "Edit workflow report",
         icon: faEdit,
-        panel: true,
-        visible: true,
-        optional: true,
-    },
-    {
-        title: "README",
-        id: "workflow-editor-readme",
-        description: "Edit and View the README for this workflow.",
-        tooltip: "Create/Modify workflow README",
-        icon: faReadme,
         panel: true,
         visible: true,
         optional: true,

--- a/client/src/components/Workflow/Editor/modules/activities.ts
+++ b/client/src/components/Workflow/Editor/modules/activities.ts
@@ -1,3 +1,4 @@
+import { faReadme } from "@fortawesome/free-brands-svg-icons";
 import { faSave as farSave } from "@fortawesome/free-regular-svg-icons";
 import {
     faDownload,
@@ -64,6 +65,16 @@ export const workflowEditorActivities = [
         description: "Edit the report for this workflow.",
         tooltip: "Edit workflow report",
         icon: faEdit,
+        panel: true,
+        visible: true,
+        optional: true,
+    },
+    {
+        title: "README",
+        id: "workflow-editor-readme",
+        description: "Edit and View the README for this workflow.",
+        tooltip: "Create/Modify workflow README",
+        icon: faReadme,
         panel: true,
         visible: true,
         optional: true,


### PR DESCRIPTION
As discussed in the Galaxy US team Hackathon UI meeting, it's not ideal/convenient to edit/create a README for a workflow in the Attributes side panel in the workflow editor. It could make more sense to place the readme edit and preview in in the center panel, providing more real estate instead of the small textarea in the panel:

https://github.com/user-attachments/assets/bcae6b0b-a45e-46f9-9a2e-6d8d3d2137cc

<details>
  <summary>
    <h2>(Outdated) Initial Idea with a new README Activity</h2>
  </summary>

https://github.com/user-attachments/assets/30b539a4-b234-4d34-b502-66640bc0617d

</details>

~TODO~ Done ✅ :
- [x] ~Use a better README editor than just the textarea we are using right now~ It works well actually, just improve styling (font etc)
- [x] Add workflow logo to readme preview
- [x] Add a way to best-practice highlight READMEs
- [x] Do not reset to Attributes activity on undo/redo
- [x] Weird `.editor-top-bar` height change on switching b/w edit and view README markdown

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
