### PR TITLE
[25.0] Make invocation errors more compact

### DIFF
--- a/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
+++ b/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
@@ -168,6 +168,14 @@ function stepClicked(nodeId: number | null) {
         scrollStepToView();
     }
 }
+
+async function activateAndShowStep(nodeId: number) {
+    activeNodeId.value = nodeId;
+    await nextTick();
+    scrollStepToView();
+}
+
+defineExpose({ activateAndShowStep });
 </script>
 
 <template>

--- a/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
+++ b/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
@@ -168,14 +168,6 @@ function stepClicked(nodeId: number | null) {
         scrollStepToView();
     }
 }
-
-async function activateAndShowStep(nodeId: number) {
-    activeNodeId.value = nodeId;
-    await nextTick();
-    scrollStepToView();
-}
-
-defineExpose({ activateAndShowStep });
 </script>
 
 <template>

--- a/client/src/components/WorkflowInvocationState/InvocationMessage.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationMessage.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
+import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed } from "vue";
 
-import type { InvocationMessage } from "@/api/invocations";
+import type { InvocationMessage, WorkflowInvocationElementView } from "@/api/invocations";
 import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
 
+import GCard from "../Common/GCard.vue";
+import WorkflowStepTitle from "./WorkflowStepTitle.vue";
 import GenericHistoryItem from "@/components/History/Content/GenericItem.vue";
