### PR TITLE
[25.0] Add basic validation to workflow creator attribute

### DIFF
--- a/client/src/components/Common/ItemListEditor.vue
+++ b/client/src/components/Common/ItemListEditor.vue
@@ -118,7 +118,7 @@ function resetForm() {
 <template>
     <div>
         <div v-if="showForm">
-            <b-input v-model="currentItem" :state="currentItemError ? false : null" @click="removeErrorMessage" />
+            <b-input v-model="currentItem" :state="currentItemError ? false : null" @focus="removeErrorMessage" />
             <div class="spacer"></div>
             <div v-if="currentItemError" class="error">{{ currentItemError }}</div>
             <div v-if="props.description" v-html="description"></div>

--- a/client/src/components/Common/ItemListEditor.vue
+++ b/client/src/components/Common/ItemListEditor.vue
@@ -156,9 +156,10 @@ function resetForm() {
     </div>
 </template>
 
-<style>
+<style lang="scss" scoped>
+@import "custom_theme_variables.scss";
 .error {
-    color: red;
+    color: var(--color-red-500);
 }
 .spacer {
     padding: 5px;

--- a/client/src/components/SchemaOrg/CreatorEditor.vue
+++ b/client/src/components/SchemaOrg/CreatorEditor.vue
@@ -42,12 +42,6 @@
     </span>
 </template>
 
-<style>
-.error {
-    color: red;
-}
-</style>
-
 <script>
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faEdit, faTimes } from "@fortawesome/free-solid-svg-icons";

--- a/client/src/components/SchemaOrg/CreatorEditor.vue
+++ b/client/src/components/SchemaOrg/CreatorEditor.vue
@@ -42,6 +42,12 @@
     </span>
 </template>
 
+<style>
+.error {
+    color: red;
+}
+</style>
+
 <script>
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faEdit, faTimes } from "@fortawesome/free-solid-svg-icons";

--- a/client/src/components/SchemaOrg/OrganizationForm.vue
+++ b/client/src/components/SchemaOrg/OrganizationForm.vue
@@ -6,11 +6,14 @@
             <span v-b-tooltip.hover title="Hide Attribute"
                 ><FontAwesomeIcon icon="eye-slash" @click="onHide(attribute.key)"
             /></span>
+            <div v-if="currentErrors[attribute.key]" class="error">{{ currentErrors[attribute.key] }}</div>
             <b-form-input
                 :id="attribute.key"
                 v-model="currentValues[attribute.key]"
                 :placeholder="'Enter ' + attribute.placeholder + '.'"
-                :type="attribute.type">
+                :type="attribute.type"
+                :state="currentErrors[attribute.key] ? false : null"
+                @click="removeErrorMessage(attribute.key)">
             </b-form-input>
         </div>
         <div role="group" class="form-group">
@@ -55,6 +58,7 @@ export default {
     },
     data() {
         const currentValues = {};
+        const currentErrors = {};
         const show = {};
         for (const attribute of ATTRIBUTES) {
             const showAttribute = attribute in this.organization;
@@ -73,6 +77,7 @@ export default {
             attributeInfo: ATTRIBUTES_INFO,
             show: show,
             currentValues: currentValues,
+            currentErrors: currentErrors,
             addAttribute: null,
             schemaOrgClass: "Organization",
         };

--- a/client/src/components/SchemaOrg/OrganizationForm.vue
+++ b/client/src/components/SchemaOrg/OrganizationForm.vue
@@ -13,7 +13,7 @@
                 :placeholder="'Enter ' + attribute.placeholder + '.'"
                 :type="attribute.type"
                 :state="currentErrors[attribute.key] ? false : null"
-                @click="removeErrorMessage(attribute.key)">
+                @focus="removeErrorMessage(attribute.key)">
             </b-form-input>
         </div>
         <div role="group" class="form-group">

--- a/client/src/components/SchemaOrg/OrganizationForm.vue
+++ b/client/src/components/SchemaOrg/OrganizationForm.vue
@@ -25,7 +25,6 @@
 </template>
 
 <style lang="scss" scoped>
-@import "custom_theme_variables.scss";
 .error {
     color: var(--color-red-500);
 }

--- a/client/src/components/SchemaOrg/OrganizationForm.vue
+++ b/client/src/components/SchemaOrg/OrganizationForm.vue
@@ -24,6 +24,13 @@
     </b-form>
 </template>
 
+<style lang="scss" scoped>
+@import "custom_theme_variables.scss";
+.error {
+    color: var(--color-red-500);
+}
+</style>
+
 <script>
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faEyeSlash, faLink } from "@fortawesome/free-solid-svg-icons";

--- a/client/src/components/SchemaOrg/PersonForm.vue
+++ b/client/src/components/SchemaOrg/PersonForm.vue
@@ -6,11 +6,14 @@
             <span v-b-tooltip.hover title="Hide Attribute"
                 ><FontAwesomeIcon icon="eye-slash" @click="onHide(attribute.key)"
             /></span>
+            <div v-if="currentErrors[attribute.key]" class="error">{{ currentErrors[attribute.key] }}</div>
             <b-form-input
                 :id="attribute.key"
                 v-model="currentValues[attribute.key]"
                 :placeholder="'Enter ' + attribute.placeholder + '.'"
-                :type="attribute.type">
+                :type="attribute.type"
+                :state="currentErrors[attribute.key] ? false : null"
+                @click="removeErrorMessage(attribute.key)">
             </b-form-input>
         </div>
         <div role="group" class="form-group">
@@ -60,6 +63,7 @@ export default {
     },
     data() {
         const currentValues = {};
+        const currentErrors = {};
         const show = {};
         for (const attribute of ATTRIBUTES) {
             const showAttribute = attribute in this.person;
@@ -78,6 +82,7 @@ export default {
             attributeInfo: ATTRIBUTES_INFO,
             show: show,
             currentValues: currentValues,
+            currentErrors: currentErrors,
             addAttribute: null,
             schemaOrgClass: "Person",
         };

--- a/client/src/components/SchemaOrg/PersonForm.vue
+++ b/client/src/components/SchemaOrg/PersonForm.vue
@@ -13,7 +13,7 @@
                 :placeholder="'Enter ' + attribute.placeholder + '.'"
                 :type="attribute.type"
                 :state="currentErrors[attribute.key] ? false : null"
-                @click="removeErrorMessage(attribute.key)">
+                @focus="removeErrorMessage(attribute.key)">
             </b-form-input>
         </div>
         <div role="group" class="form-group">

--- a/client/src/components/SchemaOrg/PersonForm.vue
+++ b/client/src/components/SchemaOrg/PersonForm.vue
@@ -24,6 +24,13 @@
     </b-form>
 </template>
 
+<style lang="scss" scoped>
+@import "custom_theme_variables.scss";
+.error {
+    color: var(--color-red-500);
+}
+</style>
+
 <script>
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faEyeSlash, faLink } from "@fortawesome/free-solid-svg-icons";

--- a/client/src/components/SchemaOrg/ThingFormMixin.js
+++ b/client/src/components/SchemaOrg/ThingFormMixin.js
@@ -27,6 +27,7 @@ export default {
     methods: {
         onReset(evt) {
             evt.preventDefault();
+            this.removeErrorMessage();
             this.$emit("onReset");
         },
         onHide(attributeKey) {
@@ -34,21 +35,43 @@ export default {
         },
         onSave(evt) {
             evt.preventDefault();
-            const newThing = {};
-            newThing.class = this.schemaOrgClass;
-            for (const attributeInfo of this.attributeInfo) {
-                const attribute = attributeInfo.key;
-                if (this.show[attribute]) {
-                    let value = this.currentValues[attribute];
-                    if (attribute == "email") {
-                        if (value.indexOf("mailto:") !== 0) {
-                            value = "mailto:" + value;
+            if (this.validate()) {
+                const newThing = {};
+                newThing.class = this.schemaOrgClass;
+                for (const attributeInfo of this.attributeInfo) {
+                    const attribute = attributeInfo.key;
+                    if (this.show[attribute]) {
+                        let value = this.currentValues[attribute];
+                        if (attribute == "email") {
+                            if (value.indexOf("mailto:") !== 0) {
+                                value = "mailto:" + value;
+                            }
                         }
+                        newThing[attribute] = value;
                     }
-                    newThing[attribute] = value;
+                }
+                this.$emit("onSave", newThing);
+            }
+        },
+        removeErrorMessage(key) {
+            if (key) {
+                this.$set(this.currentErrors, key, null);
+            } else {
+                for (const key in this.currentErrors) {
+                    this.$set(this.currentErrors, key, null);
                 }
             }
-            this.$emit("onSave", newThing);
+        },
+        validate() {
+            for (const attr of this.displayedAttributes) {
+                const item = this.currentValues[attr.key];
+                if (!item) {
+                    this.$set(this.currentErrors, attr.key, "Please provide a value");
+                    return false;
+                }
+            }
+
+            return true;
         },
     },
 };


### PR DESCRIPTION
Fixes #20314

We don't check for duplicate values here because this would require not only a comparison of the full set of a creator's fields to the fields of existing creators, but also adding a disambiguation policy for cases when those fields have identical values, which is ..not worth the effort.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
