### PR TITLE
[25.0] Fix add button is enabled when empty tag list

### DIFF
--- a/client/src/components/BaseComponents/GModal.vue
+++ b/client/src/components/BaseComponents/GModal.vue
@@ -33,6 +33,10 @@ const props = defineProps<{
     title?: string;
     /** Fixes the height of the modal to a pre-set height based on `size` */
     fixedHeight?: boolean;
+    /** Disables the Ok button */
+    okDisabled?: boolean;
+    /** Title to show when the Ok button is disabled */
+    okDisabledTitle?: string;
 }>();
 
 const emit = defineEmits<{
@@ -170,7 +174,13 @@ defineExpose({ showModal, hideModal });
 
                 <div v-if="props.confirm" class="g-modal-confirm-buttons">
                     <GButton @click="hideModal(false)"> {{ props.cancelText ?? "Cancel" }} </GButton>
-                    <GButton color="blue" @click="hideModal(true)"> {{ props.okText ?? "Ok" }} </GButton>
+                    <GButton
+                        :disabled="okDisabled"
+                        :disabled-title="okDisabledTitle"
+                        color="blue"
+                        @click="hideModal(true)">
+                        {{ props.okText ?? "Ok" }}
+                    </GButton>
                 </div>
             </footer>
         </section>

--- a/client/src/components/Common/TagsSelectionDialog.vue
+++ b/client/src/components/Common/TagsSelectionDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 import GModal from "@/components/BaseComponents/GModal.vue";
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
@@ -16,6 +16,10 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const tags = ref(props.initialTags);
+
+const emptyTagList = computed(() => {
+    return tags.value.length === 0;
+});
 
 const emit = defineEmits<{
     (e: "cancel"): void;
@@ -42,7 +46,16 @@ function resetTags() {
 </script>
 
 <template>
-    <GModal :show="show" ok-text="Add" :confirm="true" size="small" :title="title" @ok="onOk" @cancel="onCancel">
+    <GModal
+        :show="show"
+        ok-text="Add"
+        :confirm="true"
+        size="small"
+        :title="title"
+        :ok-disabled="emptyTagList"
+        ok-disabled-title="Please select at least one tag"
+        @ok="onOk"
+        @cancel="onCancel">
         <StatelessTags :value="tags" @input="onTagsChange($event)" />
     </GModal>
 </template>


### PR DESCRIPTION
When you open the "add tags in bulk" dialog for selected workflows, the button is enabled by default, letting you add an empty list of tags to the workflows... this just disables the button when the list of tags is empty.

It is required to augment the GModal slightly to support disabling the OK button, along with an appropriate title message.

![image](https://github.com/user-attachments/assets/2c09bb1c-2c28-4be6-a668-cf56dbb608ab)


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
