### PR TITLE
Add DOI to workflow metadata

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -16610,6 +16610,11 @@ export interface components {
              */
             deleted: boolean;
             /**
+             * DOI
+             * @description A list of Digital Object Identifiers associated with this workflow.
+             */
+            doi?: string[] | null;
+            /**
              * Email Hash
              * @description The hash of the email of the creator of this workflow
              */

--- a/client/src/components/Common/ItemListEditor.vue
+++ b/client/src/components/Common/ItemListEditor.vue
@@ -19,7 +19,7 @@ const emit = defineEmits<{
     (e: "onItems", items: string[]): void;
 }>();
 
-const itemsCurrent = computed(() => props.items);
+const itemsCurrent = computed(() => props.items || []);
 const showForm = ref(false);
 const editIndex = ref<number | null>(null);
 const currentItem = ref<string | null>(null);

--- a/client/src/components/Common/ItemListEditor.vue
+++ b/client/src/components/Common/ItemListEditor.vue
@@ -7,11 +7,15 @@ import { computed, ref } from "vue";
 
 interface Props {
     itemName?: string;
+    description?: string | null;
+    itemFormat?: string | null;
     items?: string[];
 }
 
 const props = withDefaults(defineProps<Props>(), {
     itemName: "item",
+    description: null,
+    itemFormat: null,
     items: () => [],
 });
 
@@ -81,6 +85,14 @@ function validate() {
             return false;
         }
     }
+    // Check format if regexp provided.
+    if (props.itemFormat) {
+        const re = new RegExp(props.itemFormat);
+        if (!re.exec(item)) {
+            currentItemError.value = `This ${props.itemName} has an invalid format`;
+            return false;
+        }
+    }
     return true;
 }
 
@@ -109,6 +121,7 @@ function resetForm() {
             <b-input v-model="currentItem" :state="currentItemError ? false : null" @click="removeErrorMessage" />
             <div class="spacer"></div>
             <div v-if="currentItemError" class="error">{{ currentItemError }}</div>
+            <div v-if="props.description" v-html="description"></div>
             <b-button variant="primary" @click="onSave">Save</b-button>
             <b-button variant="danger" @click="onReset">Cancel</b-button>
         </div>

--- a/client/src/components/Common/ItemListEditor.vue
+++ b/client/src/components/Common/ItemListEditor.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+/**
+ * Editable list of items: add/edit/remove (no duplictes/empty values)
+ */
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import type { ComputedRef } from "vue";
+import { computed, ref } from "vue";
+
+interface Props {
+    itemName?: string;
+    items?: string[];
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    itemName: "item",
+    items: () => [],
+});
+
+const emit = defineEmits<{
+    (e: "onItems", items: string[]): void;
+}>();
+
+const itemsCurrent: ComputedRef<string[]> = computed(() => props.items);
+const showForm = ref(false);
+const editIndex = ref(null);
+const currentItem = ref(null);
+const currentItemError = ref(null);
+
+/** Start adding a new item. */
+function onAdd() {
+    showForm.value = true;
+}
+
+/** Start editing an item. */
+function onEdit(index) {
+    showForm.value = true;
+    editIndex.value = index;
+    currentItem.value = itemsCurrent.value[index];
+}
+
+/** Remove an item. */
+function onRemove(index) {
+    const itms = [...itemsCurrent.value];
+    itms.splice(index, 1);
+    emit("onItems", itms);
+}
+
+/** Save a new or existing item. */
+function onSave() {
+    if (validate()) {
+        const itms = [...itemsCurrent.value];
+        if (isNewItem()) {
+            itms.push(currentItem.value);
+        } else {
+            itms[editIndex.value] = currentItem.value;
+        }
+        resetForm();
+        emit("onItems", itms);
+    }
+}
+
+/** Cancel editing. */
+function onReset() {
+    resetForm();
+}
+
+/** Validate an item. */
+function validate() {
+    // Check if item is not empty.
+    const item = currentItem.value;
+    if (!item) {
+        currentItemError.value = "Please provide a value";
+        return false;
+    }
+    // Check if item is unique.
+    const foundIndex = itemsCurrent.value.indexOf(item);
+    if (foundIndex > -1) {
+        if (isNewItem() || (!isNewItem() && foundIndex != editIndex.value)) {
+            currentItemError.value = `This ${props.itemName} has already been added`;
+            return false;
+        }
+    }
+    return true;
+}
+
+/** Are we adding a new item or editing an existing item. */
+function isNewItem() {
+    return editIndex.value === null;
+}
+
+/** Clear error message from current item. */
+function removeErrorMessage() {
+    currentItemError.value = null;
+}
+
+/** Reset and hide form.  */
+function resetForm() {
+    removeErrorMessage();
+    editIndex.value = null;
+    currentItem.value = null;
+    showForm.value = false;
+}
+</script>
+
+<template>
+    <div>
+        <div v-if="showForm">
+            <b-input v-model="currentItem" :state="currentItemError ? false : null" @click="removeErrorMessage" />
+            <div class="spacer"></div>
+            <div v-if="currentItemError" class="error">{{ currentItemError }}</div>
+            <b-button variant="primary" @click="onSave">Save</b-button>
+            <b-button variant="danger" @click="onReset">Cancel</b-button>
+        </div>
+        <div v-else>
+            <div v-if="itemsCurrent.length > 0">
+                <div v-for="(item, index) in itemsCurrent" :key="index">
+                    {{ item }}
+                    <b-button
+                        v-b-tooltip.hover
+                        class="inline-icon-button"
+                        variant="link"
+                        size="sm"
+                        :title="`Edit ${props.itemName}`"
+                        @click="onEdit(index)">
+                        <FontAwesomeIcon icon="edit" />
+                    </b-button>
+                    <b-button
+                        v-b-tooltip.hover
+                        class="inline-icon-button"
+                        variant="link"
+                        size="sm"
+                        :title="`Remove ${props.itemName}`"
+                        @click="onRemove(index)">
+                        <FontAwesomeIcon icon="times" />
+                    </b-button>
+                </div>
+            </div>
+            <i>
+                <a href="#" @click.prevent="onAdd()">Add a new {{ itemName }}</a>
+            </i>
+        </div>
+    </div>
+</template>
+
+<style>
+.error {
+    color: red;
+}
+.spacer {
+    padding: 5px;
+}
+</style>

