### PR TITLE
[24.2] Skip validation of expression.json input in workflow parameter validator

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1630,7 +1630,19 @@ class InputParameterModule(WorkflowModule):
         input_param = self.get_runtime_inputs(self)["input"]
         # TODO: raise DelayedWorkflowEvaluation if replacement not ready ? Need test
         try:
-            input_param.validate(input_value, trans)
+            if not isinstance(
+                input_value,
+                (
+                    model.DatasetInstance,
+                    model.HistoryDatasetCollectionAssociation,
+                    model.DatasetCollection,
+                    model.DatasetCollectionElement,
+                ),
+            ):
+                # We could attempt to turn expression.json datasets back into validatable values,
+                # but then we'd have to delay scheduling until they are ready. workflow parmater value validators are
+                # likely most important for parent workflows, where they run on primitive values.
+                input_param.validate(input_value, trans)
         except ValueError as e:
             raise FailWorkflowEvaluation(
                 why=InvocationFailureWorkflowParameterInvalid(


### PR DESCRIPTION
Fixes 
```
Workflow parameter on step 4 failed validation: Parameter 'input': Validator 'float('-inf') <= float(value) <= float('inf')' could not be evaluated on '<galaxy.model.HistoryDatasetAssociation(153812452) at 0x7f6ebd751e10>'
```
which would happen on a subworkflow input connected to a expression tool output.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
