### PR TITLE
Assorted Improvements for the Rule Builder

### DIFF
--- a/client/src/components/Help/HelpText.vue
+++ b/client/src/components/Help/HelpText.vue
@@ -23,13 +23,4 @@ const helpTarget = ref();
     </span>
 </template>
 
-<style scoped>
-/* Give visual indication of mouseover info */
-.help-text {
-    text-decoration-line: underline;
-    text-decoration-style: dashed;
-}
-.title-help-text {
-    text-decoration-thickness: 1px;
-}
-</style>
+<style scoped src="@/components/Help/help-text.scss" />

--- a/client/src/components/Help/help-text.scss
+++ b/client/src/components/Help/help-text.scss
@@ -1,0 +1,8 @@
+/* Give visual indication of mouseover info */
+.help-text {
+    text-decoration-line: underline;
+    text-decoration-style: dashed;
+}
+.title-help-text {
+    text-decoration-thickness: 1px;
+}

--- a/client/src/components/RuleBuilder/ColumnSelector.vue
+++ b/client/src/components/RuleBuilder/ColumnSelector.vue
@@ -11,7 +11,7 @@
         </label>
     </div>
     <div v-else class="rule-column-selector">
-        <span>{{ label }}</span>
+        <span :title="help">{{ label }}</span>
         <slot></slot>
         <ol>
             <li v-for="(targetEl, index) in target" :key="targetEl" :index="index" class="rule-column-selector-target">

--- a/client/src/components/RuleBuilder/ColumnSelector.vue
+++ b/client/src/components/RuleBuilder/ColumnSelector.vue
@@ -1,7 +1,7 @@
 <template>
     <div v-if="!multiple || !ordered" class="rule-column-selector">
         <label class="d-flex justify-content-end align-items-center">
-            <span v-b-tooltip.hover class="mr-auto" :title="help">{{ label }}</span>
+            <span v-b-tooltip.hover class="mr-auto help-text" :title="help">{{ label }}</span>
             <div v-b-tooltip.hover class="mr-1" :title="title">
                 <Select2 :value="target" :multiple="multiple" @input="handleInput">
                     <option v-for="(col, index) in colHeaders" :key="col" :value="index">{{ col }}</option>
@@ -11,7 +11,7 @@
         </label>
     </div>
     <div v-else class="rule-column-selector">
-        <span :title="help">{{ label }}</span>
+        <span class="help-text" :title="help">{{ label }}</span>
         <slot></slot>
         <ol>
             <li v-for="(targetEl, index) in target" :key="targetEl" :index="index" class="rule-column-selector-target">
@@ -136,3 +136,5 @@ export default {
     },
 };
 </script>
+
+<style scoped src="@/components/Help/help-text.scss" />

