### PR TITLE
[25.0] Set ``GALAXY_CONFIG_FILE`` env var if starting handler with `-c`

### DIFF
--- a/scripts/galaxy_main.py
+++ b/scripts/galaxy_main.py
@@ -225,6 +225,13 @@ def main(func=app_loop):
     args = arg_parser.parse_args()
     if args.ini_path and not args.config_file:
         args.config_file = args.ini_path
+    if (config_file_env := os.environ.get("GALAXY_CONFIG_FILE")) and os.path.abspath(
+        config_file_env
+    ) != os.path.abspath(args.config_file):
+        sys.exit(
+            "Error: GALAXY_CONFIG_FILE environment variable is set to a different config file than the one specified on the command line."
+        )
+    os.environ["GALAXY_CONFIG_FILE"] = os.path.abspath(args.config_file)
     if args.log_file:
         os.environ["GALAXY_CONFIG_LOG_DESTINATION"] = os.path.abspath(args.log_file)
     if args.server_name:


### PR DESCRIPTION
I think this should fix https://github.com/galaxyproject/galaxy/issues/20307
I had previously already tried to fix this via https://github.com/galaxyproject/galaxy/pull/18819, but this seems to be back in 25.0. It's a bit of a brute-force method, but it looks like once we build the `celery_app` that's the one the tasks get bound to. We probably could change the decorator to delay celery_app construction until the first use, this should also always work.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
