### PR TITLE
[25.0] Bug fix: allow any collection type in FormCollectionType.

### DIFF
--- a/client/src/components/Workflow/Editor/Forms/FormCollectionType.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormCollectionType.vue
@@ -47,11 +47,11 @@ const emit = defineEmits(["onChange"]);
     <FormElement
         id="collection_type"
         :value="currentValue"
-        :attributes="{ data: collectionTypeOptions, display: 'simple' }"
+        :attributes="{ datalist: collectionTypeOptions }"
         :warning="warning ?? undefined"
         :error="error ?? undefined"
         title="Collection type"
         :optional="true"
-        type="select"
+        type="text"
         @input="onInput" />
 </template>


### PR DESCRIPTION
This is just a reversion of 239b2acd22b2d3c547161b9d563e69b9bbd87c83 which I let in as part of #19313 but it is broken. That change makes things prettier but it breaks all sorts of completely valid workflow inputs (arbitrarily nested lists and lists of pairs and more exotic things also). 

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Try creating a workflow with type ``list:list:paired`` with and without the change.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
