### PR TITLE
Add activity panel width to local storage

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -90,7 +90,7 @@ const emit = defineEmits<{
 }>();
 
 // activities from store
-const { activities, isSideBarOpen } = storeToRefs(activityStore);
+const { activities, isSideBarOpen, sidePanelWidth } = storeToRefs(activityStore);
 
 // drag references
 const dragTarget: Ref<EventTarget | null> = ref(null);
@@ -325,7 +325,11 @@ defineExpose({
                 </template>
             </b-nav>
         </div>
-        <FlexPanel v-if="isSideBarOpen && !hidePanel" side="left" :collapsible="false">
+        <FlexPanel
+            v-if="isSideBarOpen && !hidePanel"
+            side="left"
+            :collapsible="false"
+            :reactive-width.sync="sidePanelWidth">
             <ToolPanel v-if="isActiveSideBar('tools')" />
             <InvocationsPanel v-else-if="isActiveSideBar('invocation')" :activity-bar-id="props.activityBarId" />
             <VisualizationPanel v-else-if="isActiveSideBar('visualizations')" />

--- a/client/src/components/Panels/FlexPanel.vue
+++ b/client/src/components/Panels/FlexPanel.vue
@@ -8,22 +8,44 @@ import DraggableSeparator from "@/components/Common/DraggableSeparator.vue";
 
 library.add(faChevronLeft, faChevronRight);
 
+const DEFAULT_WIDTH = 300;
+
 interface Props {
     collapsible?: boolean;
     side?: "left" | "right";
     minWidth?: number;
     maxWidth?: number;
-    defaultWidth?: number;
+    reactiveWidth?: number;
 }
 const props = withDefaults(defineProps<Props>(), {
     collapsible: true,
     side: "right",
     minWidth: 200,
     maxWidth: 800,
-    defaultWidth: 300,
+    reactiveWidth: undefined,
 });
 
-const panelWidth = ref(props.defaultWidth);
+const emit = defineEmits<{
+    (e: "update:reactive-width", width: number): void;
+}>();
+
+const localPanelWidth = ref(DEFAULT_WIDTH);
+
+const panelWidth = computed({
+    get: () => {
+        if (props.reactiveWidth !== undefined) {
+            return props.reactiveWidth;
+        }
+        return localPanelWidth.value;
+    },
+    set: (width) => {
+        if (props.reactiveWidth !== undefined) {
+            emit("update:reactive-width", width);
+        } else {
+            localPanelWidth.value = width;
+        }
+    },
+});
 
 const root = ref<HTMLElement | null>(null);
 const show = ref(true);

--- a/client/src/entry/analysis/modules/Analysis.vue
+++ b/client/src/entry/analysis/modules/Analysis.vue
@@ -1,8 +1,10 @@
 <script setup>
+import { storeToRefs } from "pinia";
 import { onMounted, onUnmounted, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { usePanels } from "@/composables/usePanels";
+import { useUserStore } from "@/stores/userStore";
 
 import CenterFrame from "./CenterFrame.vue";
 import ActivityBar from "@/components/ActivityBar/ActivityBar.vue";
@@ -13,6 +15,8 @@ import DragAndDropModal from "@/components/Upload/DragAndDropModal.vue";
 const router = useRouter();
 const showCenter = ref(false);
 const { showPanels } = usePanels();
+
+const { historyPanelWidth } = storeToRefs(useUserStore());
 
 // methods
 function hideCenter() {
@@ -44,7 +48,7 @@ onUnmounted(() => {
                 <router-view :key="$route.fullPath" class="h-100" />
             </div>
         </div>
-        <FlexPanel v-if="showPanels" side="right">
+        <FlexPanel v-if="showPanels" side="right" :reactive-width.sync="historyPanelWidth">
             <HistoryIndex />
         </FlexPanel>
         <DragAndDropModal />

--- a/client/src/stores/activityStore.ts
+++ b/client/src/stores/activityStore.ts
@@ -33,6 +33,7 @@ export const useActivityStore = defineScopedStore("activityStore", (scope) => {
     const isSideBarOpen = computed(() => toggledSideBar.value !== "" && toggledSideBar.value !== "closed");
 
     const toggledSideBar = useUserLocalStorage(`activity-store-current-side-bar-${scope}`, "tools");
+    const sidePanelWidth = useUserLocalStorage(`activity-store-side-panel-width-${scope}`, 300);
 
     function toggleSideBar(currentOpen = "") {
         toggledSideBar.value = toggledSideBar.value === currentOpen ? "" : currentOpen;
@@ -170,6 +171,7 @@ export const useActivityStore = defineScopedStore("activityStore", (scope) => {
 
     return {
         toggledSideBar,
+        sidePanelWidth,
         toggleSideBar,
         closeSideBar,
         isSideBarOpen,

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -39,6 +39,8 @@ export const useUserStore = defineStore("userStore", () => {
 
     const hasSeenUploadHelp = useUserLocalStorageFromHashId("user-store-seen-upload-help", false, hashedUserId);
 
+    const historyPanelWidth = useUserLocalStorageFromHashId("user-store-history-panel-width", 300, hashedUserId);
+
     let loadPromise: Promise<void> | null = null;
 
     function $reset() {
@@ -168,6 +170,7 @@ export const useUserStore = defineStore("userStore", () => {
         currentFavorites,
         currentListViewPreferences,
         hasSeenUploadHelp,
+        historyPanelWidth,
         loadUser,
         matchesCurrentUsername,
         setCurrentUser,


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20067

Adds activity bar side panel and history panel width to local storage.

https://github.com/user-attachments/assets/c8108e2a-7461-4d3a-a222-a1c2ee11fde0

### Questions 🤔 :
- ~Should we make it different widths for different panels? (e.g.: remember the tool panel width and invocation panel width separately, instead of same widths for all activity panels right now)~ Nooooo 👎 
- Should we also put the history panel collapse state in local storage?

✅ Otherwise, good to go!

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Change activity bar side panel (tool panel/invocations panel etc.) width via the drag handle
  2. Close and open the panels, and switch between them to note that the width is retained
  3. Refresh the page to note that the width is retained (via local storage)
  4. Do the same for the history panel

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
