### PR TITLE
[24.2] Job cache backports

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -95,6 +95,7 @@ from galaxy.tools.evaluation import (
     PartialToolEvaluator,
     ToolEvaluator,
 )
+from galaxy.tools.parameters import params_to_json_internal
 from galaxy.util import (
     parse_xml_string,
     RWXRWXRWX,
@@ -1279,6 +1280,24 @@ class MinimalJobWrapper(HasResourceParameters):
             self.environment_variables,
             self.interactivetools,
         ) = tool_evaluator.build()
+        if tool_evaluator.use_cached_job and job.user and job.tool_id and not tool_evaluator.consumes_names:
+            # search again, now we know tool doesn't require name match
+            param_dump = {p.name: p.value for p in job.parameters if not p.name.startswith("__")}
+            assert self.tool
+            params = self.tool.params_from_strings(param_dump, self.app)
+            json_internal = params_to_json_internal(self.tool.inputs, params, self.app)
+            job_to_copy = self.app.job_search.by_tool_input(
+                job.user,
+                job.tool_id,
+                job.tool_version,
+                param=params,
+                param_dump=json_internal,
+                require_name_match=False,
+            )
+            if job_to_copy and isinstance(job_to_copy, model.Job):
+                job.copy_from_job(job_to_copy, copy_outputs=True)
+                self.sa_session.commit()
+                return False
         job.command_line = self.command_line
 
         # Ensure galaxy_lib_dir is set in case there are any later chdirs

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -538,20 +538,7 @@ class JobHandlerQueue(BaseJobHandlerQueue):
                 # Some of these states will only happen when using the in-memory job queue
                 if job.copied_from_job_id:
                     copied_from_job = self.sa_session.query(model.Job).get(job.copied_from_job_id)
-                    job.numeric_metrics = copied_from_job.numeric_metrics
-                    job.text_metrics = copied_from_job.text_metrics
-                    job.dependencies = copied_from_job.dependencies
-                    job.state = copied_from_job.state
-                    job.job_stderr = copied_from_job.job_stderr
-                    job.job_stdout = copied_from_job.job_stdout
-                    job.tool_stderr = copied_from_job.tool_stderr
-                    job.tool_stdout = copied_from_job.tool_stdout
-                    job.command_line = copied_from_job.command_line
-                    job.traceback = copied_from_job.traceback
-                    job.tool_version = copied_from_job.tool_version
-                    job.exit_code = copied_from_job.exit_code
-                    job.job_runner_name = copied_from_job.job_runner_name
-                    job.job_runner_external_id = copied_from_job.job_runner_external_id
+                    job.copy_from_job(copied_from_job)
                     continue
                 job_state = self.__check_job_state(job)
                 if job_state == JOB_WAIT:

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -300,7 +300,9 @@ class BaseJobRunner:
 
         # Prepare the job
         try:
