### PR TITLE
Fix tapis typing

### DIFF
--- a/lib/galaxy/authnz/tapis.py
+++ b/lib/galaxy/authnz/tapis.py
@@ -31,7 +31,7 @@ class TapisOAuth2(BaseOAuth2):
     USE_BASIC_AUTH = True
 
     # Upstream this is initialized to None, but it is expected this will be a list of tuples
-    EXTRA_DATA = [  # type: ignore[assignment]
+    EXTRA_DATA = [
         ("refresh_token", "refresh_token"),
     ]
 

--- a/lib/galaxy/authnz/tapis.py
+++ b/lib/galaxy/authnz/tapis.py
@@ -77,7 +77,7 @@ class TapisOAuth2(BaseOAuth2):
         self.process_error(self.data)
         state = self.validate_state()
         data, params = None, None
-            data = self.auth_complete_params(state)
+        data = self.auth_complete_params(state)
 
         response = self.request_access_token(
             self.access_token_url(),
@@ -88,8 +88,8 @@ class TapisOAuth2(BaseOAuth2):
             method=self.ACCESS_TOKEN_METHOD,
         )
         self.process_error(response)
-        result = response.get("result")
-        token = result.get("access_token")
+        result = response.get("result") or {}
+        token = result.get("access_token") or {}
         # ignore B026, we keep the same signature as the base class
         return self.do_auth(token, response=response, *args, **kwargs)  # noqa: B026
 

--- a/lib/galaxy/authnz/tapis.py
+++ b/lib/galaxy/authnz/tapis.py
@@ -77,9 +77,6 @@ class TapisOAuth2(BaseOAuth2):
         self.process_error(self.data)
         state = self.validate_state()
         data, params = None, None
-        if self.ACCESS_TOKEN_METHOD == "GET":
-            params = self.auth_complete_params(state)
-        else:
             data = self.auth_complete_params(state)
 
         response = self.request_access_token(


### PR DESCRIPTION
Fixes linting:

```
lib/galaxy/authnz/tapis.py:34: error: Unused "type: ignore" comment 
[unused-ignore]
        EXTRA_DATA = [  # type: ignore[assignment]
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lib/galaxy/authnz/tapis.py:80: error: Non-overlapping equality check (left
operand type: "Literal['POST']", right operand type: "Literal['GET']") 
[comparison-overlap]
            if self.ACCESS_TOKEN_METHOD == "GET":
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lib/galaxy/authnz/tapis.py:81: error: Statement is unreachable  [unreachable]
                params = self.auth_complete_params(state)
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lib/galaxy/authnz/tapis.py:95: error: Item "None" of "Optional[Any]" has no
attribute "get"  [union-attr]
            token = result.get("access_token")
                    ^~~~~~~~~~
```

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
