### PR TITLE
[25.0] Fixes for the admin jobs interface

### DIFF
--- a/client/src/components/admin/JobsList.vue
+++ b/client/src/components/admin/JobsList.vue
@@ -8,14 +8,14 @@
         <JobLock />
         <Heading h2 size="md" separator>Job Overview</Heading>
         <p>
-            Unfinished jobs (in the 'new', 'queued', 'running', or 'waiting' states) and finished
-            jobs (in 'error' or 'ok' states) are displayed below.
+            Unfinished jobs (in the 'new', 'queued', 'running', or 'waiting' states) and finished jobs (in 'error' or
+            'ok' states) are displayed below.
         </p>
         <p>
             You may choose to stop some of the unfinished jobs and provide the user with a message. Your stop message
             will be displayed to the user as:
-            </p>
-            <p>
+        </p>
+        <p>
             "This job was stopped by an administrator:
             <strong>&lt;YOUR MESSAGE&gt;</strong>
             For more information or help, report this error".

--- a/client/src/components/admin/JobsList.vue
+++ b/client/src/components/admin/JobsList.vue
@@ -8,12 +8,15 @@
         <JobLock />
         <Heading h2 size="md" separator>Job Overview</Heading>
         <p>
-            Below unfinished jobs are displayed (in the 'new', 'queued', 'running', or 'upload' states) and recently
-            completed jobs (in 'error' or 'ok' states).
+            Unfinished jobs (in the 'new', 'queued', 'running', or 'waiting' states) and finished
+            jobs (in 'error' or 'ok' states) are displayed below.
         </p>
         <p>
-            You may choose to stop some of the displayed jobs and provide the user with a message. Your stop message
-            will be displayed to the user as: "This job was stopped by an administrator:
+            You may choose to stop some of the unfinished jobs and provide the user with a message. Your stop message
+            will be displayed to the user as:
+            </p>
+            <p>
+            "This job was stopped by an administrator:
             <strong>&lt;YOUR MESSAGE&gt;</strong>
             For more information or help, report this error".
         </p>

--- a/client/src/components/admin/JobsList.vue
+++ b/client/src/components/admin/JobsList.vue
@@ -19,7 +19,7 @@
         </p>
         <b-row>
             <b-col class="col-sm-4">
-                <b-form-group description="Select whether or not to use the cutoff below.">
+                <b-form-group>
                     <b-form-checkbox id="show-all-running" v-model="showAllRunning" switch size="lg" @change="update">
                         {{ showAllRunning ? "Showing all unfinished jobs" : "Time cutoff applied to query" }}
                     </b-form-checkbox>

--- a/client/src/components/admin/JobsList.vue
+++ b/client/src/components/admin/JobsList.vue
@@ -35,7 +35,7 @@
                         </b-input-group>
                     </b-form-group>
                 </b-form>
-                <b-form-group description="Use strings or regular expressions to search jobs.">
+                <b-form-group>
                     <IndexFilter v-bind="filterAttrs" id="job-search" v-model="filter" />
                 </b-form-group>
             </b-col>
@@ -183,7 +183,12 @@ export default {
             return `These jobs have completed in the previous ${this.cutoffMin} minutes.`;
         },
         runningTableCaption() {
-            return `These jobs are unfinished and have had their state updated in the previous ${this.cutoffMin} minutes. For currently running jobs, the "Last Update" column should indicate the runtime so far.`;
+            let message = `These jobs are unfinished`;
+            if (!this.showAllRunning) {
+                message += ` and have had their state updated in the previous ${this.cutoffMin} minutes`;
+            }
+            message += `. For currently running jobs, the "Last Update" column should indicate the runtime so far.`;
+            return message;
         },
         finishedNoJobsMessage() {
             return `There are no recently finished jobs to show with current cutoff time of ${this.cutoffMin} minutes.`;
@@ -238,7 +243,7 @@ export default {
             this.busy = true;
             const params = { view: "admin_job_list" };
             if (this.showAllRunning) {
-                params.state = "running";
+                params.state = NON_TERMINAL_STATES;
             } else {
                 const cutoff = Math.floor(this.cutoffMin);
                 const dateRangeMin = new Date(Date.now() - cutoff * 60 * 1000).toISOString();


### PR DESCRIPTION
- fix the filtering for "unfinished jobs" to all non-terminal
- do not mention cutoff when all unfinished are displayed
- drop mention of regex for search, that is not implemented
- drop description for a hidden form element, when shown the element has own description

<img width="882" alt="Screenshot 2025-06-05 at 11 53 49" src="https://github.com/user-attachments/assets/cb18c99f-4a9e-49b1-bb24-8b4055c5992f" />

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
