### PR TITLE
Revise transiently failing data source test.

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -295,9 +295,12 @@ class NavigatesGalaxy(HasDriver):
         """Return to root Galaxy page and wait for some basic widgets to appear."""
         self.get()
         try:
-            self.components.masthead._.wait_for_visible()
+            self.wait_for_masthead()
         except SeleniumTimeoutException as e:
             raise ClientBuildException(e)
+
+    def wait_for_masthead(self):
+        self.components.masthead._.wait_for_visible()
 
     def go_to_workflow_landing(self, uuid: str, public: Literal["false", "true"], client_secret: Optional[str]):
         path = f"workflow_landings/{uuid}?public={public}"
@@ -505,6 +508,10 @@ class NavigatesGalaxy(HasDriver):
     def wait_for_history_to_have_hid(self, history_id, hid):
         def get_hids():
             contents = self.api_get(f"histories/{history_id}/contents")
+            if contents and isinstance(contents, dict) and "err_msg" in contents:
+                raise Exception(f"Error getting history contents: {contents['err_msg']}")
+            if not isinstance(contents, list):
+                raise Exception(f"Expected list of contents, got {type(contents)} for {contents}")
             return [d["hid"] for d in contents]
 
         def history_has_hid(driver):

--- a/lib/galaxy_test/selenium/test_data_source_tools.py
+++ b/lib/galaxy_test/selenium/test_data_source_tools.py
@@ -1,3 +1,5 @@
+from selenium.webdriver.support.ui import Select
+
 from galaxy.util.unittest_utils import skip_if_site_down
 from .framework import (
     managed_history,
@@ -17,12 +19,18 @@ class TestDataSource(SeleniumTestCase, UsesHistoryItemAssertions):
         self.home()
         self.datasource_tool_open("ucsc_table_direct1")
         self.screenshot("ucsc_table_browser_first_page")
+        # only 4mb instead of 10 times that for human by default
+        Select(self.wait_for_selector("#org")).select_by_value("Tree shrew")
         checkbox = self.wait_for_selector("#checkboxGalaxy")
         assert checkbox.get_attribute("checked") == "true"
         submit_button = self.wait_for_selector("#hgta_doTopSubmit")
         submit_button.click()
         self.screenshot("ucsc_table_browser_second_page")
         self.wait_for_selector("#hgta_doGalaxyQuery").click()
+        # make sure we're back at Galaxy before we use the current session cookie to monitor the new hda.
+        # It doesn't seem to me this should be needed but we're getting occasional failures about inaccessible
+        # history I cannot explain otherwise. -John
+        self.wait_for_masthead()
         self.history_panel_wait_for_hid_ok(1)
         # Make sure we're still logged in (xref https://github.com/galaxyproject/galaxy/issues/11374)
         self.components.masthead.logged_in_only.wait_for_visible()


### PR DESCRIPTION
- Wait until we've return the Galaxy UI before tracking the new HDA in case this is why we're getting "history inaccessible" errors when monitoring for that HDA.
- Surface the actual error ("history inaccessible") instead of the index error when it does happen. 
- Download a much smaller amount of data from the UCSC site (10% of what we were downloading for humans by default)
- Cause an odd but persistent spike in "Tree shrew" data accessed at UCSC that will baffle someone at some point.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
