### PR TITLE
[25.0] Fix conda_link to use platform.machine() for architecture detection

### DIFF
--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -54,13 +54,14 @@ USE_LOCAL_DEFAULT = False
 
 
 def conda_link() -> str:
+    arch = platform.machine()
     if IS_OS_X:
-        if "arm64" in platform.platform():
+        if "arm64" in arch:
             url = "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh"
         else:
             url = "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh"
     else:
-        if "arm64" in platform.platform():
+        if "arm64" in arch or "aarch64" in arch:
             url = "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh"
         else:
             url = "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh"


### PR DESCRIPTION
Fixed a bug when installing the Conda environment on ARM64 platforms. The original code relied on matching "arm64" within the string returned by `platform.platform()`. However, ARM64 Linux instances can also return `aarch64` as the architecture, making the relevant functions download the x86 version of Conda instead.
To make the code more robust, I changed the usage of `platform.platform()` to `platform.machine()` as the output is more reliable when comparing architecture strings.

Relevant error traceback (on an Ubuntu 22.04 ARM64 virtual machine):
```
galaxy.tool_util.deps.conda_util INFO 2025-05-30 16:44:59,643 [pN:MainProcess,p:3352,tN:MainThread] Installing conda, this may take several minutes.
PREFIX=/home/cgrams/galaxy/database/dependencies/_conda
Unpacking payload ...
/tmp/conda_installnmn2xwtp.sh: line 391: /home/cgrams/galaxy/database/dependencies/_conda/_conda: cannot execute binary file: Exec format error
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- `test/unit/tool_util/test_conda_resolution.py`
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
