### PR TITLE
[24.2] Allow access to published workflows

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -315,7 +315,12 @@ class WorkflowsManager(sharable.SharableModelManager, deletable.DeletableManager
         stored_workflow = self.get_stored_workflow(trans, workflow_id, by_stored_id=by_stored_id)
 
         # check to see if user has permissions to selected workflow
-        if stored_workflow.user != trans.user and not trans.user_is_admin and not stored_workflow.importable:
+        if (
+            stored_workflow.user != trans.user
+            and not trans.user_is_admin
+            and not stored_workflow.importable
+            and not stored_workflow.published
+        ):
             stmt = select(StoredWorkflowUserShareAssociation).filter_by(
                 user=trans.user, stored_workflow=stored_workflow
             )

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -655,7 +655,7 @@ class WorkflowsAPIController(
             stored_workflow = self.get_stored_workflow(trans, workflow_id, check_ownership=False)
         except Exception:
             raise exceptions.ObjectNotFound("Malformed workflow id specified.")
-        if stored_workflow.importable is False:
+        if stored_workflow.published is False and stored_workflow.importable is False:
             raise exceptions.ItemAccessibilityException(
                 "The owner of this workflow has disabled imports via this link."
             )

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -228,7 +228,12 @@ class WorkflowsService(ServiceBase):
 
     def show_workflow(self, trans, workflow_id, instance, legacy, version) -> StoredWorkflowDetailed:
         stored_workflow = self._workflows_manager.get_stored_workflow(trans, workflow_id, by_stored_id=not instance)
-        if stored_workflow.importable is False and stored_workflow.user != trans.user and not trans.user_is_admin:
+        if (
+            stored_workflow.published is False
+            and stored_workflow.importable is False
+            and stored_workflow.user != trans.user
+            and not trans.user_is_admin
+        ):
             wf_count = 0 if not trans.user else trans.user.count_stored_workflow_user_assocs(stored_workflow)
             if wf_count == 0:
                 message = "Workflow is neither importable, nor owned by or shared with current user"


### PR DESCRIPTION
Which is how it was before
https://github.com/galaxyproject/galaxy/commit/2ff6aa51334ecaccdfecc39ed9ab4f9f4b880ef6. Alternatively I could update all iwc workflows to also be accessible. I guess that would be more cosistent ...

The UI forces you to make the workflow accessible if you want to publish the workflow, which makes sense I guess.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
