### PR TITLE
[24.0] Fall back to name in job summary if no input label given

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -977,7 +977,7 @@ def summarize_job_parameters(trans, job: Job):
                             raise Exception(
                                 f"Unhandled data input parameter type encountered {element.__class__.__name__}"
                             )
-                    rval.append(dict(text=input.label, depth=depth, value=value))
+                    rval.append(dict(text=input.label or input.name, depth=depth, value=value))
                 elif input.visible:
                     if hasattr(input, "label") and input.label:
                         label = input.label


### PR DESCRIPTION
Fixes #20257, which would also happen for regular tools if an input had a null label. Guess that doesn't happen with XML tools, but you can technically load yaml tools on 24.0.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
