### PR TITLE
[24.2] Fix `mulled-search --destination quay`, add index reuse

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/mulled_search.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_search.py
@@ -47,6 +47,7 @@ class QuaySearch:
     """
     Tool to search within a quay organization for a given software name.
     """
+
     tmp_dir_prefix = "mulled_search.quay."
 
     def __init__(self, organization, cache_time=900):
@@ -90,8 +91,9 @@ class QuaySearch:
             entries.append((entry_st.st_mtime, entry.path))
         if entries:
             tmp_dir = sorted(entries)[-1][1]
-            print(f"Using existing quay.io index, remove or decrease --cache-time to rebuild: {tmp_dir}",
-                  file=sys.stderr)
+            print(
+                f"Using existing quay.io index, remove or decrease --cache-time to rebuild: {tmp_dir}", file=sys.stderr
+            )
             self.index = open_dir(tmp_dir)
         else:
             tmp_dir = tempfile.mkdtemp(prefix=QuaySearch.tmp_dir_prefix)

--- a/lib/galaxy/tool_util/deps/mulled/mulled_search.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_search.py
@@ -67,6 +67,7 @@ class QuaySearch:
             r = requests.get(
                 QUAY_API_URL, headers={"Accept-encoding": "gzip"}, params=parameters, timeout=MULLED_SOCKET_TIMEOUT
             )
+            r.raise_for_status()
             decoded_request = json_decoder.decode(r.text)
             next_page = decoded_request.get("next_page")
             yield decoded_request


### PR DESCRIPTION
This was broken because the API is paginated. Because fetching the full list of biocontainers repos takes some time, I also added index reuse.

Mentioned here: https://lpembleton.rbind.io/posts/mulled-biocontainers/

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Make a venv and activate it
  2. Check out vanilla 24.2
  3. `cd packages/tool_util && pip install -e '.[mulled]'`
  4. `mulled-search -d quay -s samtools bwa`
  5. No results
  6. Apply PR
  7. Repeat search
  8. Results!

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
