### PR TITLE
Enhance Storage Dashboard Selected Item UI

### DIFF
--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -5,6 +5,8 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BBadge, BButton, BButtonGroup, BDropdown, BDropdownItem, BFormCheckbox, BLink } from "bootstrap-vue";
 import { ref } from "vue";
 
+import { useMarkdown } from "@/composables/markdown";
+import { useUid } from "@/composables/utils/uid";
 import localize from "@/utils/localization";
 
 import { type CardAttributes, type CardBadge, type Title, type TitleIcon } from "./GCard.types";
@@ -16,7 +18,7 @@ import UtcDate from "@/components/UtcDate.vue";
 
 interface Props {
     /** Unique identifier for the card */
-    id: string;
+    id?: string;
     /** Array of badges to display on the card */
     badges?: CardBadge[];
     /** Indicates if the card is bookmarked */
@@ -33,6 +35,8 @@ interface Props {
     description?: string;
     /** Array of extra actions available for the card */
     extraActions?: CardAttributes[];
+    /** Indicates if the card is expanded to show full description */
+    fullDescription?: boolean;
     /** Indicates if the card is displayed in grid view mode */
     gridView?: boolean;
     /** Array of indicators to display on the card */
@@ -78,6 +82,7 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
+    id: () => useUid("g-card-").value,
     badges: () => [],
     containerClass: "",
     contentClass: "",
@@ -124,6 +129,8 @@ async function toggleBookmark() {
     await emit("bookmark");
     bookmarkLoading.value = false;
 }
+
+const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true });
 
 const getElementId = (cardId: string, element: string) => `g-card-${element}-${cardId}`;
 const getIndicatorId = (cardId: string, indicatorId: string) => `g-card-indicator-${indicatorId}-${cardId}`;
@@ -214,7 +221,7 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
                                 </div>
                             </div>
 
-                            <div class="align-items-center d-flex">
+                            <div class="align-items-center d-flex flex-gapx-1">
                                 <slot name="titleBadges">
                                     <template v-for="badge in props.titleBadges">
                                         <BBadge
@@ -378,9 +385,13 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
                     <div :id="getElementId(props.id, 'description')">
                         <slot name="description">
                             <TextSummary
-                                v-if="props.description"
+                                v-if="props.description && !props.fullDescription"
                                 :id="getElementId(props.id, 'text-summary')"
                                 :description="props.description" />
+                            <div
+                                v-else-if="props.description && props.fullDescription"
+                                class="mb-2"
+                                v-html="renderMarkdown(props.description)" />
                         </slot>
                     </div>
                 </div>

--- a/client/src/components/User/DiskUsage/Visualizations/Charts/BarChart.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/Charts/BarChart.vue
@@ -5,6 +5,8 @@ import { computed, nextTick, onMounted, ref, watch } from "vue";
 
 import type { DataValuePoint } from ".";
 
