### PR TITLE
Use visualization dropdown solely for examples

### DIFF
--- a/client/src/api/plugins.ts
+++ b/client/src/api/plugins.ts
@@ -10,7 +10,13 @@ export interface Dataset {
 
 export interface DataSource {
     model_class?: string;
-    tests: Array<Test>;
+    tests: Array<DataSourceTest>;
+}
+
+export interface DataSourceTest {
+    attr?: string;
+    result?: string;
+    type?: string;
 }
 
 export interface Plugin {
@@ -24,17 +30,20 @@ export interface Plugin {
     name: string;
     target?: string;
     tags?: Array<string>;
-    tests?: Array<any>;
+    tests?: Array<TestType>;
 }
 
 export interface PluginData {
     hdas: Array<Dataset>;
 }
 
-export interface Test {
-    attr?: string;
-    result?: string;
-    type?: string;
+export interface ParamType {
+    name: string;
+    value: string;
+}
+
+export interface TestType {
+    param: ParamType;
 }
 
 export async function fetchPlugins(datasetId?: string): Promise<Array<Plugin>> {

--- a/client/src/components/Visualizations/VisualizationCreate.test.js
+++ b/client/src/components/Visualizations/VisualizationCreate.test.js
@@ -44,6 +44,11 @@ beforeEach(() => {
         }),
     });
     mockedStore = useFakeHistoryStore();
+
+    // prevent tooltip from throwing warning
+    const el = document.createElement("div");
+    el.id = "vis-create-ext";
+    document.body.appendChild(el);
 });
 
 it("renders plugin info after load", async () => {
@@ -52,9 +57,6 @@ it("renders plugin info after load", async () => {
         propsData: {
             visualization: "scatterplot"
         },
-        stubs: {
-            FormDataExtensions: false,
-        }
     });
     await flushPromises();
     await wrapper.vm.$nextTick();

--- a/client/src/components/Visualizations/VisualizationCreate.test.js
+++ b/client/src/components/Visualizations/VisualizationCreate.test.js
@@ -1,32 +1,35 @@
 import { mount } from "@vue/test-utils";
+import flushPromises from "flush-promises";
 import { createPinia, defineStore, setActivePinia } from "pinia";
+import { getLocalVue } from "tests/jest/helpers";
 import { ref } from "vue";
+
 import VisualizationCreate from "./VisualizationCreate.vue";
 import FormCardSticky from "@/components/Form/FormCardSticky.vue";
-import flushPromises from "flush-promises";
-import { getLocalVue } from "tests/jest/helpers";
 
 jest.mock("vue-router/composables", () => ({
     useRouter: () => ({
-        push: jest.fn()
+        push: jest.fn(),
     }),
 }));
 
 jest.mock("@/api/plugins", () => ({
-    fetchPlugin: jest.fn(() => Promise.resolve({
-        name: "scatterplot",
-        description: "A great scatterplot plugin.",
-        html: "Scatterplot Plugin",
-        logo: "/logo.png",
-        help: "Some help text",
-        tags: ["tag1", "tag2"]
-    })),
-    fetchPluginHistoryItems: jest.fn(() => Promise.resolve({ hdas: [] }))
+    fetchPlugin: jest.fn(() =>
+        Promise.resolve({
+            name: "scatterplot",
+            description: "A great scatterplot plugin.",
+            html: "Scatterplot Plugin",
+            logo: "/logo.png",
+            help: "Some help text",
+            tags: ["tag1", "tag2"],
+        })
+    ),
+    fetchPluginHistoryItems: jest.fn(() => Promise.resolve({ hdas: [] })),
 }));
 
 jest.mock("./utilities", () => ({
     getTestExtensions: jest.fn(() => ["txt"]),
-    getTestUrls: jest.fn(() => [{ name: "Example", url: "https://example.com/data.txt" }])
+    getTestUrls: jest.fn(() => [{ name: "Example", url: "https://example.com/data.txt" }]),
 }));
 
 let mockedStore;
@@ -55,7 +58,7 @@ it("renders plugin info after load", async () => {
     const wrapper = mount(VisualizationCreate, {
         localVue,
         propsData: {
-            visualization: "scatterplot"
+            visualization: "scatterplot",
         },
     });
     await flushPromises();

--- a/client/src/components/Visualizations/VisualizationCreate.test.js
+++ b/client/src/components/Visualizations/VisualizationCreate.test.js
@@ -1,0 +1,69 @@
+import { mount } from "@vue/test-utils";
+import { createPinia, defineStore, setActivePinia } from "pinia";
+import { ref } from "vue";
+import VisualizationCreate from "./VisualizationCreate.vue";
+import FormCardSticky from "@/components/Form/FormCardSticky.vue";
+import flushPromises from "flush-promises";
+import { getLocalVue } from "tests/jest/helpers";
+
+jest.mock("vue-router/composables", () => ({
+    useRouter: () => ({
+        push: jest.fn()
+    }),
+}));
+
+jest.mock("@/api/plugins", () => ({
+    fetchPlugin: jest.fn(() => Promise.resolve({
+        name: "scatterplot",
+        description: "A great scatterplot plugin.",
+        html: "Scatterplot Plugin",
+        logo: "/logo.png",
+        help: "Some help text",
+        tags: ["tag1", "tag2"]
+    })),
+    fetchPluginHistoryItems: jest.fn(() => Promise.resolve({ hdas: [] }))
+}));
+
+jest.mock("./utilities", () => ({
+    getTestExtensions: jest.fn(() => ["txt"]),
+    getTestUrls: jest.fn(() => [{ name: "Example", url: "https://example.com/data.txt" }])
+}));
+
+let mockedStore;
+jest.mock("@/stores/historyStore", () => ({
+    useHistoryStore: () => mockedStore,
+}));
+
+const localVue = getLocalVue();
+
+beforeEach(() => {
+    setActivePinia(createPinia());
+    const useFakeHistoryStore = defineStore("history", {
+        state: () => ({
+            currentHistoryId: ref("fake-history-id"),
+        }),
+    });
+    mockedStore = useFakeHistoryStore();
+});
+
+it("renders plugin info after load", async () => {
+    const wrapper = mount(VisualizationCreate, {
+        localVue,
+        propsData: {
+            visualization: "scatterplot"
+        },
+        stubs: {
+            FormDataExtensions: false,
+        }
+    });
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+    const sticky = wrapper.findComponent(FormCardSticky);
+    expect(sticky.exists()).toBe(true);
+    expect(sticky.props("description")).toBe("A great scatterplot plugin.");
+    expect(sticky.props("logo")).toBe("/logo.png");
+    expect(sticky.props("name")).toBe("Scatterplot Plugin");
+    expect(wrapper.text()).toContain("Help");
+    expect(wrapper.text()).toContain("tag1");
+    expect(wrapper.text()).toContain("tag2");
+});

--- a/client/src/components/Visualizations/VisualizationCreate.vue
+++ b/client/src/components/Visualizations/VisualizationCreate.vue
@@ -10,7 +10,7 @@ import { useHistoryStore } from "@/stores/historyStore";
 import { getTestExtensions, getTestUrls } from "./utilities";
 
 import FormDataExtensions from "../Form/Elements/FormData/FormDataExtensions.vue";
-import VisualizationDropdown from "./VisualizationDropdown.vue";
+import VisualizationExamples from "./VisualizationExamples.vue";
 import Heading from "@/components/Common/Heading.vue";
 import FormCardSticky from "@/components/Form/FormCardSticky.vue";
 import MarkdownDefault from "@/components/Markdown/Sections/MarkdownDefault.vue";
@@ -65,7 +65,7 @@ onMounted(() => {
         :logo="plugin?.logo"
         :name="plugin?.html">
         <template v-slot:buttons>
-            <VisualizationDropdown :tests="tests" />
+            <VisualizationExamples :tests="tests" />
         </template>
         <div class="my-3">
             <SelectionField

--- a/client/src/components/Visualizations/VisualizationCreate.vue
+++ b/client/src/components/Visualizations/VisualizationCreate.vue
@@ -77,7 +77,7 @@ onMounted(() => {
             <FormDataExtensions
                 v-if="extensions && extensions.length > 0"
                 :extensions="extensions"
-                formats-button-id="vis"
+                formats-button-id="vis-create-ext"
                 :formats-visible.sync="formatsVisible" />
         </div>
         <div v-if="plugin.help" class="my-2">

--- a/client/src/components/Visualizations/VisualizationCreate.vue
+++ b/client/src/components/Visualizations/VisualizationCreate.vue
@@ -27,7 +27,7 @@ const props = defineProps<{
 const errorMessage = ref("");
 const plugin: Ref<Plugin | undefined> = ref();
 
-const tests = computed(() => getTestUrls(plugin.value));
+const urlData = computed(() => getTestUrls(plugin.value));
 const extensions = computed(() => getTestExtensions(plugin.value));
 const formatsVisible = ref(false);
 
@@ -65,7 +65,7 @@ onMounted(() => {
         :logo="plugin?.logo"
         :name="plugin?.html">
         <template v-slot:buttons>
-            <VisualizationExamples :tests="tests" />
+            <VisualizationExamples :url-data="urlData" />
         </template>
         <div class="my-3">
             <SelectionField

--- a/client/src/components/Visualizations/VisualizationExamples.test.js
+++ b/client/src/components/Visualizations/VisualizationExamples.test.js
@@ -1,0 +1,119 @@
+import { mount } from "@vue/test-utils";
+import { BDropdown, BDropdownItem } from "bootstrap-vue";
+import { useToast } from "composables/toast";
+import { createPinia, defineStore, setActivePinia } from "pinia";
+import { getLocalVue } from "tests/jest/helpers";
+import { ref } from "vue";
+
+import UploadExamples from "./VisualizationExamples.vue";
+
+jest.mock("@/utils/upload-payload.js", () => ({
+    uploadPayload: jest.fn(() => "mockedPayload"),
+}));
+
+jest.mock("@/utils/upload-submit.js", () => ({
+    sendPayload: jest.fn(),
+}));
+
+jest.mock("@/composables/toast");
+const toastSuccess = jest.fn();
+const toastError = jest.fn();
+useToast.mockReturnValue({
+    success: toastSuccess,
+    error: toastError,
+});
+
+let mockedStore;
+jest.mock("@/stores/historyStore", () => ({
+    useHistoryStore: () => mockedStore,
+}));
+
+const localVue = getLocalVue();
+
+describe("UploadExamples.vue", () => {
+    const urlData = [
+        { name: "Example 1", url: "https://example.com/data1.txt" },
+        { name: "Example 2", url: "https://example.com/data2.txt" },
+    ];
+
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        const useFakeHistoryStore = defineStore("history", {
+            state: () => ({
+                currentHistoryId: ref("fake-history-id"),
+            }),
+        });
+        mockedStore = useFakeHistoryStore();
+    });
+
+    it("renders loading spinner when no historyId", () => {
+        mockedStore.currentHistoryId = ref(null);
+        const wrapper = mount(UploadExamples, {
+            localVue,
+            propsData: { urlData },
+        });
+        expect(wrapper.find("svg").exists()).toBe(true);
+    });
+
+    it("renders dropdown with upload options", () => {
+        const wrapper = mount(UploadExamples, {
+            localVue,
+            propsData: { urlData },
+        });
+        const items = wrapper.findAllComponents(BDropdownItem);
+        expect(items.length).toBe(urlData.length);
+        expect(wrapper.text()).toContain("Example 1");
+        expect(wrapper.text()).toContain("Example 2");
+    });
+
+    it("calls upload and shows success toast on item click", async () => {
+        const { uploadPayload } = require("@/utils/upload-payload.js");
+        const { sendPayload } = require("@/utils/upload-submit.js");
+        const wrapper = mount(UploadExamples, {
+            localVue,
+            propsData: { urlData },
+        });
+        const items = wrapper.findAllComponents(BDropdownItem);
+        await items.at(0).find("a").trigger("click");
+        expect(uploadPayload).toHaveBeenCalledWith([{ fileMode: "new", fileUri: urlData[0].url }], "fake-history-id");
+        expect(sendPayload).toHaveBeenCalledWith("mockedPayload", {
+            success: expect.any(Function),
+            error: expect.any(Function),
+        });
+        sendPayload.mock.calls[0][1].success();
+        expect(toastSuccess).toHaveBeenCalledWith("The sample dataset 'Example 1' is being uploaded to your history.");
+    });
+
+    it("shows error toast when upload fails", async () => {
+        const { sendPayload } = require("@/utils/upload-submit.js");
+        const wrapper = mount(UploadExamples, {
+            localVue,
+            propsData: { urlData },
+        });
+        const items = wrapper.findAllComponents(BDropdownItem);
+        await items.at(1).find("a").trigger("click");
+        sendPayload.mock.calls[0][1].error();
+        expect(toastError).toHaveBeenCalledWith("Uploading the sample dataset 'Example 2' has failed.");
+    });
+
+    it("does not render dropdown if urlData is missing", () => {
+        const wrapper = mount(UploadExamples, {
+            localVue,
+            propsData: {},
+        });
+        expect(wrapper.findComponent(BDropdown).exists()).toBe(false);
+    });
+
+    it("reacts to history ID becoming available", async () => {
+        mockedStore.currentHistoryId = ref(null);
+        const wrapper = mount(UploadExamples, {
+            localVue,
+            propsData: { urlData },
+        });
+        expect(wrapper.find("svg").exists()).toBe(true);
+        mockedStore.currentHistoryId = ref("new-history-id");
+        await wrapper.vm.$nextTick();
+        const items = wrapper.findAllComponents(BDropdownItem);
+        expect(items.length).toBe(urlData.length);
+    });
+});

--- a/client/src/components/Visualizations/VisualizationExamples.vue
+++ b/client/src/components/Visualizations/VisualizationExamples.vue
@@ -13,14 +13,14 @@ const { currentHistoryId } = storeToRefs(useHistoryStore());
 
 const toast = useToast();
 
-interface TestType {
+interface UrlDataType {
     extension: string;
     name: string;
     url: string;
 }
 
 defineProps<{
-    tests?: Array<TestType>;
+    urlData?: Array<UrlDataType>;
 }>();
 
 function onSubmit(name: string, url: string) {
@@ -37,7 +37,7 @@ function onSubmit(name: string, url: string) {
         <FontAwesomeIcon :icon="faSpinner" spin />
     </div>
     <BDropdown
-        v-else-if="tests && tests.length > 0"
+        v-else-if="urlData && urlData.length > 0"
         v-b-tooltip.hover
         no-caret
         right
@@ -52,10 +52,10 @@ function onSubmit(name: string, url: string) {
         <BDropdownText>
             <small class="text-primary text-uppercase">Upload Examples</small>
         </BDropdownText>
-        <BDropdownItem v-for="test of tests" :key="test.url" @click="() => onSubmit(test.name, test.url)">
+        <BDropdownItem v-for="ud of urlData" :key="ud.url" @click="() => onSubmit(ud.name, ud.url)">
             <span>
                 <FontAwesomeIcon :icon="faFileUpload" />
-                <span v-localize>{{ test.name }}</span>
+                <span v-localize>{{ ud.name }}</span>
             </span>
         </BDropdownItem>
     </BDropdown>

--- a/client/src/components/Visualizations/VisualizationExamples.vue
+++ b/client/src/components/Visualizations/VisualizationExamples.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faFileUpload, faSpinner, faUpload } from "@fortawesome/free-solid-svg-icons";
+import { faFileUpload, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BDropdown, BDropdownItem, BDropdownText } from "bootstrap-vue";
 import { storeToRefs } from "pinia";

--- a/client/src/components/Visualizations/VisualizationExamples.vue
+++ b/client/src/components/Visualizations/VisualizationExamples.vue
@@ -14,7 +14,6 @@ const { currentHistoryId } = storeToRefs(useHistoryStore());
 const toast = useToast();
 
 interface UrlDataType {
-    extension: string;
     name: string;
     url: string;
 }

--- a/client/src/components/Visualizations/VisualizationExamples.vue
+++ b/client/src/components/Visualizations/VisualizationExamples.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faCaretDown, faSpinner, faUpload } from "@fortawesome/free-solid-svg-icons";
+import { faFileUpload, faSpinner, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BDropdown, BDropdownItem, BDropdownText } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
@@ -42,19 +42,19 @@ function onSubmit(name: string, url: string) {
         no-caret
         right
         role="button"
-        title="Options"
+        title="Upload Examples"
         variant="link"
-        aria-label="Select Options"
+        aria-label="Upload Examples"
         size="sm">
         <template v-slot:button-content>
-            <FontAwesomeIcon :icon="faCaretDown" />
+            <FontAwesomeIcon :icon="faFileUpload" />
         </template>
         <BDropdownText>
-            <small class="font-weight-bold text-primary text-uppercase">Upload Sample</small>
+            <small class="text-primary text-uppercase">Upload Examples</small>
         </BDropdownText>
         <BDropdownItem v-for="test of tests" :key="test.url" @click="() => onSubmit(test.name, test.url)">
             <span>
-                <FontAwesomeIcon :icon="faUpload" />
+                <FontAwesomeIcon :icon="faFileUpload" />
                 <span v-localize>{{ test.name }}</span>
             </span>
         </BDropdownItem>

--- a/client/src/components/Visualizations/utilities.test.js
+++ b/client/src/components/Visualizations/utilities.test.js
@@ -1,0 +1,69 @@
+import { getFilename, getTestUrls } from "./utilities";
+
+describe("Utility Functions", () => {
+    describe("getTestUrls", () => {
+        it("returns empty array when plugin is undefined", () => {
+            expect(getTestUrls()).toEqual([]);
+        });
+
+        it("returns empty array when plugin has no tests", () => {
+            const plugin = {};
+            expect(getTestUrls(plugin)).toEqual([]);
+        });
+
+        it("returns empty array when no valid dataset_id params", () => {
+            const plugin = {
+                tests: [{ param: { name: "other_param", value: "http://example.com/file.csv" } }, { param: null }],
+            };
+            expect(getTestUrls(plugin)).toEqual([]);
+        });
+
+        it("returns valid test URLs with extracted filename", () => {
+            const plugin = {
+                tests: [
+                    { param: { name: "dataset_id", value: "http://example.com/data/test1.csv" } },
+                    { param: { name: "dataset_id", value: "http://example.com/data/test2.json" } },
+                    { param: { name: "other_param", value: "http://example.com/ignore.me" } },
+                ],
+            };
+            expect(getTestUrls(plugin)).toEqual([
+                { name: "test1.csv", url: "http://example.com/data/test1.csv" },
+                { name: "test2.json", url: "http://example.com/data/test2.json" },
+            ]);
+        });
+
+        it("handles invalid URLs gracefully", () => {
+            const plugin = {
+                tests: [{ param: { name: "dataset_id", value: "not-a-url" } }],
+            };
+            expect(getTestUrls(plugin)).toEqual([]);
+        });
+
+        it("handles URLs with multiple dots in filename", () => {
+            const plugin = {
+                tests: [{ param: { name: "dataset_id", value: "http://example.com/data/archive.tar.gz" } }],
+            };
+            expect(getTestUrls(plugin)).toEqual([
+                { name: "archive.tar.gz", url: "http://example.com/data/archive.tar.gz" },
+            ]);
+        });
+    });
+
+    describe("getFilename", () => {
+        it("extracts filename from valid URL", () => {
+            expect(getFilename("http://example.com/path/to/file.txt")).toBe("file.txt");
+        });
+
+        it("returns empty string for invalid URL", () => {
+            expect(getFilename("not-a-url")).toBe("");
+        });
+
+        it("handles URLs without path", () => {
+            expect(getFilename("http://example.com")).toBe("");
+        });
+
+        it("handles URLs with trailing slash", () => {
+            expect(getFilename("http://example.com/path/")).toBe("path");
+        });
+    });
+});

--- a/client/src/components/Visualizations/utilities.ts
+++ b/client/src/components/Visualizations/utilities.ts
@@ -19,9 +19,8 @@ export function getTestUrls(plugin?: Plugin) {
         plugin?.tests?.flatMap((item) => {
             const url = item.param?.name === "dataset_id" ? item.param?.value : "";
             const name = getFilename(url).trim();
-            const extension = getExtension(name);
-            if (url && name && extension) {
-                return [{ name, extension, url }];
+            if (url && name) {
+                return [{ name, url }];
             } else {
                 return [];
             }
@@ -29,16 +28,11 @@ export function getTestUrls(plugin?: Plugin) {
     );
 }
 
-function getFilename(url: string): string {
+export function getFilename(url: string): string {
     try {
         const { pathname } = new URL(url);
         return pathname.split("/").filter(Boolean).pop() ?? "";
     } catch {
         return "";
     }
-}
-
-function getExtension(filename: string): string {
-    const dot = filename.lastIndexOf(".");
-    return dot >= 0 ? filename.slice(dot + 1).toLowerCase() : "";
 }

--- a/lib/galaxy/visualization/plugins/datasource_testing.py
+++ b/lib/galaxy/visualization/plugins/datasource_testing.py
@@ -128,8 +128,7 @@ def is_object_applicable(trans, target_object, data_source_tests):
                     #              ' for applicability test on: %s, id: %s', datatype_class_name,
                     #              target_object, getattr( target_object, 'id', '' ) )
                     continue
-        # moving forward all tests should be explicitly handled here instead of collecting test functions in the config_parser
-        elif test_attr == "ext":
+        elif test_attr == "ext" and test_type == "eq":
             test_result = trans.app.datatypes_registry.get_datatype_by_extension(test_result)
             if isinstance(target_object.datatype, type(test_result)) and _check_uri_support(
                 target_object, supported_protocols


### PR DESCRIPTION
Follow-up on suggestions made in #20046. Revises the example datasets dropdown in the visualizations creation form:

<img src="https://github.com/user-attachments/assets/41b6d087-056f-4c02-a18e-6265271f6dba" width=400 />

Additionally, this PR adds more tests.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
