### PR TITLE
Implement dataset source requested transformations.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -281,9 +281,10 @@ CONFIGURATION_TEMPLATE_DEFINITION_TYPE = Dict[str, Any]
 
 class TransformAction(TypedDict):
     action: DatasetSourceTransformActionTypeLiteral
-    datatype_ext: NotRequired[
-        str
-    ]  # if action == 'datatype_groom', this is the datatype ext that was used to groom the dataset.
+    # if action == 'datatype_groom', this is the datatype that was used to groom the dataset.
+    datatype_class: NotRequired[str]
+    # if action == 'datatype_groom', this is the datatype ext that was used to groom the dataset.
+    datatype_ext: NotRequired[str]
 
 
 class RequestedTransformAction(TypedDict):

--- a/lib/galaxy/model/deferred.py
+++ b/lib/galaxy/model/deferred.py
@@ -253,7 +253,7 @@ class DatasetInstanceMaterializer:
             applied_transforms.append(
                 {
                     "action": "datatype_groom",
-                    "datatype_ext": datatype.ext,
+                    "datatype_ext": datatype.file_ext,
                     "datatype_class": datatype.__class__.__name__,
                 }
             )

--- a/lib/galaxy/model/deferred.py
+++ b/lib/galaxy/model/deferred.py
@@ -114,7 +114,22 @@ class DatasetInstanceMaterializer:
             materialized_dataset.state = Dataset.states.OK
             materialized_dataset.deleted = False
             materialized_dataset.purged = False
-            materialized_dataset.sources = [s.copy() for s in dataset.sources]
+            copied_sources = [s.copy() for s in dataset.sources]
+            for source in copied_sources:
+                if source.requested_transform is None and source.transform is not None:
+                    # legacy dataset being copied, new paradigm is to treat transform as
+                    # what happened and requested_transform as what should happen - so lets
+                    # swap these in this new dataset.
+                    source.requested_transform = source.transform
+
+                # we have not applied any transforms yet, so we can clear these
+                source.transform = None
+
+                # lets ensure we record we thought through requested_transform - so we use
+                # an empty list instead of None.
+                source.requested_transform = source.requested_transform or []
+
+            materialized_dataset.sources = copied_sources
             materialized_dataset.hashes = materialized_dataset_hashes
         target_source = self._find_closest_dataset_source(dataset)
         transient_paths = None
@@ -206,16 +221,19 @@ class DatasetInstanceMaterializer:
             for source_hash in target_source.hashes:
                 _validate_hash(path, source_hash, "downloaded file")
 
-        transform = target_source.transform or []
+        requested_transforms = target_source.requested_transform or []
+        applied_transforms = []
         to_posix_lines = False
         spaces_to_tabs = False
         datatype_groom = False
-        for transform_action in transform:
+        for transform_action in requested_transforms:
             action = transform_action["action"]
             if action == "to_posix_lines":
                 to_posix_lines = True
+                applied_transforms.append(transform_action)
             elif action == "spaces_to_tabs":
                 spaces_to_tabs = True
+                applied_transforms.append(transform_action)
             elif action == "datatype_groom":
                 datatype_groom = True
             else:
@@ -225,8 +243,16 @@ class DatasetInstanceMaterializer:
             convert_result = convert_fxn(path, False)
             assert convert_result.converted_path
             path = convert_result.converted_path
-        if datatype_groom:
+        if datatype_groom and datatype.dataset_content_needs_grooming(path):
             datatype.groom_dataset_content(path)
+            applied_transforms.append(
+                {
+                    "action": "datatype_groom",
+                    "datatype_ext": datatype.ext,
+                    "datatype_class": datatype.__class__.__name__,
+                }
+            )
+
             # Grooming is not reproducible (e.g. temporary paths in BAM headers), so invalidate hashes
             dataset.hashes = []
 
@@ -234,6 +260,8 @@ class DatasetInstanceMaterializer:
             for dataset_hash in dataset.hashes:
                 _validate_hash(path, dataset_hash, "dataset contents")
 
+        for materialized_source in dataset.sources:
+            materialized_source.transform = applied_transforms
         return path
 
     def _find_closest_dataset_source(self, dataset: Dataset) -> DatasetSource:

