### PR TITLE
[25.0] Add Auspice JSON datatype

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -148,7 +148,7 @@
     <datatype extension="vitesscejson" type="galaxy.datatypes.text:VitessceJson" mimetype="application/json" display_in_upload="True">
       <visualization plugin="vitessce" />
     </datatype>
-    <dataatype extension="auspicejson" type="galaxy.datatypes.text:AuspiceJson" mimetype="application/json" display_in_upload="True" />
+    <datatype extension="auspice.json" type="galaxy.datatypes.text:AuspiceJson" mimetype="application/json" display_in_upload="True" />
     <datatype extension="data_manager_json" type="galaxy.datatypes.text:DataManagerJson" mimetype="application/json" subclass="true" display_in_upload="false"/>
     <datatype extension="dbn" type="galaxy.datatypes.sequence:DotBracket" display_in_upload="true" description="Dot-Bracket format is a text-based format for storing both an RNA sequence and its corresponding 2D structure." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Dbn"/>
     <datatype extension="fai" type="galaxy.datatypes.tabular:Tabular" display_in_upload="true" subclass="true" description="A Fasta Index File is a text file consisting of lines each with five TAB-delimited columns : Name, Length, offset, linebases, Linewidth" description_url="http://www.htslib.org/doc/faidx.html"/>

--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -148,6 +148,7 @@
     <datatype extension="vitesscejson" type="galaxy.datatypes.text:VitessceJson" mimetype="application/json" display_in_upload="True">
       <visualization plugin="vitessce" />
     </datatype>
+    <dataatype extension="auspicejson" type="galaxy.datatypes.text:AuspiceJson" mimetype="application/json" display_in_upload="True" />
     <datatype extension="data_manager_json" type="galaxy.datatypes.text:DataManagerJson" mimetype="application/json" subclass="true" display_in_upload="false"/>
     <datatype extension="dbn" type="galaxy.datatypes.sequence:DotBracket" display_in_upload="true" description="Dot-Bracket format is a text-based format for storing both an RNA sequence and its corresponding 2D structure." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Dbn"/>
     <datatype extension="fai" type="galaxy.datatypes.tabular:Tabular" display_in_upload="true" subclass="true" description="A Fasta Index File is a text file consisting of lines each with five TAB-delimited columns : Name, Length, offset, linebases, Linewidth" description_url="http://www.htslib.org/doc/faidx.html"/>
@@ -1364,6 +1365,7 @@
     <sniffer type="galaxy.datatypes.text:CytoscapeJson"/>
     <sniffer type="galaxy.datatypes.text:GeoJson"/>
     <sniffer type="galaxy.datatypes.text:VitessceJson"/>
+    <snipper type="galaxy.datatypes.text:AuspiceJson"/>
     <sniffer type="galaxy.datatypes.text:PithyaResult"/>
     <sniffer type="galaxy.datatypes.text:BCSLts"/>
     <sniffer type="galaxy.datatypes.text:Json"/>

--- a/lib/galaxy/datatypes/test/1.auspicejson
+++ b/lib/galaxy/datatypes/test/1.auspicejson
@@ -1,0 +1,14 @@
+{
+  "version": "v2",
+  "meta": {
+    "title": "Minimal AuspiceJSON",
+    "updated": "2025-02-05",
+    "panels": ["tree"]
+  },
+  "tree": {
+    "name": "1",
+    "node_attrs": {
+      "div": 1
+    }
+  }
+}

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -701,6 +701,55 @@ class VitessceJson(Json):
 
 
 @build_sniff_from_prefix
+class AuspiceJson(Json):
+    """
+    Auspice is a visualization tool for phylogenetic trees and associated data.
+    It uses JSON format to represent the tree structure and metadata.
+    """
+
+    file_ext = "auspicejson"
+
+    def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
+        super().set_peek(dataset)
+        if not dataset.dataset.purged:
+            dataset.blurb = "AuspiceJSON"
+
+    def sniff_prefix(self, file_prefix: FilePrefix) -> bool:
+        """
+        Determines whether the file is in Auspice v2 JSON by looking for keys
+        like "version", "meta" and "updated" that are both required by the
+        https://docs.nextstrain.org/projects/auspice/en/stable/releases/v2.html format
+        and also will be in the first part of the file
+
+        >>> from galaxy.datatypes.sniff import get_test_fname
+        >>> fname = get_test_fname( '1.json' )
+        >>> AuspiceJson().sniff( fname )
+        False
+        >>> fname = get_test_fname( '1.auspicejson' )
+        >>> AuspiceJson().sniff( fname )
+        True
+        """
+        is_auspicejson = False
+        if self._looks_like_json(file_prefix):
+            is_auspicejson = self._looks_like_is_auspicejson(file_prefix)
+        return is_auspicejson
+
+    def _looks_like_is_auspicejson(self, file_prefix: FilePrefix, load_size: int = 20000) -> bool:
+        """
+        Expects 'meta', 'tree', and 'nodes' to be present as keys in the JSON structure.
+        """
+        try:
+            with open(file_prefix.filename) as fh:
+                segment_str = fh.read(load_size)
+
+                if all(x in segment_str for x in ["version", "meta", "updated"]):
+                    return True
+        except Exception:
+            pass
+        return False
+
+
+@build_sniff_from_prefix
 class Obo(Text):
     """
     OBO file format description

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -742,7 +742,7 @@ class AuspiceJson(Json):
             with open(file_prefix.filename) as fh:
                 segment_str = fh.read(load_size)
 
-                if all(x in segment_str for x in ["version", "meta", "updated"]):
+                if all(x in segment_str for x in ["version", "meta", "updated", "panels"]):
                     return True
         except Exception:
             pass

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -736,13 +736,13 @@ class AuspiceJson(Json):
 
     def _looks_like_is_auspicejson(self, file_prefix: FilePrefix, load_size: int = 20000) -> bool:
         """
-        Expects 'meta', 'tree', and 'nodes' to be present as keys in the JSON structure.
+        Expects JSON to start with { and 'meta', 'tree', 'updated' and 'nodes' to be present as keys in the JSON structure.
         """
         try:
             with open(file_prefix.filename) as fh:
                 segment_str = fh.read(load_size)
 
-                if all(x in segment_str for x in ["version", "meta", "updated", "panels"]):
+                if segment_str.startswith('{') and all(x in segment_str for x in ["version", "meta", "updated", "panels"]):
                     return True
         except Exception:
             pass

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -742,7 +742,9 @@ class AuspiceJson(Json):
             with open(file_prefix.filename) as fh:
                 segment_str = fh.read(load_size)
 
-                if segment_str.startswith('{') and all(x in segment_str for x in ["version", "meta", "updated", "panels"]):
+                if segment_str.startswith("{") and all(
+                    x in segment_str for x in ["version", "meta", "updated", "panels"]
+                ):
                     return True
         except Exception:
             pass

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -707,7 +707,7 @@ class AuspiceJson(Json):
     It uses JSON format to represent the tree structure and metadata.
     """
 
-    file_ext = "auspicejson"
+    file_ext = "auspice.json"
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         super().set_peek(dataset)


### PR DESCRIPTION
This adds a datatype for the JSON created by the Auspice tool from Nextstrain (see: https://docs.nextstrain.org/projects/auspice/en/stable/releases/v2.html). This format is useful for tools that ingest it and want to not simply specify "JSON" and also in the future might be useful if Auspice is embedded as a viewer within Galaxy.

The test included is a minimal file that passes the Auspice JSON schema validation but otherwise does not contain useful data. It replaces #20463.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