--- a/client/src/components/RuleBuilder/column-targets.yml
+++ b/client/src/components/RuleBuilder/column-targets.yml
@@ -1,0 +1,145 @@
+# This file defines the column targets for the rule builder.
+list_identifiers:
+  multiple: true
+  label: "List Identifier(s)"
+  columnHeader: "List Identifier"
+  help: |
+    This should be a short description of the replicate, sample name, 
+    condition, etc... that describes each level of the list structure.
+  importType: "collections"
+paired_identifier:
+  label: "Paired-end Indicator"
+  columnHeader: "Paired Indicator"
+  help: |
+    This should be set to '1', 'R1', 'forward', 'f', or 'F' to indicate 
+    forward reads, and '2', 'r', 'reverse', 'R2', 'R', or 'R2' to indicate 
+    reverse reads.
+  importType: "collections"
+paired_or_unpaired_identifier:
+  label: "Optional Paired-end Indicator"
+  columnHeader: "Optional Paired Indicator"
+  help: |
+    This should be set to '1', 'R1', 'forward', 'f', or 'F' to indicate 
+    forward reads, and '2', 'r', 'reverse', 'R2', 'R', or 'R2' to indicate 
+    reverse reads. Unmatched '1' for 'forward' elements will be 'unpaired' 
+    in the resulting list, alternatively this column can be set to 'u' or 
+    'unpaired' to force the element to be unpaired.
+  importType: "collections"
+  advanced: true
+collection_name:
+  label: "Collection Name"
+  help: |
+    If this is set, all rows with the same collection name will be joined 
+    into a collection and it is possible to create multiple collections 
+    at once.
+  modes:
+    - "raw"
+    - "ftp"
+    - "datasets"
+    - "library_datasets"
+  importType: "collections"
+name_tag:
+  label: "Name Tag"
+  help: |
+    Add a name tag or hash tag based on the specified column value for 
+    imported datasets.
+  importType: "datasets"
+  modes:
+    - "raw"
+    - "ftp"
+tags:
+  multiple: true
+  label: "General Purpose Tag(s)"
+  help: |
+    Add a general purpose tag based on the specified column value, use : 
+    to separate key-value pairs if desired. These tags are not propagated 
+    to derived datasets the way name and group tags are.
+  modes:
+    - "raw"
+    - "ftp"
+    - "datasets"
+    - "library_datasets"
+    - "collection_contents"
+group_tags:
+  multiple: true
+  label: "Group Tag(s)"
+  help: |
+    Add a group tag based on the specified column value, use : to separate 
+    key-value pairs. These tags are propagated to derived datasets and may 
+    be useful for factorial experiments.
+  modes:
+    - "raw"
+    - "ftp"
+    - "datasets"
+    - "library_datasets"
+    - "collection_contents"
+name:
+  label: "Name"
+  importType: "datasets"
+dbkey:
+  label: "Genome"
+  modes:
+    - "raw"
+    - "ftp"
+hash_sha1:
+  label: "Hash (SHA1)"
+  modes:
+    - "raw"
+    - "ftp"
+  advanced: true
+hash_md5:
+  label: "Hash (MD5)"
+  modes:
+    - "raw"
+    - "ftp"
+  advanced: true
+hash_sha256:
+  label: "Hash (SHA256)"
+  modes:
+    - "raw"
+    - "ftp"
+  advanced: true
+hash_sha512:
+  label: "Hash (SHA512)"
+  modes:
+    - "raw"
+    - "ftp"
+  advanced: true
+file_type:
+  label: "Type"
+  modes:
+    - "raw"
+    - "ftp"
+  help: |
+    This should be the Galaxy file type corresponding to this file.
+url:
+  label: "URL"
+  modes:
+    - "raw"
+  help: |
+    This should be a URL (or Galaxy-aware URI) the file can be downloaded 
+    from.
+url_deferred:
+  label: "Deferred URL"
+  modes:
+    - "raw"
+  help: |
+    This should be a URL (or Galaxy-aware URI) the file can be downloaded 
+    from - the file will not be downloaded until it used by a tool.
+info:
+  label: "Info"
+  help: |
+    Unstructured text associated with the dataset that shows up in the 
+    history panel, this is optional and can be whatever you would like.
+  modes:
+    - "raw"
+    - "ftp"
+ftp_path:
+  label: "FTP Path"
+  modes:
+    - "raw"
+    - "ftp"
+  help: |
+    This should be the path to the target file to include relative to your 
+    FTP directory on the Galaxy server.
+  requiresFtp: true

--- a/client/src/components/RuleBuilder/rule-definitions.js
+++ b/client/src/components/RuleBuilder/rule-definitions.js
@@ -814,6 +814,14 @@ const MAPPING_TARGETS = {
         ),
         importType: "collections",
     },