-            job_wrapper.prepare()
+            if job_wrapper.prepare() is False:
+                # job cache
+                return False
             job_wrapper.runner_command_line = self.build_command_line(
                 job_wrapper,
                 include_metadata=include_metadata,

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -497,7 +497,9 @@ class PulsarJobRunner(AsynchronousJobRunner):
             if rewrite_parameters:
                 compute_environment = PulsarComputeEnvironment(client, job_wrapper, remote_job_config)
                 prepare_kwds["compute_environment"] = compute_environment
-            job_wrapper.prepare(**prepare_kwds)
+
+            if job_wrapper.prepare(**prepare_kwds) is False:
+                return command_line, client, remote_job_config, compute_environment, remote_container
             self.__prepare_input_files_locally(job_wrapper)
             remote_metadata = PulsarJobRunner.__remote_metadata(client)
             dependency_resolution = PulsarJobRunner.__dependency_resolution(client)

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -586,9 +586,9 @@ class JobSearch:
                 job_states = {job_state}
             else:
                 job_states = {*job_state}
-            if wildcard_param_dump.get("__when_value__") is False:
-                job_states = {Job.states.SKIPPED}
-            stmt = stmt.where(Job.state.in_(job_states))
+        if wildcard_param_dump.get("__when_value__") is False:
+            job_states = {Job.states.SKIPPED}
+        stmt = stmt.where(Job.state.in_(job_states))
 
         # exclude jobs with deleted outputs
         stmt = stmt.where(

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -379,7 +379,7 @@ class JobSearch:
         tool_version: Optional[str],
         param: ToolStateJobInstancePopulatedT,
         param_dump: ToolStateDumpedToJsonInternalT,
-        job_state: Optional[JobStatesT] = (Job.states.OK, Job.states.SKIPPED),
+        job_state: Optional[JobStatesT] = (Job.states.OK,),
         require_name_match: bool = True,
     ):
         """Search for jobs producing same results using the 'inputs' part of a tool POST."""

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -47,9 +47,7 @@ from galaxy.job_metrics import (
     Safety,
 )
 from galaxy.managers.collections import DatasetCollectionManager
-from galaxy.managers.context import (
-    ProvidesUserContext,
-)
+from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.datasets import DatasetManager
 from galaxy.managers.hdas import HDAManager
 from galaxy.managers.lddas import LDDAManager

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -489,7 +489,8 @@ class JobSearch:
                 elif t == "dce":
                     stmt = self._build_stmt_for_dce(stmt, data_conditions, used_ids, k, v)
                 else:
-                    return []
+                    log.error("Unknown input data type %s", t)
+                    return None
 
         stmt = stmt.where(*data_conditions).group_by(model.Job.id, *used_ids).order_by(model.Job.id.desc())
 

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -525,7 +525,11 @@ class JobSearch:
                         continue
                     a = aliased(model.JobParameter)
                     job_parameter_conditions.append(
-                        and_(model.Job.id == a.job_id, a.name == k, a.value == json.dumps(v, sort_keys=True))
+                        and_(
+                            model.Job.id == a.job_id,
+                            a.name == k,
+                            a.value == (None if v is None else json.dumps(v, sort_keys=True)),
+                        )
                     )
             else:
                 job_parameter_conditions = [model.Job.id == job[0]]
@@ -610,10 +614,11 @@ class JobSearch:
             elif k == "__when_value__":
                 # TODO: really need to separate this.
                 continue
-            value_dump = json.dumps(v, sort_keys=True)
-            wildcard_value = value_dump.replace('"id": "__id_wildcard__"', '"id": %')
+            value_dump = None if v is None else json.dumps(v, sort_keys=True)
+            wildcard_value = value_dump.replace('"id": "__id_wildcard__"', '"id": %') if value_dump else None
             a = aliased(JobParameter)
             if value_dump == wildcard_value:
+                # No wildcard needed, use exact match
                 stmt = stmt.join(a).where(
                     and_(
                         Job.id == a.job_id,

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6986,6 +6986,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
         dataset_instance_attributes=None,
         flush=True,
         minimize_copies=False,
+        copy_hid=True,
     ):
         new_collection = DatasetCollection(collection_type=self.collection_type, element_count=self.element_count)
         for element in self.elements:
@@ -6996,6 +6997,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
                 dataset_instance_attributes=dataset_instance_attributes,
                 flush=flush,
                 minimize_copies=minimize_copies,
+                copy_hid=copy_hid,
             )
         object_session(self).add(new_collection)
         if flush:
@@ -7013,11 +7015,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
             self.element_count = other_collection.element_count
             # this is a new collection and elements are still to be discovered
             for element in other_collection.elements:
-                element.copy_to_collection(
-                    self,
-                    element_destination=history,
-                    flush=False,
-                )
+                element.copy_to_collection(self, element_destination=history, flush=False, copy_hid=False)
 
     def replace_elements_with_copies(self, replacements: List["DatasetCollectionElement"], history: "History"):
         assert len(replacements) == len(self.elements)
@@ -7710,6 +7708,7 @@ class DatasetCollectionElement(Base, Dictifiable, Serializable):
         dataset_instance_attributes=None,
         flush=True,
         minimize_copies=False,
+        copy_hid=True,
     ):
         dataset_instance_attributes = dataset_instance_attributes or {}
         element_object = self.element_object
@@ -7721,6 +7720,7 @@ class DatasetCollectionElement(Base, Dictifiable, Serializable):
                     dataset_instance_attributes=dataset_instance_attributes,
                     flush=flush,
                     minimize_copies=minimize_copies,
+                    copy_hid=copy_hid,
                 )
             else:
                 new_element_object = None
@@ -7733,7 +7733,9 @@ class DatasetCollectionElement(Base, Dictifiable, Serializable):
                 ):
                     element_object = new_element_object
                 else:
