### PR TITLE
Create working dir output outside of tool evaluator

### DIFF
--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -288,6 +288,9 @@ class JobIO(UsesDictVisibleKeys):
         job_outputs = []
         for da in job.output_datasets + job.output_library_datasets:
             da_false_path = dataset_path_rewriter.rewrite_dataset_path(da.dataset, "output")
+            if da_false_path:
+                with open(da_false_path, "wb"):
+                    pass
             mutable = da.dataset.dataset.external_filename is None
             dataset_path = DatasetPath(
                 da.dataset.dataset.id,

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -517,13 +517,6 @@ class ToolEvaluator:
                 unqualified_name = name.split("|__part__|")[-1]
                 if unqualified_name not in param_dict:
                     param_dict[unqualified_name] = param_dict[name]
-            output_path = str(param_dict[name])
-            # Conditionally create empty output:
-            # - may already exist (e.g. symlink output)
-            # - parent directory might not exist (e.g. Pulsar)
-            # TODO: put into JobIO, needed for fetch_data tasks
-            if not os.path.exists(output_path) and os.path.exists(os.path.dirname(output_path)):
-                open(output_path, "w").close()
 
         for out_name, output in self.tool.outputs.items():
             if out_name not in param_dict and output.filters:


### PR DESCRIPTION
This was a long standing TODO item. Importantly that allows using outputs_to_working_directory with tools that don't need to pass through command line templating.

Pulled out of #19434 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
