### PR TITLE
Restore Nora

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -51,6 +51,9 @@ ngl:
 niivue:
     package: "@galaxyproject/niivue"
     version: 0.0.17
+nora:
+    package: "@galaxyproject/nora"
+    version: 1.2.1
 openlayers:
     package: "@galaxyproject/openlayers"
     version: 0.0.6


### PR DESCRIPTION
Requires #20303. Resolves #19205. Fixes and adds Nora back to the list of visualizations.

<img width="1190" alt="image" src="https://github.com/user-attachments/assets/28df696b-bb77-4666-a99d-ae71ff89e35e" />


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
