### PR TITLE
Update breadcrumb item 'to' type for better routing support

### DIFF
--- a/client/src/components/Common/index.ts
+++ b/client/src/components/Common/index.ts
@@ -1,8 +1,10 @@
+import type { RawLocation } from "vue-router";
+
 // TODO: Not sure if this is the best place for this type
 export type ColorVariant = "primary" | "secondary" | "success" | "danger" | "warning" | "info" | "light" | "dark";
 
 export interface BreadcrumbItem {
     title: string;
-    to?: string;
+    to?: RawLocation;
     superText?: string;
 }

--- a/client/src/components/User/DiskUsage/Management/StorageManager.vue
+++ b/client/src/components/User/DiskUsage/Management/StorageManager.vue
@@ -18,7 +18,7 @@ interface ModalDialog {
 }
 
 const breadcrumbItems = [
-    { title: "Storage Dashboard", to: "StorageDashboard" },
+    { title: "Storage Dashboard", to: { name: "StorageDashboard" } },
     { title: "Manage your account storage", superText: "(Beta)" },
 ];
 

--- a/client/src/components/User/DiskUsage/Visualizations/OverviewPage.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/OverviewPage.vue
@@ -7,7 +7,7 @@ interface Props {
 
 const props = defineProps<Props>();
 
-const breadcrumbItems = [{ title: "Storage Dashboard", to: "StorageDashboard" }, { title: props.title }];
+const breadcrumbItems = [{ title: "Storage Dashboard", to: { name: "StorageDashboard" } }, { title: props.title }];
 </script>
 
 <template>


### PR DESCRIPTION
Change the breadcrumb item's `to` property type from string to typed `RawLocation` from `vue-router`, allowing for named locations as expected by `RouterLink/vue-router`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
