### PR TITLE
Add DRS compact identifier support

### DIFF
--- a/lib/galaxy/files/sources/util.py
+++ b/lib/galaxy/files/sources/util.py
@@ -87,14 +87,14 @@ def retry_and_get(get_url: str, retry_options: RetryOptions, headers: Optional[d
 
 def _get_access_info(obj_url: str, access_method: dict, headers: Optional[dict] = None) -> tuple[str, dict]:
     # Prefer access_id resolution to get signed/authenticated URLs
-    if "access_id" in access_method:
+    if access_method.get("access_id"):
         access_id = access_method["access_id"]
         access_get_url = f"{obj_url}/access/{access_id}"
         access_response = requests.get(access_get_url, timeout=DEFAULT_SOCKET_TIMEOUT, headers=headers)
         access_response.raise_for_status()
         access_response_object = access_response.json()
         access_url = access_response_object
-    elif "access_url" in access_method:
+    elif access_method.get("access_url"):
         access_url = access_method["access_url"]
     else:
         raise ValueError("Access method must contain either 'access_id' or 'access_url'")

--- a/lib/galaxy/files/sources/util.py
+++ b/lib/galaxy/files/sources/util.py
@@ -2,10 +2,7 @@ import json
 import logging
 import time
 from typing import (
-    Dict,
-    List,
     Optional,
-    Tuple,
 )
 from urllib.parse import quote
 
@@ -117,11 +114,11 @@ def _download_s3_file(s3_url: str, target_path: StrPath, headers: Optional[dict]
     try:
         # If the URL has query parameters (signed URL), use requests directly
         if "?" in s3_url and ("X-Amz-Algorithm" in s3_url or "Signature" in s3_url):
-            log.debug(f"Using requests for signed S3 URL")
+            log.debug("Using requests for signed S3 URL")
             response = requests.get(s3_url, headers=headers or {}, timeout=DEFAULT_SOCKET_TIMEOUT, stream=True)
             response.raise_for_status()
 
-            with open(target_path, 'wb') as f:
+            with open(target_path, "wb") as f:
                 for chunk in response.iter_content(chunk_size=CHUNK_SIZE):
                     f.write(chunk)
             return
@@ -129,6 +126,7 @@ def _download_s3_file(s3_url: str, target_path: StrPath, headers: Optional[dict]
         # For raw S3 URLs, try s3fs with different access patterns
         log.debug(f"Using s3fs for S3 URL: {s3_url}")
         import s3fs
+
         s3_path = s3_url[5:]  # Remove 's3://' prefix
 
         # Try different S3 access methods in order of preference
@@ -142,8 +140,8 @@ def _download_s3_file(s3_url: str, target_path: StrPath, headers: Optional[dict]
         for method_name, fs_factory in access_methods:
             try:
                 fs = fs_factory()
-                with fs.open(s3_path, 'rb') as s3_file:
-                    with open(target_path, 'wb') as local_file:
+                with fs.open(s3_path, "rb") as s3_file:
+                    with open(target_path, "wb") as local_file:
                         while True:
                             chunk = s3_file.read(CHUNK_SIZE)
                             if not chunk:
@@ -182,7 +180,7 @@ class CompactIdentifierResolver:
     def __init__(self, cache_ttl: int = 86400):
         # Prevent re-initialization of singleton
         if not self._initialized:
-            self._cache: Dict[str, Dict] = {}
+            self._cache: dict[str, dict] = {}
             self._cache_ttl = cache_ttl
             self._initialized = True
 
@@ -259,7 +257,7 @@ class CompactIdentifierResolver:
         return url_pattern
 
 
-def parse_compact_identifier(drs_uri: str) -> Tuple[str, str]:
+def parse_compact_identifier(drs_uri: str) -> tuple[str, str]:
     if not drs_uri.startswith("drs://"):
         raise ValueError(f"Not a valid DRS URI: {drs_uri}")
 

--- a/lib/galaxy/files/sources/util.py
+++ b/lib/galaxy/files/sources/util.py
@@ -21,7 +21,7 @@ from galaxy.util.path import StrPath
 
 def _not_implemented(drs_uri: str, desc: str) -> NotImplementedError:
     missing_client_func = f"Galaxy client cannot currently fetch URIs {desc}."
-    header = f"Missing client functionaltiy required to fetch DRS URI {drs_uri}."
+    header = f"Missing client functionality required to fetch DRS URI {drs_uri}."
     rest_of_message = """Currently Galaxy client only works with HTTP/HTTPS targets but extensions for
     other types would be gladly welcomed by the Galaxy team. Please
     report use cases not covered by this function to our issue tracker
@@ -132,4 +132,4 @@ def fetch_drs_to_file(
 
     if not downloaded:
         unimplemented_access_types = [m["type"] for m in access_methods]
-        raise _not_implemented(drs_uri, f"that is fetched via unimplemented types ({unimplemented_access_types})")
+        raise _not_implemented(drs_uri, f"that are fetched via unimplemented types ({unimplemented_access_types})")

--- a/test/integration/test_drs_compact_identifiers.py
+++ b/test/integration/test_drs_compact_identifiers.py
@@ -1,0 +1,98 @@
+import os
+import tempfile
+from unittest.mock import (
+    Mock,
+    patch,
+)
+
+import pytest
+
+from galaxy.files.sources.util import fetch_drs_to_file
+
+
+class TestDRSCompactIdentifiersIntegration:
+    @patch("galaxy.files.sources.util.requests.get")
+    @patch("galaxy.files.sources.util.stream_url_to_file")
+    def test_fetch_compact_identifier_drs_file(self, mock_stream, mock_get):
+        namespace_response = Mock()
+        namespace_response.json.return_value = {
+            "_links": {
+                "self": {"href": "https://registry.api.identifiers.org/restApi/namespaces/123"},
+                "resources": {"href": "https://registry.api.identifiers.org/restApi/namespaces/123/resources"},
+            }
+        }
+        namespace_response.raise_for_status.return_value = None
+
+        resources_response = Mock()
+        resources_response.json.return_value = {
+            "_embedded": {
+                "resources": [{"urlPattern": "https://example-drs.com/ga4gh/drs/v1/objects/{$id}", "official": True}]
+            }
+        }
+        resources_response.raise_for_status.return_value = None
+
+        drs_response = Mock()
+        drs_response.json.return_value = {
+            "id": "test-object-id",
+            "access_methods": [
+                {
+                    "type": "https",
+                    "access_url": {
+                        "url": "https://download.example.com/test-file.txt",
+                        "headers": ["Authorization: Bearer test-token"],
+                    },
+                }
+            ],
+        }
+        drs_response.raise_for_status.return_value = None
+        drs_response.status_code = 200
+
+        mock_get.side_effect = [namespace_response, resources_response, drs_response]
+
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            try:
+                fetch_drs_to_file("drs://drs.test:test-object-id", tmp.name, None)
+
+                assert mock_get.call_count == 3
+                mock_get.assert_any_call(
+                    "https://registry.api.identifiers.org/restApi/namespaces/search/findByPrefix?prefix=drs.test",
+                    timeout=600,
+                )
+                mock_get.assert_any_call(
+                    "https://registry.api.identifiers.org/restApi/namespaces/123/resources",
+                    timeout=600,
+                )
+
+                mock_get.assert_any_call(
+                    "https://example-drs.com/ga4gh/drs/v1/objects/test-object-id", timeout=600, headers=None
+                )
+
+                mock_stream.assert_called_once()
+                call_args = mock_stream.call_args
+                assert call_args[0][0] == "https://download.example.com/test-file.txt"
+                assert call_args[1]["target_path"] == tmp.name
+
+            finally:
+                if os.path.exists(tmp.name):
+                    os.unlink(tmp.name)
+
+    def test_compact_identifier_error_handling(self):
+        invalid_uris = [
+            "drs://",  # No identifier
+            "drs://no-colon",  # Missing colon
+            "drs://:only-accession",  # Missing prefix
+            "drs://prefix:",  # Missing accession
+            "drs://UPPERCASE:accession",  # Invalid prefix format
+            "https://not-drs:accession",  # Wrong scheme
+        ]
+
+        for uri in invalid_uris:
+            with pytest.raises(ValueError):
+                fetch_drs_to_file(uri, "/tmp/output", None)
+
+    @patch("galaxy.files.sources.util.CompactIdentifierResolver._query_identifiers_org")
+    def test_meta_resolver_failure_handling(self, mock_identifiers):
+        mock_identifiers.return_value = None
+
+        with pytest.raises(ValueError, match="Failed to resolve compact identifier DRS URI"):
+            fetch_drs_to_file("drs://unknown.prefix:accession", "/tmp/output", None)

--- a/test/unit/files/test_drs.py
+++ b/test/unit/files/test_drs.py
@@ -28,20 +28,31 @@ def test_file_source_drs_http():
             "access_methods": [
                 {
                     "type": "https",
-                    "access_url": {
-                        "url": "https://my.respository.org/myfile.txt",
-                        "headers": ["Authorization: Basic Z2E0Z2g6ZHJz"],
-                    },
                     "access_id": "1234",
                 }
             ],
         }
         return (200, {}, json.dumps(data))
 
+    def access_handler(request):
+        assert request.headers["Authorization"] == "Bearer IBearTokens"
+        access_data = {
+            "url": "https://my.respository.org/myfile.txt",
+            "headers": ["Authorization: Basic Z2E0Z2g6ZHJz"],
+        }
+        return (200, {}, json.dumps(access_data))
+
     responses.add_callback(
         responses.GET,
         "https://drs.example.org/ga4gh/drs/v1/objects/314159",
         callback=drs_repo_handler,
+        content_type="application/json",
+    )
+
+    responses.add_callback(
+        responses.GET,
+        "https://drs.example.org/ga4gh/drs/v1/objects/314159/access/1234",
+        callback=access_handler,
         content_type="application/json",
     )
 
@@ -76,9 +87,6 @@ def test_file_source_drs_s3():
             "access_methods": [
                 {
                     "type": "s3",
-                    "access_url": {
-                        "url": "s3://ga4gh-demo-data/phenopackets/Cao-2018-TGFBR2-Patient_4.json",
-                    },
                     "access_id": "1234",
                     "region": "us-east-1",
                 }
@@ -86,10 +94,24 @@ def test_file_source_drs_s3():
         }
         return (200, {}, json.dumps(data))
 
+    def access_handler(request):
+        assert request.headers["Authorization"] == "Bearer IBearTokens"
+        access_data = {
+            "url": "s3://ga4gh-demo-data/phenopackets/Cao-2018-TGFBR2-Patient_4.json",
+        }
+        return (200, {}, json.dumps(access_data))
+
     responses.add_callback(
         responses.GET,
         "https://drs.example.org/ga4gh/drs/v1/objects/314160",
         callback=drs_repo_handler,
+        content_type="application/json",
+    )
+
+    responses.add_callback(
+        responses.GET,
+        "https://drs.example.org/ga4gh/drs/v1/objects/314160/access/1234",
+        callback=access_handler,
         content_type="application/json",
     )
 

--- a/test/unit/files/test_drs_compact_identifiers.py
+++ b/test/unit/files/test_drs_compact_identifiers.py
@@ -1,0 +1,167 @@
+from unittest.mock import (
+    Mock,
+    patch,
+)
+
+import pytest
+
+from galaxy.files.sources.util import (
+    CompactIdentifierResolver,
+    parse_compact_identifier,
+    resolve_compact_identifier_to_url,
+)
+
+
+class TestCompactIdentifierParsing:
+    def test_parse_valid_compact_identifier(self):
+        prefix, accession = parse_compact_identifier("drs://drs.anv0:v2_64634a63-6ab8-361c-9bc2-e0f04ac9f7fd")
+        assert prefix == "drs.anv0"
+        assert accession == "v2_64634a63-6ab8-361c-9bc2-e0f04ac9f7fd"
+
+    def test_parse_with_provider_code(self):
+        prefix, accession = parse_compact_identifier("drs://provider.namespace:12345")
+        assert prefix == "provider.namespace"
+        assert accession == "12345"
+
+    def test_parse_invalid_format(self):
+        with pytest.raises(ValueError, match="Invalid compact identifier format"):
+            parse_compact_identifier("drs://no-colon-here")
+
+    def test_parse_empty_components(self):
+        with pytest.raises(ValueError, match="Empty prefix or accession"):
+            parse_compact_identifier("drs://:accession-only")
+
+    def test_parse_invalid_prefix_format(self):
+        with pytest.raises(ValueError, match="Invalid prefix format"):
+            parse_compact_identifier("drs://UPPERCASE:accession")
+
+    def test_parse_not_drs_uri(self):
+        with pytest.raises(ValueError, match="Not a valid DRS URI"):
+            parse_compact_identifier("https://example.com")
+
+
+class TestCompactIdentifierResolver:
+    @patch("galaxy.files.sources.util.requests.get")
+    def test_identifiers_org_resolution(self, mock_get):
+        namespace_response = Mock()
+        namespace_response.json.return_value = {
+            "_links": {
+                "self": {"href": "https://registry.api.identifiers.org/restApi/namespaces/123"},
+                "resources": {"href": "https://registry.api.identifiers.org/restApi/namespaces/123/resources"},
+            }
+        }
+        namespace_response.raise_for_status.return_value = None
+
+        resources_response = Mock()
+        resources_response.json.return_value = {
+            "_embedded": {"resources": [{"urlPattern": "https://example.com/objects/{$id}", "official": True}]}
+        }
+        resources_response.raise_for_status.return_value = None
+
+        mock_get.side_effect = [namespace_response, resources_response]
+
+        resolver = CompactIdentifierResolver()
+        url_pattern = resolver._query_identifiers_org("test.prefix")
+
+        assert url_pattern == "https://example.com/objects/{$id}"
+
+        assert mock_get.call_count == 2
+        mock_get.assert_any_call(
+            "https://registry.api.identifiers.org/restApi/namespaces/search/findByPrefix?prefix=test.prefix",
+            timeout=600,
+        )
+        mock_get.assert_any_call("https://registry.api.identifiers.org/restApi/namespaces/123/resources", timeout=600)
+
+    @patch("galaxy.files.sources.util.requests.get")
+    def test_identifiers_org_resolution_unofficial_resource(self, mock_get):
+        namespace_response = Mock()
+        namespace_response.json.return_value = {
+            "_links": {"resources": {"href": "https://registry.api.identifiers.org/restApi/namespaces/456/resources"}}
+        }
+        namespace_response.raise_for_status.return_value = None
+
+        resources_response = Mock()
+        resources_response.json.return_value = {
+            "_embedded": {
+                "resources": [{"urlPattern": "https://unofficial.example.com/objects/{$id}", "official": False}]
+            }
+        }
+        resources_response.raise_for_status.return_value = None
+
+        mock_get.side_effect = [namespace_response, resources_response]
+
+        resolver = CompactIdentifierResolver()
+        url_pattern = resolver._query_identifiers_org("test.prefix")
+
+        assert url_pattern == "https://unofficial.example.com/objects/{$id}"
+
+    def test_cache_behavior(self):
+        # Reset singleton for test isolation
+        CompactIdentifierResolver._reset_singleton()
+
+        resolver = CompactIdentifierResolver(cache_ttl=3600)
+        resolver._cache_result("test.prefix", "https://example.com/{$id}")
+
+        assert resolver._is_cached("test.prefix")
+        assert resolver.resolve_prefix("test.prefix") == "https://example.com/{$id}"
+
+        import time
+
+        resolver._cache["test.prefix"]["timestamp"] = time.time() - 3700
+        assert not resolver._is_cached("test.prefix")
+
+
+class TestResolution:
+    @patch("galaxy.files.sources.util.CompactIdentifierResolver.resolve_prefix")
+    def test_full_resolution(self, mock_resolve):
+        mock_resolve.return_value = "https://example.com/ga4gh/drs/v1/objects/{$id}"
+
+        url = resolve_compact_identifier_to_url("drs://test.prefix:abc/123")
+
+        assert url == "https://example.com/ga4gh/drs/v1/objects/abc%2F123"
+
+    @patch("galaxy.files.sources.util.CompactIdentifierResolver.resolve_prefix")
+    def test_resolution_with_special_chars(self, mock_resolve):
+        mock_resolve.return_value = "https://example.com/objects/{$id}"
+
+        url = resolve_compact_identifier_to_url("drs://test.prefix:abc:def/123#456")
+        assert url == "https://example.com/objects/abc%3Adef%2F123%23456"
+
+    @patch("galaxy.files.sources.util.CompactIdentifierResolver.resolve_prefix")
+    def test_resolution_failure(self, mock_resolve):
+        mock_resolve.return_value = None
+
+        with pytest.raises(ValueError, match="Could not resolve prefix"):
+            resolve_compact_identifier_to_url("drs://unknown.prefix:accession")
+
+    @patch("galaxy.files.sources.util.CompactIdentifierResolver.resolve_prefix")
+    def test_invalid_resolved_url(self, mock_resolve):
+        mock_resolve.return_value = "ftp://example.com/{$id}"
+
+        with pytest.raises(ValueError, match="Resolved URL is not HTTP"):
+            resolve_compact_identifier_to_url("drs://test.prefix:accession")
+
+
+class TestFetchDrsToFile:
+    @patch("galaxy.files.sources.util.resolve_compact_identifier_to_url")
+    @patch("galaxy.files.sources.util.retry_and_get")
+    @patch("galaxy.files.sources.util.stream_url_to_file")
+    def test_fetch_compact_identifier_drs(self, mock_stream, mock_retry_get, mock_resolve):
+        from galaxy.files.sources.util import fetch_drs_to_file
+
+        mock_resolve.return_value = "https://example.com/ga4gh/drs/v1/objects/object123"
+
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "access_methods": [{"type": "https", "access_url": {"url": "https://download.example.com/file.txt"}}]
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_retry_get.return_value = mock_response
+
+        fetch_drs_to_file("drs://test.prefix:object123", "/tmp/output.txt", None)
+
+        mock_resolve.assert_called_once()
+        mock_retry_get.assert_called_once()
+        args = mock_retry_get.call_args[0]
+        assert args[0] == "https://example.com/ga4gh/drs/v1/objects/object123"
+        mock_stream.assert_called_once()


### PR DESCRIPTION
Support compact identifiers (e.g., drs://drs.anv0:object-id) by resolving prefixes via identifiers.org. Includes caching and tests.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
