### PR TITLE
[25.0] Upgrade tensorflow conditional dependency version to 2.15.1

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -56,7 +56,7 @@ pygithub
 influxdb
 
 # Deep learning packages for tool recommendation
-tensorflow==2.9.3
+tensorflow==2.15.1
 
 # weasyprint has problematic requirements (cairo, Pango, see:
 # https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#linux)


### PR DESCRIPTION
According to this issue: https://github.com/galaxyproject/galaxy/issues/17857, 2.15.1 will work with tool recommendations, which is the condition under which tensorflow is installed in the venv (enable_tool_recommendations: true in galaxy.yml). Galaxy Europe uses this tensorflow version on their fork of galaxy.

With tensorflow pinned to 2.9.3, we have to use python <=3.10 for our galaxy virtual environment.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
