### PR TITLE
Prepare ``ToolBox.dynamic_tool_to_tool()`` for CWL formats

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -9930,11 +9930,6 @@ export interface components {
              */
             active: boolean | null;
             /**
-             * Allow Load
-             * @default true
-             */
-            allow_load: boolean | null;
-            /**
              * Hidden
              * @default false
              */
@@ -9947,8 +9942,6 @@ export interface components {
              * @constant
              */
             src: "representation";
-            /** Uuid */
-            uuid?: string | null;
         };
         /** DynamicUnprivilegedToolCreatePayload */
         DynamicUnprivilegedToolCreatePayload: {
@@ -9957,11 +9950,6 @@ export interface components {
              * @default true
              */
             active: boolean | null;
-            /**
-             * Allow Load
-             * @default true
-             */
-            allow_load: boolean | null;
             /**
              * Hidden
              * @default false
@@ -9974,8 +9962,6 @@ export interface components {
              * @constant
              */
             src: "representation";
-            /** Uuid */
-            uuid?: string | null;
         };
         /**
          * ElementsFromType
@@ -16944,11 +16930,6 @@ export interface components {
         PathBasedDynamicToolCreatePayload: {
             /** Active */
             active?: boolean | null;
-            /**
-             * Allow Load
-             * @default true
-             */
-            allow_load: boolean;
             /** Hidden */
             hidden?: boolean | null;
             /** Path */
@@ -16960,8 +16941,6 @@ export interface components {
             src: "from_path";
             /** Tool Directory */
             tool_directory?: string | null;
-            /** Uuid */
-            uuid?: string | null;
         };
         /** PathDataElement */
         PathDataElement: {

--- a/client/src/components/Tool/CustomToolEditor.vue
+++ b/client/src/components/Tool/CustomToolEditor.vue
@@ -90,7 +90,6 @@ async function saveTool() {
         hidden: false,
         representation: parse(yamlRepresentation.value),
         src: "representation",
-        allow_load: true,
     };
     const { data, error } = await GalaxyApi().POST("/api/unprivileged_tools", { body: payload });
     if (error) {

--- a/client/src/components/Tool/runTimeModel.ts
+++ b/client/src/components/Tool/runTimeModel.ts
@@ -7,7 +7,6 @@ async function fetchRuntimeSchema(toolSource: any) {
     const { data, error } = await GalaxyApi().POST("/api/unprivileged_tools/runtime_model", {
         body: {
             active: true,
-            allow_load: false,
             hidden: false,
             representation: toolSource,
             src: "representation",

--- a/lib/galaxy/managers/tools.py
+++ b/lib/galaxy/managers/tools.py
@@ -21,7 +21,6 @@ from galaxy import (
     exceptions,
     model,
 )
-from galaxy.exceptions import DuplicatedIdentifierException
 from galaxy.model import (
     DynamicTool,
     UserDynamicToolAssociation,
@@ -46,7 +45,6 @@ log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from galaxy.managers.base import OrmFilterParsersType
-    from galaxy.managers.context import ProvidesUserContext
 
 
 def tool_payload_to_tool(app, tool_dict: Dict[str, Any]) -> Optional[Tool]:
@@ -98,76 +96,60 @@ class DynamicToolManager(ModelManager[model.DynamicTool]):
         stmt = select(DynamicTool).where(DynamicTool.id == object_id, DynamicTool.public == true())
         return self.session().scalars(stmt).one_or_none()
 
-    def create_tool(self, trans: "ProvidesUserContext", tool_payload: DynamicToolPayload, allow_load=True):
+    def create_tool(self, tool_payload: DynamicToolPayload):
         if not getattr(self.app.config, "enable_beta_tool_formats", False):
             raise exceptions.ConfigDoesNotAllowException(
                 "Set 'enable_beta_tool_formats' in Galaxy config to create dynamic tools."
             )
 
-        dynamic_tool = None
-        uuid_str = tool_payload.uuid
-        # Convert uuid_str to UUID or generate new if None
-        uuid = model.get_uuid(uuid_str)
-        if uuid_str:
-            # TODO: enforce via DB constraint and catch appropriate
-            # exception.
-            dynamic_tool = self.get_tool_by_uuid(uuid_str)
-            if dynamic_tool:
-                if not allow_load:
-                    raise DuplicatedIdentifierException(
-                        f"Attempted to create dynamic tool with duplicate UUID '{uuid_str}'"
-                    )
-                assert dynamic_tool.uuid == uuid
-        if not dynamic_tool:
-            if tool_payload.src == "from_path":
-                tool_format, representation, _ = artifact_class(None, tool_payload.model_dump())
+        uuid = model.get_uuid()
+        tool_directory: Optional[str] = None
+        tool_path: Optional[str] = None
+        if tool_payload.src == "from_path":
+            tool_format, representation, _ = artifact_class(None, tool_payload.model_dump())
+            tool_directory = tool_payload.tool_directory
+            tool_path = tool_payload.path
+        else:
+            representation = tool_payload.representation.model_dump(by_alias=True, exclude_unset=True)
+            if not representation:
+                raise exceptions.ObjectAttributeMissingException("A tool 'representation' is required.")
+
+            tool_format = representation.get("class")
+            if not tool_format:
+                raise exceptions.ObjectAttributeMissingException("Current tool representations require 'class'.")
+
+        if tool_format in ("GalaxyTool", "GalaxyUserTool"):
+            tool_id = representation.get("id")
+            if not tool_id:
+                tool_id = str(uuid)
+        elif tool_format in ("CommandLineTool", "ExpressionTool"):
+            # CWL tools
+            if tool_path:
+                proxy = tool_proxy(tool_path=tool_path, uuid=uuid)
             else:
-                representation = tool_payload.representation.model_dump(by_alias=True, exclude_unset=True)
-                if not representation:
-                    raise exceptions.ObjectAttributeMissingException("A tool 'representation' is required.")
-
-                tool_format = representation.get("class")
-                if not tool_format:
-                    raise exceptions.ObjectAttributeMissingException("Current tool representations require 'class'.")
-
-            tool_directory: Optional[str] = None
-            tool_path: Optional[str] = None
-            if tool_payload.src == "from_path":
-                tool_directory = tool_payload.tool_directory
-                tool_path = tool_payload.path
-
-            if tool_format in ("GalaxyTool", "GalaxyUserTool"):
-                tool_id = representation.get("id")
-                if not tool_id:
-                    tool_id = str(uuid)
-            elif tool_format in ("CommandLineTool", "ExpressionTool"):
-                # CWL tools
-                if tool_path:
-                    proxy = tool_proxy(tool_path=tool_path, uuid=uuid)
-                else:
-                    # Build a tool proxy so that we can convert to the persistable
-                    # hash.
-                    proxy = tool_proxy(
-                        tool_object=representation["raw_process_reference"],
-                        tool_directory=tool_directory,
-                        uuid=uuid,
-                    )
-                tool_id = proxy.galaxy_id()
-            else:
-                raise Exception(f"Unknown tool format [{tool_format}] encountered.")
-            tool_version = representation.get("version")
-            dynamic_tool = self.create(
-                tool_format=tool_format,
-                tool_id=tool_id,
-                tool_version=tool_version,
-                tool_path=tool_path,
-                tool_directory=tool_directory,
-                uuid=uuid,
-                active=tool_payload.active,
-                hidden=tool_payload.hidden,
-                value=representation,
-                public=True,
-            )
+                # Build a tool proxy so that we can convert to the persistable
+                # hash.
+                proxy = tool_proxy(
+                    tool_object=representation["raw_process_reference"],
+                    tool_directory=tool_directory,
+                    uuid=uuid,
+                )
+            tool_id = proxy.galaxy_id()
+        else:
+            raise Exception(f"Unknown tool format [{tool_format}] encountered.")
+        tool_version = representation.get("version")
+        dynamic_tool = self.create(
+            tool_format=tool_format,
+            tool_id=tool_id,
+            tool_version=tool_version,
+            tool_path=tool_path,
+            tool_directory=tool_directory,
+            uuid=uuid,
+            active=tool_payload.active,
+            hidden=tool_payload.hidden,
+            value=representation,
+            public=True,
+        )
         self.app.toolbox.load_dynamic_tool(dynamic_tool)
         return dynamic_tool
 

--- a/lib/galaxy/tool_util/parser/__init__.py
+++ b/lib/galaxy/tool_util/parser/__init__.py
@@ -3,7 +3,6 @@
 from .factory import (
     get_input_source,
     get_tool_source,
-    get_tool_source_from_representation,
 )
 from .interface import (
     RequiredFiles,
@@ -14,7 +13,6 @@ from .output_objects import ToolOutputCollectionPart
 __all__ = (
     "get_input_source",
     "get_tool_source",
-    "get_tool_source_from_representation",
     "RequiredFiles",
     "ToolOutputCollectionPart",
     "ToolSource",

--- a/lib/galaxy/tool_util/parser/factory.py
+++ b/lib/galaxy/tool_util/parser/factory.py
@@ -2,7 +2,6 @@
 
 import logging
 from typing import (
-    Any,
     Callable,
     Dict,
     List,
@@ -106,17 +105,6 @@ def get_tool_source(
     else:
         tree, macro_paths = load_tool_with_refereces(config_file)
         return XmlToolSource(tree, source_path=config_file, macro_paths=macro_paths)
-
-
-def get_tool_source_from_representation(tool_format: Optional[str], tool_representation: Dict[str, Any]):
-    # TODO: make sure whatever is consuming this method uses ordered load.
-    log.info("Loading dynamic tool - this is experimental - tool may not function in future.")
-    if tool_format in ("GalaxyTool", "GalaxyUserTool"):
-        if "version" not in tool_representation:
-            tool_representation["version"] = "1.0.0"  # Don't require version for embedded tools.
-        return YamlToolSource(tool_representation)
-    else:
-        raise Exception(f"Unknown tool representation format [{tool_format}].")
 
 
 def get_input_source(content, trusted: bool = True):

--- a/lib/galaxy/tool_util/parser/util.py
+++ b/lib/galaxy/tool_util/parser/util.py
@@ -61,7 +61,7 @@ def parse_tool_version_with_defaults(
             # For backward compatibility, some tools may not have versions yet.
             version = "1.0.0"
         else:
-            raise Exception(f"Missing tool 'version' for tool with id '{id}' at '{tool_source}'")
+            raise ValueError(f"Missing tool 'version' for tool with id '{id}' at '{tool_source}'")
     return version
 
 

--- a/lib/galaxy/tool_util_models/dynamic_tool_models.py
+++ b/lib/galaxy/tool_util_models/dynamic_tool_models.py
@@ -15,7 +15,6 @@ from galaxy.tool_util_models import (
 class BaseDynamicToolCreatePayload(BaseModel):
     active: Optional[bool] = None
     hidden: Optional[bool] = None
-    uuid: Optional[str] = None
 
 
 class DynamicToolCreatePayload(BaseDynamicToolCreatePayload):
@@ -23,8 +22,6 @@ class DynamicToolCreatePayload(BaseDynamicToolCreatePayload):
     representation: DynamicToolSources
     active: Optional[bool] = True
     hidden: Optional[bool] = False
-    # TODO: split out, doesn't mean anything for unprivileged tools
-    allow_load: Optional[bool] = True
 
 
 class DynamicUnprivilegedToolCreatePayload(DynamicToolCreatePayload):
@@ -35,7 +32,6 @@ class PathBasedDynamicToolCreatePayload(BaseDynamicToolCreatePayload):
     src: Literal["from_path"]
     path: str
     tool_directory: Optional[str] = None
-    allow_load: bool = True
 
 
 DynamicToolPayload = Union[DynamicToolCreatePayload, PathBasedDynamicToolCreatePayload]

--- a/lib/galaxy/webapps/galaxy/api/dynamic_tools.py
+++ b/lib/galaxy/webapps/galaxy/api/dynamic_tools.py
@@ -138,9 +138,9 @@ class DynamicToolApi:
         return dynamic_tool.to_dict()
 
     @router.post("/api/dynamic_tools", require_admin=True)
-    def create(self, payload: DynamicToolPayload, trans: ProvidesUserContext = DependsOnTrans):
+    def create(self, payload: DynamicToolPayload):
         try:
-            dynamic_tool = self.dynamic_tools_manager.create_tool(trans, payload, allow_load=payload.allow_load)
+            dynamic_tool = self.dynamic_tools_manager.create_tool(payload)
         except MessageException:
             raise
         except Exception as e:

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1900,7 +1900,7 @@ class ToolModule(WorkflowModule):
     # ---- Creating modules from various representations ---------------------
 
     @classmethod
-    def from_dict(Class, trans, d, **kwds):
+    def from_dict(Class, trans: "ProvidesUserContext", d, **kwds):
         tool_id = d.get("content_id") or d.get("tool_id")
         tool_version = d.get("tool_version")
         if tool_version:
@@ -1912,7 +1912,7 @@ class ToolModule(WorkflowModule):
                 create_request = DynamicToolCreatePayload(src="representation", representation=tool_representation)
                 if not trans.user_is_admin:
                     raise exceptions.AdminRequiredException("Only admin users can create tools dynamically.")
-                dynamic_tool = trans.app.dynamic_tool_manager.create_tool(trans, create_request, allow_load=False)
+                dynamic_tool = trans.app.dynamic_tool_manager.create_tool(create_request)
                 tool_uuid = dynamic_tool.uuid
         if tool_id is None and tool_uuid is None:
             raise exceptions.RequestParameterInvalidException(f"No content id could be located for for step [{d}]")

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1163,6 +1163,7 @@ steps:
   - label: embed1
     run:
       class: GalaxyTool
+      version: "0.1"
       command: echo 'hello world 2' > $output1
       outputs:
         output1:
@@ -8263,6 +8264,7 @@ steps:
   - label: embed1
     run:
       class: GalaxyTool
+      version: "0.1"
       command: echo 'hello world 2' > $output1
       outputs:
         output1:

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -2622,24 +2622,17 @@ class WorkflowPopulator(GalaxyInteractorHttpMixin, BaseWorkflowPopulator, Import
         return upload_response.json()
 
     def import_tool(self, tool) -> Dict[str, Any]:
-        """Import a workflow via POST /api/workflows or
-        comparable interface into Galaxy.
+        """Import a new dynamically defined tool
+
+        Required to implement ImporterGalaxyInterface.
         """
-        upload_response = self._import_tool_response(tool)
-        assert upload_response.status_code == 200, upload_response.text
-        return upload_response.json()
+        return self.dataset_populator.create_tool(tool)
 
     def build_module(self, step_type: str, content_id: Optional[str] = None, inputs: Optional[Dict[str, Any]] = None):
         payload = {"inputs": inputs or {}, "type": step_type, "content_id": content_id}
         response = self._post("workflows/build_module", data=payload, json=True)
         assert response.status_code == 200, response
         return response.json()
-
-    def _import_tool_response(self, tool) -> Response:
-        using_requirement("admin")
-        data = {"representation": tool}
-        upload_response = self._post("dynamic_tools", data=data, admin=True, json=True)
-        return upload_response
 
     def scaling_workflow_yaml(self, **kwd):
         workflow_dict = self._scale_workflow_dict(**kwd)

--- a/test/unit/app/managers/test_DynamicToolManager.py
+++ b/test/unit/app/managers/test_DynamicToolManager.py
@@ -1,0 +1,28 @@
+from galaxy.app_unittest_utils.toolbox_support import BaseToolBoxTestCase
+from galaxy.managers.tools import DynamicToolManager
+from galaxy.tool_util_models.dynamic_tool_models import DynamicToolCreatePayload
+
+
+class TestDynamicToolManager(BaseToolBoxTestCase):
+    def setUp(self):
+        super().setUp()
+        # Initialize toolbox
+        assert self.toolbox
+        self.dynamic_tool_manager = DynamicToolManager(self.app)
+        self.app.config.enable_beta_tool_formats = True
+
+    def test_create_tool(self):
+        tool_version = "0.1"
+        payload = DynamicToolCreatePayload(
+            representation={"class": "GalaxyTool", "version": tool_version, "command": "echo 42"}
+        )
+        dynamic_tool = self.dynamic_tool_manager.create_tool(payload)
+        assert dynamic_tool.active
+        assert dynamic_tool.public
+        assert dynamic_tool.tool_format == "GalaxyTool"
+        assert dynamic_tool.tool_version == tool_version
+
+    def test_create_tool_no_version(self):
+        payload = DynamicToolCreatePayload(representation={"class": "GalaxyTool", "command": "echo 42"})
+        with self.assertRaises(ValueError):
+            self.dynamic_tool_manager.create_tool(payload)


### PR DESCRIPTION
and make `create_dynamic_tool()` use it.

Also:
- Reuse `BaseDatasetPopulator.create_tool()`
- Drop now unneeded `get_tool_source_from_representation()` .
- Require version also for `GalaxyTool`s
- Drop ``uuid`` and ``allow_load`` from ``DynamicToolPayload``. Passing a UUID is unused and unnecessarily complicates the code.
- Add unit tests for `DynamicToolManager` .

Changes largely taken from the CWL branch.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
