### PR TITLE
[25.0] Fix $app attribute access in cheetah templates

### DIFF
--- a/lib/galaxy/di.py
+++ b/lib/galaxy/di.py
@@ -46,3 +46,10 @@ class Container(LagomContainer):
             return self[dep_type]
         except UnresolvableType:
             return None
+
+    def __getitem__(self, dep_type: Type[T]) -> T:
+        if isinstance(dep_type, str):
+            # Workaround for accessing attributes of $app inside cheetah templates.
+            # Cheetah's searchList implementation tests access via __getitem__ before __getattr__.
+            return getattr(self, dep_type)  # type: ignore[unreachable]
+        return self.resolve(dep_type)


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20365, which occurs only on Python 3.13 on datasets that can be visualized by a display application.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