--- a/client/src/components/Common/ItemListEditor.vue
+++ b/client/src/components/Common/ItemListEditor.vue
@@ -3,7 +3,6 @@
  * Editable list of items: add/edit/remove (no duplictes/empty values)
  */
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import type { ComputedRef } from "vue";
 import { computed, ref } from "vue";
 
 interface Props {
@@ -20,11 +19,11 @@ const emit = defineEmits<{
     (e: "onItems", items: string[]): void;
 }>();
 
-const itemsCurrent: ComputedRef<string[]> = computed(() => props.items);
+const itemsCurrent = computed(() => props.items);
 const showForm = ref(false);
-const editIndex = ref(null);
-const currentItem = ref(null);
-const currentItemError = ref(null);
+const editIndex = ref<number | null>(null);
+const currentItem = ref<string | null>(null);
+const currentItemError = ref<string | null>(null);
 
 /** Start adding a new item. */
 function onAdd() {
@@ -32,30 +31,32 @@ function onAdd() {
 }
 
 /** Start editing an item. */
-function onEdit(index) {
+function onEdit(index: number) {
     showForm.value = true;
     editIndex.value = index;
-    currentItem.value = itemsCurrent.value[index];
+    currentItem.value = itemsCurrent.value[index] as string;
 }
 
 /** Remove an item. */
-function onRemove(index) {
-    const itms = [...itemsCurrent.value];
-    itms.splice(index, 1);
-    emit("onItems", itms);
+function onRemove(index: number) {
+    const items = [...itemsCurrent.value];
+    items.splice(index, 1);
+    emit("onItems", items);
 }
 
 /** Save a new or existing item. */
 function onSave() {
     if (validate()) {
-        const itms = [...itemsCurrent.value];
+        const itemValue = currentItem.value as string;
+        const items = [...itemsCurrent.value];
         if (isNewItem()) {
-            itms.push(currentItem.value);
+            items.push(itemValue);
         } else {
-            itms[editIndex.value] = currentItem.value;
+            const i = editIndex.value as number;
+            items[i] = itemValue;
         }
         resetForm();
-        emit("onItems", itms);
+        emit("onItems", items);
     }
 }
 

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -91,6 +91,7 @@
                     :versions="versions"
                     :license="license"
                     :creator="creator"
+                    :doi="doi"
                     :logo-url="logoUrl"
                     :readme="readme"
                     :help="help"
@@ -98,6 +99,7 @@
                     @tags="setTags"
                     @license="onLicense"
                     @creator="onCreator"
+                    @doi="onDoi"
                     @update:nameCurrent="setName"
                     @update:annotationCurrent="setAnnotation"
                     @update:logoUrlCurrent="setLogoUrl"
@@ -366,6 +368,17 @@ export default {
             setCreatorHandler.set(creator.value, newCreator);
         }
 
+        const doi = ref(null);
+        const setDoiHandler = new SetValueActionHandler(
+            undoRedoStore,
+            (value) => (doi.value = value),
+            showAttributes,
+            "set DOI"
+        );
+        function setDoi(newDoi) {
+            setDoiHandler.set(doi.value, newDoi);
+        }
+
         const annotation = ref(null);
         const setAnnotationHandler = new SetValueActionHandler(
             undoRedoStore,
@@ -544,6 +557,8 @@ export default {
             setLicense,
             creator,
             setCreator,
+            doi,
+            setDoi,
             annotation,
             setAnnotation,
             readme,
@@ -1068,6 +1083,7 @@ export default {
             const has_changes = this.stateMessages.length > 0;
             this.license = data.license;
             this.creator = data.creator;
+            this.doi = data.doi;
             getVersions(this.id).then((versions) => {
                 this.versions = versions;
             });
@@ -1103,6 +1119,12 @@ export default {
             if (this.creator != creator) {
                 this.hasChanges = true;
                 this.setCreator(creator);
+            }
+        },
+        onDoi(doi) {
+            if (this.doi != doi) {
+                this.hasChanges = true;
+                this.setDoi(doi);
             }
         },
         onInsertedStateMessages(insertedStateMessages) {

--- a/client/src/components/Workflow/Editor/WorkflowAttributes.vue
+++ b/client/src/components/Workflow/Editor/WorkflowAttributes.vue
@@ -90,7 +90,12 @@
 
         <div id="workflow-doi-area" class="mt-2">
             <b>Digital Object Identifier (DOI)</b>
-            <ItemListEditor :items="doi" item-name="DOI" @onItems="onDoi" />
+            <ItemListEditor
+                :items="doi"
+                item-name="DOI"
+                :description="doiDescription"
+                :item-format="doiRegex"
+                @onItems="onDoi" />
         </div>
 
         <div class="mt-2">
@@ -250,6 +255,14 @@ export default {
             showCreatorHightlight: false,
             showReadmePreview: false,
             faEye,
+            doiDescription: `
+Acceptable format:
+<ul>
+    <li>https://doi.org/DOI-VALUE</li>
+    <li>doi.org/DOI-VALUE</li>
+    <li>doi:DOI-VALUE</li>
+</ul>`,
+            doiRegex: "^(https://doi.org/|doi.org/|doi:)10\\.\\d+/\\S+$",
         };
     },
     computed: {

--- a/client/src/components/Workflow/Editor/WorkflowAttributes.vue
+++ b/client/src/components/Workflow/Editor/WorkflowAttributes.vue
@@ -87,6 +87,12 @@
                 :content="bestPracticeWarningCreator">
             </b-popover>
         </div>
+
+        <div id="workflow-doi-area" class="mt-2">
+            <b>Digital Object Identifier (DOI)</b>
+            <ItemListEditor :items="doiAsList" item-name="DOI" @onItems="onDoi" />
+        </div>
+
         <div class="mt-2">
             <b>Tags</b>
             <StatelessTags :value="tags" @input="onTags" />
@@ -148,6 +154,7 @@ import {
 } from "./modules/linting";
 import { UntypedParameters } from "./modules/parameters";
 
+import ItemListEditor from "@/components/Common/ItemListEditor.vue";
 import LicenseSelector from "@/components/License/LicenseSelector.vue";
 import ActivityPanel from "@/components/Panels/ActivityPanel.vue";
 import CreatorEditor from "@/components/SchemaOrg/CreatorEditor.vue";
@@ -163,6 +170,7 @@ export default {
         StatelessTags,
         LicenseSelector,
         CreatorEditor,
+        ItemListEditor,
         ActivityPanel,
         BModal,
         ToolHelpMarkdown,
@@ -193,6 +201,10 @@ export default {
             default: "",
         },
         creator: {
+            type: Array,
+            default: null,
+        },
+        doi: {
             type: Array,
             default: null,
         },
@@ -249,6 +261,15 @@ export default {
                 creator = [creator];
             }
             return creator;
+        },
+        doiAsList() {
+            let doiList = this.doi;
+            if (!doiList) {
+                doiList = [];
+            } else if (!(doiList instanceof Array)) {
+                doiList = [doiList];
+            }
+            return doiList;
         },
         hasParameters() {
             return this.parameters && this.parameters.parameters.length > 0;
@@ -385,6 +406,9 @@ export default {
         },
         onCreator(creator) {
             this.$emit("creator", creator);
+        },
+        onDoi(doiItems) {
+            this.$emit("doi", doiItems);
         },
         onError(error) {
             this.message = error;

--- a/client/src/components/Workflow/Editor/WorkflowAttributes.vue
+++ b/client/src/components/Workflow/Editor/WorkflowAttributes.vue
@@ -90,7 +90,7 @@
 
         <div id="workflow-doi-area" class="mt-2">
             <b>Digital Object Identifier (DOI)</b>
-            <ItemListEditor :items="doiAsList" item-name="DOI" @onItems="onDoi" />
+            <ItemListEditor :items="doi" item-name="DOI" @onItems="onDoi" />
         </div>
 
         <div class="mt-2">
@@ -261,15 +261,6 @@ export default {
                 creator = [creator];
             }
             return creator;
-        },
-        doiAsList() {
-            let doiList = this.doi;
-            if (!doiList) {
-                doiList = [];
-            } else if (!(doiList instanceof Array)) {
-                doiList = [doiList];
-            }
-            return doiList;
         },
         hasParameters() {
             return this.parameters && this.parameters.parameters.length > 0;

--- a/client/src/components/Workflow/Editor/modules/model.ts
+++ b/client/src/components/Workflow/Editor/modules/model.ts
@@ -22,6 +22,7 @@ export interface Workflow {
     logo_url?: string | null;
     readme?: string | null;
     help?: string | null;
+    doi?: string[];
 }
 
 export interface LoadWorkflowOptions {
@@ -144,6 +145,7 @@ export function toSimple(id: string, workflow: Workflow): Omit<Workflow, "versio
     const logo_url = workflow.logo_url;
     const readme = workflow.readme;
     const help = workflow.help;
+    const doi = workflow.doi;
 
     const commentStore = useWorkflowCommentStore(id);
     commentStore.resolveCommentsInFrames();
@@ -151,5 +153,5 @@ export function toSimple(id: string, workflow: Workflow): Omit<Workflow, "versio
 
     const comments = workflow.comments.filter((comment) => !(comment.type === "text" && comment.data.text === ""));
 
-    return { steps, report, license, creator, annotation, name, comments, tags, readme, help, logo_url };
+    return { steps, report, license, creator, annotation, name, comments, tags, readme, help, logo_url, doi };
 }

--- a/client/src/components/Workflow/Published/WorkflowInformation.vue
+++ b/client/src/components/Workflow/Published/WorkflowInformation.vue
@@ -50,6 +50,14 @@ const owner = computed(() => {
     }
     return props.workflowInfo.owner;
 });
+
+function hasDoi() {
+    if (props.workflowInfo.doi && props.workflowInfo.doi.length > 0) {
+        return true;
+    } else {
+        return false;
+    }
+}
 </script>
 
 <template>
@@ -105,7 +113,7 @@ const owner = computed(() => {
             <StatelessTags class="tags mt-2" :value="workflowInfo.tags" disabled />
         </div>
 
-        <div v-if="workflowInfo?.doi" class="workflow-info-box">
+        <div v-if="hasDoi()" class="workflow-info-box">
             <Heading h3 size="md" class="mb-0">DOI</Heading>
             <span v-for="doi in workflowInfo?.doi" :key="doi"> {{ doi }}<br /> </span>
         </div>

--- a/client/src/components/Workflow/Published/WorkflowInformation.vue
+++ b/client/src/components/Workflow/Published/WorkflowInformation.vue
@@ -107,9 +107,7 @@ const owner = computed(() => {
 
         <div v-if="workflowInfo?.doi" class="workflow-info-box">
             <Heading h3 size="md" class="mb-0">DOI</Heading>
-            <span v-for="doi in workflowInfo?.doi" >
-                {{ doi }}<br />
-            </span>
+            <span v-for="doi in workflowInfo?.doi" :key="doi"> {{ doi }}<br /> </span>
         </div>
 
         <div class="workflow-info-box">

--- a/client/src/components/Workflow/Published/WorkflowInformation.vue
+++ b/client/src/components/Workflow/Published/WorkflowInformation.vue
@@ -105,6 +105,13 @@ const owner = computed(() => {
             <StatelessTags class="tags mt-2" :value="workflowInfo.tags" disabled />
         </div>
 
+        <div v-if="workflowInfo?.doi" class="workflow-info-box">
+            <Heading h3 size="md" class="mb-0">DOI</Heading>
+            <span v-for="doi in workflowInfo?.doi" >
+                {{ doi }}<br />
+            </span>
+        </div>
+
         <div class="workflow-info-box">
             <Heading h3 size="md" class="mb-0">License</Heading>
 

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -818,6 +818,8 @@ class WorkflowContentsManager(UsesAnnotations):
 
         if "logo_url" in data:
             workflow.logo_url = data["logo_url"]
+        if "doi" in data:
+            workflow.doi = data["doi"]
         try:
             if "help" in data:
                 workflow.help = data["help"]
@@ -1245,6 +1247,7 @@ class WorkflowContentsManager(UsesAnnotations):
         data["readme"] = workflow.readme
         data["help"] = workflow.help
         data["logo_url"] = workflow.logo_url
+        data["doi"] = workflow.doi
         data["source_metadata"] = workflow.source_metadata
         data["annotation"] = self.get_item_annotation_str(trans.sa_session, trans.user, stored) or ""
         data["comments"] = [comment.to_dict() for comment in workflow.comments]
@@ -1507,6 +1510,8 @@ class WorkflowContentsManager(UsesAnnotations):
             data["help"] = workflow.help
         if workflow.logo_url is not None:
             data["logo_url"] = workflow.logo_url
+        if workflow.doi is not None:
+            data["doi"] = workflow.doi
 
         # For each step, rebuild the form and encode the state
         for step in workflow.steps:
@@ -1714,6 +1719,7 @@ class WorkflowContentsManager(UsesAnnotations):
         item["readme"] = workflow.readme
         item["help"] = workflow.help
         item["logo_url"] = workflow.logo_url
+        item["doi"] = workflow.doi
 
         steps = {}
         steps_to_order_index = {}

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -818,8 +818,10 @@ class WorkflowContentsManager(UsesAnnotations):
 
         if "logo_url" in data:
             workflow.logo_url = data["logo_url"]
-        if "doi" in data:
-            for doi in data["doi"]:
+
+        dois = data.get("doi", None)
+        if dois:
+            for doi in dois:
                 if not util.validate_doi(doi):
                     raise exceptions.RequestParameterInvalidException(f"Invalid DOI format: {doi}")
             workflow.doi = data["doi"]

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -819,6 +819,9 @@ class WorkflowContentsManager(UsesAnnotations):
         if "logo_url" in data:
             workflow.logo_url = data["logo_url"]
         if "doi" in data:
+            for doi in data["doi"]:
+                if not util.validate_doi(doi):
+                    raise exceptions.RequestParameterInvalidException(f"Invalid DOI format: {doi}")
             workflow.doi = data["doi"]
         try:
             if "help" in data:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -83,6 +83,7 @@ from sqlalchemy import (
     inspect,
     Integer,
     join,
+    JSON,
     MetaData,
     not_,
     Numeric,
@@ -8051,6 +8052,7 @@ class Workflow(Base, Dictifiable, RepresentById):
     logo_url: Mapped[Optional[str]] = mapped_column(Text)
     help: Mapped[Optional[str]] = mapped_column(Text)
     uuid: Mapped[Optional[Union[UUID, str]]] = mapped_column(UUIDType)
+    doi: Mapped[Optional[List[str]]] = mapped_column(JSON)
 
     steps: Mapped[List["WorkflowStep"]] = relationship(
         "WorkflowStep",

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/23143e0bf1d8_add_doi_column_to_workflow_table.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/23143e0bf1d8_add_doi_column_to_workflow_table.py
@@ -1,0 +1,34 @@
+"""Add doi column to workflow table
+
+Revision ID: 23143e0bf1d8
+Revises: 71eeb8d91f92
+Create Date: 2025-04-16 13:19:04.848395
+
+"""
+
+from sqlalchemy import (
+    Column,
+    JSON,
+)
+
+from galaxy.model.migrations.util import (
+    add_column,
+    drop_column,
+)
+
+# revision identifiers, used by Alembic.
+revision = "b964490175fd"
+down_revision = "71eeb8d91f92"
+branch_labels = None
+depends_on = None
+
+table_name = "workflow"
+column_name = "doi"
+
+
+def upgrade():
+    add_column(table_name, Column(column_name, JSON))
+
+
+def downgrade():
+    drop_column(table_name, column_name)

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -228,6 +228,9 @@ class StoredWorkflowDetailed(StoredWorkflowSummary):
         title="Creator deleted",
         description="Whether the creator of this Workflow has been deleted.",
     )
+    doi: Optional[List[str]] = Field(
+        None, title="DOI", description="A list of Digital Object Identifiers associated with this workflow."
+    )
     steps: Dict[
         int,
         Annotated[

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -2033,4 +2033,4 @@ def validate_doi(doi: str) -> bool:
     doi_prefix = r"10\.\d+"
     doi_suffix = r"\S+"
     doi_re = re.compile(f"^{prefix}{doi_prefix}/{doi_suffix}$")
-    return doi_re.match(doi)
+    return bool(doi_re.match(doi))

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -181,6 +181,8 @@ defaultdict = collections.defaultdict
 
 UNKNOWN = "unknown"
 
+DOI_MAX_LENGTH = 200  # This is a reasonable limit. The DOI spec does not set a limit.
+
 
 def str_removeprefix(s: str, prefix: str):
     """
@@ -2022,3 +2024,13 @@ def to_content_disposition(target: str) -> str:
     sanitized_filename = "".join(c in FILENAME_VALID_CHARS and c or "_" for c in filename)[0:character_limit] + ext
     utf8_encoded_filename = quote(re.sub(r'[\/\\\?%*:|"<>]', "_", filename), safe="")[0:character_limit] + ext
     return f"attachment; filename=\"{sanitized_filename}\"; filename*=UTF-8''{utf8_encoded_filename}"
+
+
+def validate_doi(doi: str) -> bool:
+    if len(doi) > DOI_MAX_LENGTH:
+        return False
+    prefix = "https://doi.org/|doi.org/|doi:"
+    doi_prefix = "10\.\d+"
+    doi_suffix = "\S+"
+    doi_re = re.compile(f"^{prefix}{doi_prefix}/{doi_suffix}$")
+    return doi_re.match(doi)

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -2030,7 +2030,7 @@ def validate_doi(doi: str) -> bool:
     if len(doi) > DOI_MAX_LENGTH:
         return False
     prefix = "https://doi.org/|doi.org/|doi:"
-    doi_prefix = "10\.\d+"
-    doi_suffix = "\S+"
+    doi_prefix = r"10\.\d+"
+    doi_suffix = r"\S+"
     doi_re = re.compile(f"^{prefix}{doi_prefix}/{doi_suffix}$")
     return doi_re.match(doi)

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1236,9 +1236,11 @@ steps:
         readme = "This is the body of my readme..."
         logo_url = "https://galaxyproject.org/images/galaxy_logo_hub_white.svg"
         help = "This is my instruction for the workflow!"
+        doi = ["test-doi-1", "test-doi-2"]
         base_workflow_json["readme"] = readme
         base_workflow_json["logo_url"] = logo_url
         base_workflow_json["help"] = help
+        base_workflow_json["doi"] = doi
         workflow_with_metadata_str = json.dumps(base_workflow_json)
         base64_url = "base64://" + base64.b64encode(workflow_with_metadata_str.encode("utf-8")).decode("utf-8")
         response = self._post("workflows", data={"archive_source": base64_url})
@@ -1249,6 +1251,7 @@ steps:
         assert workflow["readme"] == readme
         assert workflow["help"] == help
         assert workflow["logo_url"] == logo_url
+        assert workflow["doi"] == doi
 
     def test_readme_too_large(self):
         big_but_valid_readme = "READ_" * 3999

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1236,7 +1236,7 @@ steps:
         readme = "This is the body of my readme..."
         logo_url = "https://galaxyproject.org/images/galaxy_logo_hub_white.svg"
         help = "This is my instruction for the workflow!"
-        doi = ["test-doi-1", "test-doi-2"]
+        doi = ["doi:10.1000/1", "doi:10.1000/2"]
         base_workflow_json["readme"] = readme
         base_workflow_json["logo_url"] = logo_url
         base_workflow_json["help"] = help

--- a/test/unit/util/test_utils.py
+++ b/test/unit/util/test_utils.py
@@ -140,3 +140,42 @@ def test_enum_values():
         B = "b"
 
     assert util.enum_values(Stuff) == ["a", "c", "b"]
+
+
+DOI_VALID_VALUES = [
+    "https://doi.org/10.1234/42",
+    "doi.org/10.1234/42",
+    "doi:10.1234/42",
+    "doi:10.1234567890/42",  # longer prefix
+    "doi:10.1234/42ab:%&*$//crazy-suffix/%/&/",
+    "doi:10.1234/aa",
+]
+
+
+@pytest.mark.parametrize("input", DOI_VALID_VALUES)
+def test_validate_doi_pass(input):
+    assert util.validate_doi(input)
+
+
+DOI_INVALID_VALUES = [
+    "http://doi.org/10.1234/42",
+    "invalid:10.1234/42",
+    "doi:11.1234/42",
+    "doi:101234/42",
+    "doi:10. 1234/42",
+    "doi:10.abc/42",
+    "doi:10.1234/ 42",
+    "doi:10.1234/42/a b",
+]
+
+
+@pytest.mark.parametrize("input", DOI_INVALID_VALUES)
+def test_validate_doi_fail(input):
+    assert not util.validate_doi(input)
+
+
+def test_validate_doi_fail_too_long():
+    long_suffix = "a" * (util.DOI_MAX_LENGTH - 12)
+    doi = f"doi:10.1000/{long_suffix}"
+    assert util.validate_doi(doi)
+    assert not util.validate_doi(doi + "a")  # Increase length by 1 past max limit


### PR DESCRIPTION
Implements #19794

Uses SQLAlchemy JSON data type (which translates to native JSON data type in postgres).
Validates DOI values on the client. Edited in workflow attributes sidebar, validated for non-empty and unique values, displayed on workflow preview.

Todo:
- [x] Adding a DOI and saving the WF, then removing all DOIs and saving it again will result in an empty json array stored in the database. Empty json array is not the same as the null json primitive (or the database null) and is not treated as falsy by the `v-if` directive on the client. We should either store consistent values for "no DOIs" in the database, or add a check for empty json array on the client.
- [x] Validate DOI format
- [x] Limit max size

For a follow-up:
- [ ] The DOI regex pattern is duplicated here between the backend and the client, which is not ideal. 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Create WF, save. Check database: workflow doi field is empty
  2. Add one or more DOIs. Save workflow. Check database.
  3. Edit one or more DOIs, remove one or more DOIs. Save workflow. Check database.
  4. Validation: try to add an empty DOI; try to add a DOI that exists; try to edit a DOI changing it to an existing value.
  5. Preview workflow: DOIs should be displayed. Preview workflow that has no DOIs: nothing should be displayed.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).

