### PR TITLE
[25.0] Fix pagination state in FilesDialog

### DIFF
--- a/client/src/components/DataDialog/utilities.js
+++ b/client/src/components/DataDialog/utilities.js
@@ -6,11 +6,12 @@ export class UrlTracker {
     }
 
     /** Returns urls for data drilling **/
-    getUrl(url) {
+    getUrl(url, returnWithPrevious = false) {
+        let previous = undefined;
         if (url) {
             this.navigation.push(url);
         } else {
-            this.navigation.pop();
+            previous = this.navigation.pop();
             const navigationLength = this.navigation.length;
             if (navigationLength > 0) {
                 url = this.navigation[navigationLength - 1];
@@ -18,7 +19,12 @@ export class UrlTracker {
                 url = this.root;
             }
         }
-        return url;
+
+        if (returnWithPrevious) {
+            return { url, popped: previous };
+        } else {
+            return url;
+        }
     }
 
     /** Returns true if the last data is at navigation root **/

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -45,6 +45,7 @@ interface Props {
     searchTitle?: string;
     okButtonText?: string;
     filterClass?: Filtering<any>;
+    watchOnPageChanges?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -71,6 +72,7 @@ const props = withDefaults(defineProps<Props>(), {
     searchTitle: undefined,
     okButtonText: "Select",
     filterClass: undefined,
+    watchOnPageChanges: true,
 });
 
 const emit = defineEmits<{
@@ -143,31 +145,26 @@ function resetFilter() {
     filter.value = "";
 }
 
-function resetPagination() {
-    currentPage.value = 1;
+function resetPagination(toInitialPage = 1) {
+    currentPage.value = toInitialPage;
+}
+
+if (props.watchOnPageChanges) {
+    watch(
+        () => props.items,
+        () => {
+            if (props.itemsProvider === undefined) {
+                resetPagination();
+            }
+        }
+    );
 }
 
 defineExpose({
     resetFilter,
     resetPagination,
+    currentPage,
 });
-
-watch(
-    () => props.items,
-    () => {
-        filtered(props.items);
-    }
-);
-
-watch(
-    () => props.providerUrl,
-    () => {
-        // We need to reset the current page when drilling down sub-folders
-        if (props.itemsProvider !== undefined) {
-            resetPagination();
-        }
-    }
-);
 </script>
 
 <template>


### PR DESCRIPTION
Not quite related to #20448, but it reminded me that we have a temporal fix that we forgot to PR here regarding FilesDialog.

This fixes navigation when there are multiple pages and we drill down into a folder. When going "back", the current behaviour just lands you on the first page always. With this change, we will land on the last page where we drilled down into a folder.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open the remote files dialog
  2. Select a plugin that contains many pages, like "zenodo"
  3. Navigate to any page
  4. Go inside one of the folders
  5. Go back
  6. Observe that you are now on the same page before entering the folder

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