--- a/lib/galaxy/model/deferred.py
+++ b/lib/galaxy/model/deferred.py
@@ -28,6 +28,7 @@ from galaxy.model import (
     HistoryDatasetCollectionAssociation,
     LibraryDatasetDatasetAssociation,
     required_object_session,
+    TRANSFORM_ACTIONS,
 )
 from galaxy.objectstore import (
     ObjectStore,
@@ -222,7 +223,7 @@ class DatasetInstanceMaterializer:
                 _validate_hash(path, source_hash, "downloaded file")
 
         requested_transforms = target_source.requested_transform or []
-        applied_transforms = []
+        applied_transforms: TRANSFORM_ACTIONS = []
         to_posix_lines = False
         spaces_to_tabs = False
         datatype_groom = False
@@ -230,10 +231,8 @@ class DatasetInstanceMaterializer:
             action = transform_action["action"]
             if action == "to_posix_lines":
                 to_posix_lines = True
-                applied_transforms.append(transform_action)
             elif action == "spaces_to_tabs":
                 spaces_to_tabs = True
-                applied_transforms.append(transform_action)
             elif action == "datatype_groom":
                 datatype_groom = True
             else:
@@ -243,6 +242,12 @@ class DatasetInstanceMaterializer:
             convert_result = convert_fxn(path, False)
             assert convert_result.converted_path
             path = convert_result.converted_path
+            if convert_result.converted_newlines:
+                applied_transforms.append({"action": "to_posix_lines"})
+            if convert_result.converted_regex:
+                # TODO: rename this converted_regex nonsense to converted_spaces to match upload
+                # utility used in data_fetch.py.
+                applied_transforms.append({"action": "spaces_to_tabs"})
         if datatype_groom and datatype.dataset_content_needs_grooming(path):
             datatype.groom_dataset_content(path)
             applied_transforms.append(

--- a/lib/galaxy/model/dereference.py
+++ b/lib/galaxy/model/dereference.py
@@ -60,13 +60,12 @@ def dereference_to_model(
     dataset_source.hashes = hashes
     assert hda.dataset
     hda.dataset.sources = [dataset_source]
-    transform: List[TransformAction] = []
+    transform: List[TransformAction] = [{"action": "datatype_groom"}]
     if data_request_uri.space_to_tab:
         transform.append({"action": "spaces_to_tabs"})
     elif data_request_uri.to_posix_lines:
         transform.append({"action": "to_posix_lines"})
-    if len(transform) > 0:
-        dataset_source.transform = transform
+    dataset_source.requested_transform = transform
 
     sa_session.add(hda)
     sa_session.add(dataset_source)

--- a/lib/galaxy/model/dereference.py
+++ b/lib/galaxy/model/dereference.py
@@ -1,8 +1,5 @@
 import os.path
-from typing import (
-    List,
-    Union,
-)
+from typing import Union
 
 from galaxy.model import (
     DatasetCollection,
@@ -12,7 +9,7 @@ from galaxy.model import (
     History,
     HistoryDatasetAssociation,
     HistoryDatasetCollectionAssociation,
-    TransformAction,
+    REQUESTED_TRANSFORM_ACTIONS,
     User,
 )
 from galaxy.model.scoped_session import galaxy_scoped_session
@@ -60,7 +57,7 @@ def dereference_to_model(
     dataset_source.hashes = hashes
     assert hda.dataset
     hda.dataset.sources = [dataset_source]
-    transform: List[TransformAction] = [{"action": "datatype_groom"}]
+    transform: REQUESTED_TRANSFORM_ACTIONS = [{"action": "datatype_groom"}]
     if data_request_uri.space_to_tab:
         transform.append({"action": "spaces_to_tabs"})
     elif data_request_uri.to_posix_lines:

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/fb16d09348db_dataset_source_requested_actions.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/fb16d09348db_dataset_source_requested_actions.py
@@ -1,0 +1,44 @@
+"""Add requested_actions column to dataset_source table
+
+Revision ID: fb16d09348db
+Revises: 3af58c192752
+Create Date: 2025-06-11 08:48:10.124300
+"""
+
+import sqlalchemy as sa
+
+from galaxy.model.custom_types import MutableJSONType
+from galaxy.model.migrations.util import (
+    add_column,
+    drop_column,
+)
+
+# revision identifiers, used by Alembic.
+revision = "fb16d09348db"
+down_revision = "3af58c192752"
+branch_labels = None
+depends_on = None
+
+# database object names used in this revision
+table_name = "dataset_source"
+column_name = "requested_actions"
+
+
+def upgrade():
+    column = sa.Column(
+        column_name,
+        MutableJSONType,
+        nullable=True,  # Allow nulls for existing rows
+        default=None,  # Default to None if not provided
+    )
+    add_column(
+        table_name,
+        column,
+    )
+
+
+def downgrade():
+    drop_column(
+        table_name,
+        column_name,
+    )

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/fb16d09348db_dataset_source_requested_transform.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/fb16d09348db_dataset_source_requested_transform.py
@@ -1,7 +1,7 @@
-"""Add requested_actions column to dataset_source table
+"""Add requested_transform column to dataset_source table
 
 Revision ID: fb16d09348db
-Revises: 3af58c192752
+Revises: a91ea1d97111
 Create Date: 2025-06-11 08:48:10.124300
 """
 
@@ -15,13 +15,13 @@ from galaxy.model.migrations.util import (
 
 # revision identifiers, used by Alembic.
 revision = "fb16d09348db"
-down_revision = "3af58c192752"
+down_revision = "a91ea1d97111"
 branch_labels = None
 depends_on = None
 
 # database object names used in this revision
 table_name = "dataset_source"
-column_name = "requested_actions"
+column_name = "requested_transform"
 
 
 def upgrade():

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -450,6 +450,8 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 recorded_requested_transform = "requested_transform" in source_attrs
                 if recorded_requested_transform:
                     source_obj.requested_transform = source_attrs["requested_transform"]
+                    if dataset_instance.state != "deferred":
+                        source_obj.transform = transform_actions
                 else:
                     # legacy transform actions - if this is a deferred dataset treat as requested
                     # transform actions

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -446,7 +446,17 @@ class ModelImportStore(metaclass=abc.ABCMeta):
             for source_attrs in dataset_or_file_attrs["sources"]:
                 source_obj = model.DatasetSource()
                 source_obj.source_uri = source_attrs["source_uri"]
-                source_obj.transform = source_attrs["transform"]
+                transform_actions = source_attrs["transform"]
+                recorded_requested_transform = "requested_transform" in source_attrs
+                if recorded_requested_transform:
+                    source_obj.requested_transform = source_attrs["requested_transform"]
+                else:
+                    # legacy transform actions - if this is a deferred dataset treat as requested
+                    # transform actions
+                    if dataset_instance.state == "deferred":
+                        source_obj.requested_transform = transform_actions or []
+                    else:
+                        source_obj.transform = transform_actions
                 source_obj.extra_files_path = source_attrs["extra_files_path"]
                 for hash_attrs in source_attrs["hashes"]:
                     hash_obj = model.DatasetSourceHash()

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -172,6 +172,7 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
             source = galaxy.model.DatasetSource()
             source.source_uri = source_dict["source_uri"]
             source.transform = source_dict.get("transform")
+            source.requested_transform = source_dict.get("requested_transform")
             primary_data.dataset.sources.append(source)
 
         for hash_dict in hashes:

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -321,10 +321,13 @@ def _fetch_target(upload_config: "UploadConfig", target: Dict[str, Any]):
                 convert_spaces_to_tabs=space_to_tab,
             )
             transform = []
+            requested_transform = [{"action": "datatype_groom"}]
             if converted_newlines:
                 transform.append({"action": "to_posix_lines"})
+                requested_transform.append({"action": "to_posix_lines"})
             if converted_spaces:
                 transform.append({"action": "spaces_to_tabs"})
+                requested_transform.append({"action": "spaces_to_tabs"})
             if link_data_only:
                 # Never alter a file that will not be copied to Galaxy's local file store.
                 if datatype.dataset_content_needs_grooming(path):
@@ -392,6 +395,7 @@ def _fetch_target(upload_config: "UploadConfig", target: Dict[str, Any]):
                 transform.append({"action": "to_posix_lines"})
             if space_to_tab:
                 transform.append({"action": "spaces_to_tabs"})
+            source_dict["requested_transform"] = transform
             effective_state = "deferred"
             registry = upload_config.registry
             ext = sniff.guess_ext_from_file_name(name, registry=registry, requested_ext=requested_ext)

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -298,6 +298,12 @@ def _fetch_target(upload_config: "UploadConfig", target: Dict[str, Any]):
         space_to_tab = upload_config.get_option(item, "space_to_tab")
         auto_decompress = upload_config.get_option(item, "auto_decompress")
 
+        requested_transform = [{"action": "datatype_groom"}]
+        if space_to_tab:
+            requested_transform.append({"action": "spaces_to_tabs"})
+        if to_posix_lines:
+            requested_transform.append({"action": "to_posix_lines"})
+        source_dict["requested_transform"] = requested_transform
         effective_state = "ok"
         if not deferred and not error_message:
             in_place = item.get("in_place", default_in_place)
@@ -321,13 +327,10 @@ def _fetch_target(upload_config: "UploadConfig", target: Dict[str, Any]):
                 convert_spaces_to_tabs=space_to_tab,
             )
             transform = []
-            requested_transform = [{"action": "datatype_groom"}]
             if converted_newlines:
                 transform.append({"action": "to_posix_lines"})
-                requested_transform.append({"action": "to_posix_lines"})
             if converted_spaces:
                 transform.append({"action": "spaces_to_tabs"})
-                requested_transform.append({"action": "spaces_to_tabs"})
             if link_data_only:
                 # Never alter a file that will not be copied to Galaxy's local file store.
                 if datatype.dataset_content_needs_grooming(path):
@@ -387,15 +390,10 @@ def _fetch_target(upload_config: "UploadConfig", target: Dict[str, Any]):
                 assert path
                 datatype.groom_dataset_content(path)
 
+            # if length is 0, we should probably persist the empty list? -John
             if len(transform) > 0:
                 source_dict["transform"] = transform
         elif not error_message:
-            transform = []
-            if to_posix_lines:
-                transform.append({"action": "to_posix_lines"})
-            if space_to_tab:
-                transform.append({"action": "spaces_to_tabs"})
-            source_dict["requested_transform"] = transform
             effective_state = "deferred"
             registry = upload_config.registry
             ext = sniff.guess_ext_from_file_name(name, registry=registry, requested_ext=requested_ext)

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2804,7 +2804,7 @@ def raw_to_galaxy(
         source = DatasetSource()
         source.source_uri = location
         # TODO: validate this...
-        source.transform = as_dict_value.get("transform")
+        source.requested_transform = as_dict_value.get("transform")
         dataset.sources.append(source)
 
         for hash_name in HASH_NAMES:

--- a/test/unit/data/test_dataset_materialization.py
+++ b/test/unit/data/test_dataset_materialization.py
@@ -16,6 +16,7 @@ from galaxy.model.deferred import (
 )
 from galaxy.model.unittest_utils.store_fixtures import (
     deferred_hda_model_store_dict,
+    deferred_hda_model_store_dict_space_to_tab,
     one_ld_library_deferred_model_store_dict,
 )
 from .model.test_model_store import (
@@ -87,6 +88,34 @@ def test_hash_invalid():
     materialized_hda = materializer.ensure_materialized(deferred_hda)
     materialized_dataset = materialized_hda.dataset
     assert materialized_dataset.state == "error"
+
+
+def test_legacy_transform_actions_on_deferred_hdas_become_requested_actions():
+    # pre 25.1 we didn't have the distinction between requested and applied transforms,
+    # so we need to ensure that legacy transforms are converted to requested transforms for
+    # deferred datasets. In 25.1 - deferred datasets should always have empty transforms as
+    # no actions have been applied yet.
+    fixture_context = setup_fixture_context_with_history()
+    store_dict = deferred_hda_model_store_dict()
+    store_dict["datasets"][0]["file_metadata"]["sources"][0]["transform"] = [{"action": "spaces_to_tabs"}]
+    perform_import_from_store_dict(fixture_context, store_dict)
+    deferred_hda = fixture_context.history.datasets[0]
+    deferred_dataset = deferred_hda.dataset
+    assert deferred_dataset.sources[0].transform is None
+    assert deferred_dataset.sources[0].requested_transform == [{"action": "spaces_to_tabs"}]
+
+
+def test_requested_transform_actions_on_deferred_hdas_preserved():
+    # Continued from previous comment, in 25.1 - deferred datasets should have transforms saved
+    # as requested transforms, so we need to ensure that these are preserved during store import.
+    fixture_context = setup_fixture_context_with_history()
+    store_dict = deferred_hda_model_store_dict()
+    store_dict["datasets"][0]["file_metadata"]["sources"][0]["requested_transform"] = [{"action": "spaces_to_tabs"}]
+    perform_import_from_store_dict(fixture_context, store_dict)
+    deferred_hda = fixture_context.history.datasets[0]
+    deferred_dataset = deferred_hda.dataset
+    assert deferred_dataset.sources[0].transform is None
+    assert deferred_dataset.sources[0].requested_transform == [{"action": "spaces_to_tabs"}]
 
 
 def test_hash_validate_source_of_download():
@@ -161,6 +190,96 @@ def test_deferred_hdas_basic_detached(tmpdir):
     assert external_filename.startswith(str(tmpdir))
     _assert_path_contains_2_bed(external_filename)
     _assert_2_bed_metadata(materialized_hda)
+
+
+def test_deferred_datasets_with_legacy_transforms_respect_transform(tmpdir):
+    fixture_context = setup_fixture_context_with_history()
+    store_dict = deferred_hda_model_store_dict_space_to_tab("legacy")
+    perform_import_from_store_dict(fixture_context, store_dict)
+    deferred_hda = fixture_context.history.datasets[0]
+    assert deferred_hda
+    assert deferred_hda.dataset.state == "deferred"
+    assert deferred_hda.dataset.sources[0].transform is None
+    assert deferred_hda.dataset.sources[0].requested_transform == [{"action": "spaces_to_tabs"}]
+    materializer = materializer_factory(False, transient_directory=tmpdir)
+    materialized_hda = materializer.ensure_materialized(deferred_hda)
+    materialized_dataset = materialized_hda.dataset
+    assert materialized_dataset.sources[0].transform == [{"action": "spaces_to_tabs"}]
+    assert materialized_dataset.sources[0].requested_transform == [{"action": "spaces_to_tabs"}]
+    assert materialized_dataset.state == "ok"
+    external_filename = materialized_dataset.external_filename
+    assert external_filename
+    assert external_filename.startswith(str(tmpdir))
+    _assert_path_contains_simple_lines_as_tsv(external_filename)
+
+
+def test_deferred_datasets_with_requested_transforms_respect_transform(tmpdir):
+    fixture_context = setup_fixture_context_with_history()
+    store_dict = deferred_hda_model_store_dict_space_to_tab("25.1")
+    perform_import_from_store_dict(fixture_context, store_dict)
+    deferred_hda = fixture_context.history.datasets[0]
+    assert deferred_hda
+    assert deferred_hda.dataset.state == "deferred"
+    assert deferred_hda.dataset.sources[0].transform is None
+    assert deferred_hda.dataset.sources[0].requested_transform == [
+        {"action": "datatype_groom"},
+        {"action": "spaces_to_tabs"},
+    ]
+    materializer = materializer_factory(False, transient_directory=tmpdir)
+    materialized_hda = materializer.ensure_materialized(deferred_hda)
+    materialized_dataset = materialized_hda.dataset
+    assert materialized_dataset.sources[0].transform == [{"action": "spaces_to_tabs"}]
+    assert materialized_dataset.sources[0].requested_transform == [
+        {"action": "datatype_groom"},
+        {"action": "spaces_to_tabs"},
+    ]
+    assert materialized_dataset.state == "ok"
+    external_filename = materialized_dataset.external_filename
+    assert external_filename
+    assert external_filename.startswith(str(tmpdir))
+    _assert_path_contains_simple_lines_as_tsv(external_filename)
+
+
+def test_deferred_datasets_do_not_apply_unspecified_transforms_legacy(tmpdir):
+    fixture_context = setup_fixture_context_with_history()
+    store_dict = deferred_hda_model_store_dict_space_to_tab("legacy", apply_transform=False)
+    perform_import_from_store_dict(fixture_context, store_dict)
+    deferred_hda = fixture_context.history.datasets[0]
+    assert deferred_hda
+    assert deferred_hda.dataset.state == "deferred"
+    assert deferred_hda.dataset.sources[0].transform is None
+    assert deferred_hda.dataset.sources[0].requested_transform == []
+    materializer = materializer_factory(False, transient_directory=tmpdir)
+    materialized_hda = materializer.ensure_materialized(deferred_hda)
+    materialized_dataset = materialized_hda.dataset
+    assert materialized_dataset.sources[0].transform == []
+    assert materialized_dataset.sources[0].requested_transform == []
+    assert materialized_dataset.state == "ok"
+    external_filename = materialized_dataset.external_filename
+    assert external_filename
+    assert external_filename.startswith(str(tmpdir))
+    _assert_path_contains_simple_lines_as_text(external_filename)
+
+
+def test_deferred_datasets_do_not_apply_unspecified_transforms(tmpdir):
+    fixture_context = setup_fixture_context_with_history()
+    store_dict = deferred_hda_model_store_dict_space_to_tab("25.1", apply_transform=False)
+    perform_import_from_store_dict(fixture_context, store_dict)
+    deferred_hda = fixture_context.history.datasets[0]
+    assert deferred_hda
+    assert deferred_hda.dataset.state == "deferred"
+    assert deferred_hda.dataset.sources[0].transform is None
+    assert deferred_hda.dataset.sources[0].requested_transform == [{"action": "datatype_groom"}]
+    materializer = materializer_factory(False, transient_directory=tmpdir)
+    materialized_hda = materializer.ensure_materialized(deferred_hda)
+    materialized_dataset = materialized_hda.dataset
+    assert materialized_dataset.sources[0].transform == []
+    assert materialized_dataset.sources[0].requested_transform == [{"action": "datatype_groom"}]
+    assert materialized_dataset.state == "ok"
+    external_filename = materialized_dataset.external_filename
+    assert external_filename
+    assert external_filename.startswith(str(tmpdir))
+    _assert_path_contains_simple_lines_as_text(external_filename)
 
 
 def test_deferred_hdas_basic_detached_from_detached_hda(tmpdir):
@@ -405,3 +524,15 @@ def _assert_path_contains_2_bed(path) -> None:
     with open(path) as f:
         contents = f.read()
     assert contents == CONTENTS_2_BED
+
+
+def _assert_path_contains_simple_lines_as_tsv(path) -> None:
+    with open(path) as f:
+        contents = f.read()
+    assert contents == "This\tis\ta\tline\tof\ttext.\n"  # simple lines as TSV
+
+
+def _assert_path_contains_simple_lines_as_text(path) -> None:
+    with open(path) as f:
+        contents = f.read()
+    assert contents == "This is a line of text.\n"  # simple lines as text

--- a/test/unit/data/test_dereference.py
+++ b/test/unit/data/test_dereference.py
@@ -54,4 +54,9 @@ def test_dereference_to_posix():
     hda = dereference_to_model(sa_session, user, history, uri_request)
     assert hda.name == "foobar.txt"
     assert hda.dataset.sources[0].source_uri == TEST_BASE64_URI
-    assert hda.dataset.sources[0].transform[0]["action"] == "spaces_to_tabs"
+    assert hda.dataset.sources[0].requested_transform[0]["action"] == "datatype_groom"
+    assert hda.dataset.sources[0].requested_transform[1]["action"] == "spaces_to_tabs"
+    assert hda.dataset.state == hda.states.DEFERRED
+    # all deferred datasets post 25.1 should have empty transforms, requested_transform
+    # is used to track transforms that should be applied when the dataset is ready.
+    assert hda.dataset.sources[0].transform is None


### PR DESCRIPTION
I overloaded the meaning of "DatasetSource.transform" in a gross way - for deferred datasets they were what one should do (but also there was a bug) and for materialized datasets it was the transformations applied. Separating these out I think makes the provenance tracking more correct and should ease searching for existing public datasetsources in a Galaxy instance. Also I've added some more unit tests around materializing that I think are important as well as some tests to ensure this all still works with what would now be legacy model stores (history exports, etc...).

Might also fix #20407 ? 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
