### PR TITLE
Use GModal in Selection Dialog

### DIFF
--- a/client/src/components/DataDialog/DataDialog.test.js
+++ b/client/src/components/DataDialog/DataDialog.test.js
@@ -12,7 +12,6 @@ vi.mock("app");
 const mockOptions = {
     callback: () => {},
     history: "history",
-    modalStatic: true,
 };
 
 describe("model.js", () => {

--- a/client/src/components/DataDialog/DataDialog.vue
+++ b/client/src/components/DataDialog/DataDialog.vue
@@ -25,7 +25,6 @@ interface Props {
     filterByTypeIds?: string[];
     format?: string;
     library?: boolean;
-    modalStatic?: boolean;
     multiple?: boolean;
     title?: string;
     history: string;
@@ -38,7 +37,6 @@ const props = withDefaults(defineProps<Props>(), {
     filterByTypeIds: undefined,
     format: "download",
     library: true,
-    modalStatic: false,
     multiple: false,
     title: "",
 });

--- a/client/src/components/FilesDialog/FilesDialog.test.ts
+++ b/client/src/components/FilesDialog/FilesDialog.test.ts
@@ -120,7 +120,7 @@ const initComponent = async (props: { multiple: boolean; mode?: string }, hasTem
     const testingPinia = createTestingPinia({ createSpy: vi.fn, stubActions: false });
     const wrapper = mount(FilesDialog as object, {
         localVue,
-        propsData: { ...props, modalStatic: true },
+        propsData: { ...props },
         pinia: testingPinia,
     });
 

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -38,8 +38,6 @@ interface FilesDialogProps {
     callback?: (files: SelectionItem | SelectionItem[]) => void;
     /** Options to filter the file sources */
     filterOptions?: FilterFileSourcesOptions;
-    /** Decide wether to keep the underlying modal static or dynamic */
-    modalStatic?: boolean;
     /** Browsing mode to define the selection behavior */
     mode?: FileSourceBrowsingMode;
     /** Whether to allow multiple selections */
@@ -57,7 +55,6 @@ interface FilesDialogProps {
 const props = withDefaults(defineProps<FilesDialogProps>(), {
     callback: () => {},
     filterOptions: undefined,
-    modalStatic: false,
     mode: "file",
     multiple: false,
     requireWritable: false,
@@ -475,7 +472,6 @@ onMounted(() => {
         :items-provider="itemsProvider"
         :total-items="totalItems"
         :modal-show="modalShow"
-        :modal-static="modalStatic"
         :multiple="multiple"
         :options-show="optionsShow"
         :select-all-variant="selectAllIcon"

--- a/client/src/components/SelectionDialog/DatasetCollectionDialog.test.js
+++ b/client/src/components/SelectionDialog/DatasetCollectionDialog.test.js
@@ -14,7 +14,6 @@ const { server, http } = useServerMock();
 
 const mockOptions = {
     callback: () => {},
-    modalStatic: true,
     history: "f2db41e1fa331b3e",
 };
 

--- a/client/src/components/SelectionDialog/DatasetCollectionDialog.vue
+++ b/client/src/components/SelectionDialog/DatasetCollectionDialog.vue
@@ -19,13 +19,11 @@ interface HistoryItem {
 interface Props {
     callback?: (results: SelectionItem) => void;
     history: string;
-    modalStatic?: boolean;
     collectionTypes?: string[];
 }
 
 const props = withDefaults(defineProps<Props>(), {
     callback: () => {},
-    modalStatic: false,
 });
 
 const emit = defineEmits<{
@@ -90,7 +88,6 @@ onMounted(() => {
         :error-message="errorMessage"
         :options-show="optionsShow"
         :modal-show="modalShow"
-        :modal-static="modalStatic"
         leaf-icon="fa fa-folder"
         :items="items"
         @onCancel="onCancel"

--- a/client/src/components/SelectionDialog/SelectionDialog.test.js
+++ b/client/src/components/SelectionDialog/SelectionDialog.test.js
@@ -8,7 +8,6 @@ import SelectionDialog from "./SelectionDialog.vue";
 const mockOptions = {
     callback: () => {},
     modalShow: true,
-    modalStatic: true,
 };
 
 describe("SelectionDialog.vue", () => {

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -3,7 +3,7 @@ import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import { faCheckSquare, faMinusSquare, faSquare } from "@fortawesome/free-regular-svg-icons";
 import { faCaretLeft, faCheck, faFolder, faSpinner, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BButton, BLink, BModal, BPagination, BSpinner, BTable } from "bootstrap-vue";
+import { BAlert, BButton, BLink, BPagination, BSpinner, BTable } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
 
 import { type ItemsProvider, SELECTION_STATES, type SelectionState } from "@/components/SelectionDialog/selectionTypes";
@@ -11,8 +11,9 @@ import type Filtering from "@/utils/filtering";
 
 import type { FieldEntry, SelectionItem } from "./selectionTypes";
 
+import GModal from "../BaseComponents/GModal.vue";
+import Heading from "../Common/Heading.vue";
 import FilterMenu from "@/components/Common/FilterMenu.vue";
-import Heading from "@/components/Common/Heading.vue";
 import DataDialogSearch from "@/components/SelectionDialog/DataDialogSearch.vue";
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 
@@ -33,7 +34,6 @@ interface Props {
     leafIcon?: string;
     folderIcon?: IconDefinition;
     modalShow?: boolean;
-    modalStatic?: boolean;
     multiple?: boolean;
     optionsShow?: boolean;
     undoShow?: boolean;
@@ -60,7 +60,6 @@ const props = withDefaults(defineProps<Props>(), {
     leafIcon: "fa fa-file-o",
     folderIcon: () => faFolder,
     modalShow: true,
-    modalStatic: false,
     multiple: false,
     optionsShow: false,
     undoShow: false,
@@ -158,6 +157,17 @@ if (props.watchOnPageChanges) {
     );
 }
 
+const dialog = ref<InstanceType<typeof GModal> | null>(null);
+watch(
+    () => dialog.value,
+    (newValue) => {
+        if (newValue) {
+            dialog.value?.showModal();
+        }
+    },
+    { immediate: true },
+);
+
 defineExpose({
     resetFilter,
     resetPagination,
@@ -166,17 +176,17 @@ defineExpose({
 </script>
 
 <template>
-    <BModal
-        v-if="modalShow"
-        modal-class="selection-dialog-modal"
-        header-class="flex-column"
-        visible
-        :static="modalStatic"
-        :title="title"
-        @hide="emit('onCancel')">
-        <template v-slot:modal-header>
-            <slot name="header">
-                <Heading v-if="props.title" h2> {{ props.title }} </Heading>
+    <GModal
+        ref="dialog"
+        class="selection-dialog-modal"
+        size="medium"
+        :show="props.modalShow"
+        fixed-height
+        footer
+        @close="emit('onCancel')">
+        <template v-slot:header>
+            <div class="d-flex flex-column">
+                <Heading v-if="props.title" size="sm"> {{ props.title }} </Heading>
 
                 <FilterMenu
                     v-if="props.filterClass"
@@ -189,7 +199,7 @@ defineExpose({
                     :show-advanced.sync="showAdvancedSearch" />
 
                 <DataDialogSearch v-else v-model="filter" :title="props.searchTitle || props.title" />
-            </slot>
+            </div>
         </template>
         <slot name="helper" />
         <BAlert v-if="errorMessage" variant="danger" show>
@@ -269,7 +279,7 @@ defineExpose({
                 <span>Please wait...</span>
             </div>
         </div>
-        <template v-slot:modal-footer>
+        <template v-slot:footer>
             <div class="d-flex justify-content-between w-100">
                 <div>
                     <BButton v-if="undoShow" data-description="selection dialog undo" size="sm" @click="emit('onUndo')">
@@ -307,13 +317,5 @@ defineExpose({
                 </div>
             </div>
         </template>
-    </BModal>
+    </GModal>
 </template>
-
-<style>
-.selection-dialog-modal .modal-body {
-    max-height: 50vh;
-    height: 50vh;
-    overflow-y: auto;
-}
-</style>


### PR DESCRIPTION
Replaces the existing `BModal` with the new `GModal` base component.

One of the modals being converted in https://github.com/galaxyproject/galaxy/issues/21976

https://github.com/user-attachments/assets/18ef3cec-ddf8-4448-b3ab-7f4803f99bb7

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