-                    new_element_object = element_object.copy(flush=flush, copy_tags=element_object.tags)
+                    new_element_object = element_object.copy(
+                        flush=flush, copy_tags=element_object.tags, copy_hid=copy_hid
+                    )
                     for attribute, value in dataset_instance_attributes.items():
                         setattr(new_element_object, attribute, value)
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1635,11 +1635,31 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
             outputs_to_copy = job.io_dicts(exclude_implicit_outputs=True)
             self_io = self.io_dicts(exclude_implicit_outputs=True)
             for output_name, out_data in outputs_to_copy.out_data.items():
-                self_output = self_io.out_data[output_name]
-                if isinstance(self_output, HistoryDatasetAssociation) and isinstance(
-                    out_data, HistoryDatasetAssociation
-                ):
-                    self_output.copy_from(out_data, include_metadata=True)
+                if output_name in self_io.out_data:
+                    self_output = self_io.out_data[output_name]
+                    if isinstance(self_output, HistoryDatasetAssociation) and isinstance(
+                        out_data, HistoryDatasetAssociation
+                    ):
+                        self_output.copy_from(out_data, include_metadata=True)
+                else:
+                    assert output_name.startswith("__") and isinstance(out_data, HistoryDatasetAssociation)
+                    if output_name.startswith("__new_primary_file_"):
+                        # Check if output is part of a discovered collection, in which case we don't need to make a copy.
+                        # Not tracking the discoverd HDA as a job to output dataset association creates a slightly inconsistent state for the copied job outputs,
+                        # but I wonder if we ever really intended to track the discovered collection outputs like this in the first place.
+                        # Maintaining a consistent state here would require traversing the output collection and adding the job output dataset associations,
+                        # which is a little tricky and probably not worth it.
+                        split_name = output_name[len("__new_primary_file_") :].split("|")
+                        if len(split_name) > 1:
+                            collection_name = split_name[0]
+                            if collection_name in outputs_to_copy.out_collections:
+                                continue
+                    # Should be discovered primary output. The newly created job hasn't discovered this yet, so we have to copy the dataset to the job history and track it among the job outputs.
+                    requires_addition_to_history = True
+                    copied_output = out_data.copy(copy_tags=out_data.tags, flush=False)  # type: ignore[attr-defined]
+                    copied_output.history = self.history
+                    self.history.stage_addition(copied_output)
+                    self.add_output_dataset(output_name, copied_output)
             for output_name, out_collection in outputs_to_copy.out_collections.items():
                 self_out_collection = self_io.out_collections[output_name]
                 if isinstance(self_out_collection, DatasetCollection) and isinstance(out_collection, DatasetCollection):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1931,20 +1931,25 @@ class Tool(UsesDictVisibleKeys):
             validate_input(request_context, errors, legacy_non_dce_params, self.inputs)
 
     def completed_jobs(
-        self, trans, use_cached_job: bool, all_params: List[ToolStateJobInstancePopulatedT]
-    ) -> Dict[int, Optional[model.Job]]:
-        completed_jobs: Dict[int, Optional[model.Job]] = {}
+        self,
+        trans,
+        use_cached_job: bool,
+        all_params: List[ToolStateJobInstancePopulatedT],
+    ) -> Dict[int, Optional[Job]]:
+        completed_jobs: Dict[int, Optional[Job]] = {}
         for i, param in enumerate(all_params):
             if use_cached_job and trans.user:
                 tool_id = self.id
                 assert tool_id
                 param_dump: ToolStateDumpedToJsonInternalT = params_to_json_internal(self.inputs, param, self.app)
+                require_name_match = param.get("__when_value__") is not False
                 completed_jobs[i] = self.job_search.by_tool_input(
                     user=trans.user,
                     tool_id=tool_id,
                     tool_version=self.version,
                     param=param,
                     param_dump=param_dump,
+                    require_name_match=require_name_match,
                 )
             else:
                 completed_jobs[i] = None

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1935,12 +1935,12 @@ class Tool(UsesDictVisibleKeys):
     ) -> Dict[int, Optional[model.Job]]:
         completed_jobs: Dict[int, Optional[model.Job]] = {}
         for i, param in enumerate(all_params):
