### PR TITLE
Fix transient selenium error when adding collection input.

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1252,6 +1252,8 @@ class NavigatesGalaxy(HasDriver):
 
         if editor.inputs.activity_panel.is_absent:
             editor.inputs.activity_button.wait_for_and_click()
+            # occasionally the tooltip on the input will block the collection input click
+            self.clear_tooltips()
 
         editor.inputs.input(id=item_name).wait_for_and_click()
         self.sleep_for(self.wait_types.UX_RENDER)


### PR DESCRIPTION
Expanding the activity panel for inputs leaves a tooltip there that blocks the collection input - this happens pretty consistently locally but I saw it in dev for the first time so I'm backporting my fix.

The exception looks like this:

```
lib/galaxy_test/selenium/test_workflow_editor.py::TestWorkflowEditor::test_collection_input - selenium.common.exceptions.ElementClickInterceptedException: Message: element click intercepted: Element <button data-v-b6d842cc="" data-v-535ecea5="" data-id="data_collection_input" class="workflow-input-button">...</button> is not clickable at point (251, 184). Other element would receive the click: <div data-v-52e55e3d="" data-v-bd5fefe2="" class="text-center px-2 py-1">...</div>
```

https://github.com/galaxyproject/galaxy/actions/runs/15643730294/job/44077231845?pr=20282

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
