### PR TITLE
Automatically initialize Apptainer

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -369,6 +369,7 @@ class MinimalGalaxyApplication(BasicSharedApp, HaltableContainer, SentryClientMi
             involucro_path=self.config.involucro_path,
             involucro_auto_init=self.config.involucro_auto_init,
             mulled_channels=self.config.mulled_channels,
+            apptainer_prefix=self.config.apptainer_prefix,
         )
         mulled_resolution_cache = None
         if self.config.mulled_resolution_cache_type:

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -399,6 +399,14 @@ mapping:
           This will prevent problems with some specific packages (perl, R), at the cost
           of extra disk space usage and extra time spent copying packages.
 
+      apptainer_prefix:
+        type: str
+        default: _apptainer
+        path_resolves_to: tool_dependency_dir
+        required: false
+        desc: |
+          Apptainer installation prefix.
+
       local_conda_mapping_file:
         type: str
         default: 'local_conda_mapping.yml'

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -109,6 +109,7 @@ from galaxy.util import (
 from galaxy.util.bunch import Bunch
 from galaxy.util.expressions import ExpressionContext
 from galaxy.util.path import external_chown
+from galaxy.util.properties import running_from_source
 from galaxy.util.xml_macros import load
 from galaxy.web_stack.handlers import ConfiguresHandlers
 from galaxy.work.context import WorkRequestContext
@@ -1161,6 +1162,22 @@ class MinimalJobWrapper(HasResourceParameters):
     @property
     def requires_containerization(self):
         return util.asbool(self.get_destination_configuration("require_container", "False"))
+
+    @property
+    def use_metadata_venv(self):
+        return util.asbool(self.get_destination_configuration("use_metadata_venv", not running_from_source))
+
+    @property
+    def create_metadata_venv(self):
+        return util.asbool(self.get_destination_configuration("create_metadata_venv", self.use_metadata_venv))
+
+    @property
+    def metadata_venv_python(self):
+        return self.get_destination_configuration("metadata_venv_python", sys.executable)
+
+    @property
+    def metadata_venv_path(self):
+        return util.asbool(self.get_destination_configuration("metadata_venv_path", "False")) or None
 
     @property
     def use_metadata_binary(self):

--- a/lib/galaxy/tool_util/deps/apptainer_util.py
+++ b/lib/galaxy/tool_util/deps/apptainer_util.py
@@ -1,0 +1,114 @@
+import logging
+import os
+import packaging.version
+import platform
+import tempfile
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    TYPE_CHECKING,
+    Union,
+)
+
+from galaxy.util import (
+    commands,
+    download_to_file,
+    requests,
+)
+
+from . import installable
+
+APPTAINER_VERSION = "1.4.0"
+APPTAINER_URL_TEMPLATE = "https://github.com/galaxyproject/apptainer-build-unprivileged/releases/download/v{version}/apptainer-{version}-{el}-{arch}.tar.gz"
+
+
+log = logging.getLogger(__name__)
+
+
+def _glibc_version() -> Optional[packaging.version.Version]:
+    try:
+        # First line should always be 'ldd (dist-specific) VERSION'
+        glibc_version = commands.execute(["ldd", "--version"]).splitlines()[0].split()[-1]
+        return packaging.version.parse(glibc_version)
+    except Exception as exc:
+        log.warning(f"Unable to get glibc version: {str(exc)}")
+
+
+def apptainer_url() -> str:
+    glibc_version = _glibc_version()
+    el = "el8"
+    if glibc_version >= packaging.version.parse("2.34"):
+        el = "el9"
+    url = APPTAINER_URL_TEMPLATE.format(version=APPTAINER_VERSION, el=el, arch=platform.machine())
+    return url
+
+
+class ApptainerContext(installable.InstallableContext):
+    installable_description = "Apptainer"
+
+    def __init__(
+        self,
+        apptainer_prefix: Optional[str] = None,
+        apptainer_exec: Optional[Union[str, List[str]]] = None,
+    ) -> None:
+        self.apptainer_prefix = apptainer_prefix
+
+        if apptainer_exec and isinstance(apptainer_exec, str):
+            apptainer_exec = os.path.normpath(apptainer_exec)
+
+        if apptainer_exec is not None:
+            self.apptainer_exec = apptainer_exec
+        elif apptainer_prefix is not None:
+            self.apptainer_exec = os.path.join(apptainer_prefix, "bin", "apptainer")
+        else:
+            self.apptainer_exec = "apptainer"
+
+    def apptainer_version(self) -> str:
+        cmd = [self.apptainer_exec, "version"]
+        version_out = commands.execute(cmd).strip()
+        return version_out
+
+    def is_installed(self) -> bool:
+        try:
+            self.apptainer_version()
+            return True
+        except Exception:
+            return False
+
+    def can_install(self) -> bool:
+        if (platform.system() != "Linux" or platform.machine() not in ("x86_64", "aarch64")):
+            return False
+        glibc_version = _glibc_version()
+        if not glibc_version or glibc_version < packaging.version.parse("2.28"):
+            return False
+        return True
+
+    @property
+    def parent_path(self) -> str:
+        return os.path.dirname(os.path.abspath(self.apptainer_prefix))
+
+
+def install_apptainer(apptainer_context: ApptainerContext) -> int:
+    with tempfile.NamedTemporaryFile(suffix=".tar.gz", prefix="apptainer_install", delete=False) as temp:
+        tarball_path = temp.name
+    install_cmd = ["tar", "zxf", tarball_path, "-C", apptainer_context.apptainer_prefix, "--strip-components=1"]
+    fetch_url = apptainer_url()
+    log.info("Installing Apptainer, this may take several minutes.")
+    log.info(f"Fetching from: {fetch_url}")
+    try:
+        os.makedirs(apptainer_context.apptainer_prefix)
+        download_to_file(fetch_url, tarball_path)
+        commands.execute(install_cmd)
+    except Exception:
+        log.exception("Failed to fetch Apptainer tarball")
+        return 1
+    finally:
+        if os.path.exists(tarball_path):
+            os.remove(tarball_path)
+    log.info(f"Apptainer installed to: {apptainer_context.apptainer_prefix}")

--- a/lib/galaxy/tool_util/deps/apptainer_util.py
+++ b/lib/galaxy/tool_util/deps/apptainer_util.py
@@ -16,6 +16,7 @@ from galaxy.util import (
 )
 from . import installable
 
