### PR TITLE
[25.0] Fix masthead logo height

### DIFF
--- a/client/src/style/scss/custom_theme_variables.scss
+++ b/client/src/style/scss/custom_theme_variables.scss
@@ -83,7 +83,7 @@ html,
 
     // masthead specific
     --masthead-height: #{$masthead-height};
-    --masthead-logo-height: calc(var(--masthead-height) * 0.6);
+    --masthead-logo-height: calc(var(--masthead-height) - 0.5rem);
 
     --masthead-color: #{$masthead-color};
     --masthead-text-color: #{$masthead-text-color};

--- a/client/src/style/scss/theme/blue.scss
+++ b/client/src/style/scss/theme/blue.scss
@@ -114,7 +114,7 @@ $body-bg: $white;
 
 // Masthead
 $masthead-height: 2.5rem;
-$masthead-logo-height: $masthead-height * 0.6;
+$masthead-logo-height: $masthead-height - 0.5rem;
 
 // Side panels
 $panel-bg-color: $brand-light;


### PR DESCRIPTION
Fixes #20298. Follow up to #19581. As mentioned in the comment, I would assume that `masthead-logo-height` is likely not a necessary theme setting, since it is directly correlated with the masthead height. Thanks for reporting this @martenson.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
