### PR TITLE
[25.0] Fix interactive activity highlighting

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -183,10 +183,9 @@ function onDragOver(evt: MouseEvent) {
 function toggleSidebar(toggle: string = "", to: string | null = null) {
     // if an activity's dedicated panel/sideBar is already active
     // but the route is different, don't collapse
-    if (toggle && to && !(route.path === to) && isActiveSideBar(toggle)) {
-        return;
+    if (!toggle || !to || route.path === to || !isActiveSideBar(toggle)) {
+        activityStore.toggleSideBar(toggle);
     }
-    activityStore.toggleSideBar(toggle);
 }
 
 function onActivityClicked(activity: Activity) {
@@ -248,13 +247,13 @@ defineExpose({
                                 :key="activity.id"
                                 :activity-bar-id="props.activityBarId"
                                 :icon="activity.icon"
-                                :is-active="isActiveRoute(activity.to)"
+                                :is-active="panelActivityIsActive(activity)"
                                 :title="activity.title"
                                 :tooltip="activity.tooltip"
                                 :to="activity.to"
-                                @click="toggleSidebar('interactivetools')" />
+                                @click="toggleSidebar(activity.id, activity.to)" />
                             <ActivityItem
-                                v-else-if="activity.id === 'admin' || activity.panel"
+                                v-else-if="activity.panel"
                                 :id="`${activity.id}`"
                                 :key="activity.id"
                                 :activity-bar-id="props.activityBarId"

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -183,9 +183,10 @@ function onDragOver(evt: MouseEvent) {
 function toggleSidebar(toggle: string = "", to: string | null = null) {
     // if an activity's dedicated panel/sideBar is already active
     // but the route is different, don't collapse
-    if (!toggle || !to || route.path === to || !isActiveSideBar(toggle)) {
-        activityStore.toggleSideBar(toggle);
+    if (toggle && to && !(route.path === to) && isActiveSideBar(toggle)) {
+        return;
     }
+    activityStore.toggleSideBar(toggle);
 }
 
 function onActivityClicked(activity: Activity) {


### PR DESCRIPTION
Fixes highlighting of the interactive tools activity. When clicked once it is currently not highlighted as `active`. Additionally includes a small clarity improvement.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