+DEFAULT_APPTAINER_COMMAND = "apptainer"
 APPTAINER_VERSION = "1.4.0"
 APPTAINER_URL_TEMPLATE = "https://github.com/galaxyproject/apptainer-build-unprivileged/releases/download/v{version}/apptainer-{version}-{el}-{arch}.tar.gz"
 

--- a/lib/galaxy/tool_util/deps/apptainer_util.py
+++ b/lib/galaxy/tool_util/deps/apptainer_util.py
@@ -1,27 +1,19 @@
 import logging
 import os
-import packaging.version
 import platform
 import tempfile
 from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    Iterator,
     List,
     Optional,
-    Tuple,
-    TYPE_CHECKING,
     Union,
 )
+
+import packaging.version
 
 from galaxy.util import (
     commands,
     download_to_file,
-    requests,
 )
-
 from . import installable
 
 APPTAINER_VERSION = "1.4.0"
@@ -82,7 +74,9 @@ class ApptainerContext(installable.InstallableContext):
             return False
 
     def can_install(self) -> bool:
-        if (platform.system() != "Linux" or platform.machine() not in ("x86_64", "aarch64")):
+        if self.apptainer_prefix is None:
+            return False
+        if platform.system() != "Linux" or platform.machine() not in ("x86_64", "aarch64"):
             return False
         glibc_version = _glibc_version()
         if not glibc_version or glibc_version < packaging.version.parse("2.28"):
@@ -90,8 +84,9 @@ class ApptainerContext(installable.InstallableContext):
         return True
 
     @property
-    def parent_path(self) -> str:
-        return os.path.dirname(os.path.abspath(self.apptainer_prefix))
+    def parent_path(self) -> Optional[str]:
+        if self.apptainer_prefix:
+            return os.path.dirname(os.path.abspath(self.apptainer_prefix))
 
 
 def install_apptainer(apptainer_context: ApptainerContext) -> int:

--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -532,8 +532,11 @@ class SingularityContainer(Container, HasDockerLikeVolumes):
     container_type = SINGULARITY_CONTAINER_TYPE
 
     def get_singularity_target_kwds(self) -> Dict[str, Any]:
+        cmd_default = (
+            self.container_description and self.container_description.cmd
+        ) or singularity_util.DEFAULT_SINGULARITY_COMMAND
         return dict(
-            singularity_cmd=self.prop("cmd", singularity_util.DEFAULT_SINGULARITY_COMMAND),
+            singularity_cmd=self.prop("cmd", cmd_default),
             sudo=asbool(self.prop("sudo", singularity_util.DEFAULT_SUDO)),
             sudo_cmd=self.prop("sudo_cmd", singularity_util.DEFAULT_SUDO_COMMAND),
         )

--- a/lib/galaxy/tool_util/deps/container_resolvers/__init__.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/__init__.py
@@ -1,5 +1,7 @@
 """The module defines the abstract interface for resolving container images for tool execution."""
 
+import logging
+import os
 from abc import (
     ABCMeta,
     abstractmethod,
@@ -38,6 +40,8 @@ if TYPE_CHECKING:
         ToolInfo,
     )
     from ..requirements import ContainerDescription
+
+log = logging.getLogger(__name__)
 
 
 class CachedMulledImageSingleTarget(NamedTuple):

