### PR TITLE
Fix client build, set create_time

### DIFF
--- a/client/src/components/History/Content/Collection/CollectionDescription.test.ts
+++ b/client/src/components/History/Content/Collection/CollectionDescription.test.ts
@@ -17,7 +17,7 @@ const defaultTestHDCA: HDCASummary = {
     collection_type: "list",
     history_content_type: "dataset_collection",
     element_count: null,
-    create_time: null,
+    create_time: "2020-01-01T00:00:00",
     update_time: null,
     deleted: false,
     visible: true,


### PR DESCRIPTION
This broke when merging https://github.com/galaxyproject/galaxy/pull/20357, likely because the base didn't contain the test that was added in https://github.com/galaxyproject/galaxy/pull/20356

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
