### PR TITLE
Flexible mapping from collection parameter types to collection builder components.

### DIFF
--- a/client/src/api/datasetCollections.ts
+++ b/client/src/api/datasetCollections.ts
@@ -3,6 +3,8 @@ import { rethrowSimple } from "@/utils/simple-error";
 
 const DEFAULT_LIMIT = 50;
 
+export type CollectionType = string;
+
 /**
  * Fetches the details of a collection.
  * @param params.id The ID of the collection (HDCA) to fetch.

--- a/client/src/components/Collections/CollectionCreatorIndex.vue
+++ b/client/src/components/Collections/CollectionCreatorIndex.vue
@@ -5,6 +5,7 @@ import { BAlert, BLink, BModal } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
 
 import type { HDASummary, HistoryItemSummary, HistorySummary } from "@/api";
+import type { CollectionType } from "@/api/datasetCollections";
 import { createDatasetCollection } from "@/components/History/model/queries";
 import { useCollectionBuilderItemsStore } from "@/stores/collectionBuilderItemsStore";
 import { useHistoryItemsStore } from "@/stores/historyItemsStore";
@@ -13,7 +14,7 @@ import localize from "@/utils/localization";
 import { orList } from "@/utils/strings";
 import { stateIsTerminal } from "@/utils/utils";
 
-import type { CollectionType, DatasetPair } from "../History/adapters/buildCollectionModal";
+import type { CollectionBuilderType, DatasetPair } from "../History/adapters/buildCollectionModal";
 
 import ListCollectionCreator from "./ListCollectionCreator.vue";
 import PairCollectionCreator from "./PairCollectionCreator.vue";
@@ -25,7 +26,7 @@ import LoadingSpan from "@/components/LoadingSpan.vue";
 interface Props {
     historyId: string;
     show: boolean;
-    collectionType: CollectionType;
+    collectionType: CollectionBuilderType;
     selectedItems?: HistoryItemSummary[];
     defaultHideSourceItems?: boolean;
     extensions?: string[];

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -70,7 +70,7 @@ const validInput = computed(() => {
 /** Plain language for what is being created */
 const shortWhatIsBeingCreated = computed<string>(() => {
     const collectionType: string | undefined = props.collectionType;
-    if (collectionType in COLLECTION_TYPE_TO_LABEL) {
+    if (collectionType && collectionType in COLLECTION_TYPE_TO_LABEL) {
         return COLLECTION_TYPE_TO_LABEL[collectionType] as string;
     } else {
         return "collection";

--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -780,7 +780,7 @@ const noOptionsWarningMessage = computed(() => {
                     :can-browse="canBrowse"
                     :loading="props.loading"
                     :workflow-run="props.workflowRun"
-                    :collection-type="props.collectionTypes?.length ? props.collectionTypes[0] : undefined"
+                    :collection-types="props.collectionTypes"
                     :current-source="currentSource || undefined"
                     :is-populated="currentValue && currentValue.length > 0"
                     show-field-options
@@ -838,7 +838,7 @@ const noOptionsWarningMessage = computed(() => {
             <FormDataContextButtons
                 v-if="props.workflowRun && usingSimpleSelect"
                 compact
-                :collection-type="props.collectionTypes?.length ? props.collectionTypes[0] : undefined"
+                :collection-types="props.collectionTypes"
                 :current-source="currentSource || undefined"
                 :is-populated="currentValue && currentValue.length > 0"
                 show-view-create-options

--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -13,9 +13,9 @@ import {
     isHDCA,
     isHistoryItem,
 } from "@/api";
+import type { CollectionType } from "@/api/datasetCollections";
 import type { HistoryContentType } from "@/api/datasets";
 import { getGalaxyInstance } from "@/app";
-import type { CollectionType } from "@/components/History/adapters/buildCollectionModal";
 import { useDatatypesMapper } from "@/composables/datatypesMapper";
 import { useUid } from "@/composables/utils/uid";
 import { type EventData, useEventStore } from "@/stores/eventStore";

--- a/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
+++ b/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
@@ -47,6 +47,10 @@ function createCollectionType(colType: string) {
     emit("create-collection-type", colType as CollectionType);
     emit("update:workflow-tab", "create");
 }
+
+const sourceIsCollection = computed(() => {
+    return props.currentSource === "hdca";
+});
 </script>
 
 <template>
@@ -89,7 +93,7 @@ function createCollectionType(colType: string) {
             <span v-if="!props.compact" v-localize>View</span>
         </BButton>
         <BDropdown
-            v-if="props.showViewCreateOptions && props.currentSource === 'hdca' && !props.collectionType"
+            v-if="props.showViewCreateOptions && sourceIsCollection && !props.collectionType"
             v-b-tooltip.bottom.hover.noninteractive
             class="d-flex flex-gapx-1 align-items-center"
             title="Create a new collection"

--- a/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
+++ b/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
@@ -5,7 +5,8 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton, BButtonGroup, BDropdown, BDropdownItem } from "bootstrap-vue";
 import { computed } from "vue";
 
-import { COLLECTION_TYPE_TO_LABEL, type CollectionType } from "@/components/History/adapters/buildCollectionModal";
+import { type CollectionType } from "@/api/datasetCollections";
+import { COLLECTION_TYPE_TO_LABEL } from "@/components/History/adapters/buildCollectionModal";
 import { capitalizeFirstLetter } from "@/utils/strings";
 
 import type { VariantInterface } from "./variants";

--- a/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
+++ b/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import { faFolder } from "@fortawesome/free-regular-svg-icons";
-import { faCaretDown, faEye, faPlus, faSpinner, faUpload } from "@fortawesome/free-solid-svg-icons";
+import { faEye, faPlus, faSpinner, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton, BButtonGroup, BDropdown, BDropdownItem } from "bootstrap-vue";
 import { computed } from "vue";
 
 import { type CollectionType } from "@/api/datasetCollections";
-import { COLLECTION_TYPE_TO_LABEL, type CollectionBuilderType } from "@/components/History/adapters/buildCollectionModal";
+import {
+    COLLECTION_TYPE_TO_LABEL,
+    type CollectionBuilderType,
+} from "@/components/History/adapters/buildCollectionModal";
 import { capitalizeFirstLetter } from "@/utils/strings";
 
 import { buildersForCollectionTypes, unconstrainedCollectionTypeBuilders } from "./collections";
@@ -60,7 +63,7 @@ const availableCollectionBuilders = computed(() => {
     } else {
         return unconstrainedCollectionTypeBuilders;
     }
-})
+});
 
 const hasSingleAvailableCollectionBuilderType = computed(() => {
     return availableCollectionBuilders.value.length === 1;
@@ -119,14 +122,11 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
         <BDropdown
             v-if="props.showViewCreateOptions && sourceIsCollection && !hasSingleAvailableCollectionBuilderType"
             v-b-tooltip.bottom.hover.noninteractive
-            class="d-flex flex-gapx-1 align-items-center"
+            class="d-flex"
             :title="createTitle"
-            no-caret
-            toggle-class="d-flex flex-gapx-1 align-items-center">
-            <template v-slot:button-content>
-                <FontAwesomeIcon :icon="faCaretDown" />
-                <span v-localize>Create</span>
-            </template>
+            split
+            text="Create"
+            @click="createCollectionType(defaultCollectionBuilderType)">
             <BDropdownItem
                 v-for="colType in availableCollectionBuilders"
                 :key="colType"
@@ -135,9 +135,7 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
             </BDropdownItem>
         </BDropdown>
         <BButton
-            v-else-if="
-                props.showViewCreateOptions && sourceIsCollection
-            "
+            v-else-if="props.showViewCreateOptions && sourceIsCollection"
             v-b-tooltip.bottom.hover.noninteractive
             class="d-flex flex-gapx-1 align-items-center"
             data-description="upload"
@@ -148,9 +146,7 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
             <span v-localize>Create</span>
         </BButton>
         <BButton
-            v-else-if="
-                props.showViewCreateOptions && !sourceIsCollection
-            "
+            v-else-if="props.showViewCreateOptions && !sourceIsCollection"
             v-b-tooltip.bottom.hover.noninteractive
             class="d-flex flex-gapx-1 align-items-center"
             data-description="upload"

--- a/client/src/components/Form/Elements/FormData/FormDataWorkflowRunTabs.vue
+++ b/client/src/components/Form/Elements/FormData/FormDataWorkflowRunTabs.vue
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { storeToRefs } from "pinia";
 import { computed } from "vue";
 
-import type { CollectionType } from "@/components/History/adapters/buildCollectionModal";
+import type { CollectionType } from "@/api/datasetCollections";
 import { useUploadConfigurations } from "@/composables/uploadConfigurations";
 import { useHistoryStore } from "@/stores/historyStore";
 

--- a/client/src/components/Form/Elements/FormData/collections.test.ts
+++ b/client/src/components/Form/Elements/FormData/collections.test.ts
@@ -1,0 +1,41 @@
+import { type CollectionType } from "@/api/datasetCollections";
+
+import { buildersForCollectionType, buildersForCollectionTypes } from "./collections";
+
+describe("buildersForCollectionType", () => {
+    it("should return the list builder for flat list collections", () => {
+        const result = buildersForCollectionType("list" as CollectionType);
+        expect(result).toEqual(["list"]);
+    });
+
+    it("should return both the obvious paired builder but the paired list builder also for mapping over", () => {
+        const result = buildersForCollectionType("paired" as CollectionType);
+        expect(result).toEqual(["list:paired", "paired"]);
+    });
+
+    it("should return an empty array for unknown collectionType, we have no collection builders for these", () => {
+        const result = buildersForCollectionType("unknown" as CollectionType);
+        expect(result).toEqual([]);
+    });
+});
+
+describe("buildersForCollectionTypes", () => {
+    it("should return unique builders for multiple collection types", () => {
+        const collectionTypes: CollectionType[] = ["list", "paired", "list:paired"];
+        const result = buildersForCollectionTypes(collectionTypes);
+        expect(result).toEqual(expect.arrayContaining(["list", "paired", "list:paired"]));
+        expect(result.length).toBe(3); // Ensure uniqueness
+    });
+
+    it("should return an empty array for an empty input", () => {
+        const result = buildersForCollectionTypes([]);
+        expect(result).toEqual([]);
+    });
+
+    it("should handle unknown collection types gracefully", () => {
+        const collectionTypes: CollectionType[] = ["paired:paired:list", "list"];
+        const result = buildersForCollectionTypes(collectionTypes);
+        expect(result).toEqual(expect.arrayContaining(["list"]));
+        expect(result.length).toBe(1);
+    });
+});

--- a/client/src/components/Form/Elements/FormData/collections.ts
+++ b/client/src/components/Form/Elements/FormData/collections.ts
@@ -1,6 +1,7 @@
 import { type CollectionType } from "@/api/datasetCollections";
 import { type CollectionBuilderType } from "@/components/History/adapters/buildCollectionModal";
 
+export const unconstrainedCollectionTypeBuilders: CollectionBuilderType[] = ["list", "list:paired", "paired"];
 
 export function buildersForCollectionType(collectionType: CollectionType): CollectionBuilderType[] {
     if (collectionType === "list") {

--- a/client/src/components/Form/Elements/FormData/collections.ts
+++ b/client/src/components/Form/Elements/FormData/collections.ts
@@ -1,0 +1,26 @@
+import { type CollectionType } from "@/api/datasetCollections";
+import { type CollectionBuilderType } from "@/components/History/adapters/buildCollectionModal";
+
+
+export function buildersForCollectionType(collectionType: CollectionType): CollectionBuilderType[] {
+    if (collectionType === "list") {
+        return ["list"];
+    } else if (collectionType == "paired") {
+        // generally prefer list:paired over paired, most people operate on these as lists
+        // according to analysts.
+        return ["list:paired", "paired"];
+    } else if (collectionType == "list:paired") {
+        return ["list:paired"];
+    } else {
+        return [];
+    }
+}
+
+export function buildersForCollectionTypes(collectionTypes: CollectionType[]): CollectionBuilderType[] {
+    const uniqueBuilders = new Set<CollectionBuilderType>();
+    for (const collectionType of collectionTypes) {
+        const builders = buildersForCollectionType(collectionType);
+        builders.forEach((builder) => uniqueBuilders.add(builder));
+    }
+    return Array.from(uniqueBuilders);
+}

--- a/client/src/components/History/adapters/buildCollectionModal.ts
+++ b/client/src/components/History/adapters/buildCollectionModal.ts
@@ -12,9 +12,14 @@
 import jQuery from "jquery";
 
 import type { HDASummary, HistoryItemSummary } from "@/api";
+import type { CollectionType } from "@/api/datasetCollections";
 import RULE_BASED_COLLECTION_CREATOR from "@/components/Collections/RuleBasedCollectionCreatorModal";
 
-export type CollectionType = "list" | "paired" | "list:paired" | "rules";
+// This is type describes builders we know about - not valid "collection type"s
+// as the backend/model layer of Galaxy would understand them. Rules is a collection
+// builder but not a collection type, paired:paired:list is a valid collection type but
+// not something we would ever make a builder for.
+export type CollectionBuilderType = "list" | "paired" | "list:paired" | "rules";
 export type DatasetPair = {
     forward: HDASummary;
     reverse: HDASummary;

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -14,7 +14,7 @@ import {
 import { computed, reactive, ref } from "vue";
 
 import { GalaxyApi } from "@/api";
-import type { CollectionType } from "@/components/History/adapters/buildCollectionModal";
+import type { CollectionBuilderType } from "@/components/History/adapters/buildCollectionModal";
 import { Services } from "@/components/Libraries/LibraryFolder/services";
 import { deleteSelectedItems } from "@/components/Libraries/LibraryFolder/TopToolbar/delete-selected";
 import download from "@/components/Libraries/LibraryFolder/TopToolbar/download";
@@ -100,7 +100,7 @@ const totalRows = computed(() => {
 });
 
 // Variables for Collection Creation
-const collectionModalType = ref<CollectionType | null>(null);
+const collectionModalType = ref<CollectionBuilderType | null>(null);
 const collectionModalShow = ref(false);
 const collectionSelection = ref<any[]>([]);
 const collectionHistoryId = ref<string | null>(null);
@@ -209,7 +209,7 @@ async function importToHistoryModal(isCollection: boolean) {
                 ) => {
                     try {
                         collectionHistoryId.value = historyId;
-                        collectionModalType.value = collectionType as CollectionType;
+                        collectionModalType.value = collectionType as CollectionBuilderType;
                         collectionSelection.value = selection.models;
                         collectionModalShow.value = true;
                     } catch (err) {


### PR DESCRIPTION
I don't have a great, concise language for this but I have outlined this approach in https://github.com/galaxyproject/galaxy/issues/20048. This makes like the paired collection handling more usable immediately and provides a much needed extension point for #19377.

<img width="918" alt="Screenshot 2025-04-23 at 2 34 32 PM" src="https://github.com/user-attachments/assets/35462a62-41e3-4d02-a223-d655f7e0660e" />

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  1. Create a workflow with a data collection input. Set the collection type to "paired" on that input. Row the workflow - see screenshot above.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
