### PR TITLE
[25.0] Fix minor IT panel/display issues

### DIFF
--- a/client/src/components/InteractiveTools/InteractiveTools.vue
+++ b/client/src/components/InteractiveTools/InteractiveTools.vue
@@ -125,17 +125,16 @@ onMounted(() => {
                     :name="row.item.name"
                     @click.prevent="openInteractiveTool(row.item.id)"
                     >{{ row.item.name }}
-                    <FontAwesomeIcon :icon="faExternalLinkAlt" />
                 </a>
-                <!-- Add a direct link option as well -->
                 <a
+                    v-if="row.item.target"
                     :id="createId('external-link', row.item.id)"
                     v-b-tooltip
                     class="ml-2"
                     title="Open in new tab"
                     :href="row.item.target"
                     target="_blank">
-                    <small>(new tab)</small>
+                    <FontAwesomeIcon :icon="faExternalLinkAlt" />
                 </a>
             </template>
             <template v-slot:cell(job_info)="row">

--- a/client/src/components/InteractiveTools/InteractiveTools.vue
+++ b/client/src/components/InteractiveTools/InteractiveTools.vue
@@ -139,8 +139,8 @@ onMounted(() => {
                 </a>
             </template>
             <template v-slot:cell(job_info)="row">
-                <label v-if="row.item.active"> running </label>
-                <label v-else> stopped </label>
+                <label v-if="row.item.active"> Running </label>
+                <label v-else> Starting </label>
             </template>
             <template v-slot:cell(created_time)="row">
                 <UtcDate :date="row.item.created_time" mode="elapsed" />

--- a/client/src/components/Panels/InteractiveToolsPanel.vue
+++ b/client/src/components/Panels/InteractiveToolsPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faStop, faTools } from "@fortawesome/free-solid-svg-icons";
+import { faExternalLinkAlt, faStop, faTools } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { storeToRefs } from "pinia";
 import { computed, onMounted, ref } from "vue";
@@ -88,12 +88,22 @@ function openInteractiveTool(toolId: string) {
                                 | Created <UtcDate :date="tool.created_time" mode="elapsed" />
                             </div>
                         </div>
-                        <button
-                            class="btn btn-sm btn-link text-danger"
-                            title="Stop this interactive tool"
-                            @click="stopInteractiveTool(tool.id, tool.name)">
-                            <FontAwesomeIcon :icon="faStop" />
-                        </button>
+                        <div class="d-flex align-items-center">
+                            <a
+                                v-if="tool.target"
+                                :href="tool.target"
+                                target="_blank"
+                                class="btn btn-sm btn-link text-muted me-1"
+                                title="Open in new tab">
+                                <FontAwesomeIcon :icon="faExternalLinkAlt" />
+                            </a>
+                            <button
+                                class="btn btn-sm btn-link text-danger"
+                                title="Stop this interactive tool"
+                                @click="stopInteractiveTool(tool.id, tool.name)">
+                                <FontAwesomeIcon :icon="faStop" />
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Just a couple things noticed in the Live! walkthrough today:

Fix 'starting' text, fix and standardize open in center vs new tab functionality.


Does anyone see value in keeping the center pane list of ITs around?  Users can only have one running IT anyway (at least on main), and it seems largely redundant now anyway.  We could go ahead and drop it with the swap if folks want.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
