### PR TITLE
[24.0] Fix single data element identifier to be a regular string

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -364,7 +364,7 @@ A generalisation for macro tokens, templates and xml macros, i.e.
 `<macro name="a_template" type="template">` is identical to `<template name="a_template">`, and
 `<macro name="a_token" type="xml">` is identical to `<token name="a_token">`.
 
-Note that 
+Note that
        ]]></xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -5778,7 +5778,7 @@ More information can be found on Planemo's documentation for
         <xs:documentation xml:lang="en"><![CDATA[
         A string `[reverse_][SORT_COMP_]SORTBY` describing the desired sort order of the collection elements.
         `SORTBY` can be `filename`, `name`, `designation`, `dbkey` and the optional `SORT_COMP` can be either
-        `lexical` or `numeric`. Default is lexical sorting by filename. 
+        `lexical` or `numeric`. Default is lexical sorting by filename.
         Note that lexical sorting is case sensitive, i.e. upper case characters come before lower case characters (e.g. "Apple" < "Banana" < "apple" < "banana").
         ]]></xs:documentation>
       </xs:annotation>
@@ -6563,8 +6563,10 @@ paths for data or collection inputs set the ``data_style`` attribute to ``paths`
 To include a dictionary with element identifiers, datatypes, staging paths, paths and metadata files set the ``data_style`` attribute to ``staging_path_and_source_path`` (element identifiers and datatypes are available since 24.0).
 An example tool that uses ``staging_path_and_source_path`` is [inputs_as_json_with_staging_path_and_source_path.xml](https://github.com/galaxyproject/galaxy/blob/dev/test/functional/tools/inputs_as_json_with_staging_path_and_source_path.xml)
 
-Note that the element identifiers are stored as lists, where the last element is the actual element identifier of the dataset
-and the other elements the identifiers of the collections containing the dataset.
+Note that the ``element_identifier`` field matches the type of input, which means for simple data inputs ``element_identifier`` is a string,
+for multiple="true" data inputs ``element_identifier`` is a list of strings corresponding to the element identifiers of each dataset passed to the input.
+For dataset collections the element identifier is a list of strings with as many items in the list as the nesting level of the collection (i.e. 1 for list, 2 for list:list, 3 for list:list:list etc),
+where the first item represents the outermost element identifier and the innermost item represents the innermost element identifier of the collection.
 
 For tools with profile >= 20.05 a select with ``multiple="true"`` is rendered as an array which is empty if nothing is selected. For older profile versions select lists are rendered as comma separated strings or a literal ``null`` in case nothing is selected.
 ]]></xs:documentation>

--- a/lib/galaxy/tools/parameters/wrapped_json.py
+++ b/lib/galaxy/tools/parameters/wrapped_json.py
@@ -78,9 +78,8 @@ def data_input_to_staging_path_and_source_path(
     v: "DatasetFilenameWrapper", invalid_chars: Sequence[str] = ("/",)
 ) -> Dict[str, Any]:
     staging_path = v.get_staging_path(invalid_chars=invalid_chars)
-    # note that the element identifier should be always a list
     return {
-        "element_identifier": [v.element_identifier],
+        "element_identifier": v.element_identifier,
         "ext": v.file_ext,
         "staging_path": staging_path,
         "source_path": data_input_to_path(v),

--- a/test/functional/tools/inputs_as_json_with_staging_path_and_source_path.xml
+++ b/test/functional/tools/inputs_as_json_with_staging_path_and_source_path.xml
@@ -12,14 +12,14 @@ input_json_path = sys.argv[1]
 as_dict = json.load(open(input_json_path, "r"))
 
 data_input_with_staging_details = as_dict["data_input"]
-assert data_input_with_staging_details['element_identifier'] == ["1.tabular"]
+assert data_input_with_staging_details['element_identifier'] == "1.tabular"
 assert data_input_with_staging_details['ext'] == "tabular"
 assert data_input_with_staging_details['staging_path'] == "1.tabular.tabular"
 assert len(data_input_with_staging_details['metadata_files']) == 0
 
 multiple_data_input_with_staging_details = as_dict["multiple_data_input"]
 assert len(multiple_data_input_with_staging_details) == 2
-assert multiple_data_input_with_staging_details[0]['element_identifier'] == ["simple_line.txt"]
+assert multiple_data_input_with_staging_details[0]['element_identifier'] == "simple_line.txt"
 assert multiple_data_input_with_staging_details[0]['ext'] == "txt"
 assert multiple_data_input_with_staging_details[0]['staging_path'] == "simple_line.txt.txt"
 assert len(multiple_data_input_with_staging_details[0]['metadata_files']) == 0


### PR DESCRIPTION
These must adhere to the input parameter they belong to.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
