### PR TITLE
[25.0] Dataset Display and Preferred Viz fixes

### DIFF
--- a/lib/galaxy/datatypes/images.py
+++ b/lib/galaxy/datatypes/images.py
@@ -65,6 +65,7 @@ class Image(data.Data):
     edam_data = "data_2968"
     edam_format = "format_3547"
     file_ext = ""
+    display_behavior = "inline"  # Most image formats can be displayed inline in browsers
 
     MetadataElement(
         name="axes",
@@ -419,18 +420,22 @@ class OMEZarr(data.ZarrDirectory):
 
 class Hamamatsu(Image):
     file_ext = "vms"
+    display_behavior = "download"  # Proprietary microscopy format, not browser-displayable
 
 
 class Mirax(Image):
     file_ext = "mrxs"
+    display_behavior = "download"  # Proprietary microscopy format, not browser-displayable
 
 
 class Sakura(Image):
     file_ext = "svslide"
+    display_behavior = "download"  # Proprietary microscopy format, not browser-displayable
 
 
 class Nrrd(Image):
     file_ext = "nrrd"
+    display_behavior = "download"  # Medical imaging format, not browser-displayable
 
 
 class Bmp(Image):

--- a/lib/galaxy/datatypes/images.py
+++ b/lib/galaxy/datatypes/images.py
@@ -20,6 +20,7 @@ import mrcfile
 import numpy as np
 import png
 import tifffile
+from typing_extensions import Literal
 
 try:
     import PIL
@@ -65,7 +66,7 @@ class Image(data.Data):
     edam_data = "data_2968"
     edam_format = "format_3547"
     file_ext = ""
-    display_behavior = "inline"  # Most image formats can be displayed inline in browsers
+    display_behavior: Literal["inline", "download"] = "inline"  # Most image formats can be displayed inline in browsers
 
     MetadataElement(
         name="axes",

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -516,56 +516,6 @@ class Registry:
     def get_display_sites(self, site_type):
         return self.display_sites.get(site_type, [])
 
-    def get_preferred_visualization(self, datatype_extension):
-        """
-        Get the preferred visualization mapping for a specific datatype extension.
-        Returns a dictionary with 'visualization' and 'default_params' keys, or None if no mapping exists.
-
-        Preferred visualizations are defined inline within each datatype definition in the
-        datatypes_conf.xml configuration file. These mappings determine which visualization plugin
-        should be used by default when viewing datasets of a specific type.
-
-        If no direct mapping exists for the extension, this method will walk up the inheritance
-        chain to find a preferred visualization from a parent datatype class.
-
-        Example configuration:
-        <datatype extension="bam" type="galaxy.datatypes.binary:Bam" mimetype="application/octet-stream" display_in_upload="true">
-            <visualization plugin="igv" />
-        </datatype>
-        """
-        direct_mapping = self.visualization_mappings.get(datatype_extension)
-        if direct_mapping:
-            return direct_mapping
-
-        current_datatype = self.get_datatype_by_extension(datatype_extension)
-        if not current_datatype:
-            return None
-
-        # Use the same mapping approach as the datatypes API for consistency
-        from galaxy.managers.datatypes import view_mapping
-
-        mapping_data = view_mapping(self)
-
-        current_class_name = mapping_data.ext_to_class_name.get(datatype_extension)
-        if not current_class_name:
-            return None
-
-        current_class_mappings = mapping_data.class_to_classes.get(current_class_name, {})
-
-        # Find parent extensions that have preferred visualizations
-        for ext, visualization_mapping in self.visualization_mappings.items():
-            if ext == datatype_extension:
-                continue
-
-            parent_class_name = mapping_data.ext_to_class_name.get(ext)
-            if parent_class_name and parent_class_name in current_class_mappings:
-                self.log.debug(
-                    f"Found inherited preferred visualization '{visualization_mapping['visualization']}' for datatype '{datatype_extension}' from parent '{ext}'"
-                )
-                return visualization_mapping
-
-        return None
-
     def get_all_visualization_mappings(self):
         """
         Get all datatype to visualization mappings.

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -525,12 +525,46 @@ class Registry:
         datatypes_conf.xml configuration file. These mappings determine which visualization plugin
         should be used by default when viewing datasets of a specific type.
 
+        If no direct mapping exists for the extension, this method will walk up the inheritance
+        chain to find a preferred visualization from a parent datatype class.
+
         Example configuration:
         <datatype extension="bam" type="galaxy.datatypes.binary:Bam" mimetype="application/octet-stream" display_in_upload="true">
             <visualization plugin="igv" />
         </datatype>
         """
-        return self.visualization_mappings.get(datatype_extension)
+        direct_mapping = self.visualization_mappings.get(datatype_extension)
+        if direct_mapping:
+            return direct_mapping
+
+        current_datatype = self.get_datatype_by_extension(datatype_extension)
+        if not current_datatype:
+            return None
+
+        # Use the same mapping approach as the datatypes API for consistency
+        from galaxy.managers.datatypes import view_mapping
+
+        mapping_data = view_mapping(self)
+
+        current_class_name = mapping_data.ext_to_class_name.get(datatype_extension)
+        if not current_class_name:
+            return None
+
+        current_class_mappings = mapping_data.class_to_classes.get(current_class_name, {})
+
+        # Find parent extensions that have preferred visualizations
+        for ext, visualization_mapping in self.visualization_mappings.items():
+            if ext == datatype_extension:
+                continue
+
+            parent_class_name = mapping_data.ext_to_class_name.get(ext)
+            if parent_class_name and parent_class_name in current_class_mappings:
+                self.log.debug(
+                    f"Found inherited preferred visualization '{visualization_mapping['visualization']}' for datatype '{datatype_extension}' from parent '{ext}'"
+                )
+                return visualization_mapping
+
+        return None
 
     def get_all_visualization_mappings(self):
         """

--- a/lib/galaxy/managers/datatypes.py
+++ b/lib/galaxy/managers/datatypes.py
@@ -163,6 +163,51 @@ def view_visualization_mappings(
     return parse_obj_as(DatatypeVisualizationMappingsList, mappings)
 
 
+def get_preferred_visualization(datatypes_registry: Registry, datatype_extension: str) -> Optional[Dict[str, str]]:
+    """
+    Get the preferred visualization mapping for a specific datatype extension.
+    Returns a dictionary with 'visualization' and 'default_params' keys, or None if no mapping exists.
+
+    Preferred visualizations are defined inline within each datatype definition in the
+    datatypes_conf.xml configuration file. These mappings determine which visualization plugin
+    should be used by default when viewing datasets of a specific type.
+
+    If no direct mapping exists for the extension, this method will walk up the inheritance
+    chain to find a preferred visualization from a parent datatype class.
+
+    Example configuration:
+    <datatype extension="bam" type="galaxy.datatypes.binary:Bam" mimetype="application/octet-stream" display_in_upload="true">
+        <visualization plugin="igv" />
+    </datatype>
+    """
+    direct_mapping = datatypes_registry.visualization_mappings.get(datatype_extension)
+    if direct_mapping:
+        return direct_mapping
+
+    current_datatype = datatypes_registry.get_datatype_by_extension(datatype_extension)
+    if not current_datatype:
+        return None
+
+    # Use the same mapping approach as the datatypes API for consistency
+    mapping_data = view_mapping(datatypes_registry)
+
+    current_class_name = mapping_data.ext_to_class_name.get(datatype_extension)
+    if not current_class_name:
+        return None
+
+    current_class_mappings = mapping_data.class_to_classes.get(current_class_name, {})
+
+    for ext, visualization_mapping in datatypes_registry.visualization_mappings.items():
+        if ext == datatype_extension:
+            continue
+
+        parent_class_name = mapping_data.ext_to_class_name.get(ext)
+        if parent_class_name and parent_class_name in current_class_mappings:
+            return visualization_mapping
+
+    return None
+
+
 __all__ = (
     "DatatypeConverterList",
     "DatatypeDetails",
@@ -179,4 +224,5 @@ __all__ = (
     "view_edam_formats",
     "view_edam_data",
     "view_visualization_mappings",
+    "get_preferred_visualization",
 )

--- a/lib/galaxy/webapps/galaxy/api/datatypes.py
+++ b/lib/galaxy/webapps/galaxy/api/datatypes.py
@@ -26,6 +26,7 @@ from galaxy.managers.datatypes import (
     DatatypesEDAMDetailsDict,
     DatatypesMap,
     DatatypeVisualizationMappingsList,
+    get_preferred_visualization,
     view_converters,
     view_edam_data,
     view_edam_formats,
@@ -258,7 +259,7 @@ class FastAPIDatatypes:
             result["converters"] = list(converters.keys())
 
         # Add preferred visualization if any and if the plugin is available
-        preferred_viz = self.datatypes_registry.get_preferred_visualization(datatype)
+        preferred_viz = get_preferred_visualization(self.datatypes_registry, datatype)
         if preferred_viz:
             plugin_name = preferred_viz["visualization"]
 


### PR DESCRIPTION
More uncovered walking through live:

- Fix image datatype inline vs download display -- for browser-safe images we simply rely on that for display (png, etc.)
- Look at parent preferred datatypes in addition to specific (h5ad should use h5's preferred viz if no h5ad specific one is set)
- If a preferred viz is unavailable, don't try to display using it.

Also refactored to shift the get_preferred_viz logic to the manager to clean up imports and reuse the mapping hierarchy.

https://github.com/user-attachments/assets/e95a59b9-2e55-4d70-bf00-41247aac9c06




## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