-import JobInformation from "@/components/JobInformation/JobInformation.vue";
-import WorkflowInvocationStep from "@/components/WorkflowInvocationState/WorkflowInvocationStep.vue";
 
 type ReasonToLevel = {
     history_deleted: "cancel";
@@ -44,17 +46,17 @@ const levelClasses = {
     error: "errormessage",
 };
 
-interface Invocation {
-    workflow_id: string;
-    state: string;
-}
-
 interface InvocationMessageProps {
     invocationMessage: InvocationMessage;
-    invocation: Invocation;
+    invocation: WorkflowInvocationElementView;
 }
 
 const props = defineProps<InvocationMessageProps>();
+
+const emit = defineEmits<{
+    (e: "view-step", stepId: number): void;
+}>();
+
 const levelClass = computed(() => levelClasses[level[props.invocationMessage.reason]]);
 
 const workflow = computed(() => {
@@ -76,6 +78,12 @@ const workflowStep = computed(() => {
     }
     return undefined;
 });
+const invocationStep = computed(() => {
+    if (workflowStep.value) {
+        return props.invocation.steps[workflowStep.value.id];
+    }
+    return undefined;
+});
 
 const dependentWorkflowStep = computed(() => {
     if ("dependent_workflow_step_id" in props.invocationMessage && workflow.value) {
@@ -83,6 +91,12 @@ const dependentWorkflowStep = computed(() => {
         if (stepId !== undefined && stepId !== null) {
             return workflow.value.steps[stepId];
         }
+    }
+    return undefined;
+});
+const dependentInvocationStep = computed(() => {
+    if (dependentWorkflowStep.value) {
+        return props.invocation.steps[dependentWorkflowStep.value.id];
     }
     return undefined;
 });
@@ -175,6 +189,11 @@ const infoString = computed(() => {
         return reason;
     }
 });
+
+function openJobInNewTab(jobId: string) {
+    const url = `/jobs/${jobId}/view`;
+    window.open(url, "_blank");
+}
 </script>
 
 <template>
@@ -182,31 +201,62 @@ const infoString = computed(() => {
         <div :class="levelClass" style="text-align: center">
             {{ infoString }}
         </div>
-        <div v-if="dependentWorkflowStep">
-            Problem occurred at this step:
-            <WorkflowInvocationStep
-                :invocation="invocation"
-                :workflow="workflow"
-                :workflow-step="dependentWorkflowStep"></WorkflowInvocationStep>
-        </div>
-        <div v-if="workflowStep">
-            {{ stepDescription }}
-            <WorkflowInvocationStep
-                :invocation="invocation"
-                :workflow="workflow"
-                :workflow-step="workflowStep"></WorkflowInvocationStep>
-        </div>
-        <div v-if="HdaId">
-            This dataset failed:
-            <GenericHistoryItem :item-id="HdaId" item-src="hda" />
-        </div>
-        <div v-if="HdcaId">
-            This dataset collection failed:
-            <GenericHistoryItem :item-id="HdcaId" item-src="hdca" />
-        </div>
-        <div v-if="jobId">
-            This job failed:
-            <JobInformation :job_id="jobId" />
+        <div class="invocation-error-grid d-flex flex-wrap">
+            <GCard
+                v-if="dependentWorkflowStep"
+                clickable
+                grid-view
+                @click="emit('view-step', dependentWorkflowStep.id)">
+                Problem occurred at this step:
+                <strong>
+                    <WorkflowStepTitle
+                        :step-index="dependentWorkflowStep.id"
+                        :step-label="
+                            dependentInvocationStep?.workflow_step_label || `Step ${dependentWorkflowStep.id + 1}`
+                        "
+                        :step-type="dependentWorkflowStep.type"
+                        :step-tool-id="dependentWorkflowStep.tool_id || undefined"
+                        :step-subworkflow-id="
+                            'workflow_id' in dependentWorkflowStep ? dependentWorkflowStep.workflow_id : undefined
+                        " />
+                </strong>
+            </GCard>
+            <GCard v-if="workflowStep" clickable grid-view @click="emit('view-step', workflowStep.id)">
+                {{ stepDescription }}:
+                <strong>
+                    <WorkflowStepTitle
+                        :step-index="workflowStep.id"
+                        :step-label="invocationStep?.workflow_step_label || `Step ${workflowStep.id + 1}`"
+                        :step-type="workflowStep.type"
+                        :step-tool-id="workflowStep.tool_id || undefined"
+                        :step-subworkflow-id="'workflow_id' in workflowStep ? workflowStep.workflow_id : undefined" />
+                </strong>
+            </GCard>
+            <GCard v-if="HdaId" grid-view>
+                This dataset failed:
+                <GenericHistoryItem :item-id="HdaId" item-src="hda" />
+            </GCard>
+            <GCard v-if="HdcaId" grid-view>
+                This dataset collection failed:
+                <GenericHistoryItem :item-id="HdcaId" item-src="hdca" />
+            </GCard>
+            <GCard v-if="jobId" clickable grid-view @click="openJobInNewTab(jobId)">
+                <span>
+                    This job failed: <strong> {{ jobId }} </strong>
+                </span>
+                <i>
+                    Click to view job details in a new tab
+                    <FontAwesomeIcon :icon="faExternalLinkAlt" />
+                </i>
+            </GCard>
         </div>
     </div>
 </template>
+
+<style scoped lang="scss">
+@import "_breakpoints.scss";
+
+.invocation-error-grid {
+    container: cards-list / inline-size;
+}
+</style>

--- a/client/src/components/WorkflowInvocationState/InvocationMessage.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationMessage.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { storeToRefs } from "pinia";
 import { computed } from "vue";
 
 import type { InvocationMessage, WorkflowInvocationElementView } from "@/api/invocations";
 import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
+import { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
 
 import GCard from "../Common/GCard.vue";
 import WorkflowStepTitle from "./WorkflowStepTitle.vue";
@@ -100,6 +102,11 @@ const dependentInvocationStep = computed(() => {
     }
     return undefined;
 });
+
+// This is used to indicate on the step cards whether the step is currently active in the invocation graph.\
+const storeId = computed(() => `invocation-${props.invocation.id}`);
+const stateStore = useWorkflowStateStore(storeId.value);
+const { activeNodeId } = storeToRefs(stateStore);
 
 const jobId = computed(() => "job_id" in props.invocationMessage && props.invocationMessage.job_id);
 const HdaId = computed(() => "hda_id" in props.invocationMessage && props.invocationMessage.hda_id);
@@ -205,6 +212,7 @@ function openJobInNewTab(jobId: string) {
             <GCard
                 v-if="dependentWorkflowStep"
                 clickable
+                :current="activeNodeId === dependentWorkflowStep.id"
                 grid-view
                 @click="emit('view-step', dependentWorkflowStep.id)">
                 Problem occurred at this step:
@@ -221,7 +229,12 @@ function openJobInNewTab(jobId: string) {
                         " />
                 </strong>
             </GCard>
-            <GCard v-if="workflowStep" clickable grid-view @click="emit('view-step', workflowStep.id)">
+            <GCard
+                v-if="workflowStep"
+                clickable
+                :current="activeNodeId === workflowStep.id"
+                grid-view
+                @click="emit('view-step', workflowStep.id)">
                 {{ stepDescription }}:
                 <strong>
                     <WorkflowStepTitle

--- a/client/src/components/WorkflowInvocationState/InvocationMessage.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationMessage.vue
@@ -223,9 +223,9 @@ function openJobInNewTab(jobId: string) {
                             dependentInvocationStep?.workflow_step_label || `Step ${dependentWorkflowStep.id + 1}`
                         "
                         :step-type="dependentWorkflowStep.type"
-                        :step-tool-id="dependentWorkflowStep.tool_id || undefined"
+                        :step-tool-id="dependentWorkflowStep.tool_id"
                         :step-subworkflow-id="
-                            'workflow_id' in dependentWorkflowStep ? dependentWorkflowStep.workflow_id : undefined
+                            'workflow_id' in dependentWorkflowStep ? dependentWorkflowStep.workflow_id : null
                         " />
                 </strong>
             </GCard>
@@ -241,8 +241,8 @@ function openJobInNewTab(jobId: string) {
                         :step-index="workflowStep.id"
                         :step-label="invocationStep?.workflow_step_label || `Step ${workflowStep.id + 1}`"
                         :step-type="workflowStep.type"
-                        :step-tool-id="workflowStep.tool_id || undefined"
-                        :step-subworkflow-id="'workflow_id' in workflowStep ? workflowStep.workflow_id : undefined" />
+                        :step-tool-id="workflowStep.tool_id"
+                        :step-subworkflow-id="'workflow_id' in workflowStep ? workflowStep.workflow_id : null" />
                 </strong>
             </GCard>
             <GCard v-if="HdaId" grid-view>

--- a/client/src/components/WorkflowInvocationState/InvocationMessage.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationMessage.vue
@@ -51,6 +51,7 @@ const levelClasses = {
 interface InvocationMessageProps {
     invocationMessage: InvocationMessage;
     invocation: WorkflowInvocationElementView;
+    storeId: string;
 }
 
 const props = defineProps<InvocationMessageProps>();
@@ -104,9 +105,7 @@ const dependentInvocationStep = computed(() => {
 });
 
 // This is used to indicate on the step cards whether the step is currently active in the invocation graph.\
-const storeId = computed(() => `invocation-${props.invocation.id}`);
-const stateStore = useWorkflowStateStore(storeId.value);
-const { activeNodeId } = storeToRefs(stateStore);
+const { activeNodeId } = storeToRefs(useWorkflowStateStore(props.storeId));
 
 const jobId = computed(() => "job_id" in props.invocationMessage && props.invocationMessage.job_id);
 const HdaId = computed(() => "hda_id" in props.invocationMessage && props.invocationMessage.hda_id);

--- a/client/src/components/WorkflowInvocationState/WorkflowStepTitle.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowStepTitle.vue
@@ -11,8 +11,8 @@ interface WorkflowInvocationStepTitleProps {
     stepIndex: number;
     stepLabel?: string;
     stepType: string;
-    stepToolId?: string;
-    stepSubworkflowId?: string;
+    stepToolId?: string | null;
+    stepSubworkflowId?: string | null;
 }
 
 const props = defineProps<WorkflowInvocationStepTitleProps>();


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20243

## Before:

https://github.com/user-attachments/assets/62413709-2344-4c59-832e-5192b94791bf

## After:

https://github.com/user-attachments/assets/941bec65-7316-43f2-bf73-bdd855309123

### Minor additional change: The workflow step cards are synced with the invocation graph:

![sync_invocation_error_below_graph_SYNC_NODE](https://github.com/user-attachments/assets/9706e65b-96d8-4e9b-bb09-4f353425db2b)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
