### PR TITLE
Blur input path instead of requiring explicit enter in FormDirectory input

### DIFF
--- a/client/src/components/Form/Elements/FormDirectory.test.js
+++ b/client/src/components/Form/Elements/FormDirectory.test.js
@@ -23,7 +23,7 @@ async function init(wrapper, data) {
     expect(filesDialogComponent.exists()).toBe(true);
     filesDialogComponent.vm.callback({ url: data.url });
     // HACK: URL implementation in test environment is not the same as global node
-    wrapper.vm.pathChunks = data.pathChunks;
+    wrapper.vm.pathChunks = [...data.pathChunks];
     await flushPromises();
     await validateLatestEmittedPath(wrapper, data.url);
 }
@@ -174,5 +174,21 @@ describe("DirectoryPathEditableBreadcrumb", () => {
         // the init function itself validates that the emits and path display
         // retain special characters in the url
         await init(wrapper, testingDataWithSpecialChars);
+    });
+
+    it("should save on blur", async () => {
+        await init(wrapper, testingData);
+        // enter a new path chunk
+        const input = wrapper.find("#path-input-breadcrumb");
+        await input.setValue(validPath);
+        expect(input.element.value).toBe(validPath);
+
+        await input.trigger("blur");
+        await flushPromises();
+
+        expect(spyOnAddPath).toHaveBeenCalled();
+        expect(input.element.value).toBe("");
+        expect(wrapper.findAll("li.breadcrumb-item").length).toBe(testingData.expectedNumberOfPaths + 1);
+        await validateLatestEmittedPath(wrapper, `${testingData.url}/${validPath}`);
     });
 });

--- a/client/src/components/Form/Elements/FormDirectory.vue
+++ b/client/src/components/Form/Elements/FormDirectory.vue
@@ -35,7 +35,8 @@
                     trim
                     @keyup.enter="addPath"
                     @keydown.191.capture.prevent.stop="addPath"
-                    @keydown.8.capture="removeLastPath" />
+                    @keydown.8.capture="removeLastPath"
+                    @blur="handleBlur" />
             </b-breadcrumb-item>
         </b-breadcrumb>
 
@@ -157,6 +158,14 @@ export default {
                 url = decodeURI(url);
             }
             this.$emit("input", url);
+        },
+        handleBlur() {
+            if (this.currentDirectoryName && this.isValidName) {
+                const newFolder = this.currentDirectoryName;
+                this.pathChunks.push({ pathChunk: newFolder, editable: true });
+                this.currentDirectoryName = "";
+            }
+            this.updateURL();
         },
     },
 };

--- a/client/src/components/Form/Elements/FormDirectory.vue
+++ b/client/src/components/Form/Elements/FormDirectory.vue
@@ -140,11 +140,22 @@ export default {
         },
         addPath({ key }) {
             if ((key === "Enter" || key === "/") && this.isValidName) {
-                const newFolder = this.currentDirectoryName;
-                this.pathChunks.push({ pathChunk: newFolder, editable: true });
-                this.currentDirectoryName = "";
+                this.addDirectoryToPath();
+            }
+        },
+        handleBlur() {
+            if (this.currentDirectoryName && this.isValidName) {
+                this.addDirectoryToPath();
+            } else {
+                // If the input was touched let's propagate the change either way.
                 this.updateURL();
             }
+        },
+        addDirectoryToPath() {
+            const newFolder = this.currentDirectoryName;
+            this.pathChunks.push({ pathChunk: newFolder, editable: true });
+            this.currentDirectoryName = "";
+            this.updateURL();
         },
         updateURL(isReset = false) {
             let url = undefined;
@@ -158,14 +169,6 @@ export default {
                 url = decodeURI(url);
             }
             this.$emit("input", url);
-        },
-        handleBlur() {
-            if (this.currentDirectoryName && this.isValidName) {
-                const newFolder = this.currentDirectoryName;
-                this.pathChunks.push({ pathChunk: newFolder, editable: true });
-                this.currentDirectoryName = "";
-            }
-            this.updateURL();
         },
     },
 };


### PR DESCRIPTION
This should address users not knowing they need to explicitly hit enter to add the path; instead, we check when focus is lost and if it's valid we apply pending changes.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
