### PR TITLE
Option allowing add_column_regex rule to be unmatched.

### DIFF
--- a/client/src/components/RuleBuilder/rule-definitions.js
+++ b/client/src/components/RuleBuilder/rule-definitions.js
@@ -26,7 +26,7 @@ const removeColumns = function (columns, targetColumns) {
     return newColumns;
 };
 
-const applyRegex = function (regex, target, data, replacement, groupCount) {
+const applyRegex = function (regex, target, data, replacement, groupCount, allowUnmatched = false) {
     let regExp;
     try {
         regExp = pyre(String(regex));
@@ -38,22 +38,40 @@ const applyRegex = function (regex, target, data, replacement, groupCount) {
         const source = row[target];
         const match = regExp.exec(source);
         if (!match) {
-            failedCount++;
-            return null;
-        }
-        if (!replacement) {
-            groupCount = groupCount && parseInt(groupCount, 10);
-            if (groupCount) {
-                if (match.length != groupCount + 1) {
-                    failedCount++;
-                    return null;
+            if (allowUnmatched) {
+                if (!replacement) {
+                    groupCount = groupCount && parseInt(groupCount, 10);
+                    let emptyColumns = [];
+                    if (groupCount) {
+                        for (let i = 0; i < groupCount; i++) {
+                            emptyColumns = emptyColumns.concat([""]);
+                        }
+                        return row.concat(emptyColumns);
+                    } else {
+                        return row.concat([""]);
+                    }
+                } else {
+                    return row.concat([""]);
                 }
-                return row.concat(match.splice(1, match.length));
             } else {
-                return row.concat([match[0]]);
+                failedCount++;
+                return null;
             }
         } else {
-            return row.concat([regExp.pyreReplace(match[0], replacement)]);
+            if (!replacement) {
+                groupCount = groupCount && parseInt(groupCount, 10);
+                if (groupCount) {
+                    if (match.length != groupCount + 1) {
+                        failedCount++;
+                        return null;
+                    }
+                    return row.concat(match.splice(1, match.length));
+                } else {
+                    return row.concat([match[0]]);
+                }
+            } else {
+                return row.concat([regExp.pyreReplace(match[0], replacement)]);
+            }
         }
     }
     data = data.map(newRow);
@@ -249,11 +267,13 @@ const RULES = {
                 component.addColumnRegexExpression = "";
                 component.addColumnRegexReplacement = null;
                 component.addColumnRegexGroupCount = null;
+                component.addColumnRegexAllowUnmatched = false;
             } else {
                 component.addColumnRegexTarget = rule.target_column;
                 component.addColumnRegexExpression = rule.expression;
                 component.addColumnRegexReplacement = rule.replacement;
                 component.addColumnRegexGroupCount = parseInt(rule.group_count);
+                component.addColumnRegexAllowUnmatched = rule.allow_unmatched ?? false;
             }
             let addColumnRegexType = "global";
             if (component.addColumnRegexGroupCount) {
@@ -266,6 +286,7 @@ const RULES = {
         save: (component, rule) => {
             rule.target_column = component.addColumnRegexTarget;
             rule.expression = component.addColumnRegexExpression;
+            rule.allow_unmatched = component.addColumnRegexAllowUnmatched;
             if (component.addColumnRegexType == "replacement" && component.addColumnRegexReplacement) {
                 rule.replacement = component.addColumnRegexReplacement;
                 rule.group_count = null;
@@ -279,7 +300,14 @@ const RULES = {
         },
         apply: (rule, data, sources, columns) => {
             const target = rule.target_column;
-            const rval = applyRegex(rule.expression, target, data, rule.replacement, rule.group_count);
+            const rval = applyRegex(
+                rule.expression,
+                target,
+                data,
+                rule.replacement,
+                rule.group_count,
+                rule.allow_unmatched
+            );
             if (rule.group_count) {
                 for (let i = 0; i < rule.group_count; i++) {
                     columns.push(NEW_COLUMN);

--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -132,6 +132,10 @@
                                 {{ l("Replacement Expression") }}
                                 <input v-model="addColumnRegexReplacement" type="text" class="rule-replacement" />
                             </label>
+                            <label v-b-tooltip.hover>
+                                <input v-model="addColumnRegexAllowUnmatched" type="checkbox" />
+                                {{ l("Allow regular expression unmatched.") }}
+                            </label>
                         </RuleComponent>
                         <RuleComponent
                             rule-type="add_column_concatenate"
@@ -782,6 +786,7 @@ export default {
             addColumnRegexExpression: "",
             addColumnRegexReplacement: null,
             addColumnRegexGroupCount: null,
+            addColumnRegexAllowUnmatched: false,
             addColumnRegexType: "global",
             addColumnMetadataValue: 0,
             addColumnGroupTagValueValue: "",

--- a/client/tests/jest/standalone/RuleDefinitions.test.ts
+++ b/client/tests/jest/standalone/RuleDefinitions.test.ts
@@ -27,18 +27,24 @@ function itShouldConform(specTestCase: SpecTestCase, i: number) {
     }
     it(`should pass conformance test case ${i} (from rules_dsl_spec.yml) ${doc}`, () => {
         expect(specTestCase).toHaveProperty("rules");
+        const expectError = specTestCase.error;
         if (specTestCase.initial) {
-            expect(specTestCase).toHaveProperty("final");
-
-            const result = applyRules(specTestCase.rules, specTestCase.initial.data, specTestCase.initial.sources);
-            const finalData = specTestCase.final?.data;
-            const finalSources = specTestCase.final?.sources;
-            expect(result.data).toEqual(finalData);
-            if (finalSources !== undefined) {
-                expect(result.sources).toEqual(finalSources);
+            if (!expectError) {
+                expect(specTestCase).toHaveProperty("final");
+            }
+            try {
+                const result = applyRules(specTestCase.rules, specTestCase.initial.data, specTestCase.initial.sources);
+                const finalData = specTestCase.final?.data;
+                const finalSources = specTestCase.final?.sources;
+                expect(result.data).toEqual(finalData);
+                if (finalSources !== undefined) {
+                    expect(result.sources).toEqual(finalSources);
+                }
+            } catch (e) {
+                expect(expectError).toBe(true);
             }
         } else {
-            expect(specTestCase.error).toBe(true);
+            expect(expectError).toBe(true);
             // TODO: test these...
         }
     });

--- a/lib/galaxy/util/rules_dsl_spec.yml
+++ b/lib/galaxy/util/rules_dsl_spec.yml
@@ -41,6 +41,39 @@
     sources: [1,2]
   final:
     data: [["foo", "o", "o"], ["boo", "o", "o"]]
+- doc: add_column_regex fails if unmatched by default
+  rules:
+    - type: add_column_regex
+      target_column: 0
+      expression: '(o)+'
+  initial:
+    data: [[foo], [cow], [cat]]
+    sources: [1,2]
+  error: true
+- doc: add_column_regex allowed to unmatched with allow_unmatched property
+  rules:
+    - type: add_column_regex
+      target_column: 0
+      expression: '(o)+'
+      allow_unmatched: true
+  initial:
+    data: [[foo], [cow], [cat]]
+    sources: [1,2]
+  final:
+    data: [["foo", "oo"], ["cow", "o"], ["cat", ""]]
+- doc: add_column_regex allowed to unmatched with group counts
+  rules:
+    - type: add_column_regex
+      target_column: 0
+      expression: '.*(o)(o)'
+      group_count: 2
+      allow_unmatched: true
+  initial:
+    data: [[foo], [boo], [cat]]
+    sources: [1,2]
+  final:
+    data: [["foo", "o", "o"], ["boo", "o", "o"], ["cat", "", ""]]
+
 - doc: add_column_substr works for keeping a fixed length prefix
   rules:
     - type: add_column_substr

--- a/test/unit/util/test_rule_utils.py
+++ b/test/unit/util/test_rule_utils.py
@@ -5,25 +5,36 @@ def test_rules():
     for test_case in rules_dsl.get_rules_specification():
         rule_set = rules_dsl.RuleSet(test_case)
         if "initial" in test_case:
-            initial = test_case["initial"]
-            final_data, final_sources = rule_set.apply(initial["data"], initial["sources"])
-            expected_final = test_case["final"]
-            expected_final_data = expected_final["data"]
-            msg = f"Incorrect number of rows, {final_data} != {expected_final_data}"
-            assert len(expected_final_data) == len(final_data), msg
-            for final_row, expected_final_row in zip(final_data, expected_final_data):
-                msg = f"{final_row} != {expected_final_row}"
-                assert len(final_row) == len(expected_final_row), msg
-                for final_val, expected_final_val in zip(final_row, expected_final_row):
-                    assert final_val == expected_final_val, msg
-            expected_final_sources = expected_final.get("sources", None)
-            if expected_final_sources:
-                msg = f"Incorrect number of sources, {expected_final_sources} != {final_sources}"
-                assert len(expected_final_sources) == len(final_sources), msg
-                for final_source, expected_final_source in zip(final_sources, expected_final_sources):
-                    msg = f"{final_source} != {expected_final_source}"
-                    assert final_source == expected_final_source, msg
+            expect_errors = test_case.get("error", False)
+            found_error = None
+            try:
+                initial = test_case["initial"]
+                final_data, final_sources = rule_set.apply(initial["data"], initial["sources"])
+                expected_final = test_case["final"]
+                expected_final_data = expected_final["data"]
+                msg = f"Incorrect number of rows, {final_data} != {expected_final_data}"
+                assert len(expected_final_data) == len(final_data), msg
+                for final_row, expected_final_row in zip(final_data, expected_final_data):
+                    msg = f"{final_row} != {expected_final_row}"
+                    assert len(final_row) == len(expected_final_row), msg
+                    for final_val, expected_final_val in zip(final_row, expected_final_row):
+                        assert final_val == expected_final_val, msg
+                expected_final_sources = expected_final.get("sources", None)
+                if expected_final_sources:
+                    msg = f"Incorrect number of sources, {expected_final_sources} != {final_sources}"
+                    assert len(expected_final_sources) == len(final_sources), msg
+                    for final_source, expected_final_source in zip(final_sources, expected_final_sources):
+                        msg = f"{final_source} != {expected_final_source}"
+                        assert final_source == expected_final_source, msg
+            except AssertionError:
+                raise
+            except Exception as e:
+                found_error = e
 
+            if expect_errors and found_error is None:
+                raise AssertionError(f"Did not find expected runtime errors for test case [{test_case}].")
+            elif not expect_errors and found_error:
+                raise AssertionError(f"Unexpected error when evaluating test case [{test_case}] - [{found_error}].")
         elif "error" in test_case:
             assert rule_set.has_errors, f"rule [{test_case}] does not contain errors"
         else:


### PR DESCRIPTION
Specification tests describe the behavior and these tests are run on both frontend and backend components. The tests:

```yaml
- doc: add_column_regex fails if unmatched by default
  rules:
    - type: add_column_regex
      target_column: 0
      expression: '(o)+'
  initial:
    data: [[foo], [cow], [cat]]
    sources: [1,2]
  error: true
- doc: add_column_regex allowed to unmatched with allow_unmatched property
  rules:
    - type: add_column_regex
      target_column: 0
      expression: '(o)+'
      allow_unmatched: true
  initial:
    data: [[foo], [cow], [cat]]
    sources: [1,2]
  final:
    data: [["foo", "oo"], ["cow", "o"], ["cat", ""]]
- doc: add_column_regex allowed to unmatched with group counts
  rules:
    - type: add_column_regex
      target_column: 0
      expression: '.*(o)(o)'
      group_count: 2
      allow_unmatched: true
  initial:
    data: [[foo], [boo], [cat]]
    sources: [1,2]
  final:
    data: [["foo", "o", "o"], ["boo", "o", "o"], ["cat", "", ""]]
```

Can easily be combined concatenate and such to get conditionals on rewriting values. Used for new tests in new collection types branch (#19377) that mirror I think useful, real-world examples. Also extends the test framework a bit to allow testing errors during evaluation and not just errors that can be caught statically by inspecting the rule itself (e.g. a valid regex that fails to match at runtime).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
