### PR TITLE
Sort visualization datasets by hid

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/plugins.py
+++ b/lib/galaxy/webapps/galaxy/api/plugins.py
@@ -56,6 +56,7 @@ class PluginsController(BaseGalaxyAPIController):
             for hda in history.contents_iter(types=["dataset"], deleted=False, visible=True):
                 if registry.get_visualization(trans, id, hda):
                     result["hdas"].append({"id": trans.security.encode_id(hda.id), "hid": hda.hid, "name": hda.name})
+            result["hdas"].sort(key=lambda h: h["hid"], reverse=True)
         else:
             result = registry.get_plugin(id).to_dict()
         return result


### PR DESCRIPTION
This PR fixes the sort order of datasets in the visualization dataset selection input element. On another note, this endpoint should be migrated to FastAPI soon.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
