### PR TITLE
Fix linting with markdown in tool help

### DIFF
--- a/lib/galaxy/tool_util/linters/datatypes.py
+++ b/lib/galaxy/tool_util/linters/datatypes.py
@@ -78,7 +78,7 @@ class ValidDatatypes(Linter):
         for attrib in ["format", "ftype", "ext"]:
             for elem in tool_xml.findall(f".//*[@{attrib}]"):
                 # skip help section, "format" in help has a different meaning
-                if elem.tag == 'help':
+                if elem.tag == "help":
                     return
                 formats = elem.get(attrib, "").split(",")
                 # Certain elements (e.g. `data`) can only have one format. This

--- a/lib/galaxy/tool_util/linters/datatypes.py
+++ b/lib/galaxy/tool_util/linters/datatypes.py
@@ -77,6 +77,9 @@ class ValidDatatypes(Linter):
                 datatypes |= _parse_datatypes(datatypes_conf_path)
         for attrib in ["format", "ftype", "ext"]:
             for elem in tool_xml.findall(f".//*[@{attrib}]"):
+                # skip help section, "format" in help has a different meaning
+                if elem.tag == 'help':
+                    return
                 formats = elem.get(attrib, "").split(",")
                 # Certain elements (e.g. `data`) can only have one format. This
                 # is checked separately by linting against the XSD.

--- a/lib/galaxy/tool_util/linters/datatypes.py
+++ b/lib/galaxy/tool_util/linters/datatypes.py
@@ -79,7 +79,7 @@ class ValidDatatypes(Linter):
             for elem in tool_xml.findall(f".//*[@{attrib}]"):
                 # skip help section, "format" in help has a different meaning
                 if elem.tag == "help":
-                    return
+                    continue
                 formats = elem.get(attrib, "").split(",")
                 # Certain elements (e.g. `data`) can only have one format. This
                 # is checked separately by linting against the XSD.


### PR DESCRIPTION
Linting tools with format="markdown" in a tool help will lead to an error. With this change we will ignore the help element in a tool for linting against valid datatypes.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
