### PR TITLE
[24.2] Fix edit permission for datasets delete button in storage dashboard overview by location

### DIFF
--- a/client/src/components/User/DiskUsage/Visualizations/ObjectStoreStorageOverview.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/ObjectStoreStorageOverview.vue
@@ -118,6 +118,7 @@ function onUndelete(datasetId: string) {
                         :data="data"
                         item-type="dataset"
                         :is-recoverable="isRecoverableDataPoint(data)"
+                        :can-edit="!isRecoverableDataPoint(data)"
                         @view-item="onViewDataset"
                         @permanently-delete-item="onPermDelete"
                         @undelete-item="onUndelete" />


### PR DESCRIPTION
Fix edit permission for datasets in the storage dashboard overview by location

|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/ad08cddc-7ad4-4b46-bbbc-d77f6a18dd48)|![image](https://github.com/user-attachments/assets/4b63db76-9772-4879-877e-915793d2dfda)|

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Go to `Storage Dashboard> Visually explore your disk usage by storage location` 
  2. Select a location to view its largest datasets chart
  3. View the delete action by clicking on a dataset/bar in the chart

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