-            if use_cached_job:
+            if use_cached_job and trans.user:
                 tool_id = self.id
                 assert tool_id
                 param_dump: ToolStateDumpedToJsonInternalT = params_to_json_internal(self.inputs, param, self.app)
                 completed_jobs[i] = self.job_search.by_tool_input(
-                    trans=trans,
+                    user=trans.user,
                     tool_id=tool_id,
                     tool_version=self.version,
                     param=param,
@@ -1976,7 +1976,9 @@ class Tool(UsesDictVisibleKeys):
         self.handle_incoming_errors(all_errors)
 
         mapping_params = MappingParameters(incoming, all_params)
-        completed_jobs: Dict[int, Optional[model.Job]] = self.completed_jobs(trans, use_cached_job, all_params)
+        if use_cached_job:
+            mapping_params.param_template["__use_cached_job__"] = use_cached_job
+        completed_jobs: Dict[int, Optional[Job]] = self.completed_jobs(trans, use_cached_job, all_params)
         execution_tracker = execute_job(
             trans,
             self,

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -138,6 +138,8 @@ class ToolEvaluator:
         self.version_command_line: Optional[str] = None
         self.command_line: Optional[str] = None
         self.interactivetools: List[Dict[str, Any]] = []
+        self.consumes_names = False
+        self.use_cached_job = False
 
     def set_compute_environment(self, compute_environment: ComputeEnvironment, get_special: Optional[Callable] = None):
         """
@@ -149,6 +151,8 @@ class ToolEvaluator:
         job = self.job
         incoming = {p.name: p.value for p in job.parameters}
         incoming = self.tool.params_from_strings(incoming, self.app)
+        if "__use_cached_job__" in incoming:
+            self.use_cached_job = bool(incoming["__use_cached_job__"])
 
         self.file_sources_dict = compute_environment.get_file_sources_dict()
 
@@ -393,6 +397,7 @@ class ToolEvaluator:
                     tool=self.tool,
                     name=input.name,
                     formats=input.formats,
+                    tool_evaluator=self,
                 )
 
             elif isinstance(input, DataToolParameter):
@@ -402,6 +407,7 @@ class ToolEvaluator:
                     tool=self.tool,
                     name=input.name,
                     compute_environment=self.compute_environment,
+                    tool_evaluator=self,
                 )
                 element_identifier = element_identifier_mapper.identifier(dataset, param_dict)
                 if element_identifier:
@@ -415,6 +421,7 @@ class ToolEvaluator:
                     compute_environment=self.compute_environment,
                     tool=self.tool,
                     name=input.name,
+                    tool_evaluator=self,
                 )
                 wrapper = DatasetCollectionWrapper(job_working_directory, dataset_collection, **wrapper_kwds)
                 input_values[input.name] = wrapper

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -120,6 +120,8 @@ def execute(
         params = execution_slice.param_combination
         if "__data_manager_mode" in mapping_params.param_template:
             params["__data_manager_mode"] = mapping_params.param_template["__data_manager_mode"]
+        if "__use_cached_job__" in mapping_params.param_template:
+            params["__use_cached_job__"] = mapping_params.param_template["__use_cached_job__"]
         if workflow_invocation_uuid:
             params["__workflow_invocation_uuid__"] = workflow_invocation_uuid
         elif "__workflow_invocation_uuid__" in params:

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
     from galaxy.job_execution.compute_environment import ComputeEnvironment
     from galaxy.model.metadata import MetadataCollection
     from galaxy.tools import Tool
+    from galaxy.tools.evaluation import ToolEvaluator
     from galaxy.tools.parameters.basic import (
         SelectToolParameter,
         ToolParameter,
@@ -356,6 +357,7 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
         identifier: Optional[str] = None,
         io_type: str = "input",
         formats: Optional[List[str]] = None,
+        tool_evaluator: Optional["ToolEvaluator"] = None,
     ) -> None:
         dataset_instance: Optional[DatasetInstance] = None
         if not dataset:
@@ -393,6 +395,7 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
                 # May be a 'FakeDatasetAssociation'
                 self.groups = set()
         self.compute_environment = compute_environment
+        self.tool_evaluator = tool_evaluator
         # TODO: lazy initialize this...
         self.__io_type = io_type
         self.false_path: Optional[str] = None
@@ -498,6 +501,10 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
                 return self.compute_environment.input_extra_files_rewrite(self.unsanitized)
             else:
                 return self.compute_environment.output_extra_files_rewrite(self.unsanitized)
+        elif key == "name":
+            if self.tool_evaluator:
+                self.tool_evaluator.consumes_names = True
+            return getattr(self.dataset, key)
         elif key == "serialize":
             return self.serialize
         else:
@@ -627,6 +634,7 @@ class DatasetCollectionWrapper(ToolParameterValueWrapper, HasDatasets):
         job_working_directory: Optional[str],
         has_collection: Union[None, DatasetCollectionElement, HistoryDatasetCollectionAssociation],
         datatypes_registry: "Registry",
+        tool_evaluator: Optional["ToolEvaluator"] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__()
@@ -635,6 +643,7 @@ class DatasetCollectionWrapper(ToolParameterValueWrapper, HasDatasets):
         self._element_identifiers_extensions_paths_and_metadata_files: Optional[List[List[Any]]] = None
         self.datatypes_registry = datatypes_registry
         kwargs["datatypes_registry"] = datatypes_registry
+        self.tool_evaluator = tool_evaluator
         self.kwargs = kwargs
 
         if has_collection is None:
@@ -664,10 +673,12 @@ class DatasetCollectionWrapper(ToolParameterValueWrapper, HasDatasets):
 
             if dataset_collection_element.is_collection:
                 element_wrapper: DatasetCollectionElementWrapper = DatasetCollectionWrapper(
-                    job_working_directory, dataset_collection_element, **kwargs
+                    job_working_directory, dataset_collection_element, tool_evaluator=self.tool_evaluator, **kwargs
                 )
             else:
-                element_wrapper = self._dataset_wrapper(element_object, identifier=element_identifier, **kwargs)
+                element_wrapper = self._dataset_wrapper(
+                    element_object, identifier=element_identifier, tool_evaluator=self.tool_evaluator, **kwargs
+                )
 
             element_instances[element_identifier] = element_wrapper
             element_instance_list.append(element_wrapper)

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -515,9 +515,10 @@ class FastAPIJobs:
             return []
         params_dump = [tool.params_to_strings(param, trans.app, nested=True) for param in all_params]
         jobs = []
+        assert trans.user
         for param_dump, param in zip(params_dump, all_params):
             job = self.service.job_search.by_tool_input(
-                trans=trans,
+                user=trans.user,
                 tool_id=tool_id,
                 tool_version=tool.version,
                 param=param,

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2411,6 +2411,8 @@ class ToolModule(WorkflowModule):
         completed_jobs: Dict[int, Optional[Job]] = tool.completed_jobs(trans, use_cached_job, param_combinations)
         try:
             mapping_params = MappingParameters(tool_state.inputs, param_combinations)
+            if use_cached_job:
+                mapping_params.param_template["__use_cached_job__"] = use_cached_job
             max_num_jobs = progress.maximum_jobs_to_schedule_or_none
 
             validate_outputs = False

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2408,7 +2408,11 @@ class ToolModule(WorkflowModule):
             param_combinations.append(execution_state.inputs)
 
         complete = False
-        completed_jobs: Dict[int, Optional[Job]] = tool.completed_jobs(trans, use_cached_job, param_combinations)
+        completed_jobs: Dict[int, Optional[Job]] = tool.completed_jobs(
+            trans,
+            use_cached_job,
+            param_combinations,
+        )
         try:
             mapping_params = MappingParameters(tool_state.inputs, param_combinations)
             if use_cached_job:

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -1187,6 +1187,14 @@ class TestToolsApi(ApiTestCase, TestsTools):
             # 2 output collections
             # with 6 HDAs each
             assert len(contents) == 15
+            hdca_details = self.dataset_populator.get_history_collection_details(
+                history_id=history_id, content_id=outputs_two["output_collections"][0]["id"]
+            )
+            assert hdca_details["collection_type"] == "list:paired"
+            assert hdca_details["element_count"] == 3
+            assert hdca_details["populated"]
+            assert hdca_details["populated_state"] == "ok"
+            assert hdca_details["elements_datatypes"] == ["fastqsanger"]
 
     @skip_without_tool("multi_output_assign_primary_ext_dbkey")
     @requires_new_history

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -1058,6 +1058,67 @@ class TestToolsApi(ApiTestCase, TestsTools):
             job_details = self.dataset_populator.get_job_details(copied_job_id, full=True).json()
             assert job_details["copied_from_job_id"] == outputs_one["jobs"][0]["id"]
 
+    @skip_without_tool("collection_creates_list")
+    @requires_new_history
+    def test_run_collection_creates_list_use_cached_job(self):
+        with self.dataset_populator.test_history_for(
+            self.test_run_collection_creates_list_use_cached_job
+        ) as history_id:
+            # Run tool that consumes and produces hdca
+            create_response = self.dataset_collection_populator.create_list_in_history(
+                history_id, contents=["123", "456"], wait=True
+            ).json()
+            hdca = create_response["output_collections"][0]
+            outputs_one = self._run(
+                "collection_creates_list",
+                history_id,
+                inputs={"input1": {"src": "hdca", "id": hdca["id"]}},
+                assert_ok=True,
+                wait_for_job=True,
+            )
+            outputs_two = self._run(
+                "collection_creates_list",
+                history_id,
+                inputs={"input1": {"src": "hdca", "id": hdca["id"]}},
+                assert_ok=True,
+                wait_for_job=True,
+                use_cached_job=True,
+            )
+            copied_job_id = outputs_two["jobs"][0]["id"]
+            job_details = self.dataset_populator.get_job_details(copied_job_id, full=True).json()
+            assert job_details["copied_from_job_id"] == outputs_one["jobs"][0]["id"]
+
+    @skip_without_tool("collection_creates_list")
+    @requires_new_history
+    def test_run_collection_creates_list_use_cached_job_renamed_input(self):
+        with self.dataset_populator.test_history_for(
+            self.test_run_collection_creates_list_use_cached_job
+        ) as history_id:
+            # Run tool that consumes and produces hdca
+            create_response = self.dataset_collection_populator.create_list_in_history(
+                history_id, contents=["123", "456"], wait=True
+            ).json()
+            hdca = create_response["output_collections"][0]
+            outputs_one = self._run(
+                "collection_creates_list",
+                history_id,
+                inputs={"input1": {"src": "hdca", "id": hdca["id"]}},
+                assert_ok=True,
+                wait_for_job=True,
+            )
+            self.dataset_populator.rename_collection(history_id, hdca["id"])
+            outputs_two = self._run(
+                "collection_creates_list",
+                history_id,
+                inputs={"input1": {"src": "hdca", "id": hdca["id"]}},
+                assert_ok=True,
+                wait_for_job=True,
+                use_cached_job=True,
+            )
+            copied_job_id = outputs_two["jobs"][0]["id"]
+            job_details = self.dataset_populator.get_job_details(copied_job_id, full=True).json()
+            assert job_details["copied_from_job_id"] == outputs_one["jobs"][0]["id"]
+
     @skip_without_tool("identifier_single")
     @requires_new_history
     def test_run_identifier_single_use_cached_job_renamed_input(self):

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -1154,6 +1154,73 @@ class TestToolsApi(ApiTestCase, TestsTools):
             job_details = self.dataset_populator.get_job_details(copied_job_id, full=True).json()
             assert job_details["copied_from_job_id"] is None
 
+    @skip_without_tool("collection_creates_dynamic_list_of_pairs")
+    @requires_new_history
+    def test_run_collection_creates_dynamic_list_of_pairs_use_cached_job(self):
+        with self.dataset_populator.test_history_for(
+            self.test_run_collection_creates_dynamic_list_of_pairs_use_cached_job
+        ) as history_id:
+            dataset = self.dataset_populator.new_dataset(history_id, content="123")
+            outputs_one = self._run(
+                "collection_creates_dynamic_list_of_pairs",
+                history_id,
+                inputs={"file": {"src": "hda", "id": dataset["id"]}, "foo": "abc"},
+                assert_ok=True,
+                wait_for_job=True,
+                use_cached_job=False,
+            )
+            self.dataset_populator.rename_dataset(dataset["id"])
+            outputs_two = self._run(
+                "collection_creates_dynamic_list_of_pairs",
+                history_id,
+                inputs={"file": {"src": "hda", "id": dataset["id"]}, "foo": "abc"},
+                assert_ok=True,
+                wait_for_job=True,
+                use_cached_job=True,
+            )
+            copied_job_id = outputs_two["jobs"][0]["id"]
+            job_details = self.dataset_populator.get_job_details(copied_job_id, full=True).json()
+            assert job_details["copied_from_job_id"] == outputs_one["jobs"][0]["id"]
+            contents = self.dataset_populator.get_history_contents(history_id)
+            # Make sure we add the correct number of output to the history
+            # 1 input dataset
+            # 2 output collections
+            # with 6 HDAs each
+            assert len(contents) == 15
+
+    @skip_without_tool("multi_output_assign_primary_ext_dbkey")
+    @requires_new_history
+    def test_run_multi_output_assign_primary_ext_dbkey_use_cached_job(self):
+        with self.dataset_populator.test_history_for(
+            self.test_run_multi_output_assign_primary_ext_dbkey_use_cached_job
+        ) as history_id:
+            dataset = self.dataset_populator.new_dataset(history_id, content="123")
+            outputs_one = self._run(
+                "multi_output_assign_primary_ext_dbkey",
+                history_id,
+                inputs={"input": {"src": "hda", "id": dataset["id"]}, "num_param": 1},
+                assert_ok=True,
+                wait_for_job=True,
+                use_cached_job=False,
+            )
+            self.dataset_populator.rename_dataset(dataset["id"])
+            outputs_two = self._run(
+                "multi_output_assign_primary_ext_dbkey",
+                history_id,
+                inputs={"input": {"src": "hda", "id": dataset["id"]}, "num_param": 1},
+                assert_ok=True,
+                wait_for_job=True,
+                use_cached_job=True,
+            )
+            copied_job_id = outputs_two["jobs"][0]["id"]
+            job_details = self.dataset_populator.get_job_details(copied_job_id, full=True).json()
+            assert job_details["copied_from_job_id"] == outputs_one["jobs"][0]["id"]
+            contents = self.dataset_populator.get_history_contents(history_id)
+            # Make sure we add the correct number of output to the history
+            # 1 input dataset
+            # 2 output datasets each
+            assert len(contents) == 5
+
     @skip_without_tool("cat1")
     def test_run_cat1_listified_param(self):
         with self.dataset_populator.test_history_for(self.test_run_cat1_listified_param) as history_id:

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -832,6 +832,20 @@ class BaseDatasetPopulator(BasePopulator):
         wait_on(_wait_for_purge, "dataset to become purged", timeout=2)
         return self._get(dataset_url)
 
+    def rename_dataset(
+        self,
+        content_id: str,
+        new_name: Optional[str] = None,
+    ):
+        if not new_name:
+            new_name = self.get_random_name()
+        return self.update_dataset(content_id, {"name": new_name})
+
+    def rename_collection(self, history_id: str, content_id: str, new_name: Optional[str] = None):
+        if not new_name:
+            new_name = self.get_random_name()
+        self.update_dataset_collection(history_id, content_id, {"name": new_name})
+
     def create_tool_landing(self, payload: CreateToolLandingRequestPayload) -> ToolLandingRequest:
         create_url = "tool_landings"
         json = payload.model_dump(mode="json")
@@ -1525,6 +1539,18 @@ class BaseDatasetPopulator(BasePopulator):
         update_url = f"histories/{history_id}"
         put_response = self._put(update_url, payload, json=True)
         return put_response
+
+    def update_dataset(self, dataset_id: str, update_payload: Dict[str, Any]):
+        update_url = f"datasets/{dataset_id}"
+        put_response = self._put(update_url, update_payload, json=True)
+        api_asserts.assert_status_code_is_ok(put_response)
+        return put_response.json()
+
+    def update_dataset_collection(self, history_id: str, dataset_collection_id: str, update_payload: Dict[str, Any]):
+        update_url = f"histories/{history_id}/contents/dataset_collections/{dataset_collection_id}"
+        put_response = self._put(update_url, update_payload, json=True)
+        api_asserts.assert_status_code_is_ok(put_response)
+        return put_response.json()
 
     def get_histories(self):
         history_index_response = self._get("histories")

--- a/test/unit/app/jobs/test_job_wrapper.py
+++ b/test/unit/app/jobs/test_job_wrapper.py
@@ -112,6 +112,7 @@ class MockEvaluator:
         self.job = job
         self.local_working_directory = local_working_directory
         self.param_dict = {}
+        self.use_cached_job = False
 
     def set_compute_environment(self, *args, **kwds):
         pass


### PR DESCRIPTION
It's a bit of a stretch to call this a bug, but it does fix the job cache to work in a more meaningful way, and we're going to run this on main. Happy to just deploy from usegalaxy.org, but I do want to see the tests here.

Backport of https://github.com/galaxyproject/galaxy/pull/19962 and https://github.com/galaxyproject/galaxy/pull/19999

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
