### PR TITLE
Always render Outputs tab in invocation view

### DIFF
--- a/client/src/components/Workflow/test/json/invocation.json
+++ b/client/src/components/Workflow/test/json/invocation.json
@@ -19,7 +19,10 @@
             "action": null,
             "order_index": 0,
             "workflow_step_label": "input dataset",
-            "workflow_step_uuid": "161efd0b-9cdb-42eb-bc9a-fc529b1bb638"
+            "jobs": [],
+            "workflow_step_uuid": "161efd0b-9cdb-42eb-bc9a-fc529b1bb638",
+            "outputs": {},
+            "output_collections": {}
         }
     ],
     "inputs": {
@@ -30,9 +33,27 @@
             "workflow_step_id": "84e9a019416adb3d"
         }
     },
-    "input_step_parameters": {},
-    "outputs": {},
-    "output_collections": {},
+    "input_step_parameters": {
+        "Workflow Input Parameter": {
+            "parameter_value": true,
+            "label": "Workflow Input Parameter",
+            "workflow_step_id": "22bdbe9d6e0775fe" 
+        }
+    },
+    "outputs": {
+        "Workflow Output Dataset": {
+            "id": "4f352876a933b584",
+            "workflow_step_id": "05f39d2a289deb5a",
+            "src": "hda"
+        }
+    },
+    "output_collections": {
+        "Workflow Output Collection": {
+            "id": "ecbc86ac41da8f7b",
+            "workflow_step_id": "c486c1d29a0743d3",
+            "src": "hdca"
+        }
+    },
     "output_values": {},
     "messages": []
 }

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.test.ts
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.test.ts
@@ -1,0 +1,180 @@
+import { createTestingPinia } from "@pinia/testing";
+import { mount, type Wrapper } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+
+import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
+import type { WorkflowInvocationElementView } from "@/api/invocations";
+
+import invocationData from "../Workflow/test/json/invocation.json";
+
+import WorkflowInvocationInputOutputTabs from "./WorkflowInvocationInputOutputTabs.vue";
+
+const { server, http } = useServerMock();
+
+const selectors = {
+    parametersTable: "[data-description='input parameters table']",
+    terminalInvocationOutput: "[data-description='terminal invocation output']",
+    terminalInvocationOutputItem: "[data-description='terminal invocation output item']",
+    nonTerminalInvocationOutput: "[data-description='non-terminal invocation output']",
+    nonTerminalInvocationOutputLoading: "[data-description='non-terminal invocation output loading']",
+};
+
+// Mock the workflow store to return a workflow for `getStoredWorkflowByInstanceId`
+jest.mock("@/stores/workflowStore", () => {
+    const originalModule = jest.requireActual("@/stores/workflowStore");
+    return {
+        ...originalModule,
+        useWorkflowStore: () => ({
+            ...originalModule.useWorkflowStore(),
+            getStoredWorkflowByInstanceId: jest.fn().mockImplementation(() => {
+                return {
+                    id: "workflow-id",
+                    name: "Test Workflow",
+                    version: 0,
+                };
+            }),
+            getFullWorkflowCached: jest.fn().mockImplementation(() => {
+                /** The actual outputs of the workflow invocation */
+                const testDatasetOutputLabels = Object.keys(invocationData.outputs);
+                const testCollectionOutputsLabels = Object.keys(invocationData.output_collections);
+
+                return {
+                    id: "workflow-id",
+                    name: "Test Workflow",
+                    version: 0,
+                    steps: {
+                        "0": {
+                            workflow_outputs: testDatasetOutputLabels.map((label) => ({
+                                output_name: `output`,
+                                label,
+                                uuid: `uuid`,
+                            })),
+                        },
+                        "1": {
+                            workflow_outputs: testCollectionOutputsLabels.map((label) => ({
+                                output_name: `output`,
+                                label,
+                                uuid: `uuid`,
+                            })),
+                        },
+                    },
+                };
+            }),
+        }),
+    };
+});
+
+/** Mount the WorkflowInvocationInputOutputTabs component with the given invocation
+ * @param invocation The invocation data to be used
+ * @param terminal Whether the invocation is terminal
+ * @returns The mounted wrapper
+ */
+async function mountWorkflowInvocationInputOutputTabs(invocation: WorkflowInvocationElementView, terminal = true) {
+    server.use(
+        http.get("/api/datasets/{dataset_id}", ({ response, params }) => {
+            // We need to use untyped here because this endpoint is not
+            // described in the OpenAPI spec due to its complexity for now.
+            return response.untyped(
+                HttpResponse.json({
+                    id: params.dataset_id,
+                })
+            );
+        }),
+        http.get("/api/dataset_collections/{hdca_id}", ({ response, params }) => {
+            // We need to use untyped here because this endpoint is not
+            // described in the OpenAPI spec due to its complexity for now.
+            return response.untyped(
+                HttpResponse.json({
+                    id: params.hdca_id,
+                })
+            );
+        })
+    );
+
+    const wrapper = mount(WorkflowInvocationInputOutputTabs as object, {
+        propsData: {
+            invocation,
+            terminal,
+        },
+        stubs: {
+            ContentItem: true,
+            ParameterStep: true,
+        },
+        pinia: createTestingPinia(),
+    });
+    await flushPromises();
+    return wrapper;
+}
+
+describe("WorkflowInvocationInputOutputTabs", () => {
+    it("shows invocation inputs", async () => {
+        const wrapper = await mountWorkflowInvocationInputOutputTabs(invocationData as WorkflowInvocationElementView);
+
+        /** The actual parameters are in the input_step_parameters field of the invocation data */
+        const testParameters = Object.values(invocationData.input_step_parameters);
+
+        // Test that the parameters table is displayed
+        const parametersTable = wrapper.find(selectors.parametersTable);
+        expect(parametersTable.exists()).toBe(true);
+
+        // Test that the parameters table has the correct number of rows
+        const tableParamValues = parametersTable.findAll("tbody tr");
+        expect(tableParamValues.length).toEqual(testParameters.length);
+
+        // Test that the parameters are displayed correctly
+        for (let i = 0; i < testParameters.length; i++) {
+            const testParameter = testParameters[i];
+            const tableRow = tableParamValues.at(i);
+            expect(tableRow.find("td").text()).toEqual(testParameter?.label);
+            expect(tableRow.findAll("td").at(1).text()).toEqual(testParameter?.parameter_value.toString());
+        }
+
+        /** The actual inputs of the workflow invocation */
+        const testInputs = Object.values(invocationData.inputs);
+
+        // Test that the inputs are displayed
+        for (let i = 0; i < testInputs.length; i++) {
+            const testInput = testInputs[i];
+            expect(wrapper.find(`[data-label='${testInput?.label}']`).exists()).toBe(true);
+        }
+    });
+
+    it("shows invocation outputs when invocation is terminal", async () => {
+        const wrapper = await mountWorkflowInvocationInputOutputTabs(invocationData as WorkflowInvocationElementView);
+
+        testOutputsDisplayed(wrapper);
+    });
+
+    it("shows workflow output labels when invocation is not terminal", async () => {
+        const nonTerminalInvocation = {
+            ...invocationData,
+            outputs: {},
+            output_collections: {},
+        } as WorkflowInvocationElementView;
+        const wrapper = await mountWorkflowInvocationInputOutputTabs(nonTerminalInvocation, false);
+
+        testOutputsDisplayed(wrapper, false);
+    });
+
+    function testOutputsDisplayed(wrapper: Wrapper<Vue>, terminal = true) {
+        /** The actual outputs of the workflow invocation */
+        const testDatasetOutputLabels = Object.keys(invocationData.outputs);
+        const testCollectionOutputsLabels = Object.keys(invocationData.output_collections);
+        const expectedLabels = [...testDatasetOutputLabels, ...testCollectionOutputsLabels];
+
+        // Test that the invocation outputs are displayed
+        const invocationOutputs = wrapper.findAll(
+            terminal ? selectors.terminalInvocationOutput : selectors.nonTerminalInvocationOutput
+        );
+        expect(invocationOutputs.length).toEqual(expectedLabels.length);
+
+        // Test that the output labels are shown
+        for (let i = 0; i < invocationOutputs.length; i++) {
+            const testOutput = invocationOutputs.at(i);
+            const testLabel = expectedLabels[i];
+            expect(testOutput.text()).toContain(testLabel);
+            expect(testOutput.find(selectors.terminalInvocationOutputItem).exists()).toBe(terminal);
+            expect(testOutput.find(selectors.nonTerminalInvocationOutputLoading).exists()).toBe(!terminal);
+        }
+    }
+});

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.vue
@@ -82,7 +82,7 @@ function dataInputStepLabel(key: string, input: InvocationInput) {
             <div v-if="parameters.length">
                 <Heading size="text" bold separator>Parameter Values</Heading>
                 <div class="mx-1">
-                    <ParameterStep :parameters="parameters" styled-table />
+                    <ParameterStep data-description="input parameters table" :parameters="parameters" styled-table />
                 </div>
             </div>
             <div v-if="inputData.length">
@@ -100,15 +100,29 @@ function dataInputStepLabel(key: string, input: InvocationInput) {
         </BTab>
         <BTab title="Outputs">
             <div v-if="outputs.length">
-                <div v-for="([key, output], index) in outputs" :key="index">
+                <div
+                    v-for="([key, output], index) in outputs"
+                    :key="index"
+                    data-description="terminal invocation output">
                     <Heading size="text" bold separator>{{ key }}</Heading>
-                    <GenericHistoryItem :item-id="output.id" :item-src="output.src" />
+                    <GenericHistoryItem
+                        :item-id="output.id"
+                        :item-src="output.src"
+                        data-description="terminal invocation output item" />
                 </div>
             </div>
             <div v-else-if="workflowOutputLabels.length">
-                <div v-for="(label, index) in workflowOutputLabels" :key="index">
+                <div
+                    v-for="(label, index) in workflowOutputLabels"
+                    :key="index"
+                    data-description="non-terminal invocation output">
                     <Heading size="text" bold separator>{{ label }}</Heading>
-                    <BAlert v-if="!props.terminal" class="m-1 py-2" show variant="info">
+                    <BAlert
+                        v-if="!props.terminal"
+                        class="m-1 py-2"
+                        show
+                        variant="info"
+                        data-description="non-terminal invocation output loading">
                         <LoadingSpan message="Output not created yet" />
                     </BAlert>
                     <BAlert v-else class="m-1 py-2" show variant="danger">

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.vue
@@ -1,16 +1,21 @@
 <script setup lang="ts">
-import { BTab } from "bootstrap-vue";
+import { BAlert, BTab } from "bootstrap-vue";
 import { computed } from "vue";
 
 import type { InvocationInput, WorkflowInvocationElementView } from "@/api/invocations";
 
 import Heading from "../Common/Heading.vue";
+import LoadingSpan from "../LoadingSpan.vue";
 import ParameterStep from "./ParameterStep.vue";
 import GenericHistoryItem from "components/History/Content/GenericItem.vue";
 
+const OUTPUTS_NOT_AVAILABLE_YET_MSG =
+    "Either no outputs have been produced yet, or no steps were checked to " +
+    "mark their outputs as primary workflow outputs.";
+
 const props = defineProps<{
     invocation: WorkflowInvocationElementView;
-    notLazy?: boolean;
+    terminal?: boolean;
 }>();
 
 const inputData = computed(() => Object.entries(props.invocation.inputs));
@@ -38,26 +43,49 @@ function dataInputStepLabel(key: string, input: InvocationInput) {
 }
 </script>
 <template>
-    <span v-if="invocation">
-        <BTab v-if="inputData.length || parameters.length" title="Inputs">
+    <span>
+        <BTab title="Inputs">
             <div v-if="parameters.length">
                 <Heading size="text" bold separator>Parameter Values</Heading>
                 <div class="mx-1">
                     <ParameterStep :parameters="parameters" styled-table />
                 </div>
             </div>
-            <div v-for="([key, input], index) in inputData" :key="index" :data-label="dataInputStepLabel(key, input)">
-                <Heading size="text" bold separator>
-                    {{ dataInputStepLabel(key, input) }}
-                </Heading>
-                <GenericHistoryItem :item-id="input.id" :item-src="input.src" />
+            <div v-if="inputData.length">
+                <div
+                    v-for="([key, input], index) in inputData"
+                    :key="index"
+                    :data-label="dataInputStepLabel(key, input)">
+                    <Heading size="text" bold separator>
+                        {{ dataInputStepLabel(key, input) }}
+                    </Heading>
+                    <GenericHistoryItem :item-id="input.id" :item-src="input.src" />
+                </div>
             </div>
+            <BAlert v-else show variant="info"> No input data was provided for this workflow invocation. </BAlert>
         </BTab>
-        <BTab v-if="outputs.length" title="Outputs" :lazy="!props.notLazy">
-            <div v-for="([key, output], index) in outputs" :key="index">
-                <Heading size="text" bold separator>{{ key }}</Heading>
-                <GenericHistoryItem :item-id="output.id" :item-src="output.src" />
+        <BTab title="Outputs" :lazy="!props.terminal">
+            <div v-if="outputs.length">
+                <div v-for="([key, output], index) in outputs" :key="index">
+                    <Heading size="text" bold separator>{{ key }}</Heading>
+                    <GenericHistoryItem :item-id="output.id" :item-src="output.src" />
+                </div>
             </div>
+            <BAlert v-else show variant="info">
+                <p>
+                    <LoadingSpan v-if="!props.terminal" :message="OUTPUTS_NOT_AVAILABLE_YET_MSG" />
+                    <span v-else v-localize>
+                        No steps were checked to mark their outputs as primary workflow outputs.
+                    </span>
+                </p>
+                <p>
+                    To get outputs from a workflow in this tab, you need to check the
+                    <i>
+                        "Checked outputs will become primary workflow outputs and are available as subworkflow outputs."
+                    </i>
+                    option on individual outputs on individual steps in the workflow.
+                </p>
+            </BAlert>
         </BTab>
     </span>
 </template>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.vue
@@ -98,7 +98,7 @@ function dataInputStepLabel(key: string, input: InvocationInput) {
             </div>
             <BAlert v-else show variant="info"> No input data was provided for this workflow invocation. </BAlert>
         </BTab>
-        <BTab title="Outputs" :lazy="!props.terminal">
+        <BTab title="Outputs">
             <div v-if="outputs.length">
                 <div v-for="([key, output], index) in outputs" :key="index">
                     <Heading size="text" bold separator>{{ key }}</Heading>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -339,7 +339,7 @@ async function onCancel() {
                     :store-id="storeId"
                     :is-full-page="props.isFullPage" />
             </BTab>
-            <WorkflowInvocationInputOutputTabs :invocation="invocation" :not-lazy="invocationAndJobTerminal" />
+            <WorkflowInvocationInputOutputTabs :invocation="invocation" :terminal="invocationAndJobTerminal" />
             <!-- <BTab title="Workflow Overview">
                 <p>TODO: Insert readonly version of workflow editor here</p>
             </BTab> -->

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -340,9 +340,6 @@ async function onCancel() {
                     :is-full-page="props.isFullPage" />
             </BTab>
             <WorkflowInvocationInputOutputTabs :invocation="invocation" :terminal="invocationAndJobTerminal" />
-            <!-- <BTab title="Workflow Overview">
-                <p>TODO: Insert readonly version of workflow editor here</p>
-            </BTab> -->
             <BTab
                 v-if="!props.isSubworkflow"
                 title="Report"

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -662,7 +662,7 @@ export function getRouter(Galaxy) {
                         props: (route) => ({
                             invocationId: route.params.invocationId,
                             isFullPage: true,
-                            success: route.query.success,
+                            success: Boolean(route.query.success),
                         }),
                     },
                     {


### PR DESCRIPTION
As opposed to conditionally rendering it when outputs become available.

Fixes https://github.com/galaxyproject/galaxy/issues/20069

https://github.com/user-attachments/assets/d5195128-d008-45e6-9ad3-a4ab326515b1

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
