### PR TITLE
[24.2] Fix unit tests returning values

### DIFF
--- a/lib/tool_shed/util/hg_util.py
+++ b/lib/tool_shed/util/hg_util.py
@@ -5,6 +5,7 @@ import subprocess
 import tempfile
 from datetime import datetime
 from time import gmtime
+from typing import TYPE_CHECKING
 
 from galaxy.tool_shed.util import basic_util
 from galaxy.tool_shed.util.hg_util import (
@@ -21,12 +22,15 @@ from galaxy.tool_shed.util.hg_util import (
 )
 from galaxy.util import unicodify
 
+if TYPE_CHECKING:
+    from galaxy.util.path import StrPath
+
 log = logging.getLogger(__name__)
 
 INITIAL_CHANGELOG_HASH = "000000000000"
 
 
-def add_changeset(repo_path, path_to_filename_in_archive):
+def add_changeset(repo_path: "StrPath", path_to_filename_in_archive: "StrPath"):
     try:
         subprocess.check_output(["hg", "add", path_to_filename_in_archive], stderr=subprocess.STDOUT, cwd=repo_path)
     except Exception as e:
@@ -51,7 +55,7 @@ def archive_repository_revision(app, repository, archive_dir, changeset_revision
         raise Exception(error_message)
 
 
-def commit_changeset(repo_path: str, full_path_to_changeset: str, username: str, message: str) -> None:
+def commit_changeset(repo_path: "StrPath", full_path_to_changeset: "StrPath", username: str, message: str) -> None:
     try:
         subprocess.check_output(
             ["hg", "commit", "-u", username, "-m", message, full_path_to_changeset],
@@ -215,7 +219,7 @@ def get_rev_label_from_changeset_revision(repo, changeset_revision, include_date
     return rev, label
 
 
-def remove_path(repo_path, selected_file):
+def remove_path(repo_path: "StrPath", selected_file: "StrPath"):
     cmd = ["hg", "remove", "--force", selected_file]
     try:
         subprocess.check_output(cmd, stderr=subprocess.STDOUT, cwd=repo_path)
@@ -236,7 +240,7 @@ def remove_path(repo_path, selected_file):
         raise Exception(error_message)
 
 
-def init_repository(repo_path):
+def init_repository(repo_path: "StrPath"):
     """
     Create a new Mercurial repository in the given directory.
     """


### PR DESCRIPTION
These break with pytest 8.4.0, see https://docs.pytest.org/en/stable/changelog.html#pytest-8-4-0-2025-06-02

Fix the following errors in test_galaxy_packages tests:

```
FAILED tests/tool_shed/test_hg_util.py::test_add_file_and_commmit_changeset - Failed: Expected None, but test returned local('/tmp/pytest-of-runner/pytest-7/test_add_file_and_commmit_chan0/test.txt'). Did you mean to use `assert` instead of `return`?
FAILED tests/tool_shed/test_hg_util.py::test_add_dir_and_commit_changeset - Failed: Expected None, but test returned local('/tmp/pytest-of-runner/pytest-7/test_add_dir_and_commit_change0/abc'). Did you mean to use `assert` instead of `return`?
```

Also:
- Replace legacy `tmpdir` fixtures with `tmp_path`.
- Improve type annotations.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
