### PR TITLE
[25.0] Bug fix: paired_or_unpaired also endswith paired.

### DIFF
--- a/client/src/components/Collections/common/usePairingSummary.ts
+++ b/client/src/components/Collections/common/usePairingSummary.ts
@@ -17,7 +17,7 @@ export function usePairingSummary<T extends HasName>(props: PropsWithCollectionT
             const numMatchedText = `Auto-matched ${summary.pairs.length} pair(s) of datasets from target datasets.`;
             const numUnmatched = summary.unpaired.length;
             let numUnmatchedText = "";
-            if (numUnmatched > 0 && props.collectionType.endsWith("paired")) {
+            if (numUnmatched > 0 && props.collectionType.endsWith(":paired")) {
                 numUnmatchedText = `${numUnmatched} dataset(s) were not paired and will not be included in the resulting list of pairs.`;
             } else if (numUnmatched > 0) {
                 numUnmatchedText = `${numUnmatched} dataset(s) were not paired and will be included in the resulting list as unpaired datasets.`;


### PR DESCRIPTION
This causes the wrong help text to appear on the screen.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
