### PR TITLE
[25.0] Increase proxy API robustness by validating URL before use

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/proxy.py
+++ b/lib/galaxy/webapps/galaxy/api/proxy.py
@@ -35,13 +35,15 @@ URLQueryParam: str = Query(
     description="The URL of the remote file",
 )
 
+ALLOWED_SCHEMES = ("https", "http")
+
 
 def is_valid_url(url: str) -> bool:
     if url.count("://") != 1:
         return False  # Ensure there is exactly one scheme
     try:
         parsed = urlparse(url)
-        return all([parsed.scheme in ("http", "https"), parsed.netloc])
+        return all([parsed.scheme in ALLOWED_SCHEMES, parsed.netloc])
     except ValueError:
         return False
 

--- a/lib/galaxy_test/api/test_proxy.py
+++ b/lib/galaxy_test/api/test_proxy.py
@@ -1,3 +1,5 @@
+import pytest
+
 from galaxy.util.unittest_utils import skip_if_github_down
 from galaxy_test.base.populators import DatasetPopulator
 from ._framework import ApiTestCase
@@ -55,3 +57,21 @@ class TestProxyApi(ApiTestCase):
         response = self._get(f"proxy?url={local_file_url}")
         self._assert_status_code_is(response, 403)
         assert response.json()["err_msg"] == "Action requires admin account."
+
+    @pytest.mark.parametrize(
+        "invalid_url",
+        [
+            "htp://invalid-url",
+            "http:/missing-slash.com",
+            "//missing-scheme.com",
+            "invalid-url",
+            "ftp://not-allowed.com",
+            "https://first.url\nhttps://second.url",
+            "https://first.url https://second.url",
+            "https://first.urlhttps://second.url",
+        ],
+    )
+    def test_invalid_url_format(self, invalid_url: str):
+        response = self._get(f"proxy?url={invalid_url}")
+        self._assert_status_code_is(response, 400)
+        assert response.json()["err_msg"] == "Invalid URL format."

--- a/lib/galaxy_test/api/test_proxy.py
+++ b/lib/galaxy_test/api/test_proxy.py
@@ -52,12 +52,6 @@ class TestProxyApi(ApiTestCase):
         self._assert_status_code_is(response, 403)
         assert response.json()["err_msg"] == "Anonymous users are not allowed to access this endpoint"
 
-    def test_user_cannot_access_local_file(self):
-        local_file_url = "file://etc/passwd"
-        response = self._get(f"proxy?url={local_file_url}")
-        self._assert_status_code_is(response, 403)
-        assert response.json()["err_msg"] == "Action requires admin account."
-
     @pytest.mark.parametrize(
         "invalid_url",
         [
@@ -65,10 +59,12 @@ class TestProxyApi(ApiTestCase):
             "http:/missing-slash.com",
             "//missing-scheme.com",
             "invalid-url",
-            "ftp://not-allowed.com",
             "https://first.url\nhttps://second.url",
             "https://first.url https://second.url",
             "https://first.urlhttps://second.url",
+            # Schemes other than http and https are not allowed
+            "ftp://not-allowed.com",
+            "file://etc/passwd",
         ],
     )
     def test_invalid_url_format(self, invalid_url: str):


### PR DESCRIPTION
Follow up to https://github.com/galaxyproject/galaxy/pull/20300#pullrequestreview-2854030838

This will avoid raising 500 errors for malformed URLs.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
