### PR TITLE
History CitationsList export improvements

### DIFF
--- a/client/src/components/Citation/CitationsList.vue
+++ b/client/src/components/Citation/CitationsList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faCopy } from "@fortawesome/free-solid-svg-icons";
+import { faCopy, faDownload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton, BCard, BCollapse, BNav, BNavItem } from "bootstrap-vue";
 import { onMounted, onUpdated, ref } from "vue";
@@ -13,7 +13,7 @@ import type { Citation } from ".";
 
 import CitationItem from "@/components/Citation/CitationItem.vue";
 
-library.add(faCopy);
+library.add(faCopy, faDownload);
 
 const outputFormats = Object.freeze({
     CITATION: "bibliography",
@@ -77,6 +77,29 @@ function copyAPA() {
     });
     copy(text, "References copied to your clipboard as APA");
 }
+
+function downloadBibtex() {
+    let text = "";
+    citations.value.forEach((citation) => {
+        const cite = citation.cite;
+        const bibtex = cite.format("bibtex", {
+            format: "text",
+            template: "bibtex",
+            lang: "en-US",
+        });
+        text += bibtex;
+    });
+
+    const blob = new Blob([text], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "citations.bib";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}
 </script>
 
 <template>
@@ -106,16 +129,26 @@ function copyAPA() {
                     @click="copyAPA">
                     <FontAwesomeIcon icon="copy" />
                 </BButton>
-                <BButton
-                    v-if="outputFormat === outputFormats.BIBTEX"
-                    v-b-tooltip.hover
-                    title="Copy all references as BibTeX"
-                    variant="link"
-                    size="sm"
-                    class="copy-bibtex-btn"
-                    @click="copyBibtex">
-                    <FontAwesomeIcon icon="copy" />
-                </BButton>
+                <div v-if="outputFormat === outputFormats.BIBTEX" class="bibtex-actions">
+                    <BButton
+                        v-b-tooltip.hover
+                        title="Copy all references as BibTeX"
+                        variant="link"
+                        size="sm"
+                        class="copy-bibtex-btn"
+                        @click="copyBibtex">
+                        <FontAwesomeIcon icon="copy" />
+                    </BButton>
+                    <BButton
+                        v-b-tooltip.hover
+                        title="Download references as .bib file"
+                        variant="link"
+                        size="sm"
+                        class="download-bibtex-btn"
+                        @click="downloadBibtex">
+                        <FontAwesomeIcon icon="download" />
+                    </BButton>
+                </div>
             </template>
 
             <div v-if="source === 'histories'" class="infomessage">
@@ -166,9 +199,17 @@ function copyAPA() {
 .formatted-reference {
     margin-bottom: 0.5rem;
 }
-.copy-citation-btn,
-.copy-bibtex-btn {
+.copy-citation-btn {
     margin-left: auto;
+    padding: 0.25rem 0.5rem;
+}
+.bibtex-actions {
+    margin-left: auto;
+    display: flex;
+    gap: 0.25rem;
+}
+.copy-bibtex-btn,
+.download-bibtex-btn {
     padding: 0.25rem 0.5rem;
 }
 </style>

--- a/client/src/components/Citation/CitationsList.vue
+++ b/client/src/components/Citation/CitationsList.vue
@@ -1,13 +1,19 @@
 <script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faCopy } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton, BCard, BCollapse, BNav, BNavItem } from "bootstrap-vue";
 import { onMounted, onUpdated, ref } from "vue";
 
 import { getCitations } from "@/components/Citation/services";
 import { useConfig } from "@/composables/config";
+import { copy } from "@/utils/clipboard";
 
 import type { Citation } from ".";
 
 import CitationItem from "@/components/Citation/CitationItem.vue";
+
+library.add(faCopy);
 
 const outputFormats = Object.freeze({
     CITATION: "bibliography",
@@ -43,6 +49,20 @@ onMounted(async () => {
         console.error(e);
     }
 });
+
+function copyBibtex() {
+    let text = "";
+    citations.value.forEach((citation) => {
+        const cite = citation.cite;
+        const bibtex = cite.format("bibtex", {
+            format: "text",
+            template: "bibtex",
+            lang: "en-US",
+        });
+        text += bibtex;
+    });
+    copy(text, "References copied to your clipboard as BibTeX");
+}
 </script>
 
 <template>
@@ -62,6 +82,16 @@ onMounted(async () => {
                         BibTeX
                     </BNavItem>
                 </BNav>
+                <BButton
+                    v-if="outputFormat === outputFormats.BIBTEX"
+                    v-b-tooltip.hover
+                    title="Copy all references as BibTeX"
+                    variant="link"
+                    size="sm"
+                    class="copy-bibtex-btn"
+                    @click="copyBibtex">
+                    <FontAwesomeIcon icon="copy" />
+                </BButton>
             </template>
 
             <div v-if="source === 'histories'" class="infomessage">
@@ -101,10 +131,19 @@ onMounted(async () => {
 </template>
 
 <style scoped lang="scss">
+.citation-card .card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
 .citation-card .card-header .nav-tabs {
     margin-bottom: -0.75rem !important;
 }
 .formatted-reference {
     margin-bottom: 0.5rem;
+}
+.copy-bibtex-btn {
+    margin-left: auto;
+    padding: 0.25rem 0.5rem;
 }
 </style>

--- a/client/src/components/Citation/CitationsList.vue
+++ b/client/src/components/Citation/CitationsList.vue
@@ -63,6 +63,20 @@ function copyBibtex() {
     });
     copy(text, "References copied to your clipboard as BibTeX");
 }
+
+function copyAPA() {
+    let text = "";
+    citations.value.forEach((citation) => {
+        const cite = citation.cite;
+        const apa = cite.format("bibliography", {
+            format: "text",
+            template: "apa",
+            lang: "en-US",
+        });
+        text += apa + "\n\n";
+    });
+    copy(text, "References copied to your clipboard as APA");
+}
 </script>
 
 <template>
@@ -82,6 +96,16 @@ function copyBibtex() {
                         BibTeX
                     </BNavItem>
                 </BNav>
+                <BButton
+                    v-if="outputFormat === outputFormats.CITATION"
+                    v-b-tooltip.hover
+                    title="Copy all references as APA"
+                    variant="link"
+                    size="sm"
+                    class="copy-citation-btn"
+                    @click="copyAPA">
+                    <FontAwesomeIcon icon="copy" />
+                </BButton>
                 <BButton
                     v-if="outputFormat === outputFormats.BIBTEX"
                     v-b-tooltip.hover
@@ -142,6 +166,7 @@ function copyBibtex() {
 .formatted-reference {
     margin-bottom: 0.5rem;
 }
+.copy-citation-btn,
 .copy-bibtex-btn {
     margin-left: auto;
     padding: 0.25rem 0.5rem;

--- a/client/src/components/Citation/CitationsList.vue
+++ b/client/src/components/Citation/CitationsList.vue
@@ -48,16 +48,7 @@ onMounted(async () => {
 });
 
 function copyBibtex() {
-    let text = "";
-    citations.value.forEach((citation) => {
-        const cite = citation.cite;
-        const bibtex = cite.format("bibtex", {
-            format: "text",
-            template: "bibtex",
-            lang: "en-US",
-        });
-        text += bibtex;
-    });
+    const text = citationsToBibtexAsText();
     copy(text, "References copied to your clipboard as BibTeX");
 }
 
@@ -76,6 +67,19 @@ function copyAPA() {
 }
 
 function downloadBibtex() {
+    const text = citationsToBibtexAsText();
+    const blob = new Blob([text], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "citations.bib";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}
+
+function citationsToBibtexAsText() {
     let text = "";
     citations.value.forEach((citation) => {
         const cite = citation.cite;
@@ -86,16 +90,7 @@ function downloadBibtex() {
         });
         text += bibtex;
     });
-
-    const blob = new Blob([text], { type: "text/plain" });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = "citations.bib";
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+    return text;
 }
 </script>
 

--- a/client/src/components/Citation/CitationsList.vue
+++ b/client/src/components/Citation/CitationsList.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCopy, faDownload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton, BCard, BCollapse, BNav, BNavItem } from "bootstrap-vue";
@@ -12,8 +11,6 @@ import { copy } from "@/utils/clipboard";
 import type { Citation } from ".";
 
 import CitationItem from "@/components/Citation/CitationItem.vue";
-
-library.add(faCopy, faDownload);
 
 const outputFormats = Object.freeze({
     CITATION: "bibliography",
@@ -127,7 +124,7 @@ function downloadBibtex() {
                     size="sm"
                     class="copy-citation-btn"
                     @click="copyAPA">
-                    <FontAwesomeIcon icon="copy" />
+                    <FontAwesomeIcon :icon="faCopy" />
                 </BButton>
                 <div v-if="outputFormat === outputFormats.BIBTEX" class="bibtex-actions">
                     <BButton
@@ -137,7 +134,7 @@ function downloadBibtex() {
                         size="sm"
                         class="copy-bibtex-btn"
                         @click="copyBibtex">
-                        <FontAwesomeIcon icon="copy" />
+                        <FontAwesomeIcon :icon="faCopy" />
                     </BButton>
                     <BButton
                         v-b-tooltip.hover
@@ -146,7 +143,7 @@ function downloadBibtex() {
                         size="sm"
                         class="download-bibtex-btn"
                         @click="downloadBibtex">
-                        <FontAwesomeIcon icon="download" />
+                        <FontAwesomeIcon :icon="faDownload" />
                     </BButton>
                 </div>
             </template>


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/15477


This adds a citation copy button to the References (APA) tab, and a copy *and* download button to the BibTeX tab, to either copy or download the raw bibtex (without inline link refs, etc).

![image](https://github.com/user-attachments/assets/d7489c26-dd71-4db9-9867-8402b9079117)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
