### PR TITLE
Add short term storage expiration indicator to history items

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -7580,6 +7580,8 @@ export interface components {
             device?: string | null;
             /** Name */
             name?: string | null;
+            /** Object Expires After Days */
+            object_expires_after_days?: number | null;
             /** Object Store Id */
             object_store_id?: string | null;
             /** Private */
@@ -21481,6 +21483,8 @@ export interface components {
             hidden: boolean;
             /** Name */
             name?: string | null;
+            /** Object Expires After Days */
+            object_expires_after_days?: number | null;
             /** Object Store Id */
             object_store_id?: string | null;
             /** Private */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -12005,6 +12005,11 @@ export interface components {
              */
             name?: string | null;
             /**
+             * Object Store ID
+             * @description The ID of the object store that this dataset is stored in.
+             */
+            object_store_id?: string | null;
+            /**
              * Peek
              * @description A few lines of contents from the start of the file.
              */
@@ -12262,6 +12267,11 @@ export interface components {
              * @description The name of the item.
              */
             name: string | null;
+            /**
+             * Object Store ID
+             * @description The ID of the object store that this dataset is stored in.
+             */
+            object_store_id?: string | null;
             /**
              * Peek
              * @description A few lines of contents from the start of the file.
@@ -12529,6 +12539,11 @@ export interface components {
              * @description The name of the item.
              */
             name: string | null;
+            /**
+             * Object Store ID
+             * @description The ID of the object store that this dataset is stored in.
+             */
+            object_store_id?: string | null;
             /**
              * Purged
              * @description Whether this dataset has been removed from disk.

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -12688,6 +12688,11 @@ export interface components {
              */
             name?: string | null;
             /**
+             * Object Store IDs
+             * @description A list of object store IDs where the elements of the collection are stored. Most of the time it will be a single ID,  but in some cases some elements may be stored in different object stores.
+             */
+            object_store_ids?: string[] | null;
+            /**
              * Populated
              * @description Whether the dataset collection elements (and any subcollections elements) were successfully populated.
              */
@@ -12842,6 +12847,11 @@ export interface components {
              */
             name: string | null;
             /**
+             * Object Store IDs
+             * @description A list of object store IDs where the elements of the collection are stored. Most of the time it will be a single ID,  but in some cases some elements may be stored in different object stores.
+             */
+            object_store_ids?: string[] | null;
+            /**
              * Populated
              * @description Whether the dataset collection elements (and any subcollections elements) were successfully populated.
              */
@@ -12981,6 +12991,11 @@ export interface components {
              * @description The name of the item.
              */
             name: string | null;
+            /**
+             * Object Store IDs
+             * @description A list of object store IDs where the elements of the collection are stored. Most of the time it will be a single ID,  but in some cases some elements may be stored in different object stores.
+             */
+            object_store_ids?: string[] | null;
             /**
              * Populated State
              * @description Indicates the general state of the elements in the dataset collection:- 'new': new dataset collection, unpopulated elements.- 'ok': collection elements populated (HDAs may or may not have errors).- 'failed': some problem populating, won't be populated.

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -12688,11 +12688,6 @@ export interface components {
              */
             name?: string | null;
             /**
-             * Object Store IDs
-             * @description A list of object store IDs where the elements of the collection are stored. Most of the time it will be a single ID,  but in some cases some elements may be stored in different object stores.
-             */
-            object_store_ids?: string[] | null;
-            /**
              * Populated
              * @description Whether the dataset collection elements (and any subcollections elements) were successfully populated.
              */
@@ -12707,6 +12702,11 @@ export interface components {
              * @description Optional message with further information in case the population of the dataset collection failed.
              */
             populated_state_message?: string | null;
+            /**
+             * Store Times Summary
+             * @description A list of objects containing the object store ID and the oldest creation time of the datasets stored in that object store for this collection.This is used to determine the age of the datasets in the collection when the object store is short-lived.
+             */
+            store_times_summary?: components["schemas"]["OldestCreateTimeByObjectStoreId"][] | null;
             tags?: components["schemas"]["TagCollection"] | null;
             /**
              * Type
@@ -12847,11 +12847,6 @@ export interface components {
              */
             name: string | null;
             /**
-             * Object Store IDs
-             * @description A list of object store IDs where the elements of the collection are stored. Most of the time it will be a single ID,  but in some cases some elements may be stored in different object stores.
-             */
-            object_store_ids?: string[] | null;
-            /**
              * Populated
              * @description Whether the dataset collection elements (and any subcollections elements) were successfully populated.
              */
@@ -12866,6 +12861,11 @@ export interface components {
              * @description Optional message with further information in case the population of the dataset collection failed.
              */
             populated_state_message?: string | null;
+            /**
+             * Store Times Summary
+             * @description A list of objects containing the object store ID and the oldest creation time of the datasets stored in that object store for this collection.This is used to determine the age of the datasets in the collection when the object store is short-lived.
+             */
+            store_times_summary?: components["schemas"]["OldestCreateTimeByObjectStoreId"][] | null;
             tags: components["schemas"]["TagCollection"];
             /**
              * Type
@@ -12992,11 +12992,6 @@ export interface components {
              */
             name: string | null;
             /**
-             * Object Store IDs
-             * @description A list of object store IDs where the elements of the collection are stored. Most of the time it will be a single ID,  but in some cases some elements may be stored in different object stores.
-             */
-            object_store_ids?: string[] | null;
-            /**
              * Populated State
              * @description Indicates the general state of the elements in the dataset collection:- 'new': new dataset collection, unpopulated elements.- 'ok': collection elements populated (HDAs may or may not have errors).- 'failed': some problem populating, won't be populated.
              */
@@ -13006,6 +13001,11 @@ export interface components {
              * @description Optional message with further information in case the population of the dataset collection failed.
              */
             populated_state_message?: string | null;
+            /**
+             * Store Times Summary
+             * @description A list of objects containing the object store ID and the oldest creation time of the datasets stored in that object store for this collection.This is used to determine the age of the datasets in the collection when the object store is short-lived.
+             */
+            store_times_summary?: components["schemas"]["OldestCreateTimeByObjectStoreId"][] | null;
             tags: components["schemas"]["TagCollection"];
             /**
              * Type
@@ -17405,6 +17405,23 @@ export interface components {
              * @default 0
              */
             version: number;
+        };
+        /**
+         * OldestCreateTimeByObjectStoreId
+         * @description Represents the oldest creation time of a set of datasets stored in a specific object store.
+         */
+        OldestCreateTimeByObjectStoreId: {
+            /**
+             * Object Store ID
+             * @description The ID of the object store.
+             */
+            object_store_id: string;
+            /**
+             * Oldest Create Time
+             * Format: date-time
+             * @description The oldest creation time of a set of datasets stored in this object store.
+             */
+            oldest_create_time: string;
         };
         /** OutputReferenceByLabel */
         OutputReferenceByLabel: {

--- a/client/src/components/History/Content/ContentExpirationIndicator.vue
+++ b/client/src/components/History/Content/ContentExpirationIndicator.vue
@@ -32,7 +32,8 @@ const expirableObjectStoreTime = computed<ExpirableObjectStoreTime | undefined>(
         // Single object store case: check if it has an expiration policy
         const expirableObjectStore = selectableObjectStores.value?.find(
             (objectStore) =>
-                objectStore.object_store_id === item.object_store_id && (objectStore.object_expires_after_days ?? 0) > 0
+                objectStore.object_store_id === item.object_store_id &&
+                (objectStore.object_expires_after_days ?? 0) > 0,
         );
         if (!expirableObjectStore) {
             return undefined;
@@ -48,7 +49,7 @@ const expirableObjectStoreTime = computed<ExpirableObjectStoreTime | undefined>(
         const expirableStoreTimes: ExpirableObjectStoreTime[] = (item.store_times_summary ?? [])
             .map((storeTime) => {
                 const objectStore = selectableObjectStores.value?.find(
-                    (os) => os.object_store_id === storeTime.object_store_id
+                    (os) => os.object_store_id === storeTime.object_store_id,
                 );
                 if (!objectStore || (objectStore.object_expires_after_days ?? 0) <= 0) {
                     return null;
@@ -127,15 +128,18 @@ const expirationMessage = computed(() => {
 });
 
 const expirationTooltip = computed(() => {
+    const itemType = isHDA(props.item) ? "dataset" : "dataset collection (or any of its datasets)";
     if (!expirationDate.value) {
-        return "This dataset does not have an expiration date.";
+        return `This ${itemType} does not have an expiration date.`;
     }
     if (hasExpired.value) {
-        return `This dataset was stored in ${
+        return `This ${itemType} was stored in ${
             objectStoreName.value
         } and has expired on ${expirationDate.value.toDateString()}.`;
     }
-    return `This dataset is stored in ${objectStoreName.value} and expires on ${expirationDate.value.toDateString()}.`;
+    return `This ${itemType} is stored in ${
+        objectStoreName.value
+    } and expires on ${expirationDate.value.toDateString()}.`;
 });
 
 const variant = computed(() => {

--- a/client/src/components/History/Content/ContentExpirationIndicator.vue
+++ b/client/src/components/History/Content/ContentExpirationIndicator.vue
@@ -6,65 +6,98 @@ import { parseISO } from "date-fns";
 import { storeToRefs } from "pinia";
 import { computed } from "vue";
 
+import type { HDASummary, HDCASummary } from "@/api";
+import { isHDA } from "@/api";
 import { useObjectStoreStore } from "@/stores/objectStoreStore";
 
-interface ExpirableItem {
-    id: string;
-    create_time: string;
-    object_store_id?: string | null;
-    object_store_ids?: string[] | null;
+interface ExpirableObjectStoreTime {
+    objectStoreId: string;
+    objectExpiresAfterDays: number;
+    objectStoreName: string;
+    oldestCreateTime: Date;
 }
 
 const props = defineProps<{
-    item: ExpirableItem;
+    item: HDASummary | HDCASummary;
 }>();
 
 const store = useObjectStoreStore();
 const { selectableObjectStores } = storeToRefs(store);
 
-const itemCreationDate = computed(() => parseISO(`${props.item.create_time}Z`));
+const defaultName = "Unnamed Object Store";
 
-const shortTermObjectStore = computed(() => {
-    console.debug("Checking for short-term object store", props.item.object_store_id, props.item);
-    if (props.item.object_store_id !== undefined) {
+const expirableObjectStoreTime = computed<ExpirableObjectStoreTime | undefined>(() => {
+    const item = props.item;
+    if (isHDA(item)) {
         // Single object store case: check if it has an expiration policy
-        return selectableObjectStores.value?.find((objectStore) => {
-            return (
-                objectStore.object_store_id === props.item.object_store_id &&
-                objectStore.object_expires_after_days !== undefined
-            );
-        });
-    } else if (props.item.object_store_ids !== undefined) {
-        // Multiple object stores case: find the one with the shortest expiration policy
-        return selectableObjectStores.value
-            ?.filter((objectStore) => {
-                return (
-                    objectStore.object_store_id &&
-                    objectStore.object_expires_after_days !== undefined &&
-                    props.item.object_store_ids?.includes(objectStore.object_store_id)
+        const expirableObjectStore = selectableObjectStores.value?.find(
+            (objectStore) =>
+                objectStore.object_store_id === item.object_store_id && (objectStore.object_expires_after_days ?? 0) > 0
+        );
+        if (!expirableObjectStore) {
+            return undefined;
+        }
+        return {
+            objectStoreId: expirableObjectStore.object_store_id ?? "default",
+            objectExpiresAfterDays: expirableObjectStore.object_expires_after_days ?? 0,
+            objectStoreName: expirableObjectStore.name ?? defaultName,
+            oldestCreateTime: parseISO(`${item.create_time}Z`),
+        };
+    } else if (item.store_times_summary !== undefined) {
+        // Multiple object stores case: find the one with the shortest expiration date
+        const expirableStoreTimes: ExpirableObjectStoreTime[] = (item.store_times_summary ?? [])
+            .map((storeTime) => {
+                const objectStore = selectableObjectStores.value?.find(
+                    (os) => os.object_store_id === storeTime.object_store_id
                 );
+                if (!objectStore || (objectStore.object_expires_after_days ?? 0) <= 0) {
+                    return null;
+                }
+                return {
+                    objectStoreId: storeTime.object_store_id,
+                    objectExpiresAfterDays: objectStore.object_expires_after_days ?? 0,
+                    objectStoreName: objectStore.name ?? defaultName,
+                    oldestCreateTime: parseISO(`${storeTime.oldest_create_time}Z`),
+                };
             })
-            .reduce((prev, curr) => {
-                return (prev.object_expires_after_days ?? 0) < (curr.object_expires_after_days ?? 0) ? prev : curr;
-            });
+            .filter((storeTime): storeTime is ExpirableObjectStoreTime => storeTime !== null);
+        if (expirableStoreTimes.length === 0) {
+            return undefined;
+        }
+        // Find the store with the shortest expiration time according to the oldest creation time and expiration days
+        expirableStoreTimes.sort((a, b) => {
+            const aExpiration = new Date(a.oldestCreateTime);
+            aExpiration.setDate(aExpiration.getDate() + a.objectExpiresAfterDays);
+            const bExpiration = new Date(b.oldestCreateTime);
+            bExpiration.setDate(bExpiration.getDate() + b.objectExpiresAfterDays);
+            return aExpiration.getTime() - bExpiration.getTime();
+        });
+        return expirableStoreTimes[0];
     }
     return undefined;
 });
 
 const objectStoreName = computed(() => {
-    return shortTermObjectStore.value?.name ?? "Unknown";
+    return expirableObjectStoreTime.value?.objectStoreName ?? defaultName;
 });
 
-const timeToExpire = computed<number | null>(() => {
-    const targetObjectStore = shortTermObjectStore.value;
-    if (!targetObjectStore || !targetObjectStore.object_expires_after_days) {
+const expirationDate = computed(() => {
+    const target = expirableObjectStoreTime.value;
+    if (!target) {
         return null;
     }
     // Calculate the expiration date based on the creation date and the expiration days of the object store
-    const expirationDate = new Date(itemCreationDate.value);
-    expirationDate.setDate(expirationDate.getDate() + targetObjectStore.object_expires_after_days);
+    const expirationDate = new Date(target.oldestCreateTime);
+    expirationDate.setDate(expirationDate.getDate() + target.objectExpiresAfterDays);
+    return expirationDate;
+});
+
+const timeToExpire = computed<number | null>(() => {
+    if (!expirationDate.value) {
+        return null;
+    }
     // Calculate the difference in days between the expiration date and the current date
-    return expirationDate.getTime() - new Date().getTime();
+    return expirationDate.value.getTime() - new Date().getTime();
 });
 
 const canExpire = computed(() => timeToExpire.value !== null);
@@ -76,15 +109,15 @@ const daysToExpire = computed(() => {
     return timeToExpire.value < 0 ? 0 : Math.floor(timeToExpire.value / (1000 * 60 * 60 * 24));
 });
 
-const isExpired = computed(() => {
-    return daysToExpire.value === 0;
+const hasExpired = computed(() => {
+    return expirationDate.value ? expirationDate.value < new Date() : false;
 });
 
 const expirationMessage = computed(() => {
     if (daysToExpire.value === null) {
         return undefined;
     }
-    if (isExpired.value) {
+    if (hasExpired.value) {
         return "Expired";
     }
     if (daysToExpire.value !== null && daysToExpire.value <= 1) {
@@ -94,18 +127,19 @@ const expirationMessage = computed(() => {
 });
 
 const expirationTooltip = computed(() => {
-    if (isExpired.value) {
+    if (!expirationDate.value) {
+        return "This dataset does not have an expiration date.";
+    }
+    if (hasExpired.value) {
         return `This dataset was stored in ${
             objectStoreName.value
-        } and has expired on ${itemCreationDate.value.toDateString()}.`;
+        } and has expired on ${expirationDate.value.toDateString()}.`;
     }
-    return `This dataset is stored in ${
-        objectStoreName.value
-    } and expires on ${itemCreationDate.value.toDateString()}.`;
+    return `This dataset is stored in ${objectStoreName.value} and expires on ${expirationDate.value.toDateString()}.`;
 });
 
 const variant = computed(() => {
-    if (isExpired.value) {
+    if (hasExpired.value) {
         return "danger";
     }
     if (daysToExpire.value && daysToExpire.value <= 5) {

--- a/client/src/components/History/Content/ContentExpirationIndicator.vue
+++ b/client/src/components/History/Content/ContentExpirationIndicator.vue
@@ -153,7 +153,7 @@ const variant = computed(() => {
 });
 </script>
 <template>
-    <span v-if="canExpire">
+    <span v-if="canExpire" class="expiration-indicator">
         <BBadge v-b-tooltip.noninteractive.hover.left :variant="variant" :title="expirationTooltip">
             <FontAwesomeIcon :icon="faHourglass" /> {{ expirationMessage }}
         </BBadge>

--- a/client/src/components/History/Content/ContentExpirationIndicator.vue
+++ b/client/src/components/History/Content/ContentExpirationIndicator.vue
@@ -11,8 +11,8 @@ import { useObjectStoreStore } from "@/stores/objectStoreStore";
 interface ExpirableItem {
     id: string;
     create_time: string;
-    object_store_id?: string;
-    object_store_ids?: string[];
+    object_store_id?: string | null;
+    object_store_ids?: string[] | null;
 }
 
 const props = defineProps<{

--- a/client/src/components/History/Content/ContentExpirationIndicator.vue
+++ b/client/src/components/History/Content/ContentExpirationIndicator.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { faHourglass } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BBadge } from "bootstrap-vue";
+import { parseISO } from "date-fns";
+import { storeToRefs } from "pinia";
+import { computed } from "vue";
+
+import { useObjectStoreStore } from "@/stores/objectStoreStore";
+
+interface ExpirableItem {
+    id: string;
+    object_store_id: string;
+    create_time: string;
+}
+
+const props = defineProps<{
+    item: ExpirableItem;
+}>();
+
+const store = useObjectStoreStore();
+const { selectableObjectStores } = storeToRefs(store);
+
+const itemCreationDate = computed(() => parseISO(`${props.item.create_time}Z`));
+
+const associatedObjectStore = computed(() => {
+    console.debug("Checking for associated object store", props.item.object_store_id, props.item);
+    return selectableObjectStores.value?.find((objectStore) => {
+        return objectStore.object_store_id === props.item.object_store_id;
+    });
+});
+
+const objectStoreName = computed(() => {
+    return associatedObjectStore.value?.name ?? "Unknown";
+});
+
+const timeToExpire = computed<number | null>(() => {
+    const targetObjectStore = associatedObjectStore.value;
+    if (!targetObjectStore || !targetObjectStore.object_expires_after_days) {
+        return null;
+    }
+    // Calculate the expiration date based on the creation date and the expiration days of the object store
+    const expirationDate = new Date(itemCreationDate.value);
+    expirationDate.setDate(expirationDate.getDate() + targetObjectStore.object_expires_after_days);
+    // Calculate the difference in days between the expiration date and the current date
+    return expirationDate.getTime() - new Date().getTime();
+});
+
+const canExpire = computed(() => timeToExpire.value !== null);
+
+const daysToExpire = computed(() => {
+    if (timeToExpire.value === null) {
+        return null;
+    }
+    return timeToExpire.value < 0 ? 0 : Math.floor(timeToExpire.value / (1000 * 60 * 60 * 24));
+});
+
+const isExpired = computed(() => {
+    return daysToExpire.value === 0;
+});
+
+const expirationMessage = computed(() => {
+    if (daysToExpire.value === null) {
+        return undefined;
+    }
+    if (isExpired.value) {
+        return "Expired";
+    }
+    if (daysToExpire.value !== null && daysToExpire.value <= 1) {
+        return `Expires soon!`;
+    }
+    return `Expires in ${daysToExpire.value} days`;
+});
+
+const expirationTooltip = computed(() => {
+    if (isExpired.value) {
+        return `This dataset was stored in ${
+            objectStoreName.value
+        } and has expired on ${itemCreationDate.value.toDateString()}.`;
+    }
+    return `This dataset is stored in ${
+        objectStoreName.value
+    } and expires on ${itemCreationDate.value.toDateString()}.`;
+});
+
+const variant = computed(() => {
+    if (isExpired.value) {
+        return "danger";
+    }
+    if (daysToExpire.value && daysToExpire.value <= 5) {
+        return "warning";
+    }
+    return "secondary";
+});
+</script>
+<template>
+    <span v-if="canExpire">
+        <BBadge v-b-tooltip.noninteractive.hover.left :variant="variant" :title="expirationTooltip">
+            <FontAwesomeIcon :icon="faHourglass" /> {{ expirationMessage }}
+        </BBadge>
+    </span>
+</template>

--- a/client/src/components/History/Content/ContentItem.test.js
+++ b/client/src/components/History/Content/ContentItem.test.js
@@ -6,6 +6,7 @@ import VueRouter from "vue-router";
 
 import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
 import { updateContentFields } from "@/components/History/model/queries";
+import { setupSelectableMock } from "@/components/ObjectStore/mockServices";
 
 import ContentItem from "./ContentItem.vue";
 
@@ -22,6 +23,8 @@ jest.mock("vue-router/composables", () => ({
     useRoute: jest.fn(() => ({})),
     useRouter: jest.fn(() => ({})),
 }));
+
+setupSelectableMock();
 
 // mock queries
 updateContentFields.mockImplementation(async () => {});

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -23,6 +23,7 @@ import { getContentItemState, type State, STATES } from "./model/states";
 import type { RouterPushOptions } from "./router-push-options";
 
 import CollectionDescription from "./Collection/CollectionDescription.vue";
+import ContentExpirationIndicator from "./ContentExpirationIndicator.vue";
 import ContentOptions from "./ContentOptions.vue";
 import DatasetDetails from "./Dataset/DatasetDetails.vue";
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
@@ -419,6 +420,7 @@ function unexpandedClick(event: Event) {
                 </span>
             </div>
         </div>
+        <ContentExpirationIndicator :item="item" class="ml-auto align-self-start btn-group p-1" />
         <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/no-static-element-interactions -->
         <span @click.stop="unexpandedClick">
             <CollectionDescription v-if="!isDataset" class="px-2 pb-2 cursor-pointer" :hdca="item" />

--- a/client/src/components/History/Content/GenericElement.test.js
+++ b/client/src/components/History/Content/GenericElement.test.js
@@ -3,9 +3,13 @@ import { mount } from "@vue/test-utils";
 import { getLocalVue, suppressLucideVue2Deprecation } from "tests/jest/helpers";
 import VueRouter from "vue-router";
 
+import { setupSelectableMock } from "@/components/ObjectStore/mockServices";
+
 import GenericElement from "./GenericElement";
 
 jest.mock("components/History/model/queries");
+
+setupSelectableMock();
 
 const localVue = getLocalVue();
 localVue.use(VueRouter);

--- a/client/src/components/History/CurrentCollection/CollectionDetails.vue
+++ b/client/src/components/History/CurrentCollection/CollectionDetails.vue
@@ -2,6 +2,7 @@
 import type { HDCASummary } from "@/api";
 
 import CollectionDescription from "@/components/History/Content/Collection/CollectionDescription.vue";
+import ContentExpirationIndicator from "@/components/History/Content/ContentExpirationIndicator.vue";
 import DetailsLayout from "@/components/History/Layout/DetailsLayout.vue";
 
 interface Props {
@@ -22,6 +23,7 @@ defineProps<Props>();
         @save="$emit('update:dsc', $event)">
         <template v-slot:description>
             <CollectionDescription :hdca="dsc" />
+            <ContentExpirationIndicator :item="dsc" />
         </template>
     </DetailsLayout>
 </template>

--- a/client/src/components/History/CurrentHistory/SelectPreferredStore.vue
+++ b/client/src/components/History/CurrentHistory/SelectPreferredStore.vue
@@ -145,6 +145,7 @@ function reset() {
 
 <template>
     <BModal
+        id="modal-select-history-storage-location"
         :visible="props.showModal"
         centered
         scrollable
@@ -154,6 +155,7 @@ function reset() {
         title-tag="h3"
         ok-title="Change Storage Location"
         cancel-variant="outline-primary"
+        dialog-class="modal-select-history-storage-location"
         :ok-disabled="currentSelectedStoreId === props.preferredObjectStoreId"
         :no-close-on-backdrop="currentSelectedStoreId !== props.preferredObjectStoreId"
         :no-close-on-esc="currentSelectedStoreId !== props.preferredObjectStoreId"

--- a/client/src/components/History/HistoryView.test.js
+++ b/client/src/components/History/HistoryView.test.js
@@ -7,6 +7,7 @@ import { setupMockConfig } from "tests/jest/mockConfig";
 import VueRouter from "vue-router";
 
 import { useServerMock } from "@/api/client/__mocks__";
+import { setupSelectableMock } from "@/components/ObjectStore/mockServices";
 import { useHistoryStore } from "@/stores/historyStore";
 import { getHistoryByIdFromServer, setCurrentHistoryOnServer } from "@/stores/services/history.services";
 import { useUserStore } from "@/stores/userStore";
@@ -18,6 +19,8 @@ const localVue = getLocalVue();
 localVue.use(VueRouter);
 
 jest.mock("stores/services/history.services");
+
+setupSelectableMock();
 
 const { server, http } = useServerMock();
 

--- a/client/src/stores/collectionElementsStore.test.ts
+++ b/client/src/stores/collectionElementsStore.test.ts
@@ -145,7 +145,7 @@ function mockCollection(id: string, numElements = 10): HDCASummary {
         type_id: "dataset_collection",
         url: "",
         type: "collection",
-        object_store_ids: null,
+        store_times_summary: null,
     };
 }
 

--- a/client/src/stores/collectionElementsStore.test.ts
+++ b/client/src/stores/collectionElementsStore.test.ts
@@ -145,6 +145,7 @@ function mockCollection(id: string, numElements = 10): HDCASummary {
         type_id: "dataset_collection",
         url: "",
         type: "collection",
+        object_store_ids: null,
     };
 }
 

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -233,6 +233,8 @@ history_panel:
       metadata_file_download: '${_} [data-description="download ${metadata_name}"]'
 
       dataset_operations: '${_} .dataset-actions'
+      
+      expiration_indicator_badge: '${_} .expiration-indicator .badge'
 
   # re-usable history editor, scoped for use in different layout scenarios (multi, etc.)
   editor:
@@ -283,6 +285,14 @@ history_panel:
       tag_area_input: '.details .stateless-tags .headless-multiselect input'
       list_items: '.dataset-collection-panel .listing-layout .content-item'
       back_to_history: svg[data-description="back to history"]
+
+  object_store_selection:
+    selectors:
+      modal: '#modal-select-history-storage-location'
+      option_cards: '[id^="g-card-"][data-source-option-card-id]'
+      option_card: '#g-card-${object_store_id}'
+      option_card_select: '#g-card-action-select-${object_store_id}'
+      confirm_button: '#modal-select-history-storage-location .btn-primary'
 
   selectors:
     _: '#current-history-panel'
@@ -336,6 +346,7 @@ history_panel:
     pagination_previous: '.list-pagination button.prev'
 
     storage_overview: '.history-storage-overview-button'
+    storage_location_button: '.storage-location-indicator button'
 
   text:
     tooltip_name: 'Rename history...'

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -301,6 +301,7 @@ class HDCASerializer(DCASerializer, taggable.TaggableSerializerMixin, annotatabl
                 "update_time",
                 "tags",
                 "contents_url",
+                "object_store_ids",
             ],
         )
         self.add_view(
@@ -338,6 +339,7 @@ class HDCASerializer(DCASerializer, taggable.TaggableSerializerMixin, annotatabl
             "elements_states": lambda item, key, **context: item.dataset_dbkeys_and_extensions_summary[2],
             "elements_deleted": lambda item, key, **context: item.dataset_dbkeys_and_extensions_summary[3],
             "collection_id": self.serialize_id,
+            "object_store_ids": self.serialize_object_store_ids,
         }
         self.serializers.update(serializers)
 
@@ -356,3 +358,7 @@ class HDCASerializer(DCASerializer, taggable.TaggableSerializerMixin, annotatabl
     def serialize_elements_datatypes(self, item, key, **context):
         extensions_set = item.dataset_dbkeys_and_extensions_summary[1]
         return list(extensions_set)
+
+    def serialize_object_store_ids(self, item, key, **context):
+        object_store_ids_set = item.dataset_dbkeys_and_extensions_summary[2]
+        return list(object_store_ids_set)

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -6,9 +6,7 @@ history.
 """
 
 import logging
-from typing import (
-    Optional,
-)
+from typing import Optional
 
 from galaxy import model
 from galaxy.exceptions import RequestParameterInvalidException
@@ -22,6 +20,7 @@ from galaxy.managers import (
 )
 from galaxy.managers.collections_util import get_hda_and_element_identifiers
 from galaxy.model.tags import GalaxyTagHandler
+from galaxy.schema.schema import OldestCreateTimeByObjectStoreId
 from galaxy.structured_app import (
     MinimalManagerApp,
     StructuredApp,
@@ -301,7 +300,7 @@ class HDCASerializer(DCASerializer, taggable.TaggableSerializerMixin, annotatabl
                 "update_time",
                 "tags",
                 "contents_url",
-                "object_store_ids",
+                "store_times_summary",
             ],
         )
         self.add_view(
@@ -339,7 +338,7 @@ class HDCASerializer(DCASerializer, taggable.TaggableSerializerMixin, annotatabl
             "elements_states": lambda item, key, **context: item.dataset_dbkeys_and_extensions_summary[2],
             "elements_deleted": lambda item, key, **context: item.dataset_dbkeys_and_extensions_summary[3],
             "collection_id": self.serialize_id,
-            "object_store_ids": self.serialize_object_store_ids,
+            "store_times_summary": self.serialize_store_times_summary,
         }
         self.serializers.update(serializers)
 
@@ -359,6 +358,8 @@ class HDCASerializer(DCASerializer, taggable.TaggableSerializerMixin, annotatabl
         extensions_set = item.dataset_dbkeys_and_extensions_summary[1]
         return list(extensions_set)
 
-    def serialize_object_store_ids(self, item, key, **context):
-        object_store_ids_set = item.dataset_dbkeys_and_extensions_summary[2]
-        return list(object_store_ids_set)
+    def serialize_store_times_summary(self, item, key, **context):
+        store_times_summary = item.dataset_dbkeys_and_extensions_summary[4]
+        return [
+            OldestCreateTimeByObjectStoreId(object_store_id=t[0], oldest_create_time=t[1]) for t in store_times_summary
+        ]

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7584,7 +7584,7 @@ class HistoryDatasetCollectionAssociation(
     def dataset_dbkeys_and_extensions_summary(self):
         if not hasattr(self, "_dataset_dbkeys_and_extensions_summary"):
             stmt = self.collection._build_nested_collection_attributes_stmt(
-                hda_attributes=("_metadata", "extension", "deleted"), dataset_attributes=("state",)
+                hda_attributes=("_metadata", "extension", "deleted"), dataset_attributes=("state", "object_store_id")
             )
             tuples = required_object_session(self).execute(stmt)
 
@@ -7592,6 +7592,7 @@ class HistoryDatasetCollectionAssociation(
             dbkeys = set()
             states = defaultdict(int)
             deleted = 0
+            object_store_ids = set()
             for row in tuples:
                 if row is not None:
                     dbkey_field = row._metadata.get("dbkey")
@@ -7606,7 +7607,9 @@ class HistoryDatasetCollectionAssociation(
                         deleted += 1
                     if row.state:
                         states[row.state] += 1
-            self._dataset_dbkeys_and_extensions_summary = (dbkeys, extensions, states, deleted)
+                    if row.object_store_id:
+                        object_store_ids.add(row.object_store_id)
+            self._dataset_dbkeys_and_extensions_summary = (dbkeys, extensions, states, deleted, object_store_ids)
         return self._dataset_dbkeys_and_extensions_summary
 
     @property

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -756,6 +756,7 @@ class ConcreteObjectStore(BaseObjectStore):
         self.description = config_dict.get("description", None)
         # Annotate this as true to prevent sharing of data.
         self.private = config_dict.get("private", DEFAULT_PRIVATE)
+        self.object_expires_after_days = config_dict.get("object_expires_after_days", None)
         # short label describing the quota source or null to use default
         # quota source right on user object.
         quota_config = config_dict.get("quota", {})
@@ -776,6 +777,7 @@ class ConcreteObjectStore(BaseObjectStore):
         }
         rval["badges"] = self._get_concrete_store_badges(None)
         rval["device"] = self.device_id
+        rval["object_expires_after_days"] = self.object_expires_after_days
         return rval
 
     def to_model(self, object_store_id: str) -> "ConcreteObjectStoreModel":
@@ -787,6 +789,7 @@ class ConcreteObjectStore(BaseObjectStore):
             quota=QuotaModel(source=self.quota_source, enabled=self.quota_enabled),
             badges=self._get_concrete_store_badges(None),
             device=self.device_id,
+            object_expires_after_days=self.object_expires_after_days,
         )
 
     def _get_concrete_store_badges(self, obj) -> List[BadgeDict]:
@@ -1778,6 +1781,7 @@ class ConcreteObjectStoreModel(BaseModel):
     quota: QuotaModel
     badges: List[BadgeDict]
     device: Optional[str] = None
+    object_expires_after_days: Optional[int] = None
 
 
 def type_to_object_store_class(

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1238,6 +1238,14 @@ class HDCASummary(HDCACommon, WithModelClass):
     )
     contents_url: ContentsUrlField
     collection_id: DatasetCollectionId
+    object_store_ids: Optional[List[str]] = Field(
+        None,
+        title="Object Store IDs",
+        description=(
+            "A list of object store IDs where the elements of the collection are stored. Most of the time it will be a single ID, "
+            " but in some cases some elements may be stored in different object stores."
+        ),
+    )
 
 
 class HDCADetailed(HDCASummary):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1194,6 +1194,21 @@ class HDCACommon(HistoryItemCommon):
     ]
 
 
+class OldestCreateTimeByObjectStoreId(Model):
+    """Represents the oldest creation time of a set of datasets stored in a specific object store."""
+
+    object_store_id: str = Field(
+        ...,
+        title="Object Store ID",
+        description="The ID of the object store.",
+    )
+    oldest_create_time: datetime = Field(
+        ...,
+        title="Oldest Create Time",
+        description="The oldest creation time of a set of datasets stored in this object store.",
+    )
+
+
 class HDCASummary(HDCACommon, WithModelClass):
     """History Dataset Collection Association summary information."""
 
@@ -1238,12 +1253,13 @@ class HDCASummary(HDCACommon, WithModelClass):
     )
     contents_url: ContentsUrlField
     collection_id: DatasetCollectionId
-    object_store_ids: Optional[List[str]] = Field(
+    store_times_summary: Optional[List[OldestCreateTimeByObjectStoreId]] = Field(
         None,
-        title="Object Store IDs",
+        title="Store Times Summary",
         description=(
-            "A list of object store IDs where the elements of the collection are stored. Most of the time it will be a single ID, "
-            " but in some cases some elements may be stored in different object stores."
+            "A list of objects containing the object store ID and the oldest creation time of the datasets stored in that object store "
+            "for this collection."
+            "This is used to determine the age of the datasets in the collection when the object store is short-lived."
         ),
     )
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -749,6 +749,11 @@ class HDASummary(HDACommon):
         description="Whether this dataset has been removed from disk.",
     )
     genome_build: Optional[str] = GenomeBuildField
+    object_store_id: Optional[str] = Field(
+        None,
+        title="Object Store ID",
+        description="The ID of the object store that this dataset is stored in.",
+    )
 
 
 class HDAInaccessible(HDACommon):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1253,7 +1253,7 @@ class HDCASummary(HDCACommon, WithModelClass):
     )
     contents_url: ContentsUrlField
     collection_id: DatasetCollectionId
-    store_times_summary: Optional[List[OldestCreateTimeByObjectStoreId]] = Field(
+    store_times_summary: Optional[list[OldestCreateTimeByObjectStoreId]] = Field(
         None,
         title="Store Times Summary",
         description=(

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1953,6 +1953,17 @@ class NavigatesGalaxy(HasDriver):
             selection_component.confirm_button.wait_for_and_click()
         selection_component.option_cards.wait_for_absent_or_hidden()
 
+    def select_history_storage(self, storage_id: str) -> None:
+        self.components.history_panel.storage_location_button.wait_for_and_click()
+        selection_component = self.components.history_panel.object_store_selection
+        selection_component.option_cards.wait_for_present()
+        button = selection_component.option_card_select(object_store_id=storage_id)
+        if not button.is_absent:
+            button.wait_for_and_click()
+        if not selection_component.confirm_button.is_absent:
+            selection_component.confirm_button.wait_for_and_click()
+        selection_component.option_cards.wait_for_absent_or_hidden()
+
     def create_page_and_edit(self, name=None, slug=None, screenshot_name=None):
         name = self.create_page(name=name, slug=slug, screenshot_name=screenshot_name)
         self.components.pages.editor.markdown_editor.wait_for_visible()

--- a/lib/galaxy_test/driver/integration_util.py
+++ b/lib/galaxy_test/driver/integration_util.py
@@ -246,13 +246,24 @@ class ConfiguresObjectStores:
         return config_path
 
     @classmethod
-    def _configure_object_store(cls, template, config):
+    def _configure_object_store(
+        cls,
+        template: string.Template,
+        config: dict[str, Any],
+        template_params: Optional[dict[str, Any]] = None,
+        format: ObjectStoreConfigFormat = "xml",
+    ):
         temp_directory = cls._test_driver.mkdtemp()
         cls.object_stores_parent = temp_directory
-        xml = template.safe_substitute({"temp_directory": temp_directory})
-        config_path = cls.write_object_store_config_file("object_store_conf.xml", xml)
+        template_config = {"temp_directory": temp_directory}
+        template_config.update(template_params or {})
+        object_stores_config = template.safe_substitute(template_config)
+        config_path = cls.write_object_store_config_file(f"object_store_conf.{format}", object_stores_config)
         config["object_store_config_file"] = config_path
-        for path in re.findall(r'files_dir path="([^"]*)"', xml):
+        paths_regex = r'files_dir path="([^"]*)"'
+        if format == "yml":
+            paths_regex = r'(?:files_dir|path): "([^"]*)"'
+        for path in re.findall(paths_regex, object_stores_config):
             assert path.startswith(temp_directory)
             dir_name = os.path.basename(path)
             os.path.join(temp_directory, dir_name)

--- a/lib/galaxy_test/driver/integration_util.py
+++ b/lib/galaxy_test/driver/integration_util.py
@@ -7,10 +7,13 @@ testing configuration.
 
 import os
 import re
+import string
 import sys
 from collections.abc import Iterator
 from typing import (
+    Any,
     ClassVar,
+    Literal,
     Optional,
     TYPE_CHECKING,
 )
@@ -225,6 +228,9 @@ def integration_tool_runner(tool_ids):
         instance._run_tool_test(tool_id)
 
     return pytest.mark.parametrize("tool_id", tool_ids)(test_tools)
+
+
+ObjectStoreConfigFormat = Literal["xml", "yml"]
 
 
 class ConfiguresObjectStores:

--- a/test/integration_selenium/test_objectstore_expiration.py
+++ b/test/integration_selenium/test_objectstore_expiration.py
@@ -1,0 +1,182 @@
+import string
+from typing import (
+    Literal,
+    TYPE_CHECKING,
+)
+
+from galaxy_test.driver.integration_util import ConfiguresObjectStores
+from galaxy_test.selenium.framework import managed_history
+from .framework import (
+    selenium_test,
+    SeleniumIntegrationTestCase,
+)
+
+if TYPE_CHECKING:
+    from galaxy_test.selenium.framework import (
+        SeleniumSessionDatasetCollectionPopulator,
+        SeleniumSessionDatasetPopulator,
+    )
+
+OBJECT_STORES_CONFIG = string.Template(
+    """
+type: distributed
+backends:
+  - id: default
+    type: disk
+    weight: 1
+    allow_selection: true
+    name: ${default_name}
+    files_dir: "${temp_directory}/files0"
+    extra_dirs:
+    - type: temp
+      path: "${temp_directory}/tmp0"
+    - type: job_work
+      path: "${temp_directory}/job_working_directory0"
+
+  - id: short_term
+    type: disk
+    weight: 1
+    allow_selection: true
+    name: ${short_term_name}
+    files_dir: "${temp_directory}/files1"
+    extra_dirs:
+    - type: temp
+      path: "${temp_directory}/tmp1"
+    - type: job_work
+      path: "${temp_directory}/job_working_directory1"
+    object_expires_after_days: ${short_term_expiration_days}
+
+  - id: mid_term
+    type: disk
+    weight: 1
+    allow_selection: true
+    name: ${mid_term_name}
+    files_dir: "${temp_directory}/files2"
+    extra_dirs:
+    - type: temp
+      path: "${temp_directory}/tmp2"
+    - type: job_work
+      path: "${temp_directory}/job_working_directory2"
+    object_expires_after_days: ${mid_term_expiration_days}
+"""
+)
+
+AvailableObjectStoreIDs = Literal["default", "short_term", "mid_term"]
+
+
+class TestObjectStoreContentsExpirationIntegration(SeleniumIntegrationTestCase, ConfiguresObjectStores):
+    ensure_registered = True
+    dataset_populator: "SeleniumSessionDatasetPopulator"
+    dataset_collection_populator: "SeleniumSessionDatasetCollectionPopulator"
+
+    template_params = {
+        "default_name": "Default Storage",
+        "short_term_name": "Test Short Term Storage",
+        "mid_term_name": "Test Mid Term Storage",
+        "short_term_expiration_days": 5,
+        "mid_term_expiration_days": 30,
+    }
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        super()._configure_object_store(
+            OBJECT_STORES_CONFIG,
+            config,
+            template_params=cls.template_params,
+            format="yml",
+        )
+        config["object_store_store_by"] = "uuid"
+        config["outputs_to_working_directory"] = True
+
+    @selenium_test
+    @managed_history
+    def test_no_expiration_for_default_storage(self):
+        self._select_history_storage("default")
+
+        self.perform_upload_of_pasted_content("default storage content")
+        self.history_panel_wait_for_hid_visible(1)
+        self._assert_no_expiration_indicator_for(hid=1)
+
+    @selenium_test
+    @managed_history
+    def test_expiration_of_single_dataset(self):
+        self._select_history_storage("short_term")
+
+        self.perform_upload_of_pasted_content("my test content")
+        self.history_panel_wait_for_hid_visible(1)
+        self._assert_expiration_indicator_visible_for(hid=1, expected_storage_id="short_term")
+
+    @selenium_test
+    @managed_history
+    def test_expiration_of_collection(self):
+        self._select_history_storage("short_term")
+
+        self.perform_upload_of_pasted_content("dataset 1 content")
+        self.history_panel_wait_for_hid_visible(1)
+
+        self.perform_upload_of_pasted_content("dataset 2 content")
+        self.history_panel_wait_for_hid_visible(2)
+
+        self.history_panel_wait_for_and_select([1, 2])
+        self.history_panel_build_list_auto()
+        self.collection_builder_set_name("Test Collection")
+        self.collection_builder_create()
+        self.history_panel_wait_for_hid_visible(5)
+
+        self._assert_expiration_indicator_visible_for(hid=5, expected_storage_id="short_term")
+
+    @selenium_test
+    @managed_history
+    def test_expiration_if_mixed_storage_in_collection(self):
+        self._select_history_storage("default")
+
+        self.perform_upload_of_pasted_content("dataset stored in default storage")
+        self.history_panel_wait_for_hid_visible(1)
+        self._assert_no_expiration_indicator_for(hid=1)
+
+        self._select_history_storage("short_term")
+
+        self.perform_upload_of_pasted_content("dataset stored in short term storage")
+        self.history_panel_wait_for_hid_visible(2)
+        self._assert_expiration_indicator_visible_for(hid=2, expected_storage_id="short_term")
+
+        self._select_history_storage("mid_term")
+
+        self.perform_upload_of_pasted_content("dataset stored in mid term storage")
+        self.history_panel_wait_for_hid_visible(3)
+        self._assert_expiration_indicator_visible_for(hid=3, expected_storage_id="mid_term")
+
+        self.history_panel_wait_for_and_select([1, 2, 3])
+        self.history_panel_build_list_auto()
+        self.collection_builder_set_name("Test Collection")
+        self.collection_builder_create()
+        self.history_panel_wait_for_hid_visible(7)
+
+        # The collection should show the shortest expiration time of its contents
+        self._assert_expiration_indicator_visible_for(hid=7, expected_storage_id="short_term")
+
+    def _get_expiration_indicator_for(self, hid: int):
+        content_item = self.content_item_by_attributes(hid=hid)
+        expiration_indicator = content_item.expiration_indicator_badge
+        return expiration_indicator
+
+    def _assert_no_expiration_indicator_for(self, hid: int):
+        expiration_indicator = self._get_expiration_indicator_for(hid)
+        assert expiration_indicator.is_absent
+
+    def _assert_expiration_indicator_visible_for(self, hid: int, expected_storage_id: AvailableObjectStoreIDs):
+        expiration_indicator = self._get_expiration_indicator_for(hid).wait_for_visible()
+        # The indicator should mention the remaining days to expiration
+        text = expiration_indicator.text
+        remaining_days = int(str(self.template_params.get(f"{expected_storage_id}_expiration_days", 0))) - 1
+        assert all(keyword in text.lower() for keyword in ["expire", str(remaining_days)])
+
+        # The tooltip should mention the storage name
+        tooltip_text = expiration_indicator.get_attribute("title")
+        assert tooltip_text is not None
+        expected_storage_name = str(self.template_params.get(f"{expected_storage_id}_name", ""))
+        assert all(keyword in tooltip_text.lower() for keyword in ["expires", expected_storage_name.lower()])
+
+    def _select_history_storage(self, storage_id: AvailableObjectStoreIDs):
+        self.select_history_storage(storage_id)

--- a/test/unit/app/managers/test_markdown_export.py
+++ b/test/unit/app/managers/test_markdown_export.py
@@ -383,6 +383,7 @@ history_dataset_collection_display(history_dataset_collection_id=1)
         with (
             mock.patch.object(HDCASerializer, "url_for", return_value="http://google.com"),
             mock.patch.object(HDCASerializer, "serialize_to_view", return_value=mock_hdca_view),
+            mock.patch.object(HDCASerializer, "serialize_object_store_ids", return_value=[]),
         ):
             export, extra_data = self._ready_export(example)
         assert "history_dataset_collections" in extra_data

--- a/test/unit/app/managers/test_markdown_export.py
+++ b/test/unit/app/managers/test_markdown_export.py
@@ -383,7 +383,7 @@ history_dataset_collection_display(history_dataset_collection_id=1)
         with (
             mock.patch.object(HDCASerializer, "url_for", return_value="http://google.com"),
             mock.patch.object(HDCASerializer, "serialize_to_view", return_value=mock_hdca_view),
-            mock.patch.object(HDCASerializer, "serialize_object_store_ids", return_value=[]),
+            mock.patch.object(HDCASerializer, "serialize_store_times_summary", return_value=[]),
         ):
             export, extra_data = self._ready_export(example)
         assert "history_dataset_collections" in extra_data


### PR DESCRIPTION
xref #20169

This simple approach should not be too expensive and can help the user identify when a dataset might be gone because it is stored in a short-term object store.

![image](https://github.com/user-attachments/assets/1a4c88a3-bd38-46a9-b50c-ec5e7b1d2b32)

![image](https://github.com/user-attachments/assets/9f20da64-b6d4-4ed4-9d5d-e14bf754cb21)

This works just by annotating the object store config with a new property `object_expires_after_days`:

```yml
    - id: scratch
      type: disk
      device: device2
      weight: 0
      allow_selection: true
      private: true
      name: Scratch Storage
      description: >
          This object store is connected to institutional scratch storage. This disk space is not backed up and private to
          your user, and datasets belonging to this storage will be automatically deleted after one month.
      quota:
          source: second_tier
      files_dir: /home/dlopez/sandbox/data-gx/dev/objects/temp
      badges:
          - type: faster
          - type: less_stable
          - type: not_backed_up
          - type: short_term
            message: The data stored here is purged after a month.
      object_expires_after_days: 30
```

There are still some drawbacks to consider/resolve:

- [x] **Collections do not have an `object_store_id` property**. I wonder if we could "estimate" or "assume" the object store ID of a collection by looking at the object store ID of the first dataset in the collection. This is not ideal, but maybe it could be a good enough workaround? I'm not sure how often collection elements are stored in mixed object stores, but I guess it could happen. **Resolved, see https://github.com/galaxyproject/galaxy/pull/20332#issuecomment-2934795799**

- [ ] **Synchronize the object store config property `object_expires_after_days` with the actual expiration time of the object store**. It seems the cleanup of the object store is handled by external processes, so this value must be in sync with the actual expiration time of the object store. Unfortunately, this requires manual setup by the admin for now.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
