### PR TITLE
Decouple visualization installation from the client build process

### DIFF
--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -4,6 +4,250 @@
  */
 
 export interface paths {
+    "/api/admin/visualizations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List all installed visualization packages.
+         * @description Return a list of all installed visualization packages with their status.
+         */
+        get: operations["index_api_admin_visualizations_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/visualizations/available": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List available visualization packages from npm registry.
+         * @description Return a list of available @galaxyproject visualization packages from npm registry.
+         */
+        get: operations["available_api_admin_visualizations_available_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/visualizations/reload": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reload the visualization registry.
+         * @description Reload the visualization registry to pick up configuration changes.
+         */
+        post: operations["reload_api_admin_visualizations_reload_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/visualizations/stage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Stage all visualization assets.
+         * @description Stage all visualization assets from config/plugins to static/plugins for Galaxy to serve.
+         */
+        post: operations["stage_all_api_admin_visualizations_stage_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/visualizations/staged": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Clean all staged visualization assets.
+         * @description Clean all staged visualization assets from static/plugins.
+         */
+        delete: operations["clean_staged_api_admin_visualizations_staged_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/visualizations/staging_status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get staging status information.
+         * @description Get information about currently staged visualizations.
+         */
+        get: operations["staging_status_api_admin_visualizations_staging_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/visualizations/usage_stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get usage statistics for visualizations.
+         * @description Return usage statistics for installed visualizations.
+         */
+        get: operations["usage_stats_api_admin_visualizations_usage_stats_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/visualizations/{viz_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get details for a specific visualization package.
+         * @description Return detailed information about a specific visualization package.
+         */
+        get: operations["show_api_admin_visualizations__viz_id__get"];
+        put?: never;
+        post?: never;
+        /**
+         * Uninstall a visualization package.
+         * @description Uninstall a visualization package and clean up its assets.
+         */
+        delete: operations["uninstall_api_admin_visualizations__viz_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/visualizations/{viz_id}/install": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Install a visualization package.
+         * @description Install a visualization package from npm registry.
+         */
+        post: operations["install_api_admin_visualizations__viz_id__install_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/visualizations/{viz_id}/stage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Stage assets for a specific visualization.
+         * @description Stage assets for a specific visualization from config/plugins to static/plugins.
+         */
+        post: operations["stage_visualization_api_admin_visualizations__viz_id__stage_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/visualizations/{viz_id}/toggle": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Enable or disable a visualization package.
+         * @description Enable or disable a visualization package without uninstalling it.
+         */
+        put: operations["toggle_api_admin_visualizations__viz_id__toggle_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/visualizations/{viz_id}/update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Update a visualization package to a new version.
+         * @description Update an installed visualization package to a new version.
+         */
+        put: operations["update_api_admin_visualizations__viz_id__update_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/ai/agents": {
         parameters: {
             query?: never;
@@ -7965,6 +8209,57 @@ export interface components {
              */
             specialties?: string[];
         };
+        /** AvailableVisualizationListResponse */
+        AvailableVisualizationListResponse: components["schemas"]["AvailableVisualizationResponse"][];
+        /** AvailableVisualizationResponse */
+        AvailableVisualizationResponse: {
+            /** Author */
+            author?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Date
+             * @description Last publish date.
+             */
+            date?: string | null;
+            /**
+             * Description
+             * @description Package description.
+             * @default
+             */
+            description: string;
+            /** Keywords */
+            keywords?: string[];
+            /**
+             * Links
+             * @description Homepage, repository, etc.
+             */
+            links?: {
+                [key: string]: unknown;
+            } | null;
+            /** Maintainers */
+            maintainers?: {
+                [key: string]: unknown;
+            }[];
+            /**
+             * Name
+             * @description The npm package name.
+             */
+            name: string;
+            /**
+             * Score
+             * @description NPM search score.
+             */
+            score?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Version
+             * @description Latest published version.
+             * @default
+             */
+            version: string;
+        };
         /** BadgeDict */
         BadgeDict: {
             /** Message */
@@ -8733,6 +9028,15 @@ export interface components {
         ClaimLandingPayload: {
             /** Client Secret */
             client_secret?: string | null;
+        };
+        /** CleanStagingResultResponse */
+        CleanStagingResultResponse: {
+            /** Cleaned Count */
+            cleaned_count: number;
+            /** Cleaned Items */
+            cleaned_items?: string[];
+            /** Message */
+            message: string;
         };
         /** CleanableItemsSummary */
         CleanableItemsSummary: {
@@ -16325,6 +16629,19 @@ export interface components {
              */
             step_output: string;
         };
+        /** InstallVisualizationRequest */
+        InstallVisualizationRequest: {
+            /**
+             * Package
+             * @description The npm package name to install.
+             */
+            package: string;
+            /**
+             * Version
+             * @description The package version to install.
+             */
+            version: string;
+        };
         /** InstalledRepositoryToolShedStatus */
         InstalledRepositoryToolShedStatus: {
             /**
@@ -16401,6 +16718,58 @@ export interface components {
             tool_shed_status?: components["schemas"]["InstalledRepositoryToolShedStatus"] | null;
             /** Uninstalled */
             uninstalled: boolean;
+        };
+        /** InstalledVisualizationListResponse */
+        InstalledVisualizationListResponse: components["schemas"]["InstalledVisualizationResponse"][];
+        /** InstalledVisualizationResponse */
+        InstalledVisualizationResponse: {
+            /**
+             * Enabled
+             * @description Whether this visualization is enabled.
+             */
+            enabled: boolean;
+            /**
+             * ID
+             * @description The visualization identifier.
+             */
+            id: string;
+            /**
+             * Installed
+             * @description Whether files are present on disk.
+             */
+            installed: boolean;
+            /**
+             * Message
+             * @description Status message.
+             */
+            message?: string | null;
+            /**
+             * Metadata
+             * @description Package metadata from package.json.
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Package
+             * @description The npm package name.
+             */
+            package: string;
+            /**
+             * Path
+             * @description Filesystem path to the installed package.
+             */
+            path?: string | null;
+            /**
+             * Size
+             * @description Total size in bytes.
+             */
+            size?: number | null;
+            /**
+             * Version
+             * @description The installed package version.
+             */
+            version: string;
         };
         /** IntegerParameterModel */
         IntegerParameterModel: {
@@ -19213,6 +19582,11 @@ export interface components {
              * @description The subject of the notification.
              */
             subject: string;
+        };
+        /** MessageResponse */
+        MessageResponse: {
+            /** Message */
+            message: string;
         };
         /**
          * MetadataFile
@@ -22708,6 +23082,42 @@ export interface components {
          * @enum {string}
          */
         Src: "url" | "pasted" | "files" | "path" | "composite" | "ftp_import" | "server_dir";
+        /** StagedVisualizationInfo */
+        StagedVisualizationInfo: {
+            /** Last Modified */
+            last_modified: number;
+            /** Name */
+            name: string;
+            /** Path */
+            path: string;
+            /** Size */
+            size: number;
+        };
+        /** StagingResultResponse */
+        StagingResultResponse: {
+            /** Errors */
+            errors?: string[];
+            /** Message */
+            message: string;
+            /** Staged Count */
+            staged_count: number;
+            /** Staged Visualizations */
+            staged_visualizations?: string[];
+        };
+        /** StagingStatusResponse */
+        StagingStatusResponse: {
+            /** Message */
+            message: string;
+            /** Staged Count */
+            staged_count: number;
+            /** Staged Visualizations */
+            staged_visualizations?: components["schemas"]["StagedVisualizationInfo"][];
+            /**
+             * Total Size
+             * @default 0
+             */
+            total_size: number;
+        };
         /**
          * State
          * @enum {string}
@@ -24065,6 +24475,23 @@ export interface components {
             /** Value */
             value?: string | null;
         };
+        /** ToggleVisualizationRequest */
+        ToggleVisualizationRequest: {
+            /**
+             * Enabled
+             * @description Whether to enable or disable the visualization.
+             */
+            enabled: boolean;
+        };
+        /** ToggleVisualizationResponse */
+        ToggleVisualizationResponse: {
+            /** Enabled */
+            enabled: boolean;
+            /** ID */
+            id: string;
+            /** Message */
+            message: string;
+        };
         /** ToolDataDetails */
         ToolDataDetails: {
             /**
@@ -25049,6 +25476,14 @@ export interface components {
                 [key: string]: components["schemas"]["NotificationCategorySettings"];
             };
         };
+        /** UpdateVisualizationRequest */
+        UpdateVisualizationRequest: {
+            /**
+             * Version
+             * @description The new version to update to.
+             */
+            version: string;
+        };
         /** UpgradeAllStepsAction */
         UpgradeAllStepsAction: {
             /**
@@ -25227,6 +25662,17 @@ export interface components {
              * @description URL to upload
              */
             url: string;
+        };
+        /** UsageStatsResponse */
+        UsageStatsResponse: {
+            /** Days */
+            days: number;
+            /** Message */
+            message: string;
+            /** Stats */
+            stats?: {
+                [key: string]: unknown;
+            };
         };
         /** UserBeaconSetting */
         UserBeaconSetting: {
@@ -26192,6 +26638,22 @@ export interface components {
              * @description The name of the user owning this Visualization.
              */
             username: string;
+        };
+        /** VisualizationStagingResultResponse */
+        VisualizationStagingResultResponse: {
+            /** Message */
+            message: string;
+            /**
+             * Size
+             * @default 0
+             */
+            size: number;
+            /** Source Path */
+            source_path: string;
+            /** Target Path */
+            target_path: string;
+            /** Visualization ID */
+            visualization_id: string;
         };
         /** VisualizationSummary */
         VisualizationSummary: {
@@ -31027,6 +31489,576 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    index_api_admin_visualizations_get: {
+        parameters: {
+            query?: {
+                /** @description Whether to include disabled visualizations in the result. */
+                include_disabled?: boolean;
+            };
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InstalledVisualizationListResponse"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    available_api_admin_visualizations_available_get: {
+        parameters: {
+            query?: {
+                /** @description Filter available packages by name or description. */
+                search?: string | null;
+            };
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AvailableVisualizationListResponse"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    reload_api_admin_visualizations_reload_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageResponse"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    stage_all_api_admin_visualizations_stage_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StagingResultResponse"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    clean_staged_api_admin_visualizations_staged_delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CleanStagingResultResponse"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    staging_status_api_admin_visualizations_staging_status_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StagingStatusResponse"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    usage_stats_api_admin_visualizations_usage_stats_get: {
+        parameters: {
+            query?: {
+                /** @description Number of days to look back for usage statistics */
+                days?: number;
+            };
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UsageStatsResponse"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    show_api_admin_visualizations__viz_id__get: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The identifier of the visualization package. */
+                viz_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InstalledVisualizationResponse"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    uninstall_api_admin_visualizations__viz_id__delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The identifier of the visualization package. */
+                viz_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    install_api_admin_visualizations__viz_id__install_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The identifier of the visualization package. */
+                viz_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InstallVisualizationRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InstalledVisualizationResponse"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    stage_visualization_api_admin_visualizations__viz_id__stage_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The identifier of the visualization package. */
+                viz_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VisualizationStagingResultResponse"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    toggle_api_admin_visualizations__viz_id__toggle_put: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The identifier of the visualization package. */
+                viz_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ToggleVisualizationRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ToggleVisualizationResponse"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    update_api_admin_visualizations__viz_id__update_put: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The identifier of the visualization package. */
+                viz_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateVisualizationRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InstalledVisualizationResponse"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
     list_agents_api_ai_agents_get: {
         parameters: {
             query?: never;

--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -144,6 +144,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/visualizations/versions/{package_name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get available versions for an npm package.
+         * @description Return available versions for a specific npm package.
+         */
+        get: operations["package_versions_api_admin_visualizations_versions__package_name__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/visualizations/{viz_id}": {
         parameters: {
             query?: never;
@@ -20206,6 +20226,19 @@ export interface components {
              */
             output_name: string | null;
         };
+        /** PackageVersionsResponse */
+        PackageVersionsResponse: {
+            /**
+             * Package
+             * @description The npm package name.
+             */
+            package: string;
+            /**
+             * Versions
+             * @description Available versions, newest first.
+             */
+            versions?: string[];
+        };
         /**
          * PageContentFormat
          * @enum {string}
@@ -31763,6 +31796,50 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["UsageStatsResponse"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    package_versions_api_admin_visualizations_versions__package_name__get: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The npm package name (e.g., @galaxyproject/circster). */
+                package_name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PackageVersionsResponse"];
                 };
             };
             /** @description Request Error */

--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -75,7 +75,7 @@ export interface paths {
         put?: never;
         /**
          * Stage all visualization assets.
-         * @description Stage all visualization assets from config/plugins to static/plugins for Galaxy to serve.
+         * @description Stage all visualization assets into Galaxy's static serving directory.
          */
         post: operations["stage_all_api_admin_visualizations_stage_post"];
         delete?: never;
@@ -219,7 +219,7 @@ export interface paths {
         put?: never;
         /**
          * Stage assets for a specific visualization.
-         * @description Stage assets for a specific visualization from config/plugins to static/plugins.
+         * @description Stage assets for a specific visualization into Galaxy's static serving directory.
          */
         post: operations["stage_visualization_api_admin_visualizations__viz_id__stage_post"];
         delete?: never;

--- a/client/src/components/admin/AdminHome.vue
+++ b/client/src/components/admin/AdminHome.vue
@@ -55,6 +55,13 @@
                 </strong>
                 - Manage the notifications and broadcast messages that are displayed to users.
             </li>
+            <li>
+                <strong>
+                    <router-link to="/admin/visualizations">Visualizations</router-link>
+                </strong>
+                - Install and manage visualization packages. Add new visualizations from npm registry and stage assets
+                for Galaxy to serve.
+            </li>
         </ul>
 
         <Heading h2 :icon="faUser" size="md">User Management</Heading>

--- a/client/src/components/admin/AdminPanel.vue
+++ b/client/src/components/admin/AdminPanel.vue
@@ -55,6 +55,11 @@ const sections = computed(() => {
                     title: "Notifications and Broadcasts",
                     route: "/admin/notifications",
                 },
+                {
+                    id: "admin-link-visualizations",
+                    title: "Visualizations",
+                    route: "/admin/visualizations",
+                },
             ],
         },
         {

--- a/client/src/components/admin/Visualizations/AvailableVisualizationCard.vue
+++ b/client/src/components/admin/Visualizations/AvailableVisualizationCard.vue
@@ -1,0 +1,123 @@
+<template>
+    <b-card class="available-visualization-card">
+        <div class="d-flex justify-content-between align-items-start">
+            <div class="flex-grow-1">
+                <div class="d-flex align-items-center mb-2">
+                    <h5 class="mb-0 mr-2">{{ packageData.name }}</h5>
+                    <b-badge variant="info" class="mr-2">v{{ packageData.version }}</b-badge>
+                    <b-badge v-if="isInstalled" variant="success">Installed</b-badge>
+                </div>
+
+                <p v-if="packageData.description" class="text-muted mb-2">
+                    {{ packageData.description }}
+                </p>
+
+                <div class="small text-muted mb-2">
+                    <div class="d-flex flex-wrap">
+                        <span v-if="packageData.keywords?.length" class="mr-3">
+                            <strong>Keywords:</strong> {{ packageData.keywords.join(", ") }}
+                        </span>
+                        <span v-if="packageData.modified" class="mr-3">
+                            <strong>Last Updated:</strong> {{ formatDate(packageData.modified) }}
+                        </span>
+                    </div>
+                </div>
+
+                <div v-if="packageData.maintainers?.length" class="small text-muted mb-2">
+                    <strong>Maintainers:</strong>
+                    <span v-for="(maintainer, index) in packageData.maintainers" :key="`maintainer-${index}`">
+                        {{ maintainer.username || maintainer.email
+                        }}{{ index < packageData.maintainers.length - 1 ? ", " : "" }}
+                    </span>
+                </div>
+
+                <div class="small">
+                    <a
+                        v-if="packageData.homepage"
+                        :href="packageData.homepage"
+                        target="_blank"
+                        rel="noopener"
+                        class="mr-3">
+                        Homepage <i class="fa fa-external-link-alt fa-sm"></i>
+                    </a>
+                    <a v-if="packageData.repository" :href="packageData.repository" target="_blank" rel="noopener">
+                        Repository <i class="fa fa-external-link-alt fa-sm"></i>
+                    </a>
+                </div>
+            </div>
+
+            <div class="ml-3">
+                <b-button
+                    v-if="!isInstalled"
+                    variant="primary"
+                    size="sm"
+                    :disabled="isLoading"
+                    @click="$emit('install', packageData)">
+                    <b-spinner v-if="isLoading" small></b-spinner>
+                    <i v-else class="fa fa-download mr-1"></i>
+                    Install
+                </b-button>
+
+                <b-button v-else variant="outline-success" size="sm" disabled>
+                    <i class="fa fa-check mr-1"></i>
+                    Installed
+                </b-button>
+            </div>
+        </div>
+    </b-card>
+</template>
+
+<script>
+export default {
+    name: "AvailableVisualizationCard",
+
+    props: {
+        packageData: {
+            type: Object,
+            required: true,
+        },
+        installedVisualizations: {
+            type: Array,
+            default: () => [],
+        },
+        loadingActions: {
+            type: Set,
+            default: () => new Set(),
+        },
+    },
+
+    computed: {
+        isInstalled() {
+            return this.installedVisualizations.some((viz) => viz.package === this.visualization.name);
+        },
+
+        isLoading() {
+            return this.loadingActions.has(`install-${this.visualization.name}`);
+        },
+    },
+
+    methods: {
+        formatDate(dateString) {
+            try {
+                return new Date(dateString).toLocaleDateString();
+            } catch {
+                return dateString;
+            }
+        },
+    },
+};
+</script>
+
+<style scoped>
+.available-visualization-card {
+    transition: box-shadow 0.15s ease-in-out;
+}
+
+.available-visualization-card:hover {
+    box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+}
+
+.badge {
+    font-size: 0.75em;
+}
+</style>

--- a/client/src/components/admin/Visualizations/AvailableVisualizationCard.vue
+++ b/client/src/components/admin/Visualizations/AvailableVisualizationCard.vue
@@ -34,7 +34,7 @@
                 <div class="small">
                     <a
                         v-if="packageData.links?.homepage"
-                        :href="packageData.links.homepage"
+                        :href="String(packageData.links.homepage)"
                         target="_blank"
                         rel="noopener"
                         class="mr-3">
@@ -42,7 +42,7 @@
                     </a>
                     <a
                         v-if="packageData.links?.repository"
-                        :href="packageData.links.repository"
+                        :href="String(packageData.links.repository)"
                         target="_blank"
                         rel="noopener">
                         Repository <FontAwesomeIcon :icon="faExternalLinkAlt" size="sm" />

--- a/client/src/components/admin/Visualizations/AvailableVisualizationCard.vue
+++ b/client/src/components/admin/Visualizations/AvailableVisualizationCard.vue
@@ -88,11 +88,11 @@ export default {
 
     computed: {
         isInstalled() {
-            return this.installedVisualizations.some((viz) => viz.package === this.visualization.name);
+            return this.installedVisualizations.some((viz) => viz.package === this.packageData.name);
         },
 
         isLoading() {
-            return this.loadingActions.has(`install-${this.visualization.name}`);
+            return this.loadingActions.has(`install-${this.packageData.name}`);
         },
     },
 

--- a/client/src/components/admin/Visualizations/AvailableVisualizationCard.vue
+++ b/client/src/components/admin/Visualizations/AvailableVisualizationCard.vue
@@ -17,8 +17,8 @@
                         <span v-if="packageData.keywords?.length" class="mr-3">
                             <strong>Keywords:</strong> {{ packageData.keywords.join(", ") }}
                         </span>
-                        <span v-if="packageData.modified" class="mr-3">
-                            <strong>Last Updated:</strong> {{ formatDate(packageData.modified) }}
+                        <span v-if="packageData.date" class="mr-3">
+                            <strong>Last Updated:</strong> {{ formatDate(packageData.date) }}
                         </span>
                     </div>
                 </div>
@@ -33,15 +33,19 @@
 
                 <div class="small">
                     <a
-                        v-if="packageData.homepage"
-                        :href="packageData.homepage"
+                        v-if="packageData.links?.homepage"
+                        :href="packageData.links.homepage"
                         target="_blank"
                         rel="noopener"
                         class="mr-3">
-                        Homepage <i class="fa fa-external-link-alt fa-sm"></i>
+                        Homepage <FontAwesomeIcon :icon="faExternalLinkAlt" size="sm" />
                     </a>
-                    <a v-if="packageData.repository" :href="packageData.repository" target="_blank" rel="noopener">
-                        Repository <i class="fa fa-external-link-alt fa-sm"></i>
+                    <a
+                        v-if="packageData.links?.repository"
+                        :href="packageData.links.repository"
+                        target="_blank"
+                        rel="noopener">
+                        Repository <FontAwesomeIcon :icon="faExternalLinkAlt" size="sm" />
                     </a>
                 </div>
             </div>
@@ -52,14 +56,14 @@
                     variant="primary"
                     size="sm"
                     :disabled="isLoading"
-                    @click="$emit('install', packageData)">
-                    <b-spinner v-if="isLoading" small></b-spinner>
-                    <i v-else class="fa fa-download mr-1"></i>
+                    @click="emit('install', packageData)">
+                    <b-spinner v-if="isLoading" small />
+                    <FontAwesomeIcon v-else :icon="faDownload" class="mr-1" />
                     Install
                 </b-button>
 
                 <b-button v-else variant="outline-success" size="sm" disabled>
-                    <i class="fa fa-check mr-1"></i>
+                    <FontAwesomeIcon :icon="faCheck" class="mr-1" />
                     Installed
                 </b-button>
             </div>
@@ -67,45 +71,43 @@
     </b-card>
 </template>
 
-<script>
-export default {
-    name: "AvailableVisualizationCard",
+<script setup lang="ts">
+import { faCheck, faDownload, faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { computed } from "vue";
 
-    props: {
-        packageData: {
-            type: Object,
-            required: true,
-        },
-        installedVisualizations: {
-            type: Array,
-            default: () => [],
-        },
-        loadingActions: {
-            type: Set,
-            default: () => new Set(),
-        },
-    },
+import type { AvailableVisualization, Visualization } from "./services";
 
-    computed: {
-        isInstalled() {
-            return this.installedVisualizations.some((viz) => viz.package === this.packageData.name);
-        },
+interface Props {
+    packageData: AvailableVisualization;
+    installedPackages?: Visualization[];
+    loadingActions?: Record<string, boolean>;
+}
 
-        isLoading() {
-            return this.loadingActions.has(`install-${this.packageData.name}`);
-        },
-    },
+const props = withDefaults(defineProps<Props>(), {
+    installedPackages: () => [],
+    loadingActions: () => ({}),
+});
 
-    methods: {
-        formatDate(dateString) {
-            try {
-                return new Date(dateString).toLocaleDateString();
-            } catch {
-                return dateString;
-            }
-        },
-    },
-};
+const emit = defineEmits<{
+    (e: "install", packageData: AvailableVisualization): void;
+}>();
+
+const isInstalled = computed(() => {
+    return props.installedPackages.some((viz) => viz.package === props.packageData.name);
+});
+
+const isLoading = computed(() => {
+    return !!props.loadingActions[`install-${props.packageData.name}`];
+});
+
+function formatDate(dateString: string) {
+    try {
+        return new Date(dateString).toLocaleDateString();
+    } catch {
+        return dateString;
+    }
+}
 </script>
 
 <style scoped>
@@ -115,9 +117,5 @@ export default {
 
 .available-visualization-card:hover {
     box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
-}
-
-.badge {
-    font-size: 0.75em;
 }
 </style>

--- a/client/src/components/admin/Visualizations/InstallVisualizationModal.vue
+++ b/client/src/components/admin/Visualizations/InstallVisualizationModal.vue
@@ -1,0 +1,117 @@
+<template>
+    <b-modal
+        :visible="show"
+        title="Install Visualization"
+        :ok-disabled="!visualizationId || installing"
+        :ok-title="installing ? 'Installing...' : 'Install'"
+        @hidden="$emit('cancel')"
+        @ok="handleInstall">
+        <div v-if="installing" class="text-center">
+            <b-spinner label="Installing..."></b-spinner>
+            <p class="mt-2">Installing visualization package...</p>
+            <p class="small text-muted">This may take a few minutes...</p>
+        </div>
+
+        <div v-else-if="visualization">
+            <div class="mb-3">
+                <h5>{{ visualization.name }}</h5>
+                <p v-if="visualization.description" class="text-muted">{{ visualization.description }}</p>
+                <div class="small"><strong>Version:</strong> {{ visualization.version }}</div>
+            </div>
+
+            <b-form-group
+                label="Visualization ID:"
+                label-for="viz-id-input"
+                description="Choose a unique identifier for this visualization in Galaxy">
+                <b-form-input
+                    id="viz-id-input"
+                    v-model="visualizationId"
+                    :placeholder="suggestedId"
+                    :state="visualizationId ? (isValidId ? true : false) : null"
+                    @input="validateId"></b-form-input>
+                <b-form-invalid-feedback v-if="!isValidId">
+                    ID must contain only letters, numbers, and underscores
+                </b-form-invalid-feedback>
+            </b-form-group>
+
+            <b-alert v-if="idConflict" variant="warning" show>
+                <i class="fa fa-exclamation-triangle mr-1"></i>
+                A visualization with this ID already exists and will be overwritten.
+            </b-alert>
+        </div>
+    </b-modal>
+</template>
+
+<script>
+export default {
+    name: "InstallVisualizationModal",
+
+    props: {
+        show: {
+            type: Boolean,
+            default: false,
+        },
+        visualization: {
+            type: Object,
+            default: null,
+        },
+        installing: {
+            type: Boolean,
+            default: false,
+        },
+        installedVisualizations: {
+            type: Array,
+            default: () => [],
+        },
+    },
+
+    data() {
+        return {
+            visualizationId: "",
+        };
+    },
+
+    computed: {
+        suggestedId() {
+            if (!this.visualization) {
+                return "";
+            }
+            // Extract name from scoped package (e.g., @galaxyproject/foo -> foo)
+            const name = this.visualization.name.includes("/")
+                ? this.visualization.name.split("/").pop()
+                : this.visualization.name;
+            return name.replace(/[^a-zA-Z0-9_]/g, "_");
+        },
+
+        isValidId() {
+            return /^[a-zA-Z0-9_]+$/.test(this.visualizationId);
+        },
+
+        idConflict() {
+            return this.installedVisualizations?.some((viz) => viz.id === this.visualizationId);
+        },
+    },
+
+    watch: {
+        show(isShown) {
+            if (isShown && this.visualization) {
+                this.visualizationId = this.suggestedId;
+            } else if (!isShown) {
+                this.visualizationId = "";
+            }
+        },
+    },
+
+    methods: {
+        handleInstall() {
+            if (this.visualizationId && this.isValidId) {
+                this.$emit("confirm", this.visualizationId);
+            }
+        },
+
+        validateId() {
+            // Called on input change to trigger validation
+        },
+    },
+};
+</script>

--- a/client/src/components/admin/Visualizations/InstallVisualizationModal.vue
+++ b/client/src/components/admin/Visualizations/InstallVisualizationModal.vue
@@ -35,7 +35,7 @@
 
             <BAlert v-if="idConflict" variant="warning" show>
                 <FontAwesomeIcon :icon="faExclamationTriangle" class="mr-1" />
-                A visualization with this ID already exists and will be overwritten.
+                A visualization with this ID is already installed. Installing will replace it.
             </BAlert>
         </div>
     </b-modal>

--- a/client/src/components/admin/Visualizations/InstallVisualizationModal.vue
+++ b/client/src/components/admin/Visualizations/InstallVisualizationModal.vue
@@ -4,19 +4,19 @@
         title="Install Visualization"
         :ok-disabled="!visualizationId || installing"
         :ok-title="installing ? 'Installing...' : 'Install'"
-        @hidden="$emit('cancel')"
+        @hidden="emit('cancel')"
         @ok="handleInstall">
         <div v-if="installing" class="text-center">
-            <b-spinner label="Installing..."></b-spinner>
+            <b-spinner label="Installing..." />
             <p class="mt-2">Installing visualization package...</p>
             <p class="small text-muted">This may take a few minutes...</p>
         </div>
 
-        <div v-else-if="visualization">
+        <div v-else-if="packageData">
             <div class="mb-3">
-                <h5>{{ visualization.name }}</h5>
-                <p v-if="visualization.description" class="text-muted">{{ visualization.description }}</p>
-                <div class="small"><strong>Version:</strong> {{ visualization.version }}</div>
+                <h5>{{ packageData.name }}</h5>
+                <p v-if="packageData.description" class="text-muted">{{ packageData.description }}</p>
+                <div class="small"><strong>Version:</strong> {{ packageData.version }}</div>
             </div>
 
             <b-form-group
@@ -27,91 +27,81 @@
                     id="viz-id-input"
                     v-model="visualizationId"
                     :placeholder="suggestedId"
-                    :state="visualizationId ? (isValidId ? true : false) : null"
-                    @input="validateId"></b-form-input>
+                    :state="visualizationId ? (isValidId ? true : false) : null" />
                 <b-form-invalid-feedback v-if="!isValidId">
                     ID must contain only letters, numbers, and underscores
                 </b-form-invalid-feedback>
             </b-form-group>
 
-            <b-alert v-if="idConflict" variant="warning" show>
-                <i class="fa fa-exclamation-triangle mr-1"></i>
+            <BAlert v-if="idConflict" variant="warning" show>
+                <FontAwesomeIcon :icon="faExclamationTriangle" class="mr-1" />
                 A visualization with this ID already exists and will be overwritten.
-            </b-alert>
+            </BAlert>
         </div>
     </b-modal>
 </template>
 
-<script>
-export default {
-    name: "InstallVisualizationModal",
+<script setup lang="ts">
+import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BAlert } from "bootstrap-vue";
+import { computed, ref, watch } from "vue";
 
-    props: {
-        show: {
-            type: Boolean,
-            default: false,
-        },
-        visualization: {
-            type: Object,
-            default: null,
-        },
-        installing: {
-            type: Boolean,
-            default: false,
-        },
-        installedVisualizations: {
-            type: Array,
-            default: () => [],
-        },
+import type { AvailableVisualization, Visualization } from "./services";
+
+interface Props {
+    show?: boolean;
+    packageData?: AvailableVisualization | null;
+    installing?: boolean;
+    installedVisualizations?: Visualization[];
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    show: false,
+    packageData: null,
+    installing: false,
+    installedVisualizations: () => [],
+});
+
+const emit = defineEmits<{
+    (e: "confirm", visualizationId: string): void;
+    (e: "cancel"): void;
+}>();
+
+const visualizationId = ref("");
+
+const suggestedId = computed(() => {
+    if (!props.packageData) {
+        return "";
+    }
+    const name = props.packageData.name.includes("/")
+        ? props.packageData.name.split("/").pop()!
+        : props.packageData.name;
+    return name.replace(/[^a-zA-Z0-9_]/g, "_");
+});
+
+const isValidId = computed(() => {
+    return /^[a-zA-Z0-9_]+$/.test(visualizationId.value);
+});
+
+const idConflict = computed(() => {
+    return props.installedVisualizations?.some((viz) => viz.id === visualizationId.value);
+});
+
+watch(
+    () => props.show,
+    (isShown) => {
+        if (isShown && props.packageData) {
+            visualizationId.value = suggestedId.value;
+        } else if (!isShown) {
+            visualizationId.value = "";
+        }
     },
+);
 
-    data() {
-        return {
-            visualizationId: "",
-        };
-    },
-
-    computed: {
-        suggestedId() {
-            if (!this.visualization) {
-                return "";
-            }
-            // Extract name from scoped package (e.g., @galaxyproject/foo -> foo)
-            const name = this.visualization.name.includes("/")
-                ? this.visualization.name.split("/").pop()
-                : this.visualization.name;
-            return name.replace(/[^a-zA-Z0-9_]/g, "_");
-        },
-
-        isValidId() {
-            return /^[a-zA-Z0-9_]+$/.test(this.visualizationId);
-        },
-
-        idConflict() {
-            return this.installedVisualizations?.some((viz) => viz.id === this.visualizationId);
-        },
-    },
-
-    watch: {
-        show(isShown) {
-            if (isShown && this.visualization) {
-                this.visualizationId = this.suggestedId;
-            } else if (!isShown) {
-                this.visualizationId = "";
-            }
-        },
-    },
-
-    methods: {
-        handleInstall() {
-            if (this.visualizationId && this.isValidId) {
-                this.$emit("confirm", this.visualizationId);
-            }
-        },
-
-        validateId() {
-            // Called on input change to trigger validation
-        },
-    },
-};
+function handleInstall() {
+    if (visualizationId.value && isValidId.value) {
+        emit("confirm", visualizationId.value);
+    }
+}
 </script>

--- a/client/src/components/admin/Visualizations/UsageStatsView.vue
+++ b/client/src/components/admin/Visualizations/UsageStatsView.vue
@@ -1,0 +1,174 @@
+<template>
+    <div>
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <h3>Usage Statistics</h3>
+            <b-button variant="outline-secondary" :disabled="loading" @click="$emit('refresh')">
+                <i class="fa fa-sync mr-1" :class="{ 'fa-spin': loading }"></i>
+                Refresh
+            </b-button>
+        </div>
+
+        <div v-if="loading" class="text-center py-4">
+            <b-spinner label="Loading..."></b-spinner>
+            <p class="mt-2">Loading usage statistics...</p>
+        </div>
+
+        <div v-else-if="stats.message" class="text-center py-4">
+            <div class="alert alert-info">
+                <i class="fa fa-info-circle mr-2"></i>
+                {{ stats.message }}
+            </div>
+            <p class="text-muted">Usage tracking will be implemented in a future version.</p>
+        </div>
+
+        <div v-else-if="hasStats">
+            <div class="row mb-4">
+                <div class="col-md-4">
+                    <div class="card">
+                        <div class="card-body text-center">
+                            <h4 class="text-primary">{{ totalUsage }}</h4>
+                            <p class="text-muted mb-0">Total Visualizations Used</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="card">
+                        <div class="card-body text-center">
+                            <h4 class="text-success">{{ activeVisualizations }}</h4>
+                            <p class="text-muted mb-0">Active Visualizations</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="card">
+                        <div class="card-body text-center">
+                            <h4 class="text-info">{{ stats.days }}</h4>
+                            <p class="text-muted mb-0">Days Analyzed</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="mb-0">Usage by Visualization</h5>
+                </div>
+                <div class="card-body">
+                    <div v-if="Object.keys(stats.stats).length === 0" class="text-center text-muted py-3">
+                        No usage data available for the selected period.
+                    </div>
+                    <div v-else>
+                        <div
+                            v-for="(count, vizId) in sortedStats"
+                            :key="vizId"
+                            class="d-flex justify-content-between align-items-center py-2 border-bottom">
+                            <div>
+                                <strong>{{ vizId }}</strong>
+                            </div>
+                            <div class="d-flex align-items-center">
+                                <div class="progress mr-3" style="width: 100px; height: 20px">
+                                    <div
+                                        class="progress-bar"
+                                        role="progressbar"
+                                        :style="{ width: getPercentage(count) + '%' }"
+                                        :aria-valuenow="count"
+                                        :aria-valuemin="0"
+                                        :aria-valuemax="maxUsage"></div>
+                                </div>
+                                <span class="badge badge-primary">{{ count }}</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div v-else class="text-center py-4">
+            <p class="text-muted">No usage statistics available.</p>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: "UsageStatsView",
+
+    props: {
+        loading: {
+            type: Boolean,
+            default: false,
+        },
+        stats: {
+            type: Object,
+            default: () => ({ days: 30, stats: {} }),
+        },
+    },
+
+    computed: {
+        hasStats() {
+            return this.stats && typeof this.stats.stats === "object";
+        },
+
+        totalUsage() {
+            if (!this.hasStats) {
+                return 0;
+            }
+            return Object.values(this.stats.stats).reduce((sum, count) => sum + count, 0);
+        },
+
+        activeVisualizations() {
+            if (!this.hasStats) {
+                return 0;
+            }
+            return Object.keys(this.stats.stats).length;
+        },
+
+        sortedStats() {
+            if (!this.hasStats) {
+                return {};
+            }
+
+            const entries = Object.entries(this.stats.stats);
+            entries.sort((a, b) => b[1] - a[1]); // Sort by usage count descending
+
+            return Object.fromEntries(entries);
+        },
+
+        maxUsage() {
+            if (!this.hasStats) {
+                return 0;
+            }
+            const values = Object.values(this.stats.stats);
+            return values.length > 0 ? Math.max(...values) : 0;
+        },
+    },
+
+    methods: {
+        getPercentage(count) {
+            if (this.maxUsage === 0) {
+                return 0;
+            }
+            return (count / this.maxUsage) * 100;
+        },
+    },
+};
+</script>
+
+<style scoped>
+.card {
+    border: 1px solid #dee2e6;
+    border-radius: 0.375rem;
+}
+
+.progress {
+    background-color: #e9ecef;
+}
+
+.progress-bar {
+    background-color: #007bff;
+}
+
+.border-bottom:last-child {
+    border-bottom: none !important;
+}
+</style>

--- a/client/src/components/admin/Visualizations/UsageStatsView.vue
+++ b/client/src/components/admin/Visualizations/UsageStatsView.vue
@@ -1,86 +1,73 @@
 <template>
     <div>
         <div class="d-flex justify-content-between align-items-center mb-3">
-            <h3>Usage Statistics</h3>
-            <b-button variant="outline-secondary" :disabled="loading" @click="$emit('refresh')">
-                <i class="fa fa-sync mr-1" :class="{ 'fa-spin': loading }"></i>
+            <Heading h3 size="md">Usage Statistics</Heading>
+            <b-button variant="outline-secondary" :disabled="loading" @click="emit('refresh')">
+                <FontAwesomeIcon :icon="faSync" :spin="loading" class="mr-1" />
                 Refresh
             </b-button>
         </div>
 
         <div v-if="loading" class="text-center py-4">
-            <b-spinner label="Loading..."></b-spinner>
+            <b-spinner label="Loading..." />
             <p class="mt-2">Loading usage statistics...</p>
         </div>
 
         <div v-else-if="stats.message" class="text-center py-4">
-            <div class="alert alert-info">
-                <i class="fa fa-info-circle mr-2"></i>
+            <BAlert variant="info" show>
+                <FontAwesomeIcon :icon="faInfoCircle" class="mr-2" />
                 {{ stats.message }}
-            </div>
+            </BAlert>
             <p class="text-muted">Usage tracking will be implemented in a future version.</p>
         </div>
 
         <div v-else-if="hasStats">
             <div class="row mb-4">
                 <div class="col-md-4">
-                    <div class="card">
-                        <div class="card-body text-center">
-                            <h4 class="text-primary">{{ totalUsage }}</h4>
-                            <p class="text-muted mb-0">Total Visualizations Used</p>
-                        </div>
-                    </div>
+                    <b-card class="text-center">
+                        <h4 class="text-primary">{{ totalUsage }}</h4>
+                        <p class="text-muted mb-0">Total Visualizations Used</p>
+                    </b-card>
                 </div>
                 <div class="col-md-4">
-                    <div class="card">
-                        <div class="card-body text-center">
-                            <h4 class="text-success">{{ activeVisualizations }}</h4>
-                            <p class="text-muted mb-0">Active Visualizations</p>
-                        </div>
-                    </div>
+                    <b-card class="text-center">
+                        <h4 class="text-success">{{ activeVisualizations }}</h4>
+                        <p class="text-muted mb-0">Active Visualizations</p>
+                    </b-card>
                 </div>
                 <div class="col-md-4">
-                    <div class="card">
-                        <div class="card-body text-center">
-                            <h4 class="text-info">{{ stats.days }}</h4>
-                            <p class="text-muted mb-0">Days Analyzed</p>
-                        </div>
-                    </div>
+                    <b-card class="text-center">
+                        <h4 class="text-info">{{ stats.days }}</h4>
+                        <p class="text-muted mb-0">Days Analyzed</p>
+                    </b-card>
                 </div>
             </div>
 
-            <div class="card">
-                <div class="card-header">
+            <b-card>
+                <template v-slot:header>
                     <h5 class="mb-0">Usage by Visualization</h5>
+                </template>
+
+                <div v-if="Object.keys(stats.stats).length === 0" class="text-center text-muted py-3">
+                    No usage data available for the selected period.
                 </div>
-                <div class="card-body">
-                    <div v-if="Object.keys(stats.stats).length === 0" class="text-center text-muted py-3">
-                        No usage data available for the selected period.
-                    </div>
-                    <div v-else>
-                        <div
-                            v-for="(count, vizId) in sortedStats"
-                            :key="vizId"
-                            class="d-flex justify-content-between align-items-center py-2 border-bottom">
-                            <div>
-                                <strong>{{ vizId }}</strong>
-                            </div>
-                            <div class="d-flex align-items-center">
-                                <div class="progress mr-3" style="width: 100px; height: 20px">
-                                    <div
-                                        class="progress-bar"
-                                        role="progressbar"
-                                        :style="{ width: getPercentage(count) + '%' }"
-                                        :aria-valuenow="count"
-                                        :aria-valuemin="0"
-                                        :aria-valuemax="maxUsage"></div>
-                                </div>
-                                <span class="badge badge-primary">{{ count }}</span>
-                            </div>
+                <div v-else>
+                    <div
+                        v-for="(count, vizId) in sortedStats"
+                        :key="vizId"
+                        class="d-flex justify-content-between align-items-center py-2 border-bottom">
+                        <div>
+                            <strong>{{ vizId }}</strong>
+                        </div>
+                        <div class="d-flex align-items-center">
+                            <b-progress class="mr-3" style="width: 100px; height: 20px">
+                                <b-progress-bar :value="getPercentage(count as number)" :max="100" />
+                            </b-progress>
+                            <b-badge variant="primary">{{ count }}</b-badge>
                         </div>
                     </div>
                 </div>
-            </div>
+            </b-card>
         </div>
 
         <div v-else class="text-center py-4">
@@ -89,85 +76,74 @@
     </div>
 </template>
 
-<script>
-export default {
-    name: "UsageStatsView",
+<script setup lang="ts">
+import { faInfoCircle, faSync } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BAlert } from "bootstrap-vue";
+import { computed } from "vue";
 
-    props: {
-        loading: {
-            type: Boolean,
-            default: false,
-        },
-        stats: {
-            type: Object,
-            default: () => ({ days: 30, stats: {} }),
-        },
-    },
+import type { UsageStats } from "./services";
 
-    computed: {
-        hasStats() {
-            return this.stats && typeof this.stats.stats === "object";
-        },
+import Heading from "@/components/Common/Heading.vue";
 
-        totalUsage() {
-            if (!this.hasStats) {
-                return 0;
-            }
-            return Object.values(this.stats.stats).reduce((sum, count) => sum + count, 0);
-        },
+interface Props {
+    loading?: boolean;
+    stats?: UsageStats;
+}
 
-        activeVisualizations() {
-            if (!this.hasStats) {
-                return 0;
-            }
-            return Object.keys(this.stats.stats).length;
-        },
+const props = withDefaults(defineProps<Props>(), {
+    loading: false,
+    stats: () => ({ days: 30, stats: {} }) as UsageStats,
+});
 
-        sortedStats() {
-            if (!this.hasStats) {
-                return {};
-            }
+const emit = defineEmits<{
+    (e: "refresh"): void;
+}>();
 
-            const entries = Object.entries(this.stats.stats);
-            entries.sort((a, b) => b[1] - a[1]); // Sort by usage count descending
+const hasStats = computed(() => {
+    return props.stats && typeof props.stats.stats === "object" && Object.keys(props.stats.stats).length > 0;
+});
 
-            return Object.fromEntries(entries);
-        },
+const totalUsage = computed(() => {
+    if (!hasStats.value) {
+        return 0;
+    }
+    return Object.values(props.stats.stats).reduce((sum, count) => sum + count, 0);
+});
 
-        maxUsage() {
-            if (!this.hasStats) {
-                return 0;
-            }
-            const values = Object.values(this.stats.stats);
-            return values.length > 0 ? Math.max(...values) : 0;
-        },
-    },
+const activeVisualizations = computed(() => {
+    if (!hasStats.value) {
+        return 0;
+    }
+    return Object.keys(props.stats.stats).length;
+});
 
-    methods: {
-        getPercentage(count) {
-            if (this.maxUsage === 0) {
-                return 0;
-            }
-            return (count / this.maxUsage) * 100;
-        },
-    },
-};
+const sortedStats = computed(() => {
+    if (!hasStats.value) {
+        return {};
+    }
+    const entries = Object.entries(props.stats.stats);
+    entries.sort((a, b) => (b[1] as number) - (a[1] as number));
+    return Object.fromEntries(entries);
+});
+
+const maxUsage = computed(() => {
+    if (!hasStats.value) {
+        return 0;
+    }
+    const values = Object.values(props.stats.stats) as number[];
+    return values.length > 0 ? Math.max(...values) : 0;
+});
+
+function getPercentage(count: number): number {
+    if (maxUsage.value === 0) {
+        return 0;
+    }
+    return (count / maxUsage.value) * 100;
+}
 </script>
 
 <style scoped>
-.card {
-    border: 1px solid #dee2e6;
-    border-radius: 0.375rem;
-}
-
-.progress {
-    background-color: #e9ecef;
-}
-
-.progress-bar {
-    background-color: #007bff;
-}
-
 .border-bottom:last-child {
     border-bottom: none !important;
 }

--- a/client/src/components/admin/Visualizations/UsageStatsView.vue
+++ b/client/src/components/admin/Visualizations/UsageStatsView.vue
@@ -48,7 +48,7 @@
                     <h5 class="mb-0">Usage by Visualization</h5>
                 </template>
 
-                <div v-if="Object.keys(stats.stats).length === 0" class="text-center text-muted py-3">
+                <div v-if="!hasStats" class="text-center text-muted py-3">
                     No usage data available for the selected period.
                 </div>
                 <div v-else>
@@ -61,7 +61,7 @@
                         </div>
                         <div class="d-flex align-items-center">
                             <b-progress class="mr-3" style="width: 100px; height: 20px">
-                                <b-progress-bar :value="getPercentage(count as number)" :max="100" />
+                                <b-progress-bar :value="getPercentage(Number(count))" :max="100" />
                             </b-progress>
                             <b-badge variant="primary">{{ count }}</b-badge>
                         </div>
@@ -88,50 +88,45 @@ import Heading from "@/components/Common/Heading.vue";
 
 interface Props {
     loading?: boolean;
-    stats?: UsageStats;
+    stats: UsageStats;
 }
 
-const props = withDefaults(defineProps<Props>(), {
-    loading: false,
-    stats: () => ({ days: 30, stats: {} }) as UsageStats,
-});
+const props = defineProps<Props>();
 
 const emit = defineEmits<{
     (e: "refresh"): void;
 }>();
 
-const hasStats = computed(() => {
-    return props.stats && typeof props.stats.stats === "object" && Object.keys(props.stats.stats).length > 0;
-});
-
-const totalUsage = computed(() => {
-    if (!hasStats.value) {
-        return 0;
-    }
-    return Object.values(props.stats.stats).reduce((sum, count) => sum + count, 0);
-});
-
-const activeVisualizations = computed(() => {
-    if (!hasStats.value) {
-        return 0;
-    }
-    return Object.keys(props.stats.stats).length;
-});
-
-const sortedStats = computed(() => {
-    if (!hasStats.value) {
+function getStatsRecord(): Record<string, number> {
+    const raw = props.stats.stats;
+    if (!raw) {
         return {};
     }
-    const entries = Object.entries(props.stats.stats);
-    entries.sort((a, b) => (b[1] as number) - (a[1] as number));
+    const result: Record<string, number> = {};
+    for (const [k, v] of Object.entries(raw)) {
+        result[k] = Number(v);
+    }
+    return result;
+}
+
+const hasStats = computed(() => Object.keys(getStatsRecord()).length > 0);
+
+const totalUsage = computed(() => {
+    const rec = getStatsRecord();
+    return Object.values(rec).reduce((sum, count) => sum + count, 0);
+});
+
+const activeVisualizations = computed(() => Object.keys(getStatsRecord()).length);
+
+const sortedStats = computed(() => {
+    const rec = getStatsRecord();
+    const entries = Object.entries(rec);
+    entries.sort((a, b) => b[1] - a[1]);
     return Object.fromEntries(entries);
 });
 
 const maxUsage = computed(() => {
-    if (!hasStats.value) {
-        return 0;
-    }
-    const values = Object.values(props.stats.stats) as number[];
+    const values = Object.values(getStatsRecord());
     return values.length > 0 ? Math.max(...values) : 0;
 });
 

--- a/client/src/components/admin/Visualizations/VisualizationCard.vue
+++ b/client/src/components/admin/Visualizations/VisualizationCard.vue
@@ -1,0 +1,277 @@
+<template>
+    <b-card class="visualization-card">
+        <div class="d-flex justify-content-between align-items-start">
+            <div class="flex-grow-1">
+                <div class="d-flex align-items-center mb-2">
+                    <h5 class="mb-0 mr-2">{{ visualization.id }}</h5>
+                    <b-badge :variant="visualization.enabled ? 'success' : 'secondary'" class="mr-2">
+                        {{ visualization.enabled ? "Enabled" : "Disabled" }}
+                    </b-badge>
+                    <b-badge :variant="visualization.installed ? 'primary' : 'warning'" class="mr-2">
+                        {{ visualization.installed ? "Installed" : "Not Installed" }}
+                    </b-badge>
+                </div>
+
+                <div class="text-muted mb-2">
+                    <div class="d-flex flex-wrap">
+                        <span class="mr-3"> <strong>Package:</strong> {{ visualization.package }} </span>
+                        <span class="mr-3"> <strong>Version:</strong> {{ visualization.version }} </span>
+                        <span v-if="visualization.size" class="mr-3">
+                            <strong>Size:</strong> {{ formatSize(visualization.size) }}
+                        </span>
+                    </div>
+                </div>
+
+                <div v-if="visualization.metadata?.description" class="mb-2">
+                    <p class="text-muted mb-1">{{ visualization.metadata.description }}</p>
+                </div>
+
+                <div v-if="visualization.metadata" class="small text-muted">
+                    <div class="d-flex flex-wrap">
+                        <span v-if="visualization.metadata.author" class="mr-3">
+                            <strong>Author:</strong> {{ visualization.metadata.author }}
+                        </span>
+                        <span v-if="visualization.metadata.license" class="mr-3">
+                            <strong>License:</strong> {{ visualization.metadata.license }}
+                        </span>
+                        <span v-if="visualization.metadata.homepage" class="mr-3">
+                            <a :href="visualization.metadata.homepage" target="_blank" rel="noopener">
+                                Homepage
+                                <i class="fa fa-external-link-alt fa-sm"></i>
+                            </a>
+                        </span>
+                    </div>
+                </div>
+
+                <!-- Dependencies -->
+                <div
+                    v-if="
+                        visualization.metadata?.dependencies &&
+                        Object.keys(visualization.metadata.dependencies).length > 0
+                    "
+                    class="mt-2">
+                    <b-button v-b-toggle="`deps-${visualization.id}`" variant="link" size="sm" class="p-0 text-info">
+                        <i class="fa fa-caret-right fa-fw"></i>
+                        Dependencies ({{ Object.keys(visualization.metadata.dependencies).length }})
+                    </b-button>
+                    <b-collapse :id="`deps-${visualization.id}`" class="mt-2">
+                        <div class="small">
+                            <div
+                                v-for="(version, dep) in visualization.metadata.dependencies"
+                                :key="`dep-${dep}`"
+                                class="mb-1">
+                                <code>{{ dep }}@{{ version }}</code>
+                            </div>
+                        </div>
+                    </b-collapse>
+                </div>
+            </div>
+
+            <div class="ml-3">
+                <b-dropdown variant="outline-secondary" size="sm" right text="Actions" :disabled="isLoading">
+                    <b-dropdown-item :disabled="isLoading" @click="$emit('toggle', visualization)">
+                        <i class="fa fa-fw" :class="visualization.enabled ? 'fa-eye-slash' : 'fa-eye'"></i>
+                        {{ visualization.enabled ? "Disable" : "Enable" }}
+                    </b-dropdown-item>
+
+                    <b-dropdown-item
+                        v-if="visualization.installed"
+                        :disabled="isLoading"
+                        @click="showUpdateModal = true">
+                        <i class="fa fa-fw fa-arrow-up"></i>
+                        Update
+                    </b-dropdown-item>
+
+                    <b-dropdown-item :disabled="isLoading" @click="$emit('stage', visualization)">
+                        <i class="fa fa-fw fa-upload"></i>
+                        Stage Assets
+                    </b-dropdown-item>
+
+                    <b-dropdown-item
+                        v-if="visualization.installed"
+                        :disabled="isLoading"
+                        variant="danger"
+                        @click="$emit('uninstall', visualization)">
+                        <i class="fa fa-fw fa-trash"></i>
+                        Uninstall
+                    </b-dropdown-item>
+
+                    <b-dropdown-divider v-if="visualization.installed"></b-dropdown-divider>
+
+                    <b-dropdown-item :disabled="isLoading" @click="showDetails = !showDetails">
+                        <i class="fa fa-fw fa-info-circle"></i>
+                        {{ showDetails ? "Hide Details" : "Show Details" }}
+                    </b-dropdown-item>
+                </b-dropdown>
+            </div>
+        </div>
+
+        <!-- Details Section -->
+        <b-collapse v-model="showDetails" class="mt-3">
+            <hr />
+            <div class="small">
+                <div class="row">
+                    <div class="col-md-6">
+                        <div v-if="visualization.path" class="mb-2">
+                            <strong>Installation Path:</strong>
+                            <br />
+                            <code class="small">{{ visualization.path }}</code>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div v-if="visualization.metadata" class="mb-2">
+                            <strong>Package Metadata:</strong>
+                            <br />
+                            <pre class="small bg-light p-2 rounded">{{
+                                JSON.stringify(visualization.metadata, null, 2)
+                            }}</pre>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </b-collapse>
+
+        <!-- Update Modal -->
+        <b-modal
+            v-model="showUpdateModal"
+            title="Update Visualization"
+            :ok-disabled="!updateVersion || updating"
+            ok-title="Update"
+            @ok="handleUpdate">
+            <div v-if="updating" class="text-center">
+                <b-spinner label="Updating..."></b-spinner>
+                <p class="mt-2">Updating visualization package...</p>
+            </div>
+
+            <div v-else>
+                <p>
+                    Update <strong>{{ visualization.id }}</strong> to a new version:
+                </p>
+
+                <b-form-group label="New Version:" label-for="version-input">
+                    <b-form-input
+                        id="version-input"
+                        v-model="updateVersion"
+                        placeholder="e.g., 1.2.3"
+                        :state="updateVersion ? true : null"></b-form-input>
+                    <b-form-text> Current version: {{ visualization.version }} </b-form-text>
+                </b-form-group>
+            </div>
+        </b-modal>
+    </b-card>
+</template>
+
+<script>
+export default {
+    name: "VisualizationCard",
+
+    props: {
+        visualization: {
+            type: Object,
+            required: true,
+        },
+        loadingActions: {
+            type: Set,
+            default: () => new Set(),
+        },
+    },
+
+    data() {
+        return {
+            showDetails: false,
+            showUpdateModal: false,
+            updateVersion: "",
+            updating: false,
+        };
+    },
+
+    computed: {
+        isLoading() {
+            return (
+                this.loadingActions.has(`toggle-${this.visualization.id}`) ||
+                this.loadingActions.has(`update-${this.visualization.id}`) ||
+                this.loadingActions.has(`uninstall-${this.visualization.id}`) ||
+                this.loadingActions.has(`stage-${this.visualization.id}`) ||
+                this.updating
+            );
+        },
+    },
+
+    watch: {
+        showUpdateModal(isShown) {
+            if (!isShown) {
+                this.updateVersion = "";
+                this.updating = false;
+            }
+        },
+    },
+
+    methods: {
+        formatSize(bytes) {
+            if (bytes === 0) {
+                return "0 B";
+            }
+            const k = 1024;
+            const sizes = ["B", "KB", "MB", "GB"];
+            const i = Math.floor(Math.log(bytes) / Math.log(k));
+            return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
+        },
+
+        async handleUpdate() {
+            if (!this.updateVersion) {
+                return;
+            }
+
+            this.updating = true;
+            try {
+                this.$emit("update", this.visualization, this.updateVersion);
+                this.showUpdateModal = false;
+                this.updateVersion = "";
+            } catch (error) {
+                console.error("Error in update handler:", error);
+            } finally {
+                this.updating = false;
+            }
+        },
+    },
+};
+</script>
+
+<style scoped>
+.visualization-card {
+    transition: box-shadow 0.15s ease-in-out;
+}
+
+.visualization-card:hover {
+    box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+}
+
+.badge {
+    font-size: 0.75em;
+}
+
+.btn-link {
+    text-decoration: none;
+}
+
+.btn-link:hover {
+    text-decoration: underline;
+}
+
+code {
+    font-size: 0.875em;
+    color: #6f42c1;
+}
+
+pre {
+    font-size: 0.75rem;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.collapse-content {
+    border-top: 1px solid #dee2e6;
+    margin-top: 1rem;
+    padding-top: 1rem;
+}
+</style>

--- a/client/src/components/admin/Visualizations/VisualizationCard.vue
+++ b/client/src/components/admin/Visualizations/VisualizationCard.vue
@@ -7,8 +7,12 @@
                     <b-badge :variant="visualization.enabled ? 'success' : 'secondary'" class="mr-2">
                         {{ visualization.enabled ? "Enabled" : "Disabled" }}
                     </b-badge>
-                    <b-badge :variant="visualization.installed ? 'primary' : 'warning'" class="mr-2">
-                        {{ visualization.installed ? "Installed" : "Not Installed" }}
+                    <b-badge
+                        v-if="!visualization.installed"
+                        variant="warning"
+                        class="mr-2"
+                        title="Registered in config but package files are missing from disk">
+                        Missing Files
                     </b-badge>
                 </div>
 

--- a/client/src/components/admin/Visualizations/VisualizationCard.vue
+++ b/client/src/components/admin/Visualizations/VisualizationCard.vue
@@ -17,7 +17,7 @@
                         <span class="mr-3"> <strong>Package:</strong> {{ visualization.package }} </span>
                         <span class="mr-3"> <strong>Version:</strong> {{ visualization.version }} </span>
                         <span v-if="visualization.size" class="mr-3">
-                            <strong>Size:</strong> {{ formatSize(visualization.size) }}
+                            <strong>Size:</strong> {{ bytesToString(visualization.size, true, 1) }}
                         </span>
                     </div>
                 </div>
@@ -37,13 +37,12 @@
                         <span v-if="visualization.metadata.homepage" class="mr-3">
                             <a :href="visualization.metadata.homepage" target="_blank" rel="noopener">
                                 Homepage
-                                <i class="fa fa-external-link-alt fa-sm"></i>
+                                <FontAwesomeIcon :icon="faExternalLinkAlt" size="sm" />
                             </a>
                         </span>
                     </div>
                 </div>
 
-                <!-- Dependencies -->
                 <div
                     v-if="
                         visualization.metadata?.dependencies &&
@@ -51,7 +50,7 @@
                     "
                     class="mt-2">
                     <b-button v-b-toggle="`deps-${visualization.id}`" variant="link" size="sm" class="p-0 text-info">
-                        <i class="fa fa-caret-right fa-fw"></i>
+                        <FontAwesomeIcon :icon="faCaretRight" fixed-width />
                         Dependencies ({{ Object.keys(visualization.metadata.dependencies).length }})
                     </b-button>
                     <b-collapse :id="`deps-${visualization.id}`" class="mt-2">
@@ -69,8 +68,8 @@
 
             <div class="ml-3">
                 <b-dropdown variant="outline-secondary" size="sm" right text="Actions" :disabled="isLoading">
-                    <b-dropdown-item :disabled="isLoading" @click="$emit('toggle', visualization)">
-                        <i class="fa fa-fw" :class="visualization.enabled ? 'fa-eye-slash' : 'fa-eye'"></i>
+                    <b-dropdown-item :disabled="isLoading" @click="emit('toggle', visualization)">
+                        <FontAwesomeIcon :icon="visualization.enabled ? faEyeSlash : faEye" fixed-width />
                         {{ visualization.enabled ? "Disable" : "Enable" }}
                     </b-dropdown-item>
 
@@ -78,12 +77,12 @@
                         v-if="visualization.installed"
                         :disabled="isLoading"
                         @click="showUpdateModal = true">
-                        <i class="fa fa-fw fa-arrow-up"></i>
+                        <FontAwesomeIcon :icon="faArrowUp" fixed-width />
                         Update
                     </b-dropdown-item>
 
-                    <b-dropdown-item :disabled="isLoading" @click="$emit('stage', visualization)">
-                        <i class="fa fa-fw fa-upload"></i>
+                    <b-dropdown-item :disabled="isLoading" @click="emit('stage', visualization)">
+                        <FontAwesomeIcon :icon="faUpload" fixed-width />
                         Stage Assets
                     </b-dropdown-item>
 
@@ -91,22 +90,21 @@
                         v-if="visualization.installed"
                         :disabled="isLoading"
                         variant="danger"
-                        @click="$emit('uninstall', visualization)">
-                        <i class="fa fa-fw fa-trash"></i>
+                        @click="emit('uninstall', visualization)">
+                        <FontAwesomeIcon :icon="faTrash" fixed-width />
                         Uninstall
                     </b-dropdown-item>
 
-                    <b-dropdown-divider v-if="visualization.installed"></b-dropdown-divider>
+                    <b-dropdown-divider v-if="visualization.installed" />
 
                     <b-dropdown-item :disabled="isLoading" @click="showDetails = !showDetails">
-                        <i class="fa fa-fw fa-info-circle"></i>
+                        <FontAwesomeIcon :icon="faInfoCircle" fixed-width />
                         {{ showDetails ? "Hide Details" : "Show Details" }}
                     </b-dropdown-item>
                 </b-dropdown>
             </div>
         </div>
 
-        <!-- Details Section -->
         <b-collapse v-model="showDetails" class="mt-3">
             <hr />
             <div class="small">
@@ -131,7 +129,6 @@
             </div>
         </b-collapse>
 
-        <!-- Update Modal -->
         <b-modal
             v-model="showUpdateModal"
             title="Update Visualization"
@@ -139,7 +136,7 @@
             ok-title="Update"
             @ok="handleUpdate">
             <div v-if="updating" class="text-center">
-                <b-spinner label="Updating..."></b-spinner>
+                <b-spinner label="Updating..." />
                 <p class="mt-2">Updating visualization package...</p>
             </div>
 
@@ -153,7 +150,7 @@
                         id="version-input"
                         v-model="updateVersion"
                         placeholder="e.g., 1.2.3"
-                        :state="updateVersion ? true : null"></b-form-input>
+                        :state="updateVersion ? true : null" />
                     <b-form-text> Current version: {{ visualization.version }} </b-form-text>
                 </b-form-group>
             </div>
@@ -161,80 +158,71 @@
     </b-card>
 </template>
 
-<script>
-export default {
-    name: "VisualizationCard",
+<script setup lang="ts">
+import {
+    faArrowUp,
+    faCaretRight,
+    faExternalLinkAlt,
+    faEye,
+    faEyeSlash,
+    faInfoCircle,
+    faTrash,
+    faUpload,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { computed, ref, watch } from "vue";
 
-    props: {
-        visualization: {
-            type: Object,
-            required: true,
-        },
-        loadingActions: {
-            type: Set,
-            default: () => new Set(),
-        },
-    },
+import { bytesToString } from "@/utils/utils";
 
-    data() {
-        return {
-            showDetails: false,
-            showUpdateModal: false,
-            updateVersion: "",
-            updating: false,
-        };
-    },
+import type { Visualization } from "./services";
 
-    computed: {
-        isLoading() {
-            return (
-                this.loadingActions.has(`toggle-${this.visualization.id}`) ||
-                this.loadingActions.has(`update-${this.visualization.id}`) ||
-                this.loadingActions.has(`uninstall-${this.visualization.id}`) ||
-                this.loadingActions.has(`stage-${this.visualization.id}`) ||
-                this.updating
-            );
-        },
-    },
+interface Props {
+    visualization: Visualization;
+    loadingActions?: Record<string, boolean>;
+}
 
-    watch: {
-        showUpdateModal(isShown) {
-            if (!isShown) {
-                this.updateVersion = "";
-                this.updating = false;
-            }
-        },
-    },
+const props = withDefaults(defineProps<Props>(), {
+    loadingActions: () => ({}),
+});
 
-    methods: {
-        formatSize(bytes) {
-            if (bytes === 0) {
-                return "0 B";
-            }
-            const k = 1024;
-            const sizes = ["B", "KB", "MB", "GB"];
-            const i = Math.floor(Math.log(bytes) / Math.log(k));
-            return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
-        },
+const emit = defineEmits<{
+    (e: "toggle", visualization: Visualization): void;
+    (e: "update", visualization: Visualization, version: string): void;
+    (e: "uninstall", visualization: Visualization): void;
+    (e: "stage", visualization: Visualization): void;
+    (e: "refresh"): void;
+}>();
 
-        async handleUpdate() {
-            if (!this.updateVersion) {
-                return;
-            }
+const showDetails = ref(false);
+const showUpdateModal = ref(false);
+const updateVersion = ref("");
+const updating = ref(false);
 
-            this.updating = true;
-            try {
-                this.$emit("update", this.visualization, this.updateVersion);
-                this.showUpdateModal = false;
-                this.updateVersion = "";
-            } catch (error) {
-                console.error("Error in update handler:", error);
-            } finally {
-                this.updating = false;
-            }
-        },
-    },
-};
+const isLoading = computed(() => {
+    return (
+        !!props.loadingActions[`toggle-${props.visualization.id}`] ||
+        !!props.loadingActions[`update-${props.visualization.id}`] ||
+        !!props.loadingActions[`uninstall-${props.visualization.id}`] ||
+        !!props.loadingActions[`stage-${props.visualization.id}`] ||
+        updating.value
+    );
+});
+
+watch(showUpdateModal, (isShown) => {
+    if (!isShown) {
+        updateVersion.value = "";
+        updating.value = false;
+    }
+});
+
+function handleUpdate() {
+    if (!updateVersion.value) {
+        return;
+    }
+    emit("update", props.visualization, updateVersion.value);
+    showUpdateModal.value = false;
+    updateVersion.value = "";
+}
 </script>
 
 <style scoped>
@@ -246,32 +234,9 @@ export default {
     box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
 }
 
-.badge {
-    font-size: 0.75em;
-}
-
-.btn-link {
-    text-decoration: none;
-}
-
-.btn-link:hover {
-    text-decoration: underline;
-}
-
-code {
-    font-size: 0.875em;
-    color: #6f42c1;
-}
-
 pre {
     font-size: 0.75rem;
     max-height: 200px;
     overflow-y: auto;
-}
-
-.collapse-content {
-    border-top: 1px solid #dee2e6;
-    margin-top: 1rem;
-    padding-top: 1rem;
 }
 </style>

--- a/client/src/components/admin/Visualizations/VisualizationCard.vue
+++ b/client/src/components/admin/Visualizations/VisualizationCard.vue
@@ -37,20 +37,16 @@
                     </div>
                 </div>
 
-                <div v-if="visualization.metadata?.description" class="mb-2">
-                    <p class="text-muted mb-1">{{ visualization.metadata.description }}</p>
+                <div v-if="meta?.description" class="mb-2">
+                    <p class="text-muted mb-1">{{ meta.description }}</p>
                 </div>
 
-                <div v-if="visualization.metadata" class="small text-muted">
+                <div v-if="meta" class="small text-muted">
                     <div class="d-flex flex-wrap">
-                        <span v-if="visualization.metadata.author" class="mr-3">
-                            <strong>Author:</strong> {{ visualization.metadata.author }}
-                        </span>
-                        <span v-if="visualization.metadata.license" class="mr-3">
-                            <strong>License:</strong> {{ visualization.metadata.license }}
-                        </span>
-                        <span v-if="visualization.metadata.homepage" class="mr-3">
-                            <a :href="visualization.metadata.homepage" target="_blank" rel="noopener">
+                        <span v-if="meta.author" class="mr-3"> <strong>Author:</strong> {{ meta.author }} </span>
+                        <span v-if="meta.license" class="mr-3"> <strong>License:</strong> {{ meta.license }} </span>
+                        <span v-if="meta.homepage" class="mr-3">
+                            <a :href="meta.homepage" target="_blank" rel="noopener">
                                 Homepage
                                 <FontAwesomeIcon :icon="faExternalLinkAlt" size="sm" />
                             </a>
@@ -58,22 +54,14 @@
                     </div>
                 </div>
 
-                <div
-                    v-if="
-                        visualization.metadata?.dependencies &&
-                        Object.keys(visualization.metadata.dependencies).length > 0
-                    "
-                    class="mt-2">
+                <div v-if="meta?.dependencies && Object.keys(meta.dependencies).length > 0" class="mt-2">
                     <b-button v-b-toggle="`deps-${visualization.id}`" variant="link" size="sm" class="p-0 text-info">
                         <FontAwesomeIcon :icon="faCaretRight" fixed-width />
-                        Dependencies ({{ Object.keys(visualization.metadata.dependencies).length }})
+                        Dependencies ({{ Object.keys(meta.dependencies).length }})
                     </b-button>
                     <b-collapse :id="`deps-${visualization.id}`" class="mt-2">
                         <div class="small">
-                            <div
-                                v-for="(version, dep) in visualization.metadata.dependencies"
-                                :key="`dep-${dep}`"
-                                class="mb-1">
+                            <div v-for="(version, dep) in meta.dependencies" :key="`dep-${dep}`" class="mb-1">
                                 <code>{{ dep }}@{{ version }}</code>
                             </div>
                         </div>
@@ -129,12 +117,10 @@
                         </div>
                     </div>
                     <div class="col-md-6">
-                        <div v-if="visualization.metadata" class="mb-2">
+                        <div v-if="meta" class="mb-2">
                             <strong>Package Metadata:</strong>
                             <br />
-                            <pre class="small bg-light p-2 rounded">{{
-                                JSON.stringify(visualization.metadata, null, 2)
-                            }}</pre>
+                            <pre class="small bg-light p-2 rounded">{{ JSON.stringify(meta, null, 2) }}</pre>
                         </div>
                     </div>
                 </div>
@@ -199,6 +185,15 @@ import { bytesToString } from "@/utils/utils";
 import type { Visualization } from "./services";
 import { getPackageVersions } from "./services";
 
+interface PackageMetadata {
+    description?: string;
+    author?: string;
+    license?: string;
+    homepage?: string;
+    dependencies?: Record<string, string>;
+    [key: string]: unknown;
+}
+
 interface Props {
     visualization: Visualization;
     loadingActions?: Record<string, boolean>;
@@ -207,8 +202,10 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
     loadingActions: () => ({}),
-    stagedNames: () => [],
+    stagedNames: () => [] as string[],
 });
+
+const meta = computed(() => (props.visualization.metadata as PackageMetadata | null) ?? null);
 
 const emit = defineEmits<{
     (e: "toggle", visualization: Visualization): void;
@@ -250,7 +247,7 @@ async function openUpdateModal() {
     loadingVersions.value = true;
     try {
         const result = await getPackageVersions(props.visualization.package);
-        availableVersions.value = result.versions;
+        availableVersions.value = result.versions ?? [];
     } catch {
         // Fall back to manual text input if version fetch fails
         availableVersions.value = [];

--- a/client/src/components/admin/Visualizations/VisualizationCard.vue
+++ b/client/src/components/admin/Visualizations/VisualizationCard.vue
@@ -14,6 +14,17 @@
                         title="Registered in config but package files are missing from disk">
                         Missing Files
                     </b-badge>
+                    <b-badge
+                        v-if="visualization.installed"
+                        :variant="isStaged ? 'info' : 'warning'"
+                        class="mr-2"
+                        :title="
+                            isStaged
+                                ? 'Assets are in Galaxy\'s serving directory'
+                                : 'Assets need to be staged before users can access this visualization'
+                        ">
+                        {{ isStaged ? "Staged" : "Not Staged" }}
+                    </b-badge>
                 </div>
 
                 <div class="text-muted mb-2">
@@ -77,10 +88,7 @@
                         {{ visualization.enabled ? "Disable" : "Enable" }}
                     </b-dropdown-item>
 
-                    <b-dropdown-item
-                        v-if="visualization.installed"
-                        :disabled="isLoading"
-                        @click="showUpdateModal = true">
+                    <b-dropdown-item v-if="visualization.installed" :disabled="isLoading" @click="openUpdateModal">
                         <FontAwesomeIcon :icon="faArrowUp" fixed-width />
                         Update
                     </b-dropdown-item>
@@ -146,15 +154,25 @@
 
             <div v-else>
                 <p>
-                    Update <strong>{{ visualization.id }}</strong> to a new version:
+                    Update <strong>{{ visualization.id }}</strong> ({{ visualization.package }})
                 </p>
 
-                <b-form-group label="New Version:" label-for="version-input">
-                    <b-form-input
-                        id="version-input"
-                        v-model="updateVersion"
-                        placeholder="e.g., 1.2.3"
-                        :state="updateVersion ? true : null" />
+                <b-form-group label="Version:" label-for="version-input">
+                    <b-form-select v-if="availableVersions.length > 0" id="version-input" v-model="updateVersion">
+                        <b-form-select-option :value="''" disabled>Select a version...</b-form-select-option>
+                        <b-form-select-option
+                            v-for="v in availableVersions"
+                            :key="v"
+                            :value="v"
+                            :disabled="v === visualization.version">
+                            {{ v }}{{ v === visualization.version ? " (current)" : "" }}
+                        </b-form-select-option>
+                    </b-form-select>
+                    <div v-else-if="loadingVersions" class="text-muted small">
+                        <b-spinner small class="mr-1" />
+                        Loading available versions...
+                    </div>
+                    <b-form-input v-else id="version-input" v-model="updateVersion" placeholder="e.g., 1.2.3" />
                     <b-form-text> Current version: {{ visualization.version }} </b-form-text>
                 </b-form-group>
             </div>
@@ -179,14 +197,17 @@ import { computed, ref, watch } from "vue";
 import { bytesToString } from "@/utils/utils";
 
 import type { Visualization } from "./services";
+import { getPackageVersions } from "./services";
 
 interface Props {
     visualization: Visualization;
     loadingActions?: Record<string, boolean>;
+    stagedNames?: string[];
 }
 
 const props = withDefaults(defineProps<Props>(), {
     loadingActions: () => ({}),
+    stagedNames: () => [],
 });
 
 const emit = defineEmits<{
@@ -201,6 +222,8 @@ const showDetails = ref(false);
 const showUpdateModal = ref(false);
 const updateVersion = ref("");
 const updating = ref(false);
+const availableVersions = ref<string[]>([]);
+const loadingVersions = ref(false);
 
 const isLoading = computed(() => {
     return (
@@ -212,12 +235,29 @@ const isLoading = computed(() => {
     );
 });
 
+const isStaged = computed(() => props.stagedNames.includes(props.visualization.id));
+
 watch(showUpdateModal, (isShown) => {
     if (!isShown) {
         updateVersion.value = "";
         updating.value = false;
+        availableVersions.value = [];
     }
 });
+
+async function openUpdateModal() {
+    showUpdateModal.value = true;
+    loadingVersions.value = true;
+    try {
+        const result = await getPackageVersions(props.visualization.package);
+        availableVersions.value = result.versions;
+    } catch {
+        // Fall back to manual text input if version fetch fails
+        availableVersions.value = [];
+    } finally {
+        loadingVersions.value = false;
+    }
+}
 
 function handleUpdate() {
     if (!updateVersion.value) {

--- a/client/src/components/admin/Visualizations/VisualizationsAdmin.vue
+++ b/client/src/components/admin/Visualizations/VisualizationsAdmin.vue
@@ -1,0 +1,594 @@
+<template>
+    <div aria-labelledby="visualizations-admin-heading">
+        <h1 id="visualizations-admin-heading" class="h-lg">Visualizations Management</h1>
+
+        <Message :message="message" :status="messageStatus" />
+
+        <div class="mb-3">
+            <b-button-group>
+                <b-button
+                    :variant="activeTab === 'installed' ? 'primary' : 'outline-primary'"
+                    @click="activeTab = 'installed'">
+                    <i class="fa fa-list mr-1"></i>
+                    Installed ({{ installedVisualizations.length }})
+                </b-button>
+                <b-button
+                    :variant="activeTab === 'available' ? 'primary' : 'outline-primary'"
+                    @click="activeTab = 'available'">
+                    <i class="fa fa-download mr-1"></i>
+                    Available
+                </b-button>
+                <b-button :variant="activeTab === 'usage' ? 'primary' : 'outline-primary'" @click="activeTab = 'usage'">
+                    <i class="fa fa-chart-bar mr-1"></i>
+                    Usage Stats
+                </b-button>
+                <b-button
+                    :variant="activeTab === 'staging' ? 'primary' : 'outline-primary'"
+                    @click="activeTab = 'staging'">
+                    <i class="fa fa-server mr-1"></i>
+                    Staging
+                </b-button>
+            </b-button-group>
+
+            <b-button
+                v-if="activeTab === 'installed'"
+                variant="outline-secondary"
+                class="ml-2"
+                :disabled="loading"
+                @click="reloadRegistry">
+                <i class="fa fa-sync mr-1" :class="{ 'fa-spin': loading }"></i>
+                Reload Registry
+            </b-button>
+        </div>
+
+        <!-- Installed Visualizations Tab -->
+        <div v-if="activeTab === 'installed'">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <div>
+                    <b-form-checkbox v-model="showDisabled" class="mr-3">
+                        Show disabled visualizations
+                    </b-form-checkbox>
+                </div>
+                <div>
+                    <b-input-group>
+                        <b-form-input
+                            v-model="searchFilter"
+                            placeholder="Filter visualizations..."
+                            @input="filterInstalled" />
+                        <b-input-group-append>
+                            <b-button
+                                variant="outline-secondary"
+                                @click="
+                                    searchFilter = '';
+                                    filterInstalled();
+                                ">
+                                <i class="fa fa-times"></i>
+                            </b-button>
+                        </b-input-group-append>
+                    </b-input-group>
+                </div>
+            </div>
+
+            <div v-if="loading" class="text-center py-4">
+                <b-spinner label="Loading..."></b-spinner>
+                <p class="mt-2">Loading visualization packages...</p>
+            </div>
+
+            <div v-else-if="filteredInstalledVisualizations.length === 0" class="text-center py-4">
+                <p class="text-muted">No visualization packages found.</p>
+            </div>
+
+            <div v-else>
+                <VisualizationCard
+                    v-for="viz in filteredInstalledVisualizations"
+                    :key="viz.id"
+                    :visualization="viz"
+                    :loading-actions="loadingActions"
+                    class="mb-3"
+                    @toggle="handleToggle"
+                    @update="handleUpdate"
+                    @uninstall="handleUninstall"
+                    @stage="handleStage"
+                    @refresh="loadInstalledPackages" />
+            </div>
+        </div>
+
+        <!-- Available Visualizations Tab -->
+        <div v-if="activeTab === 'available'">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h3>Available Visualization Packages</h3>
+                <b-input-group style="max-width: 300px">
+                    <b-form-input
+                        v-model="availableSearchFilter"
+                        placeholder="Search packages..."
+                        @input="searchAvailablePackages" />
+                    <b-input-group-append>
+                        <b-button
+                            variant="outline-secondary"
+                            @click="
+                                availableSearchFilter = '';
+                                searchAvailablePackages();
+                            ">
+                            <i class="fa fa-times"></i>
+                        </b-button>
+                    </b-input-group-append>
+                </b-input-group>
+            </div>
+
+            <div v-if="loadingAvailable" class="text-center py-4">
+                <b-spinner label="Loading..."></b-spinner>
+                <p class="mt-2">Searching available packages...</p>
+            </div>
+
+            <div v-else-if="availableVisualizations.length === 0" class="text-center py-4">
+                <p class="text-muted">No packages found. Try adjusting your search terms.</p>
+            </div>
+
+            <div v-else>
+                <AvailableVisualizationCard
+                    v-for="viz in availableVisualizations"
+                    :key="viz.name"
+                    :package-data="viz"
+                    :installed-packages="installedVisualizations"
+                    :loading-actions="loadingActions"
+                    class="mb-3"
+                    @install="handleInstall" />
+            </div>
+        </div>
+
+        <!-- Usage Stats Tab -->
+        <div v-if="activeTab === 'usage'">
+            <UsageStatsView :loading="loadingStats" :stats="usageStats" @refresh="loadUsageStats" />
+        </div>
+
+        <!-- Staging Tab -->
+        <div v-if="activeTab === 'staging'">
+            <div class="row">
+                <div class="col-md-6">
+                    <div class="card">
+                        <div class="card-header">
+                            <h5 class="card-title mb-0">
+                                <i class="fa fa-upload mr-2"></i>
+                                Stage Assets
+                            </h5>
+                        </div>
+                        <div class="card-body">
+                            <p class="text-muted">
+                                Staging copies visualization assets from <code>config/plugins/visualizations</code> to
+                                <code>static/plugins/visualizations</code> where Galaxy can serve them.
+                            </p>
+                            <div class="d-flex gap-2">
+                                <b-button variant="primary" :disabled="stagingLoading" @click="stageAllAssets">
+                                    <i class="fa fa-upload mr-1" :class="{ 'fa-spin': stagingLoading }"></i>
+                                    Stage All Visualizations
+                                </b-button>
+                                <b-button variant="warning" :disabled="stagingLoading" @click="cleanStagedAssets">
+                                    <i class="fa fa-trash mr-1"></i>
+                                    Clean Staged Assets
+                                </b-button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="card">
+                        <div class="card-header">
+                            <h5 class="card-title mb-0">
+                                <i class="fa fa-info-circle mr-2"></i>
+                                Staging Status
+                            </h5>
+                        </div>
+                        <div class="card-body">
+                            <div v-if="stagingStatus">
+                                <p class="mb-2">
+                                    <strong>{{ stagingStatus.staged_count }}</strong> visualizations staged
+                                </p>
+                                <p class="mb-2 text-muted">
+                                    Total size: {{ formatFileSize(stagingStatus.total_size) }}
+                                </p>
+                                <div v-if="stagingStatus.staged_visualizations.length > 0" class="mt-3">
+                                    <h6>Staged Visualizations:</h6>
+                                    <div class="staged-viz-list" style="max-height: 200px; overflow-y: auto">
+                                        <div
+                                            v-for="viz in stagingStatus.staged_visualizations"
+                                            :key="viz.name"
+                                            class="d-flex justify-content-between align-items-center border-bottom py-1">
+                                            <span class="small">{{ viz.name }}</span>
+                                            <span class="text-muted small">{{ formatFileSize(viz.size) }}</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div v-else class="text-center">
+                                <b-spinner small></b-spinner>
+                                Loading staging status...
+                            </div>
+                            <div class="mt-3">
+                                <b-button size="sm" variant="outline-secondary" @click="loadStagingStatus">
+                                    <i class="fa fa-sync mr-1"></i>
+                                    Refresh Status
+                                </b-button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Install Modal -->
+        <InstallVisualizationModal
+            :show="showInstallModal"
+            :package-data="selectedVisualization"
+            :installing="installing"
+            @confirm="confirmInstall"
+            @cancel="showInstallModal = false" />
+    </div>
+</template>
+
+<script>
+import {
+    cleanStagedAssets,
+    getAvailableVisualizations,
+    getInstalledVisualizations,
+    getStagingStatus,
+    getVisualizationUsageStats,
+    installVisualization,
+    reloadVisualizationRegistry,
+    stageAllVisualizations,
+    stageVisualization,
+    toggleVisualization,
+    uninstallVisualization,
+    updateVisualization,
+} from "./services";
+
+import Message from "../../Message.vue";
+import AvailableVisualizationCard from "./AvailableVisualizationCard.vue";
+import InstallVisualizationModal from "./InstallVisualizationModal.vue";
+import UsageStatsView from "./UsageStatsView.vue";
+import VisualizationCard from "./VisualizationCard.vue";
+
+export default {
+    name: "VisualizationsAdmin",
+
+    components: {
+        Message,
+        VisualizationCard,
+        AvailableVisualizationCard,
+        InstallVisualizationModal,
+        UsageStatsView,
+    },
+
+    data() {
+        return {
+            activeTab: "installed",
+            loading: false,
+            loadingAvailable: false,
+            loadingStats: false,
+            loadingActions: new Set(),
+            installing: false,
+            message: "",
+            messageStatus: "",
+
+            // Installed packages
+            installedVisualizations: [],
+            filteredInstalledVisualizations: [],
+            showDisabled: true,
+            searchFilter: "",
+
+            // Available packages
+            availableVisualizations: [],
+            availableSearchFilter: "",
+
+            // Usage stats
+            usageStats: { days: 30, stats: {} },
+
+            // Staging
+            stagingLoading: false,
+            stagingStatus: null,
+
+            // Install modal
+            showInstallModal: false,
+            selectedVisualization: null,
+        };
+    },
+
+    watch: {
+        showDisabled() {
+            this.filterInstalled();
+        },
+
+        async activeTab(newTab) {
+            if (newTab === "available" && this.availableVisualizations.length === 0) {
+                await this.loadAvailablePackages();
+            } else if (newTab === "usage") {
+                await this.loadUsageStats();
+            } else if (newTab === "staging") {
+                await this.loadStagingStatus();
+            }
+        },
+    },
+
+    async mounted() {
+        await this.loadInstalledPackages();
+        await this.loadAvailablePackages();
+    },
+
+    methods: {
+        async loadInstalledPackages() {
+            this.loading = true;
+            try {
+                this.installedVisualizations = await getInstalledVisualizations(this.showDisabled);
+                this.filterInstalled();
+                this.clearMessage();
+            } catch (error) {
+                this.showMessage("Failed to load installed visualizations", "error");
+                console.error("Error loading installed visualizations:", error);
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        async loadAvailablePackages() {
+            this.loadingAvailable = true;
+            try {
+                this.availableVisualizations = await getAvailableVisualizations(this.availableSearchFilter);
+                this.clearMessage();
+            } catch (error) {
+                this.showMessage("Failed to load available visualizations", "error");
+                console.error("Error loading available visualizations:", error);
+            } finally {
+                this.loadingAvailable = false;
+            }
+        },
+
+        async loadUsageStats() {
+            this.loadingStats = true;
+            try {
+                this.usageStats = await getVisualizationUsageStats(30);
+                this.clearMessage();
+            } catch (error) {
+                this.showMessage("Failed to load usage statistics", "error");
+                console.error("Error loading usage stats:", error);
+            } finally {
+                this.loadingStats = false;
+            }
+        },
+
+        filterInstalled() {
+            let filtered = this.installedVisualizations;
+
+            // Filter by enabled/disabled
+            if (!this.showDisabled) {
+                filtered = filtered.filter((viz) => viz.enabled);
+            }
+
+            // Filter by search term
+            if (this.searchFilter) {
+                const searchLower = this.searchFilter.toLowerCase();
+                filtered = filtered.filter(
+                    (viz) =>
+                        viz.id.toLowerCase().includes(searchLower) ||
+                        viz.package.toLowerCase().includes(searchLower) ||
+                        (viz.metadata?.description && viz.metadata.description.toLowerCase().includes(searchLower))
+                );
+            }
+
+            this.filteredInstalledVisualizations = filtered;
+        },
+
+        async searchAvailablePackages() {
+            await this.loadAvailablePackages();
+        },
+
+        async handleToggle(viz) {
+            const actionKey = `toggle-${viz.id}`;
+            this.loadingActions.add(actionKey);
+
+            try {
+                await toggleVisualization(viz.id, !viz.enabled);
+                this.showMessage(
+                    `Visualization ${viz.id} ${!viz.enabled ? "enabled" : "disabled"} successfully`,
+                    "success"
+                );
+                await this.loadInstalledPackages();
+            } catch (error) {
+                this.showMessage(`Failed to toggle visualization ${viz.id}`, "error");
+                console.error("Error toggling visualization:", error);
+            } finally {
+                this.loadingActions.delete(actionKey);
+            }
+        },
+
+        async handleUpdate(viz, newVersion) {
+            const actionKey = `update-${viz.id}`;
+            this.loadingActions.add(actionKey);
+
+            try {
+                await updateVisualization(viz.id, newVersion);
+                this.showMessage(`Visualization ${viz.id} updated to version ${newVersion}`, "success");
+                await this.loadInstalledPackages();
+            } catch (error) {
+                this.showMessage(`Failed to update visualization ${viz.id}`, "error");
+                console.error("Error updating visualization:", error);
+            } finally {
+                this.loadingActions.delete(actionKey);
+            }
+        },
+
+        async handleUninstall(viz) {
+            if (!confirm(`Are you sure you want to uninstall ${viz.id}?`)) {
+                return;
+            }
+
+            const actionKey = `uninstall-${viz.id}`;
+            this.loadingActions.add(actionKey);
+
+            try {
+                await uninstallVisualization(viz.id);
+                this.showMessage(`Visualization ${viz.id} uninstalled successfully`, "success");
+                await this.loadInstalledPackages();
+            } catch (error) {
+                this.showMessage(`Failed to uninstall visualization ${viz.id}`, "error");
+                console.error("Error uninstalling visualization:", error);
+            } finally {
+                this.loadingActions.delete(actionKey);
+            }
+        },
+
+        async handleStage(viz) {
+            const actionKey = `stage-${viz.id}`;
+            this.loadingActions.add(actionKey);
+
+            try {
+                const result = await stageVisualization(viz.id);
+                this.showMessage(result.message, "success");
+
+                // Refresh staging status if we're on the staging tab
+                if (this.activeTab === "staging") {
+                    await this.loadStagingStatus();
+                }
+            } catch (error) {
+                this.showMessage(`Failed to stage visualization ${viz.id}`, "error");
+                console.error("Error staging visualization:", error);
+            } finally {
+                this.loadingActions.delete(actionKey);
+            }
+        },
+
+        handleInstall(viz) {
+            this.selectedVisualization = viz;
+            this.showInstallModal = true;
+        },
+
+        async confirmInstall(vizId) {
+            this.installing = true;
+
+            try {
+                await installVisualization(vizId, this.selectedVisualization.name, this.selectedVisualization.version);
+                this.showMessage(`Visualization ${vizId} installed successfully`, "success");
+                this.showInstallModal = false;
+                await this.loadInstalledPackages();
+            } catch (error) {
+                this.showMessage(`Failed to install visualization ${vizId}`, "error");
+                console.error("Error installing visualization:", error);
+            } finally {
+                this.installing = false;
+            }
+        },
+
+        async reloadRegistry() {
+            this.loading = true;
+            try {
+                await reloadVisualizationRegistry();
+                this.showMessage("Visualization registry reloaded successfully", "success");
+                await this.loadInstalledPackages();
+            } catch (error) {
+                this.showMessage("Failed to reload visualization registry", "error");
+                console.error("Error reloading registry:", error);
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        // Staging methods
+        async loadStagingStatus() {
+            try {
+                this.stagingStatus = await getStagingStatus();
+            } catch (error) {
+                this.showMessage("Failed to load staging status", "error");
+                console.error("Error loading staging status:", error);
+            }
+        },
+
+        async stageAllAssets() {
+            this.stagingLoading = true;
+            try {
+                const result = await stageAllVisualizations();
+                this.showMessage(result.message, "success");
+                await this.loadStagingStatus();
+            } catch (error) {
+                this.showMessage("Failed to stage visualizations", "error");
+                console.error("Error staging visualizations:", error);
+            } finally {
+                this.stagingLoading = false;
+            }
+        },
+
+        async cleanStagedAssets() {
+            if (
+                !confirm(
+                    "Are you sure you want to clean all staged assets? This will remove all visualizations from Galaxy's serving directory."
+                )
+            ) {
+                return;
+            }
+
+            this.stagingLoading = true;
+            try {
+                const result = await cleanStagedAssets();
+                this.showMessage(result.message, "success");
+                await this.loadStagingStatus();
+            } catch (error) {
+                this.showMessage("Failed to clean staged assets", "error");
+                console.error("Error cleaning staged assets:", error);
+            } finally {
+                this.stagingLoading = false;
+            }
+        },
+
+        formatFileSize(bytes) {
+            if (bytes === 0) {
+                return "0 B";
+            }
+            const k = 1024;
+            const sizes = ["B", "KB", "MB", "GB"];
+            const i = Math.floor(Math.log(bytes) / Math.log(k));
+            return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
+        },
+
+        showMessage(text, status) {
+            this.message = text;
+            this.messageStatus = status;
+        },
+
+        clearMessage() {
+            this.message = "";
+            this.messageStatus = "";
+        },
+    },
+};
+</script>
+
+<style scoped>
+.card {
+    border: 1px solid #dee2e6;
+    border-radius: 0.375rem;
+}
+
+.card-header {
+    background-color: #f8f9fa;
+    border-bottom: 1px solid #dee2e6;
+    padding: 0.75rem 1rem;
+}
+
+.card-body {
+    padding: 1rem;
+}
+
+.btn-group .btn {
+    border-radius: 0.375rem;
+}
+
+.btn-group .btn:not(:last-child) {
+    margin-right: 0.5rem;
+}
+
+.input-group {
+    box-shadow: none;
+}
+
+.spinner-border-sm {
+    width: 1rem;
+    height: 1rem;
+}
+</style>

--- a/client/src/components/admin/Visualizations/VisualizationsAdmin.vue
+++ b/client/src/components/admin/Visualizations/VisualizationsAdmin.vue
@@ -1,45 +1,43 @@
 <template>
     <div aria-labelledby="visualizations-admin-heading">
-        <h1 id="visualizations-admin-heading" class="h-lg">Visualizations Management</h1>
+        <Heading id="visualizations-admin-heading" h1 size="lg">Visualizations Management</Heading>
 
-        <Message :message="message" :status="messageStatus" />
-
-        <div class="mb-3">
-            <b-button-group>
-                <b-button
-                    :variant="activeTab === 'installed' ? 'primary' : 'outline-primary'"
-                    @click="activeTab = 'installed'">
-                    <i class="fa fa-list mr-1"></i>
+        <b-tabs v-model="activeTabIndex" class="mb-3">
+            <b-tab>
+                <template v-slot:title>
+                    <FontAwesomeIcon :icon="faList" class="mr-1" />
                     Installed ({{ installedVisualizations.length }})
-                </b-button>
-                <b-button
-                    :variant="activeTab === 'available' ? 'primary' : 'outline-primary'"
-                    @click="activeTab = 'available'">
-                    <i class="fa fa-download mr-1"></i>
+                </template>
+            </b-tab>
+            <b-tab>
+                <template v-slot:title>
+                    <FontAwesomeIcon :icon="faDownload" class="mr-1" />
                     Available
-                </b-button>
-                <b-button :variant="activeTab === 'usage' ? 'primary' : 'outline-primary'" @click="activeTab = 'usage'">
-                    <i class="fa fa-chart-bar mr-1"></i>
+                </template>
+            </b-tab>
+            <b-tab>
+                <template v-slot:title>
+                    <FontAwesomeIcon :icon="faChartBar" class="mr-1" />
                     Usage Stats
-                </b-button>
-                <b-button
-                    :variant="activeTab === 'staging' ? 'primary' : 'outline-primary'"
-                    @click="activeTab = 'staging'">
-                    <i class="fa fa-server mr-1"></i>
+                </template>
+            </b-tab>
+            <b-tab>
+                <template v-slot:title>
+                    <FontAwesomeIcon :icon="faServer" class="mr-1" />
                     Staging
-                </b-button>
-            </b-button-group>
+                </template>
+            </b-tab>
+        </b-tabs>
 
-            <b-button
-                v-if="activeTab === 'installed'"
-                variant="outline-secondary"
-                class="ml-2"
-                :disabled="loading"
-                @click="reloadRegistry">
-                <i class="fa fa-sync mr-1" :class="{ 'fa-spin': loading }"></i>
-                Reload Registry
-            </b-button>
-        </div>
+        <b-button
+            v-if="activeTab === 'installed'"
+            variant="outline-secondary"
+            class="mb-3"
+            :disabled="loading"
+            @click="reloadRegistry">
+            <FontAwesomeIcon :icon="faSync" :spin="loading" class="mr-1" />
+            Reload Registry
+        </b-button>
 
         <!-- Installed Visualizations Tab -->
         <div v-if="activeTab === 'installed'">
@@ -62,7 +60,7 @@
                                     searchFilter = '';
                                     filterInstalled();
                                 ">
-                                <i class="fa fa-times"></i>
+                                <FontAwesomeIcon :icon="faTimes" />
                             </b-button>
                         </b-input-group-append>
                     </b-input-group>
@@ -70,7 +68,7 @@
             </div>
 
             <div v-if="loading" class="text-center py-4">
-                <b-spinner label="Loading..."></b-spinner>
+                <b-spinner label="Loading..." />
                 <p class="mt-2">Loading visualization packages...</p>
             </div>
 
@@ -109,14 +107,14 @@
                                 availableSearchFilter = '';
                                 searchAvailablePackages();
                             ">
-                            <i class="fa fa-times"></i>
+                            <FontAwesomeIcon :icon="faTimes" />
                         </b-button>
                     </b-input-group-append>
                 </b-input-group>
             </div>
 
             <div v-if="loadingAvailable" class="text-center py-4">
-                <b-spinner label="Loading..."></b-spinner>
+                <b-spinner label="Loading..." />
                 <p class="mt-2">Searching available packages...</p>
             </div>
 
@@ -145,72 +143,70 @@
         <div v-if="activeTab === 'staging'">
             <div class="row">
                 <div class="col-md-6">
-                    <div class="card">
-                        <div class="card-header">
+                    <b-card>
+                        <template v-slot:header>
                             <h5 class="card-title mb-0">
-                                <i class="fa fa-upload mr-2"></i>
+                                <FontAwesomeIcon :icon="faUpload" class="mr-2" />
                                 Stage Assets
                             </h5>
+                        </template>
+
+                        <p class="text-muted">
+                            Staging copies visualization assets from <code>config/plugins/visualizations</code> to
+                            <code>static/plugins/visualizations</code> where Galaxy can serve them.
+                        </p>
+                        <div class="d-flex">
+                            <b-button variant="primary" class="mr-2" :disabled="stagingLoading" @click="stageAllAssets">
+                                <FontAwesomeIcon :icon="faUpload" :spin="stagingLoading" class="mr-1" />
+                                Stage All Visualizations
+                            </b-button>
+                            <b-button variant="warning" :disabled="stagingLoading" @click="cleanStagedAssetsAction">
+                                <FontAwesomeIcon :icon="faTrash" class="mr-1" />
+                                Clean Staged Assets
+                            </b-button>
                         </div>
-                        <div class="card-body">
-                            <p class="text-muted">
-                                Staging copies visualization assets from <code>config/plugins/visualizations</code> to
-                                <code>static/plugins/visualizations</code> where Galaxy can serve them.
-                            </p>
-                            <div class="d-flex gap-2">
-                                <b-button variant="primary" :disabled="stagingLoading" @click="stageAllAssets">
-                                    <i class="fa fa-upload mr-1" :class="{ 'fa-spin': stagingLoading }"></i>
-                                    Stage All Visualizations
-                                </b-button>
-                                <b-button variant="warning" :disabled="stagingLoading" @click="cleanStagedAssets">
-                                    <i class="fa fa-trash mr-1"></i>
-                                    Clean Staged Assets
-                                </b-button>
-                            </div>
-                        </div>
-                    </div>
+                    </b-card>
                 </div>
                 <div class="col-md-6">
-                    <div class="card">
-                        <div class="card-header">
+                    <b-card>
+                        <template v-slot:header>
                             <h5 class="card-title mb-0">
-                                <i class="fa fa-info-circle mr-2"></i>
+                                <FontAwesomeIcon :icon="faInfoCircle" class="mr-2" />
                                 Staging Status
                             </h5>
-                        </div>
-                        <div class="card-body">
-                            <div v-if="stagingStatus">
-                                <p class="mb-2">
-                                    <strong>{{ stagingStatus.staged_count }}</strong> visualizations staged
-                                </p>
-                                <p class="mb-2 text-muted">
-                                    Total size: {{ formatFileSize(stagingStatus.total_size) }}
-                                </p>
-                                <div v-if="stagingStatus.staged_visualizations.length > 0" class="mt-3">
-                                    <h6>Staged Visualizations:</h6>
-                                    <div class="staged-viz-list" style="max-height: 200px; overflow-y: auto">
-                                        <div
-                                            v-for="viz in stagingStatus.staged_visualizations"
-                                            :key="viz.name"
-                                            class="d-flex justify-content-between align-items-center border-bottom py-1">
-                                            <span class="small">{{ viz.name }}</span>
-                                            <span class="text-muted small">{{ formatFileSize(viz.size) }}</span>
-                                        </div>
+                        </template>
+
+                        <div v-if="stagingStatus">
+                            <p class="mb-2">
+                                <strong>{{ stagingStatus.staged_count }}</strong> visualizations staged
+                            </p>
+                            <p class="mb-2 text-muted">
+                                Total size: {{ bytesToString(stagingStatus.total_size, true, 2) }}
+                            </p>
+                            <div v-if="stagingStatus.staged_visualizations.length > 0" class="mt-3">
+                                <h6>Staged Visualizations:</h6>
+                                <div class="staged-viz-list" style="max-height: 200px; overflow-y: auto">
+                                    <div
+                                        v-for="viz in stagingStatus.staged_visualizations"
+                                        :key="viz.name"
+                                        class="d-flex justify-content-between align-items-center border-bottom py-1">
+                                        <span class="small">{{ viz.name }}</span>
+                                        <span class="text-muted small">{{ bytesToString(viz.size, true, 2) }}</span>
                                     </div>
                                 </div>
                             </div>
-                            <div v-else class="text-center">
-                                <b-spinner small></b-spinner>
-                                Loading staging status...
-                            </div>
-                            <div class="mt-3">
-                                <b-button size="sm" variant="outline-secondary" @click="loadStagingStatus">
-                                    <i class="fa fa-sync mr-1"></i>
-                                    Refresh Status
-                                </b-button>
-                            </div>
                         </div>
-                    </div>
+                        <div v-else class="text-center">
+                            <b-spinner small />
+                            Loading staging status...
+                        </div>
+                        <div class="mt-3">
+                            <b-button size="sm" variant="outline-secondary" @click="loadStagingStatus">
+                                <FontAwesomeIcon :icon="faSync" class="mr-1" />
+                                Refresh Status
+                            </b-button>
+                        </div>
+                    </b-card>
                 </div>
             </div>
         </div>
@@ -225,7 +221,26 @@
     </div>
 </template>
 
-<script>
+<script setup lang="ts">
+import {
+    faChartBar,
+    faDownload,
+    faInfoCircle,
+    faList,
+    faServer,
+    faSync,
+    faTimes,
+    faTrash,
+    faUpload,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { computed, onMounted, reactive, ref, watch } from "vue";
+
+import { useConfirmDialog } from "@/composables/confirmDialog";
+import { useToast } from "@/composables/toast";
+import { bytesToString } from "@/utils/utils";
+
+import type { AvailableVisualization, StagingStatus, UsageStats, Visualization } from "./services";
 import {
     cleanStagedAssets,
     getAvailableVisualizations,
@@ -241,354 +256,268 @@ import {
     updateVisualization,
 } from "./services";
 
-import Message from "../../Message.vue";
 import AvailableVisualizationCard from "./AvailableVisualizationCard.vue";
 import InstallVisualizationModal from "./InstallVisualizationModal.vue";
 import UsageStatsView from "./UsageStatsView.vue";
 import VisualizationCard from "./VisualizationCard.vue";
+import Heading from "@/components/Common/Heading.vue";
 
-export default {
-    name: "VisualizationsAdmin",
+const { confirm } = useConfirmDialog();
+const toast = useToast();
 
-    components: {
-        Message,
-        VisualizationCard,
-        AvailableVisualizationCard,
-        InstallVisualizationModal,
-        UsageStatsView,
-    },
+const TAB_NAMES = ["installed", "available", "usage", "staging"] as const;
+const activeTabIndex = ref(0);
+const activeTab = computed(() => TAB_NAMES[activeTabIndex.value]!);
 
-    data() {
-        return {
-            activeTab: "installed",
-            loading: false,
-            loadingAvailable: false,
-            loadingStats: false,
-            loadingActions: new Set(),
-            installing: false,
-            message: "",
-            messageStatus: "",
+const loading = ref(false);
+const loadingAvailable = ref(false);
+const loadingStats = ref(false);
+const loadingActions: Record<string, boolean> = reactive({});
+const installing = ref(false);
 
-            // Installed packages
-            installedVisualizations: [],
-            filteredInstalledVisualizations: [],
-            showDisabled: true,
-            searchFilter: "",
+const installedVisualizations = ref<Visualization[]>([]);
+const filteredInstalledVisualizations = ref<Visualization[]>([]);
+const showDisabled = ref(true);
+const searchFilter = ref("");
 
-            // Available packages
-            availableVisualizations: [],
-            availableSearchFilter: "",
+const availableVisualizations = ref<AvailableVisualization[]>([]);
+const availableSearchFilter = ref("");
 
-            // Usage stats
-            usageStats: { days: 30, stats: {} },
+const usageStats = ref<UsageStats>({ days: 30, stats: {} } as UsageStats);
 
-            // Staging
-            stagingLoading: false,
-            stagingStatus: null,
+const stagingLoading = ref(false);
+const stagingStatus = ref<StagingStatus | null>(null);
 
-            // Install modal
-            showInstallModal: false,
-            selectedVisualization: null,
-        };
-    },
+const showInstallModal = ref(false);
+const selectedVisualization = ref<AvailableVisualization | null>(null);
 
-    watch: {
-        showDisabled() {
-            this.filterInstalled();
-        },
+watch(showDisabled, () => {
+    filterInstalled();
+});
 
-        async activeTab(newTab) {
-            if (newTab === "available" && this.availableVisualizations.length === 0) {
-                await this.loadAvailablePackages();
-            } else if (newTab === "usage") {
-                await this.loadUsageStats();
-            } else if (newTab === "staging") {
-                await this.loadStagingStatus();
-            }
-        },
-    },
+watch(activeTab, async (newTab) => {
+    if (newTab === "available" && availableVisualizations.value.length === 0) {
+        await loadAvailablePackages();
+    } else if (newTab === "usage") {
+        await loadUsageStats();
+    } else if (newTab === "staging") {
+        await loadStagingStatus();
+    }
+});
 
-    async mounted() {
-        await this.loadInstalledPackages();
-        await this.loadAvailablePackages();
-    },
+onMounted(async () => {
+    await loadInstalledPackages();
+});
 
-    methods: {
-        async loadInstalledPackages() {
-            this.loading = true;
-            try {
-                this.installedVisualizations = await getInstalledVisualizations(this.showDisabled);
-                this.filterInstalled();
-                this.clearMessage();
-            } catch (error) {
-                this.showMessage("Failed to load installed visualizations", "error");
-                console.error("Error loading installed visualizations:", error);
-            } finally {
-                this.loading = false;
-            }
-        },
+function filterInstalled() {
+    let filtered = installedVisualizations.value;
 
-        async loadAvailablePackages() {
-            this.loadingAvailable = true;
-            try {
-                this.availableVisualizations = await getAvailableVisualizations(this.availableSearchFilter);
-                this.clearMessage();
-            } catch (error) {
-                this.showMessage("Failed to load available visualizations", "error");
-                console.error("Error loading available visualizations:", error);
-            } finally {
-                this.loadingAvailable = false;
-            }
-        },
+    if (!showDisabled.value) {
+        filtered = filtered.filter((viz) => viz.enabled);
+    }
 
-        async loadUsageStats() {
-            this.loadingStats = true;
-            try {
-                this.usageStats = await getVisualizationUsageStats(30);
-                this.clearMessage();
-            } catch (error) {
-                this.showMessage("Failed to load usage statistics", "error");
-                console.error("Error loading usage stats:", error);
-            } finally {
-                this.loadingStats = false;
-            }
-        },
+    if (searchFilter.value) {
+        const searchLower = searchFilter.value.toLowerCase();
+        filtered = filtered.filter(
+            (viz) =>
+                viz.id.toLowerCase().includes(searchLower) ||
+                viz.package.toLowerCase().includes(searchLower) ||
+                (viz.metadata?.description && (viz.metadata.description as string).toLowerCase().includes(searchLower)),
+        );
+    }
 
-        filterInstalled() {
-            let filtered = this.installedVisualizations;
+    filteredInstalledVisualizations.value = filtered;
+}
 
-            // Filter by enabled/disabled
-            if (!this.showDisabled) {
-                filtered = filtered.filter((viz) => viz.enabled);
-            }
+async function loadInstalledPackages() {
+    loading.value = true;
+    try {
+        installedVisualizations.value = await getInstalledVisualizations(showDisabled.value);
+        filterInstalled();
+    } catch (error) {
+        toast.error("Failed to load installed visualizations");
+        console.error("Error loading installed visualizations:", error);
+    } finally {
+        loading.value = false;
+    }
+}
 
-            // Filter by search term
-            if (this.searchFilter) {
-                const searchLower = this.searchFilter.toLowerCase();
-                filtered = filtered.filter(
-                    (viz) =>
-                        viz.id.toLowerCase().includes(searchLower) ||
-                        viz.package.toLowerCase().includes(searchLower) ||
-                        (viz.metadata?.description && viz.metadata.description.toLowerCase().includes(searchLower)),
-                );
-            }
+async function loadAvailablePackages() {
+    loadingAvailable.value = true;
+    try {
+        availableVisualizations.value = await getAvailableVisualizations(availableSearchFilter.value);
+    } catch (error) {
+        toast.error("Failed to load available visualizations");
+        console.error("Error loading available visualizations:", error);
+    } finally {
+        loadingAvailable.value = false;
+    }
+}
 
-            this.filteredInstalledVisualizations = filtered;
-        },
+async function loadUsageStats() {
+    loadingStats.value = true;
+    try {
+        usageStats.value = await getVisualizationUsageStats(30);
+    } catch (error) {
+        toast.error("Failed to load usage statistics");
+        console.error("Error loading usage stats:", error);
+    } finally {
+        loadingStats.value = false;
+    }
+}
 
-        async searchAvailablePackages() {
-            await this.loadAvailablePackages();
-        },
+async function searchAvailablePackages() {
+    await loadAvailablePackages();
+}
 
-        async handleToggle(viz) {
-            const actionKey = `toggle-${viz.id}`;
-            this.loadingActions.add(actionKey);
+async function handleToggle(viz: Visualization) {
+    const actionKey = `toggle-${viz.id}`;
+    loadingActions[actionKey] = true;
 
-            try {
-                await toggleVisualization(viz.id, !viz.enabled);
-                this.showMessage(
-                    `Visualization ${viz.id} ${!viz.enabled ? "enabled" : "disabled"} successfully`,
-                    "success",
-                );
-                await this.loadInstalledPackages();
-            } catch (error) {
-                this.showMessage(`Failed to toggle visualization ${viz.id}`, "error");
-                console.error("Error toggling visualization:", error);
-            } finally {
-                this.loadingActions.delete(actionKey);
-            }
-        },
+    try {
+        await toggleVisualization(viz.id, !viz.enabled);
+        toast.success(`Visualization ${viz.id} ${!viz.enabled ? "enabled" : "disabled"} successfully`);
+        await loadInstalledPackages();
+    } catch (error) {
+        toast.error(`Failed to toggle visualization ${viz.id}`);
+        console.error("Error toggling visualization:", error);
+    } finally {
+        delete loadingActions[actionKey];
+    }
+}
 
-        async handleUpdate(viz, newVersion) {
-            const actionKey = `update-${viz.id}`;
-            this.loadingActions.add(actionKey);
+async function handleUpdate(viz: Visualization, newVersion: string) {
+    const actionKey = `update-${viz.id}`;
+    loadingActions[actionKey] = true;
 
-            try {
-                await updateVisualization(viz.id, newVersion);
-                this.showMessage(`Visualization ${viz.id} updated to version ${newVersion}`, "success");
-                await this.loadInstalledPackages();
-            } catch (error) {
-                this.showMessage(`Failed to update visualization ${viz.id}`, "error");
-                console.error("Error updating visualization:", error);
-            } finally {
-                this.loadingActions.delete(actionKey);
-            }
-        },
+    try {
+        await updateVisualization(viz.id, newVersion);
+        toast.success(`Visualization ${viz.id} updated to version ${newVersion}`);
+        await loadInstalledPackages();
+    } catch (error) {
+        toast.error(`Failed to update visualization ${viz.id}`);
+        console.error("Error updating visualization:", error);
+    } finally {
+        delete loadingActions[actionKey];
+    }
+}
 
-        async handleUninstall(viz) {
-            if (!confirm(`Are you sure you want to uninstall ${viz.id}?`)) {
-                return;
-            }
+async function handleUninstall(viz: Visualization) {
+    const confirmed = await confirm(`Are you sure you want to uninstall ${viz.id}?`);
+    if (!confirmed) {
+        return;
+    }
 
-            const actionKey = `uninstall-${viz.id}`;
-            this.loadingActions.add(actionKey);
+    const actionKey = `uninstall-${viz.id}`;
+    loadingActions[actionKey] = true;
 
-            try {
-                await uninstallVisualization(viz.id);
-                this.showMessage(`Visualization ${viz.id} uninstalled successfully`, "success");
-                await this.loadInstalledPackages();
-            } catch (error) {
-                this.showMessage(`Failed to uninstall visualization ${viz.id}`, "error");
-                console.error("Error uninstalling visualization:", error);
-            } finally {
-                this.loadingActions.delete(actionKey);
-            }
-        },
+    try {
+        await uninstallVisualization(viz.id);
+        toast.success(`Visualization ${viz.id} uninstalled successfully`);
+        await loadInstalledPackages();
+    } catch (error) {
+        toast.error(`Failed to uninstall visualization ${viz.id}`);
+        console.error("Error uninstalling visualization:", error);
+    } finally {
+        delete loadingActions[actionKey];
+    }
+}
 
-        async handleStage(viz) {
-            const actionKey = `stage-${viz.id}`;
-            this.loadingActions.add(actionKey);
+async function handleStage(viz: Visualization) {
+    const actionKey = `stage-${viz.id}`;
+    loadingActions[actionKey] = true;
 
-            try {
-                const result = await stageVisualization(viz.id);
-                this.showMessage(result.message, "success");
+    try {
+        const result = await stageVisualization(viz.id);
+        toast.success(result.message);
 
-                // Refresh staging status if we're on the staging tab
-                if (this.activeTab === "staging") {
-                    await this.loadStagingStatus();
-                }
-            } catch (error) {
-                this.showMessage(`Failed to stage visualization ${viz.id}`, "error");
-                console.error("Error staging visualization:", error);
-            } finally {
-                this.loadingActions.delete(actionKey);
-            }
-        },
+        if (activeTab.value === "staging") {
+            await loadStagingStatus();
+        }
+    } catch (error) {
+        toast.error(`Failed to stage visualization ${viz.id}`);
+        console.error("Error staging visualization:", error);
+    } finally {
+        delete loadingActions[actionKey];
+    }
+}
 
-        handleInstall(viz) {
-            this.selectedVisualization = viz;
-            this.showInstallModal = true;
-        },
+function handleInstall(viz: AvailableVisualization) {
+    selectedVisualization.value = viz;
+    showInstallModal.value = true;
+}
 
-        async confirmInstall(vizId) {
-            this.installing = true;
+async function confirmInstall(vizId: string) {
+    installing.value = true;
 
-            try {
-                await installVisualization(vizId, this.selectedVisualization.name, this.selectedVisualization.version);
-                this.showMessage(`Visualization ${vizId} installed successfully`, "success");
-                this.showInstallModal = false;
-                await this.loadInstalledPackages();
-            } catch (error) {
-                this.showMessage(`Failed to install visualization ${vizId}`, "error");
-                console.error("Error installing visualization:", error);
-            } finally {
-                this.installing = false;
-            }
-        },
+    try {
+        await installVisualization(vizId, selectedVisualization.value!.name, selectedVisualization.value!.version);
+        toast.success(`Visualization ${vizId} installed successfully`);
+        showInstallModal.value = false;
+        await loadInstalledPackages();
+    } catch (error) {
+        toast.error(`Failed to install visualization ${vizId}`);
+        console.error("Error installing visualization:", error);
+    } finally {
+        installing.value = false;
+    }
+}
 
-        async reloadRegistry() {
-            this.loading = true;
-            try {
-                await reloadVisualizationRegistry();
-                this.showMessage("Visualization registry reloaded successfully", "success");
-                await this.loadInstalledPackages();
-            } catch (error) {
-                this.showMessage("Failed to reload visualization registry", "error");
-                console.error("Error reloading registry:", error);
-            } finally {
-                this.loading = false;
-            }
-        },
+async function reloadRegistry() {
+    loading.value = true;
+    try {
+        await reloadVisualizationRegistry();
+        toast.success("Visualization registry reloaded successfully");
+        await loadInstalledPackages();
+    } catch (error) {
+        toast.error("Failed to reload visualization registry");
+        console.error("Error reloading registry:", error);
+    } finally {
+        loading.value = false;
+    }
+}
 
-        // Staging methods
-        async loadStagingStatus() {
-            try {
-                this.stagingStatus = await getStagingStatus();
-            } catch (error) {
-                this.showMessage("Failed to load staging status", "error");
-                console.error("Error loading staging status:", error);
-            }
-        },
+async function loadStagingStatus() {
+    try {
+        stagingStatus.value = await getStagingStatus();
+    } catch (error) {
+        toast.error("Failed to load staging status");
+        console.error("Error loading staging status:", error);
+    }
+}
 
-        async stageAllAssets() {
-            this.stagingLoading = true;
-            try {
-                const result = await stageAllVisualizations();
-                this.showMessage(result.message, "success");
-                await this.loadStagingStatus();
-            } catch (error) {
-                this.showMessage("Failed to stage visualizations", "error");
-                console.error("Error staging visualizations:", error);
-            } finally {
-                this.stagingLoading = false;
-            }
-        },
+async function stageAllAssets() {
+    stagingLoading.value = true;
+    try {
+        const result = await stageAllVisualizations();
+        toast.success(result.message);
+        await loadStagingStatus();
+    } catch (error) {
+        toast.error("Failed to stage visualizations");
+        console.error("Error staging visualizations:", error);
+    } finally {
+        stagingLoading.value = false;
+    }
+}
 
-        async cleanStagedAssets() {
-            if (
-                !confirm(
-                    "Are you sure you want to clean all staged assets? This will remove all visualizations from Galaxy's serving directory.",
-                )
-            ) {
-                return;
-            }
+async function cleanStagedAssetsAction() {
+    const confirmed = await confirm(
+        "Are you sure you want to clean all staged assets? This will remove all visualizations from Galaxy's serving directory.",
+    );
+    if (!confirmed) {
+        return;
+    }
 
-            this.stagingLoading = true;
-            try {
-                const result = await cleanStagedAssets();
-                this.showMessage(result.message, "success");
-                await this.loadStagingStatus();
-            } catch (error) {
-                this.showMessage("Failed to clean staged assets", "error");
-                console.error("Error cleaning staged assets:", error);
-            } finally {
-                this.stagingLoading = false;
-            }
-        },
-
-        formatFileSize(bytes) {
-            if (bytes === 0) {
-                return "0 B";
-            }
-            const k = 1024;
-            const sizes = ["B", "KB", "MB", "GB"];
-            const i = Math.floor(Math.log(bytes) / Math.log(k));
-            return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
-        },
-
-        showMessage(text, status) {
-            this.message = text;
-            this.messageStatus = status;
-        },
-
-        clearMessage() {
-            this.message = "";
-            this.messageStatus = "";
-        },
-    },
-};
+    stagingLoading.value = true;
+    try {
+        const result = await cleanStagedAssets();
+        toast.success(result.message);
+        await loadStagingStatus();
+    } catch (error) {
+        toast.error("Failed to clean staged assets");
+        console.error("Error cleaning staged assets:", error);
+    } finally {
+        stagingLoading.value = false;
+    }
+}
 </script>
-
-<style scoped>
-.card {
-    border: 1px solid #dee2e6;
-    border-radius: 0.375rem;
-}
-
-.card-header {
-    background-color: #f8f9fa;
-    border-bottom: 1px solid #dee2e6;
-    padding: 0.75rem 1rem;
-}
-
-.card-body {
-    padding: 1rem;
-}
-
-.btn-group .btn {
-    border-radius: 0.375rem;
-}
-
-.btn-group .btn:not(:last-child) {
-    margin-right: 0.5rem;
-}
-
-.input-group {
-    box-shadow: none;
-}
-
-.spinner-border-sm {
-    width: 1rem;
-    height: 1rem;
-}
-</style>

--- a/client/src/components/admin/Visualizations/VisualizationsAdmin.vue
+++ b/client/src/components/admin/Visualizations/VisualizationsAdmin.vue
@@ -2,6 +2,11 @@
     <div aria-labelledby="visualizations-admin-heading">
         <Heading id="visualizations-admin-heading" h1 size="lg">Visualizations Management</Heading>
 
+        <p class="text-muted mb-3">
+            Install and manage visualization packages from the npm registry. Installed visualizations are automatically
+            staged so Galaxy can serve them to users.
+        </p>
+
         <b-tabs v-model="activeTabIndex" class="mb-3">
             <b-tab>
                 <template v-slot:title>
@@ -29,29 +34,23 @@
             </b-tab>
         </b-tabs>
 
-        <b-button
-            v-if="activeTab === 'installed'"
-            variant="outline-secondary"
-            class="mb-3"
-            :disabled="loading"
-            @click="reloadRegistry">
-            <FontAwesomeIcon :icon="faSync" :spin="loading" class="mr-1" />
-            Reload Registry
-        </b-button>
-
         <!-- Installed Visualizations Tab -->
         <div v-if="activeTab === 'installed'">
             <div class="d-flex justify-content-between align-items-center mb-3">
-                <div>
+                <div class="d-flex align-items-center">
                     <b-form-checkbox v-model="showDisabled" class="mr-3">
                         Show disabled visualizations
                     </b-form-checkbox>
+                    <b-button variant="outline-secondary" size="sm" :disabled="loading" @click="reloadRegistry">
+                        <FontAwesomeIcon :icon="faSync" :spin="loading" class="mr-1" />
+                        Refresh
+                    </b-button>
                 </div>
                 <div>
                     <b-input-group>
                         <b-form-input v-model="searchFilter" placeholder="Filter visualizations..." />
                         <b-input-group-append>
-                            <b-button variant="outline-secondary" @click="searchFilter = ''">
+                            <b-button variant="outline-secondary" aria-label="Clear filter" @click="searchFilter = ''">
                                 <FontAwesomeIcon :icon="faTimes" />
                             </b-button>
                         </b-input-group-append>
@@ -65,7 +64,15 @@
             </div>
 
             <div v-else-if="filteredInstalledVisualizations.length === 0" class="text-center py-4">
-                <p class="text-muted">No visualization packages found.</p>
+                <p v-if="installedVisualizations.length === 0 && !searchFilter" class="text-muted mb-2">
+                    No visualization packages installed yet.
+                </p>
+                <p v-if="installedVisualizations.length === 0 && !searchFilter" class="text-muted">
+                    Browse the
+                    <b-link @click="activeTabIndex = 1">Available</b-link>
+                    tab to find and install visualization packages from the npm registry.
+                </p>
+                <p v-else class="text-muted">No visualizations match your filter.</p>
             </div>
 
             <div v-else>
@@ -86,7 +93,7 @@
         <!-- Available Visualizations Tab -->
         <div v-if="activeTab === 'available'">
             <div class="d-flex justify-content-between align-items-center mb-3">
-                <h3>Available Visualization Packages</h3>
+                <Heading h3 size="sm">Available Visualization Packages</Heading>
                 <b-input-group style="max-width: 300px">
                     <b-form-input
                         v-model="availableSearchFilter"
@@ -95,6 +102,7 @@
                     <b-input-group-append>
                         <b-button
                             variant="outline-secondary"
+                            aria-label="Clear search"
                             @click="
                                 availableSearchFilter = '';
                                 searchAvailablePackages();
@@ -107,11 +115,21 @@
 
             <div v-if="loadingAvailable" class="text-center py-4">
                 <b-spinner label="Loading..." />
-                <p class="mt-2">Searching available packages...</p>
+                <p class="mt-2">Searching npm registry for @galaxyproject packages...</p>
             </div>
 
+            <b-alert v-else-if="availableLoadError" variant="warning" show>
+                Could not reach the npm registry. Check that this Galaxy server has internet access.
+            </b-alert>
+
             <div v-else-if="availableVisualizations.length === 0" class="text-center py-4">
-                <p class="text-muted">No packages found. Try adjusting your search terms.</p>
+                <p class="text-muted">
+                    {{
+                        availableSearchFilter
+                            ? "No packages match your search."
+                            : "No visualization packages found in the npm registry."
+                    }}
+                </p>
             </div>
 
             <div v-else>
@@ -133,6 +151,10 @@
 
         <!-- Staging Tab -->
         <div v-if="activeTab === 'staging'">
+            <p class="text-muted mb-3">
+                Staging copies visualization assets into Galaxy's static serving directory. Visualizations are
+                automatically staged after installation, but you can manually re-stage here if needed.
+            </p>
             <div class="row">
                 <div class="col-md-6">
                     <b-card>
@@ -143,10 +165,6 @@
                             </h5>
                         </template>
 
-                        <p class="text-muted">
-                            Staging copies visualization assets from <code>config/plugins/visualizations</code> to
-                            <code>static/plugins/visualizations</code> where Galaxy can serve them.
-                        </p>
                         <div class="d-flex">
                             <b-button variant="primary" class="mr-2" :disabled="stagingLoading" @click="stageAllAssets">
                                 <FontAwesomeIcon :icon="faUpload" :spin="stagingLoading" class="mr-1" />
@@ -292,6 +310,7 @@ const filteredInstalledVisualizations = computed(() => {
 
 const availableVisualizations = ref<AvailableVisualization[]>([]);
 const availableSearchFilter = ref("");
+const availableLoadError = ref(false);
 
 const usageStats = ref<UsageStats>({ days: 30, stats: {} } as UsageStats);
 
@@ -315,13 +334,19 @@ onMounted(async () => {
     await loadInstalledPackages();
 });
 
+function errorMessage(error: unknown): string {
+    if (error instanceof Error) {
+        return error.message;
+    }
+    return String(error);
+}
+
 async function loadInstalledPackages() {
     loading.value = true;
     try {
         installedVisualizations.value = await getInstalledVisualizations(showDisabled.value);
     } catch (error) {
-        toast.error("Failed to load installed visualizations");
-        console.error("Error loading installed visualizations:", error);
+        toast.error(`Failed to load installed visualizations: ${errorMessage(error)}`);
     } finally {
         loading.value = false;
     }
@@ -329,11 +354,12 @@ async function loadInstalledPackages() {
 
 async function loadAvailablePackages() {
     loadingAvailable.value = true;
+    availableLoadError.value = false;
     try {
         availableVisualizations.value = await getAvailableVisualizations(availableSearchFilter.value);
     } catch (error) {
-        toast.error("Failed to load available visualizations");
-        console.error("Error loading available visualizations:", error);
+        availableLoadError.value = true;
+        toast.error(`Failed to search npm registry: ${errorMessage(error)}`);
     } finally {
         loadingAvailable.value = false;
     }
@@ -344,8 +370,7 @@ async function loadUsageStats() {
     try {
         usageStats.value = await getVisualizationUsageStats(30);
     } catch (error) {
-        toast.error("Failed to load usage statistics");
-        console.error("Error loading usage stats:", error);
+        toast.error(`Failed to load usage statistics: ${errorMessage(error)}`);
     } finally {
         loadingStats.value = false;
     }
@@ -359,11 +384,10 @@ async function handleToggle(viz: Visualization) {
 
     try {
         await toggleVisualization(viz.id, !viz.enabled);
-        toast.success(`Visualization ${viz.id} ${!viz.enabled ? "enabled" : "disabled"} successfully`);
+        toast.success(`Visualization ${viz.id} ${!viz.enabled ? "enabled" : "disabled"}`);
         await loadInstalledPackages();
     } catch (error) {
-        toast.error(`Failed to toggle visualization ${viz.id}`);
-        console.error("Error toggling visualization:", error);
+        toast.error(`Failed to toggle ${viz.id}: ${errorMessage(error)}`);
     } finally {
         delete loadingActions[actionKey];
     }
@@ -375,11 +399,10 @@ async function handleUpdate(viz: Visualization, newVersion: string) {
 
     try {
         await updateVisualization(viz.id, newVersion);
-        toast.success(`Visualization ${viz.id} updated to version ${newVersion}`);
+        toast.success(`Updated ${viz.id} to version ${newVersion}`);
         await loadInstalledPackages();
     } catch (error) {
-        toast.error(`Failed to update visualization ${viz.id}`);
-        console.error("Error updating visualization:", error);
+        toast.error(`Failed to update ${viz.id}: ${errorMessage(error)}`);
     } finally {
         delete loadingActions[actionKey];
     }
@@ -396,11 +419,10 @@ async function handleUninstall(viz: Visualization) {
 
     try {
         await uninstallVisualization(viz.id);
-        toast.success(`Visualization ${viz.id} uninstalled successfully`);
+        toast.success(`Uninstalled ${viz.id}`);
         await loadInstalledPackages();
     } catch (error) {
-        toast.error(`Failed to uninstall visualization ${viz.id}`);
-        console.error("Error uninstalling visualization:", error);
+        toast.error(`Failed to uninstall ${viz.id}: ${errorMessage(error)}`);
     } finally {
         delete loadingActions[actionKey];
     }
@@ -411,15 +433,14 @@ async function handleStage(viz: Visualization) {
     loadingActions[actionKey] = true;
 
     try {
-        const result = await stageVisualization(viz.id);
-        toast.success(result.message);
+        await stageVisualization(viz.id);
+        toast.success(`Staged ${viz.id}`);
 
         if (activeTab.value === "staging") {
             await loadStagingStatus();
         }
     } catch (error) {
-        toast.error(`Failed to stage visualization ${viz.id}`);
-        console.error("Error staging visualization:", error);
+        toast.error(`Failed to stage ${viz.id}: ${errorMessage(error)}`);
     } finally {
         delete loadingActions[actionKey];
     }
@@ -435,12 +456,19 @@ async function confirmInstall(vizId: string) {
 
     try {
         await installVisualization(vizId, selectedVisualization.value!.name, selectedVisualization.value!.version);
-        toast.success(`Visualization ${vizId} installed successfully`);
         showInstallModal.value = false;
+
+        // Auto-stage so the visualization is immediately available
+        try {
+            await stageVisualization(vizId);
+            toast.success(`Installed and staged ${vizId} -- it should now be available to users`);
+        } catch {
+            toast.warning(`Installed ${vizId}, but staging failed. Go to the Staging tab to stage it manually.`);
+        }
+
         await loadInstalledPackages();
     } catch (error) {
-        toast.error(`Failed to install visualization ${vizId}`);
-        console.error("Error installing visualization:", error);
+        toast.error(`Failed to install ${vizId}: ${errorMessage(error)}`);
     } finally {
         installing.value = false;
     }
@@ -450,11 +478,10 @@ async function reloadRegistry() {
     loading.value = true;
     try {
         await reloadVisualizationRegistry();
-        toast.success("Visualization registry reloaded successfully");
+        toast.success("Visualization list refreshed");
         await loadInstalledPackages();
     } catch (error) {
-        toast.error("Failed to reload visualization registry");
-        console.error("Error reloading registry:", error);
+        toast.error(`Failed to refresh: ${errorMessage(error)}`);
     } finally {
         loading.value = false;
     }
@@ -464,8 +491,7 @@ async function loadStagingStatus() {
     try {
         stagingStatus.value = await getStagingStatus();
     } catch (error) {
-        toast.error("Failed to load staging status");
-        console.error("Error loading staging status:", error);
+        toast.error(`Failed to load staging status: ${errorMessage(error)}`);
     }
 }
 
@@ -476,8 +502,7 @@ async function stageAllAssets() {
         toast.success(result.message);
         await loadStagingStatus();
     } catch (error) {
-        toast.error("Failed to stage visualizations");
-        console.error("Error staging visualizations:", error);
+        toast.error(`Failed to stage visualizations: ${errorMessage(error)}`);
     } finally {
         stagingLoading.value = false;
     }
@@ -485,7 +510,7 @@ async function stageAllAssets() {
 
 async function cleanStagedAssetsAction() {
     const confirmed = await confirm(
-        "Are you sure you want to clean all staged assets? This will remove all visualizations from Galaxy's serving directory.",
+        "Are you sure? This removes all visualizations from Galaxy's serving directory until they are re-staged.",
     );
     if (!confirmed) {
         return;
@@ -497,8 +522,7 @@ async function cleanStagedAssetsAction() {
         toast.success(result.message);
         await loadStagingStatus();
     } catch (error) {
-        toast.error("Failed to clean staged assets");
-        console.error("Error cleaning staged assets:", error);
+        toast.error(`Failed to clean staged assets: ${errorMessage(error)}`);
     } finally {
         stagingLoading.value = false;
     }

--- a/client/src/components/admin/Visualizations/VisualizationsAdmin.vue
+++ b/client/src/components/admin/Visualizations/VisualizationsAdmin.vue
@@ -194,7 +194,7 @@
                             <p class="mb-2 text-muted">
                                 Total size: {{ bytesToString(stagingStatus.total_size, true, 2) }}
                             </p>
-                            <div v-if="stagingStatus.staged_visualizations.length > 0" class="mt-3">
+                            <div v-if="stagingStatus.staged_visualizations?.length" class="mt-3">
                                 <h6>Staged Visualizations:</h6>
                                 <div class="staged-viz-list" style="max-height: 200px; overflow-y: auto">
                                     <div
@@ -317,7 +317,7 @@ const usageStats = ref<UsageStats>({ days: 30, stats: {} } as UsageStats);
 
 const stagingLoading = ref(false);
 const stagingStatus = ref<StagingStatus | null>(null);
-const stagedNames = computed(() => stagingStatus.value?.staged_visualizations.map((v) => v.name) ?? []);
+const stagedNames = computed(() => stagingStatus.value?.staged_visualizations?.map((v) => v.name) ?? []);
 
 const showInstallModal = ref(false);
 const selectedVisualization = ref<AvailableVisualization | null>(null);

--- a/client/src/components/admin/Visualizations/VisualizationsAdmin.vue
+++ b/client/src/components/admin/Visualizations/VisualizationsAdmin.vue
@@ -49,17 +49,9 @@
                 </div>
                 <div>
                     <b-input-group>
-                        <b-form-input
-                            v-model="searchFilter"
-                            placeholder="Filter visualizations..."
-                            @input="filterInstalled" />
+                        <b-form-input v-model="searchFilter" placeholder="Filter visualizations..." />
                         <b-input-group-append>
-                            <b-button
-                                variant="outline-secondary"
-                                @click="
-                                    searchFilter = '';
-                                    filterInstalled();
-                                ">
+                            <b-button variant="outline-secondary" @click="searchFilter = ''">
                                 <FontAwesomeIcon :icon="faTimes" />
                             </b-button>
                         </b-input-group-append>
@@ -216,6 +208,7 @@
             :show="showInstallModal"
             :package-data="selectedVisualization"
             :installing="installing"
+            :installed-visualizations="installedVisualizations"
             @confirm="confirmInstall"
             @cancel="showInstallModal = false" />
     </div>
@@ -234,6 +227,7 @@ import {
     faUpload,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { useDebounceFn } from "@vueuse/core";
 import { computed, onMounted, reactive, ref, watch } from "vue";
 
 import { useConfirmDialog } from "@/composables/confirmDialog";
@@ -276,9 +270,25 @@ const loadingActions: Record<string, boolean> = reactive({});
 const installing = ref(false);
 
 const installedVisualizations = ref<Visualization[]>([]);
-const filteredInstalledVisualizations = ref<Visualization[]>([]);
 const showDisabled = ref(true);
 const searchFilter = ref("");
+
+const filteredInstalledVisualizations = computed(() => {
+    let filtered = installedVisualizations.value;
+    if (!showDisabled.value) {
+        filtered = filtered.filter((viz) => viz.enabled);
+    }
+    if (searchFilter.value) {
+        const q = searchFilter.value.toLowerCase();
+        filtered = filtered.filter(
+            (viz) =>
+                viz.id.toLowerCase().includes(q) ||
+                viz.package.toLowerCase().includes(q) ||
+                (viz.metadata?.description && (viz.metadata.description as string).toLowerCase().includes(q)),
+        );
+    }
+    return filtered;
+});
 
 const availableVisualizations = ref<AvailableVisualization[]>([]);
 const availableSearchFilter = ref("");
@@ -290,10 +300,6 @@ const stagingStatus = ref<StagingStatus | null>(null);
 
 const showInstallModal = ref(false);
 const selectedVisualization = ref<AvailableVisualization | null>(null);
-
-watch(showDisabled, () => {
-    filterInstalled();
-});
 
 watch(activeTab, async (newTab) => {
     if (newTab === "available" && availableVisualizations.value.length === 0) {
@@ -309,31 +315,10 @@ onMounted(async () => {
     await loadInstalledPackages();
 });
 
-function filterInstalled() {
-    let filtered = installedVisualizations.value;
-
-    if (!showDisabled.value) {
-        filtered = filtered.filter((viz) => viz.enabled);
-    }
-
-    if (searchFilter.value) {
-        const searchLower = searchFilter.value.toLowerCase();
-        filtered = filtered.filter(
-            (viz) =>
-                viz.id.toLowerCase().includes(searchLower) ||
-                viz.package.toLowerCase().includes(searchLower) ||
-                (viz.metadata?.description && (viz.metadata.description as string).toLowerCase().includes(searchLower)),
-        );
-    }
-
-    filteredInstalledVisualizations.value = filtered;
-}
-
 async function loadInstalledPackages() {
     loading.value = true;
     try {
         installedVisualizations.value = await getInstalledVisualizations(showDisabled.value);
-        filterInstalled();
     } catch (error) {
         toast.error("Failed to load installed visualizations");
         console.error("Error loading installed visualizations:", error);
@@ -366,9 +351,7 @@ async function loadUsageStats() {
     }
 }
 
-async function searchAvailablePackages() {
-    await loadAvailablePackages();
-}
+const searchAvailablePackages = useDebounceFn(loadAvailablePackages, 300);
 
 async function handleToggle(viz: Visualization) {
     const actionKey = `toggle-${viz.id}`;

--- a/client/src/components/admin/Visualizations/VisualizationsAdmin.vue
+++ b/client/src/components/admin/Visualizations/VisualizationsAdmin.vue
@@ -3,8 +3,8 @@
         <Heading id="visualizations-admin-heading" h1 size="lg">Visualizations Management</Heading>
 
         <p class="text-muted mb-3">
-            Install and manage visualization packages from the npm registry. Installed visualizations are automatically
-            staged so Galaxy can serve them to users.
+            Install and manage visualization packages from the npm registry. Installed packages are kept separately from
+            Galaxy's served static assets and staged into the serving directory when needed.
         </p>
 
         <b-tabs v-model="activeTabIndex" class="mb-3">
@@ -153,8 +153,8 @@
         <!-- Staging Tab -->
         <div v-if="activeTab === 'staging'">
             <p class="text-muted mb-3">
-                Staging copies visualization assets into Galaxy's static serving directory. Visualizations are
-                automatically staged after installation, but you can manually re-stage here if needed.
+                Staging copies visualization assets into Galaxy's static serving directory. Install and update actions
+                automatically re-stage packages, and you can manually re-stage here if needed.
             </p>
             <div class="row">
                 <div class="col-md-6">
@@ -401,8 +401,10 @@ async function handleUpdate(viz: Visualization, newVersion: string) {
 
     try {
         await updateVisualization(viz.id, newVersion);
-        toast.success(`Updated ${viz.id} to version ${newVersion}`);
+        await stageVisualization(viz.id);
+        toast.success(`Updated and staged ${viz.id} to version ${newVersion}`);
         await loadInstalledPackages();
+        await loadStagingStatus();
     } catch (error) {
         toast.error(`Failed to update ${viz.id}: ${errorMessage(error)}`);
     } finally {
@@ -423,6 +425,7 @@ async function handleUninstall(viz: Visualization) {
         await uninstallVisualization(viz.id);
         toast.success(`Uninstalled ${viz.id}`);
         await loadInstalledPackages();
+        await loadStagingStatus();
     } catch (error) {
         toast.error(`Failed to uninstall ${viz.id}: ${errorMessage(error)}`);
     } finally {
@@ -455,17 +458,11 @@ async function confirmInstall(vizId: string) {
 
     try {
         await installVisualization(vizId, selectedVisualization.value!.name, selectedVisualization.value!.version);
+        await stageVisualization(vizId);
         showInstallModal.value = false;
-
-        // Auto-stage so the visualization is immediately available
-        try {
-            await stageVisualization(vizId);
-            toast.success(`Installed and staged ${vizId} -- it should now be available to users`);
-        } catch {
-            toast.warning(`Installed ${vizId}, but staging failed. Go to the Staging tab to stage it manually.`);
-        }
-
+        toast.success(`Installed and staged ${vizId}`);
         await loadInstalledPackages();
+        await loadStagingStatus();
     } catch (error) {
         toast.error(`Failed to install ${vizId}: ${errorMessage(error)}`);
     } finally {

--- a/client/src/components/admin/Visualizations/VisualizationsAdmin.vue
+++ b/client/src/components/admin/Visualizations/VisualizationsAdmin.vue
@@ -369,7 +369,7 @@ export default {
                     (viz) =>
                         viz.id.toLowerCase().includes(searchLower) ||
                         viz.package.toLowerCase().includes(searchLower) ||
-                        (viz.metadata?.description && viz.metadata.description.toLowerCase().includes(searchLower))
+                        (viz.metadata?.description && viz.metadata.description.toLowerCase().includes(searchLower)),
                 );
             }
 
@@ -388,7 +388,7 @@ export default {
                 await toggleVisualization(viz.id, !viz.enabled);
                 this.showMessage(
                     `Visualization ${viz.id} ${!viz.enabled ? "enabled" : "disabled"} successfully`,
-                    "success"
+                    "success",
                 );
                 await this.loadInstalledPackages();
             } catch (error) {
@@ -517,7 +517,7 @@ export default {
         async cleanStagedAssets() {
             if (
                 !confirm(
-                    "Are you sure you want to clean all staged assets? This will remove all visualizations from Galaxy's serving directory."
+                    "Are you sure you want to clean all staged assets? This will remove all visualizations from Galaxy's serving directory.",
                 )
             ) {
                 return;

--- a/client/src/components/admin/Visualizations/VisualizationsAdmin.vue
+++ b/client/src/components/admin/Visualizations/VisualizationsAdmin.vue
@@ -81,6 +81,7 @@
                     :key="viz.id"
                     :visualization="viz"
                     :loading-actions="loadingActions"
+                    :staged-names="stagedNames"
                     class="mb-3"
                     @toggle="handleToggle"
                     @update="handleUpdate"
@@ -316,6 +317,7 @@ const usageStats = ref<UsageStats>({ days: 30, stats: {} } as UsageStats);
 
 const stagingLoading = ref(false);
 const stagingStatus = ref<StagingStatus | null>(null);
+const stagedNames = computed(() => stagingStatus.value?.staged_visualizations.map((v) => v.name) ?? []);
 
 const showInstallModal = ref(false);
 const selectedVisualization = ref<AvailableVisualization | null>(null);
@@ -331,7 +333,7 @@ watch(activeTab, async (newTab) => {
 });
 
 onMounted(async () => {
-    await loadInstalledPackages();
+    await Promise.all([loadInstalledPackages(), loadStagingStatus()]);
 });
 
 function errorMessage(error: unknown): string {
@@ -435,10 +437,7 @@ async function handleStage(viz: Visualization) {
     try {
         await stageVisualization(viz.id);
         toast.success(`Staged ${viz.id}`);
-
-        if (activeTab.value === "staging") {
-            await loadStagingStatus();
-        }
+        await loadStagingStatus();
     } catch (error) {
         toast.error(`Failed to stage ${viz.id}: ${errorMessage(error)}`);
     } finally {

--- a/client/src/components/admin/Visualizations/services.ts
+++ b/client/src/components/admin/Visualizations/services.ts
@@ -1,0 +1,251 @@
+/**
+ * API service for admin visualization management
+ */
+
+import axios from "axios";
+
+import { getAppRoot } from "@/onload/loadConfig";
+import { rethrowSimple } from "@/utils/simple-error";
+
+export interface Visualization {
+    id: string;
+    package: string;
+    version: string;
+    enabled: boolean;
+    installed: boolean;
+    path?: string;
+    size?: number;
+    metadata?: {
+        description?: string;
+        author?: string;
+        license?: string;
+        dependencies?: Record<string, string>;
+        homepage?: string;
+    };
+}
+
+export interface AvailableVisualization {
+    name: string;
+    description: string;
+    version: string;
+    keywords: string[];
+    modified: string;
+    maintainers: Array<{
+        username: string;
+        email: string;
+    }>;
+    homepage?: string;
+    repository?: string;
+}
+
+export interface InstallRequest {
+    package: string;
+    version: string;
+}
+
+export interface UsageStats {
+    days: number;
+    stats: Record<string, number>;
+}
+
+export interface StagingResult {
+    message: string;
+    staged_count: number;
+    staged_visualizations: string[];
+    errors?: string[];
+}
+
+export interface VisualizationStagingResult {
+    message: string;
+    visualization_id: string;
+    source_path: string;
+    target_path: string;
+    size: number;
+}
+
+export interface CleanStagingResult {
+    message: string;
+    cleaned_count: number;
+    cleaned_items: string[];
+}
+
+export interface StagingStatus {
+    message: string;
+    staged_count: number;
+    staged_visualizations: Array<{
+        name: string;
+        path: string;
+        size: number;
+        last_modified: number;
+    }>;
+    total_size: number;
+}
+
+export async function getInstalledVisualizations(includeDisabled = true): Promise<Visualization[]> {
+    const url = `${getAppRoot()}api/admin/visualizations`;
+    const params = includeDisabled ? { include_disabled: true } : {};
+
+    try {
+        const response = await axios.get(url, { params });
+        return response.data;
+    } catch (error) {
+        rethrowSimple(error);
+        throw error;
+    }
+}
+
+export async function getAvailableVisualizations(search?: string): Promise<AvailableVisualization[]> {
+    const url = `${getAppRoot()}api/admin/visualizations/available`;
+    const params = search ? { search } : {};
+
+    try {
+        const response = await axios.get(url, { params });
+        return response.data;
+    } catch (error) {
+        rethrowSimple(error);
+        throw error;
+    }
+}
+
+export async function getVisualizationDetails(vizId: string): Promise<Visualization> {
+    const url = `${getAppRoot()}api/admin/visualizations/${vizId}`;
+
+    try {
+        const response = await axios.get(url);
+        return response.data;
+    } catch (error) {
+        rethrowSimple(error);
+        throw error;
+    }
+}
+
+export async function installVisualization(
+    vizId: string,
+    packageName: string,
+    version: string
+): Promise<Visualization> {
+    const url = `${getAppRoot()}api/admin/visualizations/${vizId}/install`;
+
+    try {
+        const response = await axios.post(url, {
+            package: packageName,
+            version: version,
+        });
+        return response.data;
+    } catch (error) {
+        rethrowSimple(error);
+        throw error;
+    }
+}
+
+export async function updateVisualization(vizId: string, version: string): Promise<Visualization> {
+    const url = `${getAppRoot()}api/admin/visualizations/${vizId}/update`;
+
+    try {
+        const response = await axios.put(url, { version });
+        return response.data;
+    } catch (error) {
+        rethrowSimple(error);
+        throw error;
+    }
+}
+
+export async function uninstallVisualization(vizId: string): Promise<void> {
+    const url = `${getAppRoot()}api/admin/visualizations/${vizId}`;
+
+    try {
+        await axios.delete(url);
+    } catch (error) {
+        rethrowSimple(error);
+        throw error;
+    }
+}
+
+export async function toggleVisualization(
+    vizId: string,
+    enabled: boolean
+): Promise<{ id: string; enabled: boolean; message: string }> {
+    const url = `${getAppRoot()}api/admin/visualizations/${vizId}/toggle`;
+
+    try {
+        const response = await axios.put(url, { enabled });
+        return response.data;
+    } catch (error) {
+        rethrowSimple(error);
+        throw error;
+    }
+}
+
+export async function reloadVisualizationRegistry(): Promise<{ message: string }> {
+    const url = `${getAppRoot()}api/admin/visualizations/reload`;
+
+    try {
+        const response = await axios.post(url);
+        return response.data;
+    } catch (error) {
+        rethrowSimple(error);
+        throw error;
+    }
+}
+
+export async function getVisualizationUsageStats(days = 30): Promise<UsageStats> {
+    const url = `${getAppRoot()}api/admin/visualizations/usage_stats`;
+    const params = { days };
+
+    try {
+        const response = await axios.get(url, { params });
+        return response.data;
+    } catch (error) {
+        rethrowSimple(error);
+        throw error;
+    }
+}
+
+// Staging operations
+export async function stageAllVisualizations(): Promise<StagingResult> {
+    const url = `${getAppRoot()}api/admin/visualizations/stage`;
+
+    try {
+        const response = await axios.post(url);
+        return response.data;
+    } catch (error) {
+        rethrowSimple(error);
+        throw error;
+    }
+}
+
+export async function stageVisualization(vizId: string): Promise<VisualizationStagingResult> {
+    const url = `${getAppRoot()}api/admin/visualizations/${vizId}/stage`;
+
+    try {
+        const response = await axios.post(url);
+        return response.data;
+    } catch (error) {
+        rethrowSimple(error);
+        throw error;
+    }
+}
+
+export async function cleanStagedAssets(): Promise<CleanStagingResult> {
+    const url = `${getAppRoot()}api/admin/visualizations/staged`;
+
+    try {
+        const response = await axios.delete(url);
+        return response.data;
+    } catch (error) {
+        rethrowSimple(error);
+        throw error;
+    }
+}
+
+export async function getStagingStatus(): Promise<StagingStatus> {
+    const url = `${getAppRoot()}api/admin/visualizations/staging_status`;
+
+    try {
+        const response = await axios.get(url);
+        return response.data;
+    } catch (error) {
+        rethrowSimple(error);
+        throw error;
+    }
+}

--- a/client/src/components/admin/Visualizations/services.ts
+++ b/client/src/components/admin/Visualizations/services.ts
@@ -37,6 +37,18 @@ export async function getAvailableVisualizations(search?: string) {
     return data!;
 }
 
+export async function getPackageVersions(packageName: string) {
+    const { data, error } = await GalaxyApi().GET("/api/admin/visualizations/versions/{package_name}", {
+        params: { path: { package_name: packageName } },
+    });
+
+    if (error) {
+        rethrowSimple(error);
+    }
+
+    return data!;
+}
+
 export async function installVisualization(vizId: string, packageName: string, version: string) {
     const { data, error } = await GalaxyApi().POST("/api/admin/visualizations/{viz_id}/install", {
         params: { path: { viz_id: vizId } },

--- a/client/src/components/admin/Visualizations/services.ts
+++ b/client/src/components/admin/Visualizations/services.ts
@@ -37,18 +37,6 @@ export async function getAvailableVisualizations(search?: string) {
     return data!;
 }
 
-export async function getVisualizationDetails(vizId: string) {
-    const { data, error } = await GalaxyApi().GET("/api/admin/visualizations/{viz_id}", {
-        params: { path: { viz_id: vizId } },
-    });
-
-    if (error) {
-        rethrowSimple(error);
-    }
-
-    return data!;
-}
-
 export async function installVisualization(vizId: string, packageName: string, version: string) {
     const { data, error } = await GalaxyApi().POST("/api/admin/visualizations/{viz_id}/install", {
         params: { path: { viz_id: vizId } },

--- a/client/src/components/admin/Visualizations/services.ts
+++ b/client/src/components/admin/Visualizations/services.ts
@@ -2,250 +2,162 @@
  * API service for admin visualization management
  */
 
-import axios from "axios";
-
-import { getAppRoot } from "@/onload/loadConfig";
+import { type components, GalaxyApi } from "@/api";
 import { rethrowSimple } from "@/utils/simple-error";
 
-export interface Visualization {
-    id: string;
-    package: string;
-    version: string;
-    enabled: boolean;
-    installed: boolean;
-    path?: string;
-    size?: number;
-    metadata?: {
-        description?: string;
-        author?: string;
-        license?: string;
-        dependencies?: Record<string, string>;
-        homepage?: string;
-    };
-}
+export type Visualization = components["schemas"]["InstalledVisualizationResponse"];
+export type AvailableVisualization = components["schemas"]["AvailableVisualizationResponse"];
+export type StagingResult = components["schemas"]["StagingResultResponse"];
+export type VisualizationStagingResult = components["schemas"]["VisualizationStagingResultResponse"];
+export type CleanStagingResult = components["schemas"]["CleanStagingResultResponse"];
+export type StagingStatus = components["schemas"]["StagingStatusResponse"];
+export type UsageStats = components["schemas"]["UsageStatsResponse"];
 
-export interface AvailableVisualization {
-    name: string;
-    description: string;
-    version: string;
-    keywords: string[];
-    modified: string;
-    maintainers: Array<{
-        username: string;
-        email: string;
-    }>;
-    homepage?: string;
-    repository?: string;
-}
+export async function getInstalledVisualizations(includeDisabled = true) {
+    const { data, error } = await GalaxyApi().GET("/api/admin/visualizations", {
+        params: { query: { include_disabled: includeDisabled } },
+    });
 
-export interface InstallRequest {
-    package: string;
-    version: string;
-}
-
-export interface UsageStats {
-    days: number;
-    stats: Record<string, number>;
-}
-
-export interface StagingResult {
-    message: string;
-    staged_count: number;
-    staged_visualizations: string[];
-    errors?: string[];
-}
-
-export interface VisualizationStagingResult {
-    message: string;
-    visualization_id: string;
-    source_path: string;
-    target_path: string;
-    size: number;
-}
-
-export interface CleanStagingResult {
-    message: string;
-    cleaned_count: number;
-    cleaned_items: string[];
-}
-
-export interface StagingStatus {
-    message: string;
-    staged_count: number;
-    staged_visualizations: Array<{
-        name: string;
-        path: string;
-        size: number;
-        last_modified: number;
-    }>;
-    total_size: number;
-}
-
-export async function getInstalledVisualizations(includeDisabled = true): Promise<Visualization[]> {
-    const url = `${getAppRoot()}api/admin/visualizations`;
-    const params = includeDisabled ? { include_disabled: true } : {};
-
-    try {
-        const response = await axios.get(url, { params });
-        return response.data;
-    } catch (error) {
+    if (error) {
         rethrowSimple(error);
-        throw error;
+    }
+
+    return data!;
+}
+
+export async function getAvailableVisualizations(search?: string) {
+    const { data, error } = await GalaxyApi().GET("/api/admin/visualizations/available", {
+        params: { query: { search: search ?? null } },
+    });
+
+    if (error) {
+        rethrowSimple(error);
+    }
+
+    return data!;
+}
+
+export async function getVisualizationDetails(vizId: string) {
+    const { data, error } = await GalaxyApi().GET("/api/admin/visualizations/{viz_id}", {
+        params: { path: { viz_id: vizId } },
+    });
+
+    if (error) {
+        rethrowSimple(error);
+    }
+
+    return data!;
+}
+
+export async function installVisualization(vizId: string, packageName: string, version: string) {
+    const { data, error } = await GalaxyApi().POST("/api/admin/visualizations/{viz_id}/install", {
+        params: { path: { viz_id: vizId } },
+        body: { package: packageName, version },
+    });
+
+    if (error) {
+        rethrowSimple(error);
+    }
+
+    return data!;
+}
+
+export async function updateVisualization(vizId: string, version: string) {
+    const { data, error } = await GalaxyApi().PUT("/api/admin/visualizations/{viz_id}/update", {
+        params: { path: { viz_id: vizId } },
+        body: { version },
+    });
+
+    if (error) {
+        rethrowSimple(error);
+    }
+
+    return data!;
+}
+
+export async function uninstallVisualization(vizId: string) {
+    const { error } = await GalaxyApi().DELETE("/api/admin/visualizations/{viz_id}", {
+        params: { path: { viz_id: vizId } },
+    });
+
+    if (error) {
+        rethrowSimple(error);
     }
 }
 
-export async function getAvailableVisualizations(search?: string): Promise<AvailableVisualization[]> {
-    const url = `${getAppRoot()}api/admin/visualizations/available`;
-    const params = search ? { search } : {};
+export async function toggleVisualization(vizId: string, enabled: boolean) {
+    const { data, error } = await GalaxyApi().PUT("/api/admin/visualizations/{viz_id}/toggle", {
+        params: { path: { viz_id: vizId } },
+        body: { enabled },
+    });
 
-    try {
-        const response = await axios.get(url, { params });
-        return response.data;
-    } catch (error) {
+    if (error) {
         rethrowSimple(error);
-        throw error;
     }
+
+    return data!;
 }
 
-export async function getVisualizationDetails(vizId: string): Promise<Visualization> {
-    const url = `${getAppRoot()}api/admin/visualizations/${vizId}`;
+export async function reloadVisualizationRegistry() {
+    const { data, error } = await GalaxyApi().POST("/api/admin/visualizations/reload");
 
-    try {
-        const response = await axios.get(url);
-        return response.data;
-    } catch (error) {
+    if (error) {
         rethrowSimple(error);
-        throw error;
     }
+
+    return data!;
 }
 
-export async function installVisualization(
-    vizId: string,
-    packageName: string,
-    version: string
-): Promise<Visualization> {
-    const url = `${getAppRoot()}api/admin/visualizations/${vizId}/install`;
+export async function getVisualizationUsageStats(days = 30) {
+    const { data, error } = await GalaxyApi().GET("/api/admin/visualizations/usage_stats", {
+        params: { query: { days } },
+    });
 
-    try {
-        const response = await axios.post(url, {
-            package: packageName,
-            version: version,
-        });
-        return response.data;
-    } catch (error) {
+    if (error) {
         rethrowSimple(error);
-        throw error;
     }
+
+    return data!;
 }
 
-export async function updateVisualization(vizId: string, version: string): Promise<Visualization> {
-    const url = `${getAppRoot()}api/admin/visualizations/${vizId}/update`;
+export async function stageAllVisualizations() {
+    const { data, error } = await GalaxyApi().POST("/api/admin/visualizations/stage");
 
-    try {
-        const response = await axios.put(url, { version });
-        return response.data;
-    } catch (error) {
+    if (error) {
         rethrowSimple(error);
-        throw error;
     }
+
+    return data!;
 }
 
-export async function uninstallVisualization(vizId: string): Promise<void> {
-    const url = `${getAppRoot()}api/admin/visualizations/${vizId}`;
+export async function stageVisualization(vizId: string) {
+    const { data, error } = await GalaxyApi().POST("/api/admin/visualizations/{viz_id}/stage", {
+        params: { path: { viz_id: vizId } },
+    });
 
-    try {
-        await axios.delete(url);
-    } catch (error) {
+    if (error) {
         rethrowSimple(error);
-        throw error;
     }
+
+    return data!;
 }
 
-export async function toggleVisualization(
-    vizId: string,
-    enabled: boolean
-): Promise<{ id: string; enabled: boolean; message: string }> {
-    const url = `${getAppRoot()}api/admin/visualizations/${vizId}/toggle`;
+export async function cleanStagedAssets() {
+    const { data, error } = await GalaxyApi().DELETE("/api/admin/visualizations/staged");
 
-    try {
-        const response = await axios.put(url, { enabled });
-        return response.data;
-    } catch (error) {
+    if (error) {
         rethrowSimple(error);
-        throw error;
     }
+
+    return data!;
 }
 
-export async function reloadVisualizationRegistry(): Promise<{ message: string }> {
-    const url = `${getAppRoot()}api/admin/visualizations/reload`;
+export async function getStagingStatus() {
+    const { data, error } = await GalaxyApi().GET("/api/admin/visualizations/staging_status");
 
-    try {
-        const response = await axios.post(url);
-        return response.data;
-    } catch (error) {
+    if (error) {
         rethrowSimple(error);
-        throw error;
     }
-}
 
-export async function getVisualizationUsageStats(days = 30): Promise<UsageStats> {
-    const url = `${getAppRoot()}api/admin/visualizations/usage_stats`;
-    const params = { days };
-
-    try {
-        const response = await axios.get(url, { params });
-        return response.data;
-    } catch (error) {
-        rethrowSimple(error);
-        throw error;
-    }
-}
-
-// Staging operations
-export async function stageAllVisualizations(): Promise<StagingResult> {
-    const url = `${getAppRoot()}api/admin/visualizations/stage`;
-
-    try {
-        const response = await axios.post(url);
-        return response.data;
-    } catch (error) {
-        rethrowSimple(error);
-        throw error;
-    }
-}
-
-export async function stageVisualization(vizId: string): Promise<VisualizationStagingResult> {
-    const url = `${getAppRoot()}api/admin/visualizations/${vizId}/stage`;
-
-    try {
-        const response = await axios.post(url);
-        return response.data;
-    } catch (error) {
-        rethrowSimple(error);
-        throw error;
-    }
-}
-
-export async function cleanStagedAssets(): Promise<CleanStagingResult> {
-    const url = `${getAppRoot()}api/admin/visualizations/staged`;
-
-    try {
-        const response = await axios.delete(url);
-        return response.data;
-    } catch (error) {
-        rethrowSimple(error);
-        throw error;
-    }
-}
-
-export async function getStagingStatus(): Promise<StagingStatus> {
-    const url = `${getAppRoot()}api/admin/visualizations/staging_status`;
-
-    try {
-        const response = await axios.get(url);
-        return response.data;
-    } catch (error) {
-        rethrowSimple(error);
-        throw error;
-    }
+    return data!;
 }

--- a/client/src/entry/analysis/routes/admin-routes.js
+++ b/client/src/entry/analysis/routes/admin-routes.js
@@ -24,6 +24,7 @@ import NotificationsManagement from "@/components/admin/Notifications/Notificati
 import ResetMetadata from "@/components/admin/ResetMetadata.vue";
 import RoleForm from "@/components/admin/RoleForm.vue";
 import SanitizeAllow from "@/components/admin/SanitizeAllow.vue";
+import VisualizationsAdmin from "@/components/admin/Visualizations/VisualizationsAdmin.vue";
 import FormGeneric from "@/components/Form/FormGeneric.vue";
 import GridInvocation from "@/components/Grid/GridInvocation.vue";
 import GridList from "@/components/Grid/GridList.vue";
@@ -62,6 +63,7 @@ export default [
             { path: "sanitize_allow", component: SanitizeAllow },
             { path: "toolbox_dependencies", component: ToolboxDependencies },
             { path: "toolshed", component: Toolshed },
+            { path: "visualizations", component: VisualizationsAdmin },
 
             // user registration route
             {

--- a/doc/source/admin/index.rst
+++ b/doc/source/admin/index.rst
@@ -21,6 +21,7 @@ Galaxy Deployment & Administration
    authentication
    ai_agents
    enable_headers_in_fetch_requests
+   visualization_packages
    tool_panel
    data_tables
    mq

--- a/doc/source/admin/visualization_packages.md
+++ b/doc/source/admin/visualization_packages.md
@@ -1,0 +1,37 @@
+# Visualization Package Administration
+
+Galaxy can manage visualization plugins at runtime through the admin interface instead of requiring a client rebuild.
+
+## Storage model
+
+Runtime-installed visualization packages are stored under `config/visualization_packages/`.
+
+This directory is the managed package store. It is not served directly to users.
+
+Served visualization assets live under `static/plugins/visualizations/`.
+
+This directory is staging output only. Galaxy serves visualizations from here after assets have been staged.
+
+Legacy built-in visualizations under `config/plugins/visualizations/` are still supported and are staged the same way.
+
+## Admin workflow
+
+The visualization admin UI installs npm packages into the managed package store and then stages them into the static serving directory.
+
+Update operations replace the managed package contents first and then re-stage the visualization so Galaxy serves the new version.
+
+Uninstall operations remove both the managed package and any staged assets.
+
+## Startup and recovery
+
+Galaxy stages visualizations on startup so both legacy built-ins and runtime-installed packages are available after a restart.
+
+If staged assets are removed or become stale, use the admin staging controls to re-stage one visualization or all visualizations.
+
+Reloading the visualization registry refreshes plugin discovery, but it does not replace staging.
+
+## Failure behavior
+
+Visualization updates use a safe swap. Galaxy installs the requested version into a temporary location, validates it, and only replaces the current managed package on success.
+
+If the replacement step fails, Galaxy restores the previous managed package and leaves the saved configuration unchanged.

--- a/lib/galaxy/app/__init__.py
+++ b/lib/galaxy/app/__init__.py
@@ -86,6 +86,7 @@ from galaxy.managers.tasks import (
 )
 from galaxy.managers.tools import DynamicToolManager
 from galaxy.managers.users import UserManager
+from galaxy.managers.visualization_admin import VisualizationPackageManager
 from galaxy.managers.workflow_completion import WorkflowCompletionManager
 from galaxy.managers.workflows import (
     WorkflowContentsManager,
@@ -707,6 +708,7 @@ class GalaxyManagerApplication(MinimalManagerApp, MinimalGalaxyApplication):
         )
         self.notification_manager = self._register_singleton(NotificationManager)
         self.interactivetool_manager = InteractiveToolManager(self)
+        self.visualization_package_manager = self._register_singleton(VisualizationPackageManager)
 
         self.task_manager = self._register_abstract_singleton(
             AsyncTasksManager,  # type: ignore[type-abstract]  # https://github.com/python/mypy/issues/4717

--- a/lib/galaxy/app/__init__.py
+++ b/lib/galaxy/app/__init__.py
@@ -933,6 +933,13 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication, InstallationT
                 directories_setting=self.config.visualization_plugins_directory,
             ),
         )
+        # Stage visualization assets so they're available for serving
+        try:
+            result = self.visualization_package_manager.stage_all_visualizations()
+            if result["staged_count"] > 0:
+                log.info(f"Staged {result['staged_count']} visualization(s) on startup")
+        except Exception:
+            log.warning("Failed to stage visualization assets on startup", exc_info=True)
         # Tours registry
         tour_registry = build_tours_registry(self.config.tour_config_dir)
         self.tour_registry = tour_registry

--- a/lib/galaxy/managers/visualization_admin.py
+++ b/lib/galaxy/managers/visualization_admin.py
@@ -1,0 +1,510 @@
+"""
+Manager for visualization package administration.
+
+Handles low-level operations for managing visualization packages including
+npm package operations, file system management, and configuration updates.
+"""
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from glob import glob
+from typing import (
+    Dict,
+    List,
+    Optional,
+    Union,
+)
+
+import requests
+import yaml
+
+from galaxy import exceptions
+from galaxy.managers.base import ModelManager
+from galaxy.structured_app import MinimalManagerApp
+
+log = logging.getLogger(__name__)
+
+
+class VisualizationPackageManager(ModelManager):
+    """Manager for visualization package operations."""
+
+    model_class = type(None)  # Not managing database models
+
+    def __init__(self, app: MinimalManagerApp):
+        super().__init__(app)
+        self.config_path = os.path.join(app.config.root, "client", "visualizations.yml")
+        self.static_path = os.path.join(app.config.root, "static", "plugins", "visualizations")
+
+        # Ensure directories exist
+        os.makedirs(os.path.dirname(self.config_path), exist_ok=True)
+        os.makedirs(self.static_path, exist_ok=True)
+
+    def load_config(self) -> Dict:
+        """Load the visualizations.yml configuration file."""
+        try:
+            if not os.path.exists(self.config_path):
+                return {}
+
+            with open(self.config_path) as f:
+                return yaml.safe_load(f) or {}
+
+        except Exception as e:
+            log.error(f"Failed to load visualization config: {e}")
+            raise exceptions.InternalServerError(f"Failed to load configuration: {e}")
+
+    def save_config(self, config: Dict) -> None:
+        """Save the visualizations.yml configuration file."""
+        try:
+            with open(self.config_path, "w") as f:
+                yaml.safe_dump(config, f, default_flow_style=False, sort_keys=True)
+
+        except Exception as e:
+            log.error(f"Failed to save visualization config: {e}")
+            raise exceptions.InternalServerError(f"Failed to save configuration: {e}")
+
+    def get_package_info(self, viz_id: str) -> Optional[Dict]:
+        """Get information about a specific package from config."""
+        config = self.load_config()
+        return config.get(viz_id)
+
+    def add_package_to_config(self, viz_id: str, package: str, version: str, enabled: bool = True) -> None:
+        """Add or update a package in the configuration."""
+        config = self.load_config()
+        config[viz_id] = {"package": package, "version": version, "enabled": enabled}
+        self.save_config(config)
+
+    def remove_package_from_config(self, viz_id: str) -> None:
+        """Remove a package from the configuration."""
+        config = self.load_config()
+        if viz_id in config:
+            del config[viz_id]
+            self.save_config(config)
+
+    def toggle_package_enabled(self, viz_id: str, enabled: bool) -> None:
+        """Enable or disable a package in the configuration."""
+        config = self.load_config()
+
+        if viz_id not in config:
+            raise exceptions.ObjectNotFound(f"Package '{viz_id}' not found in configuration")
+
+        if isinstance(config[viz_id], dict):
+            config[viz_id]["enabled"] = enabled
+        else:
+            # Convert string entry to dict format
+            config[viz_id] = {"package": config[viz_id], "enabled": enabled}
+
+        self.save_config(config)
+
+    def install_npm_package(self, package: str, version: str, target_dir: str) -> Dict:
+        """Install an npm package to a target directory."""
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                # Install package using npm
+                package_spec = f"{package}@{version}"
+                cmd = ["npm", "install", package_spec, "--prefix", temp_dir, "--no-audit", "--no-fund", "--production"]
+
+                log.info(f"Installing npm package: {package_spec}")
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=300, cwd=temp_dir)
+
+                if result.returncode != 0:
+                    log.error(f"npm install failed: {result.stderr}")
+                    raise exceptions.InternalServerError(f"Package installation failed: {result.stderr}")
+
+                # Find the installed package directory
+                package_name = package.split("/")[-1]  # Handle scoped packages like @galaxyproject/foo
+                source_path = os.path.join(temp_dir, "node_modules", package_name)
+
+                if not os.path.exists(source_path):
+                    # Try full package name for scoped packages
+                    source_path = os.path.join(temp_dir, "node_modules", package)
+
+                if not os.path.exists(source_path):
+                    raise exceptions.InternalServerError(
+                        f"Package directory not found after installation: {source_path}"
+                    )
+
+                # Create target directory
+                os.makedirs(target_dir, exist_ok=True)
+
+                # Copy package contents
+                shutil.copytree(source_path, target_dir, dirs_exist_ok=True)
+
+                # Validate package structure
+                self.validate_package_structure(target_dir)
+
+                # Get package metadata
+                package_json_path = os.path.join(target_dir, "package.json")
+                metadata = {}
+                if os.path.exists(package_json_path):
+                    with open(package_json_path) as f:
+                        metadata = json.load(f)
+
+                return {
+                    "package": package,
+                    "version": version,
+                    "path": target_dir,
+                    "size": self.get_directory_size(target_dir),
+                    "metadata": metadata,
+                }
+
+        except subprocess.TimeoutExpired:
+            raise exceptions.InternalServerError("Package installation timed out")
+        except Exception as e:
+            log.error(f"Failed to install npm package {package}@{version}: {e}")
+            raise exceptions.InternalServerError(f"Package installation failed: {e}")
+
+    def validate_package_structure(self, package_dir: str) -> bool:
+        """Validate that a package has the required structure for Galaxy visualizations."""
+        required_files = ["package.json"]
+
+        for required_file in required_files:
+            file_path = os.path.join(package_dir, required_file)
+            if not os.path.exists(file_path):
+                raise exceptions.ConfigurationError(f"Required file missing: {required_file}")
+
+        # Validate package.json structure
+        package_json_path = os.path.join(package_dir, "package.json")
+        try:
+            with open(package_json_path) as f:
+                package_json = json.load(f)
+
+            # Check for required fields
+            required_fields = ["name", "version"]
+            for field in required_fields:
+                if field not in package_json:
+                    raise exceptions.ConfigurationError(f"package.json missing required field: {field}")
+
+        except json.JSONDecodeError as e:
+            raise exceptions.ConfigurationError(f"Invalid package.json: {e}")
+
+        return True
+
+    def cleanup_package_files(self, viz_id: str) -> None:
+        """Remove package files from the static directory."""
+        package_dir = os.path.join(self.static_path, viz_id)
+        if os.path.exists(package_dir):
+            try:
+                shutil.rmtree(package_dir)
+                log.info(f"Cleaned up package files for {viz_id}")
+            except Exception as e:
+                log.error(f"Failed to cleanup files for {viz_id}: {e}")
+                raise exceptions.InternalServerError(f"Failed to cleanup package files: {e}")
+
+    def get_package_path(self, viz_id: str) -> str:
+        """Get the file system path for a package."""
+        return os.path.join(self.static_path, viz_id)
+
+    def is_package_installed(self, viz_id: str) -> bool:
+        """Check if a package is installed on the file system."""
+        package_path = self.get_package_path(viz_id)
+        return os.path.exists(package_path) and os.path.isdir(package_path)
+
+    def get_directory_size(self, path: str) -> int:
+        """Calculate the total size of a directory in bytes."""
+        total_size = 0
+        try:
+            for dirpath, _dirnames, filenames in os.walk(path):
+                for filename in filenames:
+                    filepath = os.path.join(dirpath, filename)
+                    if os.path.exists(filepath):
+                        total_size += os.path.getsize(filepath)
+        except Exception as e:
+            log.warning(f"Failed to calculate directory size for {path}: {e}")
+
+        return total_size
+
+    def get_package_metadata(self, viz_id: str) -> Dict:
+        """Get metadata from an installed package's package.json."""
+        package_path = self.get_package_path(viz_id)
+        package_json_path = os.path.join(package_path, "package.json")
+
+        if not os.path.exists(package_json_path):
+            return {}
+
+        try:
+            with open(package_json_path) as f:
+                return json.load(f)
+        except Exception as e:
+            log.warning(f"Failed to read package.json for {viz_id}: {e}")
+            return {}
+
+    def query_npm_registry(self, search_term: Optional[str] = None) -> List[Dict]:
+        """Query npm registry for @galaxyproject visualization packages."""
+        try:
+            # Build search URL
+            base_url = "https://registry.npmjs.org/-/search"
+            query_parts = ["scope:galaxyproject"]
+
+            if search_term:
+                query_parts.append(search_term)
+
+            params: Dict[str, Union[str, int]] = {
+                "text": " ".join(query_parts),
+                "size": 250,  # Maximum results
+            }
+
+            response = requests.get(base_url, params=params, timeout=10)
+            response.raise_for_status()
+
+            data = response.json()
+            packages = []
+
+            for result in data.get("objects", []):
+                package_info = result.get("package", {})
+
+                # Filter for visualization packages
+                keywords = package_info.get("keywords", [])
+                if "visualization" in keywords or "galaxy-visualization" in keywords:
+                    packages.append(
+                        {
+                            "name": package_info.get("name", ""),
+                            "description": package_info.get("description", ""),
+                            "version": package_info.get("version", ""),
+                            "keywords": keywords,
+                            "author": package_info.get("author", {}),
+                            "maintainers": package_info.get("maintainers", []),
+                            "links": package_info.get("links", {}),
+                            "date": package_info.get("date", ""),
+                            "score": result.get("score", {}),
+                        }
+                    )
+
+            return packages
+
+        except requests.RequestException as e:
+            log.error(f"Failed to query npm registry: {e}")
+            raise exceptions.InternalServerError(f"Failed to query package registry: {e}")
+
+    def get_package_versions(self, package_name: str) -> List[str]:
+        """Get available versions for a specific package from npm registry."""
+        try:
+            url = f"https://registry.npmjs.org/{package_name}"
+            response = requests.get(url, timeout=10)
+            response.raise_for_status()
+
+            data = response.json()
+            versions = list(data.get("versions", {}).keys())
+
+            # Sort versions (basic sort, could be improved with semver)
+            versions.sort(reverse=True)
+
+            return versions
+
+        except requests.RequestException as e:
+            log.error(f"Failed to get versions for {package_name}: {e}")
+            raise exceptions.InternalServerError(f"Failed to get package versions: {e}")
+
+    def backup_config(self) -> Optional[str]:
+        """Create a backup of the current configuration."""
+        backup_path = f"{self.config_path}.backup"
+        try:
+            if os.path.exists(self.config_path):
+                shutil.copy2(self.config_path, backup_path)
+                return backup_path
+        except Exception as e:
+            log.error(f"Failed to create config backup: {e}")
+
+        return None
+
+    def restore_config(self, backup_path: str) -> None:
+        """Restore configuration from a backup."""
+        try:
+            if os.path.exists(backup_path):
+                shutil.copy2(backup_path, self.config_path)
+                log.info("Configuration restored from backup")
+            else:
+                raise exceptions.ObjectNotFound("Backup file not found")
+        except Exception as e:
+            log.error(f"Failed to restore config: {e}")
+            raise exceptions.InternalServerError(f"Failed to restore configuration: {e}")
+
+    def stage_all_visualizations(self) -> Dict:
+        """
+        Stage all visualization assets from config/plugins/visualizations to static/plugins/visualizations.
+        This is equivalent to the gulp stagePlugins task.
+        """
+        try:
+            plugins_base_dir = os.path.join(self.app.config.root, "config", "plugins")
+            source_patterns = [
+                os.path.join(plugins_base_dir, "visualizations", "*", "static"),
+                os.path.join(plugins_base_dir, "visualizations", "*", "*", "static"),
+            ]
+
+            staged_count = 0
+            staged_visualizations = []
+            errors = []
+
+            # Find all static directories to stage
+            source_dirs = []
+            for pattern in source_patterns:
+                source_dirs.extend(glob(pattern))
+
+            for source_dir in source_dirs:
+                try:
+                    # Skip node_modules/.bin directories
+                    if "node_modules/.bin" in source_dir:
+                        continue
+
+                    # Get the relative path from plugins base dir
+                    relative_path = os.path.relpath(source_dir, plugins_base_dir)
+                    target_dir = os.path.join(self.app.config.root, "static", "plugins", relative_path)
+
+                    # Create target directory
+                    os.makedirs(os.path.dirname(target_dir), exist_ok=True)
+
+                    # Copy the static directory
+                    if os.path.exists(target_dir):
+                        shutil.rmtree(target_dir)
+
+                    shutil.copytree(source_dir, target_dir, ignore=shutil.ignore_patterns("node_modules/.bin"))
+
+                    staged_count += 1
+                    # Extract visualization name from path
+                    viz_name = self._extract_viz_name_from_path(relative_path)
+                    if viz_name:
+                        staged_visualizations.append(viz_name)
+
+                    log.info(f"Staged visualization assets: {relative_path}")
+
+                except Exception as e:
+                    error_msg = f"Failed to stage {source_dir}: {e}"
+                    log.error(error_msg)
+                    errors.append(error_msg)
+
+            return {"staged_count": staged_count, "staged_visualizations": staged_visualizations, "errors": errors}
+
+        except Exception as e:
+            log.error(f"Failed to stage visualizations: {e}")
+            raise exceptions.InternalServerError(f"Failed to stage visualizations: {e}")
+
+    def stage_visualization(self, viz_id: str) -> Dict:
+        """
+        Stage assets for a specific visualization from config/plugins to static/plugins.
+        """
+        try:
+            plugins_base_dir = os.path.join(self.app.config.root, "config", "plugins")
+
+            # Look for the visualization in both possible locations
+            possible_paths = [
+                os.path.join(plugins_base_dir, "visualizations", viz_id, "static"),
+                # Check for nested visualizations (like jqplot/jqplot_bar)
+                (
+                    os.path.join(
+                        plugins_base_dir, "visualizations", viz_id.split("/")[0], viz_id.split("/")[-1], "static"
+                    )
+                    if "/" in viz_id
+                    else None
+                ),
+            ]
+
+            source_dir = None
+            for path in possible_paths:
+                if path and os.path.exists(path):
+                    source_dir = path
+                    break
+
+            if not source_dir:
+                raise exceptions.ObjectNotFound(f"Static assets not found for visualization '{viz_id}'")
+
+            # Calculate relative path and target
+            relative_path = os.path.relpath(source_dir, plugins_base_dir)
+            target_dir = os.path.join(self.app.config.root, "static", "plugins", relative_path)
+
+            # Create target directory
+            os.makedirs(os.path.dirname(target_dir), exist_ok=True)
+
+            # Copy the static directory
+            if os.path.exists(target_dir):
+                shutil.rmtree(target_dir)
+
+            shutil.copytree(source_dir, target_dir, ignore=shutil.ignore_patterns("node_modules/.bin"))
+
+            log.info(f"Staged visualization assets for {viz_id}: {relative_path}")
+
+            return {
+                "visualization_id": viz_id,
+                "source_path": source_dir,
+                "target_path": target_dir,
+                "relative_path": relative_path,
+                "size": self.get_directory_size(target_dir),
+            }
+
+        except Exception as e:
+            log.error(f"Failed to stage visualization {viz_id}: {e}")
+            if "not found" in str(e).lower():
+                raise exceptions.ObjectNotFound(f"Visualization '{viz_id}' not found")
+            raise exceptions.InternalServerError(f"Failed to stage visualization: {e}")
+
+    def clean_staged_assets(self) -> Dict:
+        """
+        Clean all staged visualization assets from static/plugins/visualizations.
+        This is equivalent to the gulp cleanPlugins task.
+        """
+        try:
+            static_viz_dir = os.path.join(self.app.config.root, "static", "plugins", "visualizations")
+
+            if not os.path.exists(static_viz_dir):
+                return {"cleaned_count": 0, "message": "No staged assets to clean"}
+
+            # Count items before deletion
+            items = os.listdir(static_viz_dir)
+            item_count = len(items)
+
+            # Remove all contents
+            shutil.rmtree(static_viz_dir)
+
+            # Recreate empty directory
+            os.makedirs(static_viz_dir, exist_ok=True)
+
+            log.info(f"Cleaned {item_count} staged visualization assets")
+
+            return {"cleaned_count": item_count, "cleaned_items": items}
+
+        except Exception as e:
+            log.error(f"Failed to clean staged assets: {e}")
+            raise exceptions.InternalServerError(f"Failed to clean staged assets: {e}")
+
+    def get_staging_status(self) -> Dict:
+        """
+        Get information about currently staged visualizations.
+        """
+        try:
+            static_viz_dir = os.path.join(self.app.config.root, "static", "plugins", "visualizations")
+
+            if not os.path.exists(static_viz_dir):
+                return {"staged_count": 0, "staged_visualizations": [], "total_size": 0}
+
+            staged_items = []
+            total_size = 0
+
+            for item in os.listdir(static_viz_dir):
+                item_path = os.path.join(static_viz_dir, item)
+                if os.path.isdir(item_path):
+                    size = self.get_directory_size(item_path)
+                    total_size += size
+
+                    staged_items.append(
+                        {"name": item, "path": item_path, "size": size, "last_modified": os.path.getmtime(item_path)}
+                    )
+
+            return {"staged_count": len(staged_items), "staged_visualizations": staged_items, "total_size": total_size}
+
+        except Exception as e:
+            log.error(f"Failed to get staging status: {e}")
+            raise exceptions.InternalServerError(f"Failed to get staging status: {e}")
+
+    def _extract_viz_name_from_path(self, relative_path: str) -> Optional[str]:
+        """Extract visualization name from a relative path like 'visualizations/circster/static'."""
+        parts = relative_path.split(os.sep)
+        if len(parts) >= 3 and parts[0] == "visualizations" and parts[-1] == "static":
+            if len(parts) == 3:
+                # Simple case: visualizations/circster/static
+                return parts[1]
+            elif len(parts) == 4:
+                # Nested case: visualizations/jqplot/jqplot_bar/static
+                return f"{parts[1]}/{parts[2]}"
+        return None

--- a/lib/galaxy/managers/visualization_admin.py
+++ b/lib/galaxy/managers/visualization_admin.py
@@ -21,23 +21,19 @@ import requests
 import yaml
 
 from galaxy import exceptions
-from galaxy.managers.base import ModelManager
 from galaxy.structured_app import MinimalManagerApp
 
 log = logging.getLogger(__name__)
 
 
-class VisualizationPackageManager(ModelManager):
+class VisualizationPackageManager:
     """Manager for visualization package operations."""
 
-    model_class = type(None)  # Not managing database models
-
     def __init__(self, app: MinimalManagerApp):
-        super().__init__(app)
-        self.config_path = os.path.join(app.config.root, "client", "visualizations.yml")
+        self.app = app
+        self.config_path = os.path.join(app.config.root, "config", "visualization_packages.yml")
         self.static_path = os.path.join(app.config.root, "static", "plugins", "visualizations")
 
-        # Ensure directories exist
         os.makedirs(os.path.dirname(self.config_path), exist_ok=True)
         os.makedirs(self.static_path, exist_ok=True)
 

--- a/lib/galaxy/managers/visualization_admin.py
+++ b/lib/galaxy/managers/visualization_admin.py
@@ -31,9 +31,12 @@ class VisualizationPackageManager:
     def __init__(self, app: MinimalManagerApp):
         self.app = app
         self.config_path = os.path.join(app.config.root, "config", "visualization_packages.yml")
+        self.package_store_path = os.path.join(app.config.root, "config", "visualization_packages")
         self.static_path = os.path.join(app.config.root, "static", "plugins", "visualizations")
+        self.legacy_visualizations_path = os.path.join(app.config.root, "config", "plugins", "visualizations")
 
         os.makedirs(os.path.dirname(self.config_path), exist_ok=True)
+        os.makedirs(self.package_store_path, exist_ok=True)
         os.makedirs(self.static_path, exist_ok=True)
 
     @staticmethod
@@ -196,18 +199,22 @@ class VisualizationPackageManager:
         return True
 
     def cleanup_package_files(self, viz_id: str) -> None:
-        """Remove package files from the static directory."""
-        package_dir = os.path.join(self.static_path, viz_id)
-        if os.path.exists(package_dir):
-            try:
-                shutil.rmtree(package_dir)
-                log.info(f"Cleaned up package files for {viz_id}")
-            except Exception as e:
-                log.error(f"Failed to cleanup files for {viz_id}: {e}")
-                raise exceptions.InternalServerError(f"Failed to cleanup package files: {e}")
+        """Remove both managed package files and staged assets for a visualization."""
+        for path in (self.get_package_path(viz_id), self.get_staged_path(viz_id)):
+            if os.path.exists(path):
+                try:
+                    shutil.rmtree(path)
+                except Exception as e:
+                    log.error(f"Failed to cleanup files for {viz_id}: {e}")
+                    raise exceptions.InternalServerError(f"Failed to cleanup package files: {e}")
+        log.info(f"Cleaned up package files for {viz_id}")
 
     def get_package_path(self, viz_id: str) -> str:
-        """Get the file system path for a package."""
+        """Get the managed filesystem path for an installed runtime package."""
+        return os.path.join(self.package_store_path, viz_id)
+
+    def get_staged_path(self, viz_id: str) -> str:
+        """Get the served static filesystem path for a staged visualization."""
         return os.path.join(self.static_path, viz_id)
 
     def is_package_installed(self, viz_id: str) -> bool:
@@ -325,62 +332,22 @@ class VisualizationPackageManager:
             raise exceptions.InternalServerError(f"Failed to restore configuration: {e}")
 
     def stage_all_visualizations(self) -> dict:
-        """Stage all visualization assets from config/plugins to static/plugins."""
+        """Stage all visualization assets from managed and legacy sources to static/plugins."""
         try:
-            plugins_base_dir = os.path.join(self.app.config.root, "config", "plugins")
-            source_patterns = [
-                os.path.join(plugins_base_dir, "visualizations", "*", "static"),
-                os.path.join(plugins_base_dir, "visualizations", "*", "*", "static"),
-            ]
-
             staged_count = 0
             staged_visualizations = []
             errors = []
+            seen_viz_ids = set()
 
-            source_dirs = []
-            for pattern in source_patterns:
-                source_dirs.extend(glob(pattern))
-
-            for source_dir in source_dirs:
+            for stage_spec in self._iter_stage_specs():
                 try:
-                    if "node_modules/.bin" in source_dir:
-                        continue
-
-                    relative_path = os.path.relpath(source_dir, plugins_base_dir)
-                    if not safe_relpath(relative_path):
-                        log.warning(f"Skipping unsafe staging path: {source_dir}")
-                        continue
-
-                    target_dir = os.path.join(self.app.config.root, "static", "plugins", relative_path)
-
-                    # Skip if target is already up to date
-                    if os.path.exists(target_dir):
-                        src_mtime = os.path.getmtime(source_dir)
-                        tgt_mtime = os.path.getmtime(target_dir)
-                        if tgt_mtime >= src_mtime:
-                            viz_name = self._extract_viz_name_from_path(relative_path)
-                            if viz_name:
-                                staged_visualizations.append(viz_name)
-                            staged_count += 1
-                            continue
-                        shutil.rmtree(target_dir)
-
-                    os.makedirs(os.path.dirname(target_dir), exist_ok=True)
-                    shutil.copytree(
-                        source_dir,
-                        target_dir,
-                        ignore=shutil.ignore_patterns("node_modules/.bin"),
-                    )
-
+                    self._stage_spec(stage_spec)
                     staged_count += 1
-                    viz_name = self._extract_viz_name_from_path(relative_path)
-                    if viz_name:
-                        staged_visualizations.append(viz_name)
-
-                    log.info(f"Staged visualization assets: {relative_path}")
-
+                    if stage_spec["viz_id"] not in seen_viz_ids:
+                        staged_visualizations.append(stage_spec["viz_id"])
+                        seen_viz_ids.add(stage_spec["viz_id"])
                 except Exception as e:
-                    error_msg = f"Failed to stage {source_dir}: {e}"
+                    error_msg = f"Failed to stage {stage_spec['source_path']}: {e}"
                     log.error(error_msg)
                     errors.append(error_msg)
 
@@ -395,57 +362,16 @@ class VisualizationPackageManager:
             raise exceptions.InternalServerError(f"Failed to stage visualizations: {e}")
 
     def stage_visualization(self, viz_id: str) -> dict:
-        """Stage assets for a specific visualization from config/plugins to static/plugins."""
+        """Stage assets for a specific visualization from managed or legacy sources."""
         try:
-            plugins_base_dir = os.path.join(self.app.config.root, "config", "plugins")
-
-            possible_paths = [
-                os.path.join(plugins_base_dir, "visualizations", viz_id, "static"),
-            ]
-            # Nested visualizations like jqplot/jqplot_bar
-            if "/" in viz_id:
-                possible_paths.append(
-                    os.path.join(
-                        plugins_base_dir,
-                        "visualizations",
-                        viz_id.split("/")[0],
-                        viz_id.split("/")[-1],
-                        "static",
-                    )
-                )
-
-            source_dir = None
-            for path in possible_paths:
-                if os.path.exists(path):
-                    source_dir = path
-                    break
-
-            if not source_dir:
-                raise exceptions.ObjectNotFound(f"Static assets not found for visualization '{viz_id}'")
-
-            relative_path = os.path.relpath(source_dir, plugins_base_dir)
-            if not safe_relpath(relative_path):
-                raise exceptions.InternalServerError(f"Unsafe staging path for visualization '{viz_id}'")
-
-            target_dir = os.path.join(self.app.config.root, "static", "plugins", relative_path)
-
-            os.makedirs(os.path.dirname(target_dir), exist_ok=True)
-            if os.path.exists(target_dir):
-                shutil.rmtree(target_dir)
-
-            shutil.copytree(
-                source_dir,
-                target_dir,
-                ignore=shutil.ignore_patterns("node_modules/.bin"),
-            )
-            log.info(f"Staged visualization assets for {viz_id}: {relative_path}")
-
+            stage_spec = self._get_stage_spec(viz_id)
+            self._stage_spec(stage_spec)
             return {
                 "visualization_id": viz_id,
-                "source_path": source_dir,
-                "target_path": target_dir,
-                "relative_path": relative_path,
-                "size": self.get_directory_size(target_dir),
+                "source_path": stage_spec["source_path"],
+                "target_path": stage_spec["target_path"],
+                "relative_path": stage_spec["relative_path"],
+                "size": self.get_directory_size(stage_spec["target_path"]),
             }
 
         except exceptions.ObjectNotFound:
@@ -518,3 +444,97 @@ class VisualizationPackageManager:
             elif len(parts) == 4:
                 return f"{parts[1]}/{parts[2]}"
         return None
+
+    def _iter_stage_specs(self) -> list[dict]:
+        specs = []
+        managed_viz_ids = set()
+
+        config = self.load_config()
+        for viz_id in sorted(config):
+            package_path = self.get_package_path(viz_id)
+            if os.path.isdir(package_path):
+                specs.append(self._build_managed_stage_spec(viz_id, package_path))
+                managed_viz_ids.add(viz_id)
+
+        source_patterns = [
+            os.path.join(self.legacy_visualizations_path, "*", "static"),
+            os.path.join(self.legacy_visualizations_path, "*", "*", "static"),
+        ]
+        for pattern in source_patterns:
+            for source_dir in sorted(glob(pattern)):
+                if "node_modules/.bin" in source_dir:
+                    continue
+                relative_path = os.path.relpath(source_dir, os.path.join(self.app.config.root, "config", "plugins"))
+                viz_name = self._extract_viz_name_from_path(relative_path)
+                if not viz_name or viz_name in managed_viz_ids:
+                    continue
+                specs.append(self._build_legacy_stage_spec(viz_name, source_dir))
+
+        return specs
+
+    def _get_stage_spec(self, viz_id: str) -> dict:
+        package_path = self.get_package_path(viz_id)
+        if os.path.isdir(package_path):
+            return self._build_managed_stage_spec(viz_id, package_path)
+
+        legacy_paths = [os.path.join(self.legacy_visualizations_path, viz_id, "static")]
+        if "/" in viz_id:
+            first, second = viz_id.split("/", 1)
+            legacy_paths.append(os.path.join(self.legacy_visualizations_path, first, second, "static"))
+
+        for path in legacy_paths:
+            if os.path.isdir(path):
+                return self._build_legacy_stage_spec(viz_id, path)
+
+        raise exceptions.ObjectNotFound(f"Static assets not found for visualization '{viz_id}'")
+
+    def _build_managed_stage_spec(self, viz_id: str, package_path: str) -> dict:
+        plugin_name = viz_id.split("/")[-1]
+        config_file = os.path.join(package_path, "static", f"{plugin_name}.xml")
+        if not os.path.isfile(config_file):
+            raise exceptions.ConfigurationError(
+                f"Runtime visualization '{viz_id}' is missing required static config: {config_file}"
+            )
+        relative_path = os.path.relpath(package_path, self.app.config.root)
+        if not safe_relpath(relative_path):
+            raise exceptions.InternalServerError(f"Unsafe staging path for visualization '{viz_id}'")
+        return {
+            "viz_id": viz_id,
+            "source_path": package_path,
+            "target_path": self.get_staged_path(viz_id),
+            "relative_path": relative_path,
+        }
+
+    def _build_legacy_stage_spec(self, viz_id: str, source_dir: str) -> dict:
+        plugins_base_dir = os.path.join(self.app.config.root, "config", "plugins")
+        relative_path = os.path.relpath(source_dir, plugins_base_dir)
+        if not safe_relpath(relative_path):
+            raise exceptions.InternalServerError(f"Unsafe staging path for visualization '{viz_id}'")
+        return {
+            "viz_id": viz_id,
+            "source_path": source_dir,
+            "target_path": os.path.join(self.get_staged_path(viz_id), "static"),
+            "relative_path": relative_path,
+        }
+
+    def _stage_spec(self, stage_spec: dict) -> None:
+        source_path = stage_spec["source_path"]
+        target_path = stage_spec["target_path"]
+
+        if not os.path.exists(source_path):
+            raise exceptions.ObjectNotFound(f"Static assets not found for visualization '{stage_spec['viz_id']}'")
+
+        if os.path.exists(target_path):
+            src_mtime = os.path.getmtime(source_path)
+            tgt_mtime = os.path.getmtime(target_path)
+            if tgt_mtime >= src_mtime:
+                return
+            shutil.rmtree(target_path)
+
+        os.makedirs(os.path.dirname(target_path), exist_ok=True)
+        shutil.copytree(
+            source_path,
+            target_path,
+            ignore=shutil.ignore_patterns("node_modules/.bin"),
+        )
+        log.info(f"Staged visualization assets for {stage_spec['viz_id']}: {stage_spec['relative_path']}")

--- a/lib/galaxy/managers/visualization_admin.py
+++ b/lib/galaxy/managers/visualization_admin.py
@@ -1,21 +1,15 @@
-"""
-Manager for visualization package administration.
+"""Manager for visualization package administration."""
 
-Handles low-level operations for managing visualization packages including
-npm package operations, file system management, and configuration updates.
-"""
+from __future__ import annotations
 
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import tempfile
 from glob import glob
-from typing import (
-    Optional,
-    Union,
-)
 
 import requests
 import yaml
@@ -24,6 +18,11 @@ from galaxy import exceptions
 from galaxy.structured_app import MinimalManagerApp
 
 log = logging.getLogger(__name__)
+
+# Matches valid npm package names (scoped or unscoped)
+_NPM_PACKAGE_RE = re.compile(r"^(@[a-z0-9-~][a-z0-9._-~]*/)?[a-z0-9-~][a-z0-9._-~]*$")
+# Loose semver -- digits.digits.digits with optional pre-release/build suffix
+_SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+([a-zA-Z0-9.+-]*)$")
 
 
 class VisualizationPackageManager:
@@ -37,30 +36,35 @@ class VisualizationPackageManager:
         os.makedirs(os.path.dirname(self.config_path), exist_ok=True)
         os.makedirs(self.static_path, exist_ok=True)
 
+    @staticmethod
+    def validate_npm_inputs(package: str, version: str) -> None:
+        """Reject package names or versions that could be unsafe to pass to npm."""
+        if not _NPM_PACKAGE_RE.match(package):
+            raise exceptions.RequestParameterInvalidException(f"Invalid npm package name: {package}")
+        if not _SEMVER_RE.match(version):
+            raise exceptions.RequestParameterInvalidException(f"Invalid package version (expected semver): {version}")
+
     def load_config(self) -> dict:
-        """Load the visualizations.yml configuration file."""
+        """Load the visualization packages configuration file."""
         try:
             if not os.path.exists(self.config_path):
                 return {}
-
             with open(self.config_path) as f:
                 return yaml.safe_load(f) or {}
-
         except Exception as e:
             log.error(f"Failed to load visualization config: {e}")
             raise exceptions.InternalServerError(f"Failed to load configuration: {e}")
 
     def save_config(self, config: dict) -> None:
-        """Save the visualizations.yml configuration file."""
+        """Save the visualization packages configuration file."""
         try:
             with open(self.config_path, "w") as f:
                 yaml.safe_dump(config, f, default_flow_style=False, sort_keys=True)
-
         except Exception as e:
             log.error(f"Failed to save visualization config: {e}")
             raise exceptions.InternalServerError(f"Failed to save configuration: {e}")
 
-    def get_package_info(self, viz_id: str) -> Optional[dict]:
+    def get_package_info(self, viz_id: str) -> dict | None:
         """Get information about a specific package from config."""
         config = self.load_config()
         return config.get(viz_id)
@@ -88,16 +92,15 @@ class VisualizationPackageManager:
         if isinstance(config[viz_id], dict):
             config[viz_id]["enabled"] = enabled
         else:
-            # Convert string entry to dict format
             config[viz_id] = {"package": config[viz_id], "enabled": enabled}
 
         self.save_config(config)
 
     def install_npm_package(self, package: str, version: str, target_dir: str) -> dict:
         """Install an npm package to a target directory."""
+        self.validate_npm_inputs(package, version)
         try:
             with tempfile.TemporaryDirectory() as temp_dir:
-                # Install package using npm
                 package_spec = f"{package}@{version}"
                 cmd = [
                     "npm",
@@ -117,12 +120,10 @@ class VisualizationPackageManager:
                     log.error(f"npm install failed: {result.stderr}")
                     raise exceptions.InternalServerError(f"Package installation failed: {result.stderr}")
 
-                # Find the installed package directory
-                package_name = package.split("/")[-1]  # Handle scoped packages like @galaxyproject/foo
-                source_path = os.path.join(temp_dir, "node_modules", package_name)
-
-                if not os.path.exists(source_path):
-                    # Try full package name for scoped packages
+                # Scoped packages live under node_modules/@scope/name
+                if package.startswith("@"):
+                    source_path = os.path.join(temp_dir, "node_modules", *package.split("/"))
+                else:
                     source_path = os.path.join(temp_dir, "node_modules", package)
 
                 if not os.path.exists(source_path):
@@ -130,16 +131,10 @@ class VisualizationPackageManager:
                         f"Package directory not found after installation: {source_path}"
                     )
 
-                # Create target directory
                 os.makedirs(target_dir, exist_ok=True)
-
-                # Copy package contents
                 shutil.copytree(source_path, target_dir, dirs_exist_ok=True)
-
-                # Validate package structure
                 self.validate_package_structure(target_dir)
 
-                # Get package metadata
                 package_json_path = os.path.join(target_dir, "package.json")
                 metadata = {}
                 if os.path.exists(package_json_path):
@@ -156,31 +151,27 @@ class VisualizationPackageManager:
 
         except subprocess.TimeoutExpired:
             raise exceptions.InternalServerError("Package installation timed out")
+        except (
+            exceptions.InternalServerError,
+            exceptions.RequestParameterInvalidException,
+        ):
+            raise
         except Exception as e:
             log.error(f"Failed to install npm package {package}@{version}: {e}")
             raise exceptions.InternalServerError(f"Package installation failed: {e}")
 
     def validate_package_structure(self, package_dir: str) -> bool:
-        """Validate that a package has the required structure for Galaxy visualizations."""
-        required_files = ["package.json"]
-
-        for required_file in required_files:
-            file_path = os.path.join(package_dir, required_file)
-            if not os.path.exists(file_path):
-                raise exceptions.ConfigurationError(f"Required file missing: {required_file}")
-
-        # Validate package.json structure
+        """Validate that a package has the minimum required structure."""
         package_json_path = os.path.join(package_dir, "package.json")
+        if not os.path.exists(package_json_path):
+            raise exceptions.ConfigurationError("Required file missing: package.json")
+
         try:
             with open(package_json_path) as f:
                 package_json = json.load(f)
-
-            # Check for required fields
-            required_fields = ["name", "version"]
-            for field in required_fields:
+            for field in ("name", "version"):
                 if field not in package_json:
                     raise exceptions.ConfigurationError(f"package.json missing required field: {field}")
-
         except json.JSONDecodeError as e:
             raise exceptions.ConfigurationError(f"Invalid package.json: {e}")
 
@@ -217,7 +208,6 @@ class VisualizationPackageManager:
                         total_size += os.path.getsize(filepath)
         except Exception as e:
             log.warning(f"Failed to calculate directory size for {path}: {e}")
-
         return total_size
 
     def get_package_metadata(self, viz_id: str) -> dict:
@@ -235,19 +225,17 @@ class VisualizationPackageManager:
             log.warning(f"Failed to read package.json for {viz_id}: {e}")
             return {}
 
-    def query_npm_registry(self, search_term: Optional[str] = None) -> list[dict]:
+    def query_npm_registry(self, search_term: str | None = None) -> list[dict]:
         """Query npm registry for @galaxyproject visualization packages."""
         try:
-            # Build search URL
             base_url = "https://registry.npmjs.org/-/search"
             query_parts = ["scope:galaxyproject"]
-
             if search_term:
                 query_parts.append(search_term)
 
-            params: dict[str, Union[str, int]] = {
+            params: dict[str, str | int] = {
                 "text": " ".join(query_parts),
-                "size": 250,  # Maximum results
+                "size": 250,
             }
 
             response = requests.get(base_url, params=params, timeout=10)
@@ -258,8 +246,6 @@ class VisualizationPackageManager:
 
             for result in data.get("objects", []):
                 package_info = result.get("package", {})
-
-                # Filter for visualization packages
                 keywords = package_info.get("keywords", [])
                 if "visualization" in keywords or "galaxy-visualization" in keywords:
                     packages.append(
@@ -291,17 +277,14 @@ class VisualizationPackageManager:
 
             data = response.json()
             versions = list(data.get("versions", {}).keys())
-
-            # Sort versions (basic sort, could be improved with semver)
             versions.sort(reverse=True)
-
             return versions
 
         except requests.RequestException as e:
             log.error(f"Failed to get versions for {package_name}: {e}")
             raise exceptions.InternalServerError(f"Failed to get package versions: {e}")
 
-    def backup_config(self) -> Optional[str]:
+    def backup_config(self) -> str | None:
         """Create a backup of the current configuration."""
         backup_path = f"{self.config_path}.backup"
         try:
@@ -310,7 +293,6 @@ class VisualizationPackageManager:
                 return backup_path
         except Exception as e:
             log.error(f"Failed to create config backup: {e}")
-
         return None
 
     def restore_config(self, backup_path: str) -> None:
@@ -326,10 +308,7 @@ class VisualizationPackageManager:
             raise exceptions.InternalServerError(f"Failed to restore configuration: {e}")
 
     def stage_all_visualizations(self) -> dict:
-        """
-        Stage all visualization assets from config/plugins/visualizations to static/plugins/visualizations.
-        This is equivalent to the gulp stagePlugins task.
-        """
+        """Stage all visualization assets from config/plugins to static/plugins."""
         try:
             plugins_base_dir = os.path.join(self.app.config.root, "config", "plugins")
             source_patterns = [
@@ -341,25 +320,19 @@ class VisualizationPackageManager:
             staged_visualizations = []
             errors = []
 
-            # Find all static directories to stage
             source_dirs = []
             for pattern in source_patterns:
                 source_dirs.extend(glob(pattern))
 
             for source_dir in source_dirs:
                 try:
-                    # Skip node_modules/.bin directories
                     if "node_modules/.bin" in source_dir:
                         continue
 
-                    # Get the relative path from plugins base dir
                     relative_path = os.path.relpath(source_dir, plugins_base_dir)
                     target_dir = os.path.join(self.app.config.root, "static", "plugins", relative_path)
 
-                    # Create target directory
                     os.makedirs(os.path.dirname(target_dir), exist_ok=True)
-
-                    # Copy the static directory
                     if os.path.exists(target_dir):
                         shutil.rmtree(target_dir)
 
@@ -370,7 +343,6 @@ class VisualizationPackageManager:
                     )
 
                     staged_count += 1
-                    # Extract visualization name from path
                     viz_name = self._extract_viz_name_from_path(relative_path)
                     if viz_name:
                         staged_visualizations.append(viz_name)
@@ -393,17 +365,16 @@ class VisualizationPackageManager:
             raise exceptions.InternalServerError(f"Failed to stage visualizations: {e}")
 
     def stage_visualization(self, viz_id: str) -> dict:
-        """
-        Stage assets for a specific visualization from config/plugins to static/plugins.
-        """
+        """Stage assets for a specific visualization from config/plugins to static/plugins."""
         try:
             plugins_base_dir = os.path.join(self.app.config.root, "config", "plugins")
 
-            # Look for the visualization in both possible locations
             possible_paths = [
                 os.path.join(plugins_base_dir, "visualizations", viz_id, "static"),
-                # Check for nested visualizations (like jqplot/jqplot_bar)
-                (
+            ]
+            # Nested visualizations like jqplot/jqplot_bar
+            if "/" in viz_id:
+                possible_paths.append(
                     os.path.join(
                         plugins_base_dir,
                         "visualizations",
@@ -411,28 +382,21 @@ class VisualizationPackageManager:
                         viz_id.split("/")[-1],
                         "static",
                     )
-                    if "/" in viz_id
-                    else None
-                ),
-            ]
+                )
 
             source_dir = None
             for path in possible_paths:
-                if path and os.path.exists(path):
+                if os.path.exists(path):
                     source_dir = path
                     break
 
             if not source_dir:
                 raise exceptions.ObjectNotFound(f"Static assets not found for visualization '{viz_id}'")
 
-            # Calculate relative path and target
             relative_path = os.path.relpath(source_dir, plugins_base_dir)
             target_dir = os.path.join(self.app.config.root, "static", "plugins", relative_path)
 
-            # Create target directory
             os.makedirs(os.path.dirname(target_dir), exist_ok=True)
-
-            # Copy the static directory
             if os.path.exists(target_dir):
                 shutil.rmtree(target_dir)
 
@@ -441,7 +405,6 @@ class VisualizationPackageManager:
                 target_dir,
                 ignore=shutil.ignore_patterns("node_modules/.bin"),
             )
-
             log.info(f"Staged visualization assets for {viz_id}: {relative_path}")
 
             return {
@@ -459,28 +422,19 @@ class VisualizationPackageManager:
             raise exceptions.InternalServerError(f"Failed to stage visualization: {e}")
 
     def clean_staged_assets(self) -> dict:
-        """
-        Clean all staged visualization assets from static/plugins/visualizations.
-        This is equivalent to the gulp cleanPlugins task.
-        """
+        """Clean all staged visualization assets from static/plugins/visualizations."""
         try:
             static_viz_dir = os.path.join(self.app.config.root, "static", "plugins", "visualizations")
 
             if not os.path.exists(static_viz_dir):
                 return {"cleaned_count": 0, "message": "No staged assets to clean"}
 
-            # Count items before deletion
             items = os.listdir(static_viz_dir)
             item_count = len(items)
-
-            # Remove all contents
             shutil.rmtree(static_viz_dir)
-
-            # Recreate empty directory
             os.makedirs(static_viz_dir, exist_ok=True)
 
             log.info(f"Cleaned {item_count} staged visualization assets")
-
             return {"cleaned_count": item_count, "cleaned_items": items}
 
         except Exception as e:
@@ -488,9 +442,7 @@ class VisualizationPackageManager:
             raise exceptions.InternalServerError(f"Failed to clean staged assets: {e}")
 
     def get_staging_status(self) -> dict:
-        """
-        Get information about currently staged visualizations.
-        """
+        """Get information about currently staged visualizations."""
         try:
             static_viz_dir = os.path.join(self.app.config.root, "static", "plugins", "visualizations")
 
@@ -505,7 +457,6 @@ class VisualizationPackageManager:
                 if os.path.isdir(item_path):
                     size = self.get_directory_size(item_path)
                     total_size += size
-
                     staged_items.append(
                         {
                             "name": item,
@@ -525,14 +476,12 @@ class VisualizationPackageManager:
             log.error(f"Failed to get staging status: {e}")
             raise exceptions.InternalServerError(f"Failed to get staging status: {e}")
 
-    def _extract_viz_name_from_path(self, relative_path: str) -> Optional[str]:
+    def _extract_viz_name_from_path(self, relative_path: str) -> str | None:
         """Extract visualization name from a relative path like 'visualizations/circster/static'."""
         parts = relative_path.split(os.sep)
         if len(parts) >= 3 and parts[0] == "visualizations" and parts[-1] == "static":
             if len(parts) == 3:
-                # Simple case: visualizations/circster/static
                 return parts[1]
             elif len(parts) == 4:
-                # Nested case: visualizations/jqplot/jqplot_bar/static
                 return f"{parts[1]}/{parts[2]}"
         return None

--- a/lib/galaxy/managers/visualization_admin.py
+++ b/lib/galaxy/managers/visualization_admin.py
@@ -19,10 +19,9 @@ from galaxy.structured_app import MinimalManagerApp
 
 log = logging.getLogger(__name__)
 
-# Matches valid npm package names (scoped or unscoped)
 _NPM_PACKAGE_RE = re.compile(r"^(@[a-z0-9-~][a-z0-9._-~]*/)?[a-z0-9-~][a-z0-9._-~]*$")
-# Loose semver -- digits.digits.digits with optional pre-release/build suffix
 _SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+([a-zA-Z0-9.+-]*)$")
+_VIZ_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+(/[a-zA-Z0-9_-]+)?$")
 
 
 class VisualizationPackageManager:
@@ -43,6 +42,12 @@ class VisualizationPackageManager:
             raise exceptions.RequestParameterInvalidException(f"Invalid npm package name: {package}")
         if not _SEMVER_RE.match(version):
             raise exceptions.RequestParameterInvalidException(f"Invalid package version (expected semver): {version}")
+
+    @staticmethod
+    def validate_viz_id(viz_id: str) -> None:
+        """Reject viz IDs that could escape the static directory."""
+        if not viz_id or not _VIZ_ID_RE.match(viz_id) or ".." in viz_id:
+            raise exceptions.RequestParameterInvalidException(f"Invalid visualization ID: {viz_id}")
 
     def load_config(self) -> dict:
         """Load the visualization packages configuration file."""

--- a/lib/galaxy/managers/visualization_admin.py
+++ b/lib/galaxy/managers/visualization_admin.py
@@ -19,7 +19,7 @@ from galaxy.structured_app import MinimalManagerApp
 
 log = logging.getLogger(__name__)
 
-_NPM_PACKAGE_RE = re.compile(r"^(@[a-z0-9-~][a-z0-9._-~]*/)?[a-z0-9-~][a-z0-9._-~]*$")
+_NPM_PACKAGE_RE = re.compile(r"^(@[a-z0-9][a-z0-9._~-]*/)?[a-z0-9][a-z0-9._~-]*$")
 _SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+([a-zA-Z0-9.+-]*)$")
 _VIZ_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+(/[a-zA-Z0-9_-]+)?$")
 

--- a/lib/galaxy/managers/visualization_admin.py
+++ b/lib/galaxy/managers/visualization_admin.py
@@ -16,6 +16,7 @@ import yaml
 
 from galaxy import exceptions
 from galaxy.structured_app import MinimalManagerApp
+from galaxy.util.path import safe_relpath
 
 log = logging.getLogger(__name__)
 
@@ -50,12 +51,24 @@ class VisualizationPackageManager:
             raise exceptions.RequestParameterInvalidException(f"Invalid visualization ID: {viz_id}")
 
     def load_config(self) -> dict:
-        """Load the visualization packages configuration file."""
+        """Load and normalize the visualization packages config file.
+
+        Legacy entries that are bare strings get normalized to dict format
+        so callers don't need to handle both shapes.
+        """
         try:
             if not os.path.exists(self.config_path):
                 return {}
             with open(self.config_path) as f:
-                return yaml.safe_load(f) or {}
+                raw = yaml.safe_load(f) or {}
+            for viz_id, info in raw.items():
+                if not isinstance(info, dict):
+                    raw[viz_id] = {
+                        "package": str(info),
+                        "version": "unknown",
+                        "enabled": True,
+                    }
+            return raw
         except Exception as e:
             log.error(f"Failed to load visualization config: {e}")
             raise exceptions.InternalServerError(f"Failed to load configuration: {e}")
@@ -302,12 +315,11 @@ class VisualizationPackageManager:
 
     def restore_config(self, backup_path: str) -> None:
         """Restore configuration from a backup."""
+        if not os.path.exists(backup_path):
+            raise exceptions.ObjectNotFound("Backup file not found")
         try:
-            if os.path.exists(backup_path):
-                shutil.copy2(backup_path, self.config_path)
-                log.info("Configuration restored from backup")
-            else:
-                raise exceptions.ObjectNotFound("Backup file not found")
+            shutil.copy2(backup_path, self.config_path)
+            log.info("Configuration restored from backup")
         except Exception as e:
             log.error(f"Failed to restore config: {e}")
             raise exceptions.InternalServerError(f"Failed to restore configuration: {e}")
@@ -335,12 +347,25 @@ class VisualizationPackageManager:
                         continue
 
                     relative_path = os.path.relpath(source_dir, plugins_base_dir)
+                    if not safe_relpath(relative_path):
+                        log.warning(f"Skipping unsafe staging path: {source_dir}")
+                        continue
+
                     target_dir = os.path.join(self.app.config.root, "static", "plugins", relative_path)
 
-                    os.makedirs(os.path.dirname(target_dir), exist_ok=True)
+                    # Skip if target is already up to date
                     if os.path.exists(target_dir):
+                        src_mtime = os.path.getmtime(source_dir)
+                        tgt_mtime = os.path.getmtime(target_dir)
+                        if tgt_mtime >= src_mtime:
+                            viz_name = self._extract_viz_name_from_path(relative_path)
+                            if viz_name:
+                                staged_visualizations.append(viz_name)
+                            staged_count += 1
+                            continue
                         shutil.rmtree(target_dir)
 
+                    os.makedirs(os.path.dirname(target_dir), exist_ok=True)
                     shutil.copytree(
                         source_dir,
                         target_dir,
@@ -399,6 +424,9 @@ class VisualizationPackageManager:
                 raise exceptions.ObjectNotFound(f"Static assets not found for visualization '{viz_id}'")
 
             relative_path = os.path.relpath(source_dir, plugins_base_dir)
+            if not safe_relpath(relative_path):
+                raise exceptions.InternalServerError(f"Unsafe staging path for visualization '{viz_id}'")
+
             target_dir = os.path.join(self.app.config.root, "static", "plugins", relative_path)
 
             os.makedirs(os.path.dirname(target_dir), exist_ok=True)
@@ -420,10 +448,10 @@ class VisualizationPackageManager:
                 "size": self.get_directory_size(target_dir),
             }
 
+        except exceptions.ObjectNotFound:
+            raise
         except Exception as e:
             log.error(f"Failed to stage visualization {viz_id}: {e}")
-            if "not found" in str(e).lower():
-                raise exceptions.ObjectNotFound(f"Visualization '{viz_id}' not found")
             raise exceptions.InternalServerError(f"Failed to stage visualization: {e}")
 
     def clean_staged_assets(self) -> dict:

--- a/lib/galaxy/managers/visualization_admin.py
+++ b/lib/galaxy/managers/visualization_admin.py
@@ -13,8 +13,6 @@ import subprocess
 import tempfile
 from glob import glob
 from typing import (
-    Dict,
-    List,
     Optional,
     Union,
 )
@@ -43,7 +41,7 @@ class VisualizationPackageManager(ModelManager):
         os.makedirs(os.path.dirname(self.config_path), exist_ok=True)
         os.makedirs(self.static_path, exist_ok=True)
 
-    def load_config(self) -> Dict:
+    def load_config(self) -> dict:
         """Load the visualizations.yml configuration file."""
         try:
             if not os.path.exists(self.config_path):
@@ -56,7 +54,7 @@ class VisualizationPackageManager(ModelManager):
             log.error(f"Failed to load visualization config: {e}")
             raise exceptions.InternalServerError(f"Failed to load configuration: {e}")
 
-    def save_config(self, config: Dict) -> None:
+    def save_config(self, config: dict) -> None:
         """Save the visualizations.yml configuration file."""
         try:
             with open(self.config_path, "w") as f:
@@ -66,7 +64,7 @@ class VisualizationPackageManager(ModelManager):
             log.error(f"Failed to save visualization config: {e}")
             raise exceptions.InternalServerError(f"Failed to save configuration: {e}")
 
-    def get_package_info(self, viz_id: str) -> Optional[Dict]:
+    def get_package_info(self, viz_id: str) -> Optional[dict]:
         """Get information about a specific package from config."""
         config = self.load_config()
         return config.get(viz_id)
@@ -99,13 +97,22 @@ class VisualizationPackageManager(ModelManager):
 
         self.save_config(config)
 
-    def install_npm_package(self, package: str, version: str, target_dir: str) -> Dict:
+    def install_npm_package(self, package: str, version: str, target_dir: str) -> dict:
         """Install an npm package to a target directory."""
         try:
             with tempfile.TemporaryDirectory() as temp_dir:
                 # Install package using npm
                 package_spec = f"{package}@{version}"
-                cmd = ["npm", "install", package_spec, "--prefix", temp_dir, "--no-audit", "--no-fund", "--production"]
+                cmd = [
+                    "npm",
+                    "install",
+                    package_spec,
+                    "--prefix",
+                    temp_dir,
+                    "--no-audit",
+                    "--no-fund",
+                    "--production",
+                ]
 
                 log.info(f"Installing npm package: {package_spec}")
                 result = subprocess.run(cmd, capture_output=True, text=True, timeout=300, cwd=temp_dir)
@@ -217,7 +224,7 @@ class VisualizationPackageManager(ModelManager):
 
         return total_size
 
-    def get_package_metadata(self, viz_id: str) -> Dict:
+    def get_package_metadata(self, viz_id: str) -> dict:
         """Get metadata from an installed package's package.json."""
         package_path = self.get_package_path(viz_id)
         package_json_path = os.path.join(package_path, "package.json")
@@ -232,7 +239,7 @@ class VisualizationPackageManager(ModelManager):
             log.warning(f"Failed to read package.json for {viz_id}: {e}")
             return {}
 
-    def query_npm_registry(self, search_term: Optional[str] = None) -> List[Dict]:
+    def query_npm_registry(self, search_term: Optional[str] = None) -> list[dict]:
         """Query npm registry for @galaxyproject visualization packages."""
         try:
             # Build search URL
@@ -242,7 +249,7 @@ class VisualizationPackageManager(ModelManager):
             if search_term:
                 query_parts.append(search_term)
 
-            params: Dict[str, Union[str, int]] = {
+            params: dict[str, Union[str, int]] = {
                 "text": " ".join(query_parts),
                 "size": 250,  # Maximum results
             }
@@ -279,7 +286,7 @@ class VisualizationPackageManager(ModelManager):
             log.error(f"Failed to query npm registry: {e}")
             raise exceptions.InternalServerError(f"Failed to query package registry: {e}")
 
-    def get_package_versions(self, package_name: str) -> List[str]:
+    def get_package_versions(self, package_name: str) -> list[str]:
         """Get available versions for a specific package from npm registry."""
         try:
             url = f"https://registry.npmjs.org/{package_name}"
@@ -322,7 +329,7 @@ class VisualizationPackageManager(ModelManager):
             log.error(f"Failed to restore config: {e}")
             raise exceptions.InternalServerError(f"Failed to restore configuration: {e}")
 
-    def stage_all_visualizations(self) -> Dict:
+    def stage_all_visualizations(self) -> dict:
         """
         Stage all visualization assets from config/plugins/visualizations to static/plugins/visualizations.
         This is equivalent to the gulp stagePlugins task.
@@ -360,7 +367,11 @@ class VisualizationPackageManager(ModelManager):
                     if os.path.exists(target_dir):
                         shutil.rmtree(target_dir)
 
-                    shutil.copytree(source_dir, target_dir, ignore=shutil.ignore_patterns("node_modules/.bin"))
+                    shutil.copytree(
+                        source_dir,
+                        target_dir,
+                        ignore=shutil.ignore_patterns("node_modules/.bin"),
+                    )
 
                     staged_count += 1
                     # Extract visualization name from path
@@ -375,13 +386,17 @@ class VisualizationPackageManager(ModelManager):
                     log.error(error_msg)
                     errors.append(error_msg)
 
-            return {"staged_count": staged_count, "staged_visualizations": staged_visualizations, "errors": errors}
+            return {
+                "staged_count": staged_count,
+                "staged_visualizations": staged_visualizations,
+                "errors": errors,
+            }
 
         except Exception as e:
             log.error(f"Failed to stage visualizations: {e}")
             raise exceptions.InternalServerError(f"Failed to stage visualizations: {e}")
 
-    def stage_visualization(self, viz_id: str) -> Dict:
+    def stage_visualization(self, viz_id: str) -> dict:
         """
         Stage assets for a specific visualization from config/plugins to static/plugins.
         """
@@ -394,7 +409,11 @@ class VisualizationPackageManager(ModelManager):
                 # Check for nested visualizations (like jqplot/jqplot_bar)
                 (
                     os.path.join(
-                        plugins_base_dir, "visualizations", viz_id.split("/")[0], viz_id.split("/")[-1], "static"
+                        plugins_base_dir,
+                        "visualizations",
+                        viz_id.split("/")[0],
+                        viz_id.split("/")[-1],
+                        "static",
                     )
                     if "/" in viz_id
                     else None
@@ -421,7 +440,11 @@ class VisualizationPackageManager(ModelManager):
             if os.path.exists(target_dir):
                 shutil.rmtree(target_dir)
 
-            shutil.copytree(source_dir, target_dir, ignore=shutil.ignore_patterns("node_modules/.bin"))
+            shutil.copytree(
+                source_dir,
+                target_dir,
+                ignore=shutil.ignore_patterns("node_modules/.bin"),
+            )
 
             log.info(f"Staged visualization assets for {viz_id}: {relative_path}")
 
@@ -439,7 +462,7 @@ class VisualizationPackageManager(ModelManager):
                 raise exceptions.ObjectNotFound(f"Visualization '{viz_id}' not found")
             raise exceptions.InternalServerError(f"Failed to stage visualization: {e}")
 
-    def clean_staged_assets(self) -> Dict:
+    def clean_staged_assets(self) -> dict:
         """
         Clean all staged visualization assets from static/plugins/visualizations.
         This is equivalent to the gulp cleanPlugins task.
@@ -468,7 +491,7 @@ class VisualizationPackageManager(ModelManager):
             log.error(f"Failed to clean staged assets: {e}")
             raise exceptions.InternalServerError(f"Failed to clean staged assets: {e}")
 
-    def get_staging_status(self) -> Dict:
+    def get_staging_status(self) -> dict:
         """
         Get information about currently staged visualizations.
         """
@@ -488,10 +511,19 @@ class VisualizationPackageManager(ModelManager):
                     total_size += size
 
                     staged_items.append(
-                        {"name": item, "path": item_path, "size": size, "last_modified": os.path.getmtime(item_path)}
+                        {
+                            "name": item,
+                            "path": item_path,
+                            "size": size,
+                            "last_modified": os.path.getmtime(item_path),
+                        }
                     )
 
-            return {"staged_count": len(staged_items), "staged_visualizations": staged_items, "total_size": total_size}
+            return {
+                "staged_count": len(staged_items),
+                "staged_visualizations": staged_items,
+                "total_size": total_size,
+            }
 
         except Exception as e:
             log.error(f"Failed to get staging status: {e}")

--- a/lib/galaxy/schema/visualization_admin.py
+++ b/lib/galaxy/schema/visualization_admin.py
@@ -1,0 +1,116 @@
+from typing import Optional
+
+from pydantic import (
+    Field,
+    RootModel,
+)
+
+from galaxy.schema.schema import Model
+
+
+class VisualizationPackageMetadata(Model):
+    description: Optional[str] = Field(None, title="Description")
+    author: Optional[str] = Field(None, title="Author")
+    license: Optional[str] = Field(None, title="License")
+    dependencies: Optional[dict[str, str]] = Field(None, title="Dependencies")
+    homepage: Optional[str] = Field(None, title="Homepage")
+
+
+class InstalledVisualizationResponse(Model):
+    id: str = Field(..., title="ID", description="The visualization identifier.")
+    package: str = Field(..., title="Package", description="The npm package name.")
+    version: str = Field(..., title="Version", description="The installed package version.")
+    enabled: bool = Field(..., title="Enabled", description="Whether this visualization is enabled.")
+    installed: bool = Field(..., title="Installed", description="Whether files are present on disk.")
+    path: Optional[str] = Field(None, title="Path", description="Filesystem path to the installed package.")
+    size: Optional[int] = Field(None, title="Size", description="Total size in bytes.")
+    metadata: Optional[dict] = Field(None, title="Metadata", description="Package metadata from package.json.")
+    message: Optional[str] = Field(None, title="Message", description="Status message.")
+
+
+class InstalledVisualizationListResponse(RootModel):
+    root: list[InstalledVisualizationResponse]
+
+
+class AvailableVisualizationResponse(Model):
+    name: str = Field(..., title="Name", description="The npm package name.")
+    description: str = Field("", title="Description", description="Package description.")
+    version: str = Field("", title="Version", description="Latest published version.")
+    keywords: list[str] = Field(default_factory=list, title="Keywords")
+    author: Optional[dict] = Field(None, title="Author")
+    maintainers: list[dict] = Field(default_factory=list, title="Maintainers")
+    links: Optional[dict] = Field(None, title="Links", description="Homepage, repository, etc.")
+    date: Optional[str] = Field(None, title="Date", description="Last publish date.")
+    score: Optional[dict] = Field(None, title="Score", description="NPM search score.")
+
+
+class AvailableVisualizationListResponse(RootModel):
+    root: list[AvailableVisualizationResponse]
+
+
+class InstallVisualizationRequest(Model):
+    package: str = Field(..., title="Package", description="The npm package name to install.")
+    version: str = Field(..., title="Version", description="The package version to install.")
+
+
+class UpdateVisualizationRequest(Model):
+    version: str = Field(..., title="Version", description="The new version to update to.")
+
+
+class ToggleVisualizationRequest(Model):
+    enabled: bool = Field(
+        ...,
+        title="Enabled",
+        description="Whether to enable or disable the visualization.",
+    )
+
+
+class ToggleVisualizationResponse(Model):
+    id: str = Field(..., title="ID")
+    enabled: bool = Field(..., title="Enabled")
+    message: str = Field(..., title="Message")
+
+
+class MessageResponse(Model):
+    message: str = Field(..., title="Message")
+
+
+class StagingResultResponse(Model):
+    message: str = Field(..., title="Message")
+    staged_count: int = Field(..., title="Staged Count")
+    staged_visualizations: list[str] = Field(default_factory=list, title="Staged Visualizations")
+    errors: list[str] = Field(default_factory=list, title="Errors")
+
+
+class VisualizationStagingResultResponse(Model):
+    message: str = Field(..., title="Message")
+    visualization_id: str = Field(..., title="Visualization ID")
+    source_path: str = Field(..., title="Source Path")
+    target_path: str = Field(..., title="Target Path")
+    size: int = Field(0, title="Size")
+
+
+class CleanStagingResultResponse(Model):
+    message: str = Field(..., title="Message")
+    cleaned_count: int = Field(..., title="Cleaned Count")
+    cleaned_items: list[str] = Field(default_factory=list, title="Cleaned Items")
+
+
+class StagedVisualizationInfo(Model):
+    name: str = Field(..., title="Name")
+    path: str = Field(..., title="Path")
+    size: int = Field(..., title="Size")
+    last_modified: float = Field(..., title="Last Modified")
+
+
+class StagingStatusResponse(Model):
+    message: str = Field(..., title="Message")
+    staged_count: int = Field(..., title="Staged Count")
+    staged_visualizations: list[StagedVisualizationInfo] = Field(default_factory=list, title="Staged Visualizations")
+    total_size: int = Field(0, title="Total Size")
+
+
+class UsageStatsResponse(Model):
+    message: str = Field(..., title="Message")
+    days: int = Field(..., title="Days")
+    stats: dict = Field(default_factory=dict, title="Stats")

--- a/lib/galaxy/schema/visualization_admin.py
+++ b/lib/galaxy/schema/visualization_admin.py
@@ -110,6 +110,15 @@ class StagingStatusResponse(Model):
     total_size: int = Field(0, title="Total Size")
 
 
+class PackageVersionsResponse(Model):
+    package: str = Field(..., title="Package", description="The npm package name.")
+    versions: list[str] = Field(
+        default_factory=list,
+        title="Versions",
+        description="Available versions, newest first.",
+    )
+
+
 class UsageStatsResponse(Model):
     message: str = Field(..., title="Message")
     days: int = Field(..., title="Days")

--- a/lib/galaxy/webapps/galaxy/api/admin_visualizations.py
+++ b/lib/galaxy/webapps/galaxy/api/admin_visualizations.py
@@ -1,0 +1,218 @@
+"""
+Admin API for visualization package management.
+
+Provides endpoints for Galaxy administrators to manage visualization packages
+dynamically without requiring client rebuilds.
+"""
+
+import logging
+from typing import (
+    Optional,
+)
+
+from fastapi import (
+    Body,
+    Path,
+    Query,
+    status,
+)
+from typing_extensions import Annotated
+
+from galaxy.managers.context import ProvidesUserContext
+from galaxy.webapps.galaxy.api import (
+    depends,
+    DependsOnTrans,
+    Router,
+)
+from galaxy.webapps.galaxy.services.admin_visualizations import AdminVisualizationsService
+
+log = logging.getLogger(__name__)
+
+router = Router(tags=["admin_visualizations"])
+
+VisualizationIdPathParam = Annotated[
+    str,
+    Path(..., title="Visualization ID", description="The identifier of the visualization package."),
+]
+
+
+@router.cbv
+class FastAPIAdminVisualizations:
+    service: AdminVisualizationsService = depends(AdminVisualizationsService)
+
+    @router.get(
+        "/api/admin/visualizations",
+        summary="List all installed visualization packages.",
+        require_admin=True,
+    )
+    def index(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        include_disabled: bool = Query(
+            default=True,
+            title="Include disabled",
+            description="Whether to include disabled visualizations in the result.",
+        ),
+    ):
+        """Return a list of all installed visualization packages with their status."""
+        return self.service.index(trans, include_disabled=include_disabled)
+
+    @router.get(
+        "/api/admin/visualizations/available",
+        summary="List available visualization packages from npm registry.",
+        require_admin=True,
+    )
+    def available(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        search: Optional[str] = Query(
+            default=None, title="Search term", description="Filter available packages by name or description."
+        ),
+    ):
+        """Return a list of available @galaxyproject visualization packages from npm registry."""
+        return self.service.get_available_packages(trans, search=search)
+
+    @router.get(
+        "/api/admin/visualizations/{viz_id}",
+        summary="Get details for a specific visualization package.",
+        require_admin=True,
+    )
+    def show(
+        self,
+        viz_id: VisualizationIdPathParam,
+        trans: ProvidesUserContext = DependsOnTrans,
+    ):
+        """Return detailed information about a specific visualization package."""
+        return self.service.show(trans, viz_id)
+
+    @router.post(
+        "/api/admin/visualizations/{viz_id}/install",
+        summary="Install a visualization package.",
+        require_admin=True,
+        status_code=status.HTTP_201_CREATED,
+    )
+    def install(
+        self,
+        viz_id: VisualizationIdPathParam,
+        trans: ProvidesUserContext = DependsOnTrans,
+        package: str = Body(..., description="The npm package name"),
+        version: str = Body(..., description="The package version to install"),
+    ):
+        """Install a visualization package from npm registry."""
+        return self.service.install_package(trans, viz_id, package, version)
+
+    @router.put(
+        "/api/admin/visualizations/{viz_id}/update",
+        summary="Update a visualization package to a new version.",
+        require_admin=True,
+    )
+    def update(
+        self,
+        viz_id: VisualizationIdPathParam,
+        trans: ProvidesUserContext = DependsOnTrans,
+        version: str = Body(..., description="The new version to update to"),
+    ):
+        """Update an installed visualization package to a new version."""
+        return self.service.update_package(trans, viz_id, version)
+
+    @router.delete(
+        "/api/admin/visualizations/{viz_id}",
+        summary="Uninstall a visualization package.",
+        require_admin=True,
+        status_code=status.HTTP_204_NO_CONTENT,
+    )
+    def uninstall(
+        self,
+        viz_id: VisualizationIdPathParam,
+        trans: ProvidesUserContext = DependsOnTrans,
+    ):
+        """Uninstall a visualization package and clean up its assets."""
+        self.service.uninstall_package(trans, viz_id)
+
+    @router.put(
+        "/api/admin/visualizations/{viz_id}/toggle",
+        summary="Enable or disable a visualization package.",
+        require_admin=True,
+    )
+    def toggle(
+        self,
+        viz_id: VisualizationIdPathParam,
+        trans: ProvidesUserContext = DependsOnTrans,
+        enabled: bool = Body(..., description="Whether to enable or disable the visualization"),
+    ):
+        """Enable or disable a visualization package without uninstalling it."""
+        return self.service.toggle_package(trans, viz_id, enabled)
+
+    @router.post(
+        "/api/admin/visualizations/reload",
+        summary="Reload the visualization registry.",
+        require_admin=True,
+    )
+    def reload(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+    ):
+        """Reload the visualization registry to pick up configuration changes."""
+        return self.service.reload_registry(trans)
+
+    @router.get(
+        "/api/admin/visualizations/usage_stats",
+        summary="Get usage statistics for visualizations.",
+        require_admin=True,
+    )
+    def usage_stats(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        days: int = Query(default=30, title="Days", description="Number of days to look back for usage statistics"),
+    ):
+        """Return usage statistics for installed visualizations."""
+        return self.service.get_usage_stats(trans, days=days)
+
+    @router.post(
+        "/api/admin/visualizations/stage",
+        summary="Stage all visualization assets.",
+        require_admin=True,
+    )
+    def stage_all(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+    ):
+        """Stage all visualization assets from config/plugins to static/plugins for Galaxy to serve."""
+        return self.service.stage_all_visualizations(trans)
+
+    @router.post(
+        "/api/admin/visualizations/{viz_id}/stage",
+        summary="Stage assets for a specific visualization.",
+        require_admin=True,
+    )
+    def stage_visualization(
+        self,
+        viz_id: VisualizationIdPathParam,
+        trans: ProvidesUserContext = DependsOnTrans,
+    ):
+        """Stage assets for a specific visualization from config/plugins to static/plugins."""
+        return self.service.stage_visualization(trans, viz_id)
+
+    @router.delete(
+        "/api/admin/visualizations/staged",
+        summary="Clean all staged visualization assets.",
+        require_admin=True,
+    )
+    def clean_staged(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+    ):
+        """Clean all staged visualization assets from static/plugins."""
+        return self.service.clean_staged_assets(trans)
+
+    @router.get(
+        "/api/admin/visualizations/staging_status",
+        summary="Get staging status information.",
+        require_admin=True,
+    )
+    def staging_status(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+    ):
+        """Get information about currently staged visualizations."""
+        return self.service.get_staging_status(trans)

--- a/lib/galaxy/webapps/galaxy/api/admin_visualizations.py
+++ b/lib/galaxy/webapps/galaxy/api/admin_visualizations.py
@@ -164,7 +164,7 @@ class FastAPIAdminVisualizations:
         self,
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> StagingResultResponse:
-        """Stage all visualization assets from config/plugins to static/plugins for Galaxy to serve."""
+        """Stage all visualization assets into Galaxy's static serving directory."""
         return self.service.stage_all_visualizations(trans)
 
     @router.delete(
@@ -261,5 +261,5 @@ class FastAPIAdminVisualizations:
         viz_id: VisualizationIdPathParam,
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> VisualizationStagingResultResponse:
-        """Stage assets for a specific visualization from config/plugins to static/plugins."""
+        """Stage assets for a specific visualization into Galaxy's static serving directory."""
         return self.service.stage_visualization(trans, viz_id)

--- a/lib/galaxy/webapps/galaxy/api/admin_visualizations.py
+++ b/lib/galaxy/webapps/galaxy/api/admin_visualizations.py
@@ -60,6 +60,8 @@ VisualizationIdPathParam = Annotated[
 class FastAPIAdminVisualizations:
     service: AdminVisualizationsService = depends(AdminVisualizationsService)
 
+    # --- Static-segment routes (must be declared before {viz_id} routes) ---
+
     @router.get(
         "/api/admin/visualizations",
         summary="List all installed visualization packages.",
@@ -93,6 +95,73 @@ class FastAPIAdminVisualizations:
     ) -> AvailableVisualizationListResponse:
         """Return a list of available @galaxyproject visualization packages from npm registry."""
         return self.service.get_available_packages(trans, search=search)
+
+    @router.get(
+        "/api/admin/visualizations/usage_stats",
+        summary="Get usage statistics for visualizations.",
+        require_admin=True,
+    )
+    def usage_stats(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        days: int = Query(
+            default=30,
+            title="Days",
+            description="Number of days to look back for usage statistics",
+        ),
+    ) -> UsageStatsResponse:
+        """Return usage statistics for installed visualizations."""
+        return self.service.get_usage_stats(trans, days=days)
+
+    @router.get(
+        "/api/admin/visualizations/staging_status",
+        summary="Get staging status information.",
+        require_admin=True,
+    )
+    def staging_status(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+    ) -> StagingStatusResponse:
+        """Get information about currently staged visualizations."""
+        return self.service.get_staging_status(trans)
+
+    @router.post(
+        "/api/admin/visualizations/reload",
+        summary="Reload the visualization registry.",
+        require_admin=True,
+    )
+    def reload(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+    ) -> MessageResponse:
+        """Reload the visualization registry to pick up configuration changes."""
+        return self.service.reload_registry(trans)
+
+    @router.post(
+        "/api/admin/visualizations/stage",
+        summary="Stage all visualization assets.",
+        require_admin=True,
+    )
+    def stage_all(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+    ) -> StagingResultResponse:
+        """Stage all visualization assets from config/plugins to static/plugins for Galaxy to serve."""
+        return self.service.stage_all_visualizations(trans)
+
+    @router.delete(
+        "/api/admin/visualizations/staged",
+        summary="Clean all staged visualization assets.",
+        require_admin=True,
+    )
+    def clean_staged(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+    ) -> CleanStagingResultResponse:
+        """Clean all staged visualization assets from static/plugins."""
+        return self.service.clean_staged_assets(trans)
+
+    # --- Dynamic {viz_id} routes ---
 
     @router.get(
         "/api/admin/visualizations/{viz_id}",
@@ -165,47 +234,6 @@ class FastAPIAdminVisualizations:
         return self.service.toggle_package(trans, viz_id, request.enabled)
 
     @router.post(
-        "/api/admin/visualizations/reload",
-        summary="Reload the visualization registry.",
-        require_admin=True,
-    )
-    def reload(
-        self,
-        trans: ProvidesUserContext = DependsOnTrans,
-    ) -> MessageResponse:
-        """Reload the visualization registry to pick up configuration changes."""
-        return self.service.reload_registry(trans)
-
-    @router.get(
-        "/api/admin/visualizations/usage_stats",
-        summary="Get usage statistics for visualizations.",
-        require_admin=True,
-    )
-    def usage_stats(
-        self,
-        trans: ProvidesUserContext = DependsOnTrans,
-        days: int = Query(
-            default=30,
-            title="Days",
-            description="Number of days to look back for usage statistics",
-        ),
-    ) -> UsageStatsResponse:
-        """Return usage statistics for installed visualizations."""
-        return self.service.get_usage_stats(trans, days=days)
-
-    @router.post(
-        "/api/admin/visualizations/stage",
-        summary="Stage all visualization assets.",
-        require_admin=True,
-    )
-    def stage_all(
-        self,
-        trans: ProvidesUserContext = DependsOnTrans,
-    ) -> StagingResultResponse:
-        """Stage all visualization assets from config/plugins to static/plugins for Galaxy to serve."""
-        return self.service.stage_all_visualizations(trans)
-
-    @router.post(
         "/api/admin/visualizations/{viz_id}/stage",
         summary="Stage assets for a specific visualization.",
         require_admin=True,
@@ -217,27 +245,3 @@ class FastAPIAdminVisualizations:
     ) -> VisualizationStagingResultResponse:
         """Stage assets for a specific visualization from config/plugins to static/plugins."""
         return self.service.stage_visualization(trans, viz_id)
-
-    @router.delete(
-        "/api/admin/visualizations/staged",
-        summary="Clean all staged visualization assets.",
-        require_admin=True,
-    )
-    def clean_staged(
-        self,
-        trans: ProvidesUserContext = DependsOnTrans,
-    ) -> CleanStagingResultResponse:
-        """Clean all staged visualization assets from static/plugins."""
-        return self.service.clean_staged_assets(trans)
-
-    @router.get(
-        "/api/admin/visualizations/staging_status",
-        summary="Get staging status information.",
-        require_admin=True,
-    )
-    def staging_status(
-        self,
-        trans: ProvidesUserContext = DependsOnTrans,
-    ) -> StagingStatusResponse:
-        """Get information about currently staged visualizations."""
-        return self.service.get_staging_status(trans)

--- a/lib/galaxy/webapps/galaxy/api/admin_visualizations.py
+++ b/lib/galaxy/webapps/galaxy/api/admin_visualizations.py
@@ -25,6 +25,7 @@ from galaxy.schema.visualization_admin import (
     InstalledVisualizationResponse,
     InstallVisualizationRequest,
     MessageResponse,
+    PackageVersionsResponse,
     StagingResultResponse,
     StagingStatusResponse,
     ToggleVisualizationRequest,
@@ -95,6 +96,23 @@ class FastAPIAdminVisualizations:
     ) -> AvailableVisualizationListResponse:
         """Return a list of available @galaxyproject visualization packages from npm registry."""
         return self.service.get_available_packages(trans, search=search)
+
+    @router.get(
+        "/api/admin/visualizations/versions/{package_name:path}",
+        summary="Get available versions for an npm package.",
+        require_admin=True,
+    )
+    def package_versions(
+        self,
+        package_name: str = Path(
+            ...,
+            title="Package Name",
+            description="The npm package name (e.g., @galaxyproject/circster).",
+        ),
+        trans: ProvidesUserContext = DependsOnTrans,
+    ) -> PackageVersionsResponse:
+        """Return available versions for a specific npm package."""
+        return self.service.get_package_versions(trans, package_name)
 
     @router.get(
         "/api/admin/visualizations/usage_stats",

--- a/lib/galaxy/webapps/galaxy/api/admin_visualizations.py
+++ b/lib/galaxy/webapps/galaxy/api/admin_visualizations.py
@@ -7,24 +7,40 @@ dynamically without requiring client rebuilds.
 
 import logging
 from typing import (
+    Annotated,
     Optional,
 )
 
 from fastapi import (
-    Body,
     Path,
     Query,
     status,
 )
-from typing_extensions import Annotated
 
 from galaxy.managers.context import ProvidesUserContext
+from galaxy.schema.visualization_admin import (
+    AvailableVisualizationListResponse,
+    CleanStagingResultResponse,
+    InstalledVisualizationListResponse,
+    InstalledVisualizationResponse,
+    InstallVisualizationRequest,
+    MessageResponse,
+    StagingResultResponse,
+    StagingStatusResponse,
+    ToggleVisualizationRequest,
+    ToggleVisualizationResponse,
+    UpdateVisualizationRequest,
+    UsageStatsResponse,
+    VisualizationStagingResultResponse,
+)
 from galaxy.webapps.galaxy.api import (
     depends,
     DependsOnTrans,
     Router,
 )
-from galaxy.webapps.galaxy.services.admin_visualizations import AdminVisualizationsService
+from galaxy.webapps.galaxy.services.admin_visualizations import (
+    AdminVisualizationsService,
+)
 
 log = logging.getLogger(__name__)
 
@@ -32,7 +48,11 @@ router = Router(tags=["admin_visualizations"])
 
 VisualizationIdPathParam = Annotated[
     str,
-    Path(..., title="Visualization ID", description="The identifier of the visualization package."),
+    Path(
+        ...,
+        title="Visualization ID",
+        description="The identifier of the visualization package.",
+    ),
 ]
 
 
@@ -53,7 +73,7 @@ class FastAPIAdminVisualizations:
             title="Include disabled",
             description="Whether to include disabled visualizations in the result.",
         ),
-    ):
+    ) -> InstalledVisualizationListResponse:
         """Return a list of all installed visualization packages with their status."""
         return self.service.index(trans, include_disabled=include_disabled)
 
@@ -66,9 +86,11 @@ class FastAPIAdminVisualizations:
         self,
         trans: ProvidesUserContext = DependsOnTrans,
         search: Optional[str] = Query(
-            default=None, title="Search term", description="Filter available packages by name or description."
+            default=None,
+            title="Search term",
+            description="Filter available packages by name or description.",
         ),
-    ):
+    ) -> AvailableVisualizationListResponse:
         """Return a list of available @galaxyproject visualization packages from npm registry."""
         return self.service.get_available_packages(trans, search=search)
 
@@ -81,7 +103,7 @@ class FastAPIAdminVisualizations:
         self,
         viz_id: VisualizationIdPathParam,
         trans: ProvidesUserContext = DependsOnTrans,
-    ):
+    ) -> InstalledVisualizationResponse:
         """Return detailed information about a specific visualization package."""
         return self.service.show(trans, viz_id)
 
@@ -94,12 +116,11 @@ class FastAPIAdminVisualizations:
     def install(
         self,
         viz_id: VisualizationIdPathParam,
+        request: InstallVisualizationRequest,
         trans: ProvidesUserContext = DependsOnTrans,
-        package: str = Body(..., description="The npm package name"),
-        version: str = Body(..., description="The package version to install"),
-    ):
+    ) -> InstalledVisualizationResponse:
         """Install a visualization package from npm registry."""
-        return self.service.install_package(trans, viz_id, package, version)
+        return self.service.install_package(trans, viz_id, request.package, request.version)
 
     @router.put(
         "/api/admin/visualizations/{viz_id}/update",
@@ -109,11 +130,11 @@ class FastAPIAdminVisualizations:
     def update(
         self,
         viz_id: VisualizationIdPathParam,
+        request: UpdateVisualizationRequest,
         trans: ProvidesUserContext = DependsOnTrans,
-        version: str = Body(..., description="The new version to update to"),
-    ):
+    ) -> InstalledVisualizationResponse:
         """Update an installed visualization package to a new version."""
-        return self.service.update_package(trans, viz_id, version)
+        return self.service.update_package(trans, viz_id, request.version)
 
     @router.delete(
         "/api/admin/visualizations/{viz_id}",
@@ -137,11 +158,11 @@ class FastAPIAdminVisualizations:
     def toggle(
         self,
         viz_id: VisualizationIdPathParam,
+        request: ToggleVisualizationRequest,
         trans: ProvidesUserContext = DependsOnTrans,
-        enabled: bool = Body(..., description="Whether to enable or disable the visualization"),
-    ):
+    ) -> ToggleVisualizationResponse:
         """Enable or disable a visualization package without uninstalling it."""
-        return self.service.toggle_package(trans, viz_id, enabled)
+        return self.service.toggle_package(trans, viz_id, request.enabled)
 
     @router.post(
         "/api/admin/visualizations/reload",
@@ -151,7 +172,7 @@ class FastAPIAdminVisualizations:
     def reload(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-    ):
+    ) -> MessageResponse:
         """Reload the visualization registry to pick up configuration changes."""
         return self.service.reload_registry(trans)
 
@@ -163,8 +184,12 @@ class FastAPIAdminVisualizations:
     def usage_stats(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        days: int = Query(default=30, title="Days", description="Number of days to look back for usage statistics"),
-    ):
+        days: int = Query(
+            default=30,
+            title="Days",
+            description="Number of days to look back for usage statistics",
+        ),
+    ) -> UsageStatsResponse:
         """Return usage statistics for installed visualizations."""
         return self.service.get_usage_stats(trans, days=days)
 
@@ -176,7 +201,7 @@ class FastAPIAdminVisualizations:
     def stage_all(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-    ):
+    ) -> StagingResultResponse:
         """Stage all visualization assets from config/plugins to static/plugins for Galaxy to serve."""
         return self.service.stage_all_visualizations(trans)
 
@@ -189,7 +214,7 @@ class FastAPIAdminVisualizations:
         self,
         viz_id: VisualizationIdPathParam,
         trans: ProvidesUserContext = DependsOnTrans,
-    ):
+    ) -> VisualizationStagingResultResponse:
         """Stage assets for a specific visualization from config/plugins to static/plugins."""
         return self.service.stage_visualization(trans, viz_id)
 
@@ -201,7 +226,7 @@ class FastAPIAdminVisualizations:
     def clean_staged(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-    ):
+    ) -> CleanStagingResultResponse:
         """Clean all staged visualization assets from static/plugins."""
         return self.service.clean_staged_assets(trans)
 
@@ -213,6 +238,6 @@ class FastAPIAdminVisualizations:
     def staging_status(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-    ):
+    ) -> StagingStatusResponse:
         """Get information about currently staged visualizations."""
         return self.service.get_staging_status(trans)

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -117,6 +117,7 @@ api_tags_metadata = [
         "name": "chat",
         "description": "**BETA**: Chat interface for AI agents. This API is experimental and may change without notice.",
     },
+    {"name": "admin_visualizations", "description": "Admin operations for managing visualization packages."},
 ]
 
 

--- a/lib/galaxy/webapps/galaxy/services/admin_visualizations.py
+++ b/lib/galaxy/webapps/galaxy/services/admin_visualizations.py
@@ -1,0 +1,298 @@
+"""
+Service layer for admin visualization package management.
+
+Provides business logic for managing visualization packages through the admin interface.
+"""
+
+import logging
+from typing import (
+    Dict,
+    List,
+    Optional,
+)
+
+from galaxy import exceptions
+from galaxy.managers.context import ProvidesUserContext
+from galaxy.managers.visualization_admin import VisualizationPackageManager
+from galaxy.security.idencoding import IdEncodingHelper
+from galaxy.structured_app import StructuredApp
+from galaxy.webapps.galaxy.services.base import ServiceBase
+
+log = logging.getLogger(__name__)
+
+
+class AdminVisualizationsService(ServiceBase):
+    """Service for managing visualization packages through admin interface."""
+
+    def __init__(
+        self,
+        security: IdEncodingHelper,
+        app: StructuredApp,
+        package_manager: VisualizationPackageManager,
+    ):
+        super().__init__(security)
+        self.app = app
+        self.package_manager = package_manager
+
+    def index(self, trans: ProvidesUserContext, include_disabled: bool = True) -> List[Dict]:
+        """Return list of installed visualization packages."""
+        try:
+            config = self.package_manager.load_config()
+            results = []
+
+            for viz_id, info in config.items():
+                is_installed = self.package_manager.is_package_installed(viz_id)
+
+                # Parse config entry
+                if isinstance(info, dict):
+                    package = info.get("package", "")
+                    version = info.get("version", "unknown")
+                    enabled = info.get("enabled", True)
+                else:
+                    package = str(info)
+                    version = "unknown"
+                    enabled = True
+
+                if not include_disabled and not enabled:
+                    continue
+
+                package_info = {
+                    "id": viz_id,
+                    "package": package,
+                    "version": version,
+                    "enabled": enabled,
+                    "installed": is_installed,
+                }
+
+                # Add metadata if installed
+                if is_installed:
+                    package_path = self.package_manager.get_package_path(viz_id)
+                    package_info.update(
+                        {
+                            "path": package_path,
+                            "size": self.package_manager.get_directory_size(package_path),
+                            "metadata": self.package_manager.get_package_metadata(viz_id),
+                        }
+                    )
+
+                results.append(package_info)
+
+            return results
+
+        except Exception as e:
+            log.error(f"Failed to load visualization packages: {e}")
+            raise exceptions.InternalServerError(f"Failed to load visualization packages: {e}")
+
+    def get_available_packages(self, trans: ProvidesUserContext, search: Optional[str] = None) -> List[Dict]:
+        """Get available @galaxyproject visualization packages from npm registry."""
+        return self.package_manager.query_npm_registry(search)
+
+    def show(self, trans: ProvidesUserContext, viz_id: str) -> Dict:
+        """Get detailed information about a specific visualization package."""
+        package_info = self.package_manager.get_package_info(viz_id)
+
+        if not package_info:
+            raise exceptions.ObjectNotFound(f"Visualization package '{viz_id}' not found")
+
+        # Build response
+        result = {
+            "id": viz_id,
+            "package": package_info.get("package", "") if isinstance(package_info, dict) else str(package_info),
+            "version": package_info.get("version", "unknown") if isinstance(package_info, dict) else "unknown",
+            "enabled": package_info.get("enabled", True) if isinstance(package_info, dict) else True,
+            "installed": self.package_manager.is_package_installed(viz_id),
+        }
+
+        # Add metadata if installed
+        if result["installed"]:
+            package_path = self.package_manager.get_package_path(viz_id)
+            result.update(
+                {
+                    "path": package_path,
+                    "size": self.package_manager.get_directory_size(package_path),
+                    "metadata": self.package_manager.get_package_metadata(viz_id),
+                }
+            )
+
+        return result
+
+    def install_package(self, trans: ProvidesUserContext, viz_id: str, package: str, version: str) -> Dict:
+        """Install a visualization package from npm registry."""
+        # Check if package already exists
+        if self.package_manager.is_package_installed(viz_id):
+            raise exceptions.Conflict(f"Package '{viz_id}' is already installed")
+
+        # Install package
+        target_dir = self.package_manager.get_package_path(viz_id)
+        install_result = self.package_manager.install_npm_package(package, version, target_dir)
+
+        # Update configuration
+        self.package_manager.add_package_to_config(viz_id, package, version, enabled=True)
+
+        log.info(f"Successfully installed visualization package {viz_id} ({package}@{version})")
+
+        return {
+            "id": viz_id,
+            "package": package,
+            "version": version,
+            "enabled": True,
+            "installed": True,
+            "size": install_result.get("size", 0),
+            "message": "Package installed successfully",
+        }
+
+    def update_package(self, trans: ProvidesUserContext, viz_id: str, version: str) -> Dict:
+        """Update an existing visualization package to a new version."""
+        # Get current package info
+        current_info = self.show(trans, viz_id)
+        package = current_info["package"]
+
+        # Clean up old files
+        self.package_manager.cleanup_package_files(viz_id)
+
+        # Install new version
+        target_dir = self.package_manager.get_package_path(viz_id)
+        install_result = self.package_manager.install_npm_package(package, version, target_dir)
+
+        # Update configuration
+        self.package_manager.add_package_to_config(viz_id, package, version, enabled=current_info["enabled"])
+
+        log.info(f"Successfully updated visualization package {viz_id} to version {version}")
+
+        return {
+            "id": viz_id,
+            "package": package,
+            "version": version,
+            "enabled": current_info["enabled"],
+            "installed": True,
+            "size": install_result.get("size", 0),
+            "message": "Package updated successfully",
+        }
+
+    def uninstall_package(self, trans: ProvidesUserContext, viz_id: str) -> None:
+        """Uninstall a visualization package and clean up its assets."""
+        # Verify package exists
+        if not self.package_manager.get_package_info(viz_id):
+            raise exceptions.ObjectNotFound(f"Package '{viz_id}' not found")
+
+        # Remove from configuration
+        self.package_manager.remove_package_from_config(viz_id)
+
+        # Clean up files
+        self.package_manager.cleanup_package_files(viz_id)
+
+        log.info(f"Successfully uninstalled visualization package {viz_id}")
+
+    def toggle_package(self, trans: ProvidesUserContext, viz_id: str, enabled: bool) -> Dict:
+        """Enable or disable a visualization package."""
+        # Update enabled status
+        self.package_manager.toggle_package_enabled(viz_id, enabled)
+
+        log.info(f"Successfully {'enabled' if enabled else 'disabled'} visualization package {viz_id}")
+
+        return {
+            "id": viz_id,
+            "enabled": enabled,
+            "message": f"Package {'enabled' if enabled else 'disabled'} successfully",
+        }
+
+    def reload_registry(self, trans: ProvidesUserContext) -> Dict:
+        """Reload the visualization registry to pick up configuration changes."""
+        try:
+            # Trigger reload of visualization plugins
+            if hasattr(self.app, "visualizations_registry"):
+                self.app.visualizations_registry.reload()
+
+            return {"message": "Visualization registry reloaded successfully"}
+
+        except Exception as e:
+            log.error(f"Failed to reload visualization registry: {e}")
+            raise exceptions.InternalServerError(f"Failed to reload registry: {e}")
+
+    def get_usage_stats(self, trans: ProvidesUserContext, days: int = 30) -> Dict:
+        """Get usage statistics for visualizations."""
+        # TODO: Implement actual usage tracking
+        # For now, return placeholder data
+        return {"message": "Usage statistics not yet implemented", "days": days, "stats": {}}
+
+    def stage_all_visualizations(self, trans: ProvidesUserContext) -> Dict:
+        """
+        Stage all visualization assets from config/plugins to static/plugins.
+        This makes visualizations available to Galaxy for serving.
+        """
+        try:
+            result = self.package_manager.stage_all_visualizations()
+
+            log.info(f"Staged {result['staged_count']} visualizations")
+
+            return {
+                "message": f"Successfully staged {result['staged_count']} visualizations",
+                "staged_count": result["staged_count"],
+                "staged_visualizations": result["staged_visualizations"],
+                "errors": result.get("errors", []),
+            }
+
+        except Exception as e:
+            log.error(f"Failed to stage all visualizations: {e}")
+            raise exceptions.InternalServerError(f"Failed to stage visualizations: {e}")
+
+    def stage_visualization(self, trans: ProvidesUserContext, viz_id: str) -> Dict:
+        """
+        Stage assets for a specific visualization from config/plugins to static/plugins.
+        """
+        try:
+            result = self.package_manager.stage_visualization(viz_id)
+
+            log.info(f"Staged visualization {viz_id}")
+
+            return {
+                "message": f"Successfully staged visualization '{viz_id}'",
+                "visualization_id": result["visualization_id"],
+                "source_path": result["source_path"],
+                "target_path": result["target_path"],
+                "size": result["size"],
+            }
+
+        except Exception as e:
+            log.error(f"Failed to stage visualization {viz_id}: {e}")
+            if "not found" in str(e).lower():
+                raise exceptions.ObjectNotFound(f"Visualization '{viz_id}' not found for staging")
+            raise exceptions.InternalServerError(f"Failed to stage visualization: {e}")
+
+    def clean_staged_assets(self, trans: ProvidesUserContext) -> Dict:
+        """
+        Clean all staged visualization assets from static/plugins.
+        This removes all visualizations from Galaxy's serving directory.
+        """
+        try:
+            result = self.package_manager.clean_staged_assets()
+
+            log.info(f"Cleaned {result['cleaned_count']} staged assets")
+
+            return {
+                "message": f"Successfully cleaned {result['cleaned_count']} staged assets",
+                "cleaned_count": result["cleaned_count"],
+                "cleaned_items": result.get("cleaned_items", []),
+            }
+
+        except Exception as e:
+            log.error(f"Failed to clean staged assets: {e}")
+            raise exceptions.InternalServerError(f"Failed to clean staged assets: {e}")
+
+    def get_staging_status(self, trans: ProvidesUserContext) -> Dict:
+        """
+        Get information about currently staged visualizations.
+        """
+        try:
+            result = self.package_manager.get_staging_status()
+
+            return {
+                "message": "Retrieved staging status successfully",
+                "staged_count": result["staged_count"],
+                "staged_visualizations": result["staged_visualizations"],
+                "total_size": result["total_size"],
+            }
+
+        except Exception as e:
+            log.error(f"Failed to get staging status: {e}")
+            raise exceptions.InternalServerError(f"Failed to get staging status: {e}")

--- a/lib/galaxy/webapps/galaxy/services/admin_visualizations.py
+++ b/lib/galaxy/webapps/galaxy/services/admin_visualizations.py
@@ -52,15 +52,9 @@ class AdminVisualizationsService(ServiceBase):
 
             for viz_id, info in config.items():
                 is_installed = self.package_manager.is_package_installed(viz_id)
-
-                if isinstance(info, dict):
-                    package = info.get("package", "")
-                    version = info.get("version", "unknown")
-                    enabled = info.get("enabled", True)
-                else:
-                    package = str(info)
-                    version = "unknown"
-                    enabled = True
+                package = info.get("package", "")
+                version = info.get("version", "unknown")
+                enabled = info.get("enabled", True)
 
                 if not include_disabled and not enabled:
                     continue
@@ -101,21 +95,12 @@ class AdminVisualizationsService(ServiceBase):
         if not package_info:
             raise exceptions.ObjectNotFound(f"Visualization package '{viz_id}' not found")
 
-        if isinstance(package_info, dict):
-            package = package_info.get("package", "")
-            version = package_info.get("version", "unknown")
-            enabled = package_info.get("enabled", True)
-        else:
-            package = str(package_info)
-            version = "unknown"
-            enabled = True
-
         is_installed = self.package_manager.is_package_installed(viz_id)
         result = InstalledVisualizationResponse(
             id=viz_id,
-            package=package,
-            version=version,
-            enabled=enabled,
+            package=package_info.get("package", ""),
+            version=package_info.get("version", "unknown"),
+            enabled=package_info.get("enabled", True),
             installed=is_installed,
         )
 

--- a/lib/galaxy/webapps/galaxy/services/admin_visualizations.py
+++ b/lib/galaxy/webapps/galaxy/services/admin_visualizations.py
@@ -1,14 +1,11 @@
-"""
-Service layer for admin visualization package management.
+"""Service layer for admin visualization package management."""
 
-Provides business logic for managing visualization packages through the admin interface.
-"""
+from __future__ import annotations
 
 import logging
 import os
 import shutil
 import tempfile
-from typing import Optional
 
 from galaxy import exceptions
 from galaxy.managers.context import ProvidesUserContext
@@ -91,7 +88,7 @@ class AdminVisualizationsService(ServiceBase):
             raise exceptions.InternalServerError(f"Failed to load visualization packages: {e}")
 
     def get_available_packages(
-        self, trans: ProvidesUserContext, search: Optional[str] = None
+        self, trans: ProvidesUserContext, search: str | None = None
     ) -> AvailableVisualizationListResponse:
         """Get available @galaxyproject visualization packages from npm registry."""
         raw = self.package_manager.query_npm_registry(search)

--- a/lib/galaxy/webapps/galaxy/services/admin_visualizations.py
+++ b/lib/galaxy/webapps/galaxy/services/admin_visualizations.py
@@ -5,15 +5,28 @@ Provides business logic for managing visualization packages through the admin in
 """
 
 import logging
-from typing import (
-    Dict,
-    List,
-    Optional,
-)
+import os
+import shutil
+import tempfile
+from typing import Optional
 
 from galaxy import exceptions
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.visualization_admin import VisualizationPackageManager
+from galaxy.schema.visualization_admin import (
+    AvailableVisualizationListResponse,
+    AvailableVisualizationResponse,
+    CleanStagingResultResponse,
+    InstalledVisualizationListResponse,
+    InstalledVisualizationResponse,
+    MessageResponse,
+    StagedVisualizationInfo,
+    StagingResultResponse,
+    StagingStatusResponse,
+    ToggleVisualizationResponse,
+    UsageStatsResponse,
+    VisualizationStagingResultResponse,
+)
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.structured_app import StructuredApp
 from galaxy.webapps.galaxy.services.base import ServiceBase
@@ -34,7 +47,7 @@ class AdminVisualizationsService(ServiceBase):
         self.app = app
         self.package_manager = package_manager
 
-    def index(self, trans: ProvidesUserContext, include_disabled: bool = True) -> List[Dict]:
+    def index(self, trans: ProvidesUserContext, include_disabled: bool = True) -> InstalledVisualizationListResponse:
         """Return list of installed visualization packages."""
         try:
             config = self.package_manager.load_config()
@@ -43,7 +56,6 @@ class AdminVisualizationsService(ServiceBase):
             for viz_id, info in config.items():
                 is_installed = self.package_manager.is_package_installed(viz_id)
 
-                # Parse config entry
                 if isinstance(info, dict):
                     package = info.get("package", "")
                     version = info.get("version", "unknown")
@@ -56,202 +68,210 @@ class AdminVisualizationsService(ServiceBase):
                 if not include_disabled and not enabled:
                     continue
 
-                package_info = {
-                    "id": viz_id,
-                    "package": package,
-                    "version": version,
-                    "enabled": enabled,
-                    "installed": is_installed,
-                }
+                item = InstalledVisualizationResponse(
+                    id=viz_id,
+                    package=package,
+                    version=version,
+                    enabled=enabled,
+                    installed=is_installed,
+                )
 
-                # Add metadata if installed
                 if is_installed:
                     package_path = self.package_manager.get_package_path(viz_id)
-                    package_info.update(
-                        {
-                            "path": package_path,
-                            "size": self.package_manager.get_directory_size(package_path),
-                            "metadata": self.package_manager.get_package_metadata(viz_id),
-                        }
-                    )
+                    item.path = package_path
+                    item.size = self.package_manager.get_directory_size(package_path)
+                    item.metadata = self.package_manager.get_package_metadata(viz_id)
 
-                results.append(package_info)
+                results.append(item)
 
-            return results
+            return InstalledVisualizationListResponse(root=results)
 
         except Exception as e:
             log.error(f"Failed to load visualization packages: {e}")
             raise exceptions.InternalServerError(f"Failed to load visualization packages: {e}")
 
-    def get_available_packages(self, trans: ProvidesUserContext, search: Optional[str] = None) -> List[Dict]:
+    def get_available_packages(
+        self, trans: ProvidesUserContext, search: Optional[str] = None
+    ) -> AvailableVisualizationListResponse:
         """Get available @galaxyproject visualization packages from npm registry."""
-        return self.package_manager.query_npm_registry(search)
+        raw = self.package_manager.query_npm_registry(search)
+        return AvailableVisualizationListResponse(root=[AvailableVisualizationResponse(**pkg) for pkg in raw])
 
-    def show(self, trans: ProvidesUserContext, viz_id: str) -> Dict:
+    def show(self, trans: ProvidesUserContext, viz_id: str) -> InstalledVisualizationResponse:
         """Get detailed information about a specific visualization package."""
         package_info = self.package_manager.get_package_info(viz_id)
 
         if not package_info:
             raise exceptions.ObjectNotFound(f"Visualization package '{viz_id}' not found")
 
-        # Build response
-        result = {
-            "id": viz_id,
-            "package": package_info.get("package", "") if isinstance(package_info, dict) else str(package_info),
-            "version": package_info.get("version", "unknown") if isinstance(package_info, dict) else "unknown",
-            "enabled": package_info.get("enabled", True) if isinstance(package_info, dict) else True,
-            "installed": self.package_manager.is_package_installed(viz_id),
-        }
+        if isinstance(package_info, dict):
+            package = package_info.get("package", "")
+            version = package_info.get("version", "unknown")
+            enabled = package_info.get("enabled", True)
+        else:
+            package = str(package_info)
+            version = "unknown"
+            enabled = True
 
-        # Add metadata if installed
-        if result["installed"]:
+        is_installed = self.package_manager.is_package_installed(viz_id)
+        result = InstalledVisualizationResponse(
+            id=viz_id,
+            package=package,
+            version=version,
+            enabled=enabled,
+            installed=is_installed,
+        )
+
+        if is_installed:
             package_path = self.package_manager.get_package_path(viz_id)
-            result.update(
-                {
-                    "path": package_path,
-                    "size": self.package_manager.get_directory_size(package_path),
-                    "metadata": self.package_manager.get_package_metadata(viz_id),
-                }
-            )
+            result.path = package_path
+            result.size = self.package_manager.get_directory_size(package_path)
+            result.metadata = self.package_manager.get_package_metadata(viz_id)
 
         return result
 
-    def install_package(self, trans: ProvidesUserContext, viz_id: str, package: str, version: str) -> Dict:
+    def install_package(
+        self, trans: ProvidesUserContext, viz_id: str, package: str, version: str
+    ) -> InstalledVisualizationResponse:
         """Install a visualization package from npm registry."""
-        # Check if package already exists
         if self.package_manager.is_package_installed(viz_id):
             raise exceptions.Conflict(f"Package '{viz_id}' is already installed")
 
-        # Install package
         target_dir = self.package_manager.get_package_path(viz_id)
         install_result = self.package_manager.install_npm_package(package, version, target_dir)
 
-        # Update configuration
         self.package_manager.add_package_to_config(viz_id, package, version, enabled=True)
 
         log.info(f"Successfully installed visualization package {viz_id} ({package}@{version})")
 
-        return {
-            "id": viz_id,
-            "package": package,
-            "version": version,
-            "enabled": True,
-            "installed": True,
-            "size": install_result.get("size", 0),
-            "message": "Package installed successfully",
-        }
+        return InstalledVisualizationResponse(
+            id=viz_id,
+            package=package,
+            version=version,
+            enabled=True,
+            installed=True,
+            size=install_result.get("size", 0),
+            message="Package installed successfully",
+        )
 
-    def update_package(self, trans: ProvidesUserContext, viz_id: str, version: str) -> Dict:
-        """Update an existing visualization package to a new version."""
-        # Get current package info
+    def update_package(self, trans: ProvidesUserContext, viz_id: str, version: str) -> InstalledVisualizationResponse:
+        """Update an existing visualization package to a new version.
+
+        Uses a safe update pattern: installs the new version to a temporary
+        location first, then swaps it in on success. If the new install fails,
+        the old version is preserved.
+        """
         current_info = self.show(trans, viz_id)
-        package = current_info["package"]
-
-        # Clean up old files
-        self.package_manager.cleanup_package_files(viz_id)
-
-        # Install new version
+        package = current_info.package
         target_dir = self.package_manager.get_package_path(viz_id)
-        install_result = self.package_manager.install_npm_package(package, version, target_dir)
 
-        # Update configuration
-        self.package_manager.add_package_to_config(viz_id, package, version, enabled=current_info["enabled"])
+        with tempfile.TemporaryDirectory() as staging_dir:
+            new_pkg_dir = os.path.join(staging_dir, viz_id)
+            try:
+                install_result = self.package_manager.install_npm_package(package, version, new_pkg_dir)
+            except Exception:
+                log.warning(f"Failed to install {package}@{version}, keeping existing version")
+                raise
+
+            backup_dir = os.path.join(staging_dir, f"{viz_id}_backup")
+            if os.path.exists(target_dir):
+                shutil.move(target_dir, backup_dir)
+
+            try:
+                shutil.move(new_pkg_dir, target_dir)
+            except Exception:
+                if os.path.exists(backup_dir):
+                    shutil.move(backup_dir, target_dir)
+                raise
+
+        self.package_manager.add_package_to_config(viz_id, package, version, enabled=current_info.enabled)
 
         log.info(f"Successfully updated visualization package {viz_id} to version {version}")
 
-        return {
-            "id": viz_id,
-            "package": package,
-            "version": version,
-            "enabled": current_info["enabled"],
-            "installed": True,
-            "size": install_result.get("size", 0),
-            "message": "Package updated successfully",
-        }
+        return InstalledVisualizationResponse(
+            id=viz_id,
+            package=package,
+            version=version,
+            enabled=current_info.enabled,
+            installed=True,
+            size=install_result.get("size", 0),
+            message="Package updated successfully",
+        )
 
     def uninstall_package(self, trans: ProvidesUserContext, viz_id: str) -> None:
         """Uninstall a visualization package and clean up its assets."""
-        # Verify package exists
         if not self.package_manager.get_package_info(viz_id):
             raise exceptions.ObjectNotFound(f"Package '{viz_id}' not found")
 
-        # Remove from configuration
         self.package_manager.remove_package_from_config(viz_id)
-
-        # Clean up files
         self.package_manager.cleanup_package_files(viz_id)
 
         log.info(f"Successfully uninstalled visualization package {viz_id}")
 
-    def toggle_package(self, trans: ProvidesUserContext, viz_id: str, enabled: bool) -> Dict:
+    def toggle_package(self, trans: ProvidesUserContext, viz_id: str, enabled: bool) -> ToggleVisualizationResponse:
         """Enable or disable a visualization package."""
-        # Update enabled status
         self.package_manager.toggle_package_enabled(viz_id, enabled)
 
         log.info(f"Successfully {'enabled' if enabled else 'disabled'} visualization package {viz_id}")
 
-        return {
-            "id": viz_id,
-            "enabled": enabled,
-            "message": f"Package {'enabled' if enabled else 'disabled'} successfully",
-        }
+        return ToggleVisualizationResponse(
+            id=viz_id,
+            enabled=enabled,
+            message=f"Package {'enabled' if enabled else 'disabled'} successfully",
+        )
 
-    def reload_registry(self, trans: ProvidesUserContext) -> Dict:
+    def reload_registry(self, trans: ProvidesUserContext) -> MessageResponse:
         """Reload the visualization registry to pick up configuration changes."""
         try:
-            # Trigger reload of visualization plugins
             if hasattr(self.app, "visualizations_registry"):
                 self.app.visualizations_registry.reload()
 
-            return {"message": "Visualization registry reloaded successfully"}
+            return MessageResponse(message="Visualization registry reloaded successfully")
 
         except Exception as e:
             log.error(f"Failed to reload visualization registry: {e}")
             raise exceptions.InternalServerError(f"Failed to reload registry: {e}")
 
-    def get_usage_stats(self, trans: ProvidesUserContext, days: int = 30) -> Dict:
+    def get_usage_stats(self, trans: ProvidesUserContext, days: int = 30) -> UsageStatsResponse:
         """Get usage statistics for visualizations."""
-        # TODO: Implement actual usage tracking
-        # For now, return placeholder data
-        return {"message": "Usage statistics not yet implemented", "days": days, "stats": {}}
+        return UsageStatsResponse(
+            message="Usage statistics not yet implemented",
+            days=days,
+            stats={},
+        )
 
-    def stage_all_visualizations(self, trans: ProvidesUserContext) -> Dict:
-        """
-        Stage all visualization assets from config/plugins to static/plugins.
-        This makes visualizations available to Galaxy for serving.
-        """
+    def stage_all_visualizations(self, trans: ProvidesUserContext) -> StagingResultResponse:
+        """Stage all visualization assets from config/plugins to static/plugins."""
         try:
             result = self.package_manager.stage_all_visualizations()
 
             log.info(f"Staged {result['staged_count']} visualizations")
 
-            return {
-                "message": f"Successfully staged {result['staged_count']} visualizations",
-                "staged_count": result["staged_count"],
-                "staged_visualizations": result["staged_visualizations"],
-                "errors": result.get("errors", []),
-            }
+            return StagingResultResponse(
+                message=f"Successfully staged {result['staged_count']} visualizations",
+                staged_count=result["staged_count"],
+                staged_visualizations=result["staged_visualizations"],
+                errors=result.get("errors", []),
+            )
 
         except Exception as e:
             log.error(f"Failed to stage all visualizations: {e}")
             raise exceptions.InternalServerError(f"Failed to stage visualizations: {e}")
 
-    def stage_visualization(self, trans: ProvidesUserContext, viz_id: str) -> Dict:
-        """
-        Stage assets for a specific visualization from config/plugins to static/plugins.
-        """
+    def stage_visualization(self, trans: ProvidesUserContext, viz_id: str) -> VisualizationStagingResultResponse:
+        """Stage assets for a specific visualization from config/plugins to static/plugins."""
         try:
             result = self.package_manager.stage_visualization(viz_id)
 
             log.info(f"Staged visualization {viz_id}")
 
-            return {
-                "message": f"Successfully staged visualization '{viz_id}'",
-                "visualization_id": result["visualization_id"],
-                "source_path": result["source_path"],
-                "target_path": result["target_path"],
-                "size": result["size"],
-            }
+            return VisualizationStagingResultResponse(
+                message=f"Successfully staged visualization '{viz_id}'",
+                visualization_id=result["visualization_id"],
+                source_path=result["source_path"],
+                target_path=result["target_path"],
+                size=result["size"],
+            )
 
         except Exception as e:
             log.error(f"Failed to stage visualization {viz_id}: {e}")
@@ -259,39 +279,34 @@ class AdminVisualizationsService(ServiceBase):
                 raise exceptions.ObjectNotFound(f"Visualization '{viz_id}' not found for staging")
             raise exceptions.InternalServerError(f"Failed to stage visualization: {e}")
 
-    def clean_staged_assets(self, trans: ProvidesUserContext) -> Dict:
-        """
-        Clean all staged visualization assets from static/plugins.
-        This removes all visualizations from Galaxy's serving directory.
-        """
+    def clean_staged_assets(self, trans: ProvidesUserContext) -> CleanStagingResultResponse:
+        """Clean all staged visualization assets from static/plugins."""
         try:
             result = self.package_manager.clean_staged_assets()
 
             log.info(f"Cleaned {result['cleaned_count']} staged assets")
 
-            return {
-                "message": f"Successfully cleaned {result['cleaned_count']} staged assets",
-                "cleaned_count": result["cleaned_count"],
-                "cleaned_items": result.get("cleaned_items", []),
-            }
+            return CleanStagingResultResponse(
+                message=f"Successfully cleaned {result['cleaned_count']} staged assets",
+                cleaned_count=result["cleaned_count"],
+                cleaned_items=result.get("cleaned_items", []),
+            )
 
         except Exception as e:
             log.error(f"Failed to clean staged assets: {e}")
             raise exceptions.InternalServerError(f"Failed to clean staged assets: {e}")
 
-    def get_staging_status(self, trans: ProvidesUserContext) -> Dict:
-        """
-        Get information about currently staged visualizations.
-        """
+    def get_staging_status(self, trans: ProvidesUserContext) -> StagingStatusResponse:
+        """Get information about currently staged visualizations."""
         try:
             result = self.package_manager.get_staging_status()
 
-            return {
-                "message": "Retrieved staging status successfully",
-                "staged_count": result["staged_count"],
-                "staged_visualizations": result["staged_visualizations"],
-                "total_size": result["total_size"],
-            }
+            return StagingStatusResponse(
+                message="Retrieved staging status successfully",
+                staged_count=result["staged_count"],
+                staged_visualizations=[StagedVisualizationInfo(**viz) for viz in result["staged_visualizations"]],
+                total_size=result["total_size"],
+            )
 
         except Exception as e:
             log.error(f"Failed to get staging status: {e}")

--- a/lib/galaxy/webapps/galaxy/services/admin_visualizations.py
+++ b/lib/galaxy/webapps/galaxy/services/admin_visualizations.py
@@ -95,7 +95,7 @@ class AdminVisualizationsService(ServiceBase):
         return AvailableVisualizationListResponse(root=[AvailableVisualizationResponse(**pkg) for pkg in raw])
 
     def show(self, trans: ProvidesUserContext, viz_id: str) -> InstalledVisualizationResponse:
-        """Get detailed information about a specific visualization package."""
+        self.package_manager.validate_viz_id(viz_id)
         package_info = self.package_manager.get_package_info(viz_id)
 
         if not package_info:
@@ -130,8 +130,8 @@ class AdminVisualizationsService(ServiceBase):
     def install_package(
         self, trans: ProvidesUserContext, viz_id: str, package: str, version: str
     ) -> InstalledVisualizationResponse:
-        """Install a visualization package from npm registry."""
-        if self.package_manager.is_package_installed(viz_id):
+        self.package_manager.validate_viz_id(viz_id)
+        if self.package_manager.get_package_info(viz_id) or self.package_manager.is_package_installed(viz_id):
             raise exceptions.Conflict(f"Package '{viz_id}' is already installed")
 
         target_dir = self.package_manager.get_package_path(viz_id)
@@ -152,12 +152,8 @@ class AdminVisualizationsService(ServiceBase):
         )
 
     def update_package(self, trans: ProvidesUserContext, viz_id: str, version: str) -> InstalledVisualizationResponse:
-        """Update an existing visualization package to a new version.
-
-        Uses a safe update pattern: installs the new version to a temporary
-        location first, then swaps it in on success. If the new install fails,
-        the old version is preserved.
-        """
+        """Safe update: install new version to temp, swap on success, keep old on failure."""
+        self.package_manager.validate_viz_id(viz_id)
         current_info = self.show(trans, viz_id)
         package = current_info.package
         target_dir = self.package_manager.get_package_path(viz_id)
@@ -196,7 +192,7 @@ class AdminVisualizationsService(ServiceBase):
         )
 
     def uninstall_package(self, trans: ProvidesUserContext, viz_id: str) -> None:
-        """Uninstall a visualization package and clean up its assets."""
+        self.package_manager.validate_viz_id(viz_id)
         if not self.package_manager.get_package_info(viz_id):
             raise exceptions.ObjectNotFound(f"Package '{viz_id}' not found")
 
@@ -206,7 +202,7 @@ class AdminVisualizationsService(ServiceBase):
         log.info(f"Successfully uninstalled visualization package {viz_id}")
 
     def toggle_package(self, trans: ProvidesUserContext, viz_id: str, enabled: bool) -> ToggleVisualizationResponse:
-        """Enable or disable a visualization package."""
+        self.package_manager.validate_viz_id(viz_id)
         self.package_manager.toggle_package_enabled(viz_id, enabled)
 
         log.info(f"Successfully {'enabled' if enabled else 'disabled'} visualization package {viz_id}")
@@ -256,7 +252,7 @@ class AdminVisualizationsService(ServiceBase):
             raise exceptions.InternalServerError(f"Failed to stage visualizations: {e}")
 
     def stage_visualization(self, trans: ProvidesUserContext, viz_id: str) -> VisualizationStagingResultResponse:
-        """Stage assets for a specific visualization from config/plugins to static/plugins."""
+        self.package_manager.validate_viz_id(viz_id)
         try:
             result = self.package_manager.stage_visualization(viz_id)
 
@@ -270,10 +266,10 @@ class AdminVisualizationsService(ServiceBase):
                 size=result["size"],
             )
 
+        except exceptions.ObjectNotFound:
+            raise
         except Exception as e:
             log.error(f"Failed to stage visualization {viz_id}: {e}")
-            if "not found" in str(e).lower():
-                raise exceptions.ObjectNotFound(f"Visualization '{viz_id}' not found for staging")
             raise exceptions.InternalServerError(f"Failed to stage visualization: {e}")
 
     def clean_staged_assets(self, trans: ProvidesUserContext) -> CleanStagingResultResponse:

--- a/lib/galaxy/webapps/galaxy/services/admin_visualizations.py
+++ b/lib/galaxy/webapps/galaxy/services/admin_visualizations.py
@@ -224,7 +224,7 @@ class AdminVisualizationsService(ServiceBase):
         )
 
     def stage_all_visualizations(self, trans: ProvidesUserContext) -> StagingResultResponse:
-        """Stage all visualization assets from config/plugins to static/plugins."""
+        """Stage all visualization assets from managed and legacy sources to static/plugins."""
         try:
             result = self.package_manager.stage_all_visualizations()
 

--- a/lib/galaxy/webapps/galaxy/services/admin_visualizations.py
+++ b/lib/galaxy/webapps/galaxy/services/admin_visualizations.py
@@ -17,6 +17,7 @@ from galaxy.schema.visualization_admin import (
     InstalledVisualizationListResponse,
     InstalledVisualizationResponse,
     MessageResponse,
+    PackageVersionsResponse,
     StagedVisualizationInfo,
     StagingResultResponse,
     StagingStatusResponse,
@@ -87,6 +88,10 @@ class AdminVisualizationsService(ServiceBase):
         """Get available @galaxyproject visualization packages from npm registry."""
         raw = self.package_manager.query_npm_registry(search)
         return AvailableVisualizationListResponse(root=[AvailableVisualizationResponse(**pkg) for pkg in raw])
+
+    def get_package_versions(self, trans: ProvidesUserContext, package_name: str) -> PackageVersionsResponse:
+        versions = self.package_manager.get_package_versions(package_name)
+        return PackageVersionsResponse(package=package_name, versions=versions)
 
     def show(self, trans: ProvidesUserContext, viz_id: str) -> InstalledVisualizationResponse:
         self.package_manager.validate_viz_id(viz_id)

--- a/lib/galaxy/webapps/galaxy/services/admin_visualizations.py
+++ b/lib/galaxy/webapps/galaxy/services/admin_visualizations.py
@@ -27,6 +27,7 @@ from galaxy.schema.visualization_admin import (
 )
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.structured_app import StructuredApp
+from galaxy.visualization.plugins.registry import VisualizationsRegistry
 from galaxy.webapps.galaxy.services.base import ServiceBase
 
 log = logging.getLogger(__name__)
@@ -207,7 +208,10 @@ class AdminVisualizationsService(ServiceBase):
         """Reload the visualization registry to pick up configuration changes."""
         try:
             if hasattr(self.app, "visualizations_registry"):
-                self.app.visualizations_registry.reload()
+                self.app.visualizations_registry = VisualizationsRegistry(
+                    self.app,
+                    directories_setting=self.app.config.visualization_plugins_directory,
+                )
 
             return MessageResponse(message="Visualization registry reloaded successfully")
 

--- a/lib/galaxy_test/api/test_admin_visualizations.py
+++ b/lib/galaxy_test/api/test_admin_visualizations.py
@@ -1,0 +1,115 @@
+"""API tests for admin visualization management endpoints."""
+
+from galaxy_test.base.api_asserts import (
+    assert_has_keys,
+    assert_status_code_is,
+)
+from galaxy_test.base.decorators import requires_admin
+from ._framework import ApiTestCase
+
+
+class TestAdminVisualizationsApi(ApiTestCase):
+    @requires_admin
+    def test_index(self):
+        response = self._get("admin/visualizations", admin=True)
+        assert_status_code_is(response, 200)
+        data = response.json()
+        assert isinstance(data, list)
+
+    @requires_admin
+    def test_index_non_admin_rejected(self):
+        response = self._get("admin/visualizations")
+        assert_status_code_is(response, 403)
+
+    @requires_admin
+    def test_available(self):
+        response = self._get("admin/visualizations/available", admin=True)
+        assert_status_code_is(response, 200)
+        data = response.json()
+        assert isinstance(data, list)
+
+    @requires_admin
+    def test_available_non_admin_rejected(self):
+        response = self._get("admin/visualizations/available")
+        assert_status_code_is(response, 403)
+
+    @requires_admin
+    def test_show_nonexistent(self):
+        response = self._get("admin/visualizations/nonexistent_viz_id_12345", admin=True)
+        assert_status_code_is(response, 404)
+
+    @requires_admin
+    def test_uninstall_nonexistent(self):
+        response = self._delete("admin/visualizations/nonexistent_viz_id_12345", admin=True)
+        assert_status_code_is(response, 404)
+
+    @requires_admin
+    def test_toggle_nonexistent(self):
+        response = self._put(
+            "admin/visualizations/nonexistent_viz_id_12345/toggle",
+            data={"enabled": False},
+            admin=True,
+            json=True,
+        )
+        assert_status_code_is(response, 404)
+
+    @requires_admin
+    def test_reload_registry(self):
+        response = self._post("admin/visualizations/reload", admin=True)
+        assert_status_code_is(response, 200)
+        data = response.json()
+        assert_has_keys(data, "message")
+
+    @requires_admin
+    def test_usage_stats(self):
+        response = self._get("admin/visualizations/usage_stats", admin=True)
+        assert_status_code_is(response, 200)
+        data = response.json()
+        assert_has_keys(data, "message", "days", "stats")
+
+    @requires_admin
+    def test_staging_status(self):
+        response = self._get("admin/visualizations/staging_status", admin=True)
+        assert_status_code_is(response, 200)
+        data = response.json()
+        assert_has_keys(data, "staged_count", "staged_visualizations", "total_size")
+
+    @requires_admin
+    def test_stage_all(self):
+        response = self._post("admin/visualizations/stage", admin=True)
+        assert_status_code_is(response, 200)
+        data = response.json()
+        assert_has_keys(data, "message", "staged_count", "staged_visualizations")
+
+    @requires_admin
+    def test_clean_staged(self):
+        response = self._delete("admin/visualizations/staged", admin=True)
+        assert_status_code_is(response, 200)
+        data = response.json()
+        assert_has_keys(data, "message", "cleaned_count")
+
+    @requires_admin
+    def test_stage_nonexistent(self):
+        response = self._post("admin/visualizations/nonexistent_viz_id_12345/stage", admin=True)
+        assert_status_code_is(response, 404)
+
+    @requires_admin
+    def test_all_admin_endpoints_reject_non_admin(self):
+        """Verify all endpoints require admin access."""
+        endpoints = [
+            ("GET", "admin/visualizations"),
+            ("GET", "admin/visualizations/available"),
+            ("GET", "admin/visualizations/usage_stats"),
+            ("GET", "admin/visualizations/staging_status"),
+            ("POST", "admin/visualizations/reload"),
+            ("POST", "admin/visualizations/stage"),
+            ("DELETE", "admin/visualizations/staged"),
+        ]
+        for method, path in endpoints:
+            if method == "GET":
+                response = self._get(path)
+            elif method == "POST":
+                response = self._post(path)
+            elif method == "DELETE":
+                response = self._delete(path)
+            assert_status_code_is(response, 403, f"{method} {path} should require admin")

--- a/lib/galaxy_test/api/test_admin_visualizations.py
+++ b/lib/galaxy_test/api/test_admin_visualizations.py
@@ -1,5 +1,7 @@
 """API tests for admin visualization management endpoints."""
 
+from unittest.mock import patch
+
 from galaxy_test.base.api_asserts import (
     assert_has_keys,
     assert_status_code_is,
@@ -32,6 +34,35 @@ class TestAdminVisualizationsApi(ApiTestCase):
     def test_available_non_admin_rejected(self):
         response = self._get("admin/visualizations/available")
         assert_status_code_is(response, 403)
+
+    @requires_admin
+    @patch("galaxy.managers.visualization_admin.VisualizationPackageManager.install_npm_package")
+    def test_install(self, mock_install):
+        viz_id = "api_install_test_viz"
+        mock_install.return_value = {
+            "package": "@galaxyproject/api-install-test-viz",
+            "version": "1.2.3",
+            "size": 123,
+        }
+        response = self._post(
+            f"admin/visualizations/{viz_id}/install",
+            data={"package": "@galaxyproject/api-install-test-viz", "version": "1.2.3"},
+            admin=True,
+            json=True,
+        )
+        assert_status_code_is(response, 201)
+        data = response.json()
+        assert_has_keys(data, "id", "package", "version", "installed", "message")
+
+    @requires_admin
+    @patch("galaxy.managers.visualization_admin.VisualizationPackageManager.get_package_versions")
+    def test_package_versions(self, mock_versions):
+        mock_versions.return_value = ["2.0.0", "1.0.0"]
+        response = self._get("admin/visualizations/versions/@galaxyproject/circster", admin=True)
+        assert_status_code_is(response, 200)
+        data = response.json()
+        assert_has_keys(data, "package", "versions")
+        assert data["versions"] == ["2.0.0", "1.0.0"]
 
     @requires_admin
     def test_show_nonexistent(self):

--- a/lib/galaxy_test/api/test_admin_visualizations.py
+++ b/lib/galaxy_test/api/test_admin_visualizations.py
@@ -1,5 +1,6 @@
 """API tests for admin visualization management endpoints."""
 
+import uuid
 from unittest.mock import patch
 
 from galaxy_test.base.api_asserts import (
@@ -24,7 +25,21 @@ class TestAdminVisualizationsApi(ApiTestCase):
         assert_status_code_is(response, 403)
 
     @requires_admin
-    def test_available(self):
+    @patch("galaxy.managers.visualization_admin.VisualizationPackageManager.query_npm_registry")
+    def test_available(self, mock_query):
+        mock_query.return_value = [
+            {
+                "name": "@galaxyproject/circster",
+                "description": "Circster",
+                "version": "1.2.3",
+                "keywords": ["visualization"],
+                "author": {},
+                "maintainers": [],
+                "links": {},
+                "date": "2026-01-01",
+                "score": {},
+            }
+        ]
         response = self._get("admin/visualizations/available", admin=True)
         assert_status_code_is(response, 200)
         data = response.json()
@@ -38,7 +53,7 @@ class TestAdminVisualizationsApi(ApiTestCase):
     @requires_admin
     @patch("galaxy.managers.visualization_admin.VisualizationPackageManager.install_npm_package")
     def test_install(self, mock_install):
-        viz_id = "api_install_test_viz"
+        viz_id = f"api_install_test_viz_{uuid.uuid4().hex[:8]}"
         mock_install.return_value = {
             "package": "@galaxyproject/api-install-test-viz",
             "version": "1.2.3",

--- a/test/unit/app/managers/test_visualization_admin.py
+++ b/test/unit/app/managers/test_visualization_admin.py
@@ -3,6 +3,7 @@
 import json
 import os
 import shutil
+import subprocess
 import tempfile
 from unittest.mock import (
     MagicMock,
@@ -11,12 +12,13 @@ from unittest.mock import (
 
 import pytest
 
+from galaxy import exceptions
+from galaxy.managers.visualization_admin import VisualizationPackageManager
+
 
 @pytest.fixture()
 def manager():
     """Create a VisualizationPackageManager with a temp directory as root."""
-    from galaxy.managers.visualization_admin import VisualizationPackageManager
-
     tmpdir = tempfile.mkdtemp()
     app = MagicMock()
     app.config.root = tmpdir
@@ -27,10 +29,107 @@ def manager():
     shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+def _create_installed_package(manager, viz_id, package_name="@galaxyproject/test", version="1.0.0"):
+    """Helper to simulate an installed package (directory + package.json + config entry)."""
+    pkg_dir = manager.get_package_path(viz_id)
+    os.makedirs(pkg_dir, exist_ok=True)
+    with open(os.path.join(pkg_dir, "package.json"), "w") as f:
+        json.dump({"name": package_name, "version": version}, f)
+    manager.add_package_to_config(viz_id, package_name, version, enabled=True)
+    return pkg_dir
+
+
+def _create_viz_static(manager, viz_name, content="test"):
+    """Helper to create config/plugins visualization static assets."""
+    plugins_dir = os.path.join(
+        manager.app.config.root,
+        "config",
+        "plugins",
+        "visualizations",
+        viz_name,
+        "static",
+    )
+    os.makedirs(plugins_dir, exist_ok=True)
+    with open(os.path.join(plugins_dir, "index.html"), "w") as f:
+        f.write(content)
+    return plugins_dir
+
+
+# --- Input validation ---
+
+
+class TestVizIdValidation:
+    def test_valid_simple_id(self, manager):
+        manager.validate_viz_id("circster")
+
+    def test_valid_id_with_hyphens(self, manager):
+        manager.validate_viz_id("my-viz-plugin")
+
+    def test_valid_nested_id(self, manager):
+        manager.validate_viz_id("jqplot/jqplot_bar")
+
+    def test_rejects_path_traversal(self, manager):
+        with pytest.raises(exceptions.RequestParameterInvalidException):
+            manager.validate_viz_id("../../etc/passwd")
+
+    def test_rejects_empty(self, manager):
+        with pytest.raises(exceptions.RequestParameterInvalidException):
+            manager.validate_viz_id("")
+
+    def test_rejects_spaces(self, manager):
+        with pytest.raises(exceptions.RequestParameterInvalidException):
+            manager.validate_viz_id("my viz")
+
+    def test_rejects_semicolons(self, manager):
+        with pytest.raises(exceptions.RequestParameterInvalidException):
+            manager.validate_viz_id("viz; rm -rf /")
+
+
+class TestNpmInputValidation:
+    def test_valid_scoped_package(self, manager):
+        manager.validate_npm_inputs("@galaxyproject/circster", "1.0.0")
+
+    def test_valid_unscoped_package(self, manager):
+        manager.validate_npm_inputs("some-package", "2.3.4")
+
+    def test_valid_semver_with_prerelease(self, manager):
+        manager.validate_npm_inputs("pkg", "1.0.0-beta.1")
+
+    def test_rejects_path_traversal_in_package(self, manager):
+        with pytest.raises(exceptions.RequestParameterInvalidException):
+            manager.validate_npm_inputs("../../etc/passwd", "1.0.0")
+
+    def test_rejects_shell_injection_in_package(self, manager):
+        with pytest.raises(exceptions.RequestParameterInvalidException):
+            manager.validate_npm_inputs("foo; rm -rf /", "1.0.0")
+
+    def test_rejects_git_url_version(self, manager):
+        with pytest.raises(exceptions.RequestParameterInvalidException):
+            manager.validate_npm_inputs("pkg", "git+https://evil.com/repo")
+
+    def test_rejects_file_url_version(self, manager):
+        with pytest.raises(exceptions.RequestParameterInvalidException):
+            manager.validate_npm_inputs("pkg", "file:../local-pkg")
+
+    def test_rejects_range_version(self, manager):
+        with pytest.raises(exceptions.RequestParameterInvalidException):
+            manager.validate_npm_inputs("pkg", "^1.0.0")
+
+    def test_rejects_latest_tag(self, manager):
+        with pytest.raises(exceptions.RequestParameterInvalidException):
+            manager.validate_npm_inputs("pkg", "latest")
+
+    def test_rejects_incomplete_semver(self, manager):
+        with pytest.raises(exceptions.RequestParameterInvalidException):
+            manager.validate_npm_inputs("pkg", "1.2")
+
+
+# --- Config management ---
+
+
 class TestConfigManagement:
     def test_load_config_empty(self, manager):
-        config = manager.load_config()
-        assert config == {}
+        assert manager.load_config() == {}
 
     def test_save_and_load_config(self, manager):
         config = {
@@ -41,13 +140,11 @@ class TestConfigManagement:
             }
         }
         manager.save_config(config)
-        loaded = manager.load_config()
-        assert loaded == config
+        assert manager.load_config() == config
 
     def test_add_package_to_config(self, manager):
         manager.add_package_to_config("circster", "@galaxyproject/circster", "1.0.0", enabled=True)
         config = manager.load_config()
-        assert "circster" in config
         assert config["circster"]["package"] == "@galaxyproject/circster"
         assert config["circster"]["version"] == "1.0.0"
         assert config["circster"]["enabled"] is True
@@ -55,25 +152,23 @@ class TestConfigManagement:
     def test_remove_package_from_config(self, manager):
         manager.add_package_to_config("circster", "@galaxyproject/circster", "1.0.0")
         manager.remove_package_from_config("circster")
-        config = manager.load_config()
-        assert "circster" not in config
+        assert "circster" not in manager.load_config()
 
-    def test_remove_nonexistent_package_is_noop(self, manager):
+    def test_remove_nonexistent_is_noop(self, manager):
         manager.remove_package_from_config("nonexistent")
-        config = manager.load_config()
-        assert config == {}
+        assert manager.load_config() == {}
 
-    def test_toggle_package_enabled(self, manager):
+    def test_toggle_enabled(self, manager):
         manager.add_package_to_config("circster", "@galaxyproject/circster", "1.0.0", enabled=True)
         manager.toggle_package_enabled("circster", False)
-        config = manager.load_config()
-        assert config["circster"]["enabled"] is False
+        assert manager.load_config()["circster"]["enabled"] is False
 
     def test_toggle_nonexistent_raises(self, manager):
-        from galaxy import exceptions
-
         with pytest.raises(exceptions.ObjectNotFound):
             manager.toggle_package_enabled("nonexistent", True)
+
+
+# --- Package info ---
 
 
 class TestPackageInfo:
@@ -83,50 +178,29 @@ class TestPackageInfo:
     def test_get_package_info_present(self, manager):
         manager.add_package_to_config("circster", "@galaxyproject/circster", "2.0.0")
         info = manager.get_package_info("circster")
-        assert info["package"] == "@galaxyproject/circster"
         assert info["version"] == "2.0.0"
 
     def test_is_package_installed_false(self, manager):
         assert manager.is_package_installed("circster") is False
 
     def test_is_package_installed_true(self, manager):
-        pkg_dir = manager.get_package_path("circster")
-        os.makedirs(pkg_dir)
+        os.makedirs(manager.get_package_path("circster"))
         assert manager.is_package_installed("circster") is True
-
-    def test_get_package_metadata_no_package_json(self, manager):
-        pkg_dir = manager.get_package_path("circster")
-        os.makedirs(pkg_dir)
-        assert manager.get_package_metadata("circster") == {}
 
     def test_get_package_metadata_with_package_json(self, manager):
         pkg_dir = manager.get_package_path("circster")
         os.makedirs(pkg_dir)
-        metadata = {
-            "name": "@galaxyproject/circster",
-            "version": "1.0.0",
-            "description": "A viz",
-        }
         with open(os.path.join(pkg_dir, "package.json"), "w") as f:
-            json.dump(metadata, f)
+            json.dump({"name": "@galaxyproject/circster", "description": "A viz"}, f)
         result = manager.get_package_metadata("circster")
-        assert result["name"] == "@galaxyproject/circster"
         assert result["description"] == "A viz"
 
+    def test_get_package_metadata_no_package_json(self, manager):
+        os.makedirs(manager.get_package_path("circster"))
+        assert manager.get_package_metadata("circster") == {}
 
-class TestDirectorySize:
-    def test_empty_directory(self, manager):
-        pkg_dir = manager.get_package_path("test_pkg")
-        os.makedirs(pkg_dir)
-        assert manager.get_directory_size(pkg_dir) == 0
 
-    def test_directory_with_files(self, manager):
-        pkg_dir = manager.get_package_path("test_pkg")
-        os.makedirs(pkg_dir)
-        with open(os.path.join(pkg_dir, "file.txt"), "w") as f:
-            f.write("hello world")
-        size = manager.get_directory_size(pkg_dir)
-        assert size > 0
+# --- Package validation ---
 
 
 class TestPackageValidation:
@@ -138,16 +212,12 @@ class TestPackageValidation:
         assert manager.validate_package_structure(pkg_dir) is True
 
     def test_missing_package_json(self, manager):
-        from galaxy import exceptions
-
         pkg_dir = manager.get_package_path("test_pkg")
         os.makedirs(pkg_dir)
         with pytest.raises(exceptions.ConfigurationError, match="package.json"):
             manager.validate_package_structure(pkg_dir)
 
     def test_missing_required_field(self, manager):
-        from galaxy import exceptions
-
         pkg_dir = manager.get_package_path("test_pkg")
         os.makedirs(pkg_dir)
         with open(os.path.join(pkg_dir, "package.json"), "w") as f:
@@ -156,22 +226,240 @@ class TestPackageValidation:
             manager.validate_package_structure(pkg_dir)
 
 
-class TestCleanupPackageFiles:
-    def test_cleanup_existing(self, manager):
-        pkg_dir = manager.get_package_path("circster")
-        os.makedirs(pkg_dir)
-        with open(os.path.join(pkg_dir, "file.txt"), "w") as f:
-            f.write("data")
-        manager.cleanup_package_files("circster")
-        assert not os.path.exists(pkg_dir)
+# --- npm install (mocked subprocess) ---
 
-    def test_cleanup_nonexistent_is_noop(self, manager):
-        manager.cleanup_package_files("nonexistent")
+
+class TestNpmInstall:
+    @patch("galaxy.managers.visualization_admin.subprocess.run")
+    def test_install_scoped_package(self, mock_run, manager):
+        """Scoped packages resolve to node_modules/@scope/name."""
+        target_dir = manager.get_package_path("circster")
+
+        def side_effect(cmd, **kwargs):
+            # Simulate npm creating the scoped package directory
+            pkg_path = os.path.join(kwargs["cwd"], "node_modules", "@galaxyproject", "circster")
+            os.makedirs(pkg_path, exist_ok=True)
+            with open(os.path.join(pkg_path, "package.json"), "w") as f:
+                json.dump({"name": "@galaxyproject/circster", "version": "1.0.0"}, f)
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        mock_run.side_effect = side_effect
+
+        result = manager.install_npm_package("@galaxyproject/circster", "1.0.0", target_dir)
+        assert result["package"] == "@galaxyproject/circster"
+        assert os.path.exists(os.path.join(target_dir, "package.json"))
+
+    @patch("galaxy.managers.visualization_admin.subprocess.run")
+    def test_install_unscoped_package(self, mock_run, manager):
+        target_dir = manager.get_package_path("some_viz")
+
+        def side_effect(cmd, **kwargs):
+            pkg_path = os.path.join(kwargs["cwd"], "node_modules", "some-viz-package")
+            os.makedirs(pkg_path, exist_ok=True)
+            with open(os.path.join(pkg_path, "package.json"), "w") as f:
+                json.dump({"name": "some-viz-package", "version": "2.0.0"}, f)
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        mock_run.side_effect = side_effect
+
+        result = manager.install_npm_package("some-viz-package", "2.0.0", target_dir)
+        assert result["version"] == "2.0.0"
+
+    @patch("galaxy.managers.visualization_admin.subprocess.run")
+    def test_install_npm_failure(self, mock_run, manager):
+        mock_run.return_value = MagicMock(returncode=1, stderr="npm ERR! 404 Not Found")
+        target_dir = manager.get_package_path("bad_pkg")
+        with pytest.raises(exceptions.InternalServerError, match="installation failed"):
+            manager.install_npm_package("@galaxyproject/bad-pkg", "9.9.9", target_dir)
+
+    @patch("galaxy.managers.visualization_admin.subprocess.run")
+    def test_install_timeout(self, mock_run, manager):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="npm", timeout=300)
+        target_dir = manager.get_package_path("slow_pkg")
+        with pytest.raises(exceptions.InternalServerError, match="timed out"):
+            manager.install_npm_package("@galaxyproject/slow", "1.0.0", target_dir)
+
+
+# --- Install/uninstall/reinstall lifecycle ---
+
+
+class TestInstallLifecycle:
+    @patch("galaxy.managers.visualization_admin.subprocess.run")
+    def _mock_install(self, manager, viz_id, package, version, mock_run):
+        """Helper that mocks npm and performs an install."""
+
+        def side_effect(cmd, **kwargs):
+            parts = package.split("/") if package.startswith("@") else [package]
+            pkg_path = os.path.join(kwargs["cwd"], "node_modules", *parts)
+            os.makedirs(pkg_path, exist_ok=True)
+            with open(os.path.join(pkg_path, "package.json"), "w") as f:
+                json.dump({"name": package, "version": version}, f)
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = side_effect
+        return manager.install_npm_package(package, version, manager.get_package_path(viz_id))
+
+    def test_install_then_uninstall(self, manager):
+        self._mock_install(manager, "my_viz", "@galaxyproject/my-viz", "1.0.0")
+        manager.add_package_to_config("my_viz", "@galaxyproject/my-viz", "1.0.0")
+
+        assert manager.is_package_installed("my_viz")
+        assert manager.get_package_info("my_viz") is not None
+
+        manager.remove_package_from_config("my_viz")
+        manager.cleanup_package_files("my_viz")
+
+        assert not manager.is_package_installed("my_viz")
+        assert manager.get_package_info("my_viz") is None
+
+    def test_install_then_uninstall_then_reinstall(self, manager):
+        self._mock_install(manager, "my_viz", "@galaxyproject/my-viz", "1.0.0")
+        manager.add_package_to_config("my_viz", "@galaxyproject/my-viz", "1.0.0")
+
+        manager.remove_package_from_config("my_viz")
+        manager.cleanup_package_files("my_viz")
+        assert not manager.is_package_installed("my_viz")
+
+        # Reinstall
+        self._mock_install(manager, "my_viz", "@galaxyproject/my-viz", "1.0.0")
+        manager.add_package_to_config("my_viz", "@galaxyproject/my-viz", "1.0.0")
+        assert manager.is_package_installed("my_viz")
+
+    def test_install_then_upgrade(self, manager):
+        self._mock_install(manager, "my_viz", "@galaxyproject/my-viz", "1.0.0")
+        manager.add_package_to_config("my_viz", "@galaxyproject/my-viz", "1.0.0")
+
+        assert manager.load_config()["my_viz"]["version"] == "1.0.0"
+
+        # Upgrade by installing new version over old
+        manager.cleanup_package_files("my_viz")
+        self._mock_install(manager, "my_viz", "@galaxyproject/my-viz", "2.0.0")
+        manager.add_package_to_config("my_viz", "@galaxyproject/my-viz", "2.0.0")
+
+        assert manager.load_config()["my_viz"]["version"] == "2.0.0"
+        metadata = manager.get_package_metadata("my_viz")
+        assert metadata["version"] == "2.0.0"
+
+    def test_install_then_stage_then_verify(self, manager):
+        """Full flow: install from npm, then stage so Galaxy can serve it."""
+        self._mock_install(manager, "my_viz", "@galaxyproject/my-viz", "1.0.0")
+        manager.add_package_to_config("my_viz", "@galaxyproject/my-viz", "1.0.0")
+
+        # Create config/plugins static dir (simulating what the package provides)
+        _create_viz_static(manager, "my_viz", "<html>viz content</html>")
+
+        result = manager.stage_visualization("my_viz")
+        assert result["visualization_id"] == "my_viz"
+
+        # Verify the static content is now in the serving directory
+        static_dir = os.path.join(manager.app.config.root, "static", "plugins", "visualizations")
+        staged_file = os.path.join(static_dir, "my_viz", "static", "index.html")
+        assert os.path.exists(staged_file)
+        with open(staged_file) as f:
+            assert "viz content" in f.read()
+
+
+# --- Staging (migration from old install mechanisms) ---
+
+
+class TestStaging:
+    def test_stage_all_visualizations(self, manager):
+        _create_viz_static(manager, "circster")
+        _create_viz_static(manager, "trackster")
+
+        result = manager.stage_all_visualizations()
+        assert result["staged_count"] == 2
+        assert len(result["staged_visualizations"]) == 2
+
+        static_dir = os.path.join(manager.app.config.root, "static", "plugins", "visualizations")
+        assert os.path.exists(os.path.join(static_dir, "circster", "static", "index.html"))
+        assert os.path.exists(os.path.join(static_dir, "trackster", "static", "index.html"))
+
+    def test_stage_single_visualization(self, manager):
+        _create_viz_static(manager, "circster", content="<html>circster</html>")
+
+        result = manager.stage_visualization("circster")
+        assert result["visualization_id"] == "circster"
+        assert result["size"] > 0
+
+    def test_stage_nested_visualization(self, manager):
+        """Nested visualizations like jqplot/jqplot_bar have a two-level directory structure."""
+        nested_dir = os.path.join(
+            manager.app.config.root,
+            "config",
+            "plugins",
+            "visualizations",
+            "jqplot",
+            "jqplot_bar",
+            "static",
+        )
+        os.makedirs(nested_dir, exist_ok=True)
+        with open(os.path.join(nested_dir, "index.html"), "w") as f:
+            f.write("<html>jqplot bar</html>")
+
+        result = manager.stage_visualization("jqplot/jqplot_bar")
+        assert result["visualization_id"] == "jqplot/jqplot_bar"
+
+        static_dir = os.path.join(manager.app.config.root, "static", "plugins", "visualizations")
+        assert os.path.exists(os.path.join(static_dir, "jqplot", "jqplot_bar", "static", "index.html"))
+
+    def test_stage_nonexistent_raises(self, manager):
+        with pytest.raises(exceptions.ObjectNotFound):
+            manager.stage_visualization("nonexistent")
+
+    def test_clean_staged_assets(self, manager):
+        _create_viz_static(manager, "circster")
+        manager.stage_all_visualizations()
+
+        result = manager.clean_staged_assets()
+        assert result["cleaned_count"] > 0
+
+        static_dir = os.path.join(manager.app.config.root, "static", "plugins", "visualizations")
+        assert os.path.exists(static_dir)
+        assert len(os.listdir(static_dir)) == 0
+
+    def test_staging_status(self, manager):
+        _create_viz_static(manager, "circster")
+        manager.stage_all_visualizations()
+
+        status = manager.get_staging_status()
+        assert status["staged_count"] >= 1
+        assert status["total_size"] > 0
+        names = [v["name"] for v in status["staged_visualizations"]]
+        assert "circster" in names
+
+    def test_staging_status_empty(self, manager):
+        status = manager.get_staging_status()
+        assert status["staged_count"] == 0
+        assert status["total_size"] == 0
+
+    def test_stage_all_discovers_existing_viz_plugins(self, manager):
+        """Simulates the migration scenario: existing visualizations in config/plugins
+        are discovered and staged to static/plugins on startup."""
+        # These represent pre-existing visualizations from the old build system
+        for viz_name in ["circster", "trackster", "sweepster", "phyloviz"]:
+            _create_viz_static(manager, viz_name, f"<html>{viz_name}</html>")
+
+        result = manager.stage_all_visualizations()
+        assert result["staged_count"] == 4
+        assert result["errors"] == []
+
+        # All should be servable now
+        static_dir = os.path.join(manager.app.config.root, "static", "plugins", "visualizations")
+        for viz_name in ["circster", "trackster", "sweepster", "phyloviz"]:
+            assert os.path.exists(os.path.join(static_dir, viz_name, "static", "index.html"))
+
+
+# --- npm registry query ---
 
 
 class TestNpmRegistryQuery:
     @patch("galaxy.managers.visualization_admin.requests.get")
-    def test_query_npm_registry(self, mock_get, manager):
+    def test_filters_by_visualization_keyword(self, mock_get, manager):
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "objects": [
@@ -194,9 +482,6 @@ class TestNpmRegistryQuery:
                         "description": "Some other package",
                         "version": "2.0.0",
                         "keywords": ["tool"],
-                        "author": {},
-                        "maintainers": [],
-                        "links": {},
                     },
                     "score": {},
                 },
@@ -210,7 +495,7 @@ class TestNpmRegistryQuery:
         assert results[0]["name"] == "@galaxyproject/test-viz"
 
     @patch("galaxy.managers.visualization_admin.requests.get")
-    def test_query_npm_registry_with_search(self, mock_get, manager):
+    def test_search_includes_term(self, mock_get, manager):
         mock_response = MagicMock()
         mock_response.json.return_value = {"objects": []}
         mock_response.raise_for_status = MagicMock()
@@ -228,77 +513,38 @@ class TestNpmRegistryQuery:
         mock_get.return_value = mock_response
 
         versions = manager.get_package_versions("@galaxyproject/circster")
-        assert "1.0.0" in versions
-        assert "2.0.0" in versions
         assert len(versions) == 3
+        assert "2.0.0" in versions
 
 
-class TestStaging:
-    def _create_viz_static(self, manager, viz_name, content="test"):
-        """Helper to create a visualization with static assets in config/plugins."""
-        plugins_dir = os.path.join(
-            manager.app.config.root,
-            "config",
-            "plugins",
-            "visualizations",
-            viz_name,
-            "static",
-        )
-        os.makedirs(plugins_dir, exist_ok=True)
-        with open(os.path.join(plugins_dir, "index.html"), "w") as f:
-            f.write(content)
-        return plugins_dir
+# --- Misc ---
 
-    def test_stage_all_visualizations(self, manager):
-        self._create_viz_static(manager, "circster")
-        self._create_viz_static(manager, "trackster")
 
-        result = manager.stage_all_visualizations()
-        assert result["staged_count"] == 2
-        assert len(result["staged_visualizations"]) == 2
+class TestDirectorySize:
+    def test_empty_directory(self, manager):
+        pkg_dir = manager.get_package_path("test_pkg")
+        os.makedirs(pkg_dir)
+        assert manager.get_directory_size(pkg_dir) == 0
 
-        static_dir = os.path.join(manager.app.config.root, "static", "plugins", "visualizations")
-        assert os.path.exists(os.path.join(static_dir, "circster", "static", "index.html"))
-        assert os.path.exists(os.path.join(static_dir, "trackster", "static", "index.html"))
+    def test_directory_with_files(self, manager):
+        pkg_dir = manager.get_package_path("test_pkg")
+        os.makedirs(pkg_dir)
+        with open(os.path.join(pkg_dir, "file.txt"), "w") as f:
+            f.write("hello world")
+        assert manager.get_directory_size(pkg_dir) > 0
 
-    def test_stage_single_visualization(self, manager):
-        self._create_viz_static(manager, "circster", content="<html>circster</html>")
 
-        result = manager.stage_visualization("circster")
-        assert result["visualization_id"] == "circster"
-        assert result["size"] > 0
+class TestCleanupPackageFiles:
+    def test_cleanup_existing(self, manager):
+        pkg_dir = manager.get_package_path("circster")
+        os.makedirs(pkg_dir)
+        with open(os.path.join(pkg_dir, "file.txt"), "w") as f:
+            f.write("data")
+        manager.cleanup_package_files("circster")
+        assert not os.path.exists(pkg_dir)
 
-    def test_stage_nonexistent_raises(self, manager):
-        from galaxy import exceptions
-
-        with pytest.raises(exceptions.ObjectNotFound):
-            manager.stage_visualization("nonexistent")
-
-    def test_clean_staged_assets(self, manager):
-        self._create_viz_static(manager, "circster")
-        manager.stage_all_visualizations()
-
-        result = manager.clean_staged_assets()
-        assert result["cleaned_count"] > 0
-
-        static_dir = os.path.join(manager.app.config.root, "static", "plugins", "visualizations")
-        assert os.path.exists(static_dir)
-        assert len(os.listdir(static_dir)) == 0
-
-    def test_get_staging_status(self, manager):
-        self._create_viz_static(manager, "circster")
-        manager.stage_all_visualizations()
-
-        status = manager.get_staging_status()
-        assert status["staged_count"] >= 1
-        assert status["total_size"] > 0
-        names = [v["name"] for v in status["staged_visualizations"]]
-        assert "circster" in names
-
-    def test_get_staging_status_empty(self, manager):
-        status = manager.get_staging_status()
-        assert status["staged_count"] == 0
-        assert status["total_size"] == 0
+    def test_cleanup_nonexistent_is_noop(self, manager):
+        manager.cleanup_package_files("nonexistent")
 
 
 class TestBackupRestore:
@@ -314,7 +560,6 @@ class TestBackupRestore:
 
         backup_path = manager.backup_config()
         assert backup_path is not None
-        assert os.path.exists(backup_path)
 
         manager.save_config({"different": {"package": "other", "version": "2.0.0", "enabled": False}})
         assert manager.load_config() != original
@@ -323,6 +568,6 @@ class TestBackupRestore:
         assert manager.load_config() == original
 
     def test_backup_no_config(self, manager):
-        os.remove(manager.config_path) if os.path.exists(manager.config_path) else None
-        result = manager.backup_config()
-        assert result is None
+        if os.path.exists(manager.config_path):
+            os.remove(manager.config_path)
+        assert manager.backup_config() is None

--- a/test/unit/app/managers/test_visualization_admin.py
+++ b/test/unit/app/managers/test_visualization_admin.py
@@ -30,12 +30,25 @@ def manager():
 
 
 def _create_installed_package(manager, viz_id, package_name="@galaxyproject/test", version="1.0.0"):
-    """Helper to simulate an installed package (directory + package.json + config entry)."""
+    """Helper to simulate an installed runtime package in the managed package store."""
     pkg_dir = manager.get_package_path(viz_id)
     os.makedirs(pkg_dir, exist_ok=True)
     with open(os.path.join(pkg_dir, "package.json"), "w") as f:
         json.dump({"name": package_name, "version": version}, f)
     manager.add_package_to_config(viz_id, package_name, version, enabled=True)
+    return pkg_dir
+
+
+def _create_runtime_viz_package(manager, viz_id, package_name="@galaxyproject/test", version="1.0.0", content="test"):
+    """Helper to create a managed runtime package with static assets."""
+    pkg_dir = _create_installed_package(manager, viz_id, package_name, version)
+    static_dir = os.path.join(pkg_dir, "static")
+    os.makedirs(static_dir, exist_ok=True)
+    plugin_name = viz_id.split("/")[-1]
+    with open(os.path.join(static_dir, f"{plugin_name}.xml"), "w") as f:
+        f.write(f"<visualization name='{plugin_name}' />")
+    with open(os.path.join(static_dir, "index.html"), "w") as f:
+        f.write(content)
     return pkg_dir
 
 
@@ -52,6 +65,9 @@ def _create_viz_static(manager, viz_name, content="test"):
     os.makedirs(plugins_dir, exist_ok=True)
     with open(os.path.join(plugins_dir, "index.html"), "w") as f:
         f.write(content)
+    plugin_name = viz_name.split("/")[-1]
+    with open(os.path.join(plugins_dir, f"{plugin_name}.xml"), "w") as f:
+        f.write(f"<visualization name='{plugin_name}' />")
     return plugins_dir
 
 
@@ -348,16 +364,19 @@ class TestInstallLifecycle:
         """Full flow: install from npm, then stage so Galaxy can serve it."""
         self._mock_install(manager, "my_viz", "@galaxyproject/my-viz", "1.0.0")
         manager.add_package_to_config("my_viz", "@galaxyproject/my-viz", "1.0.0")
-
-        # Create config/plugins static dir (simulating what the package provides)
-        _create_viz_static(manager, "my_viz", "<html>viz content</html>")
+        static_dir = os.path.join(manager.get_package_path("my_viz"), "static")
+        os.makedirs(static_dir, exist_ok=True)
+        with open(os.path.join(static_dir, "my_viz.xml"), "w") as f:
+            f.write("<visualization name='my_viz' />")
+        with open(os.path.join(static_dir, "index.html"), "w") as f:
+            f.write("<html>viz content</html>")
 
         result = manager.stage_visualization("my_viz")
         assert result["visualization_id"] == "my_viz"
 
         # Verify the static content is now in the serving directory
-        static_dir = os.path.join(manager.app.config.root, "static", "plugins", "visualizations")
-        staged_file = os.path.join(static_dir, "my_viz", "static", "index.html")
+        staged_dir = os.path.join(manager.app.config.root, "static", "plugins", "visualizations")
+        staged_file = os.path.join(staged_dir, "my_viz", "static", "index.html")
         assert os.path.exists(staged_file)
         with open(staged_file) as f:
             assert "viz content" in f.read()
@@ -378,6 +397,15 @@ class TestStaging:
         static_dir = os.path.join(manager.app.config.root, "static", "plugins", "visualizations")
         assert os.path.exists(os.path.join(static_dir, "circster", "static", "index.html"))
         assert os.path.exists(os.path.join(static_dir, "trackster", "static", "index.html"))
+
+    def test_stage_runtime_visualization(self, manager):
+        _create_runtime_viz_package(manager, "runtime_viz", content="<html>runtime</html>")
+
+        result = manager.stage_visualization("runtime_viz")
+        assert result["visualization_id"] == "runtime_viz"
+        assert result["source_path"] == manager.get_package_path("runtime_viz")
+        assert result["target_path"] == manager.get_staged_path("runtime_viz")
+        assert os.path.exists(os.path.join(manager.get_staged_path("runtime_viz"), "static", "runtime_viz.xml"))
 
     def test_stage_single_visualization(self, manager):
         _create_viz_static(manager, "circster", content="<html>circster</html>")
@@ -452,6 +480,17 @@ class TestStaging:
         static_dir = os.path.join(manager.app.config.root, "static", "plugins", "visualizations")
         for viz_name in ["circster", "trackster", "sweepster", "phyloviz"]:
             assert os.path.exists(os.path.join(static_dir, viz_name, "static", "index.html"))
+
+    def test_stage_all_includes_runtime_and_legacy_visualizations(self, manager):
+        _create_runtime_viz_package(manager, "runtime_viz", content="<html>runtime</html>")
+        _create_viz_static(manager, "legacy_viz", "<html>legacy</html>")
+
+        result = manager.stage_all_visualizations()
+
+        assert result["staged_count"] == 2
+        assert set(result["staged_visualizations"]) == {"runtime_viz", "legacy_viz"}
+        assert os.path.exists(os.path.join(manager.get_staged_path("runtime_viz"), "static", "index.html"))
+        assert os.path.exists(os.path.join(manager.get_staged_path("legacy_viz"), "static", "index.html"))
 
 
 # --- npm registry query ---
@@ -540,8 +579,13 @@ class TestCleanupPackageFiles:
         os.makedirs(pkg_dir)
         with open(os.path.join(pkg_dir, "file.txt"), "w") as f:
             f.write("data")
+        staged_dir = manager.get_staged_path("circster")
+        os.makedirs(staged_dir)
+        with open(os.path.join(staged_dir, "staged.txt"), "w") as f:
+            f.write("served")
         manager.cleanup_package_files("circster")
         assert not os.path.exists(pkg_dir)
+        assert not os.path.exists(staged_dir)
 
     def test_cleanup_nonexistent_is_noop(self, manager):
         manager.cleanup_package_files("nonexistent")

--- a/test/unit/app/managers/test_visualization_admin.py
+++ b/test/unit/app/managers/test_visualization_admin.py
@@ -1,0 +1,328 @@
+"""Unit tests for VisualizationPackageManager."""
+
+import json
+import os
+import shutil
+import tempfile
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
+
+import pytest
+
+
+@pytest.fixture()
+def manager():
+    """Create a VisualizationPackageManager with a temp directory as root."""
+    from galaxy.managers.visualization_admin import VisualizationPackageManager
+
+    tmpdir = tempfile.mkdtemp()
+    app = MagicMock()
+    app.config.root = tmpdir
+
+    mgr = VisualizationPackageManager(app)
+    yield mgr
+
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class TestConfigManagement:
+    def test_load_config_empty(self, manager):
+        config = manager.load_config()
+        assert config == {}
+
+    def test_save_and_load_config(self, manager):
+        config = {
+            "circster": {
+                "package": "@galaxyproject/circster",
+                "version": "1.0.0",
+                "enabled": True,
+            }
+        }
+        manager.save_config(config)
+        loaded = manager.load_config()
+        assert loaded == config
+
+    def test_add_package_to_config(self, manager):
+        manager.add_package_to_config("circster", "@galaxyproject/circster", "1.0.0", enabled=True)
+        config = manager.load_config()
+        assert "circster" in config
+        assert config["circster"]["package"] == "@galaxyproject/circster"
+        assert config["circster"]["version"] == "1.0.0"
+        assert config["circster"]["enabled"] is True
+
+    def test_remove_package_from_config(self, manager):
+        manager.add_package_to_config("circster", "@galaxyproject/circster", "1.0.0")
+        manager.remove_package_from_config("circster")
+        config = manager.load_config()
+        assert "circster" not in config
+
+    def test_remove_nonexistent_package_is_noop(self, manager):
+        manager.remove_package_from_config("nonexistent")
+        config = manager.load_config()
+        assert config == {}
+
+    def test_toggle_package_enabled(self, manager):
+        manager.add_package_to_config("circster", "@galaxyproject/circster", "1.0.0", enabled=True)
+        manager.toggle_package_enabled("circster", False)
+        config = manager.load_config()
+        assert config["circster"]["enabled"] is False
+
+    def test_toggle_nonexistent_raises(self, manager):
+        from galaxy import exceptions
+
+        with pytest.raises(exceptions.ObjectNotFound):
+            manager.toggle_package_enabled("nonexistent", True)
+
+
+class TestPackageInfo:
+    def test_get_package_info_missing(self, manager):
+        assert manager.get_package_info("nonexistent") is None
+
+    def test_get_package_info_present(self, manager):
+        manager.add_package_to_config("circster", "@galaxyproject/circster", "2.0.0")
+        info = manager.get_package_info("circster")
+        assert info["package"] == "@galaxyproject/circster"
+        assert info["version"] == "2.0.0"
+
+    def test_is_package_installed_false(self, manager):
+        assert manager.is_package_installed("circster") is False
+
+    def test_is_package_installed_true(self, manager):
+        pkg_dir = manager.get_package_path("circster")
+        os.makedirs(pkg_dir)
+        assert manager.is_package_installed("circster") is True
+
+    def test_get_package_metadata_no_package_json(self, manager):
+        pkg_dir = manager.get_package_path("circster")
+        os.makedirs(pkg_dir)
+        assert manager.get_package_metadata("circster") == {}
+
+    def test_get_package_metadata_with_package_json(self, manager):
+        pkg_dir = manager.get_package_path("circster")
+        os.makedirs(pkg_dir)
+        metadata = {
+            "name": "@galaxyproject/circster",
+            "version": "1.0.0",
+            "description": "A viz",
+        }
+        with open(os.path.join(pkg_dir, "package.json"), "w") as f:
+            json.dump(metadata, f)
+        result = manager.get_package_metadata("circster")
+        assert result["name"] == "@galaxyproject/circster"
+        assert result["description"] == "A viz"
+
+
+class TestDirectorySize:
+    def test_empty_directory(self, manager):
+        pkg_dir = manager.get_package_path("test_pkg")
+        os.makedirs(pkg_dir)
+        assert manager.get_directory_size(pkg_dir) == 0
+
+    def test_directory_with_files(self, manager):
+        pkg_dir = manager.get_package_path("test_pkg")
+        os.makedirs(pkg_dir)
+        with open(os.path.join(pkg_dir, "file.txt"), "w") as f:
+            f.write("hello world")
+        size = manager.get_directory_size(pkg_dir)
+        assert size > 0
+
+
+class TestPackageValidation:
+    def test_valid_package(self, manager):
+        pkg_dir = manager.get_package_path("test_pkg")
+        os.makedirs(pkg_dir)
+        with open(os.path.join(pkg_dir, "package.json"), "w") as f:
+            json.dump({"name": "test", "version": "1.0.0"}, f)
+        assert manager.validate_package_structure(pkg_dir) is True
+
+    def test_missing_package_json(self, manager):
+        from galaxy import exceptions
+
+        pkg_dir = manager.get_package_path("test_pkg")
+        os.makedirs(pkg_dir)
+        with pytest.raises(exceptions.ConfigurationError, match="package.json"):
+            manager.validate_package_structure(pkg_dir)
+
+    def test_missing_required_field(self, manager):
+        from galaxy import exceptions
+
+        pkg_dir = manager.get_package_path("test_pkg")
+        os.makedirs(pkg_dir)
+        with open(os.path.join(pkg_dir, "package.json"), "w") as f:
+            json.dump({"name": "test"}, f)
+        with pytest.raises(exceptions.ConfigurationError, match="version"):
+            manager.validate_package_structure(pkg_dir)
+
+
+class TestCleanupPackageFiles:
+    def test_cleanup_existing(self, manager):
+        pkg_dir = manager.get_package_path("circster")
+        os.makedirs(pkg_dir)
+        with open(os.path.join(pkg_dir, "file.txt"), "w") as f:
+            f.write("data")
+        manager.cleanup_package_files("circster")
+        assert not os.path.exists(pkg_dir)
+
+    def test_cleanup_nonexistent_is_noop(self, manager):
+        manager.cleanup_package_files("nonexistent")
+
+
+class TestNpmRegistryQuery:
+    @patch("galaxy.managers.visualization_admin.requests.get")
+    def test_query_npm_registry(self, mock_get, manager):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "objects": [
+                {
+                    "package": {
+                        "name": "@galaxyproject/test-viz",
+                        "description": "A test visualization",
+                        "version": "1.0.0",
+                        "keywords": ["visualization", "galaxy-visualization"],
+                        "author": {},
+                        "maintainers": [],
+                        "links": {},
+                        "date": "2025-01-01",
+                    },
+                    "score": {},
+                },
+                {
+                    "package": {
+                        "name": "@galaxyproject/not-a-viz",
+                        "description": "Some other package",
+                        "version": "2.0.0",
+                        "keywords": ["tool"],
+                        "author": {},
+                        "maintainers": [],
+                        "links": {},
+                    },
+                    "score": {},
+                },
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        results = manager.query_npm_registry()
+        assert len(results) == 1
+        assert results[0]["name"] == "@galaxyproject/test-viz"
+
+    @patch("galaxy.managers.visualization_admin.requests.get")
+    def test_query_npm_registry_with_search(self, mock_get, manager):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"objects": []}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        manager.query_npm_registry("circster")
+        call_args = mock_get.call_args
+        assert "circster" in call_args[1]["params"]["text"]
+
+    @patch("galaxy.managers.visualization_admin.requests.get")
+    def test_get_package_versions(self, mock_get, manager):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"versions": {"1.0.0": {}, "2.0.0": {}, "1.1.0": {}}}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        versions = manager.get_package_versions("@galaxyproject/circster")
+        assert "1.0.0" in versions
+        assert "2.0.0" in versions
+        assert len(versions) == 3
+
+
+class TestStaging:
+    def _create_viz_static(self, manager, viz_name, content="test"):
+        """Helper to create a visualization with static assets in config/plugins."""
+        plugins_dir = os.path.join(
+            manager.app.config.root,
+            "config",
+            "plugins",
+            "visualizations",
+            viz_name,
+            "static",
+        )
+        os.makedirs(plugins_dir, exist_ok=True)
+        with open(os.path.join(plugins_dir, "index.html"), "w") as f:
+            f.write(content)
+        return plugins_dir
+
+    def test_stage_all_visualizations(self, manager):
+        self._create_viz_static(manager, "circster")
+        self._create_viz_static(manager, "trackster")
+
+        result = manager.stage_all_visualizations()
+        assert result["staged_count"] == 2
+        assert len(result["staged_visualizations"]) == 2
+
+        static_dir = os.path.join(manager.app.config.root, "static", "plugins", "visualizations")
+        assert os.path.exists(os.path.join(static_dir, "circster", "static", "index.html"))
+        assert os.path.exists(os.path.join(static_dir, "trackster", "static", "index.html"))
+
+    def test_stage_single_visualization(self, manager):
+        self._create_viz_static(manager, "circster", content="<html>circster</html>")
+
+        result = manager.stage_visualization("circster")
+        assert result["visualization_id"] == "circster"
+        assert result["size"] > 0
+
+    def test_stage_nonexistent_raises(self, manager):
+        from galaxy import exceptions
+
+        with pytest.raises(exceptions.ObjectNotFound):
+            manager.stage_visualization("nonexistent")
+
+    def test_clean_staged_assets(self, manager):
+        self._create_viz_static(manager, "circster")
+        manager.stage_all_visualizations()
+
+        result = manager.clean_staged_assets()
+        assert result["cleaned_count"] > 0
+
+        static_dir = os.path.join(manager.app.config.root, "static", "plugins", "visualizations")
+        assert os.path.exists(static_dir)
+        assert len(os.listdir(static_dir)) == 0
+
+    def test_get_staging_status(self, manager):
+        self._create_viz_static(manager, "circster")
+        manager.stage_all_visualizations()
+
+        status = manager.get_staging_status()
+        assert status["staged_count"] >= 1
+        assert status["total_size"] > 0
+        names = [v["name"] for v in status["staged_visualizations"]]
+        assert "circster" in names
+
+    def test_get_staging_status_empty(self, manager):
+        status = manager.get_staging_status()
+        assert status["staged_count"] == 0
+        assert status["total_size"] == 0
+
+
+class TestBackupRestore:
+    def test_backup_and_restore(self, manager):
+        original = {
+            "circster": {
+                "package": "@galaxyproject/circster",
+                "version": "1.0.0",
+                "enabled": True,
+            }
+        }
+        manager.save_config(original)
+
+        backup_path = manager.backup_config()
+        assert backup_path is not None
+        assert os.path.exists(backup_path)
+
+        manager.save_config({"different": {"package": "other", "version": "2.0.0", "enabled": False}})
+        assert manager.load_config() != original
+
+        manager.restore_config(backup_path)
+        assert manager.load_config() == original
+
+    def test_backup_no_config(self, manager):
+        os.remove(manager.config_path) if os.path.exists(manager.config_path) else None
+        result = manager.backup_config()
+        assert result is None

--- a/test/unit/webapps/api/test_admin_visualizations_service.py
+++ b/test/unit/webapps/api/test_admin_visualizations_service.py
@@ -1,0 +1,62 @@
+import json
+import os
+import shutil
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from galaxy.webapps.galaxy.services.admin_visualizations import AdminVisualizationsService
+from galaxy.managers.visualization_admin import VisualizationPackageManager
+
+
+def _write_package(package_dir: str, package_name: str, version: str) -> None:
+    shutil.rmtree(package_dir, ignore_errors=True)
+    static_dir = os.path.join(package_dir, "static")
+    os.makedirs(static_dir, exist_ok=True)
+    with open(os.path.join(package_dir, "package.json"), "w") as f:
+        json.dump({"name": package_name, "version": version}, f)
+    plugin_name = os.path.basename(package_dir)
+    with open(os.path.join(static_dir, f"{plugin_name}.xml"), "w") as f:
+        f.write(f"<visualization name='{plugin_name}' />")
+    with open(os.path.join(static_dir, "index.html"), "w") as f:
+        f.write(version)
+
+
+@pytest.fixture()
+def service(tmp_path):
+    app = MagicMock()
+    app.config.root = str(tmp_path)
+    manager = VisualizationPackageManager(app)
+    service = AdminVisualizationsService(security=MagicMock(), app=app, package_manager=manager)
+    return service, manager
+
+
+def test_update_package_restores_previous_version_on_swap_failure(service):
+    service, manager = service
+    viz_id = "circster"
+    package_name = "@galaxyproject/circster"
+    target_dir = manager.get_package_path(viz_id)
+    _write_package(target_dir, package_name, "1.0.0")
+    manager.add_package_to_config(viz_id, package_name, "1.0.0", enabled=True)
+
+    def fake_install(package: str, version: str, destination: str):
+        _write_package(destination, package, version)
+        return {"package": package, "version": version, "size": 1}
+
+    real_move = shutil.move
+
+    def flaky_move(src: str, dst: str, *args, **kwargs):
+        if src != target_dir and dst == target_dir:
+            raise OSError("swap failed")
+        return real_move(src, dst, *args, **kwargs)
+
+    with patch.object(manager, "install_npm_package", side_effect=fake_install):
+        with patch("galaxy.webapps.galaxy.services.admin_visualizations.shutil.move", side_effect=flaky_move):
+            with pytest.raises(OSError, match="swap failed"):
+                service.update_package(MagicMock(), viz_id, "2.0.0")
+
+    with open(os.path.join(target_dir, "package.json")) as f:
+        metadata = json.load(f)
+
+    assert metadata["version"] == "1.0.0"
+    assert manager.load_config()[viz_id]["version"] == "1.0.0"

--- a/test/unit/webapps/test_admin_visualizations_service.py
+++ b/test/unit/webapps/test_admin_visualizations_service.py
@@ -5,8 +5,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from galaxy.webapps.galaxy.services.admin_visualizations import AdminVisualizationsService
 from galaxy.managers.visualization_admin import VisualizationPackageManager
+from galaxy.webapps.galaxy.services.admin_visualizations import AdminVisualizationsService
 
 
 def _write_package(package_dir: str, package_name: str, version: str) -> None:
@@ -44,9 +44,12 @@ def test_update_package_restores_previous_version_on_swap_failure(service):
         return {"package": package, "version": version, "size": 1}
 
     real_move = shutil.move
+    swap_failed = False
 
     def flaky_move(src: str, dst: str, *args, **kwargs):
-        if src != target_dir and dst == target_dir:
+        nonlocal swap_failed
+        if not swap_failed and src != target_dir and dst == target_dir:
+            swap_failed = True
             raise OSError("swap failed")
         return real_move(src, dst, *args, **kwargs)
 


### PR DESCRIPTION
Still an *early* work in progress, but this will remove the dependency on client rebuilds for visualization management by implementing a runtime admin interface. Visualizations can now be installed, updated, and managed dynamically through the web UI without requiring webpack builds or server restarts.

Key changes:
- Replace gulp-based build-time visualization bundling with runtime management
- Add admin API for dynamic package installation from npm registry
- Implement asset staging pipeline (config/plugins → static/plugins)
- Create web interface for visualization discovery and management
- Enable hot-reloading of visualization configuration

This decoupling allows administrators to manage visualization packages on live Galaxy instances, significantly improving deployment flexibility and reducing maintenance overhead.

It's also been pulled together from old branches and rebased/squashed, so it's likely a mess, but I wanted to get the gist of it up here as a WIP.  Really NOT ready for review yet, but just to illustrate the intent.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
