### PR TITLE
[25.0] Force Monaco into a separate bundle

### DIFF
--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -89,7 +89,6 @@ import ManageObjectStoreIndex from "@/components/ObjectStore/Instances/ManageInd
 import UpgradeObjectStoreInstance from "@/components/ObjectStore/Instances/UpgradeInstance.vue";
 import CreateUserObjectStore from "@/components/ObjectStore/Templates/CreateUserObjectStore.vue";
 import Sharing from "@/components/Sharing/SharingPage.vue";
-import CustomToolEditor from "@/components/Tool/CustomToolEditor.vue";
 import HistoryStorageOverview from "@/components/User/DiskUsage/Visualizations/HistoryStorageOverview.vue";
 import UserDatasetPermissions from "@/components/User/UserDatasetPermissions.vue";
 import WorkflowPublished from "@/components/Workflow/Published/WorkflowPublished.vue";
@@ -458,12 +457,12 @@ export function getRouter(Galaxy) {
                     },
                     {
                         path: "/tools/editor",
-                        component: CustomToolEditor,
+                        component: () => import("@/components/Tool/CustomToolEditor.vue"),
                         redirect: redirectAnon(),
                     },
                     {
                         path: "/tools/editor/:toolUuid",
-                        component: CustomToolEditor,
+                        component: () => import("@/components/Tool/CustomToolEditor.vue"),
                         redirect: redirectAnon(),
                         props: true,
                     },

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -89,6 +89,7 @@ import ManageObjectStoreIndex from "@/components/ObjectStore/Instances/ManageInd
 import UpgradeObjectStoreInstance from "@/components/ObjectStore/Instances/UpgradeInstance.vue";
 import CreateUserObjectStore from "@/components/ObjectStore/Templates/CreateUserObjectStore.vue";
 import Sharing from "@/components/Sharing/SharingPage.vue";
+// import CustomToolEditor from "@/components/Tool/CustomToolEditor.vue";
 import HistoryStorageOverview from "@/components/User/DiskUsage/Visualizations/HistoryStorageOverview.vue";
 import UserDatasetPermissions from "@/components/User/UserDatasetPermissions.vue";
 import WorkflowPublished from "@/components/Workflow/Published/WorkflowPublished.vue";
@@ -97,6 +98,19 @@ import WorkflowRun from "@/components/Workflow/Run/WorkflowRun.vue";
 import WorkflowInvocationState from "@/components/WorkflowInvocationState/WorkflowInvocationState.vue";
 
 Vue.use(VueRouter);
+
+// Async component for CustomToolEditor to reduce bundle size
+const CustomToolEditor = () => ({
+    component: import("@/components/Tool/CustomToolEditor.vue"),
+    loading: {
+        template: '<div class="text-center"><i class="fa fa-spinner fa-spin"></i> Loading Tool Editor...</div>'
+    },
+    error: {
+        template: '<div class="alert alert-danger">Failed to load Tool Editor</div>'
+    },
+    delay: 200,
+    timeout: 10000
+});
 
 // patches $router.push() to trigger an event and hide duplication warnings
 patchRouterPush(VueRouter);
@@ -457,12 +471,12 @@ export function getRouter(Galaxy) {
                     },
                     {
                         path: "/tools/editor",
-                        component: () => import("@/components/Tool/CustomToolEditor.vue"),
+                        component: CustomToolEditor,
                         redirect: redirectAnon(),
                     },
                     {
                         path: "/tools/editor/:toolUuid",
-                        component: () => import("@/components/Tool/CustomToolEditor.vue"),
+                        component: CustomToolEditor,
                         redirect: redirectAnon(),
                         props: true,
                     },

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -89,7 +89,6 @@ import ManageObjectStoreIndex from "@/components/ObjectStore/Instances/ManageInd
 import UpgradeObjectStoreInstance from "@/components/ObjectStore/Instances/UpgradeInstance.vue";
 import CreateUserObjectStore from "@/components/ObjectStore/Templates/CreateUserObjectStore.vue";
 import Sharing from "@/components/Sharing/SharingPage.vue";
-// import CustomToolEditor from "@/components/Tool/CustomToolEditor.vue";
 import HistoryStorageOverview from "@/components/User/DiskUsage/Visualizations/HistoryStorageOverview.vue";
 import UserDatasetPermissions from "@/components/User/UserDatasetPermissions.vue";
 import WorkflowPublished from "@/components/Workflow/Published/WorkflowPublished.vue";
@@ -100,16 +99,18 @@ import WorkflowInvocationState from "@/components/WorkflowInvocationState/Workfl
 Vue.use(VueRouter);
 
 // Async component for CustomToolEditor to reduce bundle size
+// NOTE: We use the full async component factory pattern instead of simple dynamic imports
+// (i.e., `() => import("@/components/Tool/CustomToolEditor.vue")`) due to what I think are router limitations.  Revisit with vr-4
 const CustomToolEditor = () => ({
     component: import("@/components/Tool/CustomToolEditor.vue"),
     loading: {
-        template: '<div class="text-center"><i class="fa fa-spinner fa-spin"></i> Loading Tool Editor...</div>'
+        template: '<div class="text-center"><i class="fa fa-spinner fa-spin"></i> Loading Tool Editor...</div>',
     },
     error: {
-        template: '<div class="alert alert-danger">Failed to load Tool Editor</div>'
+        template: '<div class="alert alert-danger">Failed to load Tool Editor</div>',
     },
     delay: 200,
-    timeout: 10000
+    timeout: 10000,
 });
 
 // patches $router.push() to trigger an event and hide duplication warnings

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -105,8 +105,8 @@ module.exports = (env = {}, argv = {}) => {
                     },
                     monaco: {
                         test: /[\\/]node_modules[\\/]monaco-editor[\\/]/,
-                        name: 'monaco',
-                        chunks: 'all',
+                        name: "monaco",
+                        chunks: "all",
                         enforce: true,
                     },
                 },

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -30,6 +30,7 @@ const modulesExcludedFromLibs = [
     "vega-embed",
     "vega-lite",
     "ace-builds",
+    "schema-to-ts",
 ].join("|");
 
 const buildDate = new Date();
@@ -101,6 +102,12 @@ module.exports = (env = {}, argv = {}) => {
                         test: new RegExp(`node_modules[\\/](?!(${modulesExcludedFromLibs})[\\/])|galaxy/scripts/libs`),
                         chunks: "all",
                         priority: -10,
+                    },
+                    monaco: {
+                        test: /[\\/]node_modules[\\/]monaco-editor[\\/]/,
+                        name: 'monaco',
+                        chunks: 'all',
+                        enforce: true,
                     },
                 },
             },


### PR DESCRIPTION
We use a little (temporary, but functional) async loader component around the CustomToolEditor to accomplish this.

This should close https://github.com/galaxyproject/galaxy/issues/20310

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
