### PR TITLE
Fix tool-provided metadata for CONVERTER_tar_to_directory

### DIFF
--- a/lib/galaxy/datatypes/converters/tar_to_directory.xml
+++ b/lib/galaxy/datatypes/converters/tar_to_directory.xml
@@ -1,18 +1,23 @@
-<tool id="CONVERTER_tar_to_directory" name="Convert tar to directory" version="1.0.1" profile="17.05">
+<tool id="CONVERTER_tar_to_directory" name="Convert tar to directory" version="1.0.1" profile="21.09">
     <!-- Don't use tar directly so we can verify safety of results - tar -xzf '$input1'; -->
     <requirements>
         <requirement type="package" version="23.2.1">galaxy-util</requirement>
     </requirements>
-    <command>
-        mkdir '$output1.files_path';
-        cd '$output1.files_path';
-        python -c "from galaxy.util.compression_utils import CompressedFile; CompressedFile('$input1').extract('.');"
-    </command>
+    <command detect_errors="exit_code"><![CDATA[
+cp '$provided_metadata' 'galaxy.json' &&
+mkdir '$output1.files_path' &&
+cd '$output1.files_path' &&
+python -c "from galaxy.util.compression_utils import CompressedFile; CompressedFile('$input1').extract('.');"
+    ]]></command>
+    <configfiles>
+        <configfile name="provided_metadata">{"output1": {"created_from_basename": "${input1.created_from_basename}"}}
+</configfile>
+    </configfiles>
     <inputs>
         <param format="tar" name="input1" type="data"/>
     </inputs>
     <outputs>
-        <data format="directory" name="output1"/>
+        <data format="directory" name="output1" metadata_source="input1" />
     </outputs>
     <tests>
         <test>
@@ -20,6 +25,6 @@
             <output name="output1" ftype="directory" value="testdir1.tar.directory"/>
         </test>
     </tests>
-    <help>
-    </help>
+    <help><![CDATA[
+    ]]></help>
 </tool>


### PR DESCRIPTION
The metadata are in the "default" (not "legacy") format, so need to use a newer tool profile.

Also:
- Use CDATA and `&&` in command

cherry-picked from https://github.com/galaxyproject/galaxy/pull/12909

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
