### PR TITLE
Hide non-functional and replaced visualizations (e.g. Nora, MSA)

### DIFF
--- a/config/plugins/visualizations/csg/config/csg.xml
+++ b/config/plugins/visualizations/csg/config/csg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="CSG Viewer">
+<visualization name="CSG Viewer" hidden="true">
     <description>Constructive Solid Geometry (CSG) viewer.</description>
     <data_sources>
         <data_source>

--- a/config/plugins/visualizations/graphviz/config/graphviz.xml
+++ b/config/plugins/visualizations/graphviz/config/graphviz.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Graph Visualization">
+<visualization name="Graph Visualization" hidden="true">
     <description>Cytoscape-based graph visualization plugin.</description>
     <data_sources>
         <data_source>

--- a/config/plugins/visualizations/msa/config/msa.xml
+++ b/config/plugins/visualizations/msa/config/msa.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Multiple Sequence Alignment">
+<visualization name="Multiple Sequence Alignment" hidden="true">
     <description>The MSA viewer is a modular, reusable component to visualize large MSAs interactively on the web.</description>
     <data_sources>
         <data_source>

--- a/config/plugins/visualizations/nora/config/nora.xml
+++ b/config/plugins/visualizations/nora/config/nora.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Nora" embeddable="true">
+<visualization name="Nora" hidden="true">
     <description>NORA's viewer. A medical image viewer and annotation tool.</description>
     <data_sources>
         <data_source>


### PR DESCRIPTION
See #19205. Hides legacy framework visualizations 1) Nora and 2) MSA, which fail to rebuild for at least a year but likely much longer, until their issues are resolved. Additionally hides 3) Graphview, replaced by Cytoscape and 4) CSG viewer replaced by latest VTK package.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
