### PR TITLE
Bug fixes around wizard usage.

### DIFF
--- a/client/src/components/Collections/BuildFileSetWizard.vue
+++ b/client/src/components/Collections/BuildFileSetWizard.vue
@@ -7,6 +7,7 @@ import { attemptCreate, type CollectionCreatorComponent } from "@/components/Col
 import { rawToTable } from "@/components/Collections/tables";
 import { useWizard } from "@/components/Common/Wizard/useWizard";
 import { useToolRouting } from "@/composables/route";
+import localize from "@/utils/localization";
 
 import { type RemoteFile, type RulesCreatingWhat, type RulesSourceFrom } from "./wizard/types";
 import { useFileSetSources } from "./wizard/useFileSetSources";
@@ -34,6 +35,7 @@ interface Props {
 
 const props = defineProps<Props>();
 
+const title = localize("Rule Based Data Import");
 const ruleState = ref(false);
 const creatingWhat = ref<RulesCreatingWhat>("datasets");
 const creatingWhatTitle = computed(() => {
@@ -181,7 +183,7 @@ function onRuleCreate() {
 </script>
 
 <template>
-    <GenericWizard :use="wizard" :submit-button-label="importButtonLabel" @submit="submit">
+    <GenericWizard :use="wizard" :submit-button-label="importButtonLabel" :title="title" @submit="submit">
         <div v-if="wizard.isCurrent('select-what')">
             <CreatingWhat :creating-what="creatingWhat" @onChange="setCreatingWhat" />
         </div>

--- a/client/src/components/Common/Wizard/GenericWizard.vue
+++ b/client/src/components/Common/Wizard/GenericWizard.vue
@@ -21,9 +21,10 @@ interface Props {
      *
      * This is displayed at the top of the wizard.
      *
-     * The default component can be replaced by a slot named `header`.
+     * The default component can be replaced by a slot named `header` or it can be excluded
+     * as a property to skip the wizard all together.
      *
-     * @default "Generic Wizard"
+     * @default ""
      */
     title?: string;
 
@@ -65,7 +66,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
     use: undefined,
-    title: "Generic Wizard",
+    title: undefined,
     description: undefined,
     submitButtonLabel: "Submit",
     isBusy: false,
@@ -171,7 +172,7 @@ const bodyStyle = computed(() => {
 <template>
     <component :is="props.containerComponent" class="wizard-container">
         <slot name="header">
-            <BCardTitle>
+            <BCardTitle v-if="title">
                 <h2>{{ title }}</h2>
             </BCardTitle>
         </slot>


### PR DESCRIPTION
#20054 was merged right before #19377 and there was some fallout to the wizard changes that were not accounted for my collection PR. This one is pretty egregious but there might be some more styling things that could be improved. 

I made the wizard title optional for the list builder because that component might sometimes be embedded in a tool form and we wouldn't want a huge form in that case. I do like the style of the title though and I did add a title for the new Rule Builder modality.

Note: Adding [25.0] to the title but the branch doesn't exist yet so this either needs to be merged before the branch or retargeted after the branch.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Build a List of using the Rule Builder through the Activity Panel and notice the title "Generic Wizard" no longer appears.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
