### PR TITLE
Check for ``format="input"`` as well as ``format="auto"`` in datatype linter

### DIFF
--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -250,7 +250,11 @@ class TestsParamInInputs(Linter):
                 name = name.split("|")[-1]
                 xpaths = [f"@name='{name}'", f"@argument='{name}'", f"@argument='-{name}'", f"@argument='--{name}'"]
                 if "_" in name:
-                    xpaths += [f"@argument='{name.replace('_', '-')}'", f"@argument='-{name.replace('_', '-')}'", f"@argument='--{name.replace('_', '-')}'"]
+                    xpaths += [
+                        f"@argument='{name.replace('_', '-')}'",
+                        f"@argument='-{name.replace('_', '-')}'",
+                        f"@argument='--{name.replace('_', '-')}'",
+                    ]
                 found = False
                 for xp in xpaths:
                     inxpath = f".//inputs//param[{xp}]"

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -250,7 +250,7 @@ class TestsParamInInputs(Linter):
                 name = name.split("|")[-1]
                 xpaths = [f"@name='{name}'", f"@argument='{name}'", f"@argument='-{name}'", f"@argument='--{name}'"]
                 if "_" in name:
-                    xpaths += [f"@argument='-{name.replace('_', '-')}'", f"@argument='--{name.replace('_', '-')}'"]
+                    xpaths += [f"@argument='{name.replace('_', '-')}'", f"@argument='-{name.replace('_', '-')}'", f"@argument='--{name.replace('_', '-')}'"]
                 found = False
                 for xp in xpaths:
                     inxpath = f".//inputs//param[{xp}]"

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -2205,7 +2205,7 @@ def test_valid_datatypes(lint_ctx):
     assert "Unknown datatype [collection_format] used in collection" in lint_ctx.error_messages
     assert "Unknown datatype [invalid] used in param" in lint_ctx.error_messages
     assert "Unknown datatype [invalid] used in discover_datasets" in lint_ctx.error_messages
-    assert "Format [auto] can not be used for tool or tool test inputs" in lint_ctx.error_messages  # 2x
+    assert "Invalid format (auto or input) in tool or tool test inputs" in lint_ctx.error_messages  # 2x
     assert len(lint_ctx.error_messages) == 8
 
 


### PR DESCRIPTION
better consideration of `auto` and `input`

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
