### PR TITLE
Enhance external login interface styling

### DIFF
--- a/client/src/components/Common/VerticalSeparator.vue
+++ b/client/src/components/Common/VerticalSeparator.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts"></script>
+
+<template>
+    <div class="vr-container mx-3">
+        <div class="vr" />
+        <span class="vr-text">
+            <slot />
+        </span>
+    </div>
+</template>
+
+<style scoped lang="scss">
+@import "theme/blue.scss";
+
+.vr-container {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1px;
+}
+
+.vr {
+    width: 1px;
+    height: 100%;
+    background-color: $brand-secondary;
+}
+
+.vr-text {
+    position: absolute;
+    background-color: $body-bg;
+}
+</style>

--- a/client/src/components/Login/LoginForm.vue
+++ b/client/src/components/Login/LoginForm.vue
@@ -20,6 +20,7 @@ import localize from "@/utils/localization";
 import { withPrefix } from "@/utils/redirect";
 import { errorMessageAsString } from "@/utils/simple-error";
 
+import VerticalSeparator from "../Common/VerticalSeparator.vue";
 import NewUserConfirmation from "@/components/Login/NewUserConfirmation.vue";
 import ExternalLogin from "@/components/User/ExternalIdentities/ExternalLogin.vue";
 
@@ -148,7 +149,7 @@ function returnToLogin() {
     <div class="container">
         <div class="row justify-content-md-center">
             <template v-if="!confirmURL">
-                <div class="col col-lg-6">
+                <div>
                     <BAlert :show="!!messageText" :variant="messageVariant">
                         <!-- eslint-disable-next-line vue/no-v-html -->
                         <span v-html="messageText" />
@@ -161,12 +162,12 @@ function returnToLogin() {
                     </BAlert>
 
                     <BForm id="login" @submit.prevent="submitLogin()">
-                        <BCard no-body>
+                        <BCard no-body style="width: fit-content">
                             <BCardHeader v-if="!connectExternalProvider">
                                 <span>{{ localize("Welcome to Galaxy, please log in") }}</span>
                             </BCardHeader>
 
-                            <BCardBody>
+                            <BCardBody class="d-flex">
                                 <div>
                                     <!-- standard internal galaxy login -->
                                     <BFormGroup
@@ -198,7 +199,7 @@ function returnToLogin() {
                                             type="password"
                                             autocomplete="current-password" />
 
-                                        <BFormText v-if="showResetLink">
+                                        <BFormText v-if="showResetLink" class="text-nowrap">
                                             <span v-localize>Forgot password?</span>
 
                                             <a
@@ -211,11 +212,21 @@ function returnToLogin() {
                                         </BFormText>
                                     </BFormGroup>
 
-                                    <BButton v-localize name="login" type="submit" :disabled="loading">
+                                    <BButton
+                                        v-localize
+                                        name="login"
+                                        type="submit"
+                                        :disabled="loading"
+                                        class="w-100 mt-1">
                                         {{ localize("Login") }}
                                     </BButton>
                                 </div>
-                                <div v-if="enableOidc">
+
+                                <VerticalSeparator v-if="enableOidc">
+                                    <span v-localize>or</span>
+                                </VerticalSeparator>
+
+                                <div v-if="enableOidc" class="m-1">
                                     <!-- OIDC login-->
                                     <ExternalLogin login-page :exclude-idps="excludeIdps" />
                                 </div>

--- a/client/src/components/Login/LoginForm.vue
+++ b/client/src/components/Login/LoginForm.vue
@@ -66,6 +66,11 @@ const confirmURL = ref(urlParams.has("confirm") && urlParams.get("confirm") == "
 
 const excludeIdps = computed(() => (connectExternalProvider.value ? [connectExternalProvider.value] : undefined));
 
+/** This decides if all login options should be displayed in column style
+ * (one below the other) or horizontally.
+ */
+const loginColumnDisplay = computed(() => Boolean(props.showWelcomeWithLogin && props.welcomeUrl));
+
 function toggleLogin() {
     emit("toggle-login");
 }
@@ -146,8 +151,8 @@ function returnToLogin() {
 </script>
 
 <template>
-    <div class="container">
-        <div class="row justify-content-md-center">
+    <div class="login-form">
+        <div class="d-flex justify-content-md-center">
             <template v-if="!confirmURL">
                 <div>
                     <BAlert :show="!!messageText" :variant="messageVariant">
@@ -167,7 +172,7 @@ function returnToLogin() {
                                 <span>{{ localize("Welcome to Galaxy, please log in") }}</span>
                             </BCardHeader>
 
-                            <BCardBody class="d-flex">
+                            <BCardBody :class="{ 'd-flex w-100': !loginColumnDisplay }">
                                 <div>
                                     <!-- standard internal galaxy login -->
                                     <BFormGroup
@@ -222,14 +227,21 @@ function returnToLogin() {
                                     </BButton>
                                 </div>
 
-                                <VerticalSeparator v-if="enableOidc">
-                                    <span v-localize>or</span>
-                                </VerticalSeparator>
+                                <template v-if="enableOidc">
+                                    <VerticalSeparator v-if="!loginColumnDisplay">
+                                        <span v-localize>or</span>
+                                    </VerticalSeparator>
 
-                                <div v-if="enableOidc" class="m-1">
-                                    <!-- OIDC login-->
-                                    <ExternalLogin login-page :exclude-idps="excludeIdps" />
-                                </div>
+                                    <hr v-else class="w-100" />
+
+                                    <div class="m-1 w-100">
+                                        <!-- OIDC login-->
+                                        <ExternalLogin
+                                            login-page
+                                            :exclude-idps="excludeIdps"
+                                            :column-display="loginColumnDisplay" />
+                                    </div>
+                                </template>
                             </BCardBody>
 
                             <BCardFooter>
@@ -268,7 +280,7 @@ function returnToLogin() {
                     @setRedirect="setRedirect" />
             </template>
 
-            <div v-if="showWelcomeWithLogin && props.welcomeUrl" class="col">
+            <div v-if="showWelcomeWithLogin && props.welcomeUrl" class="w-100">
                 <BEmbed type="iframe" :src="withPrefix(props.welcomeUrl)" aspect="1by1" />
             </div>
         </div>
@@ -278,5 +290,8 @@ function returnToLogin() {
 <style scoped lang="scss">
 .card-body {
     overflow: visible;
+}
+.login-form {
+    margin: 0rem 10rem;
 }
 </style>

--- a/client/src/components/Login/RegisterForm.vue
+++ b/client/src/components/Login/RegisterForm.vue
@@ -112,7 +112,7 @@ async function submit() {
                                 <BCardBody>
                                     Create a Galaxy account using an institutional account (e.g.:Google/JHU). This will
                                     redirect you to your institutional login through Custos.
-                                    <ExternalLogin />
+                                    <ExternalLogin class="mt-2" />
                                 </BCardBody>
                             </BCollapse>
                         </span>

--- a/client/src/components/User/ExternalIdentities/ExternalIdentities.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalIdentities.vue
@@ -86,6 +86,7 @@
 
         <div v-if="enable_oidc" class="external-subheading">
             <h2 class="h-md">Connect Other External Identities</h2>
+            <hr class="my-4" />
             <ExternalLogin />
         </div>
     </section>

--- a/client/src/components/User/ExternalIdentities/ExternalLogin.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalLogin.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import axios, { type AxiosError } from "axios";
-import { BAlert, BButton, BForm, BFormCheckbox, BFormGroup } from "bootstrap-vue";
+import { BAlert, BButton, BButtonGroup, BForm, BFormCheckbox, BFormGroup } from "bootstrap-vue";
 import { computed, onMounted, ref } from "vue";
 import Multiselect from "vue-multiselect";
 
@@ -45,7 +45,7 @@ const messageVariant = ref<string | null>(null);
 const cILogonIdps = ref<Idp[]>([]);
 const selected = ref<Idp | null>(null);
 const rememberIdp = ref(false);
-const cilogonOrCustos = ref<string | null>(null);
+const cilogonOrCustos = ref<"cilogon" | "custos" | null>(null);
 const toggleCilogon = ref(false);
 
 const oIDCIdps = computed<OIDCConfig>(() => (isConfigLoaded.value ? config.value.oidc : {}));
@@ -77,8 +77,10 @@ onMounted(async () => {
     }
 });
 
-function toggleCILogon(idp: string) {
-    toggleCilogon.value = !toggleCilogon.value;
+function toggleCILogon(idp: "cilogon" | "custos") {
+    if (cilogonOrCustos.value === idp || cilogonOrCustos.value === null) {
+        toggleCilogon.value = !toggleCilogon.value;
+    }
     cilogonOrCustos.value = toggleCilogon.value ? idp : null;
 }
 
@@ -227,13 +229,23 @@ function getIdpPreference() {
                 </div>
 
                 <div v-else>
-                    <BButton v-if="cILogonEnabled" @click="toggleCILogon('cilogon')">
-                        Sign in with Institutional Credentials*
-                    </BButton>
+                    <BButtonGroup class="w-100">
+                        <BButton
+                            v-if="cILogonEnabled"
+                            :pressed="cilogonOrCustos === 'cilogon'"
+                            @click="toggleCILogon('cilogon')">
+                            Sign in with Institutional Credentials*
+                        </BButton>
 
-                    <BButton v-if="custosEnabled" @click="toggleCILogon('custos')">Sign in with Custos*</BButton>
+                        <BButton
+                            v-if="custosEnabled"
+                            :pressed="cilogonOrCustos === 'custos'"
+                            @click="toggleCILogon('custos')">
+                            Sign in with Custos*
+                        </BButton>
+                    </BButtonGroup>
 
-                    <BFormGroup v-if="toggleCilogon">
+                    <BFormGroup v-if="toggleCilogon" class="mt-1">
                         <Multiselect
                             v-model="selected"
                             placeholder="Select your institution"
@@ -246,9 +258,10 @@ function getIdpPreference() {
 
                         <BButton
                             v-if="toggleCilogon"
+                            class="mt-1"
                             :disabled="loading || selected === null"
                             @click="submitCILogon(cilogonOrCustos)">
-                            Login*
+                            Login via {{ cilogonOrCustos === "cilogon" ? "CILogon" : "Custos" }} *
                         </BButton>
                     </BFormGroup>
                 </div>

--- a/client/src/components/User/ExternalIdentities/ExternalLogin.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalLogin.vue
@@ -30,11 +30,13 @@ type OIDCConfig = Record<
 interface Props {
     loginPage?: boolean;
     excludeIdps?: string[];
+    columnDisplay?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
     loginPage: false,
     excludeIdps: () => [],
+    columnDisplay: true,
 });
 
 const { config, isConfigLoaded } = useConfig();
@@ -188,7 +190,7 @@ function getIdpPreference() {
             {{ messageText }}
         </BAlert>
 
-        <BForm id="externalLogin" :class="{ 'h-100': !messageText, 'd-flex': loginPage }">
+        <BForm id="externalLogin" :class="{ 'h-100': !messageText, 'd-flex': !props.columnDisplay }">
             <!-- OIDC login-->
             <div v-if="cilogonListShow" class="cilogon">
                 <div v-if="props.loginPage">
@@ -276,57 +278,48 @@ function getIdpPreference() {
                 </p>
             </div>
 
-            <VerticalSeparator v-if="loginPage && cilogonListShow && Object.keys(filteredOIDCIdps).length > 0">
-                <span v-localize>or</span>
-            </VerticalSeparator>
+            <template v-if="cilogonListShow && Object.keys(filteredOIDCIdps).length > 0">
+                <VerticalSeparator v-if="!props.columnDisplay">
+                    <span v-localize>or</span>
+                </VerticalSeparator>
 
-            <span
-                v-if="isConfigLoaded"
-                class="d-flex flex-column h-100"
-                :class="loginPage && !messageText ? 'justify-content-center' : ''"
-                style="row-gap: 1rem">
+                <hr v-else class="w-100" />
+            </template>
+
+            <span v-if="isConfigLoaded" class="oidc-idps-grid">
                 <div v-for="(iDPInfo, idp) in filteredOIDCIdps" :key="idp">
-                    <span v-if="iDPInfo['icon']">
-                        <BButton
-                            variant="link"
-                            class="d-block p-0 text-decoration-none"
-                            :class="loginPage && !messageText ? 'w-100' : ''"
-                            :disabled="loading"
-                            @click="submitOIDCLogin(idp)">
-                            <img
-                                :src="iDPInfo['icon']"
-                                height="35"
-                                :alt="`Sign in with ${capitalizeFirstLetter(idp)}`" />
-                        </BButton>
-                    </span>
-                    <span v-else-if="iDPInfo['custom_button_text']">
-                        <BButton
-                            variant="outline-primary"
-                            class="d-block"
-                            :class="loginPage && !messageText ? 'w-100' : ''"
-                            :disabled="loading"
-                            @click="submitOIDCLogin(idp)">
-                            <i :class="oIDCIdps[idp]" />
-                            Sign in with {{ iDPInfo["custom_button_text"] }}
-                        </BButton>
-                    </span>
-                    <span v-else>
-                        <BButton
-                            variant="outline-primary"
-                            class="d-block"
-                            :class="loginPage && !messageText ? 'w-100' : ''"
-                            :disabled="loading"
-                            @click="submitOIDCLogin(idp)">
-                            <i :class="oIDCIdps[idp]" />
-                            Sign in with
-                            <span v-if="iDPInfo['label']">
-                                {{ iDPInfo["label"].charAt(0).toUpperCase() + iDPInfo["label"].slice(1) }}
-                            </span>
-                            <span v-else>
-                                {{ capitalizeFirstLetter(idp) }}
-                            </span>
-                        </BButton>
-                    </span>
+                    <BButton
+                        v-if="iDPInfo['icon']"
+                        variant="link"
+                        class="d-block p-0 text-decoration-none"
+                        :disabled="loading"
+                        @click="submitOIDCLogin(idp)">
+                        <img :src="iDPInfo['icon']" height="35" :alt="`Sign in with ${capitalizeFirstLetter(idp)}`" />
+                    </BButton>
+                    <BButton
+                        v-else-if="iDPInfo['custom_button_text']"
+                        variant="outline-primary"
+                        class="d-block"
+                        :disabled="loading"
+                        @click="submitOIDCLogin(idp)">
+                        <i :class="oIDCIdps[idp]" />
+                        Sign in with {{ iDPInfo["custom_button_text"] }}
+                    </BButton>
+                    <BButton
+                        v-else
+                        variant="outline-primary"
+                        class="d-block"
+                        :disabled="loading"
+                        @click="submitOIDCLogin(idp)">
+                        <i :class="oIDCIdps[idp]" />
+                        Sign in with
+                        <span v-if="iDPInfo['label']">
+                            {{ iDPInfo["label"].charAt(0).toUpperCase() + iDPInfo["label"].slice(1) }}
+                        </span>
+                        <span v-else>
+                            {{ capitalizeFirstLetter(idp) }}
+                        </span>
+                    </BButton>
                 </div>
             </span>
         </BForm>
@@ -336,5 +329,13 @@ function getIdpPreference() {
 <style scoped>
 .card-body {
     overflow: visible;
+}
+.oidc-idps-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 0.5rem;
+    width: 100%;
+    height: 100%;
+    justify-items: center;
 }
 </style>

--- a/client/src/components/User/ExternalIdentities/ExternalLogin.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalLogin.vue
@@ -190,7 +190,7 @@ function getIdpPreference() {
             {{ messageText }}
         </BAlert>
 
-        <BForm id="externalLogin" :class="{ 'h-100': !messageText, 'd-flex': !props.columnDisplay }">
+        <BForm id="externalLogin" :class="{ 'd-flex h-100': !props.columnDisplay }">
             <!-- OIDC login-->
             <div v-if="cilogonListShow" class="cilogon">
                 <div v-if="props.loginPage">
@@ -286,12 +286,14 @@ function getIdpPreference() {
                 <hr v-else class="w-100" />
             </template>
 
-            <span v-if="isConfigLoaded" class="oidc-idps-grid">
+            <span
+                v-if="isConfigLoaded"
+                :class="!props.columnDisplay && props.loginPage ? 'oidc-idps-column' : 'oidc-idps-grid'">
                 <div v-for="(iDPInfo, idp) in filteredOIDCIdps" :key="idp">
                     <BButton
                         v-if="iDPInfo['icon']"
                         variant="link"
-                        class="d-block p-0 text-decoration-none"
+                        class="d-block oidc-button p-0 text-decoration-none"
                         :disabled="loading"
                         @click="submitOIDCLogin(idp)">
                         <img :src="iDPInfo['icon']" height="35" :alt="`Sign in with ${capitalizeFirstLetter(idp)}`" />
@@ -299,7 +301,7 @@ function getIdpPreference() {
                     <BButton
                         v-else-if="iDPInfo['custom_button_text']"
                         variant="outline-primary"
-                        class="d-block"
+                        class="d-block oidc-button"
                         :disabled="loading"
                         @click="submitOIDCLogin(idp)">
                         <i :class="oIDCIdps[idp]" />
@@ -308,7 +310,7 @@ function getIdpPreference() {
                     <BButton
                         v-else
                         variant="outline-primary"
-                        class="d-block"
+                        class="d-block oidc-button"
                         :disabled="loading"
                         @click="submitOIDCLogin(idp)">
                         <i :class="oIDCIdps[idp]" />
@@ -330,6 +332,18 @@ function getIdpPreference() {
 .card-body {
     overflow: visible;
 }
+/* Enforce idps to appear in a column */
+.oidc-idps-column {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    height: 100%;
+    justify-items: center;
+    .oidc-button {
+        width: 100%;
+    }
+}
+/* Flexible grid for idps */
 .oidc-idps-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));

--- a/client/src/components/User/ExternalIdentities/ExternalLogin.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalLogin.vue
@@ -9,6 +9,7 @@ import { withPrefix } from "@/utils/redirect";
 import { errorMessageAsString } from "@/utils/simple-error";
 import { capitalizeFirstLetter } from "@/utils/strings";
 
+import VerticalSeparator from "@/components/Common/VerticalSeparator.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 interface Idp {
@@ -180,15 +181,13 @@ function getIdpPreference() {
 </script>
 
 <template>
-    <div>
-        <BAlert :show="messageText" :variant="messageVariant">
+    <div class="h-100">
+        <BAlert v-if="messageText" class="text-nowrap" show :variant="messageVariant">
             {{ messageText }}
         </BAlert>
 
-        <BForm id="externalLogin">
+        <BForm id="externalLogin" :class="{ 'h-100': !messageText, 'd-flex': loginPage }">
             <!-- OIDC login-->
-            <hr class="my-4" />
-
             <div v-if="cilogonListShow" class="cilogon">
                 <div v-if="props.loginPage">
                     <!--Only Display if CILogon/Custos is configured-->
@@ -264,21 +263,47 @@ function getIdpPreference() {
                 </p>
             </div>
 
-            <span v-if="isConfigLoaded">
-                <div v-for="(iDPInfo, idp) in filteredOIDCIdps" :key="idp" class="m-1">
+            <VerticalSeparator v-if="loginPage && cilogonListShow && Object.keys(filteredOIDCIdps).length > 0">
+                <span v-localize>or</span>
+            </VerticalSeparator>
+
+            <span
+                v-if="isConfigLoaded"
+                class="d-flex flex-column h-100"
+                :class="loginPage && !messageText ? 'justify-content-center' : ''"
+                style="row-gap: 1rem">
+                <div v-for="(iDPInfo, idp) in filteredOIDCIdps" :key="idp">
                     <span v-if="iDPInfo['icon']">
-                        <BButton variant="link" class="d-block mt-3" @click="submitOIDCLogin(idp)">
-                            <img :src="iDPInfo['icon']" height="45" :alt="idp" />
+                        <BButton
+                            variant="link"
+                            class="d-block p-0 text-decoration-none"
+                            :class="loginPage && !messageText ? 'w-100' : ''"
+                            :disabled="loading"
+                            @click="submitOIDCLogin(idp)">
+                            <img
+                                :src="iDPInfo['icon']"
+                                height="35"
+                                :alt="`Sign in with ${capitalizeFirstLetter(idp)}`" />
                         </BButton>
                     </span>
                     <span v-else-if="iDPInfo['custom_button_text']">
-                        <BButton class="d-block mt-3" @click="submitOIDCLogin(idp)">
+                        <BButton
+                            variant="outline-primary"
+                            class="d-block"
+                            :class="loginPage && !messageText ? 'w-100' : ''"
+                            :disabled="loading"
+                            @click="submitOIDCLogin(idp)">
                             <i :class="oIDCIdps[idp]" />
                             Sign in with {{ iDPInfo["custom_button_text"] }}
                         </BButton>
                     </span>
                     <span v-else>
-                        <BButton class="d-block mt-3" @click="submitOIDCLogin(idp)">
+                        <BButton
+                            variant="outline-primary"
+                            class="d-block"
+                            :class="loginPage && !messageText ? 'w-100' : ''"
+                            :disabled="loading"
+                            @click="submitOIDCLogin(idp)">
                             <i :class="oIDCIdps[idp]" />
                             Sign in with
                             <span v-if="iDPInfo['label']">

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -77,7 +77,7 @@ Please mind `http` and `https`.
          does NOT show consent screen for this scope, hence user will only see a login page when they try to
          login to Galaxy using their Google account.
         -->
-        <icon>https://developers.google.com/identity/images/btn_google_signin_light_normal_web.png</icon>
+        <icon>https://developers.google.com/static/identity/images/branding_guideline_sample_lt_sq_lg.svg</icon>
         <!-- (Optional) Extra scopes you need to request for your implementation -->
         <!-- <extra_scopes>offline_access,something-else</extra_scopes> -->
     </provider>


### PR DESCRIPTION
| Before | After |
| ---- | ---- |
| ![enhance_external_login_BEFORE](https://github.com/user-attachments/assets/60fbc4d1-75e2-48cf-a5ee-9f4c91c3ea39) | ![enhance_external_login_AFTER](https://github.com/user-attachments/assets/49ef8f24-5ca0-40bd-981d-1f594c6d969b) |

## In the case of Custos/CILogon:

![enhance_external_login_custos](https://github.com/user-attachments/assets/8fdf17c1-65b4-489f-bfde-01c6b2f3be71)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
