### PR TITLE
Fix tapis module typing errors

### DIFF
--- a/lib/galaxy/authnz/tapis.py
+++ b/lib/galaxy/authnz/tapis.py
@@ -89,8 +89,11 @@ class TapisOAuth2(BaseOAuth2):
         )
         self.process_error(response)
         result = response.get("result")
-        assert result
+        if not result:
+            raise ValueError("No result found in Tapis authentication response")
         token = result.get("access_token")
+        if not token:
+            raise ValueError("No access token found in Tapis authentication response")
         # ignore B026, we keep the same signature as the base class
         return self.do_auth(token, response=response, *args, **kwargs)  # noqa: B026
 

--- a/lib/galaxy/authnz/tapis.py
+++ b/lib/galaxy/authnz/tapis.py
@@ -76,16 +76,13 @@ class TapisOAuth2(BaseOAuth2):
         """Completes login process, must return user instance"""
         self.process_error(self.data)
         state = self.validate_state()
-        data, params = None, None
-        if self.ACCESS_TOKEN_METHOD == "GET":
-            params = self.auth_complete_params(state)
-        else:
-            data = self.auth_complete_params(state)
+
+        data = self.auth_complete_params(state)
 
         response = self.request_access_token(
             self.access_token_url(),
             data=data,
-            params=params,
+            params=None,
             headers=self.auth_headers(),
             auth=self.auth_complete_credentials(),
             method=self.ACCESS_TOKEN_METHOD,

--- a/lib/galaxy/authnz/tapis.py
+++ b/lib/galaxy/authnz/tapis.py
@@ -31,7 +31,7 @@ class TapisOAuth2(BaseOAuth2):
     USE_BASIC_AUTH = True
 
     # Upstream this is initialized to None, but it is expected this will be a list of tuples
-    EXTRA_DATA = [  # type: ignore[assignment]
+    EXTRA_DATA = [
         ("refresh_token", "refresh_token"),
     ]
 
@@ -92,6 +92,7 @@ class TapisOAuth2(BaseOAuth2):
         )
         self.process_error(response)
         result = response.get("result")
+        assert result
         token = result.get("access_token")
         # ignore B026, we keep the same signature as the base class
         return self.do_auth(token, response=response, *args, **kwargs)  # noqa: B026


### PR DESCRIPTION
This fixes 2 out of 4 new typing errors. The remaining 2 errors (ref https://github.com/galaxyproject/galaxy/actions/runs/14873596772/job/41766637525#step:9:65) appear to be legitimate:

```py
ACCESS_TOKEN_METHOD = "POST"
...
if self.ACCESS_TOKEN_METHOD == "GET":
    params = self.auth_complete_params(state)
else:
    data = self.auth_complete_params(state)
```
I assume `ACCESS_TOKEN_METHOD` is intended as a constant here, so the first assignment statement is indeed unreachable. If this is indeed a bug, I'm not sure what an appropriate fix would be here. @dannon?



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
