### PR TITLE
[25.0] Fix workflow bookmark filtering

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -254,11 +254,10 @@ class WorkflowsManager(sharable.SharableModelManager[model.StoredWorkflow], dele
                                 raise exceptions.RequestParameterInvalidException(message)
                             stmt = stmt.where(StoredWorkflowUserShareAssociation.user == user)
                         elif q == "bookmarked":
-                            stmt = (
-                                stmt.join(model.StoredWorkflowMenuEntry)
-                                .where(model.StoredWorkflowMenuEntry.stored_workflow_id == StoredWorkflow.id)
-                                .where(model.StoredWorkflowMenuEntry.user_id == user.id)
-                            )
+                            stmt = stmt.join(
+                                model.StoredWorkflowMenuEntry,
+                                model.StoredWorkflowMenuEntry.stored_workflow_id == StoredWorkflow.id,
+                            ).where(model.StoredWorkflowMenuEntry.user_id == user.id)
                 elif isinstance(term, RawTextTerm):
                     tf = w_tag_filter(term.text, False)
                     alias = aliased(User)

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1602,6 +1602,10 @@ class NavigatesGalaxy(HasDriver):
         self.sleep_for(self.wait_types.UX_RENDER)
         self.components._.confirm_button(name="Delete").wait_for_and_click()
 
+    def workflow_bookmark_by_name(self, name):
+        self.workflow_index_search_for(name)
+        self.components.workflows.bookmark_link(action="add").wait_for_and_click()
+
     @retry_during_transitions
     def workflow_index_name(self, workflow_index=0):
         workflow = self.workflow_card_element(workflow_index=workflow_index)

--- a/lib/galaxy_test/selenium/test_workflow_management.py
+++ b/lib/galaxy_test/selenium/test_workflow_management.py
@@ -210,3 +210,25 @@ class TestWorkflowManagement(SeleniumTestCase, TestsGalaxyPagers, UsesWorkflowAs
 
         self.workflow_index_open()
         self.components.workflows.workflows_list_empty.wait_for_visible()
+
+    @selenium_test
+    def test_workflow_bookmark_filtering(self):
+        self.workflow_index_open()
+        # Import 2 workflows
+        self._workflow_import_from_url()
+        self._workflow_import_from_url()
+        self._assert_showing_n_workflows(2)
+        # Rename and bookmark one
+        self.workflow_rename("forbookmark")
+        self.workflow_bookmark_by_name("forbookmark")
+
+        # Filter by bookmark
+        self.workflow_index_search_for("is:bookmarked")
+        self._assert_showing_n_workflows(1)
+        self.screenshot("workflow_manage_bookmark_search")
+
+        # clear filter
+        self.components.workflows.clear_filter.wait_for_and_click()
+        curr_value = self.workflow_index_get_current_filter()
+        assert curr_value == "", curr_value
+        self._assert_showing_n_workflows(2)


### PR DESCRIPTION
Fixes #20308

```
sqlalchemy.exc.AmbiguousForeignKeysError:
Can't determine join between 'Join object on Join object on Join object on stored_workflow(137780407102704) and
galaxy_user(137778601856272)(137778601858432) and stored_workflow_user_share_connection(137778603428608)
(137778604318528) and stored_workflow_tag_association(137778604398528)' and 'stored_workflow_menu_entry';
tables have more than one foreign key constraint relationship between them.
Please specify the 'onclause' of this join explicitly.
```


https://github.com/user-attachments/assets/714ca7a4-0f95-4233-8a2e-54adcacd4264



## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
