### PR TITLE
[25.0] Fix radio button options in CopyModal

### DIFF
--- a/client/src/components/History/Modals/CopyModal.vue
+++ b/client/src/components/History/Modals/CopyModal.vue
@@ -6,7 +6,7 @@ import {
     BFormGroup,
     BFormInput,
     BFormInvalidFeedback,
-    BFormRadio,
+    BFormRadioGroup,
     BModal,
     BSpinner,
 } from "bootstrap-vue";
@@ -40,6 +40,11 @@ const name = ref("");
 const copyAll = ref(false);
 const loading = ref(false);
 const localShowModal = ref(props.showModal);
+
+const datasetCopyOptions = [
+    { text: "Copy only the active, non-deleted datasets.", value: false },
+    { text: "Copy all datasets including deleted ones.", value: true },
+];
 
 const title = computed(() => {
     return `Copying History: ${props.history.name}`;
@@ -119,9 +124,11 @@ async function copy(close: () => void) {
                 </BFormGroup>
 
                 <BFormGroup label="Choose which datasets from the original history to include.">
-                    <BFormRadio v-model="copyAll"> Copy only the active, non-deleted datasets. </BFormRadio>
-
-                    <BFormRadio v-model="copyAll"> Copy all datasets including deleted ones. </BFormRadio>
+                    <BFormRadioGroup
+                        v-model="copyAll"
+                        :options="datasetCopyOptions"
+                        name="copy-datasets-options"
+                        stacked />
                 </BFormGroup>
             </BForm>
         </transition>


### PR DESCRIPTION
Fixing the vue-tsc error in https://github.com/galaxyproject/galaxy/pull/20163/commits/e822703458c81924d42cf577d5967f192b4c479f caused this issue because the "value" must be specified for each BFormRadio to be set on the v-model.

This alternative, using a BFormRadioGroup, should fix the issue and avoid the vue-tsc error.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
