### PR TITLE
[25.0] Fix bug with handling compressed file names while auto-pairing. 

### DIFF
--- a/client/src/components/Collections/auto_pairing_spec.yml
+++ b/client/src/components/Collections/auto_pairing_spec.yml
@@ -1,0 +1,40 @@
+- doc: Simple _R1 _R2 fastqs split.
+  inputs:
+  - input_R1.fastq
+  - input_R2.fastq
+  paired:
+    input:
+      forward: input_R1.fastq
+      reverse: input_R2.fastq
+
+- doc: Joining common prefixes on _R1 _R2.
+  inputs:
+  - input541_R1.fastq
+  - input541_R2.fastq
+  - input521_R1.fastq
+  - input521_R2.fastq
+  paired:
+    input541:
+      forward: input541_R1.fastq
+      reverse: input541_R2.fastq
+    input521:
+      forward: input521_R1.fastq
+      reverse: input521_R2.fastq
+
+- doc: Simple .1.fastq/.2.fastq split.
+  inputs:
+  - input.1.fastq
+  - input.2.fastq
+  paired:
+    input:
+      forward: input.1.fastq
+      reverse: input.2.fastq
+
+- doc: Simple _1/_2 split.
+  inputs:
+  - input_1.fastq
+  - input_2.fastq
+  paired:
+    input:
+      forward: input_1.fastq
+      reverse: input_2.fastq

--- a/client/src/components/Collections/auto_pairing_spec.yml
+++ b/client/src/components/Collections/auto_pairing_spec.yml
@@ -7,6 +7,15 @@
       forward: input_R1.fastq
       reverse: input_R2.fastq
 
+- doc: Compressed _R1 _R2 fastqs split.
+  inputs:
+  - input_R1.fastq.gz
+  - input_R2.fastq.gz
+  paired:
+    input:
+      forward: input_R1.fastq.gz
+      reverse: input_R2.fastq.gz
+
 - doc: Joining common prefixes on _R1 _R2.
   inputs:
   - input541_R1.fastq
@@ -30,6 +39,15 @@
       forward: input.1.fastq
       reverse: input.2.fastq
 
+- doc: Simple .1.fastq.gz/.2.fastq.gz split.
+  inputs:
+  - input.1.fastq.gz
+  - input.2.fastq.gz
+  paired:
+    input:
+      forward: input.1.fastq.gz
+      reverse: input.2.fastq.gz
+
 - doc: Simple _1/_2 split.
   inputs:
   - input_1.fastq
@@ -38,3 +56,21 @@
     input:
       forward: input_1.fastq
       reverse: input_2.fastq
+
+- doc: Simple _1/_2 split on compressed files (.gz)
+  inputs:
+  - input_1.fastq.gz
+  - input_2.fastq.gz
+  paired:
+    input:
+      forward: input_1.fastq.gz
+      reverse: input_2.fastq.gz
+
+- doc: Simple _1/_2 split on compressed files (.bz2)
+  inputs:
+  - input_1.fastq.bz2
+  - input_2.fastq.bz2
+  paired:
+    input:
+      forward: input_1.fastq.bz2
+      reverse: input_2.fastq.bz2

--- a/client/src/components/Collections/pairing.test.ts
+++ b/client/src/components/Collections/pairing.test.ts
@@ -1,3 +1,4 @@
+import AUTO_PAIRING_SPECIFICATION from "./auto_pairing_spec.yml";
 import {
     autoDetectPairs,
     autoPairWithCommonFilters,
@@ -115,5 +116,34 @@ describe("splitIntoPairedAndUnpaired", () => {
         // we cannot deduce forward from reverse
         const summary = splitIntoPairedAndUnpaired([B1, M1, F1, F2, B2, L1, L2, E1, E2], "", "", true);
         expect(summary.pairs).toHaveLength(0);
+    });
+});
+
+interface ExpectedPair {
+    name: string;
+    forward: string;
+    reverse: string;
+}
+
+interface AutoPairingTest {
+    doc?: string;
+    inputs: string[];
+    paired: Record<string, ExpectedPair>;
+}
+
+describe("fulfills auto pairing specification ", () => {
+    test("the specification", () => {
+        const tests = AUTO_PAIRING_SPECIFICATION;
+        tests.forEach((test: AutoPairingTest) => {
+            const inputs = test.inputs.map((name) => mockDataset(name));
+            const summary = autoPairWithCommonFilters(inputs, true);
+            for (const name in test.paired) {
+                const expectedPair = test.paired[name] as ExpectedPair;
+                const pair = summary.pairs?.find((p) => p.name === name);
+                expect(pair).toBeDefined();
+                expect(pair?.forward.name).toEqual(expectedPair.forward);
+                expect(pair?.reverse.name).toEqual(expectedPair.reverse);
+            }
+        });
     });
 });

--- a/client/src/components/Collections/pairing.ts
+++ b/client/src/components/Collections/pairing.ts
@@ -70,7 +70,13 @@ export function _guessNameForPair(
     if (willRemoveExtensions) {
         const lastDotIndex = lcs.lastIndexOf(".");
         if (lastDotIndex > 0) {
-            const extension = lcs.slice(lastDotIndex, lcs.length);
+            let extension = lcs.slice(lastDotIndex, lcs.length);
+            if ([".gz", ".bz", ".bzip", ".bz2"].indexOf(extension) !== -1) {
+                const secondLastDotIndex = lcs.lastIndexOf(".", lastDotIndex - 1);
+                if (secondLastDotIndex > 0) {
+                    extension = lcs.slice(secondLastDotIndex, lcs.length);
+                }
+            }
             lcs = lcs.replace(extension, "");
             fwdName = fwdName.replace(extension, "");
             revName = revName.replace(extension, "");


### PR DESCRIPTION
Includes declarative testing I wrote for testing auto-pairing downstream - needed something declarative because doing this on the backend also downstream with some new collection upload handling code. The bug fix commit though includes a readable test for the expected behavior and the assertion that it is fixed.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
