### PR TITLE
Add restart script to resolve port 8080 conflicts

### DIFF
--- a/run_restart_galaxy.sh
+++ b/run_restart_galaxy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# restart_galaxy.sh
+# This script terminates any process using port 8080 (commonly Galaxy server)
+# and restarts Galaxy using run.sh in the current directory.
+
+PORT=8080
+
+echo "🔎 Checking for processes using port $PORT..."
+PID=$(lsof -ti tcp:$PORT)
+
+if [ -n "$PID" ]; then
+  echo "⚠️  Process detected on port $PORT. Terminating PID: $PID..."
+  kill -9 $PID
+  echo "✅ Process terminated."
+else
+  echo "✅ No process found on port $PORT."
+fi
+
+# Start Galaxy server
+echo "🚀 Starting Galaxy server..."
+if [ -x "./run.sh" ]; then
+  ./run.sh
+else
+  echo "❌ Error: run.sh not found or not executable."
+  exit 1
+fi


### PR DESCRIPTION
This pull request introduces a new utility script: run_restart_galaxy.sh.

This script is designed to help developers working locally with Galaxy to quickly identify and terminate any process occupying port 8080 (commonly the Galaxy server) and restart the server using the run.sh script. This is particularly useful in environments where multiple deploys can leave orphan processes behind, causing conflicts on that port.

✅ How to test the changes?
	•	I’ve included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
	•	This is a refactoring of components with existing test coverage.
	•	Instructions for manual testing are as follows:

Make the script executable:
`chmod +x run_restart_galaxy.sh`
Run it from the Galaxy root directory:
`./run_restart_galaxy.sh`

OR

`sh run_restart_galaxy.sh`

Observe that:
•If any process is using port 8080, it is terminated.
•Galaxy is restarted using ./run.sh.
•Logs confirm Galaxy is running.

📝 License
	•	I agree to license these and all my past contributions to the core Galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).

