### PR TITLE
[25.0] Fix inconsistent styling in List Collection Builder selector

### DIFF
--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import "ui/hoverhighlight";
 
-import { faSquare } from "@fortawesome/free-regular-svg-icons";
-import { faMinus, faSortAlphaDown, faTimes, faUndo } from "@fortawesome/free-solid-svg-icons";
+import { faEdit, faSquare } from "@fortawesome/free-regular-svg-icons";
+import { faGripLines, faMinus, faSortAlphaDown, faTimes, faUndo } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
@@ -557,13 +557,16 @@ function selectionAsHdaSummary(value: any): HDASummary {
                         </strong>
                         {{
                             localize(
-                                "Once you have made your selection, if you wish to rename identifiers for elements in the list, click"
+                                [
+                                    "Once you have made your selection, if you wish to rename identifiers for elements in the list",
+                                    "or change/set the order in which they exist in the final list, you can click on ",
+                                ].join("")
                             )
                         }}
                         <i data-target=".rename-elements">
-                            {{ localize("Rename list elements") }}
+                            {{ localize("Rename/Reorder list elements") }}
                         </i>
-                        {{ localize(". This opens a modal where you can change the identifiers individually.") }}
+                        {{ localize(". This opens a modal where you can perform these actions.") }}
                     </p>
                 </template>
 
@@ -691,6 +694,7 @@ function selectionAsHdaSummary(value: any): HDASummary {
                         <draggable
                             v-model="workingElements"
                             class="collection-elements scroll-container flex-row drop-zone"
+                            style="max-height: 400px"
                             chosen-class="bg-secondary">
                             <DatasetCollectionElementView
                                 v-for="element in workingElements"
@@ -726,16 +730,37 @@ function selectionAsHdaSummary(value: any): HDASummary {
             <GModal
                 class="rename-elements-modal"
                 :show.sync="renamingElements"
+                fixed-height
                 size="small"
-                title="Click on element identifiers to change them">
-                <DatasetCollectionElementView
-                    v-for="value in inListElements"
-                    :key="value.id"
-                    class="w-100"
-                    hide-hid
-                    :element="selectionAsHdaSummary(value)"
-                    hide-extension
-                    @onRename="(name) => renameElement(value, name)" />
+                title="Rename and Reorder List Elements">
+                <div>
+                    <FontAwesomeIcon :icon="faEdit" fixed-width />
+                    {{ localize("Here, you can change the identifiers of the elements in the list.") }}
+                    {{
+                        localize(
+                            "The final list will then have these identifiers, and this does not modify the original datasets."
+                        )
+                    }}
+                </div>
+                <div>
+                    <FontAwesomeIcon :icon="faGripLines" fixed-width />
+                    {{ localize("Also, you can click and drag to reorder the elements in the list.") }}
+                </div>
+                <hr class="w-100 my-2" />
+                <draggable
+                    v-model="inListElements"
+                    class="collection-elements scroll-container flex-row"
+                    chosen-class="bg-secondary"
+                    @wheel.stop>
+                    <DatasetCollectionElementView
+                        v-for="value in inListElements"
+                        :key="value.id"
+                        class="w-100"
+                        hide-hid
+                        :element="selectionAsHdaSummary(value)"
+                        hide-extension
+                        @onRename="(name) => renameElement(value, name)" />
+                </draggable>
             </GModal>
         </div>
     </div>
@@ -748,7 +773,10 @@ function selectionAsHdaSummary(value: any): HDASummary {
 .list-collection-creator {
     .rename-elements-modal {
         .collection-element {
-            cursor: unset;
+            cursor: grab;
+            &:focus {
+                cursor: grabbing;
+            }
         }
     }
 
@@ -775,7 +803,6 @@ function selectionAsHdaSummary(value: any): HDASummary {
     }
 
     .collection-elements {
-        max-height: 400px;
         border: 0px solid lightgrey;
         overflow-y: auto;
         overflow-x: hidden;

--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -557,13 +557,13 @@ function selectionAsHdaSummary(value: any): HDASummary {
                         </strong>
                         {{
                             localize(
-                                "Once you have made your selection, if you wish to rename the elements in the list, click"
+                                "Once you have made your selection, if you wish to rename identifiers for elements in the list, click"
                             )
                         }}
                         <i data-target=".rename-elements">
                             {{ localize("Rename list elements") }}
                         </i>
-                        {{ localize(". This opens a modal where you can rename the elements individually.") }}
+                        {{ localize(". This opens a modal where you can change the identifiers individually.") }}
                     </p>
                 </template>
 
@@ -727,13 +727,14 @@ function selectionAsHdaSummary(value: any): HDASummary {
                 class="rename-elements-modal"
                 :show.sync="renamingElements"
                 size="small"
-                title="Click on dataset names to rename them">
+                title="Click on element identifiers to change them">
                 <DatasetCollectionElementView
                     v-for="value in inListElements"
                     :key="value.id"
                     class="w-100"
+                    hide-hid
                     :element="selectionAsHdaSummary(value)"
-                    :hide-extension="!showElementExtension"
+                    hide-extension
                     @onRename="(name) => renameElement(value, name)" />
             </GModal>
         </div>

--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -559,7 +559,7 @@ function selectionAsHdaSummary(value: any): HDASummary {
                             localize(
                                 [
                                     "Once you have made your selection, if you wish to rename identifiers for elements in the list",
-                                    "or change/set the order in which they exist in the final list, you can click on ",
+                                    " or change/set the order in which they exist in the final list, you can click on ",
                                 ].join("")
                             )
                         }}
@@ -756,9 +756,8 @@ function selectionAsHdaSummary(value: any): HDASummary {
                         v-for="value in inListElements"
                         :key="value.id"
                         class="w-100"
-                        hide-hid
                         :element="selectionAsHdaSummary(value)"
-                        hide-extension
+                        :hide-extension="!showElementExtension"
                         @onRename="(name) => renameElement(value, name)" />
                 </draggable>
             </GModal>

--- a/client/src/components/Collections/ListDatasetCollectionElementView.vue
+++ b/client/src/components/Collections/ListDatasetCollectionElementView.vue
@@ -15,6 +15,7 @@ interface Props {
     notEditable?: boolean;
     hideExtension?: boolean;
     showHid?: boolean;
+    textOnly?: boolean;
 }
 
 const props = defineProps<Props>();
@@ -45,10 +46,11 @@ watch(
 
 <template>
     <div
-        class="collection-element d-flex justify-content-between"
+        class="d-flex justify-content-between"
         :data-hid="element.hid"
-        :class="{ 'with-actions': hasActions }"
+        :class="{ 'collection-element': !textOnly, 'with-actions': hasActions }"
         role="button"
+        data-description="list dataset collection element"
         tabindex="0"
         @keyup.enter="emit('element-is-selected', element)"
         @click="emit('element-is-selected', element)">

--- a/client/src/components/Collections/ListDatasetCollectionElementView.vue
+++ b/client/src/components/Collections/ListDatasetCollectionElementView.vue
@@ -14,7 +14,7 @@ interface Props {
     hasActions?: boolean;
     notEditable?: boolean;
     hideExtension?: boolean;
-    showHid?: boolean;
+    hideHid?: boolean;
     textOnly?: boolean;
 }
 
@@ -55,7 +55,7 @@ watch(
         @keyup.enter="emit('element-is-selected', element)"
         @click="emit('element-is-selected', element)">
         <span class="d-flex flex-gapx-1">
-            <span v-if="element.hid ?? true">{{ element.hid }}:</span>
+            <span v-if="!hideHid && (element.hid ?? true)">{{ element.hid }}:</span>
             <strong>
                 <ClickToEdit v-if="!notEditable" v-model="elementName" :title="localize('Click to rename')" />
                 <span v-else>{{ elementName }}</span>

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -36,6 +36,7 @@ interface Props {
     showButtons?: boolean;
     collectionName: string;
     mode: "wizard" | "modal";
+    canRenameElements?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -46,12 +47,14 @@ const props = withDefaults(defineProps<Props>(), {
     collectionType: undefined,
     showButtons: true,
     mode: "modal",
+    canRenameElements: false,
 });
 
 const emit = defineEmits<{
     (e: "on-update-collection-name", name: string): void;
     (e: "remove-extensions-toggle"): void;
     (e: "clicked-create", value: string): void;
+    (e: "clicked-rename"): void;
     (e: "onUpdateHideSourceItems", value: boolean): void;
     (e: "on-update-datatype-toggle", value: "all" | "datatype" | "ext"): void;
     (e: "add-uploaded-files", value: HDASummary[]): void;
@@ -196,9 +199,11 @@ watch(
                         <CollectionCreatorFooterButtons
                             v-if="showButtons"
                             :short-what-is-being-created="shortWhatIsBeingCreated"
+                            :can-rename-elements="props.canRenameElements"
                             :valid-input="validInput"
                             @clicked-cancel="cancelCreate"
-                            @clicked-create="emit('clicked-create', collectionName)" />
+                            @clicked-create="emit('clicked-create', collectionName)"
+                            @clicked-rename="emit('clicked-rename')" />
                     </div>
                 </div>
             </BTab>

--- a/client/src/components/Collections/common/CollectionCreatorFooterButtons.vue
+++ b/client/src/components/Collections/common/CollectionCreatorFooterButtons.vue
@@ -6,12 +6,14 @@ import GButton from "@/components/BaseComponents/GButton.vue";
 interface Props {
     validInput: boolean;
     shortWhatIsBeingCreated: string;
+    canRenameElements?: boolean;
 }
 
 defineProps<Props>();
 
 const emit = defineEmits<{
     (e: "clicked-create"): void;
+    (e: "clicked-rename"): void;
     (e: "clicked-cancel"): void;
 }>();
 </script>
@@ -22,8 +24,18 @@ const emit = defineEmits<{
             {{ localize("Cancel") }}
         </GButton>
 
-        <GButton class="create-collection" color="blue" :disabled="!validInput" @click="emit('clicked-create')">
-            {{ localize("Create " + shortWhatIsBeingCreated) }}
-        </GButton>
+        <span>
+            <GButton
+                v-if="canRenameElements"
+                class="rename-elements"
+                size="small"
+                :disabled="!validInput"
+                @click="emit('clicked-rename')">
+                {{ localize("Rename " + shortWhatIsBeingCreated) + " elements" }}
+            </GButton>
+            <GButton class="create-collection" color="blue" :disabled="!validInput" @click="emit('clicked-create')">
+                {{ localize("Create " + shortWhatIsBeingCreated) }}
+            </GButton>
+        </span>
     </div>
 </template>

--- a/client/src/components/Collections/common/CollectionCreatorFooterButtons.vue
+++ b/client/src/components/Collections/common/CollectionCreatorFooterButtons.vue
@@ -31,7 +31,7 @@ const emit = defineEmits<{
                 size="small"
                 :disabled="!validInput"
                 @click="emit('clicked-rename')">
-                {{ localize("Rename " + shortWhatIsBeingCreated) + " elements" }}
+                {{ localize("Rename/Reorder " + shortWhatIsBeingCreated) + " elements" }}
             </GButton>
             <GButton class="create-collection" color="blue" :disabled="!validInput" @click="emit('clicked-create')">
                 {{ localize("Create " + shortWhatIsBeingCreated) }}

--- a/client/src/components/Form/Elements/FormSelectMany/FormSelectMany.vue
+++ b/client/src/components/Form/Elements/FormSelectMany/FormSelectMany.vue
@@ -472,6 +472,7 @@ const selectedCount = computed(() => {
     }
 
     .toggle-button {
+        display: block;
         padding-left: 0;
         padding-right: 0;
     }

--- a/client/src/components/Form/utilities.js
+++ b/client/src/components/Form/utilities.js
@@ -154,7 +154,7 @@ export function validateInputs(index, values, allowEmptyValueOnRequiredInput = f
             } else if (batchN !== n) {
                 return [
                     inputId,
-                    `Please make sure that you select the same number of inputs for all batch mode fields. This field contains <b>${n}</b> selection(s) while a previous field contains <b>${batchN}</b>.`,
+                    `Please make sure that you select the same number of inputs for all batch mode fields. This field contains ${n} selection(s) while a previous field contains ${batchN}.`,
                 ];
             }
         }

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -729,7 +729,7 @@ workflow_run:
         _: '[data-label="${label}"] .tabs'
         create: '${_} .create-collection'
         select_all: "${_} [data-description='select many select all']"
-        element_by_hid: "${_} .collection-element[data-hid='${hid}']"
+        element_by_hid: "${_} [data-description='list dataset collection element'][data-hid='${hid}']"
         <<: *upload_mixin
 
   form_element:


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20441:

<details>
<summary><i>Checklist from ticket ☑️ </i></summary>

- [x] Irregular alignment within dataset items, Aa, .* buttons, etc.
- [x] Buttons expand/contract on hover "click to select" behavior
- [x] Layout shifts causing repositioning during hover state
- [x] Are dataset names intentionally editable here? This mixed with shift to select led me to rename something randomly without an easy way to undo it.
</details>

| Before these changes 🐞 |
| ---- |
| <video src="https://github.com/user-attachments/assets/96e807d0-f78a-41ca-afda-df48e093a232" />
| Note that the styling on hover is not ideal, and renaming an element and selecting it - both being click operations can cause confusion and unintended consequences. Also a bug when you rename an element in the selected column, it gets moved back to unselected, however, the selected column still has a count of 2. |


| After these changes ✅ _(outdated, see screencasts in comments)_ |
| ---- |
| <video src="https://github.com/user-attachments/assets/a26c86d8-3312-4c15-8cdd-8cd1a6b6b6df" />
| Using the default view for our multiselects, with just text values as opposed to bordered boxes, helps fix hover/focus styling. Not renaming from the multiselect and instead using a separate modal fixes the rename issue as well. The last bug with rename causing elements to move around the selected/unselected lists unintentionally is also fixed. _At the end I demonstrate that this works nicely with a big history as well, as far as styling is concerned._ |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
