### PR TITLE
be more lenient with doi detection

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -2029,5 +2029,5 @@ def to_content_disposition(target: str) -> str:
 def validate_doi(doi: str) -> bool:
     if len(doi) > DOI_MAX_LENGTH:
         return False
-    doi_re = re.compile(r"(10\.(\d)+\/(.+))")
+    doi_re = re.compile(r"(10\.(\d)+\/(\S+))")
     return bool(doi_re.search(doi))

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -2029,8 +2029,5 @@ def to_content_disposition(target: str) -> str:
 def validate_doi(doi: str) -> bool:
     if len(doi) > DOI_MAX_LENGTH:
         return False
-    prefix = "https://doi.org/|doi.org/|doi:"
-    doi_prefix = r"10\.\d+"
-    doi_suffix = r"\S+"
-    doi_re = re.compile(f"^{prefix}{doi_prefix}/{doi_suffix}$")
-    return bool(doi_re.match(doi))
+    doi_re = re.compile(r"(10\.(\d)+\/(.+))")
+    return bool(doi_re.search(doi))

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -2088,8 +2088,5 @@ def to_content_disposition(target: str) -> str:
 def validate_doi(doi: str) -> bool:
     if len(doi) > DOI_MAX_LENGTH:
         return False
-    prefix = "https://doi.org/|doi.org/|doi:"
-    doi_prefix = r"10\.\d+"
-    doi_suffix = r"\S+"
-    doi_re = re.compile(f"^{prefix}{doi_prefix}/{doi_suffix}$")
-    return bool(doi_re.match(doi))
+    doi_re = re.compile(r"(10\.(\d)+\/(.+))")
+    return bool(doi_re.search(doi))

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -2088,5 +2088,5 @@ def to_content_disposition(target: str) -> str:
 def validate_doi(doi: str) -> bool:
     if len(doi) > DOI_MAX_LENGTH:
         return False
-    doi_re = re.compile(r"(10\.(\d)+\/(\S+))")
+    doi_re = re.compile(r"10\.\d+/\S+$")
     return bool(doi_re.search(doi))

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -2088,5 +2088,5 @@ def to_content_disposition(target: str) -> str:
 def validate_doi(doi: str) -> bool:
     if len(doi) > DOI_MAX_LENGTH:
         return False
-    doi_re = re.compile(r"(10\.(\d)+\/(.+))")
+    doi_re = re.compile(r"(10\.(\d)+\/(\S+))")
     return bool(doi_re.search(doi))

--- a/test/unit/util/test_utils.py
+++ b/test/unit/util/test_utils.py
@@ -153,7 +153,6 @@ DOI_VALID_VALUES = [
     "stillvalid:10.1234/42",
     "dx.doi.org:10.1234/42",
     "https://dx.doi.org:10.1234/42",
-    "doi:10.1234/42/a b",
     "httpss://dx.doi.org:10.1234/42",
     "doi:10.1234/ 42",
 ]
@@ -170,6 +169,7 @@ DOI_INVALID_VALUES = [
     "doi:10. 1234/42",
     "doi:10.abc/42",
     "10.1234 /42/a b",
+    "doi:10.1234/42/a b",
 ]
 
 

--- a/test/unit/util/test_utils.py
+++ b/test/unit/util/test_utils.py
@@ -149,6 +149,13 @@ DOI_VALID_VALUES = [
     "doi:10.1234567890/42",  # longer prefix
     "doi:10.1234/42ab:%&*$//crazy-suffix/%/&/",
     "doi:10.1234/aa",
+    "http://doi.org/10.1234/42",
+    "stillvalid:10.1234/42",
+    "dx.doi.org:10.1234/42",
+    "https://dx.doi.org:10.1234/42",
+    "doi:10.1234/42/a b",
+    "httpss://dx.doi.org:10.1234/42",
+    "doi:10.1234/ 42",
 ]
 
 
@@ -158,14 +165,11 @@ def test_validate_doi_pass(input):
 
 
 DOI_INVALID_VALUES = [
-    "http://doi.org/10.1234/42",
-    "invalid:10.1234/42",
     "doi:11.1234/42",
     "doi:101234/42",
     "doi:10. 1234/42",
     "doi:10.abc/42",
-    "doi:10.1234/ 42",
-    "doi:10.1234/42/a b",
+    "10.1234 /42/a b",
 ]
 
 

--- a/test/unit/util/test_utils.py
+++ b/test/unit/util/test_utils.py
@@ -151,7 +151,6 @@ DOI_VALID_VALUES = [
     "dx.doi.org:10.1234/42",
     "https://dx.doi.org:10.1234/42",
     "httpss://dx.doi.org:10.1234/42",
-    "doi:10.1234/ 42",
 ]
 
 
@@ -166,6 +165,7 @@ DOI_INVALID_VALUES = [
     "doi:10. 1234/42",
     "doi:10.abc/42",
     "10.1234 /42/a b",
+    "doi:10.1234/ 42",
     "doi:10.1234/42/a b",
 ]
 

--- a/test/unit/util/test_utils.py
+++ b/test/unit/util/test_utils.py
@@ -150,7 +150,6 @@ DOI_VALID_VALUES = [
     "stillvalid:10.1234/42",
     "dx.doi.org:10.1234/42",
     "https://dx.doi.org:10.1234/42",
-    "doi:10.1234/42/a b",
     "httpss://dx.doi.org:10.1234/42",
     "doi:10.1234/ 42",
 ]
@@ -167,6 +166,7 @@ DOI_INVALID_VALUES = [
     "doi:10. 1234/42",
     "doi:10.abc/42",
     "10.1234 /42/a b",
+    "doi:10.1234/42/a b",
 ]
 
 

--- a/test/unit/util/test_utils.py
+++ b/test/unit/util/test_utils.py
@@ -146,6 +146,13 @@ DOI_VALID_VALUES = [
     "doi:10.1234567890/42",  # longer prefix
     "doi:10.1234/42ab:%&*$//crazy-suffix/%/&/",
     "doi:10.1234/aa",
+    "http://doi.org/10.1234/42",
+    "stillvalid:10.1234/42",
+    "dx.doi.org:10.1234/42",
+    "https://dx.doi.org:10.1234/42",
+    "doi:10.1234/42/a b",
+    "httpss://dx.doi.org:10.1234/42",
+    "doi:10.1234/ 42",
 ]
 
 
@@ -155,14 +162,11 @@ def test_validate_doi_pass(input):
 
 
 DOI_INVALID_VALUES = [
-    "http://doi.org/10.1234/42",
-    "invalid:10.1234/42",
     "doi:11.1234/42",
     "doi:101234/42",
     "doi:10. 1234/42",
     "doi:10.abc/42",
-    "doi:10.1234/ 42",
-    "doi:10.1234/42/a b",
+    "10.1234 /42/a b",
 ]
 
 


### PR DESCRIPTION
the specs aren't very strict and especially the resolver does not have to be doi.org at all

https://www.doi.org/resources/DOICoreSpecificationv1.pdf

I need to detect DOIs for better interaction with zenodo/invenioRDM so this PR is basically a question whether we want to unify these patterns or not


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
