### PR TITLE
G modal implementation

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
     "@citation-js/core": "^0.7.1",
     "@citation-js/plugin-bibtex": "^0.7.2",
     "@citation-js/plugin-csl": "^0.7.2",
+    "@floating-ui/dom": "^1.7.0",
     "@fontsource/atkinson-hyperlegible": "^5.0.17",
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@fortawesome/fontawesome-svg-core": "^6.2.1",

--- a/client/src/components/BaseComponents/GButton.vue
+++ b/client/src/components/BaseComponents/GButton.vue
@@ -6,7 +6,6 @@ import { type RouterLink } from "vue-router";
 import { useClickableElement } from "@/components/BaseComponents/composables/clickableElement";
 import { useCurrentTitle } from "@/components/BaseComponents/composables/currentTitle";
 import { useResolveElement } from "@/composables/resolveElement";
-import { useUid } from "@/composables/utils/uid";
 
 import { type ComponentColor, type ComponentSize, type ComponentVariantClassList, prefix } from "./componentVariants";
 
@@ -65,7 +64,6 @@ const styleClasses = computed(() => {
 
 const baseComponent = useClickableElement(props);
 const currentTitle = useCurrentTitle(props);
-const tooltipId = useUid("g-tooltip");
 
 const showTooltip = computed(() => props.tooltip && currentTitle.value);
 
@@ -83,7 +81,6 @@ const buttonElementRef = useResolveElement(buttonRef);
         :to="!props.disabled ? props.to : ''"
         :href="!props.disabled ? props.to ?? props.href : ''"
         :title="props.tooltip ? false : currentTitle"
-        :aria-describedby="showTooltip ? tooltipId : false"
         :aria-disabled="props.disabled"
         v-bind="$attrs"
         @click="onClick">
@@ -92,7 +89,6 @@ const buttonElementRef = useResolveElement(buttonRef);
         <!-- TODO: make tooltip a sibling in Vue 3 -->
         <GTooltip
             v-if="showTooltip"
-            :id="tooltipId"
             :reference="buttonElementRef"
             :text="currentTitle"
             :placement="props.tooltipPlacement" />

--- a/client/src/components/BaseComponents/GButton.vue
+++ b/client/src/components/BaseComponents/GButton.vue
@@ -1,4 +1,9 @@
 <script setup lang="ts">
+/**
+ * Button-like element that can be used for buttons, anchors, or router-links.
+ * Defaults to button behavior.
+ */
+
 import type { Placement } from "@popperjs/core";
 import { computed, ref } from "vue";
 import { type RouterLink } from "vue-router";
@@ -12,20 +17,35 @@ import { type ComponentColor, type ComponentSize, type ComponentVariantClassList
 import GTooltip from "./GTooltip.vue";
 
 const props = defineProps<{
+    /** Href to set on the underlying 'a' element. Using this will turn the element into an anchor, not affecting the styling */
     href?: string;
+    /** Router link "to" prop. Using this will turn the element into a router-link, not affecting the styling  */
     to?: string;
+    /** Which color scheme to use for the component. Not setting this will make the button appear grey */
     color?: ComponentColor;
+    /** Outline variant of the button. Can be used together with the `pressed` state */
     outline?: boolean;
+    /** Disabled state. Changes appearance, and will no longer accept or forward clicks */
     disabled?: boolean;
+    /** Title attribute, or tooltip text */
     title?: string;
+    /** Alternative title to be displayed in a disabled state */
     disabledTitle?: string;
+    /** Displayed size of the component */
     size?: ComponentSize;
+    /** When set, uses a tooltip for the "title" prop, instead of the native title attribute */
     tooltip?: boolean;
+    /** Controls the positioning of the tooltip, if a tooltip is active */
     tooltipPlacement?: Placement;
+    /** Inline variant of the button. Affects buttons size, and positioning */
     inline?: boolean;
+    /** Small, icon-only variant of the button */
     iconOnly?: boolean;
+    /** Variant of the button without background or outline. Can be used together with the `pressed` state */
     transparent?: boolean;
+    /** Variant of the button with more rounded corners */
     pill?: boolean;
+    /** Pressed state allows for a toggle-like behavior of the button. For use with the outline and transparent variants */
     pressed?: boolean;
 }>();
 

--- a/client/src/components/BaseComponents/GButton.vue
+++ b/client/src/components/BaseComponents/GButton.vue
@@ -290,8 +290,15 @@ const buttonElementRef = useResolveElement(buttonRef);
     }
 
     &.g-transparent:not(.g-pressed) {
-        border: 1px solid rgb(100% 100% 100% / 0);
+        border: 1px solid rgb(100% 100% 100% / 0) !important;
         background-color: rgb(100% 100% 100% / 0);
+
+        color: var(--color-grey-700);
+
+        &:hover,
+        &:focus-visible {
+            background-color: var(--color-grey-200);
+        }
 
         @each $color in "blue", "green", "red", "yellow", "orange" {
             &.g-#{$color} {

--- a/client/src/components/BaseComponents/GButton.vue
+++ b/client/src/components/BaseComponents/GButton.vue
@@ -4,7 +4,7 @@
  * Defaults to button behavior.
  */
 
-import type { Placement } from "@popperjs/core";
+import type { Placement } from "@floating-ui/dom";
 import { computed, ref } from "vue";
 import { type RouterLink } from "vue-router";
 

--- a/client/src/components/BaseComponents/GButtonGroup.vue
+++ b/client/src/components/BaseComponents/GButtonGroup.vue
@@ -24,7 +24,7 @@ const styleClasses = computed(() => {
     gap: 0;
 
     &:not(.g-vertical) {
-        &:deep(.g-button) {
+        &:deep(> .g-button) {
             &:not(:nth-child(1 of .g-button)) {
                 border-top-left-radius: 0;
                 border-bottom-left-radius: 0;
@@ -42,7 +42,7 @@ const styleClasses = computed(() => {
     &.g-vertical {
         flex-direction: column;
 
-        &:deep(.g-button) {
+        &:deep(> .g-button) {
             &:not(:nth-child(1 of .g-button)) {
                 border-top-left-radius: 0;
                 border-top-right-radius: 0;

--- a/client/src/components/BaseComponents/GLink.vue
+++ b/client/src/components/BaseComponents/GLink.vue
@@ -6,7 +6,6 @@ import type { RouterLink } from "vue-router";
 import { useClickableElement } from "@/components/BaseComponents/composables/clickableElement";
 import { useCurrentTitle } from "@/components/BaseComponents/composables/currentTitle";
 import { useResolveElement } from "@/composables/resolveElement";
-import { useUid } from "@/composables/utils/uid";
 
 import GTooltip from "@/components/BaseComponents/GTooltip.vue";
 
@@ -44,7 +43,6 @@ const styleClasses = computed(() => {
 
 const baseComponent = useClickableElement(props);
 const currentTitle = useCurrentTitle(props);
-const tooltipId = useUid("g-tooltip");
 
 const showTooltip = computed(() => props.tooltip && currentTitle.value);
 
@@ -62,7 +60,6 @@ const linkElementRef = useResolveElement(linkRef);
         :to="!props.disabled ? props.to : ''"
         :href="!props.disabled ? props.to ?? props.href : ''"
         :title="props.tooltip ? false : currentTitle"
-        :aria-describedby="showTooltip ? tooltipId : false"
         :aria-disabled="props.disabled"
         v-bind="$attrs"
         @click="onClick">
@@ -71,7 +68,6 @@ const linkElementRef = useResolveElement(linkRef);
         <!-- TODO: make tooltip a sibling in Vue 3 -->
         <GTooltip
             v-if="showTooltip"
-            :id="tooltipId"
             :reference="linkElementRef"
             :text="currentTitle"
             :placement="props.tooltipPlacement" />

--- a/client/src/components/BaseComponents/GLink.vue
+++ b/client/src/components/BaseComponents/GLink.vue
@@ -4,7 +4,7 @@
  * Defaults to button behavior.
  */
 
-import type { Placement } from "@popperjs/core";
+import type { Placement } from "@floating-ui/dom";
 import { computed, ref } from "vue";
 import type { RouterLink } from "vue-router";
 

--- a/client/src/components/BaseComponents/GLink.vue
+++ b/client/src/components/BaseComponents/GLink.vue
@@ -1,4 +1,9 @@
 <script setup lang="ts">
+/**
+ * Clickable inline text element that can be used for router links, anchors, or inline text buttons.
+ * Defaults to button behavior.
+ */
+
 import type { Placement } from "@popperjs/core";
 import { computed, ref } from "vue";
 import type { RouterLink } from "vue-router";
@@ -10,14 +15,23 @@ import { useResolveElement } from "@/composables/resolveElement";
 import GTooltip from "@/components/BaseComponents/GTooltip.vue";
 
 const props = defineProps<{
+    /** Href to set on the underlying 'a' element. Using this will turn the element into an anchor, not affecting the styling */
     href?: string;
+    /** Router link "to" prop. Using this will turn the element into a router-link, not affecting the styling  */
     to?: string;
+    /** Disabled state. Changes appearance, and will no longer accept or forward clicks */
     disabled?: boolean;
+    /** Title attribute, or tooltip text */
     title?: string;
+    /** Alternative title to be displayed in a disabled state */
     disabledTitle?: string;
+    /** When set, uses a tooltip for the "title" prop, instead of the native title attribute */
     tooltip?: boolean;
+    /** Controls the positioning of the tooltip, if a tooltip is active */
     tooltipPlacement?: Placement;
+    /** Dark variant, instead of default blue */
     dark?: boolean;
+    /** Disables the default bold look of the link */
     thin?: boolean;
 }>();
 

--- a/client/src/components/BaseComponents/GModal.vue
+++ b/client/src/components/BaseComponents/GModal.vue
@@ -107,23 +107,35 @@ defineExpose({ showModal, hideModal });
     <!-- This is a convenience shortcut for mouse-users to close the dialog, so disabling this warning is fine here -->
     <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions, vuejs-accessibility/click-events-have-key-events -->
     <dialog ref="dialog" class="g-dialog" :class="sizeClass" @click="onClickDialog">
-        <header>
-            <Heading v-if="props.title" h2 size="md"> {{ Heading }} </Heading>
-            <slot name="header"></slot>
-            <GButton icon-only inline class="g-modal-close-button" size="large" transparent @click="hideModal(false)">
-                <FontAwesomeIcon :icon="faXmark" />
-            </GButton>
-        </header>
+        <section>
+            <header>
+                <Heading v-if="props.title" h2 separator size="lg" class="g-modal-title mb-0">
+                    {{ props.title }}
+                </Heading>
+                <slot name="header"></slot>
+                <GButton
+                    icon-only
+                    inline
+                    class="g-modal-close-button"
+                    size="large"
+                    transparent
+                    @click="hideModal(false)">
+                    <FontAwesomeIcon :icon="faXmark" />
+                </GButton>
+            </header>
 
-        <slot></slot>
-
-        <footer v-if="props.footer || props.confirm">
-            <slot name="footer"></slot>
-            <div v-if="props.confirm" class="g-modal-confirm-buttons">
-                <GButton @click="hideModal(false)"> Cancel </GButton>
-                <GButton color="blue" @click="hideModal(true)"> Ok </GButton>
+            <div class="g-modal-content">
+                <slot></slot>
             </div>
-        </footer>
+
+            <footer v-if="props.footer || props.confirm">
+                <slot name="footer"></slot>
+                <div v-if="props.confirm" class="g-modal-confirm-buttons">
+                    <GButton @click="hideModal(false)"> Cancel </GButton>
+                    <GButton color="blue" @click="hideModal(true)"> Ok </GButton>
+                </div>
+            </footer>
+        </section>
     </dialog>
 </template>
 
@@ -133,26 +145,48 @@ defineExpose({ showModal, hideModal });
     border-radius: var(--spacing-2);
     border: none;
 
+    section {
+        height: 100%;
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-2);
+
+        .g-modal-content {
+            flex-grow: 1;
+            overflow: auto;
+            max-height: 100%;
+        }
+    }
+
     &::backdrop {
         background-color: var(--color-blue-800);
-        opacity: 0.2;
+        opacity: 0.33;
     }
 
     &.g-small {
-        width: 600px;
+        width: var(--g-modal-width, 600px);
+        height: var(--g-modal-height, 400px);
     }
 
     &.g-medium {
-        width: 900px;
+        width: var(--g-modal-width, 900px);
+        height: var(--g-modal-height, 600px);
     }
 
     &.g-large {
-        width: 1200px;
+        width: var(--g-modal-width, 1450px);
+        height: var(--g-modal-height, 800px);
     }
 
     header {
         display: flex;
         justify-content: flex-end;
+        gap: var(--spacing-1);
+
+        .g-modal-title {
+            flex-grow: 1;
+        }
     }
 }
 </style>

--- a/client/src/components/BaseComponents/GModal.vue
+++ b/client/src/components/BaseComponents/GModal.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+/**
+ * Popup modal component. Offers a main slot, a heading slot, and a footer slot.
+ */
+
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { watchImmediate } from "@vueuse/core";
 import { faXmark } from "font-awesome-6";
@@ -11,13 +15,21 @@ import GButton from "@/components/BaseComponents/GButton.vue";
 import Heading from "@/components/Common/Heading.vue";
 
 const props = defineProps<{
+    /** Controls if the modal is showing. Syncable */
     show?: boolean;
+    /** Controls the modals size. If unset, size can be controlled via css `width` and `height` */
     size?: ComponentSize;
+    /** Shows confirm an cancel buttons in the footer, and sends out `ok` and `cancel` events */
     confirm?: boolean;
+    /** Custom text for the Ok confirm button */
     okText?: string;
+    /** Custom text for the Cancel confirm button */
     cancelText?: string;
+    /** Renders the footer region, even if confirm is disabled */
     footer?: boolean;
+    /** Text to display in the title */
     title?: string;
+    /** Fixes the height of the modal to a pre-set height based on `size` */
     fixedHeight?: boolean;
 }>();
 
@@ -31,7 +43,11 @@ const emit = defineEmits<{
 
 const sizeClass = computed(() => {
     const classObject: ComponentSizeClassList = {};
-    classObject[prefix(props.size ?? "medium")] = true;
+
+    if (props.size) {
+        classObject[prefix(props.size)] = true;
+    }
+
     return { ...classObject, "g-fixed-height": props.fixedHeight };
 });
 
@@ -157,10 +173,6 @@ defineExpose({ showModal, hideModal });
 </template>
 
 <style lang="scss" scoped>
-/**
- * If you want more control over the size of the modal, set the custom props `--g-modal-width` and `--g-modal-height`
- */
-
 .g-dialog {
     background-color: var(--background-color);
     border-radius: var(--spacing-2);
@@ -190,26 +202,26 @@ defineExpose({ showModal, hideModal });
     }
 
     &.g-small {
-        width: var(--g-modal-width, 600px);
+        width: 600px;
 
         &.g-fixed-height {
-            height: var(--g-modal-height, 700px);
+            height: 700px;
         }
     }
 
     &.g-medium {
-        width: var(--g-modal-width, 900px);
+        width: 900px;
 
         &.g-fixed-height {
-            height: var(--g-modal-height, 750px);
+            height: 750px;
         }
     }
 
     &.g-large {
-        width: var(--g-modal-width, 1450px);
+        width: 1450px;
 
         &.g-fixed-height {
-            height: var(--g-modal-height, 800px);
+            height: 800px;
         }
     }
 

--- a/client/src/components/BaseComponents/GModal.vue
+++ b/client/src/components/BaseComponents/GModal.vue
@@ -1,16 +1,35 @@
 <script setup lang="ts">
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { watchImmediate } from "@vueuse/core";
-import { onBeforeUnmount, onMounted, ref } from "vue";
+import { faXmark } from "font-awesome-6";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+
+import { type ComponentSize, type ComponentSizeClassList, prefix } from "@/components/BaseComponents/componentVariants";
+
+import GButton from "@/components/BaseComponents/GButton.vue";
+import Heading from "@/components/Common/Heading.vue";
 
 const props = defineProps<{
     show?: boolean;
+    size?: ComponentSize;
+    confirm?: boolean;
+    footer?: boolean;
+    title?: string;
 }>();
 
 const emit = defineEmits<{
     (e: "update:show", show: boolean): void;
     (e: "open"): void;
     (e: "close"): void;
+    (e: "ok"): void;
+    (e: "cancel"): void;
 }>();
+
+const sizeClass = computed(() => {
+    const classObject: ComponentSizeClassList = {};
+    classObject[prefix(props.size ?? "medium")] = true;
+    return classObject;
+});
 
 const dialog = ref<HTMLDialogElement | null>(null);
 
@@ -43,26 +62,68 @@ function showModal() {
     dialog.value?.showModal();
 }
 
-function hideModal() {
+let isOk = false;
+
+function hideModal(ok = false) {
+    isOk = ok;
     dialog.value?.close();
+}
+
+function onClickDialog(event: MouseEvent) {
+    if ((event.target as HTMLElement | null)?.tagName === "DIALOG") {
+        const rect = dialog.value?.getBoundingClientRect();
+        const insideDialogX = rect && event.clientX >= rect.left && event.clientX <= rect.right;
+        const insideDialogY = rect && event.clientY >= rect.top && event.clientY <= rect.bottom;
+        const insideDialog = insideDialogX && insideDialogY;
+
+        if (!insideDialog) {
+            hideModal(false);
+        }
+    }
 }
 
 function onOpen() {
     emit("update:show", true);
     emit("open");
+
+    isOk = false;
 }
 
 function onClose() {
     emit("update:show", false);
     emit("close");
+
+    if (props.confirm && isOk) {
+        emit("ok");
+    } else {
+        emit("cancel");
+    }
 }
 
 defineExpose({ showModal, hideModal });
 </script>
 
 <template>
-    <dialog ref="dialog" class="g-dialog">
+    <!-- This is a convenience shortcut for mouse-users to close the dialog, so disabling this warning is fine here -->
+    <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions, vuejs-accessibility/click-events-have-key-events -->
+    <dialog ref="dialog" class="g-dialog" :class="sizeClass" @click="onClickDialog">
+        <header>
+            <Heading v-if="props.title" h2 size="md"> {{ Heading }} </Heading>
+            <slot name="header"></slot>
+            <GButton icon-only inline class="g-modal-close-button" size="large" transparent @click="hideModal(false)">
+                <FontAwesomeIcon :icon="faXmark" />
+            </GButton>
+        </header>
+
         <slot></slot>
+
+        <footer v-if="props.footer || props.confirm">
+            <slot name="footer"></slot>
+            <div v-if="props.confirm" class="g-modal-confirm-buttons">
+                <GButton @click="hideModal(false)"> Cancel </GButton>
+                <GButton color="blue" @click="hideModal(true)"> Ok </GButton>
+            </div>
+        </footer>
     </dialog>
 </template>
 
@@ -70,9 +131,28 @@ defineExpose({ showModal, hideModal });
 .g-dialog {
     background-color: var(--background-color);
     border-radius: var(--spacing-2);
+    border: none;
 
     &::backdrop {
         background-color: var(--color-blue-800);
+        opacity: 0.2;
+    }
+
+    &.g-small {
+        width: 600px;
+    }
+
+    &.g-medium {
+        width: 900px;
+    }
+
+    &.g-large {
+        width: 1200px;
+    }
+
+    header {
+        display: flex;
+        justify-content: flex-end;
     }
 }
 </style>

--- a/client/src/components/BaseComponents/GModal.vue
+++ b/client/src/components/BaseComponents/GModal.vue
@@ -126,7 +126,8 @@ defineExpose({ showModal, hideModal });
                     h2
                     :separator="props.size === 'large'"
                     :size="headingSize"
-                    class="g-modal-title mb-0">
+                    class="g-modal-title mb-0"
+                    :class="props.size === 'large' ? '' : 'ml-2'">
                     {{ props.title }}
                 </Heading>
 

--- a/client/src/components/BaseComponents/GModal.vue
+++ b/client/src/components/BaseComponents/GModal.vue
@@ -113,14 +113,8 @@ defineExpose({ showModal, hideModal });
                     {{ props.title }}
                 </Heading>
                 <slot name="header"></slot>
-                <GButton
-                    icon-only
-                    inline
-                    class="g-modal-close-button"
-                    size="large"
-                    transparent
-                    @click="hideModal(false)">
-                    <FontAwesomeIcon :icon="faXmark" />
+                <GButton icon-only class="g-modal-close-button" transparent size="large" @click="hideModal(false)">
+                    <FontAwesomeIcon fixed-width :icon="faXmark" />
                 </GButton>
             </header>
 

--- a/client/src/components/BaseComponents/GModal.vue
+++ b/client/src/components/BaseComponents/GModal.vue
@@ -14,8 +14,11 @@ const props = defineProps<{
     show?: boolean;
     size?: ComponentSize;
     confirm?: boolean;
+    okText?: string;
+    cancelText?: string;
     footer?: boolean;
     title?: string;
+    fixedHeight?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -29,7 +32,7 @@ const emit = defineEmits<{
 const sizeClass = computed(() => {
     const classObject: ComponentSizeClassList = {};
     classObject[prefix(props.size ?? "medium")] = true;
-    return classObject;
+    return { ...classObject, "g-fixed-height": props.fixedHeight };
 });
 
 const dialog = ref<HTMLDialogElement | null>(null);
@@ -118,18 +121,17 @@ defineExpose({ showModal, hideModal });
     <dialog ref="dialog" class="g-dialog" :class="sizeClass" @click="onClickDialog">
         <section>
             <header>
-                <template v-if="props.title">
-                    <Heading
-                        v-if="props.size === 'large'"
-                        h2
-                        :separator="props.size === 'large'"
-                        :size="headingSize"
-                        class="g-modal-title mb-0">
-                        {{ props.title }}
-                    </Heading>
-                </template>
+                <Heading
+                    v-if="props.title"
+                    h2
+                    :separator="props.size === 'large'"
+                    :size="headingSize"
+                    class="g-modal-title mb-0">
+                    {{ props.title }}
+                </Heading>
 
                 <slot name="header"></slot>
+
                 <GButton icon-only class="g-modal-close-button" transparent size="large" @click="hideModal(false)">
                     <FontAwesomeIcon fixed-width :icon="faXmark" />
                 </GButton>
@@ -140,10 +142,13 @@ defineExpose({ showModal, hideModal });
             </div>
 
             <footer v-if="props.footer || props.confirm">
-                <slot name="footer"></slot>
+                <div class="g-modal-footer-content">
+                    <slot name="footer"></slot>
+                </div>
+
                 <div v-if="props.confirm" class="g-modal-confirm-buttons">
-                    <GButton @click="hideModal(false)"> Cancel </GButton>
-                    <GButton color="blue" @click="hideModal(true)"> Ok </GButton>
+                    <GButton @click="hideModal(false)"> {{ props.cancelText ?? "Cancel" }} </GButton>
+                    <GButton color="blue" @click="hideModal(true)"> {{ props.okText ?? "Ok" }} </GButton>
                 </div>
             </footer>
         </section>
@@ -185,17 +190,26 @@ defineExpose({ showModal, hideModal });
 
     &.g-small {
         width: var(--g-modal-width, 600px);
-        height: var(--g-modal-height, 700px);
+
+        &.g-fixed-height {
+            height: var(--g-modal-height, 700px);
+        }
     }
 
     &.g-medium {
         width: var(--g-modal-width, 900px);
-        height: var(--g-modal-height, 750px);
+
+        &.g-fixed-height {
+            height: var(--g-modal-height, 750px);
+        }
     }
 
     &.g-large {
         width: var(--g-modal-width, 1450px);
-        height: var(--g-modal-height, 800px);
+
+        &.g-fixed-height {
+            height: var(--g-modal-height, 800px);
+        }
     }
 
     header {
@@ -204,6 +218,17 @@ defineExpose({ showModal, hideModal });
         gap: var(--spacing-1);
 
         .g-modal-title {
+            flex-grow: 1;
+        }
+    }
+
+    footer {
+        margin: calc(var(--spacing-3) * -1);
+        padding: var(--spacing-3);
+        border-top: 1px solid var(--color-grey-200);
+        display: flex;
+
+        .g-modal-footer-content {
             flex-grow: 1;
         }
     }

--- a/client/src/components/BaseComponents/GModal.vue
+++ b/client/src/components/BaseComponents/GModal.vue
@@ -140,6 +140,10 @@ defineExpose({ showModal, hideModal });
 </template>
 
 <style lang="scss" scoped>
+/**
+ * If you want more control over the size of the modal, set the custom props `--g-modal-width` and `--g-modal-height`
+ */
+
 .g-dialog {
     background-color: var(--background-color);
     border-radius: var(--spacing-2);

--- a/client/src/components/BaseComponents/GModal.vue
+++ b/client/src/components/BaseComponents/GModal.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { watchImmediate } from "@vueuse/core";
+import { onBeforeUnmount, onMounted, ref } from "vue";
+
+const props = defineProps<{
+    show?: boolean;
+}>();
+
+const emit = defineEmits<{
+    (e: "update:show", show: boolean): void;
+    (e: "open"): void;
+    (e: "close"): void;
+}>();
+
+const dialog = ref<HTMLDialogElement | null>(null);
+
+onMounted(() => {
+    if (dialog.value) {
+        dialog.value.addEventListener("close", onClose);
+        dialog.value.addEventListener("open", onOpen);
+    }
+});
+
+onBeforeUnmount(() => {
+    if (dialog.value) {
+        dialog.value.removeEventListener("close", onClose);
+        dialog.value.removeEventListener("open", onOpen);
+    }
+});
+
+watchImmediate(
+    () => props.show,
+    () => {
+        if (props.show) {
+            showModal();
+        } else {
+            hideModal();
+        }
+    }
+);
+
+function showModal() {
+    dialog.value?.showModal();
+}
+
+function hideModal() {
+    dialog.value?.close();
+}
+
+function onOpen() {
+    emit("update:show", true);
+    emit("open");
+}
+
+function onClose() {
+    emit("update:show", false);
+    emit("close");
+}
+
+defineExpose({ showModal, hideModal });
+</script>
+
+<template>
+    <dialog ref="dialog" class="g-dialog">
+        <slot></slot>
+    </dialog>
+</template>
+
+<style lang="scss" scoped>
+.g-dialog {
+    background-color: var(--background-color);
+    border-radius: var(--spacing-2);
+
+    &::backdrop {
+        background-color: var(--color-blue-800);
+    }
+}
+</style>

--- a/client/src/components/BaseComponents/GModal.vue
+++ b/client/src/components/BaseComponents/GModal.vue
@@ -67,17 +67,6 @@ onBeforeUnmount(() => {
     }
 });
 
-watchImmediate(
-    () => props.show,
-    () => {
-        if (props.show) {
-            showModal();
-        } else {
-            hideModal();
-        }
-    }
-);
-
 function showModal() {
     dialog.value?.showModal();
 }
@@ -88,6 +77,17 @@ function hideModal(ok = false) {
     isOk = ok;
     dialog.value?.close();
 }
+
+watchImmediate(
+    () => props.show,
+    () => {
+        if (props.show) {
+            showModal();
+        } else {
+            hideModal();
+        }
+    }
+);
 
 function onClickDialog(event: MouseEvent) {
     if ((event.target as HTMLElement | null)?.tagName === "DIALOG") {

--- a/client/src/components/BaseComponents/GModal.vue
+++ b/client/src/components/BaseComponents/GModal.vue
@@ -5,6 +5,7 @@ import { faXmark } from "font-awesome-6";
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 
 import { type ComponentSize, type ComponentSizeClassList, prefix } from "@/components/BaseComponents/componentVariants";
+import { match } from "@/utils/utils";
 
 import GButton from "@/components/BaseComponents/GButton.vue";
 import Heading from "@/components/Common/Heading.vue";
@@ -100,6 +101,14 @@ function onClose() {
     }
 }
 
+const headingSize = computed(() =>
+    match(props.size ?? "medium", {
+        small: () => "sm" as const,
+        medium: () => "md" as const,
+        large: () => "lg" as const,
+    })
+);
+
 defineExpose({ showModal, hideModal });
 </script>
 
@@ -109,9 +118,17 @@ defineExpose({ showModal, hideModal });
     <dialog ref="dialog" class="g-dialog" :class="sizeClass" @click="onClickDialog">
         <section>
             <header>
-                <Heading v-if="props.title" h2 separator size="lg" class="g-modal-title mb-0">
-                    {{ props.title }}
-                </Heading>
+                <template v-if="props.title">
+                    <Heading
+                        v-if="props.size === 'large'"
+                        h2
+                        :separator="props.size === 'large'"
+                        :size="headingSize"
+                        class="g-modal-title mb-0">
+                        {{ props.title }}
+                    </Heading>
+                </template>
+
                 <slot name="header"></slot>
                 <GButton icon-only class="g-modal-close-button" transparent size="large" @click="hideModal(false)">
                     <FontAwesomeIcon fixed-width :icon="faXmark" />
@@ -143,6 +160,8 @@ defineExpose({ showModal, hideModal });
     border-radius: var(--spacing-2);
     border: none;
 
+    padding: var(--spacing-3);
+
     section {
         height: 100%;
         width: 100%;
@@ -154,6 +173,8 @@ defineExpose({ showModal, hideModal });
             flex-grow: 1;
             overflow: auto;
             max-height: 100%;
+            display: flex;
+            flex-direction: column;
         }
     }
 
@@ -164,12 +185,12 @@ defineExpose({ showModal, hideModal });
 
     &.g-small {
         width: var(--g-modal-width, 600px);
-        height: var(--g-modal-height, 400px);
+        height: var(--g-modal-height, 700px);
     }
 
     &.g-medium {
         width: var(--g-modal-width, 900px);
-        height: var(--g-modal-height, 600px);
+        height: var(--g-modal-height, 750px);
     }
 
     &.g-large {

--- a/client/src/components/BaseComponents/GTooltip.vue
+++ b/client/src/components/BaseComponents/GTooltip.vue
@@ -8,7 +8,7 @@
 import type { Instance as PopperInstance, Placement } from "@popperjs/core";
 import { createPopper } from "@popperjs/core";
 import { watchImmediate } from "@vueuse/core";
-import { computed, onUnmounted, ref } from "vue";
+import { computed, onBeforeUnmount, ref } from "vue";
 
 import { useAccessibleHover } from "@/composables/accessibleHover";
 import { useUid } from "@/composables/utils/uid";
@@ -83,7 +83,7 @@ watchImmediate(
     }
 );
 
-onUnmounted(() => {
+onBeforeUnmount(() => {
     props.reference?.removeAttribute("aria-describedby");
 });
 

--- a/client/src/components/BaseComponents/GTooltip.vue
+++ b/client/src/components/BaseComponents/GTooltip.vue
@@ -1,4 +1,10 @@
 <script setup lang="ts">
+/**
+ * Tooltip component integrated into most interactive galaxy base components.
+ * Can be used separately. Accepts rich content via slot.
+ * Will set "aria-describedby" property on linked element.
+ */
+
 import type { Instance as PopperInstance, Placement } from "@popperjs/core";
 import { createPopper } from "@popperjs/core";
 import { watchImmediate } from "@vueuse/core";
@@ -9,9 +15,13 @@ import { useUid } from "@/composables/utils/uid";
 import { assertDefined } from "@/utils/assertions";
 
 const props = defineProps<{
+    /** Optional id override. Will auto generate an id if none is provided */
     id?: string;
+    /** Element to listen to on hover state. Will also set "aria-describedby" attribute of linked element to this tooltip */
     reference: HTMLElement | null;
+    /** Optional text. Alternative to using the elements slot */
     text?: string;
+    /** Position of the tooltip relative to reference element */
     placement?: Placement;
 }>();
 
@@ -107,7 +117,7 @@ defineExpose({
 
 <template>
     <div
-        :id="props.id"
+        :id="elementId"
         ref="tooltip"
         role="tooltip"
         class="g-tooltip"

--- a/client/src/components/BaseComponents/componentVariants.ts
+++ b/client/src/components/BaseComponents/componentVariants.ts
@@ -1,11 +1,15 @@
 export type ComponentColor = "grey" | "blue" | "green" | "yellow" | "orange" | "red";
 export type ComponentSize = "small" | "medium" | "large";
 
-export type ComponentVariantClassList = {
+export type ComponentSizeClassList = {
     [_key in `g-${ComponentSize}`]?: true;
-} & {
+};
+
+export type ComponentColorClassList = {
     [_key in `g-${ComponentColor}`]?: true;
 };
+
+export type ComponentVariantClassList = ComponentSizeClassList & ComponentColorClassList;
 
 export function prefix<T extends string>(key: T): `g-${T}` {
     return `g-${key}`;

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -322,7 +322,6 @@ async function resumePausedJobs() {
 
         <SelectorModal
             v-if="!props.minimal"
-            v-show="showSwitchModal"
             id="selector-history-modal"
             :histories="histories"
             :additional-options="['center', 'multi']"

--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -114,7 +114,13 @@ const modalBodyClasses = computed(() => {
 </script>
 
 <template>
-    <GModal ref="modal" size="small" :show.sync="propShowModal" :class="modalBodyClasses" :title="localize(title)">
+    <GModal
+        ref="modal"
+        size="small"
+        fixed-height
+        :show.sync="propShowModal"
+        :class="modalBodyClasses"
+        :title="localize(title)">
         <BFormGroup :description="localize('Filter histories')">
             <FilterMenu
                 ref="filterMenuRef"

--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -105,7 +105,6 @@ function setFilterValue(newFilter: string, newValue: string) {
 // https://github.com/galaxyproject/galaxy/issues/17711
 const modalBodyClasses = computed(() => {
     return [
-        "history-selector-modal-body",
         showAdvanced.value
             ? "history-selector-modal-body-allow-overflow"
             : "history-selector-modal-body-prevent-overflow",
@@ -171,11 +170,6 @@ const modalBodyClasses = computed(() => {
 </template>
 
 <style scoped lang="scss">
-.history-selector-modal-body {
-    display: flex;
-    flex-direction: column;
-}
-
 .history-selector-modal-body-allow-overflow {
     overflow: visible;
 }

--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { BButton, BFormGroup, BModal } from "bootstrap-vue";
+import { BButton, BFormGroup } from "bootstrap-vue";
 import { orderBy } from "lodash";
 import isEqual from "lodash.isequal";
 import { storeToRefs } from "pinia";
@@ -10,8 +10,8 @@ import { HistoriesFilters } from "@/components/History/HistoriesFilters";
 import { useHistoryStore } from "@/stores/historyStore";
 import localize from "@/utils/localization";
 
+import GModal from "@/components/BaseComponents/GModal.vue";
 import FilterMenu from "@/components/Common/FilterMenu.vue";
-import Heading from "@/components/Common/Heading.vue";
 import HistoryList from "@/components/History/HistoryScrollList.vue";
 
 type AdditionalOptions = "set-current" | "multi" | "center";
@@ -52,7 +52,7 @@ const selectedHistories = ref<PinnedHistory[]>([]);
 const filter = ref("");
 const busy = ref(false);
 const showAdvanced = ref(false);
-const modal = ref<BModal | null>(null);
+const modal = ref<InstanceType<typeof GModal> | null>(null);
 
 const { pinnedHistories } = storeToRefs(useHistoryStore());
 
@@ -85,7 +85,7 @@ function selectHistory(history: HistorySummary) {
         }
     } else {
         emit("selectHistory", history);
-        modal.value?.hide();
+        modal.value?.hideModal();
     }
 }
 
@@ -94,7 +94,7 @@ function selectHistories() {
     emit("selectHistories", selectedHistories.value);
     // set local value equal to updated value from store
     selectedHistories.value = pinnedHistories.value;
-    modal.value?.hide();
+    modal.value?.hideModal();
 }
 
 function setFilterValue(newFilter: string, newValue: string) {
@@ -114,76 +114,57 @@ const modalBodyClasses = computed(() => {
 </script>
 
 <template>
-    <div>
-        <BModal
-            ref="modal"
-            v-model="propShowModal"
-            content-class="history-selector-modal-content"
-            v-bind="$attrs"
-            :body-class="modalBodyClasses"
-            static
-            centered
-            hide-footer
-            v-on="$listeners">
-            <template v-slot:modal-title>
-                <Heading h2 inline size="sm">{{ localize(title) }}</Heading>
+    <GModal ref="modal" size="small" :show.sync="propShowModal" :class="modalBodyClasses" :title="localize(title)">
+        <BFormGroup :description="localize('Filter histories')">
+            <FilterMenu
+                ref="filterMenuRef"
+                name="Histories"
+                placeholder="search histories"
+                :filter-class="HistoriesFilters"
+                :filter-text.sync="filter"
+                :loading="busy"
+                :show-advanced.sync="showAdvanced" />
+        </BFormGroup>
+
+        <HistoryList
+            v-show="!showAdvanced"
+            :multiple="props.multiple"
+            :selected-histories="selectedHistories"
+            :additional-options="props.additionalOptions"
+            :show-modal.sync="propShowModal"
+            in-modal
+            :filter="filter"
+            :loading.sync="busy"
+            @selectHistory="selectHistory"
+            @setFilter="setFilterValue">
+            <template v-slot:modal-button-area>
+                <span class="d-flex align-items-center">
+                    <a
+                        v-if="multiple"
+                        v-b-tooltip.noninteractive.hover
+                        :title="localize('Click here to reset selection')"
+                        class="mr-2"
+                        href="javascript:void(0)"
+                        @click="selectedHistories = []">
+                        <i>{{ selectedHistories.length }} histories selected</i>
+                    </a>
+                    <BButton
+                        v-if="multiple"
+                        v-localize
+                        data-description="change selected histories button"
+                        :disabled="pinnedSelectedEqual || showAdvanced"
+                        variant="primary"
+                        @click="selectHistories">
+                        Change Selected
+                    </BButton>
+                    <span v-else v-localize> Click a history to switch to it </span>
+                </span>
             </template>
-
-            <BFormGroup :description="localize('Filter histories')">
-                <FilterMenu
-                    ref="filterMenuRef"
-                    name="Histories"
-                    placeholder="search histories"
-                    :filter-class="HistoriesFilters"
-                    :filter-text.sync="filter"
-                    :loading="busy"
-                    :show-advanced.sync="showAdvanced" />
-            </BFormGroup>
-
-            <HistoryList
-                v-show="!showAdvanced"
-                :multiple="props.multiple"
-                :selected-histories="selectedHistories"
-                :additional-options="props.additionalOptions"
-                :show-modal.sync="propShowModal"
-                in-modal
-                :filter="filter"
-                :loading.sync="busy"
-                @selectHistory="selectHistory"
-                @setFilter="setFilterValue">
-                <template v-slot:modal-button-area>
-                    <span class="d-flex align-items-center">
-                        <a
-                            v-if="multiple"
-                            v-b-tooltip.noninteractive.hover
-                            :title="localize('Click here to reset selection')"
-                            class="mr-2"
-                            href="javascript:void(0)"
-                            @click="selectedHistories = []">
-                            <i>{{ selectedHistories.length }} histories selected</i>
-                        </a>
-                        <BButton
-                            v-if="multiple"
-                            v-localize
-                            data-description="change selected histories button"
-                            :disabled="pinnedSelectedEqual || showAdvanced"
-                            variant="primary"
-                            @click="selectHistories">
-                            Change Selected
-                        </BButton>
-                        <span v-else v-localize> Click a history to switch to it </span>
-                    </span>
-                </template>
-            </HistoryList>
-        </BModal>
-    </div>
+        </HistoryList>
+    </GModal>
 </template>
 
-<style>
-/** NOTE: Not using `<style scoped> here because these classes are
-`BModal` `body-class` and `content-class` and so don't seem to work
-with scoped or lang="scss" */
-
+<style scoped lang="scss">
 .history-selector-modal-body {
     display: flex;
     flex-direction: column;
@@ -195,9 +176,5 @@ with scoped or lang="scss" */
 
 .history-selector-modal-body-prevent-overflow {
     overflow: hidden;
-}
-
-.history-selector-modal-content {
-    max-height: 80vh !important;
 }
 </style>

--- a/client/src/components/Workflow/List/WorkflowCardList.vue
+++ b/client/src/components/Workflow/List/WorkflowCardList.vue
@@ -117,7 +117,7 @@ const workflowPublished = ref<InstanceType<typeof WorkflowPublished>>();
             title="Workflow Preview"
             hide-header
             fixed-height
-            dialog-class="workflow-card-preview-modal w-auto"
+            class="workflow-card-preview-modal"
             centered>
             <template v-slot:header>
                 <WorkflowPublishedButtons

--- a/client/src/components/Workflow/List/WorkflowCardList.vue
+++ b/client/src/components/Workflow/List/WorkflowCardList.vue
@@ -116,6 +116,7 @@ const workflowPublished = ref<InstanceType<typeof WorkflowPublished>>();
             size="large"
             title="Workflow Preview"
             hide-header
+            fixed-height
             dialog-class="workflow-card-preview-modal w-auto"
             centered>
             <template v-slot:header>

--- a/client/src/components/Workflow/List/WorkflowCardList.vue
+++ b/client/src/components/Workflow/List/WorkflowCardList.vue
@@ -111,10 +111,11 @@ function onInsertSteps(workflow: WorkflowSummary) {
         <GModal
             :show.sync="showPreview"
             size="large"
+            title="Workflow Preview"
             hide-header
             dialog-class="workflow-card-preview-modal w-auto"
             centered>
-            <WorkflowPublished v-if="showPreview" :id="modalOptions.preview.id" quick-view />
+            <WorkflowPublished v-if="showPreview" :id="modalOptions.preview.id" :show-heading="false" quick-view />
         </GModal>
     </div>
 </template>

--- a/client/src/components/Workflow/List/WorkflowCardList.vue
+++ b/client/src/components/Workflow/List/WorkflowCardList.vue
@@ -9,6 +9,7 @@ import WorkflowCard from "./WorkflowCard.vue";
 import WorkflowRename from "./WorkflowRename.vue";
 import GModal from "@/components/BaseComponents/GModal.vue";
 import WorkflowPublished from "@/components/Workflow/Published/WorkflowPublished.vue";
+import WorkflowPublishedButtons from "@/components/Workflow/Published/WorkflowPublishedButtons.vue";
 
 interface Props {
     workflows: WorkflowSummary[];
@@ -77,6 +78,8 @@ function onInsert(workflow: WorkflowSummary) {
 function onInsertSteps(workflow: WorkflowSummary) {
     emit("insertWorkflowSteps", workflow.id, workflow.number_of_steps as any);
 }
+
+const workflowPublished = ref<InstanceType<typeof WorkflowPublished>>();
 </script>
 
 <template>
@@ -115,7 +118,20 @@ function onInsertSteps(workflow: WorkflowSummary) {
             hide-header
             dialog-class="workflow-card-preview-modal w-auto"
             centered>
-            <WorkflowPublished v-if="showPreview" :id="modalOptions.preview.id" :show-heading="false" quick-view />
+            <template v-slot:header>
+                <WorkflowPublishedButtons
+                    v-if="workflowPublished?.workflowInfo"
+                    :id="modalOptions.preview.id"
+                    :workflow-info="workflowPublished?.workflowInfo" />
+            </template>
+
+            <WorkflowPublished
+                v-if="showPreview"
+                :id="modalOptions.preview.id"
+                ref="workflowPublished"
+                :show-heading="false"
+                :show-buttons="false"
+                quick-view />
         </GModal>
     </div>
 </template>

--- a/client/src/components/Workflow/List/WorkflowCardList.vue
+++ b/client/src/components/Workflow/List/WorkflowCardList.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { BModal } from "bootstrap-vue";
 import { reactive, ref } from "vue";
 
 import type { WorkflowSummary } from "@/api/workflows";
@@ -8,6 +7,7 @@ import type { SelectedWorkflow } from "./types";
 
 import WorkflowCard from "./WorkflowCard.vue";
 import WorkflowRename from "./WorkflowRename.vue";
+import GModal from "@/components/BaseComponents/GModal.vue";
 import WorkflowPublished from "@/components/Workflow/Published/WorkflowPublished.vue";
 
 interface Props {
@@ -108,15 +108,14 @@ function onInsertSteps(workflow: WorkflowSummary) {
             :name="modalOptions.rename.name"
             @close="onRenameClose" />
 
-        <BModal
-            v-model="showPreview"
-            ok-only
-            size="xl"
+        <GModal
+            :show.sync="showPreview"
+            size="large"
             hide-header
             dialog-class="workflow-card-preview-modal w-auto"
             centered>
             <WorkflowPublished v-if="showPreview" :id="modalOptions.preview.id" quick-view />
-        </BModal>
+        </GModal>
     </div>
 </template>
 

--- a/client/src/components/Workflow/Published/WorkflowPublished.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublished.vue
@@ -4,7 +4,7 @@ import { faBuilding, faDownload, faEdit, faPlay, faSpinner, faUser } from "@fort
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { until } from "@vueuse/core";
 import { type AxiosError } from "axios";
-import { BAlert, BButton, BCard } from "bootstrap-vue";
+import { BAlert, BCard } from "bootstrap-vue";
 import { computed, nextTick, onMounted, ref, watch } from "vue";
 
 import { getWorkflowInfo, type StoredWorkflowDetailed } from "@/api/workflows";
@@ -12,15 +12,14 @@ import { fromSimple } from "@/components/Workflow/Editor/modules/model";
 import { getWorkflowFull } from "@/components/Workflow/workflows.services";
 import { useDatatypesMapper } from "@/composables/datatypesMapper";
 import { provideScopedWorkflowStores } from "@/composables/workflowStores";
-import { useUserStore } from "@/stores/userStore";
 import type { Steps } from "@/stores/workflowStepStore";
 import { assertDefined } from "@/utils/assertions";
-import { withPrefix } from "@/utils/redirect";
 
 import ActivityBar from "@/components/ActivityBar/ActivityBar.vue";
 import Heading from "@/components/Common/Heading.vue";
 import WorkflowGraph from "@/components/Workflow/Editor/WorkflowGraph.vue";
 import WorkflowInformation from "@/components/Workflow/Published/WorkflowInformation.vue";
+import WorkflowPublishedButtons from "@/components/Workflow/Published/WorkflowPublishedButtons.vue";
 
 library.add(faBuilding, faDownload, faEdit, faPlay, faSpinner, faUser);
 
@@ -51,8 +50,6 @@ const props = withDefaults(defineProps<Props>(), {
     showZoomControls: true,
 });
 
-const userStore = useUserStore();
-
 const { datatypesMapper } = useDatatypesMapper();
 
 const { stateStore } = provideScopedWorkflowStores(props.id);
@@ -64,43 +61,13 @@ const workflow = ref<StoredWorkflowDetailed | null>(null);
 
 const hasError = computed(() => !!errorMessage.value);
 
-const downloadUrl = computed(() => withPrefix(`/api/workflows/${props.id}/download?format=json-download`));
-const importUrl = computed(() => withPrefix(`/workflow/imp?id=${props.id}`));
-const runUrl = computed(() => withPrefix(`/workflows/run?id=${props.id}`));
-
 const initialPosition = computed(() => ({
     x: -props.initialX * props.zoom,
     y: -props.initialY * props.zoom,
 }));
 
-const viewUrl = computed(() => withPrefix(`/published/workflow?id=${props.id}`));
-
-const sharedWorkflow = computed(() => {
-    return !userStore.matchesCurrentUsername(workflowInfo.value?.owner);
-});
-
-const editButtonTitle = computed(() => {
-    if (userStore.isAnonymous) {
-        return "Log in to edit Workflow";
-    } else {
-        if (workflowInfo.value?.deleted) {
-            return "You cannot edit a deleted workflow. Restore it first.";
-        } else {
-            return "Edit Workflow";
-        }
-    }
-});
-
 /** Workflow steps force typed as `Steps` from the `workflowStepStore` */
 const workflowSteps = computed(() => (workflow.value?.steps as unknown as Steps) ?? []);
-
-function logInTitle(title: string) {
-    if (userStore.isAnonymous) {
-        return `Log in to ${title}`;
-    } else {
-        return title;
-    }
-}
 
 async function load() {
     errorMessage.value = "";
@@ -144,6 +111,11 @@ onMounted(async () => {
     // @ts-ignore: TS2339 webpack dev issue. hopefully we can remove this with vite
     workflowGraph.value?.fitWorkflow(0.25, 1.5, 20.0);
 });
+
+defineExpose({
+    workflow,
+    workflowInfo,
+});
 </script>
 
 <template>
@@ -171,65 +143,11 @@ onMounted(async () => {
                         <span v-else> {{ workflowInfo.name }} </span>
                     </Heading>
 
-                    <span v-if="props.showButtons">
-                        <BButton
-                            v-b-tooltip.hover.noninteractive
-                            title="Download workflow in .ga format"
-                            variant="outline-primary"
-                            size="md"
-                            :href="downloadUrl">
-                            <FontAwesomeIcon :icon="faDownload" />
-                            Download
-                        </BButton>
-
-                        <BButton
-                            v-if="!props.embed && sharedWorkflow"
-                            :href="importUrl"
-                            :disabled="userStore.isAnonymous"
-                            :title="logInTitle('Import Workflow')"
-                            data-description="workflow import"
-                            target="_blank"
-                            variant="outline-primary"
-                            size="md">
-                            <FontAwesomeIcon :icon="faEdit" />
-                            Import
-                        </BButton>
-
-                        <BButton
-                            v-else-if="!props.embed && !sharedWorkflow"
-                            v-b-tooltip.hover.noninteractive
-                            :disabled="workflowInfo.deleted"
-                            class="workflow-edit-button"
-                            :title="editButtonTitle"
-                            variant="outline-primary"
-                            size="md"
-                            :to="`/workflows/edit?id=${workflowInfo.id}`">
-                            <FontAwesomeIcon :icon="faEdit" fixed-width />
-                            Edit
-                        </BButton>
-
-                        <BButton
-                            v-if="!props.embed"
-                            :to="runUrl"
-                            :disabled="userStore.isAnonymous"
-                            :title="logInTitle('Run Workflow')"
-                            variant="primary"
-                            size="md">
-                            <FontAwesomeIcon :icon="faPlay" />
-                            Run
-                        </BButton>
-
-                        <BButton
-                            v-if="props.embed"
-                            :href="viewUrl"
-                            target="blank"
-                            variant="primary"
-                            size="md"
-                            class="view-button font-weight-bold">
-                            <FontAwesomeIcon :icon="['gxd', 'galaxyLogo']" />
-                            View In Galaxy
-                        </BButton>
-                    </span>
+                    <WorkflowPublishedButtons
+                        v-if="props.showButtons"
+                        :id="props.id"
+                        :embed="props.embed"
+                        :workflow-info="workflowInfo" />
                 </div>
 
                 <BCard class="workflow-preview" :class="{ 'only-preview': !props.showAbout }">

--- a/client/src/components/Workflow/Published/WorkflowPublished.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublished.vue
@@ -188,7 +188,6 @@ defineExpose({
     .published-workflow {
         display: grid;
         gap: 0.5rem 1rem;
-        grid-template-rows: max-content;
         grid-template-columns: auto auto 30%;
 
         height: 100%;

--- a/client/src/components/Workflow/Published/WorkflowPublishedButtons.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublishedButtons.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faBuilding, faDownload, faEdit, faPlay, faSpinner, faUser } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BButton } from "bootstrap-vue";
+import { computed } from "vue";
+
+import type { StoredWorkflowDetailed } from "@/api/workflows";
+import { useUserStore } from "@/stores/userStore";
+import { withPrefix } from "@/utils/redirect";
+
+library.add(faBuilding, faDownload, faEdit, faPlay, faSpinner, faUser);
+
+const props = defineProps<{
+    id: string;
+    embed?: boolean;
+    workflowInfo: StoredWorkflowDetailed;
+}>();
+
+const userStore = useUserStore();
+
+const downloadUrl = computed(() => withPrefix(`/api/workflows/${props.id}/download?format=json-download`));
+const importUrl = computed(() => withPrefix(`/workflow/imp?id=${props.id}`));
+const runUrl = computed(() => withPrefix(`/workflows/run?id=${props.id}`));
+
+const viewUrl = computed(() => withPrefix(`/published/workflow?id=${props.id}`));
+
+const sharedWorkflow = computed(() => {
+    return !userStore.matchesCurrentUsername(props.workflowInfo.owner);
+});
+
+const editButtonTitle = computed(() => {
+    if (userStore.isAnonymous) {
+        return "Log in to edit Workflow";
+    } else {
+        if (props.workflowInfo.deleted) {
+            return "You cannot edit a deleted workflow. Restore it first.";
+        } else {
+            return "Edit Workflow";
+        }
+    }
+});
+
+function logInTitle(title: string) {
+    if (userStore.isAnonymous) {
+        return `Log in to ${title}`;
+    } else {
+        return title;
+    }
+}
+</script>
+
+<template>
+    <span>
+        <BButton
+            v-b-tooltip.hover.noninteractive
+            title="Download workflow in .ga format"
+            variant="outline-primary"
+            size="md"
+            :href="downloadUrl">
+            <FontAwesomeIcon :icon="faDownload" />
+            Download
+        </BButton>
+
+        <BButton
+            v-if="!props.embed && sharedWorkflow"
+            :href="importUrl"
+            :disabled="userStore.isAnonymous"
+            :title="logInTitle('Import Workflow')"
+            data-description="workflow import"
+            target="_blank"
+            variant="outline-primary"
+            size="md">
+            <FontAwesomeIcon :icon="faEdit" />
+            Import
+        </BButton>
+
+        <BButton
+            v-else-if="!props.embed && !sharedWorkflow"
+            v-b-tooltip.hover.noninteractive
+            :disabled="workflowInfo.deleted"
+            class="workflow-edit-button"
+            :title="editButtonTitle"
+            variant="outline-primary"
+            size="md"
+            :to="`/workflows/edit?id=${workflowInfo.id}`">
+            <FontAwesomeIcon :icon="faEdit" fixed-width />
+            Edit
+        </BButton>
+
+        <BButton
+            v-if="!props.embed"
+            :to="runUrl"
+            :disabled="userStore.isAnonymous"
+            :title="logInTitle('Run Workflow')"
+            variant="primary"
+            size="md">
+            <FontAwesomeIcon :icon="faPlay" />
+            Run
+        </BButton>
+
+        <BButton
+            v-if="props.embed"
+            :href="viewUrl"
+            target="blank"
+            variant="primary"
+            size="md"
+            class="view-button font-weight-bold">
+            <FontAwesomeIcon :icon="['gxd', 'galaxyLogo']" />
+            View In Galaxy
+        </BButton>
+    </span>
+</template>

--- a/client/src/components/Workflow/WorkflowNavigationTitle.vue
+++ b/client/src/components/Workflow/WorkflowNavigationTitle.vue
@@ -137,80 +137,76 @@ async function rerunWorkflow() {
         <BAlert v-if="error" variant="danger" show>{{ error }}</BAlert>
 
         <div class="position-relative">
-            <div v-if="workflow" class="bg-secondary px-2 py-1 rounded">
-                <div class="d-flex align-items-center flex-gapx-1">
-                    <div class="flex-grow-1" data-description="workflow heading">
-                        <div>
-                            <FontAwesomeIcon :icon="faSitemap" fixed-width />
-                            <b> {{ props.invocation ? "Invoked " : "" }}Workflow: {{ getWorkflowName() }} </b>
-                            <span>(Version: {{ workflow.version + 1 }})</span>
-                        </div>
-                    </div>
-                    <GButtonGroup data-button-group>
-                        <GButton
-                            v-if="owned && workflow"
-                            tooltip
-                            data-button-edit
-                            transparent
-                            color="blue"
-                            size="small"
-                            title="Edit Workflow"
-                            disabled-title="This workflow has been deleted."
-                            :disabled="workflow.deleted"
-                            :to="`/workflows/edit?id=${workflow.id}&version=${workflow.version}`">
-                            <FontAwesomeIcon :icon="faEdit" fixed-width />
-                        </GButton>
-                        <AsyncButton
-                            v-else
-                            data-description="import workflow button"
-                            transparent
-                            color="blue"
-                            size="small"
-                            :disabled="isAnonymous || workflowImportedAttempted"
-                            :title="workflowImportTitle"
-                            :icon="faUpload"
-                            :action="onImport">
-                        </AsyncButton>
-
-                        <slot name="workflow-title-actions" />
-                    </GButtonGroup>
-                    <ButtonSpinner
-                        v-if="!props.invocation"
-                        id="run-workflow"
-                        data-description="execute workflow button"
-                        :wait="runWaiting"
-                        :disabled="runDisabled"
-                        size="small"
-                        :tooltip="executeButtonTooltip"
-                        :title="!props.validRerun ? 'Run Workflow' : 'Rerun Workflow'"
-                        @onClick="emit('on-execute')" />
-                    <GButtonGroup v-else>
-                        <GButton
-                            title="Run Workflow"
-                            disabled-title="This workflow has been deleted."
-                            data-button-run
-                            tooltip
-                            color="blue"
-                            size="small"
-                            :disabled="workflow.deleted"
-                            :to="`/workflows/run?id=${workflow.id}&version=${workflow.version}`">
-                            <FontAwesomeIcon :icon="faPlay" fixed-width />
-                            <span v-localize>Run</span>
-                        </GButton>
-                        <GButton
-                            title="Rerun Workflow with same inputs"
-                            disabled-title="This workflow has been deleted."
-                            data-button-rerun
-                            tooltip
-                            color="blue"
-                            size="small"
-                            :disabled="workflow.deleted"
-                            @click="rerunWorkflow">
-                            <FontAwesomeIcon :icon="faRedo" fixed-width />
-                            <span v-localize>Rerun</span>
-                        </GButton>
-                    </GButtonGroup>
+            <div v-if="workflow" class="bg-secondary px-2 py-1 rounded d-flex flex-gapx-1">
+                <div class="flex-grow-1 d-flex align-items-center flex-gapx-1" data-description="workflow heading">
+                    <FontAwesomeIcon :icon="faSitemap" fixed-width />
+                    <b> {{ props.invocation ? "Invoked " : "" }}Workflow: {{ getWorkflowName() }} </b>
+                    <span>(Version: {{ workflow.version + 1 }})</span>
                 </div>
+                <GButtonGroup data-button-group>
+                    <GButton
+                        v-if="owned && workflow"
+                        tooltip
+                        data-button-edit
+                        transparent
+                        color="blue"
+                        size="small"
+                        title="Edit Workflow"
+                        disabled-title="This workflow has been deleted."
+                        :disabled="workflow.deleted"
+                        :to="`/workflows/edit?id=${workflow.id}&version=${workflow.version}`">
+                        <FontAwesomeIcon :icon="faEdit" fixed-width />
+                    </GButton>
+                    <AsyncButton
+                        v-else
+                        data-description="import workflow button"
+                        transparent
+                        color="blue"
+                        size="small"
+                        :disabled="isAnonymous || workflowImportedAttempted"
+                        :title="workflowImportTitle"
+                        :icon="faUpload"
+                        :action="onImport">
+                    </AsyncButton>
+
+                    <slot name="workflow-title-actions" />
+                </GButtonGroup>
+                <ButtonSpinner
+                    v-if="!props.invocation"
+                    id="run-workflow"
+                    data-description="execute workflow button"
+                    :wait="runWaiting"
+                    :disabled="runDisabled"
+                    size="small"
+                    :tooltip="executeButtonTooltip"
+                    :title="!props.validRerun ? 'Run Workflow' : 'Rerun Workflow'"
+                    @onClick="emit('on-execute')" />
+                <GButtonGroup v-else>
+                    <GButton
+                        title="Run Workflow"
+                        disabled-title="This workflow has been deleted."
+                        data-button-run
+                        tooltip
+                        color="blue"
+                        size="small"
+                        :disabled="workflow.deleted"
+                        :to="`/workflows/run?id=${workflow.id}&version=${workflow.version}`">
+                        <FontAwesomeIcon :icon="faPlay" fixed-width />
+                        <span v-localize>Run</span>
+                    </GButton>
+                    <GButton
+                        title="Rerun Workflow with same inputs"
+                        disabled-title="This workflow has been deleted."
+                        data-button-rerun
+                        tooltip
+                        color="blue"
+                        size="small"
+                        :disabled="workflow.deleted"
+                        @click="rerunWorkflow">
+                        <FontAwesomeIcon :icon="faRedo" fixed-width />
+                        <span v-localize>Rerun</span>
+                    </GButton>
+                </GButtonGroup>
             </div>
             <div v-if="props.success" class="donemessagelarge">
                 Successfully invoked workflow

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.test.ts
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.test.ts
@@ -168,12 +168,12 @@ describe("WorkflowInvocationShare", () => {
         const { wrapper } = await mountWorkflowInvocationShare();
 
         // Initially, the modal is not visible and opens when the button is clicked
-        expect(wrapper.find(GModal).props("show")).toBeFalsy();
+        expect(wrapper.findComponent(GModal).props("show")).toBeFalsy();
         await openShareModal(wrapper);
-        expect(wrapper.find(GModal).props("show")).toBeTruthy();
+        expect(wrapper.findComponent(GModal).props("show")).toBeTruthy();
 
-        expect(wrapper.find(GModal).text()).toContain(TEST_WORKFLOW.name);
-        expect(wrapper.find(GModal).text()).toContain(TEST_HISTORY.name);
+        expect(wrapper.findComponent(GModal).text()).toContain(TEST_WORKFLOW.name);
+        expect(wrapper.findComponent(GModal).text()).toContain(TEST_HISTORY.name);
     });
 
     it("shares the workflow and history when the share button is clicked, and copies link", async () => {
@@ -182,7 +182,7 @@ describe("WorkflowInvocationShare", () => {
         await openShareModal(wrapper);
 
         // Click the share button in the modal
-        wrapper.find(GModal).vm.$emit("ok");
+        wrapper.findComponent(GModal).vm.$emit("ok");
         await flushPromises();
 
         // We have 2 toasts
@@ -201,16 +201,16 @@ describe("WorkflowInvocationShare", () => {
     it("renders nothing when the user does not own the workflow", async () => {
         const { wrapper } = await mountWorkflowInvocationShare(false);
         expect(wrapper.find(SELECTORS.SHARE_ICON_BUTTON).exists()).toBe(false);
-        expect(wrapper.find(GModal).exists()).toBeFalsy();
+        expect(wrapper.findComponent(GModal).exists()).toBeFalsy();
     });
 
     it("just copies link and does not open modal if both workflow and history are already shareable", async () => {
         const { wrapper } = await mountWorkflowInvocationShare(true, true);
 
         // Initially, the modal is not visible and this time remains closed when the button is clicked
-        expect(wrapper.find(GModal).props("visible")).toBeFalsy();
+        expect(wrapper.findComponent(GModal).props("visible")).toBeFalsy();
         await openShareModal(wrapper);
-        expect(wrapper.find(GModal).props("visible")).toBeFalsy();
+        expect(wrapper.findComponent(GModal).props("visible")).toBeFalsy();
 
         // Instead we already have a singular toast with the link copied message
         const toasts = toastMock.mock.calls;

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.test.ts
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.test.ts
@@ -8,6 +8,7 @@ import { useServerMock } from "@/api/client/__mocks__/index";
 import { useUserStore } from "@/stores/userStore";
 
 import WorkflowInvocationShare from "./WorkflowInvocationShare.vue";
+import GModal from "@/components/BaseComponents/GModal.vue";
 
 // Constants
 const WORKFLOW_OWNER = "test-user";
@@ -40,8 +41,7 @@ const CLIPBOARD_MSG = "The link to the invocation has been copied to your clipbo
 
 const SELECTORS = {
     SHARE_ICON_BUTTON: "[data-button-share]",
-    MODAL: "[data-description='share invocation modal']",
-};
+} as const;
 
 // Mock the toast composable to track the messages
 const MSG = 0;
@@ -168,12 +168,12 @@ describe("WorkflowInvocationShare", () => {
         const { wrapper } = await mountWorkflowInvocationShare();
 
         // Initially, the modal is not visible and opens when the button is clicked
-        expect(wrapper.find(SELECTORS.MODAL).attributes("visible")).toBeUndefined();
+        expect(wrapper.find(GModal).props("show")).toBeFalsy();
         await openShareModal(wrapper);
-        expect(wrapper.find(SELECTORS.MODAL).attributes("visible")).toBe("true");
+        expect(wrapper.find(GModal).props("show")).toBeTruthy();
 
-        expect(wrapper.find(SELECTORS.MODAL).text()).toContain(TEST_WORKFLOW.name);
-        expect(wrapper.find(SELECTORS.MODAL).text()).toContain(TEST_HISTORY.name);
+        expect(wrapper.find(GModal).text()).toContain(TEST_WORKFLOW.name);
+        expect(wrapper.find(GModal).text()).toContain(TEST_HISTORY.name);
     });
 
     it("shares the workflow and history when the share button is clicked, and copies link", async () => {
@@ -182,7 +182,7 @@ describe("WorkflowInvocationShare", () => {
         await openShareModal(wrapper);
 
         // Click the share button in the modal
-        wrapper.find(SELECTORS.MODAL).vm.$emit("ok");
+        wrapper.find(GModal).vm.$emit("ok");
         await flushPromises();
 
         // We have 2 toasts
@@ -201,16 +201,16 @@ describe("WorkflowInvocationShare", () => {
     it("renders nothing when the user does not own the workflow", async () => {
         const { wrapper } = await mountWorkflowInvocationShare(false);
         expect(wrapper.find(SELECTORS.SHARE_ICON_BUTTON).exists()).toBe(false);
-        expect(wrapper.find(SELECTORS.MODAL).exists()).toBe(false);
+        expect(wrapper.find(GModal).exists()).toBeFalsy();
     });
 
     it("just copies link and does not open modal if both workflow and history are already shareable", async () => {
         const { wrapper } = await mountWorkflowInvocationShare(true, true);
 
         // Initially, the modal is not visible and this time remains closed when the button is clicked
-        expect(wrapper.find(SELECTORS.MODAL).attributes("visible")).toBeUndefined();
+        expect(wrapper.find(GModal).props("visible")).toBeFalsy();
         await openShareModal(wrapper);
-        expect(wrapper.find(SELECTORS.MODAL).attributes("visible")).toBeUndefined();
+        expect(wrapper.find(GModal).props("visible")).toBeFalsy();
 
         // Instead we already have a singular toast with the link copied message
         const toasts = toastMock.mock.calls;

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
@@ -13,7 +13,6 @@ import { useHistoryStore } from "@/stores/historyStore";
 import { copy } from "@/utils/clipboard";
 import { errorMessageAsString } from "@/utils/simple-error";
 
-import GButton from "../BaseComponents/GButton.vue";
 import LoadingSpan from "../LoadingSpan.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GModal from "@/components/BaseComponents/GModal.vue";

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
@@ -126,14 +126,14 @@ function shareInvocationButtonClicked() {
             <LoadingSpan v-else-if="loading" message="Loading details for invocation" />
 
             <div v-else-if="workflow">
-                <p v-localize>
+                <p>
                     To share this invocation, you need to make sure that the workflow
                     <strong>"{{ workflow.name }}"</strong>
                     and history
                     <strong>"{{ historyStore.getHistoryNameById(props.historyId) }}"</strong>
                     are accessible via link.
                 </p>
-                <p v-localize>
+                <p>
                     You can do this by clicking the <i>"Share"</i>
                     button below. This will
                     <strong>make the workflow and history shareable</strong>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationShare.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faShareAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BModal } from "bootstrap-vue";
+import { BAlert } from "bootstrap-vue";
 import { computed, ref } from "vue";
 
 import { GalaxyApi } from "@/api";
@@ -15,6 +15,8 @@ import { errorMessageAsString } from "@/utils/simple-error";
 
 import GButton from "../BaseComponents/GButton.vue";
 import LoadingSpan from "../LoadingSpan.vue";
+import GButton from "@/components/BaseComponents/GButton.vue";
+import GModal from "@/components/BaseComponents/GModal.vue";
 
 const CLIPBOARD_MSG = "The link to the invocation has been copied to your clipboard.";
 
@@ -97,10 +99,10 @@ function shareInvocationButtonClicked() {
 </script>
 
 <template>
-    <div v-if="owned">
+    <div v-if="owned" class="d-flex">
         <GButton
-            title="Share Invocation"
             tooltip
+            title="Share Invocation"
             size="small"
             transparent
             color="blue"
@@ -110,11 +112,12 @@ function shareInvocationButtonClicked() {
             <FontAwesomeIcon :icon="faShareAlt" fixed-width />
         </GButton>
 
-        <BModal
-            v-model="modalToggle"
+        <GModal
+            :show.sync="modalToggle"
             title="Share Workflow Invocation"
-            title-tag="h2"
-            ok-title="Share"
+            confirm
+            ok-text="Share"
+            size="small"
             data-description="share invocation modal"
             @ok="makeInvocationShareable">
             <BAlert v-if="error" variant="danger" show>
@@ -138,6 +141,6 @@ function shareInvocationButtonClicked() {
                     and generate a link that you can share with others, allowing them to view the invocation.
                 </p>
             </div>
-        </BModal>
+        </GModal>
     </div>
 </template>

--- a/client/tests/jest/jest-environment.js
+++ b/client/tests/jest/jest-environment.js
@@ -19,5 +19,19 @@ export default class CustomJSDOMEnvironment extends JSDOMEnvironment {
 
         // FIXME https://github.com/jsdom/jsdom/issues/3363
         this.global.structuredClone = structuredClone;
+
+        if (!this.global.HTMLDialogElement.prototype.showModal) {
+            this.global.HTMLDialogElement.prototype.showModal = function () {
+                this.open = true;
+            };
+        }
+
+        // FIXME https://github.com/jsdom/jsdom/issues/3294
+        if (!this.global.HTMLDialogElement.prototype.close) {
+            this.global.HTMLDialogElement.prototype.close = function (returnValue) {
+                this.open = false;
+                this.returnValue = returnValue;
+            };
+        }
     }
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1470,6 +1470,26 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.52.0.tgz#78fe5f117840f69dc4a353adf9b9cd926353378c"
   integrity sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==
 
+"@floating-ui/core@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.7.0.tgz#1aff27a993ea1b254a586318c29c3b16ea0f4d0a"
+  integrity sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA==
+  dependencies:
+    "@floating-ui/utils" "^0.2.9"
+
+"@floating-ui/dom@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.7.0.tgz#f9f83ee4fee78ac23ad9e65b128fc11a27857532"
+  integrity sha512-lGTor4VlXcesUMh1cupTUTDoCxMb0V6bm3CnxHzQcw8Eaf1jQbgQX4i02fYgT0vJ82tb5MZ4CZk1LRGkktJCzg==
+  dependencies:
+    "@floating-ui/core" "^1.7.0"
+    "@floating-ui/utils" "^0.2.9"
+
+"@floating-ui/utils@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.9.tgz#50dea3616bc8191fb8e112283b49eaff03e78429"
+  integrity sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==
+
 "@fontsource/atkinson-hyperlegible@^5.0.17":
   version "5.0.17"
   resolved "https://registry.yarnpkg.com/@fontsource/atkinson-hyperlegible/-/atkinson-hyperlegible-5.0.17.tgz#d1a43a7403644f6ad31a54e8e1ae779693fbcd9d"


### PR DESCRIPTION
requires #20063

Adds a GModal component.
The modal is based on the native Dialog Element.

Also refactors the tooltip to use floating ui, the successor to popperjs. Popper was having trouble with positioning tooltips inside dialog elements. This is fixed in floating ui.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
