### PR TITLE
Add option to disable auto_install in cached_explicit_singularity

### DIFF
--- a/lib/galaxy/config/sample/container_resolvers.yml.sample
+++ b/lib/galaxy/config/sample/container_resolvers.yml.sample
@@ -19,6 +19,8 @@
 #- type: cached_explicit_singularity
   # set the cache directory for storing images
   #cache_directory: database/container_cache/singularity/explicit
+  # automatically cache images
+  #auto_install: true
 
 # Mulled container resolvers
 # ==========================

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -635,7 +635,7 @@ class MulledDockerContainerResolver(CliContainerResolver):
             shell=self.shell,
         )
         if self.can_list_containers:
-            if install and not self.cached_container_description(
+            if (self.auto_install or install) and not self.cached_container_description(
                 targets,
                 namespace=self.namespace,
                 hash_func=self.hash_func,

--- a/lib/galaxy/tool_util/deps/containers.py
+++ b/lib/galaxy/tool_util/deps/containers.py
@@ -371,7 +371,7 @@ class ContainerRegistry:
         tool_info: "ToolInfo",
         index: Optional[int] = None,
         resolver_type: Optional[str] = None,
-        install: bool = True,
+        install: bool = False,
         resolution_cache: Optional[ResolutionCache] = None,
         session: Optional[Session] = None,
     ) -> Optional[ResolvedContainerDescription]:


### PR DESCRIPTION
Without this option there's no way to prevent writing to the cache and falling through to other resolvers if the image is not there. This will allow preconverting explicit docker requirements on CVMFS.

xref #15717

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
