### PR TITLE
[25.0] Improve performance of job cache query

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -571,7 +571,7 @@ class JobSearch:
         self, stmt, tool_id: str, user_id: int, tool_version: Optional[str], job_state, wildcard_param_dump
     ):
         """Build subquery that selects a job with correct job parameters."""
-        job_ids_materialized_cte = stmt.cte("job_ids_cte").prefix_with("MATERIALIZED")
+        job_ids_materialized_cte = stmt.cte("job_ids_cte").prefix_with("MATERIALIZED", dialect="postgresql")
         outer_select_columns = [job_ids_materialized_cte.c[col.name] for col in stmt.selected_columns]
         stmt = select(*outer_select_columns).select_from(job_ids_materialized_cte)
         stmt = (
@@ -673,7 +673,7 @@ class JobSearch:
                 ~deleted_dataset_exists,  # NOT EXISTS deleted dataset
             )
         )
-        unordered_results_cte = outer_stmt.cte("unordered_results").prefix_with("MATERIALIZED")
+        unordered_results_cte = outer_stmt.cte("unordered_results").prefix_with("MATERIALIZED", dialect="postgresql")
         final_ordered_stmt = (
             select(*unordered_results_cte.c)
             .select_from(unordered_results_cte)

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -779,8 +779,8 @@ class JobSearch:
         # Compare leaf-level HDAs
         leaf_left = dce_left[-1]
         leaf_right = dce_right[-1]
-        stmt = stmt.outerjoin(hda_left, hda_left.id == leaf_left.hda_id)
-        stmt = stmt.outerjoin(hda_right, hda_right.id == leaf_right.hda_id)
+        stmt = stmt.join(hda_left, hda_left.id == leaf_left.hda_id)
+        stmt = stmt.join(hda_right, hda_right.id == leaf_right.hda_id)
 
         data_conditions.append(
             and_(
@@ -822,8 +822,8 @@ class JobSearch:
         # Compare dataset_ids at the leaf level
         leaf_left = dce_left[-1]
         leaf_right = dce_right[-1]
-        stmt = stmt.outerjoin(hda_left, hda_left.id == leaf_left.hda_id)
-        stmt = stmt.outerjoin(hda_right, hda_right.id == leaf_right.hda_id)
+        stmt = stmt.join(hda_left, hda_left.id == leaf_left.hda_id)
+        stmt = stmt.join(hda_right, hda_right.id == leaf_right.hda_id)
 
         data_conditions.append(and_(a.name == k, hda_left.dataset_id == hda_right.dataset_id))
 

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -572,7 +572,7 @@ class JobSearch:
         self, stmt, tool_id: str, user_id: int, tool_version: Optional[str], job_state, wildcard_param_dump
     ):
         """Build subquery that selects a job with correct job parameters."""
-        job_ids_materialized_cte = stmt.cte("job_ids_cte").prefix_with("MATERIALIZED", dialect="postgresql")
+        job_ids_materialized_cte = stmt.cte("job_ids_cte")
         outer_select_columns = [job_ids_materialized_cte.c[col.name] for col in stmt.selected_columns]
         stmt = select(*outer_select_columns).select_from(job_ids_materialized_cte)
         stmt = (

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -644,8 +644,8 @@ class JobSearch:
             )
             .where(
                 and_(
-                    jtodca.job_id.is_(None),  # no matching deleted collection was found.
-                    jtoda.job_id.is_(None),  # no matching deleted dataset was found.
+                    deleted_output_hdca.id.is_(None),  # no matching deleted collection was found.
+                    deleted_output_hda.id.is_(None),  # no matching deleted dataset was found.
                 )
             )
         )

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1614,9 +1614,6 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
         back_populates="job", uselist=False
     )
 