--- a/lib/galaxy/tool_util/deps/container_resolvers/__init__.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/__init__.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import subprocess
 from abc import (
     ABCMeta,
     abstractmethod,
@@ -10,6 +11,7 @@ from typing import (
     Any,
     Callable,
     Container,
+    Dict,
     List,
     NamedTuple,
     Optional,
@@ -20,9 +22,11 @@ from typing import (
 
 from typing_extensions import Literal
 
+from galaxy.tool_util.deps.installable import ensure_installed as deps_ensure_installed
 from galaxy.util import (
     safe_makedirs,
     string_as_bool,
+    unicodify,
     which,
 )
 from galaxy.util.bunch import Bunch
@@ -31,6 +35,11 @@ from ..apptainer_util import (
     ApptainerContext,
     DEFAULT_APPTAINER_COMMAND,
     install_apptainer,
+)
+from ..docker_util import build_docker_images_command
+from ..mulled.util import (
+    split_tag,
+    version_sorted,
 )
 
 if TYPE_CHECKING:

--- a/lib/galaxy/tool_util/deps/container_resolvers/__init__.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/__init__.py
@@ -7,12 +7,28 @@ from abc import (
 from typing import (
     Any,
     Container,
+    List,
+    NamedTuple,
     Optional,
+    Type,
     TYPE_CHECKING,
+    Union,
 )
+from typing_extensions import Literal
 
+from galaxy.util import (
+    safe_makedirs,
+    string_as_bool,
+    which,
+)
 from galaxy.util.bunch import Bunch
 from galaxy.util.dictifiable import Dictifiable
+
+from ..apptainer_util import (
+    ApptainerContext,
+    DEFAULT_APPTAINER_COMMAND,
+    install_apptainer,
+)
 
 if TYPE_CHECKING:
     from beaker.cache import Cache
@@ -24,6 +40,39 @@ if TYPE_CHECKING:
     from ..requirements import ContainerDescription
 
 
+class CachedMulledImageSingleTarget(NamedTuple):
+    package_name: str
+    version: Optional[str]
+    build: Optional[str]
+    image_identifier: str
+
+
+class CachedV1MulledImageMultiTarget(NamedTuple):
+    hash: str
+    build: Optional[str]
+    image_identifier: str
+
+
+class CachedV2MulledImageMultiTarget(NamedTuple):
+    image_name: str
+    version_hash: Optional[str]
+    build: Optional[str]
+    image_identifier: str
+
+    @property
+    def package_hash(self) -> str:
+        # Make this work for Singularity file name or fully qualified Docker repository
+        # image names.
+        image_name = self.image_name
+        if "/" not in image_name:
+            return image_name
+        else:
+            return image_name.rsplit("/")[-1]
+
+
+CachedTarget = Union[CachedMulledImageSingleTarget, CachedV1MulledImageMultiTarget, CachedV2MulledImageMultiTarget]
+
+
 class ResolutionCache(Bunch):
     """Simple cache for duplicated computation created once per set of requests (likely web request in Galaxy context).
 
@@ -32,6 +81,71 @@ class ResolutionCache(Bunch):
     """
 
     mulled_resolution_cache: Optional["Cache"] = None
+
+
+class CacheDirectory(metaclass=ABCMeta):
+    def __init__(self, path: str, hash_func: Literal["v1", "v2"] = "v2") -> None:
+        self.path = path
+        self.hash_func = hash_func
+
+    def _list_cached_images_from_path(self) -> List[CachedTarget]:
+        contents = os.listdir(self.path)
+        sorted_images = version_sorted(contents)
+        raw_images = (identifier_to_cached_target(name, self.hash_func) for name in sorted_images)
+        return [i for i in raw_images if i is not None]
+
+    @abstractmethod
+    def list_cached_images_from_path(self) -> List[CachedTarget]:
+        """Generate a list of cached, mulled images in the cache."""
+
+    @abstractmethod
+    def invalidate_cache(self) -> None:
+        """Invalidate the cache."""
+
+
+class UncachedCacheDirectory(CacheDirectory):
+    cacher_type = "uncached"
+
+    def list_cached_images_from_path(
+        self,
+    ) -> List[CachedTarget]:
+        return self._list_cached_images_from_path()
+
+    def invalidate_cache(self) -> None:
+        pass
+
+
+class DirMtimeCacheDirectory(CacheDirectory):
+    cacher_type = "dir_mtime"
+
+    def __init__(self, path: str, **kwargs):
+        super().__init__(path, **kwargs)
+        self.invalidate_cache()
+
+    def __get_mtime(self) -> float:
+        return os.stat(self.path).st_mtime
+
+    def __cache(self) -> None:
+        self.__contents = self._list_cached_images_from_path()
+        self.__mtime = self.__get_mtime()
+        log.debug(f"Cached images in path {self.path} at directory mtime {self.__mtime}")
+
+    def list_cached_images_from_path(
+        self,
+    ) -> List[CachedTarget]:
+        mtime = self.__get_mtime()
+        if mtime != self.__mtime:
+            if mtime < self.__mtime:
+                log.warning(
+                    f"Modification time '{mtime}' of cache directory '{self.path}' is older than previous "
+                    f"modification time '{self.__mtime}'! Cache directory will be recached"
+                )
+            self.__cache()
+        return self.__contents
+
+    def invalidate_cache(self) -> None:
+        self.__mtime = -1.0
+        self.__contents = []
 
 
 class ContainerResolver(Dictifiable, metaclass=ABCMeta):
@@ -77,3 +191,78 @@ class ContainerResolver(Dictifiable, metaclass=ABCMeta):
 
     def __str__(self) -> str:
         return f"{self.__class__.__name__}[]"
+
+
+class CliContainerResolver(ContainerResolver):
+    container_type = "docker"
+    cli = "docker"
+
+    def __init__(self, app_info: "AppInfo", **kwargs) -> None:
+        super().__init__(app_info=app_info, **kwargs)
+        self._cli_available = bool(which(self.cli))
+
+    @property
+    def cli_available(self) -> bool:
+        return self._cli_available
+
+    @cli_available.setter
+    def cli_available(self, value: bool) -> None:
+        if not value:
+            log.info(
+                f"{self.cli} CLI not available, cannot list or pull images in Galaxy process. Does not impact kubernetes."
+            )
+        self._cli_available = value
+
+
+class SingularityCliContainerResolver(CliContainerResolver):
+    container_type = "singularity"
+    cli = "singularity"
+    cmd = None
+
+    def __init__(
+        self, app_info: "AppInfo", hash_func: Literal["v1", "v2"] = "v2", **kwargs
+    ) -> None:
+        super().__init__(app_info=app_info, **kwargs)
+        self.hash_func = hash_func
+        self.cache_directory_cacher_type = kwargs.get("cache_directory_cacher_type")
+        cacher_class = get_cache_directory_cacher(self.cache_directory_cacher_type)
+        cache_directory_path = kwargs.get("cache_directory")
+        if not cache_directory_path:
+            assert self.app_info.container_image_cache_path
+            cache_directory_path = os.path.join(self.app_info.container_image_cache_path, "singularity", "mulled")
+        self.cache_directory = cacher_class(cache_directory_path, hash_func=self.hash_func)
+        safe_makedirs(self.cache_directory.path)
+
+
+class ApptainerCliContainerResolver(SingularityCliContainerResolver):
+    container_type = "singularity"
+    cli = "apptainer"
+    cmd = None
+
+    def __init__(
+        self, app_info: "AppInfo", auto_init: bool = False, **kwargs
+    ) -> None:
+        super().__init__(app_info=app_info, **kwargs)
+        self.auto_init = string_as_bool(auto_init)
+        apptainer_exec = kwargs.get("exec")
+        if self.auto_init:
+            apptainer_prefix = kwargs.get("prefix")
+            if apptainer_prefix is None and apptainer_exec is None:
+                assert self.app_info.apptainer_prefix
+                apptainer_prefix = self.app_info.apptainer_prefix
+            apptainer_context = ApptainerContext(apptainer_prefix=apptainer_prefix, apptainer_exec=apptainer_exec)
+            deps_ensure_installed(apptainer_context, install_apptainer, self.auto_init)
+            apptainer_exec = apptainer_context.apptainer_exec
+            self._cli_available = True
+        self.apptainer_exec = apptainer_exec
+        self.cmd = apptainer_exec or DEFAULT_APPTAINER_COMMAND
+
+
+def get_cache_directory_cacher(cacher_type: Optional[str]) -> Type[CacheDirectory]:
+    # these can become a separate module and use plugin_config if we need more
+    cachers: Dict[str, Type[CacheDirectory]] = {
+        UncachedCacheDirectory.cacher_type: UncachedCacheDirectory,
+        DirMtimeCacheDirectory.cacher_type: DirMtimeCacheDirectory,
+    }
+    cacher_type = cacher_type or "uncached"
+    return cachers[cacher_type]

--- a/lib/galaxy/tool_util/deps/container_resolvers/__init__.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/__init__.py
@@ -363,3 +363,17 @@ def identifier_to_cached_target(
 def get_filter(namespace: Optional[str]) -> Callable[[str], bool]:
     prefix = "quay.io/" if namespace is None else f"quay.io/{namespace}"
     return lambda name: name.startswith(prefix) and name.count("/") == 2
+
+
+__all__ = (
+    "ApptainerCliContainerResolver",
+    "CacheDirectory",
+    "CachedMulledImageSingleTarget",
+    "CachedTarget",
+    "CachedV1MulledImageMultiTarget",
+    "CachedV2MulledImageMultiTarget",
+    "CliContainerResolver",
+    "ResolutionCache",
+    "SingularityCliContainerResolver",
+    "list_docker_cached_mulled_images",
+)

--- a/lib/galaxy/tool_util/deps/container_resolvers/__init__.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/__init__.py
@@ -14,6 +14,7 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
+
 from typing_extensions import Literal
 
 from galaxy.util import (
@@ -23,7 +24,6 @@ from galaxy.util import (
 )
 from galaxy.util.bunch import Bunch
 from galaxy.util.dictifiable import Dictifiable
-
 from ..apptainer_util import (
     ApptainerContext,
     DEFAULT_APPTAINER_COMMAND,
@@ -219,9 +219,7 @@ class SingularityCliContainerResolver(CliContainerResolver):
     cli = "singularity"
     cmd = None
 
-    def __init__(
-        self, app_info: "AppInfo", hash_func: Literal["v1", "v2"] = "v2", **kwargs
-    ) -> None:
+    def __init__(self, app_info: "AppInfo", hash_func: Literal["v1", "v2"] = "v2", **kwargs) -> None:
         super().__init__(app_info=app_info, **kwargs)
         self.hash_func = hash_func
         self.cache_directory_cacher_type = kwargs.get("cache_directory_cacher_type")
@@ -229,7 +227,10 @@ class SingularityCliContainerResolver(CliContainerResolver):
         cache_directory_path = kwargs.get("cache_directory")
         if not cache_directory_path:
             assert self.app_info.container_image_cache_path
-            cache_directory_path = os.path.join(self.app_info.container_image_cache_path, "singularity", "mulled")
+            cache_subdirectory = "mulled" if "mulled" in self.resolver_type else "explicit"
+            cache_directory_path = os.path.join(
+                self.app_info.container_image_cache_path, "singularity", cache_subdirectory
+            )
         self.cache_directory = cacher_class(cache_directory_path, hash_func=self.hash_func)
         safe_makedirs(self.cache_directory.path)
 
@@ -239,9 +240,7 @@ class ApptainerCliContainerResolver(SingularityCliContainerResolver):
     cli = "apptainer"
     cmd = None
 
-    def __init__(
-        self, app_info: "AppInfo", auto_init: bool = False, **kwargs
-    ) -> None:
+    def __init__(self, app_info: "AppInfo", auto_init: bool = False, **kwargs) -> None:
         super().__init__(app_info=app_info, **kwargs)
         self.auto_init = string_as_bool(auto_init)
         apptainer_exec = kwargs.get("exec")

--- a/lib/galaxy/tool_util/deps/container_resolvers/explicit.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/explicit.py
@@ -11,7 +11,7 @@ from typing import (
 
 from galaxy.util.commands import shell
 from . import ContainerResolver
-from .mulled import CliContainerResolver
+from . import CliContainerResolver
 from ..container_classes import SingularityContainer
 from ..requirements import ContainerDescription
 

--- a/lib/galaxy/tool_util/deps/container_resolvers/explicit.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/explicit.py
@@ -99,7 +99,7 @@ class CachedExplicitSingularityContainerResolver(SingularityCliContainerResolver
             if not self.cli_available:
                 return container_description
             image_id = container_description.identifier
-            cache_path = os.path.normpath(os.path.join(self.cache_directory_path, image_id))
+            cache_path = os.path.normpath(os.path.join(self.cache_directory.path, image_id))
             if install and not os.path.exists(cache_path):
                 destination_info = {}
                 destination_for_container_type = kwds.get("destination_for_container_type")
@@ -122,7 +122,7 @@ class CachedExplicitSingularityContainerResolver(SingularityCliContainerResolver
             return None
 
     def __str__(self):
-        return f"CachedExplicitSingularityContainerResolver[cache_directory={self.cache_directory_path}]"
+        return f"CachedExplicitSingularityContainerResolver[cache_directory={self.cache_directory.path}]"
 
 
 class CachedExplicitApptainerContainerResolver(

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -15,10 +15,8 @@ from typing import (
 from requests import Session
 from typing_extensions import Literal
 
-from galaxy.tool_util.deps.installable import ensure_installed as deps_ensure_installed
 from galaxy.util import (
     string_as_bool,
-    unicodify,
 )
 from galaxy.util.commands import shell
 from . import (
@@ -31,7 +29,6 @@ from . import (
     CliContainerResolver,
     ResolutionCache,
     SingularityCliContainerResolver,
-    identifier_to_cached_target,
     list_docker_cached_mulled_images,
 )
 from ..conda_util import CondaTarget
@@ -41,7 +38,6 @@ from ..container_classes import (
     DockerContainer,
     SingularityContainer,
 )
-from ..docker_util import build_docker_images_command
 from ..mulled.mulled_build import (
     ensure_installed,
     InvolucroContext,
@@ -55,7 +51,6 @@ from ..mulled.util import (
     split_tag,
     v1_image_name,
     v2_image_name,
-    version_sorted,
 )
 from ..requirements import (
     ContainerDescription,

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -3,10 +3,6 @@
 import logging
 import os
 import subprocess
-from abc import (
-    ABCMeta,
-    abstractmethod,
-)
 from typing import (
     Any,
     Callable,

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -27,9 +27,9 @@ from . import (
     CachedV1MulledImageMultiTarget,
     CachedV2MulledImageMultiTarget,
     CliContainerResolver,
+    list_docker_cached_mulled_images,
     ResolutionCache,
     SingularityCliContainerResolver,
-    list_docker_cached_mulled_images,
 )
 from ..conda_util import CondaTarget
 from ..container_classes import (

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -27,15 +27,15 @@ from galaxy.util import (
 )
 from galaxy.util.commands import shell
 from . import (
+    ApptainerCliContainerResolver,
     CacheDirectory,
     CachedMulledImageSingleTarget,
     CachedTarget,
     CachedV1MulledImageMultiTarget,
     CachedV2MulledImageMultiTarget,
     CliContainerResolver,
-    SingularityCliContainerResolver,
-    ApptainerCliContainerResolver,
     ResolutionCache,
+    SingularityCliContainerResolver,
 )
 from ..conda_util import CondaTarget
 from ..container_classes import (
@@ -405,7 +405,11 @@ class CachedMulledSingularityContainerResolver(SingularityCliContainerResolver):
         targets = mulled_targets(tool_info)
         log.debug(f"Image name for tool {tool_info.tool_id}: {image_name(targets, self.hash_func)}")
         return singularity_cached_container_description(
-            targets, self.cache_directory, hash_func=self.hash_func, shell=self.shell, cmd=self.cmd,
+            targets,
+            self.cache_directory,
+            hash_func=self.hash_func,
+            shell=self.shell,
+            cmd=self.cmd,
         )
 
     def __str__(self) -> str:

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -5,7 +5,6 @@ import os
 import subprocess
 from typing import (
     Any,
-    Callable,
     Container as TypingContainer,
     Dict,
     List,
@@ -32,6 +31,8 @@ from . import (
     CliContainerResolver,
     ResolutionCache,
     SingularityCliContainerResolver,
+    identifier_to_cached_target,
+    list_docker_cached_mulled_images,
 )
 from ..conda_util import CondaTarget
 from ..container_classes import (
@@ -68,90 +69,6 @@ if TYPE_CHECKING:
     )
 
 log = logging.getLogger(__name__)
-
-
-def list_docker_cached_mulled_images(
-    namespace: Optional[str] = None,
-    hash_func: Literal["v1", "v2"] = "v2",
-    resolution_cache: Optional[ResolutionCache] = None,
-) -> List[CachedTarget]:
-    cache_key = "galaxy.tool_util.deps.container_resolvers.mulled:cached_images"
-    if resolution_cache is not None and cache_key in resolution_cache:
-        images_and_versions = resolution_cache.get(cache_key)
-    else:
-        command = build_docker_images_command(truncate=True, sudo=False, to_str=False)
-        try:
-            images_and_versions = unicodify(subprocess.check_output(command)).strip().splitlines()
-        except subprocess.CalledProcessError:
-            log.info("Call to `docker images` failed, configured container resolution may be broken")
-            return []
-        images_and_versions = [":".join(line.split()[0:2]) for line in images_and_versions[1:]]
-        if resolution_cache is not None:
-            resolution_cache[cache_key] = images_and_versions
-
-    def output_line_to_image(line: str) -> Optional[CachedTarget]:
-        image = identifier_to_cached_target(line, hash_func, namespace=namespace)
-        return image
-
-    name_filter = get_filter(namespace)
-    sorted_images = version_sorted(list(filter(name_filter, images_and_versions)))
-    raw_images = (output_line_to_image(_) for _ in sorted_images)
-    return [i for i in raw_images if i is not None]
-
-
-def identifier_to_cached_target(
-    identifier: str, hash_func: Literal["v1", "v2"], namespace: Optional[str] = None
-) -> Optional[CachedTarget]:
-    if ":" in identifier:
-        image_name, version = identifier.rsplit(":", 1)
-    else:
-        image_name = identifier
-        version = None
-
-    if not version or version == "latest":
-        version = None
-
-    image: Optional[CachedTarget] = None
-    prefix = ""
-    if namespace is not None:
-        prefix = f"quay.io/{namespace}/"
-    if image_name.startswith(f"{prefix}mulled-v1-"):
-        if hash_func == "v2":
-            return None
-
-        hash = image_name
-        build = None
-        if version and version.isdigit():
-            build = version
-        image = CachedV1MulledImageMultiTarget(hash, build, identifier)
-    elif image_name.startswith(f"{prefix}mulled-v2-"):
-        if hash_func == "v1":
-            return None
-
-        version_hash = None
-        build = None
-        if version:
-            if "-" in version:
-                version_hash, build = version.rsplit("-", 1)
-            elif version.isdigit():
-                version_hash, build = None, version
-            else:
-                log.debug(f"Unparsable mulled image tag encountered [{version}]")
-
-        image = CachedV2MulledImageMultiTarget(image_name, version_hash, build, identifier)
-    else:
-        build = None
-        if version and "--" in version:
-            version, build = split_tag(version)
-        if prefix and image_name.startswith(prefix):
-            image_name = image_name[len(prefix) :]
-        image = CachedMulledImageSingleTarget(image_name, version, build, identifier)
-    return image
-
-
-def get_filter(namespace: Optional[str]) -> Callable[[str], bool]:
-    prefix = "quay.io/" if namespace is None else f"quay.io/{namespace}"
-    return lambda name: name.startswith(prefix) and name.count("/") == 2
 
 
 def find_best_matching_cached_image(

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -13,11 +13,8 @@ from typing import (
     Container as TypingContainer,
     Dict,
     List,
-    NamedTuple,
     Optional,
-    Type,
     TYPE_CHECKING,
-    Union,
 )
 
 from requests import Session
@@ -25,20 +22,20 @@ from typing_extensions import Literal
 
 from galaxy.tool_util.deps.installable import ensure_installed as deps_ensure_installed
 from galaxy.util import (
-    safe_makedirs,
     string_as_bool,
     unicodify,
-    which,
 )
 from galaxy.util.commands import shell
 from . import (
-    ContainerResolver,
+    CacheDirectory,
+    CachedMulledImageSingleTarget,
+    CachedTarget,
+    CachedV1MulledImageMultiTarget,
+    CachedV2MulledImageMultiTarget,
+    CliContainerResolver,
+    SingularityCliContainerResolver,
+    ApptainerCliContainerResolver,
     ResolutionCache,
-)
-from ..apptainer_util import (
-    ApptainerContext,
-    DEFAULT_APPTAINER_COMMAND,
-    install_apptainer,
 )
 from ..conda_util import CondaTarget
 from ..container_classes import (
@@ -75,114 +72,6 @@ if TYPE_CHECKING:
     )
 
 log = logging.getLogger(__name__)
-
-
-class CachedMulledImageSingleTarget(NamedTuple):
-    package_name: str
-    version: Optional[str]
-    build: Optional[str]
-    image_identifier: str
-
-
-class CachedV1MulledImageMultiTarget(NamedTuple):
-    hash: str
-    build: Optional[str]
-    image_identifier: str
-
-
-class CachedV2MulledImageMultiTarget(NamedTuple):
-    image_name: str
-    version_hash: Optional[str]
-    build: Optional[str]
-    image_identifier: str
-
-    @property
-    def package_hash(self) -> str:
-        # Make this work for Singularity file name or fully qualified Docker repository
-        # image names.
-        image_name = self.image_name
-        if "/" not in image_name:
-            return image_name
-        else:
-            return image_name.rsplit("/")[-1]
-
-
-CachedTarget = Union[CachedMulledImageSingleTarget, CachedV1MulledImageMultiTarget, CachedV2MulledImageMultiTarget]
-
-
-class CacheDirectory(metaclass=ABCMeta):
-    def __init__(self, path: str, hash_func: Literal["v1", "v2"] = "v2") -> None:
-        self.path = path
-        self.hash_func = hash_func
-
-    def _list_cached_mulled_images_from_path(self) -> List[CachedTarget]:
-        contents = os.listdir(self.path)
-        sorted_images = version_sorted(contents)
-        raw_images = (identifier_to_cached_target(name, self.hash_func) for name in sorted_images)
-        return [i for i in raw_images if i is not None]
-
-    @abstractmethod
-    def list_cached_mulled_images_from_path(self) -> List[CachedTarget]:
-        """Generate a list of cached, mulled images in the cache."""
-
-    @abstractmethod
-    def invalidate_cache(self) -> None:
-        """Invalidate the cache."""
-
-
-class UncachedCacheDirectory(CacheDirectory):
-    cacher_type = "uncached"
-
-    def list_cached_mulled_images_from_path(
-        self,
-    ) -> List[CachedTarget]:
-        return self._list_cached_mulled_images_from_path()
-
-    def invalidate_cache(self) -> None:
-        pass
-
-
-class DirMtimeCacheDirectory(CacheDirectory):
-    cacher_type = "dir_mtime"
-
-    def __init__(self, path: str, **kwargs):
-        super().__init__(path, **kwargs)
-        self.invalidate_cache()
-
-    def __get_mtime(self) -> float:
-        return os.stat(self.path).st_mtime
-
-    def __cache(self) -> None:
-        self.__contents = self._list_cached_mulled_images_from_path()
-        self.__mtime = self.__get_mtime()
-        log.debug(f"Cached images in path {self.path} at directory mtime {self.__mtime}")
-
-    def list_cached_mulled_images_from_path(
-        self,
-    ) -> List[CachedTarget]:
-        mtime = self.__get_mtime()
-        if mtime != self.__mtime:
-            if mtime < self.__mtime:
-                log.warning(
-                    f"Modification time '{mtime}' of cache directory '{self.path}' is older than previous "
-                    f"modification time '{self.__mtime}'! Cache directory will be recached"
-                )
-            self.__cache()
-        return self.__contents
-
-    def invalidate_cache(self) -> None:
-        self.__mtime = -1.0
-        self.__contents = []
-
-
-def get_cache_directory_cacher(cacher_type: Optional[str]) -> Type[CacheDirectory]:
-    # these can become a separate module and use plugin_config if we need more
-    cachers: Dict[str, Type[CacheDirectory]] = {
-        UncachedCacheDirectory.cacher_type: UncachedCacheDirectory,
-        DirMtimeCacheDirectory.cacher_type: DirMtimeCacheDirectory,
-    }
-    cacher_type = cacher_type or "uncached"
-    return cachers[cacher_type]
 
 
 def list_docker_cached_mulled_images(
@@ -358,7 +247,7 @@ def singularity_cached_container_description(
     if not os.path.exists(cache_directory.path):
         return None
 
-    cached_images = cache_directory.list_cached_mulled_images_from_path()
+    cached_images = cache_directory.list_cached_images_from_path()
     image = find_best_matching_cached_image(targets, cached_images, hash_func)
 
     container = None
@@ -469,71 +358,6 @@ def targets_to_mulled_name(
         unresolved_cache.add(name)
 
     return name
-
-
-class CliContainerResolver(ContainerResolver):
-    container_type = "docker"
-    cli = "docker"
-
-    def __init__(self, app_info: "AppInfo", **kwargs) -> None:
-        super().__init__(app_info=app_info, **kwargs)
-        self._cli_available = bool(which(self.cli))
-
-    @property
-    def cli_available(self) -> bool:
-        return self._cli_available
-
-    @cli_available.setter
-    def cli_available(self, value: bool) -> None:
-        if not value:
-            log.info(
-                f"{self.cli} CLI not available, cannot list or pull images in Galaxy process. Does not impact kubernetes."
-            )
-        self._cli_available = value
-
-
-class SingularityCliContainerResolver(CliContainerResolver):
-    container_type = "singularity"
-    cli = "singularity"
-    cmd = None
-
-    def __init__(
-        self, app_info: "AppInfo", hash_func: Literal["v1", "v2"] = "v2", **kwargs
-    ) -> None:
-        super().__init__(app_info=app_info, **kwargs)
-        self.hash_func = hash_func
-        self.cache_directory_cacher_type = kwargs.get("cache_directory_cacher_type")
-        cacher_class = get_cache_directory_cacher(self.cache_directory_cacher_type)
-        cache_directory_path = kwargs.get("cache_directory")
-        if not cache_directory_path:
-            assert self.app_info.container_image_cache_path
-            cache_directory_path = os.path.join(self.app_info.container_image_cache_path, "singularity", "mulled")
-        self.cache_directory = cacher_class(cache_directory_path, hash_func=self.hash_func)
-        safe_makedirs(self.cache_directory.path)
-
-
-class ApptainerCliContainerResolver(SingularityCliContainerResolver):
-    container_type = "singularity"
-    cli = "apptainer"
-    cmd = None
-
-    def __init__(
-        self, app_info: "AppInfo", auto_init: bool = False, **kwargs
-    ) -> None:
-        super().__init__(app_info=app_info, **kwargs)
-        self.auto_init = string_as_bool(auto_init)
-        apptainer_exec = kwargs.get("exec")
-        if self.auto_init:
-            apptainer_prefix = kwargs.get("prefix")
-            if apptainer_prefix is None and apptainer_exec is None:
-                assert self.app_info.apptainer_prefix
-                apptainer_prefix = self.app_info.apptainer_prefix
-            apptainer_context = ApptainerContext(apptainer_prefix=apptainer_prefix, apptainer_exec=apptainer_exec)
-            deps_ensure_installed(apptainer_context, install_apptainer, self.auto_init)
-            apptainer_exec = apptainer_context.apptainer_exec
-            self._cli_available = True
-        self.apptainer_exec = apptainer_exec
-        self.cmd = apptainer_exec or DEFAULT_APPTAINER_COMMAND
 
 
 class CachedMulledDockerContainerResolver(CliContainerResolver):

--- a/lib/galaxy/tool_util/deps/dependencies.py
+++ b/lib/galaxy/tool_util/deps/dependencies.py
@@ -32,6 +32,7 @@ class AppInfo:
         involucro_path: Optional[str] = None,
         involucro_auto_init: bool = True,
         mulled_channels: List[str] = DEFAULT_CHANNELS,
+        apptainer_prefix: Optional[str] = None,
     ) -> None:
         self.galaxy_root_dir = galaxy_root_dir
         self.default_file_path = default_file_path
@@ -48,6 +49,7 @@ class AppInfo:
         self.involucro_path = involucro_path
         self.involucro_auto_init = involucro_auto_init
         self.mulled_channels = mulled_channels
+        self.apptainer_prefix = apptainer_prefix
 
 
 class ToolInfo:

--- a/lib/galaxy/tool_util/deps/installable.py
+++ b/lib/galaxy/tool_util/deps/installable.py
@@ -59,11 +59,11 @@ def ensure_installed(installable_context: InstallableContext, install_func, auto
             installed = True
         return installed
 
-    if not os.path.lexists(parent_path):
+    if auto_init and parent_path and not os.path.lexists(parent_path):
         os.mkdir(parent_path)
 
     try:
-        if auto_init and os.access(parent_path, os.W_OK):
+        if auto_init and parent_path and os.access(parent_path, os.W_OK):
             with FileLock(os.path.join(parent_path, desc.lower()), timeout=300):
                 return _check()
         else:

--- a/lib/galaxy/tool_util/deps/requirements.py
+++ b/lib/galaxy/tool_util/deps/requirements.py
@@ -187,6 +187,7 @@ class ContainerDescription:
         type: str = DEFAULT_CONTAINER_TYPE,
         resolve_dependencies: bool = DEFAULT_CONTAINER_RESOLVE_DEPENDENCIES,
         shell: str = DEFAULT_CONTAINER_SHELL,
+        cmd: Optional[str] = None,
     ) -> None:
         # Force to lowercase because container image names must be lowercase.
         # Cached singularity images include the path on disk, so only lowercase
@@ -206,6 +207,7 @@ class ContainerDescription:
         self.resolve_dependencies = resolve_dependencies
         self.shell = shell
         self.explicit = False
+        self.cmd = cmd
 
     def to_dict(self, *args, **kwds) -> Dict[str, Any]:
         return dict(

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1906,6 +1906,7 @@ def check_github_api_response_rate_limit(response):
 def download_to_file(url, dest_file_path, timeout=30, chunk_size=2**20):
     """Download a URL to a file in chunks."""
     with requests.get(url, timeout=timeout, stream=True) as r, open(dest_file_path, "wb") as f:
+        r.raise_for_status()
         for chunk in r.iter_content(chunk_size):
             if chunk:
                 f.write(chunk)

--- a/test/integration/test_container_resolvers.py
+++ b/test/integration/test_container_resolvers.py
@@ -16,7 +16,7 @@ from typing_extensions import (
     Protocol,
 )
 
-from galaxy.tool_util.deps.container_resolvers.mulled import list_docker_cached_mulled_images
+from galaxy.tool_util.deps.container_resolvers import list_docker_cached_mulled_images
 from galaxy.util.commands import (
     execute,
     shell,

--- a/test/unit/tool_util/test_container_resolution.py
+++ b/test/unit/tool_util/test_container_resolution.py
@@ -4,9 +4,9 @@ import pytest
 
 from galaxy.tool_util.deps.container_classes import DOCKER_CONTAINER_TYPE
 from galaxy.tool_util.deps.container_resolvers.mulled import (
+    CachedMulledApptainerContainerResolver,
     CachedMulledDockerContainerResolver,
     CachedMulledSingularityContainerResolver,
-    CachedMulledApptainerContainerResolver,
     MulledDockerContainerResolver,
 )
 from galaxy.tool_util.deps.containers import ContainerRegistry

--- a/test/unit/tool_util/test_container_resolution.py
+++ b/test/unit/tool_util/test_container_resolution.py
@@ -171,7 +171,8 @@ def test_cached_apptainer_container_resolver_dir_mtime_cached(mocker):
     mocker.patch("galaxy.tool_util.deps.container_resolvers.safe_makedirs")
     mocker.patch("os.stat", return_value=mocker.Mock(st_mtime=42))
     resolver = CachedMulledApptainerContainerResolver(
-        app_info=mocker.Mock(container_image_cache_path="/"), cache_directory_cacher_type="dir_mtime",
+        app_info=mocker.Mock(container_image_cache_path="/"),
+        cache_directory_cacher_type="dir_mtime",
         exec="/bin/apptainer",
     )
     requirement = ToolRequirement(name="baz", version="2.22", type="package")

--- a/test/unit/tool_util/test_container_resolution.py
+++ b/test/unit/tool_util/test_container_resolution.py
@@ -6,6 +6,7 @@ from galaxy.tool_util.deps.container_classes import DOCKER_CONTAINER_TYPE
 from galaxy.tool_util.deps.container_resolvers.mulled import (
     CachedMulledDockerContainerResolver,
     CachedMulledSingularityContainerResolver,
+    CachedMulledApptainerContainerResolver,
     MulledDockerContainerResolver,
 )
 from galaxy.tool_util.deps.containers import ContainerRegistry
@@ -143,6 +144,47 @@ def test_cached_singularity_container_resolver_dir_mtime_cached(mocker):
     tool_info.requirements.append(requirement)
     container_description = resolver.resolve(enabled_container_types=["singularity"], tool_info=tool_info)
     assert container_description
+    assert container_description.type == "singularity"
+    assert (
+        container_description.identifier
+        == "/singularity/mulled/mulled-v2-fe8a3b846bc50d24e5df78fa0b562c43477fe9ce:9f946d13f673ab2903cb0da849ad42916d619d18-0"
+    )
+
+
+def test_cached_apptainer_container_resolver_uncached(mocker):
+    mocker.patch("os.listdir", return_value=SINGULARITY_IMAGES)
+    mocker.patch("os.path.exists", return_value=True)
+    mocker.patch("galaxy.tool_util.deps.container_resolvers.safe_makedirs")
+    resolver = CachedMulledApptainerContainerResolver(app_info=mocker.Mock(container_image_cache_path="/"))
+    requirement = ToolRequirement(name="foo", version="1.0", type="package")
+    tool_info = ToolInfo(requirements=[requirement])
+    container_description = resolver.resolve(enabled_container_types=["singularity"], tool_info=tool_info)
+    assert container_description
+    assert container_description.cmd == "apptainer"
+    assert container_description.type == "singularity"
+    assert container_description.identifier == "/singularity/mulled/foo:1.0--bar"
+
+
+def test_cached_apptainer_container_resolver_dir_mtime_cached(mocker):
+    mocker.patch("os.listdir", return_value=SINGULARITY_IMAGES)
+    mocker.patch("os.path.exists", return_value=True)
+    mocker.patch("galaxy.tool_util.deps.container_resolvers.safe_makedirs")
+    mocker.patch("os.stat", return_value=mocker.Mock(st_mtime=42))
+    resolver = CachedMulledApptainerContainerResolver(
+        app_info=mocker.Mock(container_image_cache_path="/"), cache_directory_cacher_type="dir_mtime",
+        exec="/bin/apptainer",
+    )
+    requirement = ToolRequirement(name="baz", version="2.22", type="package")
+    tool_info = ToolInfo(requirements=[requirement])
+    container_description = resolver.resolve(enabled_container_types=["singularity"], tool_info=tool_info)
+    assert container_description
+    assert container_description.type == "singularity"
+    assert container_description.identifier == "/singularity/mulled/baz:2.22"
+    requirement = ToolRequirement(name="foo", version="1.0", type="package")
+    tool_info.requirements.append(requirement)
+    container_description = resolver.resolve(enabled_container_types=["singularity"], tool_info=tool_info)
+    assert container_description
+    assert container_description.cmd == "/bin/apptainer"
     assert container_description.type == "singularity"
     assert (
         container_description.identifier

--- a/test/unit/tool_util/test_container_resolution.py
+++ b/test/unit/tool_util/test_container_resolution.py
@@ -115,7 +115,7 @@ def test_docker_container_docker_cli_exception_resolve(appinfo, mocker):
 def test_cached_singularity_container_resolver_uncached(mocker):
     mocker.patch("os.listdir", return_value=SINGULARITY_IMAGES)
     mocker.patch("os.path.exists", return_value=True)
-    mocker.patch("galaxy.tool_util.deps.container_resolvers.mulled.safe_makedirs")
+    mocker.patch("galaxy.tool_util.deps.container_resolvers.safe_makedirs")
     resolver = CachedMulledSingularityContainerResolver(app_info=mocker.Mock(container_image_cache_path="/"))
     requirement = ToolRequirement(name="foo", version="1.0", type="package")
     tool_info = ToolInfo(requirements=[requirement])
@@ -128,7 +128,7 @@ def test_cached_singularity_container_resolver_uncached(mocker):
 def test_cached_singularity_container_resolver_dir_mtime_cached(mocker):
     mocker.patch("os.listdir", return_value=SINGULARITY_IMAGES)
     mocker.patch("os.path.exists", return_value=True)
-    mocker.patch("galaxy.tool_util.deps.container_resolvers.mulled.safe_makedirs")
+    mocker.patch("galaxy.tool_util.deps.container_resolvers.safe_makedirs")
     mocker.patch("os.stat", return_value=mocker.Mock(st_mtime=42))
     resolver = CachedMulledSingularityContainerResolver(
         app_info=mocker.Mock(container_image_cache_path="/"), cache_directory_cacher_type="dir_mtime"

--- a/test/unit/tool_util/test_container_resolution.py
+++ b/test/unit/tool_util/test_container_resolution.py
@@ -54,7 +54,7 @@ def test_container_registry(container_registry, mocker):
 
 
 def test_docker_container_resolver_detects_docker_cli_absent(appinfo, mocker):
-    mocker.patch("galaxy.tool_util.deps.container_resolvers.mulled.which", return_value=None)
+    mocker.patch("galaxy.tool_util.deps.container_resolvers.which", return_value=None)
     resolver = CachedMulledDockerContainerResolver(appinfo)
     assert resolver._cli_available is False
 
@@ -69,14 +69,14 @@ def test_docker_container_resolver_detects_docker_cli(appinfo, mocker):
 
 
 def test_cached_docker_container_docker_cli_absent_resolve(appinfo, mocker) -> None:
-    mocker.patch("galaxy.tool_util.deps.container_resolvers.mulled.which", return_value=None)
+    mocker.patch("galaxy.tool_util.deps.container_resolvers.which", return_value=None)
     resolver = CachedMulledDockerContainerResolver(appinfo)
     assert resolver.cli_available is False
     assert resolver.resolve(enabled_container_types=[], tool_info=ToolInfo()) is None
 
 
 def test_docker_container_docker_cli_absent_resolve(appinfo, mocker):
-    mocker.patch("galaxy.tool_util.deps.container_resolvers.mulled.which", return_value=None)
+    mocker.patch("galaxy.tool_util.deps.container_resolvers.which", return_value=None)
     resolver = MulledDockerContainerResolver(appinfo)
     assert resolver.cli_available is False
     requirement = ToolRequirement(name="samtools", version="1.10", type="package")
@@ -92,7 +92,7 @@ def test_docker_container_docker_cli_absent_resolve(appinfo, mocker):
 
 
 def test_docker_container_docker_cli_exception_resolve(appinfo, mocker):
-    mocker.patch("galaxy.tool_util.deps.container_resolvers.mulled.which", return_value="/bin/docker")
+    mocker.patch("galaxy.tool_util.deps.container_resolvers.which", return_value="/bin/docker")
     resolver = MulledDockerContainerResolver(appinfo)
     assert resolver.cli_available is True
     requirement = ToolRequirement(name="samtools", version="1.10", type="package")

--- a/test/unit/tool_util/test_singularity_util.py
+++ b/test/unit/tool_util/test_singularity_util.py
@@ -18,3 +18,13 @@ def test_build_singularity_run_command_no_cleanenv_ipc_pid():
         ipc=False,
     )
     assert cmd == "singularity -s exec --contain --no-mount tmp busybox echo hi"
+
+
+def test_build_singularity_run_command_apptainer_no_contain():
+    cmd = build_singularity_run_command(
+        container_command="echo hi",
+        image="busybox",
+        singularity_cmd="apptainer",
+        contain=False,
+    )
+    assert cmd == "apptainer -s exec --cleanenv --ipc --pid --no-mount tmp busybox echo hi"


### PR DESCRIPTION
Ultimately the goal here is to support easier production deployments where Galaxy itself does not have to be installed in the shared FS. Admins can configure the `tool_dependency_dir` to be on the shared FS and then we can just use Apptainer + a galaxy-job-execution container for running `set_meta()`.

I should probably add a few more tests but wanted to get this out here for comment in case people don't like the direction I've taken.

## How to test the changes?
(Select all options that apply)
- [x] ~~I've included~~ I will include appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Configure some resolvers in `container_resolvers` where `s/singularity/apptainer/`
  2. Set `auto_init: true`
  3. Try setting `prefix` and/or `exec` to change where Apptainer is installed.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
