### PR TITLE
[25.0] Enable retrieving contents from extra file paths when request contains leading `/`

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -652,6 +652,9 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
             dataset_manager = self.dataset_manager_by_type[hda_ldda]
             dataset_instance = dataset_manager.get_accessible(dataset_id, trans.user)
             dataset_manager.ensure_dataset_on_disk(trans, dataset_instance)
+            if filename and filename.startswith("/"):
+                # Path needs to relative to extra files path
+                filename = filename.lstrip("/")
             if raw:
                 if filename and filename != "index":
                     object_store = trans.app.object_store


### PR DESCRIPTION
by stripping all leading `/` in filename.

I don't think there's a legitimate reason that we should treat this as an absolute path marker. Addresses @luke-c-sargent's comment in https://github.com/goeckslab/tools-mti/pull/99#issuecomment-2864667012

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
