### PR TITLE
[24.0] Fix invocation failure dataset reference

### DIFF
--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -520,7 +520,7 @@ class WorkflowProgress:
                         raise modules.FailWorkflowEvaluation(
                             why=InvocationFailureDatasetFailed(
                                 reason=FailureReason.dataset_failed,
-                                hda_id=replacement.id,
+                                hda_id=dataset_instance.id,
                                 workflow_step_id=connection.input_step_id,
                                 dependent_workflow_step_id=output_step_id,
                             )


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20049. Many thanks for pointing me at the real issue @jdavcs!
`replacement` is HistoryDatasetCollectionAssociation ...

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
