### PR TITLE
[24.2] Skip ``param_value`` filter if ref value is runtime value

### DIFF
--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -298,8 +298,11 @@ class ParamValueFilter(Filter):
 
     def filter_options(self, options: Sequence[ParameterOption], trans, other_values):
         ref = other_values.get(self.ref_name, None)
-        if ref is None or is_runtime_value(ref):
+        if ref is None:
             ref = []
+        elif is_runtime_value(ref) and trans and trans.workflow_building_mode is workflow_building_modes.USE_HISTORY:
+            # We're in the run form, can't possibly apply a param_value filter.
+            return options
 
         # - for HDCAs the list of contained HDAs is extracted
         # - single values are transformed in a single element list

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -6862,6 +6862,30 @@ steps:
         options = run_workflow["steps"][0]["inputs"][0]["options"]
         assert len(options) >= 1
 
+    @skip_without_tool("filter_param_value")
+    def test_value_restriction_with_filter_param_value(self):
+        workflow_id = self.workflow_populator.upload_yaml_workflow(
+            """
+class: GalaxyWorkflow
+inputs:
+  select_text:
+     type: text
+     restrictOnConnections: true
+steps:
+  select:
+    tool_id: filter_param_value
+    tool_state:
+      select1: "hg19_value"
+    in:
+      select3: select_text
+"""
+        )
+        with self.dataset_populator.test_history() as history_id:
+            run_workflow = self._download_workflow(workflow_id, style="run", history_id=history_id)
+        options = run_workflow["steps"][0]["inputs"][0]["options"]
+        assert len(options) == 1
+        assert options[0] == ["hg19", "hg19_value", False]
+
     def test_value_restriction_with_select_and_text_param(self):
         workflow_id = self.workflow_populator.upload_yaml_workflow(
             """

--- a/test/functional/tools/filter_param_value.xml
+++ b/test/functional/tools/filter_param_value.xml
@@ -1,7 +1,7 @@
 <tool id="filter_param_value" name="filter_param_value" version="0.1.0">
     <description>Filter input with the param_value</description>
     <command><![CDATA[
-        echo $select1 > '$output' && 
+        echo $select1 > '$output' &&
         echo $select2 >> '$output'
     ]]></command>
     <inputs>
@@ -25,6 +25,13 @@
                 <filter type="param_value" column="0" ref="select1" keep="false"/>
             </options>
         </param>
+        <param name="select3" type="select" label="keeps only values selected in select1">
+            <options from_data_table="test_fasta_indexes">
+                <column name="value" index="0"/>
+                <column name="name" index="1"/>
+                <filter type="param_value" column="0" ref="select1" keep="true"/>
+            </options>
+        </param>
     </inputs>
 
     <outputs>
@@ -37,8 +44,8 @@
             <param name="select2" value="mm10_value" />
             <output name="output">
                 <assert_contents>
-                    <has_line line="hg18_value,hg19_value" />    
-                    <has_line line="mm10_value" />    
+                    <has_line line="hg18_value,hg19_value" />
+                    <has_line line="mm10_value" />
                 </assert_contents>
             </output>
         </test>


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20136

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
