### PR TITLE
[25.0] Rerun workflows for the correct version/instance

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -925,7 +925,7 @@ class WorkflowContentsManager(UsesAnnotations):
 
         return workflow, missing_tool_tups
 
-    def workflow_to_dict(self, trans, stored, style="export", version=None, history=None):
+    def workflow_to_dict(self, trans, stored, style="export", version=None, history=None, instance_id=None):
         """Export the workflow contents to a dictionary ready for JSON-ification and to be
         sent out via API for instance. There are three styles of export allowed 'export', 'instance', and
         'editor'. The Galaxy team will do its best to preserve the backward compatibility of the
@@ -942,6 +942,12 @@ class WorkflowContentsManager(UsesAnnotations):
             version = None
         if version is not None:
             version = int(version)
+        elif instance_id:
+            # If the instance_id is provided, we need to extract the workflow instance via the version.
+            for i, workflow in enumerate(reversed(stored.workflows)):
+                if workflow.id == instance_id:
+                    version = i
+                    break
         workflow = stored.get_internal_version(version)
         if style == "export":
             style = self.app.config.default_workflow_export_format

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -339,13 +339,15 @@ class WorkflowsAPIController(
         style = kwd.get("style", "export")
         download_format = kwd.get("format")
         version = kwd.get("version")
+        instance = util.string_as_bool(kwd.get("instance", "false"))
+        instance_id = self.decode_id(workflow_id) if instance else None
         history = None
         if history_id := kwd.get("history_id"):
             history = self.history_manager.get_accessible(
                 self.decode_id(history_id), trans.user, current_history=trans.history
             )
         ret_dict = self.workflow_contents_manager.workflow_to_dict(
-            trans, stored_workflow, style=style, version=version, history=history
+            trans, stored_workflow, style=style, version=version, history=history, instance_id=instance_id
         )
         if download_format == "json-download":
             sname = stored_workflow.name

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -334,13 +334,15 @@ class WorkflowsAPIController(
                                           by default.
         :type   instance:                 boolean
         """
+        instance = util.string_as_bool(kwd.get("instance", "false"))
+        workflow_id = self.decode_id(workflow_id)
+        instance_id = workflow_id if instance else None
+
         stored_workflow = self.__get_stored_accessible_workflow(trans, workflow_id, **kwd)
 
         style = kwd.get("style", "export")
         download_format = kwd.get("format")
         version = kwd.get("version")
-        instance = util.string_as_bool(kwd.get("instance", "false"))
-        instance_id = self.decode_id(workflow_id) if instance else None
         history = None
         if history_id := kwd.get("history_id"):
             history = self.history_manager.get_accessible(


### PR DESCRIPTION
In `GET /api/workflows/{encoded_workflow_id}/download`, for the case when `instance = True`, we were correctly obtaining the **stored workflow**.

However, then in `WorkflowContentsManager.workflow_to_dict` we were not considering the case that when `instance = True`, we need to not return the `latest_workflow.workflow_to_dict`, and instead return the specific workflow instance which has been specified.

We were handling the case when `version` is explicitly provided here, but not instance.

Fixes https://github.com/galaxyproject/galaxy/issues/20223 because this bug came from the fact that `GET /api/invocations/{invocation_id}/request` returns an instance id, and when we would fetch the run data via the above mentioned API, it would always return the latest workflow run data (because `WorkflowContentsManager.workflow_to_dict` was not considering instance ids).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
