### PR TITLE
Add rerun.io web viewer

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -47,7 +47,7 @@ molstar:
     version: 0.0.2
 mvpapp:
     package: "@galaxyproject/mvpapp"
-    version: 0.0.0
+    version: 0.0.1
 ngl:
     package: "@galaxyproject/ngl"
     version: 0.0.30

--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -84,6 +84,9 @@ plotly_surface:
 plyr:
     package: "@galaxyproject/plyr"
     version: 0.0.4
+rerunio:
+    package: "@galaxyproject/rerunio"
+    version: 0.0.0
 tabulator:
     package: "@galaxyproject/tabulator"
     version: 0.0.9

--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -829,6 +829,7 @@
     <datatype extension="rdata.camera.quick" type="galaxy.datatypes.binary:RData" mimetype="application/x-gzip" subclass="true" display_in_upload="true"/>
     <datatype extension="rdata.se" type="galaxy.datatypes.hdf5:HDF5SummarizedExperiment"  mimetype="text/html" display_in_upload="true"/>
     <datatype extension="rdock_as" type="galaxy.datatypes.binary:Binary" description="rDock active site format" subclass="true" display_in_upload="true"/>
+    <datatype extension="rrd" type="galaxy.datatypes.binary:Binary" description="Rerun recording data to visualize spatial and temporal data" subclass="true" display_in_upload="true"/>
     <datatype extension="prm" type="galaxy.datatypes.text:Prm" mimetype="text/plain" description="rDock prm format for system definition files, scoring function definition files and search protocol definition files" description_url="https://rdock.github.io/documentation/html_docs/reference-guide/file-formats.html" display_in_upload="true" />
     <datatype extension="oxlicg" type="galaxy.datatypes.binary:OxliCountGraph" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="oxling" type="galaxy.datatypes.binary:OxliNodeGraph" mimetype="application/octet-stream" display_in_upload="true"/>


### PR DESCRIPTION
This PR adds a Galaxy visualization plugin for rerun.io, used to explore .rrd logs from spatial and embodied AI systems.

The PR also adds a subclass binary datatype for `.rrd`.

Also bumps the MVPApp version to fix a minor issue.

![rerunio](https://github.com/user-attachments/assets/32b443ef-3b8c-431f-a7a2-25bc48fa841c)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
