### PR TITLE
Bug fix - allow file drops into PasteData widget.

### DIFF
--- a/client/src/components/Collections/wizard/PasteData.vue
+++ b/client/src/components/Collections/wizard/PasteData.vue
@@ -34,7 +34,9 @@ const handleDrop = (event: DragEvent) => {
 </script>
 
 <template>
-    <div class="paste-data">
+    <!-- galaxy-drop-target suppresses global upload drop target so this component can be
+         dropped to -->
+    <div class="paste-data" data-galaxy-file-drop-target>
         <JaggedDataAlert :jagged-data-warning="jaggedDataWarning" />
         <div
             class="dropzone"

--- a/client/src/components/Upload/DragAndDropModal.vue
+++ b/client/src/components/Upload/DragAndDropModal.vue
@@ -1,3 +1,8 @@
+<!-- Global generic file upload modal.
+
+    This modal will be suppressed if page has any DOM elements decorated
+    with data-galaxy-file-drop-target - see fileDrop composable for more information.
+-->
 <script setup>
 import { setIframeEvents } from "components/Upload/utils";
 import { useFileDrop } from "composables/fileDrop";

--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -325,7 +325,7 @@ async function onExecute() {
 </script>
 
 <template>
-    <div class="d-flex flex-column h-100 workflow-run-form-simple">
+    <div class="d-flex flex-column h-100 workflow-run-form-simple" data-galaxy-file-drop-target>
         <div v-if="!showRightPanel" class="ui-form-header-underlay sticky-top" />
         <div v-if="isConfigLoaded" :class="{ 'sticky-top': !showRightPanel }">
             <BAlert v-if="!canRunOnHistory" variant="warning" show>

--- a/client/src/composables/fileDrop.ts
+++ b/client/src/composables/fileDrop.ts
@@ -18,11 +18,14 @@ export function useFileDrop(
     solo: MaybeRefOrGetter<boolean>,
     idleTime = 800
 ) {
-    /** returns if any bootstrap modal or workflow run form is open */
-    function isAnyModalOpen() {
+    /** returns true if any other more specific file drop target is on the screen and should
+     *  supersede the global file drop or if an existing modal is present and should likewise
+     *  take precedent.
+     */
+    function disableGlobalDropTargetTarget() {
         return (
             document.querySelectorAll(".modal.show").length > 0 ||
-            document.querySelectorAll(".workflow-run-form-simple").length > 0
+            document.querySelectorAll("[data-galaxy-file-drop-target]").length > 0
         );
     }
 
@@ -46,7 +49,7 @@ export function useFileDrop(
                 case "dragstart":
                     return "blocked";
                 case "dragenter":
-                    if (!(unref(solo) && isAnyModalOpen())) {
+                    if (!(unref(solo) && disableGlobalDropTargetTarget())) {
                         return "fileDragging";
                     }
                     break;


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20231.

I still think it was hard to find / indirect - I wish DragAndDropModal.vue had a prominent comment somewhere to point at this but I couldn't a natural place to document it. Maybe in Analysis.vue right before the DragAndDropModal component appears? At any rate - that would be an enhancement - this is the bug fix.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Go to localhost:8081/rules , pick either option on the first step of the wizard, pick "Paste Data" on the second step, drop a text file into the resulting textbox.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