+import GCard from "@/components/Common/GCard.vue";
+
 interface BarChartProps {
     data: DataValuePoint[];
     title?: string;
@@ -325,9 +327,9 @@ function setTooltipPosition(mouseX: number, mouseY: number): void {
             <div class="chart-area">
                 <div ref="barChart" class="bar-chart"></div>
                 <div ref="legend" class="legend"></div>
-                <div v-if="selectedDataPoint" class="selection-info">
+                <div v-if="selectedDataPoint" class="selection-info w-100">
                     <slot name="selection" :data="selectedDataPoint">
-                        Selected: <b>{{ selectedDataPoint.label }}</b>
+                        <GCard :title="`Selected: ${selectedDataPoint.label}`" />
                     </slot>
                 </div>
             </div>
@@ -397,19 +399,13 @@ function setTooltipPosition(mouseX: number, mouseY: number): void {
 }
 
 .selection-info {
-    background-color: #fff;
-    border: 1px solid #000;
-    border-radius: 5px;
-    padding: 5px;
     z-index: 100;
-    display: block;
-    float: right;
     position: absolute;
     bottom: 0;
     right: 0;
     margin-bottom: 2rem;
     margin-right: 2rem;
     text-align: left;
-    max-width: 300px;
+    max-width: max(250px, 35%);
 }
 </style>

--- a/client/src/components/User/DiskUsage/Visualizations/HistoriesStorageOverview.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/HistoriesStorageOverview.vue
@@ -4,7 +4,6 @@ import { useRouter } from "vue-router/composables";
 
 import { useConfirmDialog } from "@/composables/confirmDialog";
 import { useToast } from "@/composables/toast";
-import { useHistoryStore } from "@/stores/historyStore";
 import localize from "@/utils/localization";
 
 import type { DataValuePoint } from "./Charts";
@@ -18,7 +17,6 @@ import SelectedItemActions from "./SelectedItemActions.vue";
 import WarnDeletedHistories from "./WarnDeletedHistories.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
-const historyStore = useHistoryStore();
 const router = useRouter();
 const { success: successToast, error: errorToast } = useToast();
 const { confirm } = useConfirmDialog();
@@ -100,11 +98,6 @@ function isArchivedDataPoint(dataPoint: DataValuePoint): boolean {
     return false;
 }
 
-async function onSetCurrentHistory(historyId: string) {
-    await historyStore.setCurrentHistory(historyId);
-    router.push({ path: "/" });
-}
-
 function onViewHistory(historyId: string) {
     router.push({ name: "HistoryOverview", params: { historyId } });
 }
@@ -132,6 +125,7 @@ async function onPermanentlyDeleteHistory(historyId: string) {
             okVariant: "danger",
             okTitle: localize("Permanently delete"),
             cancelTitle: localize("Cancel"),
+            cancelVariant: "outline-primary",
         }
     );
     if (!confirmed) {
@@ -197,7 +191,6 @@ async function onPermanentlyDeleteHistory(historyId: string) {
                         :is-recoverable="isRecoverableDataPoint(data)"
                         :is-archived="isArchivedDataPoint(data)"
                         :can-edit="!isArchivedDataPoint(data)"
-                        @set-current-history="onSetCurrentHistory"
                         @view-item="onViewHistory"
                         @undelete-item="onUndeleteHistory"
                         @permanently-delete-item="onPermanentlyDeleteHistory" />

--- a/client/src/components/User/DiskUsage/Visualizations/ObjectStoreActions.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/ObjectStoreActions.vue
@@ -1,24 +1,15 @@
 <script setup lang="ts">
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { faChartBar } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton } from "bootstrap-vue";
-import { computed } from "vue";
-
-import localize from "@/utils/localization";
+import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 
 import type { DataValuePoint } from "./Charts";
+
+import GCard from "@/components/Common/GCard.vue";
 
 interface Props {
     data: DataValuePoint;
 }
 
 const props = defineProps<Props>();
-
-library.add(faChartBar);
-
-const label = computed(() => props.data.label);
-const viewDetailsIcon = computed(() => "chart-bar");
 
 const emit = defineEmits<{
     (e: "view-item", itemId: string): void;
@@ -27,22 +18,20 @@ const emit = defineEmits<{
 function onViewItem() {
     emit("view-item", props.data.id);
 }
-</script>
-<template>
-    <div class="selected-item-info">
-        <div class="h-md mx-2">
-            <b>{{ label }}</b>
-        </div>
 
-        <div class="my-2">
-            <BButton
-                variant="outline-primary"
-                size="sm"
-                class="mx-2"
-                :title="localize(`Go to the details of this storage location`)"
-                @click="onViewItem">
-                <FontAwesomeIcon :icon="viewDetailsIcon" />
-            </BButton>
-        </div>
-    </div>
+const primaryActions = [
+    {
+        id: "view",
+        label: "View",
+        icon: faInfoCircle,
+        title: "Go to the details of this storage location",
+        variant: "outline-primary",
+        handler: onViewItem,
+        visible: true,
+    },
+];
+</script>
+
+<template>
+    <GCard :id="props.data.id" :title="props.data.label" :primary-actions="primaryActions" />
 </template>

--- a/client/src/components/User/DiskUsage/Visualizations/ObjectStoreStorageOverview.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/ObjectStoreStorageOverview.vue
@@ -118,6 +118,7 @@ function onUndelete(datasetId: string) {
                         :data="data"
                         item-type="dataset"
                         :is-recoverable="isRecoverableDataPoint(data)"
+                        :can-edit="!isRecoverableDataPoint(data)"
                         @view-item="onViewDataset"
                         @permanently-delete-item="onPermDelete"
                         @undelete-item="onUndelete" />

--- a/client/src/components/User/DiskUsage/Visualizations/SelectedItemActions.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/SelectedItemActions.vue
@@ -1,22 +1,13 @@
 <script setup lang="ts">
-import { library } from "@fortawesome/fontawesome-svg-core";
-import {
-    faArchive,
-    faChartBar,
-    faInfoCircle,
-    faLocationArrow,
-    faTrash,
-    faUndo,
-} from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton } from "bootstrap-vue";
+import { faArchive, faDatabase, faInfoCircle, faTrash, faUndo } from "@fortawesome/free-solid-svg-icons";
 import { computed } from "vue";
 
 import { useHistoryStore } from "@/stores/historyStore";
-import localize from "@/utils/localization";
 import { bytesToString } from "@/utils/utils";
 
 import type { DataValuePoint } from "./Charts";
+
+import GCard from "@/components/Common/GCard.vue";
 
 type ItemTypes = "history" | "dataset";
 
@@ -28,18 +19,15 @@ interface SelectedItemActionsProps {
     canEdit?: boolean;
 }
 
-const { currentHistoryId } = useHistoryStore();
+const { currentHistoryId, setCurrentHistory } = useHistoryStore();
 
 const props = withDefaults(defineProps<SelectedItemActionsProps>(), {
     isArchived: false,
     canEdit: false,
 });
 
-library.add(faArchive, faChartBar, faInfoCircle, faLocationArrow, faTrash, faUndo);
-
 const label = computed(() => props.data?.label ?? "No data");
 const prettySize = computed(() => bytesToString(props.data?.value ?? 0));
-const viewDetailsIcon = computed(() => (props.itemType === "history" ? "chart-bar" : "info-circle"));
 const canSetAsCurrent = computed(() => props.itemType === "history" && props.data.id !== currentHistoryId);
 
 const emit = defineEmits<{
@@ -53,8 +41,8 @@ function onUndeleteItem() {
     emit("undelete-item", props.data.id);
 }
 
-function onSetCurrentHistory() {
-    emit("set-current-history", props.data.id);
+async function onSetCurrentHistory() {
+    await setCurrentHistory(props.data.id);
 }
 
 function onViewItem() {
@@ -64,58 +52,84 @@ function onViewItem() {
 function onPermanentlyDeleteItem() {
     emit("permanently-delete-item", props.data.id);
 }
-</script>
-<template>
-    <div class="selected-item-info">
-        <div class="h-md mx-2">
-            <b>{{ label }}</b>
-        </div>
-        <div class="text-muted mx-2">
-            <span v-if="isArchived"><FontAwesomeIcon icon="archive" /> This {{ itemType }} is archived.</span><br />
-            Total storage space taken: <b>{{ prettySize }}</b
-            >.
-            <span v-if="isRecoverable">
-                This {{ itemType }} was deleted. You can <b>undelete</b> it or <b>permanently delete</b> it to free up
-                its storage space.
-            </span>
-        </div>
 
-        <div class="my-2">
-            <BButton
-                v-if="canSetAsCurrent"
-                variant="outline-primary"
-                size="sm"
-                class="mx-2"
-                :title="localize('Set this history as current')"
-                @click="onSetCurrentHistory">
-                <FontAwesomeIcon icon="location-arrow" />
-            </BButton>
-            <BButton
-                variant="outline-primary"
-                size="sm"
-                class="mx-2"
-                :title="localize(`Go to the details of this ${itemType}`)"
-                @click="onViewItem">
-                <FontAwesomeIcon :icon="viewDetailsIcon" />
-            </BButton>
-            <BButton
-                v-if="isRecoverable && canEdit"
-                variant="outline-primary"
-                size="sm"
-                class="mx-2"
-                :title="localize(`Undelete this ${itemType}`)"
-                @click="onUndeleteItem">
-                <FontAwesomeIcon icon="undo" />
-            </BButton>
-            <BButton
-                v-if="canEdit"
-                variant="outline-danger"
-                size="sm"
-                class="mx-2"
-                :title="localize(`Permanently delete this ${itemType}`)"
-                @click="onPermanentlyDeleteItem">
-                <FontAwesomeIcon icon="trash" />
-            </BButton>
-        </div>
-    </div>
+const titleIcon = computed(() => {
+    return props.isArchived
+        ? { icon: faArchive, title: "This item is archived" }
+        : { icon: faInfoCircle, title: `Details of this ${props.itemType}` };
+});
+
+const badges = computed(() => [
+    {
+        id: "count",
+        label: prettySize.value,
+        title: "Total storage space taken",
+        icon: faDatabase,
+        visible: true,
+    },
+]);
+
+const description = computed(() => {
+    let ds = "";
+
+    if (props.isArchived) {
+        ds = `This ${props.itemType} is archived.`;
+    }
+    if (props.isRecoverable) {
+        ds = `This ${props.itemType} was deleted. You can **undelete** it or **permanently delete** it to free up its storage space.`;
+    }
+
+    return ds;
+});
+
+const primaryActions = computed(() => {
+    return [
+        {
+            id: "undelete",
+            label: "Restore",
+            icon: faUndo,
+            title: `Undelete this ${props.itemType}`,
+            variant: "outline-primary",
+            handler: onUndeleteItem,
+            visible: props.isRecoverable && props.canEdit,
+        },
+        {
+            id: "delete",
+            label: "Delete",
+            icon: faTrash,
+            title: `Permanently delete this ${props.itemType}`,
+            variant: "outline-danger",
+            handler: onPermanentlyDeleteItem,
+            visible: props.canEdit,
+        },
+        {
+            id: "select",
+            label: "Set as current",
+            title: "Set this history as current",
+            variant: "outline-primary",
+            handler: onSetCurrentHistory,
+            visible: canSetAsCurrent.value,
+        },
+        {
+            id: "explore",
+            label: "Explore content",
+            icon: faInfoCircle,
+            title: `Explore the content of this ${props.itemType}`,
+            variant: "outline-primary",
+            handler: onViewItem,
+            visible: true,
+        },
+    ];
+});
+</script>
+
+<template>
+    <GCard
+        :id="`selected-item-actions-${props.itemType}`"
+        :title="label"
+        :title-icon="titleIcon"
+        :badges="badges"
+        full-description
+        :description="description"
+        :primary-actions="primaryActions" />
 </template>


### PR DESCRIPTION
This PR replaces the custom UI components with GCard and improves the styling of the selected item in the bar chart.

Required #20066 and #20064

|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/3291ba1a-89e8-4082-9527-c9638ca84e76)|![image](https://github.com/user-attachments/assets/aabf8cf3-38e6-4245-a6ad-7e1d62076d34)|
|![image](https://github.com/user-attachments/assets/04497482-a7cc-42b4-a678-f8be032996f9)|![image](https://github.com/user-attachments/assets/c080a16d-8138-4880-ac9b-47861842f879)|
|![image](https://github.com/user-attachments/assets/16356597-ceb5-42af-89a3-67222844e3ea)|![image](https://github.com/user-attachments/assets/7b1e3b11-9bbe-412e-b1d4-29b6210d6d9f)|
|![image](https://github.com/user-attachments/assets/fccd644b-9156-4191-95de-11643706f8c4)|![image](https://github.com/user-attachments/assets/161243b4-357f-44ea-b933-8459d80d7a2e)|

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Go to `Storage Dashboard> Visually explore your disk usage by storage location` 
  2. View the information card of history/dataset/location by clicking on a bar in the chart.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
