### PR TITLE
[25.0] Bug fix - auto-pairing step not connected to collection builder in wizard.

### DIFF
--- a/client/src/components/Collections/ListWizard.vue
+++ b/client/src/components/Collections/ListWizard.vue
@@ -254,6 +254,8 @@ function onRuleState(newRuleState: boolean) {
                     :history-id="currentHistoryId"
                     :initial-elements="selectedItems || []"
                     :collection-type="collectionTypeForPairedOrUnpairedBuilder"
+                    :forward-filter="currentForwardFilter"
+                    :reverse-filter="currentReverseFilter"
                     mode="wizard"
                     :default-hide-source-items="true"
                     :from-selection="true"


### PR DESCRIPTION
In the modal version of this component - the collection builder manages its own auto-pairing widget and I think in that mode it works fine but the wizard was not wired up correctly where there is an optional step in the middle if the auto-pairing doesn't work automatically.

Fixes one of the issues identified in https://github.com/galaxyproject/galaxy/issues/20344.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. https://github.com/galaxyproject/galaxy/issues/20344

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
