### PR TITLE
[25.0] Fix default theme selection

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -1251,8 +1251,11 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             if self._path_exists(path):
                 with open(path) as f:
                     themes = yaml.safe_load(f)
-                    for key, val in themes.items():
-                        theme_dict[key] = flatten_theme(val)
+                    # Sort so that themes with `default: true` (hopefully just 1 ...) come first
+                    sorted_themes = dict(sorted(themes.items(), key=lambda item: not item[1].get("default", False)))
+                    for key, val in sorted_themes.items():
+                        if not key == "default":
+                            theme_dict[key] = flatten_theme(val)
 
         self.themes = {}
 

--- a/lib/galaxy/config/sample/themes_conf.yml.sample
+++ b/lib/galaxy/config/sample/themes_conf.yml.sample
@@ -12,6 +12,7 @@ blue:
     logo:
       img: "/static/favicon.svg"
       img-secondary: null
+  default: true
 
 lightblue:
   masthead:

--- a/lib/galaxy/config/sample/themes_conf.yml.sample
+++ b/lib/galaxy/config/sample/themes_conf.yml.sample
@@ -75,20 +75,3 @@ smoky:
       active: "#FF206E"
     logo:
       img: "/static/favicon.svg"
-
-anvil:
-  masthead:
-    color: "#012840"
-    height: "3rem"
-    text:
-      color: "#f6f7f4"
-      hover: "#e0dd10"
-      active: "#ffff"
-    link:
-      color: transparent
-      hover: transparent
-      active: "#00090e"
-    logo:
-      height: "1.8rem"
-      img: "/static/images/galaxy_project_logo_white_square.png"
-      img-secondary: "/static/images/anvilwhite.png"


### PR DESCRIPTION
It's the first theme or the one with `default: true` now.

Also drops anvil config, we wouldn't want anvil impostor galaxy instances around.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
