### PR TITLE
[25.0] Use router to route to creating a new file source

### DIFF
--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -50,6 +50,8 @@ interface FilesDialogProps {
     selectedItem?: SelectionItem;
     /** Whether the dialog is visible at the start */
     isOpen?: boolean;
+    /** Function to push a new route, used for navigation */
+    routePush?: (route: string) => void;
 }
 
 const props = withDefaults(defineProps<FilesDialogProps>(), {
@@ -61,6 +63,7 @@ const props = withDefaults(defineProps<FilesDialogProps>(), {
     requireWritable: false,
     selectedItem: undefined,
     isOpen: true,
+    routePush: () => {},
 });
 
 const { config, isConfigLoaded } = useConfig();
@@ -465,14 +468,18 @@ onMounted(() => {
             </BAlert>
         </template>
         <template v-slot:buttons>
-            <!-- TODO: Change this to a `:to` router-link button -->
             <GButton
                 v-if="fileSourceTemplatesStore.hasTemplates"
                 tooltip
                 size="small"
                 title="Create a new remote file source"
                 data-description="create new file source button"
-                href="/file_source_instances/create">
+                @click="
+                    () => {
+                        modalShow = false;
+                        props.routePush('/file_source_instances/create');
+                    }
+                ">
                 <FontAwesomeIcon :icon="faPlus" />
                 Create new
             </GButton>

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -426,6 +426,13 @@ function onOk() {
     finalize();
 }
 
+function pushToPropRouter(route: string) {
+    if (props.routePush) {
+        modalShow.value = false;
+        props.routePush(route);
+    }
+}
+
 onMounted(() => {
     load(props.selectedItem);
 });
@@ -474,12 +481,7 @@ onMounted(() => {
                 size="small"
                 title="Create a new remote file source"
                 data-description="create new file source button"
-                @click="
-                    () => {
-                        modalShow = false;
-                        props.routePush('/file_source_instances/create');
-                    }
-                ">
+                @click="pushToPropRouter('/file_source_instances/create')">
                 <FontAwesomeIcon :icon="faPlus" />
                 Create new
             </GButton>

--- a/client/src/components/Upload/DefaultBox.vue
+++ b/client/src/components/Upload/DefaultBox.vue
@@ -262,7 +262,11 @@ function eventRemoteFiles() {
                 })
             );
         },
-        { multiple: true }
+        { multiple: true },
+        (route: string) => {
+            router.push(route);
+            emit("dismiss");
+        }
     );
 }
 

--- a/client/src/utils/dataModals.js
+++ b/client/src/utils/dataModals.js
@@ -19,9 +19,10 @@ export function datasetCollectionDialog(callback, options = {}) {
     });
 }
 
-export function filesDialog(callback, options = {}) {
+export function filesDialog(callback, options = {}, routePush) {
     Object.assign(options, {
         callback: callback,
+        routePush: routePush,
     });
     mountSelectionDialog(FilesDialog, options);
 }


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20218

![firefox_3rpN1OU3sN](https://github.com/user-attachments/assets/7ab60ca4-c09c-4ac2-b036-e2bc235fd349)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
