### PR TITLE
Retrieve source hash from file sources that support it, use hash to deduplicate datasets.

### DIFF
--- a/lib/galaxy/datatypes/protocols.py
+++ b/lib/galaxy/datatypes/protocols.py
@@ -78,7 +78,7 @@ class DatasetProtocol(
     blurb: str
     dataset: Any
     dbkey: Any
-    extension: str
+    extension: "Mapped[str]"
     peek: Any
     state: Any
     states: Any

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -47,6 +47,11 @@ if TYPE_CHECKING:
     )
 
 
+class DatasetHash(TypedDict):
+    hash_function: Literal["MD5", "SHA-1", "SHA-256", "SHA-512", "DROPBOX"]
+    hash_value: str
+
+
 class PluginKind(str, Enum):
     """Enum to distinguish between different kinds or categories of plugins."""
 
@@ -164,7 +169,9 @@ class RemoteDirectory(RemoteEntry, TDirectoryClass):
 
 class RemoteFile(RemoteEntry, TFileClass):
     size: int
-    ctime: str
+    ctime: Optional[str]
+    content_hash: NotRequired[str]
+    content_hash_algorithm: NotRequired[str]
 
 
 AnyRemoteEntry = Union[RemoteDirectory, RemoteFile]
@@ -345,6 +352,9 @@ class BaseFilesSource(FilesSource):
 
     def get_scheme(self) -> str:
         return self.scheme or "gxfiles"
+
+    def _get_content_hash(self, path: str) -> Optional[DatasetHash]:
+        return None
 
     def get_writable(self) -> bool:
         return self.writable

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5458,6 +5458,7 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
 
     history_id: Mapped[Optional[int]]
     dataset_id: Mapped[Optional[int]]
