### PR TITLE
[WIP] Add content operations to implicitly converted items

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -48,6 +48,7 @@ interface Props {
     filterable?: boolean;
     isPlaceholder?: boolean;
     isSubItem?: boolean;
+    hasPurgeOption?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -63,6 +64,7 @@ const props = withDefaults(defineProps<Props>(), {
     filterable: false,
     isPlaceholder: false,
     isSubItem: false,
+    hasPurgeOption: false,
 });
 
 const emit = defineEmits<{
@@ -75,6 +77,7 @@ const emit = defineEmits<{
     (e: "select-all"): void;
     (e: "selected-to"): void;
     (e: "delete", item: any, recursive: boolean): void;
+    (e: "purge"): void;
     (e: "undelete"): void;
     (e: "unhide"): void;
     (e: "view-collection", item: any, name: string): void;
@@ -414,7 +417,9 @@ function unexpandedClick(event: Event) {
                         :is-visible="item.visible"
                         :state="state"
                         :item-urls="itemUrls"
+                        :has-purge-option="hasPurgeOption"
                         @delete="onDelete"
+                        @purge="emit('purge')"
                         @display="onDisplay"
                         @showCollectionInfo="onShowCollectionInfo"
                         @edit="onEdit"

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -320,6 +320,20 @@ async function onDelete(item: HistoryItemSummary, recursive = false, isSubItem =
     }
 }
 
+async function onPurge(item: HistoryItemSummary, recursive = false, isSubItem = false) {
+    isLoading.value = true;
+    if (!isSubItem) {
+        setInvisible(item);
+    }
+
+    try {
+        await deleteContent(item, { recursive: recursive, purge: true });
+        updateContentStats();
+    } finally {
+        isLoading.value = false;
+    }
+}
+
 function onHideSelection(selectedItems: HistoryItemSummary[]) {
     for (const item of selectedItems) {
         setInvisible(item);
@@ -615,9 +629,11 @@ function arrowNavigate(item: HistoryItemSummary, eventKey: string) {
                                                 is-history-item
                                                 :expand-dataset="isExpanded(subItem)"
                                                 :is-dataset="isDataset(subItem)"
+                                                :has-purge-option="item.purged"
                                                 :is-sub-item="true"
                                                 @update:expand-dataset="setExpanded(subItem, $event)"
                                                 @delete="(subItem, recursive) => onDelete(subItem, recursive, true)"
+                                                @purge="onPurge(subItem, false, true)"
                                                 @undelete="onUndelete(subItem, true)"
                                                 @unhide="onUnhide(subItem, true)" />
                                         </div>

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -306,9 +306,11 @@ async function loadHistoryItems() {
     }
 }
 
-async function onDelete(item: HistoryItemSummary, recursive = false) {
+async function onDelete(item: HistoryItemSummary, recursive = false, isSubItem = false) {
     isLoading.value = true;
-    setInvisible(item);
+    if (!isSubItem) {
+        setInvisible(item);
+    }
 
     try {
         await deleteContent(item, { recursive: recursive });
@@ -328,8 +330,10 @@ function onScroll(newOffset: number) {
     offsetQueryParam.value = newOffset;
 }
 
-async function onUndelete(item: HistoryItemSummary) {
-    setInvisible(item);
+async function onUndelete(item: HistoryItemSummary, isSubItem = false) {
+    if (!isSubItem) {
+        setInvisible(item);
+    }
     isLoading.value = true;
 
     try {
@@ -340,8 +344,10 @@ async function onUndelete(item: HistoryItemSummary) {
     }
 }
 
-async function onUnhide(item: HistoryItemSummary) {
-    setInvisible(item);
+async function onUnhide(item: HistoryItemSummary, isSubItem = false) {
+    if (!isSubItem) {
+        setInvisible(item);
+    }
     isLoading.value = true;
 
     try {
@@ -605,10 +611,15 @@ function arrowNavigate(item: HistoryItemSummary, eventKey: string) {
                                                 :key="subItem.id"
                                                 :item="subItem"
                                                 :name="subItem.name"
+                                                :writable="canEditHistory"
+                                                is-history-item
                                                 :expand-dataset="isExpanded(subItem)"
                                                 :is-dataset="isDataset(subItem)"
                                                 :is-sub-item="true"
-                                                @update:expand-dataset="setExpanded(subItem, $event)" />
+                                                @update:expand-dataset="setExpanded(subItem, $event)"
+                                                @delete="(subItem, recursive) => onDelete(subItem, recursive, true)"
+                                                @undelete="onUndelete(subItem, true)"
+                                                @unhide="onUnhide(subItem, true)" />
                                         </div>
                                     </template>
                                 </ContentItem>

--- a/client/src/stores/utilities/history.utilities.js
+++ b/client/src/stores/utilities/history.utilities.js
@@ -46,7 +46,15 @@ function pushSubItem(item, subItem) {
     if (!item.sub_items) {
         item["sub_items"] = [];
     }
-    if (!item["sub_items"].find((i) => i.id === subItem.id)) {
+    const foundItem = item["sub_items"].find((i) => i.id === subItem.id);
+    if (!foundItem) {
         item["sub_items"].push(subItem);
+    } else {
+        // item already exists in sub_items, so we need to update it
+        Object.keys(foundItem).forEach((key) => {
+            if (key !== "sub_items") {
+                foundItem[key] = subItem[key];
+            }
+        });
     }
 }


### PR DESCRIPTION
Fixes #19926

Adds operations to `sub_items`, including a purge option for the implicitly converted datasets, _only if the parent dataset is purged_ like so:

https://github.com/user-attachments/assets/adcee9a3-e205-41b5-b07d-46ff7bdb6eec

### Remaining Action Items:
- [ ] Fix styling of dropdown button to be in line with other content options
- [ ] Change `<icon>` to `<FontAwesomeIcon>` in these files

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
