### PR TITLE
[24.2] Fix edam selenium test

### DIFF
--- a/client/src/components/Panels/ToolPanel.test.ts
+++ b/client/src/components/Panels/ToolPanel.test.ts
@@ -1,5 +1,6 @@
 import "jest-location-mock";
 
+import { getFakeRegisteredUser } from "@tests/test-data";
 import { mount } from "@vue/test-utils";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
@@ -8,6 +9,7 @@ import { createPinia } from "pinia";
 import { getLocalVue } from "tests/jest/helpers";
 import { ref } from "vue";
 
+import { useServerMock } from "@/api/client/__mocks__";
 import toolsList from "@/components/ToolsView/testData/toolsList.json";
 import toolsListInPanel from "@/components/ToolsView/testData/toolsListInPanel.json";
 import { useUserLocalStorage } from "@/composables/userLocalStorage";
@@ -28,6 +30,7 @@ interface ToolPanelView {
 }
 
 const localVue = getLocalVue();
+const { server, http } = useServerMock();
 
 const TEST_PANELS_URI = "/api/tool_panels";
 const DEFAULT_VIEW_ID = "default";
@@ -89,6 +92,12 @@ describe("ToolPanel", () => {
             // mock response for all panel views
             axiosMock.onGet(/\/api\/tool_panels\/.*/).reply(200, toolsListInPanel);
         }
+
+        server.use(
+            http.get("/api/users/{user_id}", ({ response }) => {
+                return response(200).json(getFakeRegisteredUser());
+            })
+        );
 
         // setting this because for the default view, we just show "Tools" as the name
         // even though the backend returns "Full Tool Panel"

--- a/client/src/components/Panels/ToolPanel.vue
+++ b/client/src/components/Panels/ToolPanel.vue
@@ -5,6 +5,7 @@ import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 
 import { useToolStore } from "@/stores/toolStore";
+import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";
 import { errorMessageAsString, rethrowSimple } from "@/utils/simple-error";
 
@@ -16,6 +17,7 @@ import PanelViewMenu from "./Menus/PanelViewMenu.vue";
 import ToolBox from "./ToolBox.vue";
 import Heading from "@/components/Common/Heading.vue";
 
+const userStore = useUserStore();
 const props = defineProps({
     workflow: { type: Boolean, default: false },
     dataManagers: { type: Array, default: null },
@@ -117,6 +119,7 @@ const showFavorites = computed({
 
 async function initializeTools() {
     try {
+        await userStore.loadUser(false);
         await toolStore.fetchTools();
         await toolStore.initCurrentPanelView(defaultPanelView.value);
     } catch (error: any) {

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -379,6 +379,7 @@ edit_collection_attributes:
 
 tool_panel:
   selectors:
+    edam_link: 'a[href^="https://edamontology.github.io/edam-browser"]'
     tool_box: '[data-description="panel toolbox"]'
     tool_link: 'a[href$$="tool_runner?tool_id=${tool_id}"]'
     outer_tool_link: '.toolTitle a[href$$="tool_runner?tool_id=${tool_id}"]'

--- a/test/integration_selenium/test_edam_tool_panel_views.py
+++ b/test/integration_selenium/test_edam_tool_panel_views.py
@@ -36,6 +36,7 @@ class TestEdamToolPanelViewsSeleniumIntegration(SeleniumIntegrationTestCase):
     def _assert_displaying_edam_operations(self):
         tool_panel = self.components.tool_panel
         tool_panel.toolbox.wait_for_visible()
+        tool_panel.edam_link.wait_for_present()
         labels = tool_panel.panel_labels.all()
         assert len(labels) > 0
         label0 = labels[0]


### PR DESCRIPTION
I think that's a similar fix to @dannon's navigation guard for the workflow landing page.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
