### PR TITLE
Allow deferred and ok state datasets for vis

### DIFF
--- a/lib/galaxy/visualization/plugins/datasource_testing.py
+++ b/lib/galaxy/visualization/plugins/datasource_testing.py
@@ -129,7 +129,7 @@ def is_object_applicable(trans, target_object, data_source_tests):
                     #              target_object, getattr( target_object, 'id', '' ) )
                     continue
         elif test_attr == "ext" and test_type == "eq":
-            if target_object.state == "ok":
+            if target_object.state in ["deferred", "ok"]:
                 test_result = trans.app.datatypes_registry.get_datatype_by_extension(test_result)
                 if isinstance(target_object.datatype, type(test_result)) and _check_uri_support(
                     target_object, supported_protocols


### PR DESCRIPTION
Recent overhaul of the dataset matching for visualizations introduced dataset state requirements, which need to allow deferred datasets.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
