### PR TITLE
Enhance citations page

### DIFF
--- a/client/src/components/Citation/CitationsList.vue
+++ b/client/src/components/Citation/CitationsList.vue
@@ -11,6 +11,7 @@ import { copy } from "@/utils/clipboard";
 import type { Citation } from ".";
 
 import CitationItem from "@/components/Citation/CitationItem.vue";
+import Heading from "@/components/Common/Heading.vue";
 
 const outputFormats = Object.freeze({
     CITATION: "bibliography",
@@ -96,6 +97,7 @@ function citationsToBibtexAsText() {
 
 <template>
     <div>
+        <Heading h1 separator inline size="lg">History Tool References</Heading>
         <BCard v-if="!simple" class="citation-card" header-tag="nav">
             <template v-slot:header>
                 <BNav card-header tabs>


### PR DESCRIPTION
- Add a header like in other central pages for consistency
- Add a loading spinner while fetching citations, as it may take a while for large histories, and it may seem that it didn't work before the user clicks away (reported by @wm75)


https://github.com/user-attachments/assets/a7426267-79be-4edd-b538-017c377357a9



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
