### PR TITLE
[25.0] Deprecate ``enable_tool_document_cache``

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1222,12 +1222,13 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Whether to enable the tool document cache. This cache stores
-    expanded XML strings. Enabling the tool cache results in slightly
-    faster startup times. The tool cache is backed by a SQLite
-    database, which cannot be stored on certain network disks. The
-    cache location is configurable with the ``tool_cache_data_dir``
-    tag in tool config files.
+    This option is deprecated, and the tool document cache will be
+    removed in the next release. Whether to enable the tool document
+    cache. This cache stores expanded XML strings. Enabling the tool
+    cache results in slightly faster startup times. The tool cache is
+    backed by a SQLite database, which cannot be stored on certain
+    network disks. The cache location is configurable with the
+    ``tool_cache_data_dir`` tag in tool config files.
 :Default: ``false``
 :Type: bool
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -935,12 +935,13 @@ galaxy:
   # generated commands run in sh.
   #default_job_shell: /bin/bash
 
-  # Whether to enable the tool document cache. This cache stores
-  # expanded XML strings. Enabling the tool cache results in slightly
-  # faster startup times. The tool cache is backed by a SQLite database,
-  # which cannot be stored on certain network disks. The cache location
-  # is configurable with the ``tool_cache_data_dir`` tag in tool config
-  # files.
+  # This option is deprecated, and the tool document cache will be
+  # removed in the next release. Whether to enable the tool document
+  # cache. This cache stores expanded XML strings. Enabling the tool
+  # cache results in slightly faster startup times. The tool cache is
+  # backed by a SQLite database, which cannot be stored on certain
+  # network disks. The cache location is configurable with the
+  # ``tool_cache_data_dir`` tag in tool config files.
   #enable_tool_document_cache: false
 
   # Directory in which the toolbox search index is stored. The value of

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -887,6 +887,8 @@ mapping:
         default: false
         required: false
         desc: |
+          This option is deprecated, and the tool document cache will be removed
+          in the next release.
           Whether to enable the tool document cache. This cache stores
           expanded XML strings. Enabling the tool cache results in slightly faster startup
           times. The tool cache is backed by a SQLite database, which cannot


### PR DESCRIPTION
See https://github.com/galaxyproject/galaxy/issues/20432 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
