### PR TITLE
Attempts to address two transient test errors.

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -353,12 +353,14 @@ class NavigatesGalaxy(HasDriver):
         finally:
             self.driver.switch_to.default_content()
 
-    def api_get(self, endpoint, data=None, raw=False):
+    def api_get(self, endpoint, data=None, raw=False, assert_ok: bool = False):
         data = data or {}
         full_url = self.build_url(f"api/{endpoint}", for_selenium=False)
         response = requests.get(
             full_url, data=data, cookies=self.selenium_to_requests_cookies(), timeout=DEFAULT_SOCKET_TIMEOUT
         )
+        if assert_ok:
+            response.raise_for_status()
         return self._handle_response(response, raw)
 
     def api_post(self, endpoint, data=None):
@@ -504,7 +506,7 @@ class NavigatesGalaxy(HasDriver):
 
     def wait_for_history_to_have_hid(self, history_id, hid):
         def get_hids():
-            contents = self.api_get(f"histories/{history_id}/contents")
+            contents = self.api_get(f"histories/{history_id}/contents", assert_ok=True)
             return [d["hid"] for d in contents]
 
         def history_has_hid(driver):

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -75,6 +75,7 @@ class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows
         invocations.wizard_next_button.wait_for_and_click()
         export_button = invocations.wizard_export_button
         export_button.wait_for_present()
+        self.sleep_for(self.wait_types.UX_TRANSITION)
         self.screenshot("invocation_export_native_download_options")
         export_button.wait_for_and_click()
         self.sleep_for(self.wait_types.UX_TRANSITION)


### PR DESCRIPTION
get_hids was failing with a bad error message - I'm not sure the cause but this should be cleaner. The sleep is because sometimes the export button is on screen but the handler is not ready it seems. See the export for the workflow file export test here https://github.com/galaxyproject/galaxy/actions/runs/14598825291/artifacts/2987993086.


## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
