### PR TITLE
Bug fix - do not map over tool parameters that can be directly matched.

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -598,6 +598,8 @@ class WorkflowModule:
                     effective_input_collection_type,
                     dataset_collection_type_descriptions,
                 )
+                if history_query.direct_match(data):
+                    continue
                 subcollection_type_description = history_query.can_map_over(data) or None
                 if subcollection_type_description:
                     subcollection_type_list = subcollection_type_description.collection_type.split(":")

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -586,7 +586,8 @@ class WorkflowModule:
                         elif input_dict.get("collection_type"):
                             effective_input_collection_type = [input_dict.get("collection_type")]
                 type_list = []
-                if progress.subworkflow_structure:
+                subworkflow_structure = progress.subworkflow_structure
+                if subworkflow_structure:
                     # If we have progress.subworkflow_structure were mapping a subworkflow invocation over a higher-dimension input
                     # e.g an outer list:list over an inner list. Whatever we do, the inner workflow cannot reduce the outer list.
                     # This is what we're setting up here.
@@ -598,7 +599,7 @@ class WorkflowModule:
                     effective_input_collection_type,
                     dataset_collection_type_descriptions,
                 )
-                if history_query.direct_match(data):
+                if not subworkflow_structure and history_query.direct_match(data):
                     continue
                 subcollection_type_description = history_query.can_map_over(data) or None
                 if subcollection_type_description:

--- a/lib/galaxy_test/workflow/subcollection_rank_sorting.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/subcollection_rank_sorting.gxwf-tests.yml
@@ -1,0 +1,10 @@
+- doc: | 
+    Test to verify a tool that takes in a list or nested list is sent the most
+    specific list possible during workflow execution (the nested list). This should
+    not trigger subcollection mapping.
+  job: {}
+  outputs:
+    out:
+      asserts:
+      - that: has_text
+        text: "Nested List"

--- a/lib/galaxy_test/workflow/subcollection_rank_sorting.gxwf.yml
+++ b/lib/galaxy_test/workflow/subcollection_rank_sorting.gxwf.yml
@@ -1,0 +1,12 @@
+class: GalaxyWorkflow
+inputs: {}
+outputs:
+  out:
+    outputSource: list_handling/out1
+steps:
+  create_list:
+    tool_id: collection_creates_dynamic_nested
+  list_handling:
+    tool_id: collection_list_or_nested_list_input
+    in:
+      f1: create_list/list_output

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -409,7 +409,7 @@ do
           framework_test=1
           shift 1
           ;;
-      -w|--framework-workflows)
+      -w|-framework-workflows|--framework-workflows)
           marker="workflow"
           report_file="run_framework_workflows_tests.html"
           framework_workflows_test=1

--- a/test/functional/tools/collection_list_or_nested_list_input.xml
+++ b/test/functional/tools/collection_list_or_nested_list_input.xml
@@ -1,0 +1,22 @@
+<tool id="collection_list_or_nested_list_input" name="collection_list_or_nested_list_input" version="0.1.0">
+  <command><![CDATA[
+    #for $key in $f1.keys()#
+      echo "identifier is $key" >> "$out1";
+      #set $element = $f1[$key]
+
+    #if $element.is_collection:
+        echo "Nested List" >> "$out1";
+    #else
+        echo "Simple Dataset" >> "$out1";
+    #end if
+    #end for#
+  ]]></command>
+  <inputs>
+    <param name="f1" type="data_collection" collection_type="list,list:list" label="Input list" />
+  </inputs>
+  <outputs>
+    <data format="txt" name="out1" />
+  </outputs>
+  <tests>
+  </tests>
+</tool>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -210,6 +210,7 @@
   <tool file="collection_type_source_map_over.xml" />
   <tool file="collection_creates_list_fail.xml" />
   <tool file="collection_creates_dynamic_nested_fail.xml" />
+  <tool file="collection_list_or_nested_list_input.xml" />
   <tool file="collection_cat_group_tag.xml" />
   <tool file="collection_cat_group_tag_multiple.xml" />
   <tool file="discover_sort_by.xml" />


### PR DESCRIPTION
Discovered while working through failing tests for paired/unpaired work. We map over parameters that would directly match - which is a scary, deep bug in workflow/collection logic. I think luckily though we don't use a lot of mixed collection type parameters and even when we do we generally don't mix rank like this (a parameter that can take in a list or a nested list). So hopefully this bug has never hit a production workflow and hopefully people do not depend on the broken behavior.

The new list:paired_or_unpaired collection type parameters operate as two ranks at once (it can consume a list or a list:paired) so this bug caused some really subtle issues downstream.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
