### PR TITLE
Use ``backports.zoneinfo`` in ``job_metrics`` package under Python <3.9

### DIFF
--- a/lib/galaxy/job_metrics/instrumenters/core.py
+++ b/lib/galaxy/job_metrics/instrumenters/core.py
@@ -3,7 +3,6 @@
 import datetime
 import json
 import logging
-import zoneinfo
 from typing import (
     Any,
     Dict,
@@ -18,6 +17,12 @@ from ..formatting import (
     seconds_to_str,
 )
 from ..safety import Safety
+
+try:
+    import zoneinfo
+except ImportError:
+    # Python < 3.9
+    from backports import zoneinfo  # type: ignore[no-redef]
 
 log = logging.getLogger(__name__)
 

--- a/packages/job_metrics/setup.cfg
+++ b/packages/job_metrics/setup.cfg
@@ -35,6 +35,7 @@ version = 25.0.dev0
 include_package_data = True
 install_requires =
     galaxy-util
+    backports.zoneinfo;python_version<'3.9'
 packages = find:
 python_requires = >=3.7
 


### PR DESCRIPTION
Fix import errors in test_galaxy_packages_for_pulsar tests.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
