### PR TITLE
[25.0] Fix multiple remote file upload to collection creator

### DIFF
--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -333,7 +333,7 @@ function addUploadedFiles(files: HDASummary[]) {
                 localize(`Dataset ${f.hid}: ${f.name} ${problem} and is an invalid element for this collection`),
                 localize("Uploaded item is invalid")
             );
-        } else {
+        } else if (!file) {
             invalidElements.value.push("Uploaded item: " + f.name + " could not be added to the collection");
             Toast.error(
                 localize(`Dataset ${f.hid}: ${f.name} could not be added to the collection`),

--- a/client/src/composables/monitorUploadedHistoryItems.ts
+++ b/client/src/composables/monitorUploadedHistoryItems.ts
@@ -37,10 +37,16 @@ export function monitorUploadedHistoryItems(
         const uploadedDatasets: HistoryItemSummary[] = [];
         uploadValues.value.forEach((model) => {
             const outputs = model.outputs;
+            // Some uploads (e.g.: in the case of remote file upload) may have the entire set of uploaded files
+            // in the `outputs` object, while typically, the `outputs` object contains each individual upload.
             if (outputs) {
                 Object.entries(outputs).forEach((output) => {
                     const outputDetails = output[1] as HistoryItemSummary;
-                    uploadedDatasets.push(outputDetails);
+                    // Since there is a possibility of all uploads being in the `outputs` object,
+                    // we need to ensure that we only add unique datasets to the list.
+                    if (!uploadedDatasets.some((item) => item.id === outputDetails.id)) {
+                        uploadedDatasets.push(outputDetails);
+                    }
                 });
             }
         });


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20454

The `if` condition in `addUploadedFiles` in `ListCollectionCreator` was incorrectly flagging uploaded items as invalid if they've already been added to the list once, and the function is called again.

Now, the reason the `addUploadedFiles` function is being called multiple times for remote uploads is explained here in the next commit:

Commit message from the commit https://github.com/galaxyproject/galaxy/pull/20456/commits/e18910f19c8ad013beb60fa882edecb7f937ad00:
> In the case of remote file uploads, for each upload value, we have the entire set of uploads in the `model.outputs` object, which would cause the same dataset to appear multiple times in the `uploadedHistoryItems` object.
For other, non-remote uploads, we typically only have the matching output for the upload value in the `model.outputs` object.



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
