### PR TITLE
[25.0] Skip multiple pasted URLs when checking for remote Zip

### DIFF
--- a/client/src/composables/zipExplorer.test.ts
+++ b/client/src/composables/zipExplorer.test.ts
@@ -1,0 +1,29 @@
+import { isValidUrl } from "./zipExplorer";
+
+describe("useZipExplorer", () => {
+    describe("isValidUrl", () => {
+        it("should return true for valid URLs", () => {
+            expect(isValidUrl("http://example.com")).toBe(true);
+            expect(isValidUrl("https://example.com")).toBe(true);
+        });
+
+        it("should return false for invalid URLs", () => {
+            expect(isValidUrl("invalid-url")).toBe(false);
+            expect(isValidUrl("htp://example.com")).toBe(false);
+        });
+
+        it("should return false for empty strings", () => {
+            expect(isValidUrl("")).toBe(false);
+        });
+
+        it("should return false for null or undefined values", () => {
+            expect(isValidUrl(null)).toBe(false);
+            expect(isValidUrl(undefined)).toBe(false);
+        });
+
+        it("should return false for multiple URLs", () => {
+            expect(isValidUrl("http://example.com\nhttp://example2.com")).toBe(false);
+            expect(isValidUrl("https://example.com https://example2.com")).toBe(false);
+        });
+    });
+});

--- a/client/src/composables/zipExplorer.ts
+++ b/client/src/composables/zipExplorer.ts
@@ -340,7 +340,7 @@ export async function isRemoteZipFile(url: string): Promise<boolean> {
 }
 
 export function isValidUrl(inputUrl?: string | null): boolean {
-    if (!inputUrl) {
+    if (!inputUrl || isMultiLine(inputUrl)) {
         return false;
     }
     try {
@@ -349,6 +349,11 @@ export function isValidUrl(inputUrl?: string | null): boolean {
     } catch (_) {
         return false;
     }
+}
+
+function isMultiLine(inputString: string): boolean {
+    const hasLineBreaks = inputString.includes("\n") || inputString.includes("\\n");
+    return hasLineBreaks;
 }
 
 export function isRoCrateZip(explorer?: IZipExplorer): explorer is ROCrateZipExplorer {


### PR DESCRIPTION
Fixes #20293

We only support exploring single URLs, so we should skip checking for the Zip magic number when more than one URL is pasted in the upload.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
