### PR TITLE
[25.0] Add requires login attribute for visualizations

### DIFF
--- a/client/src/api/plugins.ts
+++ b/client/src/api/plugins.ts
@@ -29,6 +29,7 @@ export interface Plugin {
     html: string;
     logo?: string;
     name: string;
+    requires_login?: boolean;
     target?: string;
     tags?: Array<string>;
     tests?: Array<TestType>;

--- a/client/src/components/Visualizations/VisualizationCreate.vue
+++ b/client/src/components/Visualizations/VisualizationCreate.vue
@@ -76,7 +76,7 @@ defineExpose({ doQuery });
             <VisualizationExamples :url-data="urlData" />
         </template>
         <div class="my-3">
-            <BAlert v-if="plugin?.requires_login" variant="warning" show v-localize>
+            <BAlert v-if="plugin.requires_login" variant="warning" show v-localize>
                 Please login to use this visualization!
             </BAlert>
             <SelectionField
@@ -97,7 +97,7 @@ defineExpose({ doQuery });
             <div v-html="renderMarkdown(plugin.help)" />
         </div>
         <div class="my-2 pb-2">
-            <div v-for="(tag, index) in plugin?.tags" :key="index" class="badge badge-info text-capitalize mr-1">
+            <div v-for="(tag, index) in plugin.tags" :key="index" class="badge badge-info text-capitalize mr-1">
                 {{ tag }}
             </div>
         </div>

--- a/client/src/components/Visualizations/VisualizationCreate.vue
+++ b/client/src/components/Visualizations/VisualizationCreate.vue
@@ -76,7 +76,11 @@ defineExpose({ doQuery });
             <VisualizationExamples :url-data="urlData" />
         </template>
         <div class="my-3">
+            <BAlert v-if="plugin?.requires_login" variant="warning" show v-localize>
+                Please login to use this visualization!
+            </BAlert>
             <SelectionField
+                v-else
                 object-name="Select a dataset..."
                 object-title="Select to Visualize"
                 object-type="history_dataset_id"

--- a/client/src/components/Visualizations/VisualizationCreate.vue
+++ b/client/src/components/Visualizations/VisualizationCreate.vue
@@ -7,6 +7,7 @@ import { type Dataset, fetchPlugin, fetchPluginHistoryItems, type Plugin } from 
 import type { OptionType } from "@/components/SelectionField/types";
 import { useMarkdown } from "@/composables/markdown";
 import { useHistoryStore } from "@/stores/historyStore";
+import { useUserStore } from "@/stores/userStore";
 
 import { getTestExtensions, getTestUrls } from "./utilities";
 
@@ -19,6 +20,7 @@ import SelectionField from "@/components/SelectionField/SelectionField.vue";
 const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true, increaseHeadingLevelBy: 2 });
 
 const { currentHistoryId } = storeToRefs(useHistoryStore());
+const { isAnonymous } = storeToRefs(useUserStore());
 
 const router = useRouter();
 
@@ -76,8 +78,8 @@ defineExpose({ doQuery });
             <VisualizationExamples :url-data="urlData" />
         </template>
         <div class="my-3">
-            <BAlert v-if="plugin.requires_login" variant="warning" show v-localize>
-                Please login to use this visualization!
+            <BAlert v-if="plugin.requires_login && isAnonymous" v-localize variant="warning" show>
+                Please log in to access this visualization.
             </BAlert>
             <SelectionField
                 v-else

--- a/client/src/components/Visualizations/VisualizationPanel.vue
+++ b/client/src/components/Visualizations/VisualizationPanel.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { BAlert } from "bootstrap-vue";
+import { storeToRefs } from "pinia";
 import { computed, onMounted, type Ref, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { fetchPlugins, type Plugin } from "@/api/plugins";
+import { useUserStore } from "@/stores/userStore";
 
 import { getTestExtensions } from "./utilities";
 
@@ -12,6 +14,8 @@ import DelayedInput from "@/components/Common/DelayedInput.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import ActivityPanel from "@/components/Panels/ActivityPanel.vue";
 import VisualizationHeader from "@/components/Visualizations/VisualizationHeader.vue";
+
+const { isAnonymous } = storeToRefs(useUserStore());
 
 const router = useRouter();
 
@@ -59,10 +63,14 @@ const filteredPlugins = computed(() => {
 
 async function selectVisualization(plugin: Plugin) {
     if (props.datasetId) {
-        router.push(`/visualizations/display?visualization=${plugin.name}&dataset_id=${props.datasetId}`, {
-            // @ts-ignore
-            title: plugin.name,
-        });
+        if (plugin.requires_login && isAnonymous) {
+            router.push(`/login/start`);
+        } else {
+            router.push(`/visualizations/display?visualization=${plugin.name}&dataset_id=${props.datasetId}`, {
+                // @ts-ignore
+                title: plugin.name,
+            });
+        }
     } else {
         router.push(`/visualizations/create/${plugin.name}`);
     }

--- a/config/plugins/visualizations/heatmap/config/heatmap.xml
+++ b/config/plugins/visualizations/heatmap/config/heatmap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE visualization SYSTEM "../../visualization.dtd">
-<visualization name="Heatmap" embeddable="true">
+<visualization name="Heatmap" embeddable="true" requires_login="true">
     <description>Renders a heatmap from matrix data provided in 3-column format (x, y, observation).</description>
     <tags>
         <tag>Heatmap</tag>

--- a/lib/galaxy/visualization/plugins/config_parser.py
+++ b/lib/galaxy/visualization/plugins/config_parser.py
@@ -79,6 +79,11 @@ class VisualizationsConfigParser:
         if "embeddable" in xml_tree.attrib:
             returned["embeddable"] = asbool(xml_tree.attrib.get("embeddable"))
 
+        # record the requires_login flag - defaults to False
+        returned["requires_login"] = False
+        if "requires_login" in xml_tree.attrib:
+            returned["requires_login"] = asbool(xml_tree.attrib.get("requires_login"))
+
         # record the visible flag - defaults to False
         returned["hidden"] = False
         if "hidden" in xml_tree.attrib:

--- a/lib/galaxy/visualization/plugins/plugin.py
+++ b/lib/galaxy/visualization/plugins/plugin.py
@@ -126,6 +126,7 @@ class VisualizationPlugin(ServesTemplatesPluginMixin):
             "target": self.config.get("render_target", "galaxy_main"),
             "embeddable": self.config.get("embeddable"),
             "entry_point": self.config.get("entry_point"),
+            "requires_login": self.config.get("requires_login"),
             "settings": self.config.get("settings"),
             "specs": self.config.get("specs"),
             "tracks": self.config.get("tracks"),


### PR DESCRIPTION
Some visualizations require the user to be logged in, especially when they involve specific APIs such as those used to execute jobs. This PR adds an optional requires_login flag to the visualization XML to resolve this issue. If a dataset has already been selected, the user is redirected to the login page. Otherwise, a warning message is shown prompting the user to log in.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
