### PR TITLE
[25.0] Prevent waiting for history item state to be ok in uploader

### DIFF
--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -129,18 +129,18 @@ function _elementsSetUp() {
     const inListElementsPrev = inListElements.value;
     inListElements.value = [];
     inListElementsPrev.forEach((prevElem) => {
-        const element = workingElements.value.find((e) => e.id === prevElem.id);
-        const problem = isElementInvalid(prevElem);
+        const matchingElem = workingElements.value.find((e) => e.id === prevElem.id);
 
-        if (element) {
-            inListElements.value.push(element);
-        } else if (problem) {
-            const invalidMsg = `${prevElem.hid}: ${prevElem.name} ${problem} and ${NOT_VALID_ELEMENT_MSG}`;
-            invalidElements.value.push(invalidMsg);
-            Toast.error(invalidMsg, localize("Invalid element"));
+        if (matchingElem) {
+            const problem = isElementInvalid(matchingElem);
+            if (problem) {
+                const invalidMsg = `${prevElem.hid}: ${prevElem.name} ${problem} and ${NOT_VALID_ELEMENT_MSG}`;
+                Toast.error(invalidMsg, localize("Invalid element"));
+            } else {
+                inListElements.value.push(matchingElem);
+            }
         } else {
             const invalidMsg = `${prevElem.hid}: ${prevElem.name} ${localize("has been removed from the collection")}`;
-            invalidElements.value.push(invalidMsg);
             Toast.error(invalidMsg, localize("Invalid element"));
         }
     });

--- a/client/src/components/Collections/PairCollectionCreator.vue
+++ b/client/src/components/Collections/PairCollectionCreator.vue
@@ -150,19 +150,19 @@ function _elementsSetUp() {
         if (!prevElem) {
             continue;
         }
-        const element = workingElements.value.find(
+        const matchingElem = workingElements.value.find(
             (e) => e.id === inListElementsPrev[key as keyof SelectedDatasetPair]?.id
         );
-        const problem = isElementInvalid(prevElem);
-        if (element) {
-            inListElements.value[key as keyof SelectedDatasetPair] = element;
-        } else if (problem) {
-            const invalidMsg = `${prevElem.hid}: ${prevElem.name} ${problem} and ${NOT_VALID_ELEMENT_MSG}`;
-            invalidElements.value.push(invalidMsg);
-            Toast.error(invalidMsg, localize("Invalid element"));
+        if (matchingElem) {
+            const problem = isElementInvalid(matchingElem);
+            if (problem) {
+                const invalidMsg = `${prevElem.hid}: ${prevElem.name} ${problem} and ${NOT_VALID_ELEMENT_MSG}`;
+                Toast.error(invalidMsg, localize("Invalid element"));
+            } else {
+                inListElements.value[key as keyof SelectedDatasetPair] = matchingElem;
+            }
         } else {
             const invalidMsg = `${prevElem.hid}: ${prevElem.name} ${localize("has been removed from the collection")}`;
-            invalidElements.value.push(invalidMsg);
             Toast.error(invalidMsg, localize("Invalid element"));
         }
     }

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faPlus, faUpload } from "@fortawesome/free-solid-svg-icons";
+import { faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BTab, BTabs } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
@@ -221,10 +221,6 @@ watch(
                     @dismiss="currentTab = Tabs.create">
                     <template v-slot:footer>
                         <CollectionCreatorShowExtensions :extensions="extensions" upload />
-                    </template>
-                    <template v-slot:emit-btn-txt>
-                        <FontAwesomeIcon :icon="faPlus" fixed-width />
-                        {{ localize("Add Uploaded") }}
                     </template>
                 </DefaultBox>
             </BTab>

--- a/client/src/components/Collections/common/useCollectionCreator.ts
+++ b/client/src/components/Collections/common/useCollectionCreator.ts
@@ -12,6 +12,12 @@ import { useExtensionFiltering } from "./useExtensionFilter";
 
 export type Mode = "modal" | "wizard";
 
+/** Terminal states that are not usable from an upload (anything but `ok` or `deferred`)
+ */
+const UNUSABLE_FROM_UPLOAD_STATES = Object.values(STATES.READY_STATES).filter(
+    (state) => state !== STATES.OK && state !== STATES.DEFERRED
+);
+
 interface CommonCollectionBuilderProps {
     extensions?: string[];
     defaultHideSourceItems?: boolean;
@@ -96,9 +102,7 @@ export function useCollectionCreator(props: CommonCollectionBuilderProps, emit?:
             return localize("is a collection, this is not allowed");
         }
 
-        const validState = STATES.VALID_INPUT_STATES.includes(element.state as string);
-
-        if (!validState) {
+        if (UNUSABLE_FROM_UPLOAD_STATES.includes(element.state)) {
             return localize("has errored, is paused, or is not accessible");
         }
 

--- a/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
+++ b/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { faFolder } from "@fortawesome/free-regular-svg-icons";
-import { faEye, faPlus, faSpinner, faUpload } from "@fortawesome/free-solid-svg-icons";
+import { faEye, faPlus, faSpinner, faTimes, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton, BButtonGroup, BDropdown, BDropdownItem } from "bootstrap-vue";
 import { computed } from "vue";
@@ -119,22 +119,32 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
         </BButton>
         <!-- three options here - source is a collection that has multiple builders exposed, source is a collection
              that has a single builder exposed, or source is dataset(s). -->
-        <BDropdown
-            v-if="props.showViewCreateOptions && sourceIsCollection && !hasSingleAvailableCollectionBuilderType"
-            v-b-tooltip.bottom.hover.noninteractive
-            class="d-flex"
-            data-description="upload"
-            :title="createTitle"
-            split
-            text="Create"
-            @click="createCollectionType(defaultCollectionBuilderType)">
-            <BDropdownItem
-                v-for="colType in availableCollectionBuilders"
-                :key="colType"
-                @click="createCollectionType(colType)">
-                {{ capitalizeFirstLetter(COLLECTION_TYPE_TO_LABEL[colType] || "collection") }}
-            </BDropdownItem>
-        </BDropdown>
+        <template v-if="props.showViewCreateOptions && sourceIsCollection && !hasSingleAvailableCollectionBuilderType">
+            <BDropdown
+                v-b-tooltip.bottom.hover.noninteractive
+                class="d-flex"
+                data-description="upload"
+                :title="createTitle"
+                split
+                text="Create"
+                @click="createCollectionType(defaultCollectionBuilderType)">
+                <BDropdownItem
+                    v-for="colType in availableCollectionBuilders"
+                    :key="colType"
+                    @click="createCollectionType(colType)">
+                    {{ capitalizeFirstLetter(COLLECTION_TYPE_TO_LABEL[colType] || "collection") }}
+                </BDropdownItem>
+            </BDropdown>
+            <BButton
+                v-if="props.workflowTab === 'create'"
+                v-b-tooltip.bottom.hover.noninteractive
+                title="Hide Collection Creator"
+                variant="link"
+                @click="emit('update:workflow-tab', '')">
+                <FontAwesomeIcon :icon="faTimes" />
+                <span class="sr-only">Close Collection Creator</span>
+            </BButton>
+        </template>
         <BButton
             v-else-if="props.showViewCreateOptions && sourceIsCollection"
             v-b-tooltip.bottom.hover.noninteractive

--- a/client/src/components/Upload/DefaultBox.vue
+++ b/client/src/components/Upload/DefaultBox.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { faCopy, faEdit, faFolderOpen, faLaptop, faSpinner } from "@fortawesome/free-solid-svg-icons";
+import { faCopy, faEdit, faFolderOpen, faLaptop } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert } from "bootstrap-vue";
 import Vue, { computed, type Ref, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
@@ -23,7 +22,6 @@ import UploadBox from "./UploadBox.vue";
 import UploadSelect from "./UploadSelect.vue";
 import UploadSelectExtension from "./UploadSelectExtension.vue";
 import CollectionCreatorIndex from "@/components/Collections/CollectionCreatorIndex.vue";
-import LoadingSpan from "@/components/LoadingSpan.vue";
 
 const router = useRouter();
 
@@ -379,12 +377,6 @@ defineExpose({
 <template>
     <div class="upload-wrapper">
         <div class="upload-header">
-            <div v-if="props.emitUploaded && historyItemsStateInfo">
-                <BAlert show :variant="historyItemsStateInfo.variant" data-description="upload state alert">
-                    <LoadingSpan v-if="historyItemsStateInfo.spin" :message="historyItemsStateInfo.message" />
-                    <span v-else>{{ historyItemsStateInfo.message }}</span>
-                </BAlert>
-            </div>
             <div v-if="queueStopping" v-localize>Queue will pause after completing the current file...</div>
             <div v-else-if="counterAnnounce === 0">
                 <div v-if="!!hasBrowserSupport">&nbsp;</div>
@@ -526,14 +518,20 @@ defineExpose({
                 id="btn-emit"
                 :size="size"
                 :disabled="!enableBuild"
-                title="Use Uploaded Files"
-                :variant="enableBuild ? 'primary' : null"
+                :tooltip="Boolean(historyItemsStateInfo?.message)"
+                :disabled-title="historyItemsStateInfo?.message || 'Upload Valid Files to Use'"
+                :title="historyItemsStateInfo?.message || 'Use Uploaded Files'"
+                :color="historyItemsStateInfo?.color ? historyItemsStateInfo.color : undefined"
                 @click="() => eventBuild(false)">
-                <FontAwesomeIcon v-if="!uploadedHistoryItemsReady" :icon="faSpinner" spin />
-                <slot name="emit-btn-txt">
-                    <span v-localize>Use Uploaded</span>
-                </slot>
-                ({{ counterSuccess }})
+                <FontAwesomeIcon
+                    v-if="historyItemsStateInfo?.icon"
+                    :icon="historyItemsStateInfo.icon"
+                    :spin="historyItemsStateInfo.spin" />
+                <span v-localize>Use Uploaded</span>
+                <span v-if="uploadedHistoryItemsOk.length < counterSuccess">
+                    ({{ uploadedHistoryItemsOk.length }}/{{ counterSuccess }})
+                </span>
+                <span v-else> ({{ counterSuccess }}) </span>
             </GButton>
             <GButton id="btn-stop" :size="size" title="Pause" :disabled="!isRunning" @click="eventStop">
                 <span v-localize>Pause</span>

--- a/client/src/composables/monitorUploadedHistoryItems.ts
+++ b/client/src/composables/monitorUploadedHistoryItems.ts
@@ -4,10 +4,16 @@ import { computed, type Ref } from "vue";
 import { type HDASummary, type HistoryItemSummary, isHDA } from "@/api";
 import type { ComponentColor } from "@/components/BaseComponents/componentVariants";
 import type { UploadItem } from "@/components/Upload/model";
+import STATES from "@/mvc/dataset/states";
 import { useHistoryItemsStore } from "@/stores/historyItemsStore";
-import { stateIsTerminal } from "@/utils/utils";
 
 const REFER_TO_HISTORY_MSG = "Refer to the history panel to view dataset state.";
+
+/** Terminal states that are not usable from an upload (anything but `ok` or `deferred`)
+ */
+const UNUSABLE_FROM_UPLOAD_STATES = Object.values(STATES.READY_STATES).filter(
+    (state) => state !== STATES.OK && state !== STATES.DEFERRED
+);
 
 /**
  * For given uploaded items, monitor the states of those items from the history.
@@ -47,39 +53,45 @@ export function monitorUploadedHistoryItems(
     });
 
     const uploadedHistoryItemsReady = computed(() =>
-        uploadedHistoryItems.value.every((item) => item && stateIsTerminal(item))
+        uploadedHistoryItems.value.every((item) => item && item.extension !== "auto")
     );
 
+    // TODO: Could be refactored to use `useCollectionCreator.isElementInvalid()` instead? (with the added `auto` check)
     const uploadedHistoryItemsOk = computed(() =>
-        uploadedHistoryItems.value.filter((item) => item && item.state === "ok")
+        uploadedHistoryItems.value.filter(
+            (item) => item && !UNUSABLE_FROM_UPLOAD_STATES.includes(item.state) && item.extension !== "auto"
+        )
     );
 
     const historyItemsStateInfo = computed<{
-        variant: string;
         color?: ComponentColor;
         message: string;
         icon?: IconDefinition;
         spin?: boolean;
     } | null>(() => {
-        if (uploadedHistoryItems.value?.length && !enableStart.value) {
-            if (!uploadedHistoryItemsReady.value) {
+        if (!enableStart.value && uploadValues.value.length) {
+            if (!uploadedHistoryItems.value?.length) {
                 return {
-                    variant: "info",
                     color: "blue",
-                    message: `Your upload(s) are not ready to be used yet. ${REFER_TO_HISTORY_MSG}`,
+                    message: `Dataset(s) not uploaded yet. ${REFER_TO_HISTORY_MSG}`,
+                    icon: faSpinner,
+                    spin: true,
+                };
+            } else if (!uploadedHistoryItemsReady.value) {
+                return {
+                    color: "blue",
+                    message: `Waiting for upload(s) to have valid extension(s). ${REFER_TO_HISTORY_MSG}`,
                     icon: faSpinner,
                     spin: true,
                 };
             } else if (uploadedHistoryItems.value.length > uploadedHistoryItemsOk.value.length) {
                 return {
-                    variant: "warning",
                     color: "orange",
                     message: `Only ${uploadedHistoryItemsOk.value.length} / ${uploadedHistoryItems.value.length} uploaded items are usable. ${REFER_TO_HISTORY_MSG}`,
                     icon: faExclamation,
                 };
             } else if (creatingPairedType.value && uploadedHistoryItemsOk.value.length % 2 !== 0) {
                 return {
-                    variant: "danger",
                     color: "red",
                     message:
                         "Please upload an even number of datasets to create a dataset pair or a list of dataset pairs.",
@@ -87,7 +99,6 @@ export function monitorUploadedHistoryItems(
                 };
             } else if (uploadedHistoryItemsOk.value.length) {
                 return {
-                    variant: "success",
                     color: "blue", // Not "green" because this is for a `GButton`, that is ready
                     message: "Upload(s) ready to be used.",
                 };

--- a/client/src/mvc/dataset/states.ts
+++ b/client/src/mvc/dataset/states.ts
@@ -55,9 +55,6 @@ const STATES = {
         RAW_STATES.SETTING_METADATA,
         RAW_STATES.NEW,
     ],
-    VALID_INPUT_STATES: Object.values(RAW_STATES).filter(
-        (state) => ![RAW_STATES.ERROR, RAW_STATES.DISCARDED, RAW_STATES.FAILED_METADATA].includes(state)
-    ),
 };
 
 //==============================================================================

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -712,6 +712,7 @@ upload_mixin:
     row: '${_} #upload-row-${n}'
     embedded_start_button: '${_} #btn-start'
     use_button: '${_} #btn-emit'
+    use_button_disabled: '${_} #btn-emit.g-disabled'
 
 workflow_run:
   input:

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -710,7 +710,6 @@ upload_mixin:
     paste_content: '${_} #upload-row-${n} .upload-text-content'
     title: '${_} #upload-row-${n} .upload-title'
     row: '${_} #upload-row-${n}'
-    status: '${_} [data-description="upload state alert"]'
     embedded_start_button: '${_} #btn-start'
     use_button: '${_} #btn-emit'
 

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -583,7 +583,6 @@ steps: {}
             workflow_input.title(n=i).wait_for_and_clear_and_send_keys(f"hello world.{i + 1}.fastq")
 
         workflow_input.embedded_start_button.wait_for_and_click()
-        workflow_input.status.wait_for_present()
         for i in range(from_hid, from_hid + count):
             self.history_panel_wait_for_hid_ok(i)
         workflow_input.use_button.wait_for_and_click()

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -523,7 +523,6 @@ steps: {}
         input.collection_tab_upload_link.wait_for_and_click()
         builder = workflow_run.input.collection_builder._(label="input1")
         self._upload_hello_world_for_input(builder, count=2)
-        input.collection_tab_build_link.wait_for_and_click()
         builder.create.wait_for_and_click()
         self.workflow_run_submit()
         self.history_panel_wait_for_hid_ok(6)
@@ -539,7 +538,6 @@ steps: {}
         input.collection_tab_upload_link.wait_for_and_click()
         builder = workflow_run.input.collection_builder._(label="input_list")
         self._upload_hello_world_for_input(builder, count=2)
-        input.collection_tab_build_link.wait_for_and_click()
         builder.create.wait_for_and_click()
         self.workflow_run_submit()
         self.history_panel_wait_for_hid_ok(6)
@@ -583,6 +581,7 @@ steps: {}
             workflow_input.title(n=i).wait_for_and_clear_and_send_keys(f"hello world.{i + 1}.fastq")
 
         workflow_input.embedded_start_button.wait_for_and_click()
+        workflow_input.use_button_disabled.wait_for_absent()
         workflow_input.use_button.wait_for_and_click()
 
     def _create_and_run_workflow_with_unique_name(

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -583,8 +583,6 @@ steps: {}
             workflow_input.title(n=i).wait_for_and_clear_and_send_keys(f"hello world.{i + 1}.fastq")
 
         workflow_input.embedded_start_button.wait_for_and_click()
-        for i in range(from_hid, from_hid + count):
-            self.history_panel_wait_for_hid_ok(i)
         workflow_input.use_button.wait_for_and_click()
 
     def _create_and_run_workflow_with_unique_name(


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20241 _(discussion on the issue describes the reasoning here as well)_

We now wait for the extension to change from `auto` and prevent an item from being used if it gets a terminal state other than `ok` and `deferred`.

https://github.com/user-attachments/assets/71bbfc28-f572-44b0-9cb8-3d761608f96a

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
