### PR TITLE
[25.0] Avoid displaying dataset tab view in window manager

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -268,10 +268,10 @@ function onDisplay() {
         // Only conditionally force to keep urls clean most of the time.
         if (route.path === itemUrls.value.display) {
             // @ts-ignore - monkeypatched router, drop with migration.
-            router.push(itemUrls.value.display, { title: props.name, force: true });
+            router.push(itemUrls.value.display, { force: true });
         } else if (itemUrls.value.display) {
             // @ts-ignore - monkeypatched router, drop with migration.
-            router.push(itemUrls.value.display, { title: props.name });
+            router.push(itemUrls.value.display);
         }
     }
 }

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -268,10 +268,10 @@ function onDisplay() {
         // Only conditionally force to keep urls clean most of the time.
         if (route.path === itemUrls.value.display) {
             // @ts-ignore - monkeypatched router, drop with migration.
-            router.push(itemUrls.value.display, { force: true });
+            router.push(itemUrls.value.display, { force: true, preventWindowManager: true });
         } else if (itemUrls.value.display) {
             // @ts-ignore - monkeypatched router, drop with migration.
-            router.push(itemUrls.value.display);
+            router.push(itemUrls.value.display, { preventWindowManager: true });
         }
     }
 }

--- a/client/src/entry/analysis/router-push.js
+++ b/client/src/entry/analysis/router-push.js
@@ -7,13 +7,13 @@ import { addSearchParams } from "utils/url";
  * refresh if needed.
  *
  * @param {String} Location as parsed to original router.push()
- * @param {Object} Custom options, to provide a title and/or force reload
+ * @param {Object} Custom options, to provide a title, force reload, and/or prevent window manager
  */
 export function patchRouterPush(VueRouter) {
     const originalPush = VueRouter.prototype.push;
     VueRouter.prototype.push = function push(location, options = {}) {
         // add key to location to force component refresh
-        const { title, force } = options;
+        const { title, force, preventWindowManager } = options;
         if (force) {
             location = addSearchParams(location, { __vkey__: Date.now() });
         }
@@ -27,7 +27,7 @@ export function patchRouterPush(VueRouter) {
         }
         // show location in window manager
         const Galaxy = getGalaxyInstance();
-        if (title && Galaxy.frame && Galaxy.frame.active) {
+        if (title && !preventWindowManager && Galaxy.frame && Galaxy.frame.active) {
             Galaxy.frame.add({ title: title, url: location });
             return;
         }


### PR DESCRIPTION
Fixes #20273. Removing the `title` attribute from the router push call, prevents the usage of the window manager, when navigating to the dataset tab components.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