+    paired_or_unpaired_identifier: {
+        label: _l("Optional Paired-end Indicator (Advanced)"),
+        columnHeader: _l("Optional Paired Indicator"),
+        help: _l(
+            "This should be set to '1', 'R1', 'forward', 'f', or 'F' to indicate forward reads, and '2', 'r', 'reverse', 'R2', 'R', or 'R2' to indicate reverse reads. Unmatched '1' for 'forward' elements will be 'unpaired' in the resulting list, alternatively this column can be set to 'u' or 'unpaired' to force the element to be unpaired."
+        ),
+        importType: "collections",
+    },
     collection_name: {
         label: _l("Collection Name"),
         help: _l(

--- a/client/src/components/RuleBuilder/rule-definitions.js
+++ b/client/src/components/RuleBuilder/rule-definitions.js
@@ -860,6 +860,22 @@ const MAPPING_TARGETS = {
         label: _l("Genome"),
         modes: ["raw", "ftp"],
     },
+    hash_sha1: {
+        label: _l("Hash (SHA1)"),
+        modes: ["raw", "ftp"],
+    },
+    hash_md5: {
+        label: _l("Hash (MD5)"),
+        modes: ["raw", "ftp"],
+    },
+    hash_sha256: {
+        label: _l("Hash (SHA256)"),
+        modes: ["raw", "ftp"],
+    },
+    hash_sha512: {
+        label: _l("Hash (SHA512)"),
+        modes: ["raw", "ftp"],
+    },
     file_type: {
         label: _l("Type"),
         modes: ["raw", "ftp"],

--- a/client/src/components/RuleBuilder/rule-definitions.js
+++ b/client/src/components/RuleBuilder/rule-definitions.js
@@ -2,6 +2,8 @@ import pyre from "pyre-to-regexp";
 import _ from "underscore";
 import _l from "utils/localization";
 
+import MAPPING_TARGETS from "./column-targets.yml";
+
 const NEW_COLUMN = "new";
 
 const multiColumnsToString = function (targetColumns, colHeaders) {
@@ -793,125 +795,6 @@ const RULES = {
             columns = removeColumns(columns, targets0);
             return { data, sources, columns };
         },
-    },
-};
-
-const MAPPING_TARGETS = {
-    list_identifiers: {
-        multiple: true,
-        label: _l("List Identifier(s)"),
-        columnHeader: _l("List Identifier"),
-        help: _l(
-            "This should be a short description of the replicate, sample name, condition, etc... that describes each level of the list structure."
-        ),
-        importType: "collections",
-    },
-    paired_identifier: {
-        label: _l("Paired-end Indicator"),
-        columnHeader: _l("Paired Indicator"),
-        help: _l(
-            "This should be set to '1', 'R1', 'forward', 'f', or 'F' to indicate forward reads, and '2', 'r', 'reverse', 'R2', 'R', or 'R2' to indicate reverse reads."
-        ),
-        importType: "collections",
-    },
-    paired_or_unpaired_identifier: {
-        label: _l("Optional Paired-end Indicator"),
-        columnHeader: _l("Optional Paired Indicator"),
-        help: _l(
-            "This should be set to '1', 'R1', 'forward', 'f', or 'F' to indicate forward reads, and '2', 'r', 'reverse', 'R2', 'R', or 'R2' to indicate reverse reads. Unmatched '1' for 'forward' elements will be 'unpaired' in the resulting list, alternatively this column can be set to 'u' or 'unpaired' to force the element to be unpaired."
-        ),
-        importType: "collections",
-        advanced: true,
-    },
-    collection_name: {
-        label: _l("Collection Name"),
-        help: _l(
-            "If this is set, all rows with the same collection name will be joined into a collection and it is possible to create multiple collections at once."
-        ),
-        modes: ["raw", "ftp", "datasets", "library_datasets"],
-        importType: "collections",
-    },
-    name_tag: {
-        label: _l("Name Tag"),
-        help: _l("Add a name tag or hash tag based on the specified column value for imported datasets."),
-        importType: "datasets",
-        modes: ["raw", "ftp"],
-    },
-    tags: {
-        multiple: true,
-        label: _l("General Purpose Tag(s)"),
-        help: _l(
-            "Add a general purpose tag based on the specified column value, use : to separate key-value pairs if desired. These tags are not propagated to derived datasets the way name and group tags are."
-        ),
-        modes: ["raw", "ftp", "datasets", "library_datasets", "collection_contents"],
-    },
-    group_tags: {
-        multiple: true,
-        label: _l("Group Tag(s)"),
-        help: _l(
-            "Add a group tag based on the specified column value, use : to separate key-value pairs. These tags are propagated to derived datasets and may be useful for factorial experiments."
-        ),
-        modes: ["raw", "ftp", "datasets", "library_datasets", "collection_contents"],
-    },
-    name: {
-        label: _l("Name"),
-        importType: "datasets",
-    },
-    dbkey: {
-        label: _l("Genome"),
-        modes: ["raw", "ftp"],
-    },
-    hash_sha1: {
-        label: _l("Hash (SHA1)"),
-        modes: ["raw", "ftp"],
-        advanced: true,
-    },
-    hash_md5: {
-        label: _l("Hash (MD5)"),
-        modes: ["raw", "ftp"],
-        advanced: true,
-    },
-    hash_sha256: {
-        label: _l("Hash (SHA256)"),
-        modes: ["raw", "ftp"],
-        advanced: true,
-    },
-    hash_sha512: {
-        label: _l("Hash (SHA512)"),
-        modes: ["raw", "ftp"],
-        advanced: true,
-    },
-    file_type: {
-        label: _l("Type"),
-        modes: ["raw", "ftp"],
-        help: _l("This should be the Galaxy file type corresponding to this file."),
-    },
-    url: {
-        label: _l("URL"),
-        modes: ["raw"],
-        help: _l("This should be a URL (or Galaxy-aware URI) the file can be downloaded from."),
-    },
-    url_deferred: {
-        label: _l("Deferred URL"),
-        modes: ["raw"],
-        help: _l(
-            "This should be a URL (or Galaxy-aware URI) th efile can be downloaded from - the file will not be downloaded until it used by a tool."
-        ),
-    },
-    info: {
-        label: _l("Info"),
-        help: _l(
-            "Unstructured text associated with the dataset that shows up in the history panel, this is optional and can be whatever you would like."
-        ),
-        modes: ["raw", "ftp"],
-    },
-    ftp_path: {
-        label: _l("FTP Path"),
-        modes: ["raw", "ftp"],
-        help: _l(
-            "This should be the path to the target file to include relative to your FTP directory on the Galaxy server"
-        ),
-        requiresFtp: true,
     },
 };
 

--- a/client/src/components/RuleBuilder/rule-definitions.js
+++ b/client/src/components/RuleBuilder/rule-definitions.js
@@ -815,12 +815,13 @@ const MAPPING_TARGETS = {
         importType: "collections",
     },
     paired_or_unpaired_identifier: {
-        label: _l("Optional Paired-end Indicator (Advanced)"),
+        label: _l("Optional Paired-end Indicator"),
         columnHeader: _l("Optional Paired Indicator"),
         help: _l(
             "This should be set to '1', 'R1', 'forward', 'f', or 'F' to indicate forward reads, and '2', 'r', 'reverse', 'R2', 'R', or 'R2' to indicate reverse reads. Unmatched '1' for 'forward' elements will be 'unpaired' in the resulting list, alternatively this column can be set to 'u' or 'unpaired' to force the element to be unpaired."
         ),
         importType: "collections",
+        advanced: true,
     },
     collection_name: {
         label: _l("Collection Name"),
@@ -863,18 +864,22 @@ const MAPPING_TARGETS = {
     hash_sha1: {
         label: _l("Hash (SHA1)"),
         modes: ["raw", "ftp"],
+        advanced: true,
     },
     hash_md5: {
         label: _l("Hash (MD5)"),
         modes: ["raw", "ftp"],
+        advanced: true,
     },
     hash_sha256: {
         label: _l("Hash (SHA256)"),
         modes: ["raw", "ftp"],
+        advanced: true,
     },
     hash_sha512: {
         label: _l("Hash (SHA512)"),
         modes: ["raw", "ftp"],
+        advanced: true,
     },
     file_type: {
         label: _l("Type"),

--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -1861,6 +1861,24 @@ export default {
                 const info = data[dataIndex][infoColumn];
                 res["info"] = info;
             }
+            const hashTypes = [
+                { key: "hash_md5", function: "MD5" },
+                { key: "hash_sha1", function: "SHA1" },
+                { key: "hash_sha256", function: "SHA256" },
+                { key: "hash_sha515", function: "SHA512" },
+            ];
+
+            hashTypes.forEach(({ key, function: hashFunction }) => {
+                if (mappingAsDict[key]) {
+                    const hashColumn = mappingAsDict[key].columns[0];
+                    const hash = data[dataIndex][hashColumn];
+                    if (res.hashes === undefined) {
+                        res["hashes"] = [];
+                    }
+                    res["hashes"].push({ hash_function: hashFunction, hash_value: hash });
+                }
+            });
+
             const tags = [];
             if (mappingAsDict.tags) {
                 const tagColumns = mappingAsDict.tags.columns;

--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -311,7 +311,19 @@
                                 </button>
                                 <div class="dropdown-menu" role="menu">
                                     <a
-                                        v-for="target in unmappedTargets"
+                                        v-for="target in basicUnmappedTargets"
+                                        :key="target"
+                                        :index="target"
+                                        class="dropdown-item"
+                                        href="javascript:void(0)"
+                                        :class="'rule-add-mapping-' + target.replace(/_/g, '-')"
+                                        @click="addIdentifier(target)"
+                                        >{{ mappingTargets()[target].label }}</a
+                                    >
+                                    <li><hr class="dropdown-divider" /></li>
+                                    <li><h6 class="dropdown-header">Advanced</h6></li>
+                                    <a
+                                        v-for="target in advancedUnmappedTargets"
                                         :key="target"
                                         :index="target"
                                         class="dropdown-item"
@@ -956,6 +968,18 @@ export default {
                 }
             }
             return targets;
+        },
+        basicUnmappedTargets() {
+            const unmappedTargets = this.unmappedTargets;
+            return unmappedTargets.filter((target) => {
+                return !MAPPING_TARGETS[target].advanced;
+            });
+        },
+        advancedUnmappedTargets() {
+            const unmappedTargets = this.unmappedTargets;
+            return unmappedTargets.filter((target) => {
+                return MAPPING_TARGETS[target].advanced;
+            });
         },
         colHeaders() {
             const { data, columns } = this.hotData;

--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -316,6 +316,7 @@
                                         :index="target"
                                         class="dropdown-item"
                                         href="javascript:void(0)"
+                                        :title="mappingTargets()[target].help"
                                         :class="'rule-add-mapping-' + target.replace(/_/g, '-')"
                                         @click="addIdentifier(target)"
                                         >{{ mappingTargets()[target].label }}</a
@@ -328,6 +329,7 @@
                                         :index="target"
                                         class="dropdown-item"
                                         href="javascript:void(0)"
+                                        :title="mappingTargets()[target].help"
                                         :class="'rule-add-mapping-' + target.replace(/_/g, '-')"
                                         @click="addIdentifier(target)"
                                         >{{ mappingTargets()[target].label }}</a

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -755,7 +755,7 @@ class DatasetCollectionManager:
                             allow_identifiers = ["F", "R", "1", "2", "R1", "R2", "forward", "reverse"]
                             if collection_type_at_depth == "paired_or_unpaired":
                                 allow_identifiers.extend(["unpaired", "u"])
-                            raise Exception(
+                            raise RequestParameterInvalidException(
                                 f"Unknown indicator of paired status encountered ({identifier}) - only values from ({allow_identifiers}) are allowed."
                             )
 

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -744,14 +744,19 @@ class DatasetCollectionManager:
 
                 if i + 1 == len(identifier_columns):
                     # At correct final position in nested structure for this dataset.
-                    if collection_type_at_depth.collection_type == "paired":
+                    if collection_type_at_depth.collection_type in ["paired", "paired_or_unpaired"]:
                         if identifier.lower() in ["f", "1", "r1", "forward"]:
                             identifier = "forward"
                         elif identifier.lower() in ["r", "2", "r2", "reverse"]:
                             identifier = "reverse"
+                        elif identifier.lower() in ["u", "unpaired"]:
+                            identifier = "unpaired"
                         else:
+                            allow_identifiers = ["F", "R", "1", "2", "R1", "R2", "forward", "reverse"]
+                            if collection_type_at_depth == "paired_or_unpaired":
+                                allow_identifiers.extend(["unpaired", "u"])
                             raise Exception(
-                                "Unknown indicator of paired status encountered - only values of F, R, 1, 2, R1, R2, forward, or reverse are allowed."
+                                f"Unknown indicator of paired status encountered ({identifier}) - only values from ({allow_identifiers}) are allowed."
                             )
 
                     tags = []
@@ -769,7 +774,6 @@ class DatasetCollectionManager:
 
                     effective_dataset = handle_dataset(sources[data_index]["dataset"], tags)
                     elements_at_depth[identifier] = effective_dataset
-                    # log.info("Handling dataset [%s] with sources [%s], need to add tags [%s]" % (effective_dataset, sources, tags))
                 else:
                     collection_type_at_depth = collection_type_at_depth.child_collection_type_description()
                     found = False
@@ -787,6 +791,21 @@ class DatasetCollectionManager:
                         elements_at_depth[identifier] = sub_collection
                         # Subsequent loop fills elements of newly created collection
                         elements_at_depth = sub_collection["elements"]
+
+        # Recursively descend elements to handle "paired_or_unpaired" collections
+        def update_unpaired_identifiers(elements):
+            for value in elements.values():
+                if not isinstance(value, dict):
+                    continue
+                if value.get("src") == "new_collection" and value.get("collection_type") == "paired_or_unpaired":
+                    sub_elements = value["elements"]
+                    if "forward" in sub_elements and "reverse" not in sub_elements:
+                        sub_elements["unpaired"] = sub_elements.pop("forward")
+                if "elements" in value:
+                    update_unpaired_identifiers(value["elements"])
+
+        if collection_type_description.collection_type.endswith("paired_or_unpaired"):
+            update_unpaired_identifiers(elements)
 
         return elements
 

--- a/lib/galaxy/util/rules_dsl.py
+++ b/lib/galaxy/util/rules_dsl.py
@@ -596,6 +596,8 @@ class RuleSet:
             identifier_columns.extend(mapping_as_dict["list_identifiers"]["columns"])
         if "paired_identifier" in mapping_as_dict:
             identifier_columns.append(mapping_as_dict["paired_identifier"]["columns"][0])
+        if "paired_or_unpaired_identifier" in mapping_as_dict:
+            identifier_columns.append(mapping_as_dict["paired_or_unpaired_identifier"]["columns"][0])
 
         return identifier_columns
 
@@ -609,6 +611,11 @@ class RuleSet:
                 collection_type += ":paired"
             else:
                 collection_type = "paired"
+        if "paired_or_unpaired_identifier" in mapping_as_dict:
+            if collection_type:
+                collection_type += ":paired_or_unpaired"
+            else:
+                collection_type = "paired_or_unpaired"
         return collection_type
 
     @property

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -23,6 +23,7 @@ from galaxy.util import galaxy_root_path
 from galaxy.util.unittest_utils import skip_if_github_down
 from galaxy_test.base import rules_test_data
 from galaxy_test.base.api_asserts import (
+    assert_error_code_is,
     assert_has_keys,
     assert_status_code_is,
 )
@@ -922,6 +923,7 @@ class TestToolsApi(ApiTestCase, TestsTools):
             self.dataset_populator.wait_for_history(history_id)
             response = self._run("__APPLY_RULES__", history_id, inputs, assert_ok=False)
             assert_status_code_is(response, 400)
+            assert_error_code_is(response, 400008)
             assert "Unknown indicator of paired status encountered (floorward)" in response.json()["err_msg"]
 
     def test_apply_rules_flatten_paired_unpaired(self):

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -897,6 +897,9 @@ class TestToolsApi(ApiTestCase, TestsTools):
     def test_apply_rules_6(self):
         self._apply_rules_and_check(rules_test_data.EXAMPLE_6)
 
+    def test_apply_rules_create_paired_or_unpaired_list(self):
+        self._apply_rules_and_check(rules_test_data.EXAMPLE_CREATE_PAIRED_OR_UNPAIRED_COLLECTION)
+
     def test_apply_rules_flatten_with_indices(self):
         self._apply_rules_and_check(rules_test_data.EXAMPLE_FLATTEN_USING_INDICES)
 

--- a/lib/galaxy_test/base/rules_test_data.py
+++ b/lib/galaxy_test/base/rules_test_data.py
@@ -348,6 +348,100 @@ EXAMPLE_FLATTEN_USING_INDICES = {
 }
 
 
+def check_example_create_paired_or_unpaired_with_unmatched_forward_becoming_unpaired(hdca, dataset_populator):
+    assert hdca["collection_type"] == "list:paired_or_unpaired"
+    assert hdca["element_count"] == 4
+    sample1_el = hdca["elements"][0]
+    assert "object" in sample1_el, hdca
+    assert "element_identifier" in sample1_el
+    assert sample1_el["element_identifier"] == "sample1", hdca
+    child_collection_level = sample1_el["object"]
+    assert child_collection_level["collection_type"] == "paired_or_unpaired"
+    assert child_collection_level["elements"][0]["element_identifier"] == "forward", hdca
+
+    sample2_el = hdca["elements"][1]
+    assert "object" in sample2_el, hdca
+    assert "element_identifier" in sample2_el
+    assert sample2_el["element_identifier"] == "sample2", hdca
+    child_collection_level = sample2_el["object"]
+    assert child_collection_level["collection_type"] == "paired_or_unpaired"
+    assert child_collection_level["elements"][0]["element_identifier"] == "unpaired", hdca
+
+    sample3_el = hdca["elements"][2]
+    assert "object" in sample3_el, hdca
+    assert "element_identifier" in sample3_el
+    assert sample3_el["element_identifier"] == "sample3", hdca
+    child_collection_level = sample3_el["object"]
+    assert child_collection_level["collection_type"] == "paired_or_unpaired"
+    assert child_collection_level["elements"][0]["element_identifier"] == "unpaired", hdca
+
+    sample4_el = hdca["elements"][2]
+    assert "object" in sample4_el, hdca
+    assert "element_identifier" in sample4_el
+    assert sample4_el["element_identifier"] == "sample3", hdca
+    child_collection_level = sample4_el["object"]
+    assert child_collection_level["collection_type"] == "paired_or_unpaired"
+    assert child_collection_level["elements"][0]["element_identifier"] == "unpaired", hdca
+
+
+EXAMPLE_CREATE_PAIRED_OR_UNPAIRED_COLLECTION = {
+    "rules": {
+        "rules": [
+            {
+                "type": "add_column_metadata",
+                "value": "identifier0",
+            },
+            {
+                "type": "add_column_metadata",
+                "value": "identifier1",
+            },
+        ],
+        "mapping": [
+            {
+                "type": "list_identifiers",
+                "columns": [0],
+            },
+            {
+                "type": "paired_or_unpaired_identifier",
+                "columns": [1],
+            },
+        ],
+    },
+    "test_data": {
+        "type": "list:list",
+        "elements": [
+            {
+                "identifier": "sample1",
+                "elements": [
+                    {"identifier": "forward", "class": "File", "contents": "TestData123forward"},
+                    {"identifier": "reverse", "class": "File", "contents": "TestData123reverse"},
+                ],
+            },
+            {
+                "identifier": "sample2",
+                "elements": [
+                    {"identifier": "unpaired", "class": "File", "contents": "TestData123unpaired"},
+                ],
+            },
+            {
+                "identifier": "sample3",
+                "elements": [
+                    {"identifier": "u", "class": "File", "contents": "TestData123unpaired-2"},
+                ],
+            },
+            {
+                "identifier": "sample4",
+                "elements": [
+                    {"identifier": "forward", "class": "File", "contents": "TestData123unpaired-3"},
+                ],
+            },
+        ],
+    },
+    "check": check_example_create_paired_or_unpaired_with_unmatched_forward_becoming_unpaired,
+    "output_hid": 12,
+}
+
+
 def check_example_flatten_paired_or_unpaired(hdca, dataset_populator):
     assert hdca["collection_type"] == "list"
     assert hdca["element_count"] == 3

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -393,6 +393,12 @@ class TestLoggedInToolForm(SeleniumTestCase):
         self.screenshot("tool_apply_rules_example_flatten_paired_unpaired_final")
 
     @selenium_test
+    @managed_history
+    def test_run_apply_rules_create_paired_or_unpaired_list(self):
+        self._apply_rules_and_check(rules_test_data.EXAMPLE_CREATE_PAIRED_OR_UNPAIRED_COLLECTION)
+        self.screenshot("tool_apply_rules_example_flatten_paired_unpaired_final")
+
+    @selenium_test
     def test_run_apply_rules_flatten_with_indices(self):
         self._apply_rules_and_check(rules_test_data.EXAMPLE_FLATTEN_USING_INDICES)
         self.screenshot("tool_apply_rules_example_flatten_with_indices_final")


### PR DESCRIPTION
Atomic and important changes for the rule builder - these are from the sample sheet branch (#19305) and enable new functionality there but are useful and atomic changes in their own right.

- Implement a test case to ensure Apply Rule runtime errors reach the user ([Test case for rule builder backend errors.](https://github.com/galaxyproject/galaxy/commit/f5dcc12aed1f49dd37e2a100ef825144e1e849aa)) as request in https://github.com/galaxyproject/galaxy/pull/20155#issuecomment-2877394798.
- Implement backend and frontend functionality for creating "paired or unpaired" lists and nested lists using Rule Builder and the Apply Rules tool ([Update rule builder to allow list:paired_or_unpaired creation.](https://github.com/galaxyproject/galaxy/commit/db66a8430bd95e0179e34c6218fec0a317467679))
- Add various hash mapping definitions for columns for data import using the rule builder to match data fetch options already present in the data fetch API ([Implement hash validation in rule builder.](https://github.com/galaxyproject/galaxy/commit/762e753bf0ea48f243e488a807fb67c3c422708a))
- Given the new options for mapping (hashes and paired_or_unpaired indicators) are fairly sophisticated and niche - I've split the mappings into simple and advanced sections in the drop down to make it clear the advanced options are... advanced. [Simple rule builder mapping targets into advanced/simple.](https://github.com/galaxyproject/galaxy/commit/93d59f8106b1911a6d24b19830cddfca28bfe4fa)
- Various improvements/fixes to mapping help text
   - [Bug fix - missing help text in rule builder.](https://github.com/galaxyproject/galaxy/commit/981708421d5bf69f9eda6b83ff184608a804fb2f)
   - [Use help text in column definition dropdown.](https://github.com/galaxyproject/galaxy/commit/f387877c8927a5a5755e9b6e80158f4ac3ecaa75)
   - [Refactor HelpText style for reuse in other context.](https://github.com/galaxyproject/galaxy/commit/11d6744c80c2c3353c9d1e83e8af64832be001f1) 
- Finally, I extracted the rule builder mapping option JSON into a YAML file for reuse ([More readable, reusable mapping target definitions for rule builder.](https://github.com/galaxyproject/galaxy/commit/c67fea17235c926a645828425b788c18bc3a334d)). I think this is more readable given the multi-line help options and less syntax but it allows reuse downstream where I use these definitions on the backend and in the API in a couple ways and add Pydantic model for the definition (downstream models [here](https://github.com/galaxyproject/galaxy/blob/b206ca18c78a1b10748fdc8669fc0c5cc70da6fa/lib/galaxy/tools/fetch/target_models.py)). 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
