### PR TITLE
[WIP] (ARC Integration) Migrate `JobFilesAPIController` to FastAPI and support PUT requests

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -242,6 +242,9 @@ class GalaxyASGIRequest(GalaxyAbstractRequest):
     def base(self) -> str:
         return str(self.__request.base_url)
 
+    def stream(self) -> AsyncGenerator:
+        return self.__request.stream()
+
     @property
     def url_path(self) -> str:
         scope = self.__request.scope

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -266,6 +266,10 @@ class GalaxyASGIRequest(GalaxyAbstractRequest):
         return self.__environ
 
     @property
+    def method(self):
+        return self.__request.method
+
+    @property
     def headers(self):
         return self.__request.headers
 

--- a/lib/galaxy/webapps/galaxy/api/job_files.py
+++ b/lib/galaxy/webapps/galaxy/api/job_files.py
@@ -15,7 +15,6 @@ from fastapi import (
     HTTPException,
     Path,
     Query,
-    Response,
     UploadFile,
 )
 from typing_extensions import Annotated
@@ -216,7 +215,10 @@ class FastAPIJobFiles:
         "/api/job_files/resumable_upload/{session_id}",
         summary="Upload job files using the TUS protocol.",
         responses={
-            200: {"description": "Default response, since this endpoint is not implemented yet."},
+            # 200: None,
+            # Galaxy adds an HTTP 200 response to the API docs. Even though it should be removed for this endpoint,
+            # because it simply can never happen, there is no mechanism to remove it (the above won't work).
+            501: {"description": "Default response, since this endpoint is not implemented yet."},
         },
     )
     def tus_patch(
@@ -251,13 +253,16 @@ class FastAPIJobFiles:
         and the user facing upload endpoints.
         """
         ...
-        return Response(status_code=200)
+        raise HTTPException(status_code=501, detail="Not implemented yet.")
 
     @router.post(
         "/api/job_files/resumable_upload",
         summary="Upload job files using the TUS protocol.",
         responses={
-            200: {"description": "Default response, since this endpoint is not implemented yet."},
+            # 200: None,
+            # Galaxy adds an HTTP 200 response to the API docs. Even though it should be removed for this endpoint,
+            # because it simply can never happen, there is no mechanism to remove it (the above won't work).
+            501: {"description": "Default response, since this endpoint is not implemented yet."},
         },
     )
     def tus_post(self, trans: ProvidesAppContext = DependsOnTrans):
@@ -266,13 +271,16 @@ class FastAPIJobFiles:
         used. Probably it isn't needed there, but I am keeping the doc here until we remove both routes.
         """
         ...
-        return Response(status_code=200)
+        raise HTTPException(status_code=501, detail="Not implemented yet.")
 
     @router.post(
         "/api/job_files/tus_hooks",
         summary="No-op but if hook specified the way we do for user upload it would hit this action.",
         responses={
-            200: {"description": "Default response, since this endpoint is not implemented yet."},
+            # 200: None,
+            # Galaxy adds an HTTP 200 response to the API docs. Even though it should be removed for this endpoint,
+            # because it simply can never happen, there is no mechanism to remove it (the above won't work).
+            501: {"description": "Default response, since this endpoint is not implemented yet."},
         },
     )
     def tus_hooks(
@@ -283,7 +291,7 @@ class FastAPIJobFiles:
         No-op but if hook specified the way we do for user upload it would hit this action.
         """
         ...
-        return Response(status_code=200)
+        raise HTTPException(status_code=501, detail="Not implemented yet.")
 
     def __authorize_job_access(self, trans, encoded_job_id, path, job_key):
         job_id = trans.security.decode_id(encoded_job_id)

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -355,19 +355,6 @@ def populate_api_routes(webapp, app):
     webapp.mapper.connect("/api/upload/resumable_upload", controller="uploads", action="hooks")
     webapp.mapper.connect("/api/upload/hooks", controller="uploads", action="hooks", conditions=dict(method=["POST"]))
 
-    webapp.mapper.connect(
-        "/api/job_files/resumable_upload/{session_id}",
-        controller="job_files",
-        action="tus_patch",
-        conditions=dict(method=["PATCH"]),
-    )
-    # user facing upload has this endpoint enabled but the middleware completely masks it and the controller
-    # is not used. Probably it isn't needed there but I am keeping the doc here until we remove both
-    # routes.
-    # webapp.mapper.connect("/api/job_files/resumable_upload", controller="job_files", action="tus_post")
-    webapp.mapper.connect(
-        "/api/job_files/tus_hooks", controller="job_files", action="tus_hooks", conditions=dict(method=["POST"])
-    )
 
     webapp.mapper.resource(
         "revision",
@@ -860,24 +847,6 @@ def populate_api_routes(webapp, app):
         controller="jobs",
         action="build_for_rerun",
         conditions=dict(method=["GET"]),
-    )
-
-    # Job files controllers. Only for consumption by remote job runners.
-    webapp.mapper.resource(
-        "file",
-        "files",
-        controller="job_files",
-        name_prefix="job_",
-        path_prefix="/api/jobs/{job_id}",
-        parent_resources=dict(member_name="job", collection_name="jobs"),
-    )
-
-    webapp.mapper.connect(
-        "index",
-        "/api/jobs/{job_id}/files",
-        controller="job_files",
-        action="index",
-        conditions=dict(method=["HEAD"]),
     )
 
     webapp.mapper.resource(


### PR DESCRIPTION
As part of the development of an integration of Galaxy with [ARC (Advanced Resource Connector)](https://www.nordugrid.org/arc/arc7/index.html) as a Pulsar job runner, tweaks to the `JobFilesAPIController` are needed. I am opening this PR mainly as a request for feedback so that actual plans can be made (it will never be marked as ready for review but rather closed directly after discussion and possibly split into several PRs).

The commits that are part of this PR, together with their motivation are listed below:
- https://github.com/galaxyproject/galaxy/commit/84eee65cbb3a5c0016e9521dfb5e2d9daaaefaa2 migrates `JobFilesAPIController` to FastAPI. ARC expects `/api/jobs/{job_id}/files` to answer PROPFIND (a special request method for the WebDAV protocol) requests with something different than 404, as well as HEAD requests. FastAPI has these extra built-in features (free lunch!) that the legacy WSGI system does not have; it answers `HEAD` requests and returns HTTP status code 405 when unsupported request methods are used. However, these features do not work out of the box because of the way legacy WSGI endpoints are injected into the FastAPI app (using `app.mount("/", wsgi_handler)`), meaning that such requests are passed to the `wsgi_handler` sub-application. Nevertheless, when the legacy system is removed, FastAPI will just do what ARC expects without having to add any extra code. ARC's behavior here is not arbitrary, imo it just makes sense if you check the HTTP RFC.
- https://github.com/galaxyproject/galaxy/commit/ac10a1a8e3f77bf7538be38274b68810ee29680f makes TUS endpoints return HTTP 501 (not implemented), since they are dummy endpoints that are indeed not implemented. No practical use, precisely because nothing is using those endpoints, but since I am making changes, why not?
- https://github.com/galaxyproject/galaxy/commit/be82f98558344cc2c89bc80a4ba31cd2f0246477 mainly adds code to answer HEAD and PROPFIND requests, again the reason behind this code explicitly supporting said request methods is the behavior of legacy API endpoints and how they are integrated within the FastAPI app. Once the legacy endpoints go away, most of this commit can go away. There are still some improvements that should remain though (several 400 and 404 answers previously answered with 5xx errors).
- https://github.com/galaxyproject/galaxy/commit/789a1f2f8d1acd381dbbcfc48a64c64299d9f411 adds support for PUT requests, this is how ARC stages files out. Asking it to POST is somewhat unreasonable, since then it would also have to handle sending the multipart request (specially because the path of the target file and the job key come as part of the body), but currently it just PUTs something to a given URL.

Because I tried to keep the behavior of the existing endpoints intact, or at least attempted to create the least possible fallout, the end result is quite messy. That's why I am asking for feedback, because maybe some features can be dropped out so that the whole thing can be made simpler, or maybe you think things should be designed differently.