### PR TITLE
WIP: Implement TUS upload for invocation imports

### DIFF
--- a/lib/galaxy/managers/model_stores.py
+++ b/lib/galaxy/managers/model_stores.py
@@ -1,3 +1,4 @@
+import os
 from typing import (
     Optional,
     Union,
@@ -334,8 +335,13 @@ def create_objects_from_store(
         allow_library_creation=for_library,
     )
     user_context = ModelStoreUserContext(app, galaxy_user) if galaxy_user is not None else None
+    source = payload.store_content_uri or payload.store_dict
+    if isinstance(source, str) and source.startswith("tus://"):
+        session_id = source.split("tus://", 1)[-1]
+        upload_store = app.config.tus_upload_store or app.config.new_file_path
+        source = f"file://{os.path.abspath(os.path.join(upload_store, session_id))}"
     model_import_store = source_to_import_store(
-        payload.store_content_uri or payload.store_dict,
+        source=source,
         app=app,
         import_options=import_options,
         model_store_format=payload.model_store_format,

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -2113,7 +2113,12 @@ class BaseWorkflowPopulator(BasePopulator):
         store_dict: Optional[Dict[str, Any]] = None,
         store_path: Optional[str] = None,
         model_store_format: Optional[str] = None,
+        archive_path: Optional[str] = None,
     ) -> Response:
+        if archive_path is not None:
+
+            tus_session_id = self.galaxy_interactor.tus_upload(archive_path, "upload/resumable_upload")
+            store_path = f"tus://{tus_session_id}"
         url = "invocations/from_store"
         payload = _store_payload(store_dict=store_dict, store_path=store_path, model_store_format=model_store_format)
         payload["history_id"] = history_id
@@ -2126,9 +2131,14 @@ class BaseWorkflowPopulator(BasePopulator):
         store_dict: Optional[Dict[str, Any]] = None,
         store_path: Optional[str] = None,
         model_store_format: Optional[str] = None,
+        archive_path: Optional[str] = None,
     ) -> Response:
         create_response = self.create_invocation_from_store_raw(
-            history_id, store_dict=store_dict, store_path=store_path, model_store_format=model_store_format
+            history_id,
+            store_dict=store_dict,
+            store_path=store_path,
+            model_store_format=model_store_format,
+            archive_path=archive_path,
         )
         api_asserts.assert_status_code_is_ok(create_response)
         return create_response.json()

--- a/test/integration/test_workflow_tasks.py
+++ b/test/integration/test_workflow_tasks.py
@@ -10,6 +10,7 @@ from typing import (
     Any,
     cast,
     Dict,
+    Optional,
 )
 
 from galaxy.util.compression_utils import CompressedFile
@@ -51,6 +52,9 @@ class TestWorkflowTasksIntegration(PosixFileSourceSetup, IntegrationTestCase, Us
 
     def test_export_import_invocation_collection_input_sts(self):
         self._test_export_import_invocation_collection_input(False)
+
+    def test_export_import_invocation_with_input_as_output_tus(self):
+        self._test_export_import_invocation_with_input_as_output(False, use_upload=True)
 
     def test_export_import_invocation_with_input_as_output_uris(self):
         self._test_export_import_invocation_with_input_as_output(True)
@@ -107,10 +111,10 @@ class TestWorkflowTasksIntegration(PosixFileSourceSetup, IntegrationTestCase, Us
 
             self._rerun_imported_workflow(summary, invocation_details)
 
-    def _test_export_import_invocation_with_input_as_output(self, use_uris):
+    def _test_export_import_invocation_with_input_as_output(self, use_uris, use_upload=False):
         with self.dataset_populator.test_history() as history_id:
             summary = self._run_workflow_with_inputs_as_outputs(history_id)
-            invocation_details = self._export_and_import_workflow_invocation(summary, use_uris)
+            invocation_details = self._export_and_import_workflow_invocation(summary, use_uris, use_upload=use_upload)
             output_values = invocation_details["output_values"]
             assert len(output_values) == 1
             assert "wf_output_param" in output_values
@@ -171,24 +175,28 @@ steps:
             assert len(contents) == len(original_contents) == 5
 
     def _export_and_import_workflow_invocation(
-        self, summary: RunJobsSummary, use_uris: bool = True, model_store_format="tgz"
+        self, summary: RunJobsSummary, use_uris: bool = True, use_upload=False, model_store_format="tgz"
     ) -> Dict[str, Any]:
         invocation_id = summary.invocation_id
         extension = model_store_format or "tgz"
-        if use_uris:
+        archive_path: Optional[str] = None
+        if use_uris or use_upload:
             uri = f"gxfiles://posix_test/invocation.{extension}"
             self.workflow_populator.download_invocation_to_uri(invocation_id, uri, extension=extension)
             root = self.root_dir
             invocation_path = os.path.join(root, f"invocation.{extension}")
             assert os.path.exists(invocation_path)
-            uri = invocation_path
+            if use_uris:
+                uri = invocation_path
+            else:
+                archive_path = invocation_path
         else:
             temp_tar = self.workflow_populator.download_invocation_to_store(invocation_id, extension=extension)
             uri = temp_tar
 
         with self.dataset_populator.test_history() as history_id:
             response = self.workflow_populator.create_invocation_from_store(
-                history_id, store_path=uri, model_store_format=model_store_format
+                history_id, store_path=uri, model_store_format=model_store_format, archive_path=archive_path
             )
 
         imported_invocation_details = self._assert_one_invocation_created_and_get_details(response)


### PR DESCRIPTION
We'll want a separate upload store location that is configurable by admins, and we should likely target a separate tus upload endpoint ... probably ? Or we could dispatch on metadata ?

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
