### PR TITLE
Fix vue-tsc issue in ParameterStep

### DIFF
--- a/client/src/components/WorkflowInvocationState/ParameterStep.vue
+++ b/client/src/components/WorkflowInvocationState/ParameterStep.vue
@@ -20,6 +20,11 @@ const props = defineProps<{
 function isData(value: unknown): value is InvocationInput | InvocationOutput | InvocationOutputCollection {
     return typeof value === "object" && value !== null && "src" in value;
 }
+function hasValidId(
+    value: InvocationInput | InvocationOutput | InvocationOutputCollection
+): value is typeof value & { id: string } {
+    return value.id !== null && value.id !== undefined && typeof value.id === "string";
+}
 function dataStepLabel(input: InvocationStepTypes): string {
     if ("label" in input && input.label) {
         return input.label;
@@ -41,10 +46,11 @@ function dataStepLabel(input: InvocationStepTypes): string {
         :items="props.parameters">
         <template v-slot:cell(parameter_value)="{ item }">
             <GenericHistoryItem
-                v-if="isData(item)"
+                v-if="isData(item) && hasValidId(item)"
                 :item-id="item.id"
                 :item-src="item.src"
                 :data-label="dataStepLabel(item)" />
+            <div v-else-if="isData(item) && !hasValidId(item)" class="text-muted">Dataset with no ID</div>
             <i v-else-if="item.parameter_value === null || item.parameter_value === undefined" class="text-muted">
                 No value provided
             </i>


### PR DESCRIPTION
Ensure items have valid IDs before rendering.  I don't know how they might not, here, but if so we have a placeholder now.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
