### PR TITLE
Base Implementation of GFormInput

### DIFF
--- a/client/src/components/BaseComponents/Form/GForm.vue
+++ b/client/src/components/BaseComponents/Form/GForm.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+import { assertDefined } from "@/utils/assertions";
+
+const form = ref<HTMLFormElement>();
+
+function checkValidity() {
+    assertDefined(form.value);
+    return form.value.checkValidity();
+}
+
+defineExpose({
+    checkValidity,
+});
+</script>
+
+<template>
+    <form ref="form">
+        <slot></slot>
+    </form>
+</template>
+
+<style scoped lang="scss"></style>

--- a/client/src/components/BaseComponents/Form/GForm.vue
+++ b/client/src/components/BaseComponents/Form/GForm.vue
@@ -20,5 +20,3 @@ defineExpose({
         <slot></slot>
     </form>
 </template>
-
-<style scoped lang="scss"></style>

--- a/client/src/components/BaseComponents/Form/GFormInput.vue
+++ b/client/src/components/BaseComponents/Form/GFormInput.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts"></script>
+
+<template>
+    <input class="g-form-input" />
+</template>
+
+<style scoped lang="scss">
+.g-form-input {
+    border-radius: var(--spacing-1);
+    border-style: solid;
+    border-width: 1px;
+    border-color: var(--color-grey-400);
+
+    color: var(--color-grey-800);
+
+    padding: var(--spacing-1) var(--spacing-2);
+
+    &:focus {
+        outline: none;
+        box-shadow: 0 0 0 0.2rem rgb(from var(--color-blue-400) r g b / 0.33);
+        z-index: 999;
+    }
+
+    &:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 0.2rem var(--color-blue-400);
+        z-index: 999;
+    }
+}
+</style>

--- a/client/src/components/BaseComponents/Form/GFormInput.vue
+++ b/client/src/components/BaseComponents/Form/GFormInput.vue
@@ -1,7 +1,19 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+const props = defineProps<{
+    value?: string | null;
+}>();
+
+const emit = defineEmits<{
+    (e: "input", value: string | null): void;
+}>();
+
+function onInput(event: Event) {
+    emit("input", (event as InputEvent).data);
+}
+</script>
 
 <template>
-    <input class="g-form-input" />
+    <input class="g-form-input" :value="props.value" @input="onInput" />
 </template>
 
 <style scoped lang="scss">

--- a/client/src/components/BaseComponents/Form/GFormInput.vue
+++ b/client/src/components/BaseComponents/Form/GFormInput.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { computed } from "vue";
+
 const props = defineProps<{
     value?: string | null;
 }>();
@@ -7,13 +9,18 @@ const emit = defineEmits<{
     (e: "input", value: string | null): void;
 }>();
 
-function onInput(event: Event) {
-    emit("input", (event as InputEvent).data);
-}
+const inputValue = computed({
+    get() {
+        return props.value;
+    },
+    set(value) {
+        emit("input", value ?? null);
+    },
+});
 </script>
 
 <template>
-    <input class="g-form-input" :value="props.value" @input="onInput" />
+    <input v-model="inputValue" class="g-form-input" />
 </template>
 
 <style scoped lang="scss">

--- a/client/src/components/BaseComponents/Form/GFormLabel.vue
+++ b/client/src/components/BaseComponents/Form/GFormLabel.vue
@@ -7,13 +7,13 @@ const props = withDefaults(
     defineProps<{
         title?: string;
         description?: string;
-        state?: boolean;
+        state?: boolean | null;
         invalidFeedback?: string;
     }>(),
     {
         title: undefined,
         description: undefined,
-        state: undefined,
+        state: null,
         invalidFeedback: undefined,
     }
 );

--- a/client/src/components/BaseComponents/Form/GFormLabel.vue
+++ b/client/src/components/BaseComponents/Form/GFormLabel.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { faCheckCircle, faExclamationCircle } from "font-awesome-6";
+import { computed } from "vue";
+
+const props = defineProps<{
+    title?: string;
+    description?: string;
+    state?: boolean;
+    invalidFeedback?: string;
+}>();
+
+const stateClasses = computed(() => {
+    return {
+        valid: props.state === true,
+        invalid: props.state === false,
+    };
+});
+</script>
+
+<template>
+    <div class="g-form-label" :class="stateClasses">
+        <label>
+            <span v-if="props.title" class="label-text">
+                {{ props.title }}
+            </span>
+
+            <div class="input">
+                <slot></slot>
+                <FontAwesomeIcon v-if="props.state === true" :icon="faCheckCircle" class="indicator valid" />
+                <FontAwesomeIcon v-if="props.state === false" :icon="faExclamationCircle" class="indicator invalid" />
+            </div>
+        </label>
+
+        <span v-if="props.invalidFeedback && props.state === false" class="feedback-invalid">
+            {{ props.invalidFeedback }}
+        </span>
+
+        <span v-if="description" class="description">
+            {{ props.description }}
+        </span>
+    </div>
+</template>
+
+<style scoped lang="scss">
+.g-form-label {
+    display: flex;
+    flex-direction: column;
+
+    label {
+        // bootstrap override
+        margin-bottom: 0;
+    }
+
+    .feedback-invalid {
+        color: var(--color-red-600);
+    }
+
+    .description {
+        color: var(--color-grey-300);
+    }
+
+    &.valid {
+        :deep(input) {
+            border-color: var(--color-green-500) !important;
+        }
+    }
+
+    &.invalid {
+        :deep(input) {
+            border-color: var(--color-red-500) !important;
+        }
+    }
+
+    .input {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+
+        .indicator {
+            position: absolute;
+            right: var(--spacing-2);
+            top: 50%;
+            transform: translateY(-50%);
+
+            &.valid {
+                color: var(--color-green-500);
+            }
+
+            &.invalid {
+                color: var(--color-red-500);
+            }
+        }
+    }
+}
+</style>

--- a/client/src/components/BaseComponents/Form/GFormLabel.vue
+++ b/client/src/components/BaseComponents/Form/GFormLabel.vue
@@ -3,12 +3,20 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { faCheckCircle, faExclamationCircle } from "font-awesome-6";
 import { computed } from "vue";
 
-const props = defineProps<{
-    title?: string;
-    description?: string;
-    state?: boolean;
-    invalidFeedback?: string;
-}>();
+const props = withDefaults(
+    defineProps<{
+        title?: string;
+        description?: string;
+        state?: boolean;
+        invalidFeedback?: string;
+    }>(),
+    {
+        title: undefined,
+        description: undefined,
+        state: undefined,
+        invalidFeedback: undefined,
+    }
+);
 
 const stateClasses = computed(() => {
     return {

--- a/client/src/components/BaseComponents/GModal.vue
+++ b/client/src/components/BaseComponents/GModal.vue
@@ -15,27 +15,41 @@ import { match } from "@/utils/utils";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import Heading from "@/components/Common/Heading.vue";
 
-const props = defineProps<{
-    id?: string;
-    /** Controls if the modal is showing. Syncable */
-    show?: boolean;
-    /** Controls the modals size. If unset, size can be controlled via css `width` and `height` */
-    size?: ComponentSize;
-    /** Shows confirm an cancel buttons in the footer, and sends out `ok` and `cancel` events */
-    confirm?: boolean;
-    /** Custom text for the Ok confirm button */
-    okText?: string;
-    /** Custom text for the Cancel confirm button */
-    cancelText?: string;
-    /** Renders the footer region, even if confirm is disabled */
-    footer?: boolean;
-    /** Text to display in the title */
-    title?: string;
-    /** Fixes the height of the modal to a pre-set height based on `size` */
-    fixedHeight?: boolean;
-    /** When false, keeps the modal open on "ok" */
-    closeOnOk?: boolean;
-}>();
+const props = withDefaults(
+    defineProps<{
+        id?: string;
+        /** Controls if the modal is showing. Syncable */
+        show?: boolean;
+        /** Controls the modals size. If unset, size can be controlled via css `width` and `height` */
+        size?: ComponentSize;
+        /** Shows confirm an cancel buttons in the footer, and sends out `ok` and `cancel` events */
+        confirm?: boolean;
+        /** Custom text for the Ok confirm button */
+        okText?: string;
+        /** Custom text for the Cancel confirm button */
+        cancelText?: string;
+        /** Renders the footer region, even if confirm is disabled */
+        footer?: boolean;
+        /** Text to display in the title */
+        title?: string;
+        /** Fixes the height of the modal to a pre-set height based on `size` */
+        fixedHeight?: boolean;
+        /** When false, keeps the modal open on "ok" */
+        closeOnOk?: boolean;
+    }>(),
+    {
+        id: undefined,
+        show: false,
+        confirm: false,
+        size: undefined,
+        okText: undefined,
+        cancelText: undefined,
+        footer: false,
+        title: undefined,
+        fixedHeight: false,
+        closeOnOk: true,
+    }
+);
 
 const emit = defineEmits<{
     (e: "update:show", show: boolean): void;

--- a/client/src/components/BaseComponents/GModal.vue
+++ b/client/src/components/BaseComponents/GModal.vue
@@ -33,6 +33,8 @@ const props = defineProps<{
     title?: string;
     /** Fixes the height of the modal to a pre-set height based on `size` */
     fixedHeight?: boolean;
+    /** When false, keeps the modal open on "ok" */
+    closeOnOk?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -76,8 +78,12 @@ function showModal() {
 let isOk = false;
 
 function hideModal(ok = false) {
-    isOk = ok;
-    dialog.value?.close();
+    if (ok && props.closeOnOk === false) {
+        emit("ok");
+    } else {
+        isOk = ok;
+        dialog.value?.close();
+    }
 }
 
 watchImmediate(
@@ -195,6 +201,10 @@ defineExpose({ showModal, hideModal });
         .g-modal-content {
             flex-grow: 1;
             overflow: auto;
+
+            padding: var(--spacing-2);
+            margin: calc(var(--spacing-2) * -1);
+
             max-height: 100%;
             display: flex;
             flex-direction: column;
@@ -245,6 +255,8 @@ defineExpose({ showModal, hideModal });
         padding: var(--spacing-3);
         border-top: 1px solid var(--color-grey-200);
         display: flex;
+
+        margin-top: var(--spacing-2);
 
         .g-modal-footer-content {
             flex-grow: 1;

--- a/client/src/components/User/UserDeletion.vue
+++ b/client/src/components/User/UserDeletion.vue
@@ -1,19 +1,20 @@
 <template>
-    <b-row class="ml-3 mb-1">
+    <div class="ml-3 mb-1 d-flex">
         <i class="pref-icon pt-1 fa fa-lg fa-radiation" />
         <div class="pref-content pr-1">
-            <a id="delete-account" href="javascript:void(0)"
-                ><b v-b-modal.modal-prevent-closing v-localize>Delete Account</b></a
-            >
+            <GLink id="delete-account" @click="showModal = true">
+                <b v-localize>Delete Account</b>
+            </GLink>
             <div v-localize class="form-text text-muted">Delete your account on this Galaxy server.</div>
-            <b-modal
+            <GModal
                 id="modal-prevent-closing"
-                ref="modal"
-                centered
                 title="Account Deletion"
-                title-tag="h2"
-                @show="resetModal"
-                @hidden="resetModal"
+                :show.sync="showModal"
+                confirm
+                ok-text="Delete Account"
+                :close-on-ok="false"
+                @open="resetModal"
+                @close="resetModal"
                 @ok="handleOk">
                 <p>
                     <b-alert variant="danger" :show="showDeleteError">{{ deleteError }}</b-alert>
@@ -22,18 +23,17 @@
                         contained in it.
                     </b>
                 </p>
-                <b-form ref="form" @submit.prevent="handleSubmit">
-                    <b-form-group
+                <GForm ref="form" @submit.prevent="handleSubmit">
+                    <GFormLabel
                         :state="nameState"
-                        label="Enter your user email for this account as confirmation."
-                        label-for="Email"
+                        title="Enter your user email for this account as confirmation."
                         invalid-feedback="Incorrect email">
-                        <b-form-input id="name-input" v-model="name" :state="nameState" required></b-form-input>
-                    </b-form-group>
-                </b-form>
-            </b-modal>
+                        <GFormInput id="name-input" v-model="name" required></GFormInput>
+                    </GFormLabel>
+                </GForm>
+            </GModal>
         </div>
-    </b-row>
+    </div>
 </template>
 
 <script>
@@ -43,9 +43,16 @@ import { userLogoutClient } from "utils/logout";
 import { withPrefix } from "utils/redirect";
 import Vue from "vue";
 
+import GForm from "@/components/BaseComponents/Form/GForm.vue";
+import GFormInput from "@/components/BaseComponents/Form/GFormInput.vue";
+import GFormLabel from "@/components/BaseComponents/Form/GFormLabel.vue";
+import GLink from "@/components/BaseComponents/GLink.vue";
+import GModal from "@/components/BaseComponents/GModal.vue";
+
 Vue.use(BootstrapVue);
 
 export default {
+    components: { GLink, GModal, GForm, GFormLabel, GFormInput },
     props: {
         userId: {
             type: String,
@@ -58,6 +65,7 @@ export default {
     },
     data() {
         return {
+            showModal: false,
             name: "",
             nameState: null,
             deleteError: "",
@@ -78,9 +86,7 @@ export default {
             this.name = "";
             this.nameState = null;
         },
-        handleOk(bvModalEvt) {
-            // Prevent modal from closing
-            bvModalEvt.preventDefault();
+        handleOk() {
             // Trigger submit handler
             this.handleSubmit();
         },

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -76,7 +76,7 @@ preferences:
     object_store: '#select-preferred-object-store'
     delete_account: '#delete-account'
     delete_account_input: '#name-input'
-    delete_account_ok_btn: '.modal-footer .btn-primary'
+    delete_account_ok_btn: '.g-modal-confirm-buttons button.g-blue'
     email_input: "input[id='email']"
     username_input: "input[id='username']"
     preferred_storage: '.preferred-storage'


### PR DESCRIPTION
minimal implementation for:

GForm (currently empty wrapper)
GFormLabel (mostly replaces BFromGroup)
GFormInput (input wrapper with base styles)

![image](https://github.com/user-attachments/assets/ce74bee9-5608-452e-9ccc-dade780aa138)

Also makes some tweaks to GModal, and adds the ability to stay open on "ok"

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
