### PR TITLE
[25.0] Fix create file source button, show only at root

### DIFF
--- a/client/src/components/FilesDialog/FilesDialog.test.ts
+++ b/client/src/components/FilesDialog/FilesDialog.test.ts
@@ -256,8 +256,32 @@ describe("FilesDialog, file mode", () => {
         await utils.navigateBack();
         expect(utils.getRenderedRows().length).toBe(rootResponse.length);
     });
+});
 
+describe("FilesDialog, create new file source button", () => {
+    let wrapper: Wrapper<any>;
+    let utils: Utils;
+
+    beforeEach(async () => {
+        const hasTemplates = true;
+        wrapper = await initComponent({ multiple: false }, hasTemplates);
+        utils = new Utils(wrapper);
+    });
     it("should not render create new button since file source templates are not defined", async () => {
+        const hasTemplates = false;
+        wrapper = await initComponent({ multiple: true }, hasTemplates);
+        const createNewButton = wrapper.find("[data-description='create new file source button']");
+        expect(createNewButton.exists()).toBe(false);
+    });
+
+    it("should render create new button since file source templates are defined and is at root", async () => {
+        await utils.openRoot();
+        const createNewButton = wrapper.find("[data-description='create new file source button']");
+        expect(createNewButton.exists()).toBe(true);
+    });
+
+    it("should not render create new button inside folders", async () => {
+        await utils.openRootDirectory();
         const createNewButton = wrapper.find("[data-description='create new file source button']");
         expect(createNewButton.exists()).toBe(false);
     });

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -107,6 +107,10 @@ const okButtonDisabled = computed(
     () => (fileMode.value && !hasValue.value) || isBusy.value || (!fileMode.value && urlTracker.value.atRoot())
 );
 
+const canCreateNewFileSource = computed(() => {
+    return urlTracker.value.atRoot() && fileSourceTemplatesStore.hasTemplates;
+});
+
 const fileSourceTemplatesStore = useFileSourceTemplatesStore();
 fileSourceTemplatesStore.ensureTemplates();
 
@@ -476,7 +480,7 @@ onMounted(() => {
         </template>
         <template v-slot:buttons>
             <GButton
-                v-if="fileSourceTemplatesStore.hasTemplates"
+                v-if="canCreateNewFileSource"
                 tooltip
                 size="small"
                 title="Create a new remote file source"


### PR DESCRIPTION
Fixes #20379

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
