### PR TITLE
[24.2]  Conditionally import from `galaxy.config` in `galaxy.model.mapping` if `TYPE_CHECKING`

### DIFF
--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -103,7 +103,7 @@ def _build_model_mapping(engine, map_install_models, thread_local_log) -> Galaxy
 
 
 def init_models_from_config(
-    config: Type["GalaxyAppConfiguration"],
+    config: "GalaxyAppConfiguration",
     map_install_models: bool = False,
     object_store: Optional["BaseObjectStore"] = None,
     trace_logger=None,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -7,7 +7,6 @@ from typing import (
 )
 
 from galaxy import model
-from galaxy.config import GalaxyAppConfiguration
 from galaxy.model import (
     mapper_registry,
     setup_global_object_store_for_models,
@@ -18,6 +17,7 @@ from galaxy.model.security import GalaxyRBACAgent
 from galaxy.model.triggers.update_audit_table import install as install_timestamp_triggers
 
 if TYPE_CHECKING:
+    from galaxy.config import GalaxyAppConfiguration
     from galaxy.objectstore import BaseObjectStore
 
 log = logging.getLogger(__name__)
@@ -103,7 +103,7 @@ def _build_model_mapping(engine, map_install_models, thread_local_log) -> Galaxy
 
 
 def init_models_from_config(
-    config: GalaxyAppConfiguration,
+    config: Type["GalaxyAppConfiguration"],
     map_install_models: bool = False,
     object_store: Optional["BaseObjectStore"] = None,
     trace_logger=None,


### PR DESCRIPTION
~~`galaxy.metadata.set_metadata` uses `galaxy.config`.~~

Please merge before releasing 24.2.4.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `pip install galaxy-job-execution`
  2. ```console
     $ python -c 'import galaxy.metadata.set_metadata'
     Traceback (most recent call last):
       File "<string>", line 1, in <module>
       File "/home/nate/.virtualenvs/throwaway/lib/python3.11/site-packages/galaxy/metadata/__init__.py", line 10, in <module>
         from galaxy.model import store
       File "/home/nate/.virtualenvs/throwaway/lib/python3.11/site-packages/galaxy/model/store/__init__.py", line 67, in <module>
         from galaxy.model.mapping import GalaxyModelMapping
       File "/home/nate/.virtualenvs/throwaway/lib/python3.11/site-packages/galaxy/model/mapping.py", line 10, in <module>
         from galaxy.config import GalaxyAppConfiguration
     ModuleNotFoundError: No module named 'galaxy.config'
     ```
  3. Rebuild the `data` package with this PR and install
  4. Repeat import test

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
