### PR TITLE
Fix `test_workflow_run` export selenium

### DIFF
--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -926,6 +926,7 @@ invocations:
     step_job_information: '[data-step="${order_index}"] .invocation-step-job-details .info_data_table'
     step_job_information_tool_id: '[data-step="${order_index}"] .invocation-step-job-details .info_data_table #galaxy-tool-id'
     export_tab: '.invocation-export-tab'
+    export_tab_disabled: '.invocation-export-tab .nav-link.disabled'
     export_output_format: '[data-invocation-export-type="${type}"] .card-body'
     export_destination: '[data-invocation-export-destination="${destination}"] .card-body'
     wizard_next_button: '.wizard-actions .go-next-btn'

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -40,6 +40,7 @@ class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows
         self._setup_simple_invocation_for_export_testing()
         invocations = self.components.invocations
         self.workflow_run_wait_for_ok(hid=2)
+        invocations.export_tab_disabled.wait_for_absent()
         invocations.export_tab.wait_for_and_click()
         self.screenshot("invocation_export_formats")
         invocations.export_output_format(type="ro-crate").wait_for_and_click()
@@ -64,6 +65,7 @@ class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows
         self._setup_simple_invocation_for_export_testing()
         invocations = self.components.invocations
         self.workflow_run_wait_for_ok(hid=2)
+        invocations.export_tab_disabled.wait_for_absent()
         invocations.export_tab.wait_for_and_click()
         self.screenshot("invocation_export_formats")
         invocations.export_output_format(type="default-file").wait_for_and_click()


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20081

This might be a case of the selenium not waiting for the tab to **not be** disabled and instead just watching the history items, and so it tried clicking a tab that hadn't become enabled yet.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
