### PR TITLE
Have `make dist` in the web_client package build the client

### DIFF
--- a/packages/web_client/Makefile
+++ b/packages/web_client/Makefile
@@ -1,1 +1,111 @@
-../package.Makefile
+# Location of virtualenv used for development.
+VENV?=.venv
+# Open resource on Mac OS X or Linux
+OPEN_RESOURCE=bash -c 'open $$0 || xdg-open $$0'
+# Source virtualenv to execute command (flake8, sphinx, twine, etc...)
+IN_VENV=if [ -f $(VENV)/bin/activate ]; then . $(VENV)/bin/activate; fi;
+UPSTREAM?=galaxyproject
+SOURCE_DIR?=galaxy
+BUILD_SCRIPTS_DIR=scripts
+DEV_RELEASE?=0
+VERSION?=$(shell DEV_RELEASE=$(DEV_RELEASE) python $(BUILD_SCRIPTS_DIR)/print_version_for_release.py)
+PROJECT_NAME?=galaxy-$(shell basename $(CURDIR))
+PROJECT_NAME:=$(subst _,-,$(PROJECT_NAME))
+BRANCH?=$(shell git rev-parse --abbrev-ref HEAD)
+TEST_DIR?=tests
+TESTS?=$(SOURCE_DIR) $(TEST_DIR)
+
+.PHONY: clean-pyc clean-build docs clean
+
+help:
+	@echo "clean - remove all build, test, coverage and Python artifacts"
+	@echo "clean-build - remove build artifacts"
+	@echo "clean-pyc - remove Python file artifacts"
+	@echo "clean-test - remove test and coverage artifacts"
+	@echo "setup-venv - setup a development virtualenv in current directory."
+	@echo "lint-dist - twine check dist results, including validating README content"
+	@echo "dist - package project for PyPI distribution"
+
+clean: clean-build clean-pyc clean-tests clean-web-client
+
+clean-build:
+	rm -fr build/
+	rm -fr dist/
+	rm -fr galaxy_*.egg-info
+
+clean-pyc:
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+clean-tests:
+	rm -fr .tox/
+
+clean-web-client:
+	rm -rf .venv
+	rm -rf galaxy/web_client/dist galaxy/web_client/client_build_hash.txt
+
+setup-venv:
+	if [ ! -d $(VENV) ]; then virtualenv $(VENV); exit; fi;
+	$(IN_VENV) pip install -r dev-requirements.txt
+
+test:
+	$(IN_VENV) pytest $(TESTS)
+
+develop:
+	python setup.py develop
+
+dist: clean $(VENV) galaxy/web_client/client_build_hash.txt
+	$(IN_VENV) python -m build
+	ls -l dist
+
+$(VENV):
+	python3 -m venv $(VENV)
+	$(IN_VENV) pip install build nodeenv
+	$(IN_VENV) nodeenv -n $(shell cat ../../client/.node_version) -p
+	$(IN_VENV) npm install --global yarn
+
+galaxy/web_client/client_build_hash.txt:
+	$(IN_VENV) cd ../..; make client-production
+	mv ../../client/dist galaxy/web_client
+	git rev-parse HEAD > galaxy/web_client/client_build_hash.txt
+
+_twine-exists: ; @which twine > /dev/null
+
+lint-dist: _twine-exists dist
+	$(IN_VENV) twine check dist/*
+
+_release-test-artifacts:
+	$(IN_VENV) twine upload -r test dist/*
+	$(OPEN_RESOURCE) https://testpypi.python.org/pypi/$(PROJECT_NAME)
+
+release-test-artifacts: lint-dist _release-test-artifacts
+
+_release-artifacts:
+	@while [ -z "$$CONTINUE" ]; do \
+	  read -r -p "Have you executed release-test and reviewed results? [y/N]: " CONTINUE; \
+	done ; \
+	[ $$CONTINUE = "y" ] || [ $$CONTINUE = "Y" ] || (echo "Exiting."; exit 1;)
+	@echo "Releasing"
+	$(IN_VENV) twine upload dist/*
+
+release-artifacts: release-test-artifacts _release-artifacts
+
+commit-version:
+	$(IN_VENV) DEV_RELEASE=$(DEV_RELEASE) python $(BUILD_SCRIPTS_DIR)/commit_version.py $(VERSION)
+
+new-version:
+	$(IN_VENV) DEV_RELEASE=$(DEV_RELEASE) python $(BUILD_SCRIPTS_DIR)/new_version.py $(VERSION)
+
+release-local: commit-version release-artifacts new-version
+
+push-release:
+	# git push $(UPSTREAM) $(BRANCH)
+	# git push upstream $(PROJECT_NAME)-$(VERSION)
+	echo "Makefile doesn't manually push release."
+
+release: release-local push-release
+
+mypy:
+	mypy .

--- a/packages/web_client/galaxy/web_client/client_build_hash.txt
+++ b/packages/web_client/galaxy/web_client/client_build_hash.txt
@@ -1,1 +1,0 @@
-../../../../client/client_build_hash.txt


### PR DESCRIPTION
Not ideal because of package Makefile divergence. Also you have to use the Makefile, `python -m build` without it will get you an empty package. Maybe we would prefer to do this entirely in galaxy-release-util (although that does not address the second issue).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `cd packages/web_client`
  2. `make dist`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
