### PR TITLE
Improved rule builder display for non-nested lists (most of them).

### DIFF
--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -967,8 +967,13 @@ export default {
             let metadataOptions = {};
             if (this.elementsType == "collection_contents") {
                 let collectionType;
+                // true iff there aren't multiple levels of list identifiers - so we can simplify the display
+                let flatishList = false;
                 if (this.initialElements) {
                     collectionType = this.initialElements.collection_type;
+                    if (collectionType == "list:paired" || collectionType == "list") {
+                        flatishList = true;
+                    }
                 } else {
                     // give a bunch of different options if not constrained with given input
                     collectionType = "list:list:list:paired";
@@ -977,8 +982,11 @@ export default {
                 for (const index in collectionTypeRanks) {
                     const collectionTypeRank = collectionTypeRanks[index];
                     if (collectionTypeRank == "list") {
-                        // TODO: drop the numeral at the end if only flat list
-                        metadataOptions["identifier" + index] = _l("List Identifier ") + (parseInt(index) + 1);
+                        if (flatishList) {
+                            metadataOptions["identifier" + index] = _l("List Identifier");
+                        } else {
+                            metadataOptions["identifier" + index] = _l("List Identifier ") + (parseInt(index) + 1);
+                        }
                     } else {
                         metadataOptions["identifier" + index] = _l("Paired Identifier");
                     }


### PR DESCRIPTION
An old TODO was in there to cleanup the display a bit - this resolved that. Downstream (in #19377) we allow both the identifier and the numeric index to be used in this fashion so cleaning this up first made sense to me.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
