### PR TITLE
Add built visualizations path to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ config/*
 config/plugins/interactive_environments/**/*.ini
 config/plugins/**/.cache
 config/plugins/**/.parcel-cache
+config/plugins/visualizations
 !config/plugins
 static/welcome.html.*
 static/welcome.html


### PR DESCRIPTION
Added `config/plugins/visualizations` to `.gitignore` to prevent tracking of built visualization plugins. Moving forward, no visualizations should be committed directly under this path, as they are generated from npm packages. To install visualizations use `client/visualizations.yml` instead.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
