### PR TITLE
[24.2] Fix ``DataCollectionParameterModel`` factory

### DIFF
--- a/lib/galaxy/tool_util/parameters/factory.py
+++ b/lib/galaxy/tool_util/parameters/factory.py
@@ -194,6 +194,7 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
             optional = input_source.parse_optional()
             default_value = input_source.parse_default()
             return DataCollectionParameterModel(
+                collection_type=input_source.get("collection_type"),
                 name=input_source.parse_name(),
                 optional=optional,
                 value=default_value,

--- a/test/functional/tools/parameters/gx_data_collection_list.xml
+++ b/test/functional/tools/parameters/gx_data_collection_list.xml
@@ -1,0 +1,14 @@
+<tool id="gx_data_collection_list" name="gx_data_collection_list" version="1.0.0">
+    <command><![CDATA[
+cat '$parameter' >> '$output'
+    ]]></command>
+    <inputs>
+        <param name="parameter" type="data_collection" collection_type="list" ext="data" />
+    </inputs>
+    <outputs>
+        <data name="output" format="data" />
+    </outputs>
+    <tests>
+        <!-- TODO: -->
+    </tests>
+</tool>

--- a/test/unit/tool_util/test_input_models.py
+++ b/test/unit/tool_util/test_input_models.py
@@ -1,0 +1,12 @@
+from galaxy.tool_util.models import parse_tool
+from galaxy.tool_util.parameters.models import DataCollectionParameterModel
+from galaxy.tool_util.parser.factory import get_tool_source
+from galaxy.tool_util.unittest_utils import functional_test_tool_path
+
+
+def test_input_collection_type():
+    tool_source = get_tool_source(functional_test_tool_path("parameters/gx_data_collection_list.xml"))
+    tool = parse_tool(tool_source)
+    tool_input = tool.inputs[0]
+    assert isinstance(tool_input, DataCollectionParameterModel)
+    assert tool_input.collection_type == "list"


### PR DESCRIPTION
We didn't pass the collection_type attribute when building `DataCollectionParameterModel`.

Taken from #19434 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
