### PR TITLE
[25.0] DatasetView and Card Polish

### DIFF
--- a/client/src/api/datatypes.ts
+++ b/client/src/api/datatypes.ts
@@ -1,7 +1,5 @@
-import axios from "axios";
-
+import { GalaxyApi } from "@/api";
 import type { components } from "@/api";
-import { withPrefix } from "@/utils/redirect";
 import { rethrowSimple } from "@/utils/simple-error";
 
 export type CompositeFileInfo = components["schemas"]["CompositeFileInfo"];
@@ -10,10 +8,18 @@ export type DatatypeDetails = components["schemas"]["DatatypeDetails"];
 /**
  * Get details about a specific datatype
  */
-export async function fetchDatatypeDetails(extension: string) {
+export async function fetchDatatypeDetails(extension: string): Promise<DatatypeDetails> {
     try {
-        const { data } = await axios.get(withPrefix(`/api/datatypes/${extension}`));
-        return data;
+        const { GET } = GalaxyApi();
+        const { data } = await GET("/api/datatypes/{datatype}", {
+            params: {
+                path: { datatype: extension },
+            },
+        });
+        if (!data) {
+            throw new Error(`Failed to fetch datatype details for ${extension}`);
+        }
+        return data as DatatypeDetails;
     } catch (error) {
         rethrowSimple(error);
     }

--- a/client/src/api/datatypes.ts
+++ b/client/src/api/datatypes.ts
@@ -1,5 +1,5 @@
-import { GalaxyApi } from "@/api";
 import type { components } from "@/api";
+import { GalaxyApi } from "@/api";
 import { rethrowSimple } from "@/utils/simple-error";
 
 export type CompositeFileInfo = components["schemas"]["CompositeFileInfo"];

--- a/client/src/api/datatypes.ts
+++ b/client/src/api/datatypes.ts
@@ -1,3 +1,20 @@
+import axios from "axios";
+
 import type { components } from "@/api";
+import { withPrefix } from "@/utils/redirect";
+import { rethrowSimple } from "@/utils/simple-error";
 
 export type CompositeFileInfo = components["schemas"]["CompositeFileInfo"];
+export type DatatypeDetails = components["schemas"]["DatatypeDetails"];
+
+/**
+ * Get details about a specific datatype
+ */
+export async function fetchDatatypeDetails(extension: string) {
+    try {
+        const { data } = await axios.get(withPrefix(`/api/datatypes/${extension}`));
+        return data;
+    } catch (error) {
+        rethrowSimple(error);
+    }
+}

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -9302,6 +9302,11 @@ export interface components {
              */
             description_url: string | null;
             /**
+             * Display behavior
+             * @description How this datatype behaves when displayed with preview=True: 'inline' (can be displayed in browser) or 'download' (triggers download)
+             */
+            display_behavior?: string | null;
+            /**
              * Display in upload
              * @description If True, the associated file extension will be displayed in the `File Format` select list in the `Upload File from your computer` tool in the `Get Data` tool section of the tool panel
              * @default false

--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -82,7 +82,8 @@ watch(
                     class="flex-grow-1"
                     :collapse="headerState"
                     @click="toggleHeaderCollapse">
-                    {{ dataset?.hid }}: <span class="font-weight-bold">{{ dataset?.name }}</span>
+                    <span class="dataset-hid">{{ dataset?.hid }}:</span>
+                    <span class="dataset-name font-weight-bold">{{ dataset?.name }}</span>
                     <span class="dataset-state-header">
                         <DatasetState :dataset-id="datasetId" />
                     </span>
@@ -193,16 +194,16 @@ watch(
                 :is-preview="true"
                 @load="iframeLoading = false" />
         </div>
-        <div v-else-if="tab === 'visualize'" class="d-flex flex-column overflow-hidden overflow-y">
+        <div v-else-if="tab === 'visualize'" class="tab-content-panel">
             <VisualizationsList :dataset-id="datasetId" />
         </div>
-        <div v-else-if="tab === 'edit'" class="d-flex flex-column overflow-hidden overflow-y mt-2">
+        <div v-else-if="tab === 'edit'" class="tab-content-panel mt-2">
             <DatasetAttributes :dataset-id="datasetId" />
         </div>
-        <div v-else-if="tab === 'details'" class="d-flex flex-column overflow-hidden overflow-y mt-2">
+        <div v-else-if="tab === 'details'" class="tab-content-panel mt-2">
             <DatasetDetails :dataset-id="datasetId" />
         </div>
-        <div v-else-if="tab === 'error'" class="d-flex flex-column overflow-hidden overflow-y mt-2">
+        <div v-else-if="tab === 'error'" class="tab-content-panel mt-2">
             <DatasetError :dataset-id="datasetId" />
         </div>
     </div>
@@ -243,9 +244,30 @@ watch(
     opacity: 0;
 }
 
+.dataset-hid,
+.dataset-state-header {
+    white-space: nowrap;
+}
+
+.dataset-hid {
+    margin-right: 0.25rem;
+}
+
+.dataset-name {
+    word-break: break-word;
+}
+
 .dataset-state-header {
     font-size: $h5-font-size;
     vertical-align: middle;
+    margin-left: 0.5rem;
+}
+
+.tab-content-panel {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    overflow-y: auto;
 }
 
 .auto-download-message {

--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -47,12 +47,20 @@ const preferredVisualization = computed(
     () => dataset.value && datatypeStore.getPreferredVisualization(dataset.value.file_ext)
 );
 
+// Track datatype loading state
+const isDatatypeLoading = ref(false);
+const datatypeDetailsLoaded = ref(false);
+
 // Watch for changes to the dataset to fetch datatype info
 watch(
     () => dataset.value?.file_ext,
     async () => {
         if (dataset.value && dataset.value.file_ext) {
+            isDatatypeLoading.value = true;
+            datatypeDetailsLoaded.value = false;
             await datatypeStore.fetchDatatypeDetails(dataset.value.file_ext);
+            isDatatypeLoading.value = false;
+            datatypeDetailsLoaded.value = true;
         }
     },
     { immediate: true }
@@ -60,7 +68,7 @@ watch(
 </script>
 
 <template>
-    <LoadingSpan v-if="isLoading || !dataset" message="Loading dataset details" />
+    <LoadingSpan v-if="isLoading || !dataset || isDatatypeLoading" message="Loading dataset details" />
     <div v-else class="dataset-view d-flex flex-column h-100">
         <header :key="`dataset-header-${dataset.id}`" class="dataset-header flex-shrink-0">
             <div class="d-flex">

--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { library } from "@fortawesome/fontawesome-svg-core";
 import { faBug, faChartBar, faEye, faInfoCircle, faPen } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BNav, BNavItem } from "bootstrap-vue";
@@ -18,8 +17,6 @@ import DatasetDetails from "@/components/DatasetInformation/DatasetDetails.vue";
 import VisualizationsList from "@/components/Visualizations/Index.vue";
 import VisualizationFrame from "@/components/Visualizations/VisualizationFrame.vue";
 import CenterFrame from "@/entry/analysis/modules/CenterFrame.vue";
-
-library.add(faEye, faChartBar, faInfoCircle, faPen, faBug);
 
 const datasetStore = useDatasetStore();
 const datatypeVisualizationsStore = useDatatypeVisualizationsStore();

--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faBug, faChartBar, faEye, faInfoCircle, faPen } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BNav, BNavItem } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
 
@@ -15,6 +18,8 @@ import DatasetDetails from "@/components/DatasetInformation/DatasetDetails.vue";
 import VisualizationsList from "@/components/Visualizations/Index.vue";
 import VisualizationFrame from "@/components/Visualizations/VisualizationFrame.vue";
 import CenterFrame from "@/entry/analysis/modules/CenterFrame.vue";
+
+library.add(faEye, faChartBar, faInfoCircle, faPen, faBug);
 
 const datasetStore = useDatasetStore();
 const datatypeVisualizationsStore = useDatatypeVisualizationsStore();
@@ -108,21 +113,23 @@ watch(() => dataset.value?.file_ext, checkPreferredVisualization, { immediate: t
         </header>
         <BNav pills class="my-2 p-2 bg-light border-bottom">
             <BNavItem title="Preview" :active="tab === 'preview'" :to="`/datasets/${datasetId}/preview`">
-                Preview
+                <FontAwesomeIcon :icon="faEye" class="mr-1" /> Preview
             </BNavItem>
             <BNavItem
                 v-if="!showError"
                 title="Visualize"
                 :active="tab === 'visualize'"
                 :to="`/datasets/${datasetId}/visualize`">
-                Visualize
+                <FontAwesomeIcon :icon="faChartBar" class="mr-1" /> Visualize
             </BNavItem>
             <BNavItem title="Details" :active="tab === 'details'" :to="`/datasets/${datasetId}/details`">
-                Details
+                <FontAwesomeIcon :icon="faInfoCircle" class="mr-1" /> Details
             </BNavItem>
-            <BNavItem title="Edit" :active="tab === 'edit'" :to="`/datasets/${datasetId}/edit`">Edit</BNavItem>
+            <BNavItem title="Edit" :active="tab === 'edit'" :to="`/datasets/${datasetId}/edit`">
+                <FontAwesomeIcon :icon="faPen" class="mr-1" /> Edit
+            </BNavItem>
             <BNavItem v-if="showError" title="Error" :active="tab === 'error'" :to="`/datasets/${datasetId}/error`">
-                Error
+                <FontAwesomeIcon :icon="faBug" class="mr-1" /> Error
             </BNavItem>
         </BNav>
         <div v-if="tab === 'preview'" class="h-100">

--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -163,7 +163,7 @@ watch(
             <CenterFrame
                 v-else
                 :src="`/datasets/${datasetId}/display/?preview=True`"
-                :is_preview="true"
+                :is-preview="true"
                 @load="iframeLoading = false" />
         </div>
         <div v-else-if="tab === 'raw'" class="h-100">
@@ -180,7 +180,7 @@ watch(
             <CenterFrame
                 v-else
                 :src="`/datasets/${datasetId}/display/?preview=True`"
-                :is_preview="true"
+                :is-preview="true"
                 @load="iframeLoading = false" />
         </div>
         <div v-else-if="tab === 'visualize'" class="d-flex flex-column overflow-hidden overflow-y">

--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { faBug, faChartBar, faEye, faInfoCircle, faPen } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BNav, BNavItem } from "bootstrap-vue";
+import { BLink, BNav, BNavItem } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
 
 import { usePersistentToggle } from "@/composables/persistentToggle";
 import { useDatasetStore } from "@/stores/datasetStore";
 import { useDatatypeVisualizationsStore } from "@/stores/datatypeVisualizationsStore";
+import { bytesToString } from "@/utils/utils";
 
 import DatasetError from "../DatasetInformation/DatasetError.vue";
 import LoadingSpan from "../LoadingSpan.vue";
@@ -102,9 +103,10 @@ watch(() => dataset.value?.file_ext, checkPreferredVisualization, { immediate: t
                             {{ dataset.genome_build }}
                         </BLink>
                     </span>
-                    <div v-if="dataset.misc_info" class="info">
-                        <span class="value">{{ dataset.misc_info }}</span>
-                    </div>
+                    <span v-if="dataset.file_size" class="filesize">
+                        <span v-localize class="prompt">size</span>
+                        <span class="value font-weight-bold" v-html="bytesToString(dataset.file_size, false)" />
+                    </span>
                 </div>
             </transition>
         </header>
@@ -165,6 +167,21 @@ watch(() => dataset.value?.file_ext, checkPreferredVisualization, { immediate: t
     opacity: 1;
     transition: all 0.25s ease;
     overflow: hidden;
+
+    .datatype,
+    .dbkey,
+    .filesize {
+        margin-right: 1rem;
+    }
+
+    .prompt {
+        color: $text-muted;
+        margin-right: 0.25rem;
+    }
+
+    .blurb {
+        margin-bottom: 0.25rem;
+    }
 }
 
 .header-enter, /* change to header-enter-from with Vue 3 */

--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -111,23 +111,36 @@ watch(() => dataset.value?.file_ext, checkPreferredVisualization, { immediate: t
             </transition>
         </header>
         <BNav pills class="my-2 p-2 bg-light border-bottom">
-            <BNavItem title="Preview" :active="tab === 'preview'" :to="`/datasets/${datasetId}/preview`">
+            <BNavItem
+                title="View a preview of the dataset contents"
+                :active="tab === 'preview'"
+                :to="`/datasets/${datasetId}/preview`">
                 <FontAwesomeIcon :icon="faEye" class="mr-1" /> Preview
             </BNavItem>
             <BNavItem
                 v-if="!showError"
-                title="Visualize"
+                title="Explore available visualizations for this dataset"
                 :active="tab === 'visualize'"
                 :to="`/datasets/${datasetId}/visualize`">
                 <FontAwesomeIcon :icon="faChartBar" class="mr-1" /> Visualize
             </BNavItem>
-            <BNavItem title="Details" :active="tab === 'details'" :to="`/datasets/${datasetId}/details`">
+            <BNavItem
+                title="View detailed information about this dataset"
+                :active="tab === 'details'"
+                :to="`/datasets/${datasetId}/details`">
                 <FontAwesomeIcon :icon="faInfoCircle" class="mr-1" /> Details
             </BNavItem>
-            <BNavItem title="Edit" :active="tab === 'edit'" :to="`/datasets/${datasetId}/edit`">
+            <BNavItem
+                title="Edit dataset attributes and metadata"
+                :active="tab === 'edit'"
+                :to="`/datasets/${datasetId}/edit`">
                 <FontAwesomeIcon :icon="faPen" class="mr-1" /> Edit
             </BNavItem>
-            <BNavItem v-if="showError" title="Error" :active="tab === 'error'" :to="`/datasets/${datasetId}/error`">
+            <BNavItem
+                v-if="showError"
+                title="View error information for this dataset"
+                :active="tab === 'error'"
+                :to="`/datasets/${datasetId}/error`">
                 <FontAwesomeIcon :icon="faBug" class="mr-1" /> Error
             </BNavItem>
         </BNav>

--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faBug, faChartBar, faEye, faInfoCircle, faPen } from "@fortawesome/free-solid-svg-icons";
+import { faBug, faChartBar, faEye, faFileAlt, faInfoCircle, faPen } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BLink, BNav, BNavItem } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
@@ -25,7 +25,7 @@ const { toggled: headerCollapsed, toggle: toggleHeaderCollapse } = usePersistent
 
 interface Props {
     datasetId: string;
-    tab?: "details" | "edit" | "error" | "preview" | "visualize";
+    tab?: "details" | "edit" | "error" | "preview" | "raw" | "visualize";
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -118,6 +118,13 @@ watch(() => dataset.value?.file_ext, checkPreferredVisualization, { immediate: t
                 <FontAwesomeIcon :icon="faEye" class="mr-1" /> Preview
             </BNavItem>
             <BNavItem
+                v-if="preferredVisualization"
+                title="View raw dataset contents"
+                :active="tab === 'raw'"
+                :to="`/datasets/${datasetId}/raw`">
+                <FontAwesomeIcon :icon="faFileAlt" class="mr-1" /> Raw
+            </BNavItem>
+            <BNavItem
                 v-if="!showError"
                 title="Explore available visualizations for this dataset"
                 :active="tab === 'visualize'"
@@ -152,6 +159,12 @@ watch(() => dataset.value?.file_ext, checkPreferredVisualization, { immediate: t
                 @load="iframeLoading = false" />
             <CenterFrame
                 v-else
+                :src="`/datasets/${datasetId}/display/?preview=True`"
+                :is_preview="true"
+                @load="iframeLoading = false" />
+        </div>
+        <div v-else-if="tab === 'raw'" class="h-100">
+            <CenterFrame
                 :src="`/datasets/${datasetId}/display/?preview=True`"
                 :is_preview="true"
                 @load="iframeLoading = false" />

--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
+import { faExpand, faStop } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import axios from "axios";
 import { BButton, BDropdown } from "bootstrap-vue";
-import { faExpand } from "@fortawesome/free-solid-svg-icons";
-import { faStop } from "@fortawesome/free-solid-svg-icons";
 import { computed, type Ref, ref } from "vue";
 
 import { getAppRoot } from "@/onload/loadConfig";
@@ -25,7 +24,6 @@ const props = defineProps({
 const emit = defineEmits<{
     (e: "display"): void;
     (e: "showCollectionInfo"): void;
-    (e: "edit"): void;
     (e: "delete", recursive?: boolean): void;
     (e: "undelete"): void;
     (e: "unhide"): void;
@@ -35,11 +33,6 @@ const entryPointStore = useEntryPointStore();
 const errorMessage = ref("");
 const deleteCollectionMenu: Ref<BDropdown | null> = ref(null);
 
-const editButtonTitle = computed(() => (editDisabled.value ? "This dataset is not yet editable." : "Edit attributes"));
-const editDisabled = computed(() =>
-    ["discarded", "new", "upload", "queued", "running", "waiting"].includes(props.state)
-);
-const editUrl = computed(() => prependPath(props.itemUrls.edit));
 const displayUrl = computed(() => (props.itemUrls.display ? prependPath(props.itemUrls.display) : undefined));
 
 const isCollection = computed(() => !props.isDataset);
@@ -121,19 +114,6 @@ function onDisplay($event: MouseEvent) {
             :href="displayUrl"
             @click.prevent.stop="onDisplay($event)">
             <FontAwesomeIcon :icon="faExpand" />
-        </BButton>
-        <BButton
-            v-if="writable && isHistoryItem"
-            v-b-tooltip.hover
-            :disabled="editDisabled"
-            :title="editButtonTitle"
-            tabindex="0"
-            class="edit-btn px-1"
-            size="sm"
-            variant="link"
-            :href="editUrl"
-            @click.prevent.stop="emit('edit')">
-            <icon icon="pen" />
         </BButton>
         <BButton
             v-if="isRunningInteractiveTool"

--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { faExpand, faStop } from "@fortawesome/free-solid-svg-icons";
+import { faStop } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import axios from "axios";
 import { BButton, BDropdown } from "bootstrap-vue";
+//@ts-ignore deprecated package without types (vue 2, remove this comment on vue 3 migration)
+import { ScanEye } from "lucide-vue";
 import { computed, type Ref, ref } from "vue";
 
 import { getAppRoot } from "@/onload/loadConfig";
@@ -113,7 +115,7 @@ function onDisplay($event: MouseEvent) {
             variant="link"
             :href="displayUrl"
             @click.prevent.stop="onDisplay($event)">
-            <FontAwesomeIcon :icon="faExpand" />
+            <ScanEye absolute-stroke-width :size="16" />
         </BButton>
         <BButton
             v-if="isRunningInteractiveTool"

--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -2,7 +2,8 @@
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import axios from "axios";
 import { BButton, BDropdown } from "bootstrap-vue";
-import { faStop } from "font-awesome-6";
+import { faExpand } from "@fortawesome/free-solid-svg-icons";
+import { faStop } from "@fortawesome/free-solid-svg-icons";
 import { computed, type Ref, ref } from "vue";
 
 import { getAppRoot } from "@/onload/loadConfig";
@@ -112,14 +113,14 @@ function onDisplay($event: MouseEvent) {
         <BButton
             v-if="isDataset"
             v-b-tooltip.hover
-            title="Display"
+            title="View"
             tabindex="0"
             class="display-btn px-1"
             size="sm"
             variant="link"
             :href="displayUrl"
             @click.prevent.stop="onDisplay($event)">
-            <icon icon="eye" />
+            <FontAwesomeIcon :icon="faExpand" />
         </BButton>
         <BButton
             v-if="writable && isHistoryItem"

--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -26,6 +26,7 @@ const props = defineProps({
 const emit = defineEmits<{
     (e: "display"): void;
     (e: "showCollectionInfo"): void;
+    (e: "edit"): void;
     (e: "delete", recursive?: boolean): void;
     (e: "undelete"): void;
     (e: "unhide"): void;
@@ -35,6 +36,11 @@ const entryPointStore = useEntryPointStore();
 const errorMessage = ref("");
 const deleteCollectionMenu: Ref<BDropdown | null> = ref(null);
 
+const editButtonTitle = computed(() => (editDisabled.value ? "This dataset is not yet editable." : "Edit attributes"));
+const editDisabled = computed(() =>
+    ["discarded", "new", "upload", "queued", "running", "waiting"].includes(props.state)
+);
+const editUrl = computed(() => prependPath(props.itemUrls.edit));
 const displayUrl = computed(() => (props.itemUrls.display ? prependPath(props.itemUrls.display) : undefined));
 
 const isCollection = computed(() => !props.isDataset);
@@ -116,6 +122,19 @@ function onDisplay($event: MouseEvent) {
             :href="displayUrl"
             @click.prevent.stop="onDisplay($event)">
             <ScanEye absolute-stroke-width :size="16" />
+        </BButton>
+        <BButton
+            v-if="writable && isHistoryItem"
+            v-b-tooltip.hover
+            :disabled="editDisabled"
+            :title="editButtonTitle"
+            tabindex="0"
+            class="edit-btn px-1"
+            size="sm"
+            variant="link"
+            :href="editUrl"
+            @click.prevent.stop="emit('edit')">
+            <icon icon="pen" />
         </BButton>
         <BButton
             v-if="isRunningInteractiveTool"

--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -86,7 +86,7 @@ function onInfo() {
 }
 
 function onVisualize() {
-    router.push(`/visualizations?dataset_id=${props.item.id}`);
+    router.push(`/datasets/${props.item.id}/visualize`);
 }
 
 function onRerun() {

--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faBug, faChartBar, faInfoCircle, faLink, faRedo, faSitemap } from "@fortawesome/free-solid-svg-icons";
+import { faChartBar, faInfoCircle, faLink, faRedo, faSitemap } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton } from "bootstrap-vue";
 import { computed } from "vue";
@@ -15,7 +15,7 @@ import type { ItemUrls } from ".";
 
 import DatasetDownload from "@/components/History/Content/Dataset/DatasetDownload.vue";
 
-library.add(faBug, faChartBar, faInfoCircle, faLink, faRedo, faSitemap);
+library.add(faChartBar, faInfoCircle, faLink, faRedo, faSitemap);
 
 interface Props {
     item: HDADetailed;
@@ -36,14 +36,8 @@ const router = useRouter();
 const showDownloads = computed(() => {
     return !props.item.purged && ["ok", "failed_metadata", "error"].includes(props.item.state);
 });
-const showError = computed(() => {
-    return props.item.state === "error" || props.item.state === "failed_metadata";
-});
 const showRerun = computed(() => {
     return props.item.accessible && props.item.rerunnable && props.item.creating_job && props.item.state != "upload";
-});
-const reportErrorUrl = computed(() => {
-    return prependPath(props.itemUrls.reportError!);
 });
 const rerunUrl = computed(() => {
     return prependPath(props.itemUrls.rerun!);
@@ -65,10 +59,6 @@ function onHighlight() {
     emit("toggleHighlights");
 }
 
-function onError() {
-    window.location.href = reportErrorUrl.value;
-}
-
 function onRerun() {
     router.push(`/root?job_id=${props.item.creating_job}`);
 }
@@ -78,18 +68,6 @@ function onRerun() {
     <div class="dataset-actions mb-1">
         <div class="clearfix">
             <div class="btn-group float-left">
-                <BButton
-                    v-if="showError"
-                    v-b-tooltip.hover
-                    class="px-1"
-                    title="Error"
-                    size="sm"
-                    variant="link"
-                    :href="reportErrorUrl"
-                    @click.prevent.stop="onError">
-                    <FontAwesomeIcon :icon="faBug" />
-                </BButton>
-
                 <DatasetDownload v-if="showDownloads" :item="item" @on-download="onDownload" />
 
                 <BButton

--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faChartBar, faInfoCircle, faLink, faRedo, faSitemap } from "@fortawesome/free-solid-svg-icons";
+import { faBug, faChartBar, faInfoCircle, faLink, faRedo, faSitemap } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton } from "bootstrap-vue";
 import { computed } from "vue";
@@ -15,7 +15,7 @@ import type { ItemUrls } from ".";
 
 import DatasetDownload from "@/components/History/Content/Dataset/DatasetDownload.vue";
 
-library.add(faChartBar, faInfoCircle, faLink, faRedo, faSitemap);
+library.add(faBug, faChartBar, faInfoCircle, faLink, faRedo, faSitemap);
 
 interface Props {
     item: HDADetailed;
@@ -36,8 +36,26 @@ const router = useRouter();
 const showDownloads = computed(() => {
     return !props.item.purged && ["ok", "failed_metadata", "error"].includes(props.item.state);
 });
+const showError = computed(() => {
+    return props.item.state === "error" || props.item.state === "failed_metadata";
+});
+const showInfo = computed(() => {
+    return props.item.state !== "noPermission";
+});
+const showVisualizations = computed(() => {
+    return !props.item.purged && ["ok", "failed_metadata", "error"].includes(props.item.state);
+});
 const showRerun = computed(() => {
     return props.item.accessible && props.item.rerunnable && props.item.creating_job && props.item.state != "upload";
+});
+const reportErrorUrl = computed(() => {
+    return prependPath(props.itemUrls.reportError!);
+});
+const showDetailsUrl = computed(() => {
+    return prependPath(props.itemUrls.showDetails!);
+});
+const visualizeUrl = computed(() => {
+    return prependPath(props.itemUrls.visualize!);
 });
 const rerunUrl = computed(() => {
     return prependPath(props.itemUrls.rerun!);
@@ -59,6 +77,18 @@ function onHighlight() {
     emit("toggleHighlights");
 }
 
+function onError() {
+    window.location.href = reportErrorUrl.value;
+}
+
+function onInfo() {
+    router.push(`/datasets/${props.item.id}/details`);
+}
+
+function onVisualize() {
+    router.push(`/visualizations?dataset_id=${props.item.id}`);
+}
+
 function onRerun() {
     router.push(`/root?job_id=${props.item.creating_job}`);
 }
@@ -68,6 +98,18 @@ function onRerun() {
     <div class="dataset-actions mb-1">
         <div class="clearfix">
             <div class="btn-group float-left">
+                <BButton
+                    v-if="showError"
+                    v-b-tooltip.hover
+                    class="px-1"
+                    title="Error"
+                    size="sm"
+                    variant="link"
+                    :href="reportErrorUrl"
+                    @click.prevent.stop="onError">
+                    <FontAwesomeIcon :icon="faBug" />
+                </BButton>
+
                 <DatasetDownload v-if="showDownloads" :item="item" @on-download="onDownload" />
 
                 <BButton
@@ -79,6 +121,30 @@ function onRerun() {
                     variant="link"
                     @click.stop="onCopyLink">
                     <FontAwesomeIcon :icon="faLink" />
+                </BButton>
+
+                <BButton
+                    v-if="showInfo"
+                    v-b-tooltip.hover
+                    class="info-btn px-1"
+                    title="Dataset Details"
+                    size="sm"
+                    variant="link"
+                    :href="showDetailsUrl"
+                    @click.prevent.stop="onInfo">
+                    <FontAwesomeIcon :icon="faInfoCircle" />
+                </BButton>
+
+                <BButton
+                    v-if="showVisualizations"
+                    v-b-tooltip.hover
+                    class="visualize-btn px-1"
+                    title="Visualize"
+                    size="sm"
+                    variant="link"
+                    :href="visualizeUrl"
+                    @click.prevent.stop="onVisualize">
+                    <FontAwesomeIcon :icon="faChartBar" />
                 </BButton>
 
                 <BButton

--- a/client/src/stores/datatypeStore.js
+++ b/client/src/stores/datatypeStore.js
@@ -19,6 +19,10 @@ export const useDatatypeStore = defineStore("datatypeStore", {
             const details = state.datatypeDetails[extension];
             return details?.display_behavior === "download";
         },
+        getPreferredVisualization: (state) => (extension) => {
+            const details = state.datatypeDetails[extension];
+            return details?.preferred_visualization?.visualization || null;
+        },
     },
     actions: {
         async fetchUploadDatatypes() {

--- a/client/src/stores/datatypeStore.js
+++ b/client/src/stores/datatypeStore.js
@@ -1,13 +1,23 @@
 import UploadUtils from "components/Upload/utils";
 import { defineStore } from "pinia";
 
+import { fetchDatatypeDetails } from "@/api/datatypes";
+
 export const useDatatypeStore = defineStore("datatypeStore", {
     state: () => ({
         uploadDatatypes: [],
+        datatypeDetails: {},
     }),
     getters: {
         getUploadDatatypes: (state) => {
             return state.uploadDatatypes;
+        },
+        getDatatypeDetails: (state) => (extension) => {
+            return state.datatypeDetails[extension];
+        },
+        isDatatypeAutoDownload: (state) => (extension) => {
+            const details = state.datatypeDetails[extension];
+            return details?.display_behavior === "download";
         },
     },
     actions: {
@@ -17,6 +27,21 @@ export const useDatatypeStore = defineStore("datatypeStore", {
                 this.uploadDatatypes = data;
             } catch (err) {
                 console.log("Error: unable to load datatypes", err);
+            }
+        },
+        async fetchDatatypeDetails(extension) {
+            // Return cached details if available
+            if (this.datatypeDetails[extension]) {
+                return this.datatypeDetails[extension];
+            }
+
+            try {
+                const details = await fetchDatatypeDetails(extension);
+                this.datatypeDetails[extension] = details;
+                return details;
+            } catch (err) {
+                console.error(`Error: unable to load datatype details for ${extension}`, err);
+                return null;
             }
         },
     },

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -157,9 +157,9 @@ object_store_details:
 dataset_view:
   selectors:
     _: .dataset-view
-    edit_tab: ".nav-item[title='Edit'] > a.nav-link"
-    details_tab: ".nav-item[title='Details'] > a.nav-link"
-    visualize_tab: ".nav-item[title='Visualize'] > a.nav-link"
+    edit_tab: ".nav-item[title='Edit dataset attributes and metadata'] > a.nav-link"
+    details_tab: ".nav-item[title='View detailed information about this dataset'] > a.nav-link"
+    visualize_tab: ".nav-item[title='Explore available visualizations for this dataset'] > a.nav-link"
 
 history_panel:
   menu:

--- a/lib/galaxy/datatypes/_schema.py
+++ b/lib/galaxy/datatypes/_schema.py
@@ -66,6 +66,11 @@ class DatatypeDetails(BaseModel):
         title="Upload warning",
         description="End-user information regarding potential pitfalls with this upload type.",
     )
+    display_behavior: Optional[str] = Field(
+        default=None,
+        title="Display behavior",
+        description="How this datatype behaves when displayed with preview=True: 'inline' (can be displayed in browser) or 'download' (triggers download)",
+    )
 
 
 class DatatypesMap(BaseModel):

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -414,6 +414,7 @@ class CompressedZipArchive(CompressedArchive):
     """
 
     file_ext = "zip"
+    display_behavior = "download"  # Archive files trigger downloads
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
@@ -3198,6 +3199,7 @@ class Xlsx(Binary):
 
     file_ext = "xlsx"
     compressed = True
+    display_behavior = "download"  # Office documents trigger downloads
 
     def sniff_prefix(self, file_prefix: FilePrefix) -> bool:
         # Xlsx is compressed in zip format and must not be uncompressed in Galaxy.
@@ -3210,6 +3212,7 @@ class ExcelXls(Binary):
 
     file_ext = "excel.xls"
     edam_format = "format_3468"
+    display_behavior = "download"  # Office documents trigger downloads
 
     def sniff_prefix(self, file_prefix: FilePrefix) -> bool:
         return file_prefix.mime_type == self.get_mime()

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -240,6 +240,10 @@ class Data(metaclass=DataMeta):
     # A per datatype setting (inherited): max file size (in bytes) for setting optional metadata
     _max_optional_metadata_filesize = None
 
+    # Display behavior when preview=True: "inline" (can be displayed in browser),
+    # "download" (always triggers download), or None (default behavior)
+    display_behavior: Optional[Literal["inline", "download"]] = None
+
     # Trackster track type.
     track_type: Optional[str] = None
 
@@ -263,6 +267,23 @@ class Data(metaclass=DataMeta):
         if cls.allow_datatype_change is not None:
             return cls.allow_datatype_change
         return cls.composite_type is None
+
+    @classmethod
+    def get_display_behavior(cls) -> str:
+        """
+        Returns the display behavior for this datatype.
+
+        If display_behavior is set on the class, returns that value.
+        Otherwise, returns "inline" for text-based types and "download" for binary types.
+        """
+        if cls.display_behavior is not None:
+            return cls.display_behavior
+
+        # Default behavior based on whether the datatype is binary
+        if cls.is_binary is True:
+            return "download"
+        else:
+            return "inline"
 
     def dataset_content_needs_grooming(self, file_name: str) -> bool:
         """This function is called on an output dataset file after the content is initially generated."""

--- a/lib/galaxy/datatypes/images.py
+++ b/lib/galaxy/datatypes/images.py
@@ -228,6 +228,7 @@ class Png(Image):
 class Tiff(Image):
     edam_format = "format_3591"
     file_ext = "tiff"
+    display_behavior = "download"  # TIFF files trigger browser downloads
     MetadataElement(
         name="offsets",
         desc="Offsets File",
@@ -505,6 +506,7 @@ class Rast(Image):
 class Pdf(Image):
     edam_format = "format_3508"
     file_ext = "pdf"
+    display_behavior = "download"  # PDFs often trigger downloads depending on browser settings
 
     def sniff(self, filename: str) -> bool:
         """Determine if the file is in pdf format."""

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -343,6 +343,11 @@ class Registry:
                             "description": description,
                             "description_url": description_url,
                             "upload_warning": upload_warning(upload_warning_template),
+                            "display_behavior": (
+                                datatype_instance.get_display_behavior()
+                                if hasattr(datatype_instance, "get_display_behavior")
+                                else None
+                            ),
                         }
                         composite_files = datatype_instance.get_composite_files()
                         if composite_files:

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1995,7 +1995,9 @@ class NavigatesGalaxy(HasDriver):
 
         # Find and click the Edit tab - using a more reliable selector
         # BVue generates '.nav-item a' elements with a title attribute matching the tab title
-        edit_tab_button = self.wait_for_selector_clickable(".nav-item[title='Edit'] > a.nav-link")
+        edit_tab_button = self.wait_for_selector_clickable(
+            ".nav-item[title='Edit dataset attributes and metadata'] > a.nav-link"
+        )
         edit_tab_button.click()
 
         # Wait for the edit attributes panel to be visible
@@ -2010,14 +2012,18 @@ class NavigatesGalaxy(HasDriver):
     def show_dataset_details(self, hid):
         self.display_dataset(hid)
         # Find and click the Details tab
-        details_tab_button = self.wait_for_selector_clickable(".nav-item[title='Details'] > a.nav-link")
+        details_tab_button = self.wait_for_selector_clickable(
+            ".nav-item[title='View detailed information about this dataset'] > a.nav-link"
+        )
         details_tab_button.click()
         self.components.dataset_details._.wait_for_visible()
 
     def show_dataset_visualizations(self, hid):
         self.display_dataset(hid)
         # Find and click the Visualize tab
-        visualize_tab_button = self.wait_for_selector_clickable(".nav-item[title='Visualize'] > a.nav-link")
+        visualize_tab_button = self.wait_for_selector_clickable(
+            ".nav-item[title='Explore available visualizations for this dataset'] > a.nav-link"
+        )
         visualize_tab_button.click()
 
     def history_panel_item_view_dataset_details(self, hid):

--- a/lib/galaxy/webapps/galaxy/api/datatypes.py
+++ b/lib/galaxy/webapps/galaxy/api/datatypes.py
@@ -229,6 +229,9 @@ class FastAPIDatatypes:
             "display_in_upload": datatype in self.datatypes_registry.upload_file_formats,
             "mimetype": self.datatypes_registry.get_mimetype_by_extension(datatype),
             "is_binary": getattr(dt_object, "is_binary", False),
+            "display_behavior": (
+                dt_object.get_display_behavior() if hasattr(dt_object, "get_display_behavior") else None
+            ),
         }
 
         # Add composite files if applicable

--- a/package.json
+++ b/package.json
@@ -19,5 +19,6 @@
   "dependencies": {
     "@galaxyproject/galaxy-client": "^24.0.0",
     "cpy-cli": "^5.0.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Smoothing out user interactions with the new streamlined view.

xref https://github.com/galaxyproject/galaxy/issues/20301

Adjusted header:
Nicer formatting, dropped 'info', which folks agreed was usually cluttered with unhelpful stderr.  
We keep 'blurb'.
![image](https://github.com/user-attachments/assets/46662e74-248d-43c0-beb7-21bd57d21aa2)



For the card options, eye and error are dropped and we're going with a new icon.

Here's faExpand:
![image](https://github.com/user-attachments/assets/4c970098-dfc0-4127-9694-734678b64d58)

And here's ScanEye:
![image](https://github.com/user-attachments/assets/c02c8178-e160-4d0e-8851-cd227b517bb8)


I'm also going to mock up a quick composite of faEye and faExpand  (which will be a lot like ScanEye, but with fa styles) in a sec.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
