### PR TITLE
Browse multiple trees in phylocanvas

### DIFF
--- a/config/plugins/visualizations/phylocanvas/config/phylocanvas.xml
+++ b/config/plugins/visualizations/phylocanvas/config/phylocanvas.xml
@@ -18,7 +18,7 @@
         <param required="true">dataset_id</param>
     </params>
     <requirements>
-        <requirement type="npm" version="0.0.7" package="@galaxyproject/phylocanvas"/>
+        <requirement type="npm" version="0.0.10" package="@galaxyproject/phylocanvas"/>
     </requirements>
     <entry_point entry_point_type="script" src="dist/index.js" css="dist/index.css" />
     <settings>
@@ -113,7 +113,7 @@
     </settings>
     <tests>
         <test>
-            <param name="dataset_id" value="http://cdn.jsdelivr.net/gh/galaxyproject/galaxy-test-data/newick.nwk" ftype="newick" />
+            <param name="dataset_id" value="http://cdn.jsdelivr.net/gh/galaxyproject/galaxy-test-data/1.newick" ftype="newick" />
         </test>
     </tests>
     <help format="markdown"><![CDATA[

--- a/config/plugins/visualizations/phylocanvas/config/phylocanvas.xml
+++ b/config/plugins/visualizations/phylocanvas/config/phylocanvas.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
 <visualization name="Phylogenetic Tree" embeddable="true">
-    <description>Phylogenetic Tree Viewer from https://www.phylocanvas.gl</description>
+    <description>Phylogenetic Tree Browser</description>
     <tags>
         <tag>Phylogenetics</tag>
         <tag>Tree</tag>


### PR DESCRIPTION
Enables navigation through multiple phylogenetic trees using the Phylocanvas plugin.

![phylo](https://github.com/user-attachments/assets/55119930-b400-4ff4-bc1a-4c33aa1c2c16)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Test file: http://cdn.jsdelivr.net/gh/galaxyproject/galaxy-test-data/1.newick
  2. Upload it and assign datatype to `newick`
  3. Visualize with phylogenetic viz
  4. Check if navigation through multiple trees is possible

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
