### PR TITLE
Add plotly 6.0.1 to JupyterLite

### DIFF
--- a/config/plugins/visualizations/jupyterlite/config/jupyterlite.xml
+++ b/config/plugins/visualizations/jupyterlite/config/jupyterlite.xml
@@ -12,7 +12,7 @@
         <param required="true">dataset_id</param>
     </params>
     <requirements>
-        <requirement type="npm" version="0.0.7" package="@galaxyproject/jupyterlite"/>
+        <requirement type="npm" version="0.0.10" package="@galaxyproject/jupyterlite"/>
     </requirements>
     <entry_point entry_point_type="script" src="dist/index.js" />
     <tests>

--- a/config/plugins/visualizations/jupyterlite/config/jupyterlite.xml
+++ b/config/plugins/visualizations/jupyterlite/config/jupyterlite.xml
@@ -12,7 +12,7 @@
         <param required="true">dataset_id</param>
     </params>
     <requirements>
-        <requirement type="npm" version="0.0.5" package="@galaxyproject/jupyterlite"/>
+        <requirement type="npm" version="0.0.7" package="@galaxyproject/jupyterlite"/>
     </requirements>
     <entry_point entry_point_type="script" src="dist/index.js" />
     <tests>

--- a/config/plugins/visualizations/jupyterlite/config/jupyterlite.xml
+++ b/config/plugins/visualizations/jupyterlite/config/jupyterlite.xml
@@ -25,6 +25,8 @@
 
 **JupyterLite** is a lightweight version of JupyterLab that runs entirely in your web browser—no server required. It allows you to create, edit, and run notebooks using WebAssembly-based Python kernels (like Pyodide) or JavaScript kernels, all without installing anything on your local machine.
 
+For best performance, we recommend: 🦊 **Firefox**.
+
 This integration brings JupyterLite directly into Galaxy, enabling you to:
 
 - Open and run notebooks attached to Galaxy datasets.


### PR DESCRIPTION
This PR adds the latest stable version of `plotly` to JupyterLite, along with `numpy` and `pandas`, aligning the default package set with what's available in the JupyterLab tool. The version of `plotly` is locked to ensure consistent functionality, as relying on users to install it manually can lead to breakages over time. This slightly increases the bundle size; although it's not a problem at the moment, we should start considering loading visualization plugins directly via CDN instead of downloading them to the Galaxy server.

![jupyter](https://github.com/user-attachments/assets/a705bbf9-c197-445e-9c83-8e6f1f5eb8e4)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
