### PR TITLE
Attempt to address transiently failing integration_selenium test.

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -2473,6 +2473,11 @@ class NavigatesGalaxy(HasDriver):
     def _fill_configuration_template(
         self, name: str, description: Optional[str], parameters: List[ConfigTemplateParameter]
     ):
+        # create button transiently/rarely isn't becoming clickable though the form looks ready.
+        # In the CI screenshot archive the create button looks white. Is the form being filled
+        # so fast the hooks that bind create to the form elements haven't been setup yet?
+        self.sleep_for(WAIT_TYPES.UX_RENDER)
+
         self.components.tool_form.parameter_input(parameter="_meta_name").wait_for_and_send_keys(
             name,
         )


### PR DESCRIPTION
I lost the link to the CI test but I have the last.png screenshot and the stacktrace. Is this a GButton refactoring issue or has this already been addressed in another way?

![last](https://github.com/user-attachments/assets/c1c72238-5672-4597-90a7-bb8ef853a558)

```
Traceback (most recent call last):
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy_test/selenium/framework.py", line 208, in func_wrapper
    rval = f(self, *args, **kwds)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy_test/selenium/framework.py", line 126, in func_wrapper
    f(self, *args, **kwds)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy_test/base/decorators.py", line 65, in wrapped_method
    return method(*args, **kwargs)
  File "/home/runner/work/galaxy/galaxy/galaxy root/test/integration_selenium/test_user_file_source_ftp.py", line 29, in test_create_and_use
    uri_root = self.create_file_source_template(instance)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/selenium/navigates_galaxy.py", line 2519, in create_file_source_template
    file_source_instances.index._.wait_for_present()
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/selenium/smart_components.py", line 114, in wait_for_present
    return self._has_driver.wait_for_present(self._target, **kwds)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/selenium/has_driver.py", line 143, in wait_for_present
    element = self._wait_on(
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/selenium/has_driver.py", line 236, in _wait_on
    return wait.until(condition, self._timeout_message(on_str))
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.9/site-packages/selenium/webdriver/support/wait.py", line 146, in until
    raise TimeoutException(message, screen, stacktrace)
selenium.common.exceptions.TimeoutException: Message: Timeout waiting on CSS selector [#user-file-sources-index] to become present.
Stacktrace:
#0 0x55a14edbf75a <unknown>
#1 0x55a14e8724b0 <unknown>
#2 0x55a14e8c39b3 <unknown>
#3 0x55a14e8c3ba1 <unknown>
#4 0x55a14e9121f4 <unknown>
#5 0x55a14e8e95bd <unknown>
#6 0x55a14e90f5e0 <unknown>
#7 0x55a14e8e9363 <unknown>
#8 0x55a14e8b5d63 <unknown>
#9 0x55a14e8b69c1 <unknown>
#10 0x55a14ed84a6b <unknown>
#11 0x55a14ed88951 <unknown>
#12 0x55a14ed6cb62 <unknown>
#13 0x55a14ed894c4 <unknown>
#14 0x55a14ed5113f <unknown>
#15 0x55a14edad6f8 <unknown>
#16 0x55a14edad8d6 <unknown>
#17 0x55a14edbe5a6 <unknown>
#18 0x7f6b7aa9caa4 <unknown>
#19 0x7f6b7ab29c3c <unknown>
```


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
