### PR TITLE
[23.1] Renew access tokens from PSA using valid refresh tokens

### DIFF
--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -179,7 +179,11 @@ class PSAAuthnz(IdentityProvider):
         else:
             log.debug("No `expires` or `expires_in` key found in token extra data, cannot refresh")
             return False
-        if int(user_authnz_token.extra_data["auth_time"]) + int(expires) / 2 <= int(time.time()):
+        if (
+            int(user_authnz_token.extra_data["auth_time"]) + int(expires) / 2
+            <= int(time.time())
+            < int(user_authnz_token.extra_data["auth_time"]) + int(expires)
+        ):
             on_the_fly_config(trans.sa_session)
             if self.config["provider"] == "azure":
                 self.refresh_azure(user_authnz_token)


### PR DESCRIPTION
Method `PSAAuthnz.refresh()` from psa_authnz.py holds its promise to refresh tokens only if they reached their half lifetime. However, that does not exclude expired tokens. Add an extra comparison to **exclude expired refresh tokens**.

This fix gets rid of this kind of error: `Apr 17 15:54:53 sn06.galaxyproject.eu gunicorn[2716973]: requests.exceptions.HTTPError: 401 Client Error: 401 for url: https://login.elixir-czech.org/oidc/token`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
