### PR TITLE
[25.0] Add user-facing explanation for legacy workflow run form usage

### DIFF
--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -54,6 +54,9 @@ const hasStepVersionChanges = ref(false);
 const invocations = ref([]);
 const simpleForm = ref(false);
 const disableSimpleForm = ref(false);
+const disableSimpleFormReason = ref<
+    "hasReplacementParameters" | "hasDisconnectedInputs" | "hasWorkflowResourceParameters" | undefined
+>(undefined);
 const submissionError = ref("");
 const workflowError = ref("");
 const workflowName = ref("");
@@ -115,24 +118,24 @@ async function loadRun() {
             // on the frontend. If these are implemented on the backend at some
             // point this restriction can be lifted.
             if (incomingModel.hasReplacementParametersInToolForm) {
-                console.log("cannot render simple workflow form - has ${} values in tool steps");
                 simpleForm.value = false;
                 disableSimpleForm.value = true;
+                disableSimpleFormReason.value = "hasReplacementParameters";
             }
             // If there are required parameters in a tool form (a disconnected runtime
             // input), we have to render the tool form steps and cannot use the
             // simplified tool form.
             if (incomingModel.hasOpenToolSteps) {
-                console.log("cannot render simple workflow form - one or more tools have disconnected runtime inputs");
                 simpleForm.value = false;
                 disableSimpleForm.value = true;
+                disableSimpleFormReason.value = "hasDisconnectedInputs";
             }
             // Just render the whole form for resource request parameters (kind of
             // niche - I'm not sure anyone is using these currently anyway).
             if (incomingModel.hasWorkflowResourceParameters) {
-                console.log(`Cannot render simple workflow form - workflow resource parameters are configured`);
                 simpleForm.value = false;
                 disableSimpleForm.value = true;
+                disableSimpleFormReason.value = "hasWorkflowResourceParameters";
             }
         }
 
@@ -260,6 +263,7 @@ defineExpose({
                         :model="workflowModel"
                         :can-mutate-current-history="canRunOnHistory"
                         :disable-simple-form="disableSimpleForm"
+                        :disable-simple-form-reason="disableSimpleFormReason"
                         @submissionSuccess="handleInvocations"
                         @submissionError="handleSubmissionError"
                         @showSimple="advancedForm = false" />

--- a/client/src/components/Workflow/Run/WorkflowRunForm.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunForm.vue
@@ -18,9 +18,6 @@
                     @click="$emit('showSimple')">
                     <span class="fas fa-arrow-left" /> Simple Form
                 </b-button>
-                <b-badge v-else class="d-flex align-items-center flex-gapx-1" variant="warning">
-                    <span class="fas fa-exclamation-triangle" /> Legacy Form
-                </b-badge>
                 <ButtonSpinner
                     id="run-workflow"
                     title="Run Workflow"

--- a/client/src/components/Workflow/Run/WorkflowRunForm.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunForm.vue
@@ -18,6 +18,9 @@
                     @click="$emit('showSimple')">
                     <span class="fas fa-arrow-left" /> Simple Form
                 </b-button>
+                <b-badge v-else class="d-flex align-items-center flex-gapx-1" variant="warning">
+                    <span class="fas fa-exclamation-triangle" /> Legacy Form
+                </b-badge>
                 <ButtonSpinner
                     id="run-workflow"
                     title="Run Workflow"
@@ -26,6 +29,21 @@
                     @onClick="onExecute" />
             </div>
         </div>
+        <BAlert v-if="disableSimpleFormReason" show variant="warning">
+            This is the legacy workflow run form.
+            <span v-if="disableSimpleFormReason === 'hasReplacementParameters'">
+                This workflow contains parameters in tool steps that require advanced handling. The simplified form does
+                not support these parameters.
+            </span>
+            <span v-else-if="disableSimpleFormReason === 'hasDisconnectedInputs'">
+                One or more tools in this workflow have required inputs that are not connected to other steps. The
+                simplified form cannot handle disconnected runtime inputs.
+            </span>
+            <span v-else-if="disableSimpleFormReason === 'hasWorkflowResourceParameters'">
+                This workflow is configured with resource request parameters. The simplified form does not support
+                workflows with resource options.
+            </span>
+        </BAlert>
         <FormCard v-if="wpInputsAvailable" title="Workflow Parameters">
             <template v-slot:body>
                 <FormDisplay :inputs="wpInputs" @onChange="onWpInputs" />
@@ -107,6 +125,10 @@ export default {
         disableSimpleForm: {
             type: Boolean,
             default: false,
+        },
+        disableSimpleFormReason: {
+            type: String,
+            default: undefined,
         },
     },
     data() {


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20426

![image](https://github.com/user-attachments/assets/f6656b6e-5039-4e13-bc8f-55e7c131be7a)

_Update: I removed the badge, **it's just the alert now**._

I used the warning variant on purpose because it's, in a way, warning the user that something could be done to be able to use the simplified form. I feel like the primary variant (info) is used for loading indicators, informative messages, rather than such warnings.

I can still change it to `info` if we disagree.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
