### PR TITLE
[25.0] Data Libraries - persist number of entries displayed in folders

### DIFF
--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -268,6 +268,7 @@ import { initFolderTableIcons } from "components/Libraries/icons";
 import { DEFAULT_PER_PAGE, MAX_DESCRIPTION_LENGTH } from "components/Libraries/library-utils";
 import UtcDate from "components/UtcDate";
 import { Toast } from "composables/toast";
+import { usePersistentRef } from "composables/persistentRef";
 import { sanitize } from "dompurify";
 import linkifyHtml from "linkify-html";
 import { getAppRoot } from "onload/loadConfig";
@@ -318,6 +319,8 @@ export default {
         },
     },
     data() {
+        const perPageStorage = useLocalStorage("library-folder-per-page", DEFAULT_PER_PAGE);
+        
         return {
             ...initialFolderState(),
             ...{
@@ -331,7 +334,8 @@ export default {
                 folder_metadata: {},
                 fields: fields,
                 selectMode: "multi",
-                perPage: DEFAULT_PER_PAGE,
+                perPage: perPageStorage.value,
+                perPageStorage,
                 maxDescriptionLength: MAX_DESCRIPTION_LENGTH,
                 total_rows: 0,
                 root: getAppRoot(),
@@ -342,7 +346,8 @@ export default {
         ...mapState(useUserStore, ["currentUser"]),
     },
     watch: {
-        perPage() {
+        perPage(newValue) {
+            this.perPageStorage.value = newValue;
             this.fetchFolderContents();
         },
         includeDeleted() {

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -319,8 +319,8 @@ export default {
         },
     },
     data() {
-        const perPageStorage = useLocalStorage("library-folder-per-page", DEFAULT_PER_PAGE);
-        
+        const perPageRef = usePersistentRef("library-folder-per-page", DEFAULT_PER_PAGE);
+
         return {
             ...initialFolderState(),
             ...{
@@ -334,8 +334,8 @@ export default {
                 folder_metadata: {},
                 fields: fields,
                 selectMode: "multi",
-                perPage: perPageStorage.value,
-                perPageStorage,
+                perPage: perPageRef.value,
+                perPageRef,
                 maxDescriptionLength: MAX_DESCRIPTION_LENGTH,
                 total_rows: 0,
                 root: getAppRoot(),
@@ -347,7 +347,7 @@ export default {
     },
     watch: {
         perPage(newValue) {
-            this.perPageStorage.value = newValue;
+            this.perPageRef.value = newValue;
             this.fetchFolderContents();
         },
         includeDeleted() {

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -267,8 +267,8 @@ import BootstrapVue from "bootstrap-vue";
 import { initFolderTableIcons } from "components/Libraries/icons";
 import { DEFAULT_PER_PAGE, MAX_DESCRIPTION_LENGTH } from "components/Libraries/library-utils";
 import UtcDate from "components/UtcDate";
-import { Toast } from "composables/toast";
 import { usePersistentRef } from "composables/persistentRef";
+import { Toast } from "composables/toast";
 import { sanitize } from "dompurify";
 import linkifyHtml from "linkify-html";
 import { getAppRoot } from "onload/loadConfig";
@@ -319,8 +319,6 @@ export default {
         },
     },
     data() {
-        const perPageRef = usePersistentRef("library-folder-per-page", DEFAULT_PER_PAGE);
-
         return {
             ...initialFolderState(),
             ...{
@@ -334,8 +332,7 @@ export default {
                 folder_metadata: {},
                 fields: fields,
                 selectMode: "multi",
-                perPage: perPageRef.value,
-                perPageRef,
+                perPage: DEFAULT_PER_PAGE,
                 maxDescriptionLength: MAX_DESCRIPTION_LENGTH,
                 total_rows: 0,
                 root: getAppRoot(),
@@ -347,7 +344,9 @@ export default {
     },
     watch: {
         perPage(newValue) {
-            this.perPageRef.value = newValue;
+            if (this.perPageRef) {
+                this.perPageRef.value = newValue;
+            }
             this.fetchFolderContents();
         },
         includeDeleted() {
@@ -362,6 +361,8 @@ export default {
     },
     created() {
         this.services = new Services({ root: this.root });
+        this.perPageRef = usePersistentRef("library-folder-per-page", DEFAULT_PER_PAGE);
+        this.perPage = this.perPageRef.value;
         this.getFolder(this.folder_id, this.page);
     },
     methods: {
@@ -375,6 +376,10 @@ export default {
         resetData() {
             const data = initialFolderState();
             Object.keys(data).forEach((k) => (this[k] = data[k]));
+            // Restore perPage from localStorage after reset
+            if (this.perPageRef) {
+                this.perPage = this.perPageRef.value;
+            }
         },
         onSort(props) {
             this.sortBy = props.sortBy;


### PR DESCRIPTION
papercut from @mschatz, persist number of entries shown when inside data library folders.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
