### PR TITLE
Enable visualizations for anonymous user

### DIFF
--- a/client/src/components/Grid/GridVisualization.vue
+++ b/client/src/components/Grid/GridVisualization.vue
@@ -5,6 +5,7 @@ import { BNav, BNavItem } from "bootstrap-vue";
 
 import visualizationsGridConfig from "@/components/Grid/configs/visualizations";
 import visualizationsPublishedGridConfig from "@/components/Grid/configs/visualizationsPublished";
+import visualizationsSharedGridConfig from "@/components/Grid/configs/visualizationsShared";
 import { useUserStore } from "@/stores/userStore";
 
 import Heading from "@/components/Common/Heading.vue";
@@ -16,7 +17,7 @@ const userStore = useUserStore();
 library.add(faPlus);
 
 interface Props {
-    activeList?: "my" | "published";
+    activeList?: "my" | "shared" | "published";
 }
 
 withDefaults(defineProps<Props>(), {
@@ -41,11 +42,23 @@ withDefaults(defineProps<Props>(), {
                     target="visualizations-my-tab"
                     title="Manage your Visualizations" />
             </BNavItem>
+            <BNavItem
+                id="visualizations-shared-tab"
+                :active="activeList === 'shared'"
+                :disabled="userStore.isAnonymous"
+                to="/visualizations/list_shared">
+                Shared with Me
+                <LoginRequired
+                    v-if="userStore.isAnonymous"
+                    target="visualizations-shared-tab"
+                    title="Manage your Visualizations" />
+            </BNavItem>
             <BNavItem :active="activeList === 'published'" to="/visualizations/list_published">
                 Public Visualizations
             </BNavItem>
         </BNav>
         <GridList v-if="activeList === 'my'" :grid-config="visualizationsGridConfig" embedded />
+        <GridList v-else-if="activeList === 'shared'" :grid-config="visualizationsSharedGridConfig" embedded />
         <GridList v-else :grid-config="visualizationsPublishedGridConfig" embedded />
     </div>
 </template>

--- a/client/src/components/Grid/configs/visualizationsPublished.ts
+++ b/client/src/components/Grid/configs/visualizationsPublished.ts
@@ -1,11 +1,13 @@
 import { faEye } from "@fortawesome/free-solid-svg-icons";
-
+import { useEventBus } from "@vueuse/core";
 import { GalaxyApi } from "@/api";
 import Filtering, { contains, expandNameTag, type ValidFilter } from "@/utils/filtering";
 import { withPrefix } from "@/utils/redirect";
 import { rethrowSimple } from "@/utils/simple-error";
 
 import { type FieldArray, type GridConfig } from "./types";
+
+const { emit } = useEventBus<string>("grid-router-push");
 
 /**
  * Local types
@@ -57,7 +59,9 @@ const fields: FieldArray = [
                     if (data.type === "trackster") {
                         window.location.href = withPrefix(`/visualization/${data.type}?id=${data.id}`);
                     } else {
-                        window.location.href = withPrefix(`/plugins/visualizations/${data.type}/saved?id=${data.id}`);
+                        emit(`/visualizations/display?visualization=${data.type}&visualization_id=${data.id}`, {
+                            title: data.title,
+                        });
                     }
                 },
             },

--- a/client/src/components/Grid/configs/visualizationsPublished.ts
+++ b/client/src/components/Grid/configs/visualizationsPublished.ts
@@ -1,5 +1,6 @@
 import { faEye } from "@fortawesome/free-solid-svg-icons";
 import { useEventBus } from "@vueuse/core";
+
 import { GalaxyApi } from "@/api";
 import Filtering, { contains, expandNameTag, type ValidFilter } from "@/utils/filtering";
 import { withPrefix } from "@/utils/redirect";

--- a/client/src/components/Grid/configs/visualizationsShared.ts
+++ b/client/src/components/Grid/configs/visualizationsShared.ts
@@ -1,11 +1,13 @@
 import { faEye } from "@fortawesome/free-solid-svg-icons";
-
+import { useEventBus } from "@vueuse/core";
 import { GalaxyApi } from "@/api";
 import Filtering, { contains, expandNameTag, type ValidFilter } from "@/utils/filtering";
 import { withPrefix } from "@/utils/redirect";
 import { rethrowSimple } from "@/utils/simple-error";
 
 import { type FieldArray, type GridConfig } from "./types";
+
+const { emit } = useEventBus<string>("grid-router-push");
 
 /**
  * Local types
@@ -57,7 +59,9 @@ const fields: FieldArray = [
                     if (data.type === "trackster") {
                         window.location.href = withPrefix(`/visualization/${data.type}?id=${data.id}`);
                     } else {
-                        window.location.href = withPrefix(`/plugins/visualizations/${data.type}/saved?id=${data.id}`);
+                        emit(`/visualizations/display?visualization=${data.type}&visualization_id=${data.id}`, {
+                            title: data.title,
+                        });    
                     }
                 },
             },

--- a/client/src/components/Grid/configs/visualizationsShared.ts
+++ b/client/src/components/Grid/configs/visualizationsShared.ts
@@ -1,5 +1,6 @@
 import { faEye } from "@fortawesome/free-solid-svg-icons";
 import { useEventBus } from "@vueuse/core";
+
 import { GalaxyApi } from "@/api";
 import Filtering, { contains, expandNameTag, type ValidFilter } from "@/utils/filtering";
 import { withPrefix } from "@/utils/redirect";
@@ -61,7 +62,7 @@ const fields: FieldArray = [
                     } else {
                         emit(`/visualizations/display?visualization=${data.type}&visualization_id=${data.id}`, {
                             title: data.title,
-                        });    
+                        });
                     }
                 },
             },

--- a/client/src/components/Grid/configs/visualizationsShared.ts
+++ b/client/src/components/Grid/configs/visualizationsShared.ts
@@ -1,0 +1,118 @@
+import { faEye } from "@fortawesome/free-solid-svg-icons";
+
+import { GalaxyApi } from "@/api";
+import Filtering, { contains, expandNameTag, type ValidFilter } from "@/utils/filtering";
+import { withPrefix } from "@/utils/redirect";
+import { rethrowSimple } from "@/utils/simple-error";
+
+import { type FieldArray, type GridConfig } from "./types";
+
+/**
+ * Local types
+ */
+type SortKeyLiteral = "create_time" | "title" | "update_time" | "username" | undefined;
+type VisualizationEntry = Record<string, unknown>;
+
+/**
+ * Request and return data from server
+ */
+async function getData(offset: number, limit: number, search: string, sort_by: string, sort_desc: boolean) {
+    const { response, data, error } = await GalaxyApi().GET("/api/visualizations", {
+        params: {
+            query: {
+                limit,
+                offset,
+                search,
+                sort_by: sort_by as SortKeyLiteral,
+                sort_desc,
+                show_own: false,
+                show_published: false,
+                show_shared: true,
+            },
+        },
+    });
+
+    if (error) {
+        rethrowSimple(error);
+    }
+
+    const totalMatches = parseInt(response.headers.get("total_matches") ?? "0");
+    return [data, totalMatches];
+}
+
+/**
+ * Declare columns to be displayed
+ */
+const fields: FieldArray = [
+    {
+        title: "Title",
+        key: "title",
+        type: "operations",
+        width: 40,
+        operations: [
+            {
+                title: "View",
+                icon: faEye,
+                handler: (data: VisualizationEntry) => {
+                    if (data.type === "trackster") {
+                        window.location.href = withPrefix(`/visualization/${data.type}?id=${data.id}`);
+                    } else {
+                        window.location.href = withPrefix(`/plugins/visualizations/${data.type}/saved?id=${data.id}`);
+                    }
+                },
+            },
+        ],
+    },
+    {
+        key: "annotation",
+        title: "Annotation",
+        type: "text",
+    },
+    {
+        key: "username",
+        title: "Owner",
+        type: "text",
+    },
+    {
+        key: "tags",
+        title: "Tags",
+        type: "tags",
+        disabled: true,
+    },
+    {
+        key: "update_time",
+        title: "Updated",
+        type: "date",
+    },
+];
+
+/**
+ * Declare filter options
+ */
+const validFilters: Record<string, ValidFilter<string | boolean | undefined>> = {
+    title: { placeholder: "title", type: String, handler: contains("title"), menuItem: true },
+    slug: { handler: contains("slug"), menuItem: false },
+    tag: {
+        placeholder: "tag(s)",
+        type: "MultiTags",
+        handler: contains("tag", "tag", expandNameTag),
+        menuItem: true,
+    },
+};
+
+/**
+ * Grid configuration
+ */
+const gridConfig: GridConfig = {
+    id: "visualizations-published-grid",
+    fields: fields,
+    filtering: new Filtering(validFilters, undefined, false, false),
+    getData: getData,
+    plural: "Visualizations",
+    sortBy: "update_time",
+    sortDesc: true,
+    sortKeys: ["create_time", "title", "update_time"],
+    title: "Published Visualizations",
+};
+
+export default gridConfig;

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -662,6 +662,14 @@ export function getRouter(Galaxy) {
                         },
                     },
                     {
+                        path: "visualizations/list_shared",
+                        component: GridVisualization,
+                        props: {
+                            activeList: "shared",
+                        },
+                        redirect: redirectAnon(),
+                    },
+                    {
                         path: "workflows/create",
                         component: WorkflowCreate,
                         redirect: redirectAnon(),

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -617,7 +617,6 @@ export function getRouter(Galaxy) {
                         component: VisualizationCreate,
                         name: "VisualizationsCreate",
                         props: true,
-                        redirect: redirectAnon(),
                     },
                     {
                         path: "visualizations/display",

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -652,7 +652,7 @@ export function getRouter(Galaxy) {
                         props: {
                             activeList: "my",
                         },
-                        redirect: redirectAnon(),
+                        redirect: redirectAnon("/visualizations/list_published"),
                     },
                     {
                         path: "visualizations/list_published",

--- a/lib/galaxy/webapps/galaxy/api/plugins.py
+++ b/lib/galaxy/webapps/galaxy/api/plugins.py
@@ -10,10 +10,7 @@ from galaxy.managers import (
     histories,
 )
 from galaxy.util import asbool
-from galaxy.web import (
-    expose_api,
-    expose_api_anonymous_and_sessionless,
-)
+from galaxy.web import expose_api_anonymous_and_sessionless
 from . import (
     BaseGalaxyAPIController,
     depends,
@@ -42,7 +39,7 @@ class PluginsController(BaseGalaxyAPIController):
             target_object = self.hda_manager.get_accessible(self.decode_id(dataset_id), trans.user)
         return registry.get_visualizations(trans, target_object=target_object, embeddable=embeddable)
 
-    @expose_api
+    @expose_api_anonymous_and_sessionless
     def show(self, trans, id, **kwargs):
         """
         GET /api/plugins/{id}:

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -253,6 +253,7 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
     webapp.add_client_route("/visualizations/edit")
     webapp.add_client_route("/visualizations/sharing")
     webapp.add_client_route("/visualizations/list_published")
+    webapp.add_client_route("/visualizations/list_shared")
     webapp.add_client_route("/visualizations/list")
     webapp.add_client_route("/pages/list")
     webapp.add_client_route("/pages/list_published")

--- a/lib/galaxy/webapps/galaxy/controllers/visualization.py
+++ b/lib/galaxy/webapps/galaxy/controllers/visualization.py
@@ -260,7 +260,6 @@ class VisualizationController(
         )
 
     @web.expose
-    @web.require_login("use Galaxy visualizations", use_panels=True)
     def saved(self, trans, id=None, revision=None, type=None, config=None, title=None, **kwargs):
         """
         Load a visualization and render it.

--- a/lib/galaxy/webapps/galaxy/controllers/visualization.py
+++ b/lib/galaxy/webapps/galaxy/controllers/visualization.py
@@ -218,7 +218,6 @@ class VisualizationController(
 
     # ------------------------- registry.
     @web.expose
-    @web.require_login("use Galaxy visualizations", use_panels=True)
     def render(self, trans, visualization_name, embedded=None, **kwargs):
         """
         Render the appropriate visualization template, parsing the `kwargs`


### PR DESCRIPTION
Resolves #20191. This PR allows anonymous users to create visualizations and access published visualizations. 

1. Additionally, it adds a `Shared With Me` tab in the `Saved Visualizations` grid. Significantly benefiting from the consistency of the unified resource api endpoints, making this addition straightforward.

2. Also, users can now open shared and published visualizations in the window manager or center panel, avoiding page reload (previously the masthead and panels disappeared)

![cast2](https://github.com/user-attachments/assets/a98fb2f5-21c0-4159-b33a-2c24f933d12b)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
