### PR TITLE
[25.0] Error on duplicate labels

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -895,7 +895,7 @@ export default {
             this.$router.push("/workflows/edit");
         },
         async saveOrCreate() {
-            if (this.hasInvalidConnections) {
+            if (this.hasErrors) {
                 const confirmed = await this.confirm(
                     `${this.errorText}. You can save the workflow, but it may not run correctly.`,
                     {

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -116,8 +116,13 @@ const visibleHint = computed(() => {
         return `Output will be hidden in history. Click to make output visible.`;
     }
 });
+
+const isOutput = computed(() => {
+    return Boolean(workflowOutput.value?.label);
+});
+
 const label = computed(() => {
-    return workflowOutput.value?.label || props.output.name;
+    return workflowOutput.value?.label ?? props.output.name;
 });
 
 const rowClass = computed(() => {
@@ -318,7 +323,7 @@ const outputDetails = computed(() => {
 
 const isDuplicateLabel = computed(() => {
     const duplicateLabels = stepStore.duplicateLabels;
-    return Boolean(label.value && duplicateLabels.has(label.value));
+    return isOutput.value && Boolean(label.value && duplicateLabels.has(label.value));
 });
 
 const labelClass = computed(() => {

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -323,7 +323,7 @@ const isDuplicateLabel = computed(() => {
 
 const labelClass = computed(() => {
     if (isDuplicateLabel.value) {
-        return "alert-info";
+        return "alert-danger";
     }
     return null;
 });

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -120,12 +120,12 @@ export function isEmpty(value: any | Readonly<any[]>) {
  *
  * @param list List of strings to be converted in human readable list sentence
  */
-export function textify(list: Readonly<string[]>): string {
+export function textify(list: Readonly<string[]>, connectorWord = "or"): string {
     let string = list.toString().replace(/,/g, ", ");
     const pos = string.lastIndexOf(", ");
 
     if (pos !== -1) {
-        string = `${string.substring(0, pos)} or ${string.substring(pos + 2)}`;
+        string = `${string.substring(0, pos)} ${connectorWord} ${string.substring(pos + 2)}`;
     }
 
     return string;


### PR DESCRIPTION
closes #20230

Treats duplicate output labels as errors, and warns the user more clearly about them.
Also fixes non-output labels being marked as duplicate.

![image](https://github.com/user-attachments/assets/d09c57d7-aa6b-44d8-93f5-a81ccec9d459)

In the future we could add an option to fix these automatically, but I think that is beyond the scope of this bug-fix

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
