### PR TITLE
Use full page width in reports and pages

### DIFF
--- a/client/src/components/Common/PublishedItem.vue
+++ b/client/src/components/Common/PublishedItem.vue
@@ -55,7 +55,7 @@ const urlAll = computed(() => `/${pluralPath.value}/list_published`);
     <div id="columns" class="d-flex">
         <ActivityBar />
 
-        <div id="center" class="m-3 w-100 overflow-auto d-flex flex-column">
+        <div id="center" class="my-3 px-3 w-100 overflow-auto d-flex flex-column">
             <slot />
         </div>
 

--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -84,7 +84,7 @@ onMounted(() => {
 </script>
 
 <template>
-    <div class="markdown-wrapper">
+    <div class="markdown-wrapper px-2">
         <LoadingSpan v-if="loading" />
         <div v-else class="d-flex flex-column">
             <div class="d-flex flex-column sticky-top bg-white">
@@ -117,7 +117,7 @@ onMounted(() => {
                     </div>
                 </div>
             </div>
-            <div class="flex-grow-1 w-75 mx-auto">
+            <div class="flex-grow-1 w-100 mx-auto position-relative">
                 <b-alert v-if="markdownErrors.length > 0" variant="warning" show>
                     <div v-for="(obj, index) in markdownErrors" :key="index" class="mb-1">
                         <h2 class="h-text">{{ obj.error || "Error" }}</h2>
@@ -127,6 +127,7 @@ onMounted(() => {
                 <div v-for="(obj, index) in markdownObjects" :key="index" class="markdown-component py-2">
                     <SectionWrapper :name="obj.name" :content="obj.content" />
                 </div>
+                <div class="markdown-scroll-overlay" />
             </div>
             <div class="d-flex justify-content-between p-1">
                 <small v-if="updateTime" class="text-break">Last updated on {{ updateTime }}</small>
@@ -135,3 +136,14 @@ onMounted(() => {
         </div>
     </div>
 </template>
+
+<style scoped>
+.markdown-scroll-overlay {
+    background: transparent;
+    height: 100%;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 0.5rem;
+}
+</style>


### PR DESCRIPTION
This PR increases the page/report width from 75 to 100%.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