-    any_output_dataset_collection_instances_deleted = None
-    any_output_dataset_deleted = None
-
     dict_collection_visible_keys = ["id", "state", "exit_code", "update_time", "create_time", "galaxy_version"]
     dict_element_visible_keys = [
         "id",
@@ -12081,30 +12078,6 @@ mapper_registry.map_imperatively(
 
 # ----------------------------------------------------------------------------------------
 # The following statements must not precede the mapped models defined above.
-
-Job.any_output_dataset_collection_instances_deleted = deferred(
-    column_property(  # type:ignore[assignment]
-        exists(HistoryDatasetCollectionAssociation.id).where(
-            and_(
-                Job.id == JobToOutputDatasetCollectionAssociation.job_id,
-                HistoryDatasetCollectionAssociation.id == JobToOutputDatasetCollectionAssociation.dataset_collection_id,
-                HistoryDatasetCollectionAssociation.deleted == true(),
-            )
-        ),
-    )
-)
-
-Job.any_output_dataset_deleted = deferred(
-    column_property(  # type:ignore[assignment]
-        exists(HistoryDatasetAssociation.id).where(
-            and_(
-                Job.id == JobToOutputDatasetAssociation.job_id,
-                HistoryDatasetAssociation.table.c.id == JobToOutputDatasetAssociation.dataset_id,
-                HistoryDatasetAssociation.table.c.deleted == true(),
-            )
-        ),
-    )
-)
 
 History.average_rating = column_property(  # type:ignore[assignment]
     select(func.avg(HistoryRatingAssociation.rating))

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -1097,6 +1097,23 @@ class TestToolsApi(ApiTestCase, TestsTools):
             job_details = self.dataset_populator.get_job_details(copied_job_id, full=True).json()
             assert job_details["copied_from_job_id"] == outputs_one["jobs"][0]["id"]
 
+    @skip_without_tool("cat_list")
+    @requires_new_history
+    def test_run_cat_list_use_cached_job_repeated_input(self):
+        with self.dataset_populator.test_history_for(
+            self.test_run_cat_list_use_cached_job_repeated_input
+        ) as history_id:
+            # Run simple non-upload tool with an input data parameter.
+            input_value = dataset_to_param(self.dataset_populator.new_dataset(history_id=history_id))
+            inputs = {"input1": {"batch": False, "values": [input_value, input_value]}}
+            outputs_one = self._run("cat_list", history_id, inputs, assert_ok=True, wait_for_job=True)
+            outputs_two = self._run(
+                "cat_list", history_id, inputs, assert_ok=True, wait_for_job=True, use_cached_job=True
+            )
+            copied_job_id = outputs_two["jobs"][0]["id"]
+            job_details = self.dataset_populator.get_job_details(copied_job_id, full=True).json()
+            assert job_details["copied_from_job_id"] == outputs_one["jobs"][0]["id"]
+
     @skip_without_tool("collection_creates_list")
     @requires_new_history
     def test_run_collection_creates_list_use_cached_job(self):


### PR DESCRIPTION
by turning the correlated subquery that checks for deleted job outputs into an outerjoin.
Brings the query time down from 374937.263 to 19373.252, so roughly a 20-fold improvement. Still a little slow but more managable. The remainder can likely be improved by an additional compound index

SQL Before:
```sql
SELECT
	job.id,
	job_to_input_dataset_1.dataset_id,
	job_to_input_dataset_2.dataset_id AS dataset_id_1
FROM
	job
	JOIN history ON job.history_id = history.id
	JOIN job_parameter AS job_parameter_1 ON job.id = job_parameter_1.job_id
	JOIN job_parameter AS job_parameter_2 ON job.id = job_parameter_2.job_id
	JOIN job_parameter AS job_parameter_3 ON job.id = job_parameter_3.job_id
	JOIN job_parameter AS job_parameter_4 ON job.id = job_parameter_4.job_id
	JOIN job_to_input_dataset AS job_to_input_dataset_1 ON job_to_input_dataset_1.job_id = job.id
	JOIN history_dataset_association AS history_dataset_association_1 ON job_to_input_dataset_1.dataset_id = history_dataset_association_1.id
	JOIN history_dataset_association AS history_dataset_association_2 ON history_dataset_association_2.dataset_id = history_dataset_association_1.dataset_id
	JOIN job_to_input_dataset AS job_to_input_dataset_2 ON job_to_input_dataset_2.job_id = job.id
	JOIN history_dataset_association AS history_dataset_association_3 ON job_to_input_dataset_2.dataset_id = history_dataset_association_3.id
	JOIN history_dataset_association AS history_dataset_association_4 ON history_dataset_association_4.dataset_id = history_dataset_association_3.dataset_id
WHERE
	job.tool_id = 'toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.2.1+galaxy1'
	AND (
		job.user_id = 392010
		OR history.published = true
	)
	AND job.copied_from_job_id IS NULL
	AND job.tool_version = '2.2.1+galaxy1'
	AND job.state IN ('ok')
	AND (
		EXISTS (
			SELECT
				history_dataset_collection_association.id
			FROM
				history_dataset_collection_association,
				job_to_output_dataset_collection
			WHERE
				job.id = job_to_output_dataset_collection.job_id
				AND history_dataset_collection_association.id = job_to_output_dataset_collection.dataset_collection_id
				AND history_dataset_collection_association.deleted = true
		)
	) = false
	AND (
		EXISTS (
			SELECT
				history_dataset_association.id
			FROM
				history_dataset_association,
				job_to_output_dataset
			WHERE
				job.id = job_to_output_dataset.job_id
				AND history_dataset_association.id = job_to_output_dataset.dataset_id
				AND history_dataset_association.deleted = true
		)
	) = false
	AND job.id = job_parameter_1.job_id
	AND job_parameter_1.name = 'reference_genome'
	AND job_parameter_1.value LIKE '{""__current_case__"": 1, ""history_item"": {""values"": [{""id"": %, ""src"": ""hda""}]}, ""source"": ""history""}'
	AND job.id = job_parameter_2.job_id
	AND job_parameter_2.name = 'library'
	AND job_parameter_2.value LIKE '{""__current_case__"": 0, ""input_1"": {""values"": [{""id"": %, ""src"": ""hda""}]}, ""rna_strandness"": """", ""type"": ""single""}'
	AND job.id = job_parameter_3.job_id
	AND job_parameter_3.name = 'sum'
	AND job_parameter_3.value = '{""new_summary"": false, ""summary_file"": false}'
	AND job.id = job_parameter_4.job_id
	AND job_parameter_4.name = 'adv'
	AND job_parameter_4.value = '{""alignment_options"": {""__current_case__"": 0, ""alignment_options_selector"": ""defaults""}, ""input_options"": {""__current_case__"": 0, ""input_options_selector"": ""defaults""}, ""other_options"": {""__current_case__"": 0, ""other_options_selector"": ""defaults""}, ""output_options"": {""__current_case__"": 0, ""output_options_selector"": ""defaults""}, ""reporting_options"": {""__current_case__"": 0, ""reporting_options_selector"": ""defaults""}, ""sam_options"": {""__current_case__"": 0, ""sam_options_selector"": ""defaults""}, ""scoring_options"": {""__current_case__"": 0, ""scoring_options_selector"": ""defaults""}, ""spliced_options"": {""__current_case__"": 0, ""spliced_options_selector"": ""defaults""}}'
	AND job_to_input_dataset_1.name IN ('reference_genome|history_item', 'history_item')
	AND history_dataset_association_2.id = 152775960
	AND (
		(
			job_to_input_dataset_1.dataset_version IN (0, history_dataset_association_1.version)
			OR history_dataset_association_1.update_time < job.create_time
		)
		AND history_dataset_association_1.extension = history_dataset_association_2.extension
		AND history_dataset_association_1.name = history_dataset_association_2.name
		OR history_dataset_association_1.id IN (
			SELECT
				history_dataset_association.id
			FROM
				history_dataset_association,
				history_dataset_association_history AS history_dataset_association_history_1
			WHERE
				history_dataset_association.id = history_dataset_association_history_1.history_dataset_association_id
				AND history_dataset_association_history_1.name = history_dataset_association_2.name
				AND history_dataset_association_history_1.extension = history_dataset_association_2.extension
				AND job_to_input_dataset_1.dataset_version = history_dataset_association_history_1.version
				AND history_dataset_association_history_1.metadata = history_dataset_association_2.metadata
		)
	)
	AND (
		history_dataset_association_1.deleted = false
		OR history_dataset_association_2.deleted = false
	)
	AND job_to_input_dataset_2.name IN ('input_1', 'library|input_1')
	AND history_dataset_association_4.id = 152726579
	AND (
		(
			job_to_input_dataset_2.dataset_version IN (0, history_dataset_association_3.version)
			OR history_dataset_association_3.update_time < job.create_time
		)
		AND history_dataset_association_3.extension = history_dataset_association_4.extension
		AND history_dataset_association_3.name = history_dataset_association_4.name
		OR history_dataset_association_3.id IN (
			SELECT
				history_dataset_association.id
			FROM
				history_dataset_association,
				history_dataset_association_history AS history_dataset_association_history_2
			WHERE
				history_dataset_association.id = history_dataset_association_history_2.history_dataset_association_id
				AND history_dataset_association_history_2.name = history_dataset_association_4.name
				AND history_dataset_association_history_2.extension = history_dataset_association_4.extension
				AND job_to_input_dataset_2.dataset_version = history_dataset_association_history_2.version
				AND history_dataset_association_history_2.metadata = history_dataset_association_4.metadata
		)
	)
	AND (
		history_dataset_association_3.deleted = false
		OR history_dataset_association_4.deleted = false
	)
GROUP BY
	job.id,
	job_to_input_dataset_1.dataset_id,
	job_to_input_dataset_2.dataset_id
ORDER BY
	job.id DESC;
```

after (changed the aliases manually):
```sql
EXPLAIN (ANALYZE, COSTS, VERBOSE, BUFFERS, FORMAT JSON)
SELECT
    job.id,
    job_to_input_dataset_1.dataset_id,
    job_to_input_dataset_2.dataset_id AS dataset_id_1
FROM
    job
    JOIN history ON job.history_id = history.id
    LEFT OUTER JOIN job_to_output_dataset_collection AS job_to_output_dataset_collection_1 ON job.id = job_to_output_dataset_collection_1.job_id
    LEFT OUTER JOIN history_dataset_collection_association AS history_dataset_collection_association_1_deleted ON history_dataset_collection_association_1_deleted.id = job_to_output_dataset_collection_1.dataset_collection_id
    AND history_dataset_collection_association_1_deleted.deleted = true
    LEFT OUTER JOIN job_to_output_dataset AS job_to_output_dataset_1 ON job.id = job_to_output_dataset_1.job_id
    LEFT OUTER JOIN history_dataset_association AS history_dataset_association_1_deleted ON history_dataset_association_1_deleted.id = job_to_output_dataset_1.dataset_id
    AND history_dataset_association_1_deleted.deleted = true
    JOIN job_parameter AS job_parameter_1 ON job.id = job_parameter_1.job_id
    JOIN job_parameter AS job_parameter_2 ON job.id = job_parameter_2.job_id
    JOIN job_parameter AS job_parameter_3 ON job.id = job_parameter_3.job_id
    JOIN job_parameter AS job_parameter_4 ON job.id = job_parameter_4.job_id
    JOIN job_to_input_dataset AS job_to_input_dataset_1 ON job_to_input_dataset_1.job_id = job.id
    JOIN history_dataset_association AS history_dataset_association_1 ON job_to_input_dataset_1.dataset_id = history_dataset_association_1.id
    JOIN history_dataset_association AS history_dataset_association_2 ON history_dataset_association_2.dataset_id = history_dataset_association_1.dataset_id
    JOIN job_to_input_dataset AS job_to_input_dataset_2 ON job_to_input_dataset_2.job_id = job.id
    JOIN history_dataset_association AS history_dataset_association_3 ON job_to_input_dataset_2.dataset_id = history_dataset_association_3.id
    JOIN history_dataset_association AS history_dataset_association_4 ON history_dataset_association_4.dataset_id = history_dataset_association_3.dataset_id
WHERE
    job.tool_id = 'toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.2.1+galaxy1'
    AND (
        job.user_id = 392010
        OR history.published = true
    )
    AND job.copied_from_job_id IS NULL
    AND job.tool_version = '2.2.1+galaxy1'
    AND job.state IN ('ok')
    AND job_to_output_dataset_collection_1.job_id IS NULL
    AND job_to_output_dataset_1.job_id IS NULL
    AND job.id = job_parameter_1.job_id
    AND job_parameter_1.name = 'reference_genome'
    AND job_parameter_1.value LIKE '{""__current_case__"": 1, ""history_item"": {""values"": [{""id"": %, ""src"": ""hda""}]}, ""source"": ""history""}'
    AND job.id = job_parameter_2.job_id
    AND job_parameter_2.name = 'library'
    AND job_parameter_2.value LIKE '{""__current_case__"": 0, ""input_1"": {""values"": [{""id"": %, ""src"": ""hda""}]}, ""rna_strandness"": """", ""type"": ""single""}'
    AND job.id = job_parameter_3.job_id
    AND job_parameter_3.name = 'sum'
    AND job_parameter_3.value = '{""new_summary"": false, ""summary_file"": false}'
    AND job.id = job_parameter_4.job_id
    AND job_parameter_4.name = 'adv'
    AND job_parameter_4.value = '{""alignment_options"": {""__current_case__"": 0, ""alignment_options_selector"": ""defaults""}, ""input_options"": {""__current_case__"": 0, ""input_options_selector"": ""defaults""}, ""other_options"": {""__current_case__"": 0, ""other_options_selector"": ""defaults""}, ""output_options"": {""__current_case__"": 0, ""output_options_selector"": ""defaults""}, ""reporting_options"": {""__current_case__"": 0, ""reporting_options_selector"": ""defaults""}, ""sam_options"": {""__current_case__"": 0, ""sam_options_selector"": ""defaults""}, ""scoring_options"": {""__current_case__"": 0, ""scoring_options_selector"": ""defaults""}, ""spliced_options"": {""__current_case__"": 0, ""spliced_options_selector"": ""defaults""}}'
    AND job_to_input_dataset_1.name IN ('reference_genome|history_item', 'history_item')
    AND history_dataset_association_2.id = 152775960
    AND (
        (
            job_to_input_dataset_1.dataset_version IN (0, history_dataset_association_1.version)
            OR history_dataset_association_1.update_time < job.create_time
        )
        AND history_dataset_association_1.extension = history_dataset_association_2.extension
        AND history_dataset_association_1.name = history_dataset_association_2.name
        OR history_dataset_association_1.id IN (
            SELECT
                history_dataset_association.id
            FROM
                history_dataset_association,
                history_dataset_association_history AS history_dataset_association_history_1
            WHERE
                history_dataset_association.id = history_dataset_association_history_1.history_dataset_association_id
                AND history_dataset_association_history_1.name = history_dataset_association_2.name
                AND history_dataset_association_history_1.extension = history_dataset_association_2.extension
                AND job_to_input_dataset_1.dataset_version = history_dataset_association_history_1.version
                AND history_dataset_association_history_1.metadata = history_dataset_association_2.metadata
        )
    )
    AND (
        history_dataset_association_1.deleted = false
        OR history_dataset_association_2.deleted = false
    )
    AND job_to_input_dataset_2.name IN ('input_1', 'library|input_1')
    AND history_dataset_association_4.id = 152726579
    AND (
        (
            job_to_input_dataset_2.dataset_version IN (0, history_dataset_association_3.version)
            OR history_dataset_association_3.update_time < job.create_time
        )
        AND history_dataset_association_3.extension = history_dataset_association_4.extension
        AND history_dataset_association_3.name = history_dataset_association_4.name
        OR history_dataset_association_3.id IN (
            SELECT
                history_dataset_association.id
            FROM
                history_dataset_association,
                history_dataset_association_history AS history_dataset_association_history_2
            WHERE
                history_dataset_association.id = history_dataset_association_history_2.history_dataset_association_id
                AND history_dataset_association_history_2.name = history_dataset_association_4.name
                AND history_dataset_association_history_2.extension = history_dataset_association_4.extension
                AND job_to_input_dataset_2.dataset_version = history_dataset_association_history_2.version
                AND history_dataset_association_history_2.metadata = history_dataset_association_4.metadata
        )
    )
    AND (
        history_dataset_association_3.deleted = false
        OR history_dataset_association_4.deleted = false
    )
GROUP BY
    job.id,
    job_to_input_dataset_1.dataset_id,
    job_to_input_dataset_2.dataset_id
ORDER BY
    job.id DESC;

```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
