### PR TITLE
[24.2] Pass along ``other_values`` to conditionals

### DIFF
--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -89,7 +89,7 @@ class Group(UsesDictVisibleKeys):
         """
         raise TypeError("Not implemented")
 
-    def to_dict(self, trans):
+    def to_dict(self, trans, other_values=None):
         group_dict = self._dictify_view_keys()
         return group_dict
 
@@ -177,13 +177,13 @@ class Repeat(Group):
             rval.append(rval_dict)
         return rval
 
-    def to_dict(self, trans):
+    def to_dict(self, trans, other_values=None):
         if self.inputs is None:
             raise Exception("Must set 'inputs' attribute to use.")
         repeat_dict = super().to_dict(trans)
 
         def input_to_dict(input):
-            return input.to_dict(trans)
+            return input.to_dict(trans, other_values)
 
         repeat_dict["inputs"] = list(map(input_to_dict, self.inputs.values()))
         return repeat_dict
@@ -240,13 +240,13 @@ class Section(Group):
             rval[child_input.name] = child_input.get_initial_value(trans, child_context)
         return rval
 
-    def to_dict(self, trans):
+    def to_dict(self, trans, other_values=None):
         if self.inputs is None:
             raise Exception("Must set 'inputs' attribute to use.")
         section_dict = super().to_dict(trans)
 
         def input_to_dict(input):
-            return input.to_dict(trans)
+            return input.to_dict(trans, other_values)
 
         section_dict["inputs"] = list(map(input_to_dict, self.inputs.values()))
         return section_dict
@@ -818,13 +818,13 @@ class Conditional(Group):
             rval[child_input.name] = child_input.get_initial_value(trans, child_context)
         return rval
 
-    def to_dict(self, trans):
+    def to_dict(self, trans, other_values=None):
         if self.test_param is None:
             raise Exception("Must set 'test_param' attribute to use.")
-        cond_dict = super().to_dict(trans)
+        cond_dict = super().to_dict(trans, other_values=other_values)
 
         def nested_to_dict(input):
-            return input.to_dict(trans)
+            return input.to_dict(trans, other_values=other_values)
 
         cond_dict["cases"] = list(map(nested_to_dict, self.cases))
         cond_dict["test_param"] = nested_to_dict(self.test_param)
@@ -838,13 +838,13 @@ class ConditionalWhen(UsesDictVisibleKeys):
         self.value = None
         self.inputs = None
 
-    def to_dict(self, trans):
+    def to_dict(self, trans, other_values=None):
         if self.inputs is None:
             raise Exception("Must set 'inputs' attribute to use.")
         when_dict = self._dictify_view_keys()
 
         def input_to_dict(input):
-            return input.to_dict(trans)
+            return input.to_dict(trans, other_values=other_values)
 
         when_dict["inputs"] = list(map(input_to_dict, self.inputs.values()))
         return when_dict

--- a/lib/galaxy/tools/parameters/populate_model.py
+++ b/lib/galaxy/tools/parameters/populate_model.py
@@ -28,7 +28,7 @@ def populate_model(request_context, inputs, state_inputs, group_inputs: List[Dic
                 group_cache[i] = []
                 populate_model(request_context, input.inputs, group_state[i], group_cache[i], other_values)
         elif input.type == "conditional":
-            tool_dict = input.to_dict(request_context)
+            tool_dict = input.to_dict(request_context, other_values=other_values)
             if "test_param" in tool_dict:
                 test_param = tool_dict["test_param"]
                 test_param["value"] = input.test_param.value_to_basic(


### PR DESCRIPTION
I think this fixes https://github.com/galaxyproject/galaxy/issues/20136.

This allows accessing parameter values when filtering within conditionals, such as:
```xml
            <when value="select_lineage">
                <param argument="--lineage_dataset" type="select" label="Lineage">
                    <options from_data_table="busco_database_options">
                        <filter type="param_value" column="2" ref="cached_db"/>
                    </options>
                </param>
            </when>
```
where `select_lineage` is inside a conditional.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