+    extension: Mapped[str]
     hidden_beneath_collection_instance: Mapped[Optional["HistoryDatasetCollectionAssociation"]]
     tags: Mapped[Optional["HistoryDatasetAssociationTagAssociation"]]
 

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -24,7 +24,13 @@ from typing import (
 import galaxy.model
 from galaxy import util
 from galaxy.exceptions import RequestParameterInvalidException
-from galaxy.model import LibraryFolder
+from galaxy.model import (
+    Dataset,
+    DatasetHash,
+    DatasetSource,
+    DatasetSourceHash,
+    LibraryFolder,
+)
 from galaxy.model.dataset_collections.builder import BoundCollectionBuilder
 from galaxy.model.tags import GalaxySessionlessTagHandler
 from galaxy.objectstore import (
@@ -79,6 +85,16 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
 
     def get_job(self) -> Optional[galaxy.model.Job]:
         return getattr(self, "job", None)
+
+    def get_replacement_dataset(
+        self,
+        dataset_sources: List[DatasetSource],
+        dataset_hashes: List[Union[DatasetSourceHash, DatasetHash]],
+        extension: str,
+        output_name: Optional[str],
+    ) -> Optional[Dataset]:
+        """Return a replacement dataset for the given source and hash, if available."""
+        return None
 
     def create_dataset(
         self,
@@ -168,6 +184,7 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
                 if metadata_element and metadata_element.set_in_upload:
                     setattr(primary_data.metadata, key, value)
 
+        assert primary_data.dataset
         for source_dict in sources:
             source = galaxy.model.DatasetSource()
             source.source_uri = source_dict["source_uri"]
@@ -179,6 +196,17 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
             hash_object.hash_function = hash_dict["hash_function"]
             hash_object.hash_value = hash_dict["hash_value"]
             primary_data.dataset.hashes.append(hash_object)
+
+        replacement_dataset = None
+        if primary_data.dataset.hashes and primary_data.dataset.sources and not purged:
+            replacement_dataset = self.get_replacement_dataset(
+                primary_data.dataset.sources,
+                primary_data.dataset.hashes,
+                extension=primary_data.extension,
+                output_name=output_name,
+            )
+            if replacement_dataset:
+                primary_data.dataset = replacement_dataset
 
         if created_from_basename is not None:
             primary_data.created_from_basename = created_from_basename
@@ -210,7 +238,7 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
         if purged:
             primary_data.dataset.purged = True
             primary_data.purged = True
-        if filename and not purged:
+        if filename and not purged and not replacement_dataset:
             if storage_callbacks is None:
                 self.finalize_storage(
                     primary_data=primary_data,

--- a/lib/galaxy/schema/fetch_data.py
+++ b/lib/galaxy/schema/fetch_data.py
@@ -104,7 +104,7 @@ class ExtraFiles(FetchBaseModel):
 
 
 class FetchDatasetHash(Model):
-    hash_function: Literal["MD5", "SHA-1", "SHA-256", "SHA-512"]
+    hash_function: Literal["MD5", "SHA-1", "SHA-256", "SHA-512", "DROPBOX"]
     hash_value: str
 
     model_config = ConfigDict(extra="forbid")

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -33,9 +33,11 @@ from mako.template import Template
 from packaging.version import Version
 from sqlalchemy import (
     delete,
+    false,
     func,
     select,
 )
+from sqlalchemy.orm import aliased
 
 from galaxy import (
     exceptions,
@@ -901,6 +903,50 @@ class JobContext(BaseJobContext):
 
     def flush(self):
         self.sa_session.commit()
+
+    def get_replacement_dataset(
+        self,
+        dataset_sources: List[model.DatasetSource],
+        dataset_hashes: List[Union[model.DatasetHash, model.DatasetSourceHash]],
+        extension: str,
+        output_name: Optional[str],
+    ) -> Optional[model.Dataset]:
+        """
+        Get a replacement dataset for the given source URI and dataset hash.
+        If we already have such a dataset we don't need to create a new one.
+        """
+        if not self.user:
+            return None
+
+        # TODO: generalize
+        dataset_hash = dataset_hashes[0]
+        dataset_source = dataset_sources[0]
+        assert dataset_source.dataset
+
+        object_store_id = self.override_object_store_id(output_name=output_name)
+
+        existing_hash = aliased(model.DatasetHash, name="existing_hash")
+        existing_source = aliased(model.DatasetSource, name="existing_source")
+        existing_dataset_select = (
+            select(model.Dataset)
+            .join(existing_hash, existing_hash.dataset_id == model.Dataset.id)
+            .join(existing_source, existing_source.dataset_id == model.Dataset.id)
+            .join(model.HistoryDatasetAssociation, model.Dataset.id == model.HistoryDatasetAssociation.dataset_id)
+            .join(model.History, model.HistoryDatasetAssociation.history_id == model.History.id)
+            .where(
+                existing_hash.hash_function == dataset_hash.hash_function,
+                existing_hash.hash_value == dataset_hash.hash_value,
+                existing_source.transform == dataset_source.transform,
+                model.Dataset.deleted == false(),
+                model.Dataset.purged == false(),
+                model.Dataset.state == model.Dataset.states.OK,
+                model.Dataset.object_store_id == object_store_id,
+                model.HistoryDatasetAssociation.extension == extension,
+                model.History.user_id == self.user.id,
+            )
+        ).limit(1)
+        existing_dataset = self.sa_session.scalars(existing_dataset_select).first()
+        return existing_dataset
 
     def get_library_folder(self, destination: Dict[str, Any]):
         folder_id = destination.get("library_folder_id")

--- a/lib/galaxy/util/hash_util/__init__.py
+++ b/lib/galaxy/util/hash_util/__init__.py
@@ -17,14 +17,15 @@ from typing import (
     Union,
 )
 
-from . import smart_str
-from .path import StrPath
+from galaxy.util import smart_str
+from galaxy.util.path import StrPath
+from .dropbox_content_hasher import DropboxContentHasher
 
 log = logging.getLogger(__name__)
 
 BLOCK_SIZE = 1024 * 1024
 
-HashFunctionT = Callable[[], "hashlib._Hash"]
+HashFunctionT = Callable[[], Union["hashlib._Hash", DropboxContentHasher]]
 
 sha1 = hashlib.sha1
 sha256 = hashlib.sha256
@@ -40,6 +41,7 @@ class HashFunctionNameEnum(str, Enum):
     sha1 = "SHA-1"
     sha256 = "SHA-256"
     sha512 = "SHA-512"
+    dropbox = "DROPBOX"  # Special case for Dropbox content hash
 
 
 HASH_NAME_ALIAS: Dict[str, str] = {
@@ -53,6 +55,7 @@ HASH_NAME_MAP: Dict[HashFunctionNameEnum, HashFunctionT] = {
     HashFunctionNameEnum.sha1: sha1,
     HashFunctionNameEnum.sha256: sha256,
     HashFunctionNameEnum.sha512: sha512,
+    HashFunctionNameEnum.dropbox: DropboxContentHasher,
 }
 HASH_NAMES: List[HashFunctionNameEnum] = list(HASH_NAME_MAP.keys())
 

--- a/lib/galaxy/util/hash_util/dropbox_content_hasher.py
+++ b/lib/galaxy/util/hash_util/dropbox_content_hasher.py
@@ -1,0 +1,141 @@
+import hashlib
+from typing import Optional
+
+
+class DropboxContentHasher:
+    """
+    Computes a hash using the same algorithm that the Dropbox API uses for the
+    the "content_hash" metadata field.
+
+    The digest() method returns a raw binary representation of the hash.  The
+    hexdigest() convenience method returns a hexadecimal-encoded version, which
+    is what the "content_hash" metadata field uses.
+
+    This class has the same interface as the hashers in the standard 'hashlib'
+    package.
+
+    Example:
+
+        hasher = DropboxContentHasher()
+        with open('some-file', 'rb') as f:
+            while True:
+                chunk = f.read(1024)  # or whatever chunk size you want
+                if len(chunk) == 0:
+                    break
+                hasher.update(chunk)
+        print(hasher.hexdigest())
+    """
+
+    BLOCK_SIZE = 4 * 1024 * 1024
+
+    def __init__(self):
+        self._overall_hasher: Optional[hashlib._Hash] = hashlib.sha256()
+        self._block_hasher: Optional[hashlib._Hash] = hashlib.sha256()
+        self._block_pos = 0
+
+        self.digest_size = self._overall_hasher.digest_size
+        # hashlib classes also define 'block_size', but I don't know how people use that value
+
+    def update(self, new_data):
+        assert self._overall_hasher and self._block_hasher, "can't use this object anymore; you already called digest()"
+        assert isinstance(new_data, bytes), f"Expecting a byte string, got {new_data!r}"
+
+        new_data_pos = 0
+        while new_data_pos < len(new_data):
+            if self._block_pos == self.BLOCK_SIZE:
+                self._overall_hasher.update(self._block_hasher.digest())
+                self._block_hasher = hashlib.sha256()
+                self._block_pos = 0
+
+            space_in_block = self.BLOCK_SIZE - self._block_pos
+            part = new_data[new_data_pos : (new_data_pos + space_in_block)]
+            self._block_hasher.update(part)
+
+            self._block_pos += len(part)
+            new_data_pos += len(part)
+
+    def _finish(self):
+        assert (
+            self._overall_hasher and self._block_hasher
+        ), "can't use this object anymore; you already called digest() or hexdigest()"
+        if self._block_pos > 0:
+            self._overall_hasher.update(self._block_hasher.digest())
+            self._block_hasher = None
+        h = self._overall_hasher
+        self._overall_hasher = None  # Make sure we can't use this object anymore.
+        return h
+
+    def digest(self):
+        return self._finish().digest()
+
+    def hexdigest(self):
+        return self._finish().hexdigest()
+
+    def copy(self):
+        c = DropboxContentHasher.__new__(DropboxContentHasher)
+        assert (
+            self._overall_hasher and self._block_hasher
+        ), "can't copy this object; you already called digest() or hexdigest()"
+        c._overall_hasher = self._overall_hasher.copy()
+        c._block_hasher = self._block_hasher.copy()
+        c._block_pos = self._block_pos
+        return c
+
+
+class StreamHasher:
+    """
+    A wrapper around a file-like object (either for reading or writing)
+    that hashes everything that passes through it.  Can be used with
+    DropboxContentHasher or any 'hashlib' hasher.
+
+    Example:
+
+        hasher = DropboxContentHasher()
+        with open('some-file', 'rb') as f:
+            wrapped_f = StreamHasher(f, hasher)
+            response = some_api_client.upload(wrapped_f)
+
+        locally_computed = hasher.hexdigest()
+        assert response.content_hash == locally_computed
+    """
+
+    def __init__(self, f, hasher):
+        self._f = f
+        self._hasher = hasher
+
+    def close(self):
+        return self._f.close()
+
+    def flush(self):
+        return self._f.flush()
+
+    def fileno(self):
+        return self._f.fileno()
+
+    def tell(self):
+        return self._f.tell()
+
+    def read(self, *args):
+        b = self._f.read(*args)
+        self._hasher.update(b)
+        return b
+
+    def write(self, b):
+        self._hasher.update(b)
+        return self._f.write(b)
+
+    def next(self):
+        b = self._f.next()
+        self._hasher.update(b)
+        return b
+
+    def readline(self, *args):
+        b = self._f.readline(*args)
+        self._hasher.update(b)
+        return b
+
+    def readlines(self, *args):
+        bs = self._f.readlines(*args)
+        for b in bs:
+            self._hasher.update(b)
+        return b


### PR DESCRIPTION
The deduplication conditions are:

- the replacement dataset exists in the same object store that the upload job would use
- the replacement dataset exists in a history that the user owns
- the replacement dataset has a HDA of the same datatype
- the dataset hash matches
- the replacement dataset is not purged or deleted and in OK state
- the same transform is applied

For now this is most interesting for the galaxy-live demo, where we're going to upload datasets from dropbox and have the job cache kick in.

However, the deduplication is not tied to uploads, and we could consider opening this up to public datasets and/or datasets that users have access permissions on.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
