### PR TITLE
Preserve Galaxy's python env for CONVERTER_archive_to_directory

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -273,6 +273,7 @@ GALAXY_LIB_TOOLS_UNVERSIONED = [
     "CONVERTER_gff_to_interval_index_0",
     "CONVERTER_maf_to_fasta_0",
     "CONVERTER_maf_to_interval_0",
+    "CONVERTER_archive_to_directory",
     # Tools improperly migrated to the tool shed (devteam)
     "qualityFilter",
     "pileup_interval",


### PR DESCRIPTION
Preserve Galaxy's python env for the `CONVERTER_archive_to_directory` tool, otherwise we get the below error.

```
            Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'galaxy'
```