### PR TITLE
Only show custom tool editor in activity bar settings when user has access

### DIFF
--- a/client/src/components/ActivityBar/ActivitySettings.vue
+++ b/client/src/components/ActivityBar/ActivitySettings.vue
@@ -2,11 +2,13 @@
 import { faStar as faStarRegular } from "@fortawesome/free-regular-svg-icons";
 import { faStar, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { storeToRefs } from "pinia";
 import { computed, type ComputedRef } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { useActivityStore } from "@/stores/activityStore";
 import type { Activity } from "@/stores/activityStoreTypes";
+import { useUnprivilegedToolStore } from "@/stores/unprivilegedToolStore";
 
 import GButton from "@/components/BaseComponents/GButton.vue";
 
@@ -21,7 +23,14 @@ const emit = defineEmits<{
 
 const activityStore = useActivityStore(props.activityBarId);
 
-const optionalActivities = computed(() => activityStore.activities.filter((a) => a.optional));
+const unprivilegedToolStore = useUnprivilegedToolStore();
+const { canUseUnprivilegedTools } = storeToRefs(unprivilegedToolStore);
+
+const optionalActivities = computed(() => {
+    return activityStore.activities.filter(
+        (a) => (a.optional && a.id !== "user-defined-tools") || canUseUnprivilegedTools.value
+    );
+});
 
 const filteredActivities = computed(() => {
     if (props.query?.length > 0) {


### PR DESCRIPTION
xref #20240 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
