### PR TITLE
Add hid to selection field in visualization creation form

### DIFF
--- a/client/src/api/plugins.ts
+++ b/client/src/api/plugins.ts
@@ -5,6 +5,7 @@ import { rethrowSimple } from "@/utils/simple-error";
 
 export interface Dataset {
     id: string;
+    hid: string;
     name: string;
 }
 

--- a/client/src/components/Visualizations/VisualizationCreate.test.js
+++ b/client/src/components/Visualizations/VisualizationCreate.test.js
@@ -4,6 +4,8 @@ import { createPinia, defineStore, setActivePinia } from "pinia";
 import { getLocalVue } from "tests/jest/helpers";
 import { ref } from "vue";
 
+import { fetchPluginHistoryItems } from "@/api/plugins";
+
 import VisualizationCreate from "./VisualizationCreate.vue";
 import FormCardSticky from "@/components/Form/FormCardSticky.vue";
 
@@ -71,4 +73,25 @@ it("renders plugin info after load", async () => {
     expect(wrapper.text()).toContain("Help");
     expect(wrapper.text()).toContain("tag1");
     expect(wrapper.text()).toContain("tag2");
+});
+
+it("adds hid to dataset names when fetching history items", async () => {
+    fetchPluginHistoryItems.mockResolvedValueOnce({
+        hdas: [
+            { id: "dataset1", hid: 101, name: "First Dataset" },
+            { id: "dataset2", hid: 102, name: "Second Dataset" },
+        ],
+    });
+    const wrapper = mount(VisualizationCreate, {
+        localVue,
+        propsData: {
+            visualization: "scatterplot",
+        },
+    });
+    await wrapper.vm.$nextTick();
+    const results = await wrapper.vm.doQuery();
+    expect(results).toEqual([
+        { id: "dataset1", name: "101: First Dataset" },
+        { id: "dataset2", name: "102: Second Dataset" },
+    ]);
 });

--- a/client/src/components/Visualizations/VisualizationCreate.vue
+++ b/client/src/components/Visualizations/VisualizationCreate.vue
@@ -3,13 +3,13 @@ import { storeToRefs } from "pinia";
 import { computed, onMounted, type Ref, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
-import { fetchPlugin, fetchPluginHistoryItems, type Plugin } from "@/api/plugins";
+import { type Dataset, fetchPlugin, fetchPluginHistoryItems, type Plugin } from "@/api/plugins";
 import type { OptionType } from "@/components/SelectionField/types";
 import { useHistoryStore } from "@/stores/historyStore";
 
 import { getTestExtensions, getTestUrls } from "./utilities";
 
-import FormDataExtensions from "../Form/Elements/FormData/FormDataExtensions.vue";
+import FormDataExtensions from "@/components/Form/Elements/FormData/FormDataExtensions.vue";
 import VisualizationExamples from "./VisualizationExamples.vue";
 import Heading from "@/components/Common/Heading.vue";
 import FormCardSticky from "@/components/Form/FormCardSticky.vue";
@@ -31,10 +31,14 @@ const urlData = computed(() => getTestUrls(plugin.value));
 const extensions = computed(() => getTestExtensions(plugin.value));
 const formatsVisible = ref(false);
 
+function addHidToName(hdas: Array<Dataset>) {
+    return hdas.map((entry) => ({ id: entry.id, name: `${entry.hid}: ${entry.name}` }));
+}
+
 async function doQuery() {
     if (currentHistoryId.value && plugin.value) {
         const data = await fetchPluginHistoryItems(plugin.value.name, currentHistoryId.value);
-        return data.hdas;
+        return addHidToName(data.hdas);
     } else {
         return [];
     }

--- a/client/src/components/Visualizations/VisualizationCreate.vue
+++ b/client/src/components/Visualizations/VisualizationCreate.vue
@@ -9,9 +9,9 @@ import { useHistoryStore } from "@/stores/historyStore";
 
 import { getTestExtensions, getTestUrls } from "./utilities";
 
-import FormDataExtensions from "@/components/Form/Elements/FormData/FormDataExtensions.vue";
 import VisualizationExamples from "./VisualizationExamples.vue";
 import Heading from "@/components/Common/Heading.vue";
+import FormDataExtensions from "@/components/Form/Elements/FormData/FormDataExtensions.vue";
 import FormCardSticky from "@/components/Form/FormCardSticky.vue";
 import MarkdownDefault from "@/components/Markdown/Sections/MarkdownDefault.vue";
 import SelectionField from "@/components/SelectionField/SelectionField.vue";
@@ -58,6 +58,8 @@ function onSelect(dataset: OptionType) {
 onMounted(() => {
     getPlugin();
 });
+
+defineExpose({ doQuery });
 </script>
 
 <template>

--- a/lib/galaxy/webapps/galaxy/api/plugins.py
+++ b/lib/galaxy/webapps/galaxy/api/plugins.py
@@ -55,7 +55,7 @@ class PluginsController(BaseGalaxyAPIController):
             result = {"hdas": []}
             for hda in history.contents_iter(types=["dataset"], deleted=False, visible=True):
                 if registry.get_visualization(trans, id, hda):
-                    result["hdas"].append({"id": trans.security.encode_id(hda.id), "name": hda.name})
+                    result["hdas"].append({"id": trans.security.encode_id(hda.id), "hid": hda.hid, "name": hda.name})
         else:
             result = registry.get_plugin(id).to_dict()
         return result


### PR DESCRIPTION
The dataset selection field for creating visualizations currently does not display the hid alongside the dataset name. This PR addresses and resolves that issue.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
