### PR TITLE
[25.0] Add ``/api/datasets/{dataset_id}/extra_files/raw/{filename:path}``

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -484,6 +484,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/datasets/{dataset_id}/extra_files/raw/{filename}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Downloads a raw extra file associated with a dataset. */
+        get: operations["extra_file_raw_api_datasets__dataset_id__extra_files_raw__filename__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/datasets/{dataset_id}/get_content_as_text": {
         parameters: {
             query?: never;
@@ -22947,6 +22964,52 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DatasetExtraFiles"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    extra_file_raw_api_datasets__dataset_id__extra_files_raw__filename__get: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The encoded database identifier of the dataset. */
+                dataset_id: string;
+                /** @description The name of the extra file to retrieve. */
+                filename: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Request Error */

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -271,6 +271,29 @@ class FastAPIDatasets:
         return self.service.extra_files(trans, dataset_id)
 
     @router.get(
+        "/api/datasets/{dataset_id}/extra_files/raw/{filename:path}",
+        summary="Downloads a raw extra file associated with a dataset.",
+    )
+    def extra_file_raw(
+        self,
+        dataset_id: DatasetIDPathParam,
+        request: Request,
+        filename: str = Path(..., description="The name of the extra file to retrieve."),
+        trans=DependsOnTrans,
+    ) -> GalaxyFileResponse:
+        display_data, headers = self.service.display(
+            trans,
+            dataset_id,
+            preview=False,
+            filename=filename,
+            raw=True,
+        )
+        assert isinstance(display_data, IOBase)
+        file_name = getattr(display_data, "name", None)
+        assert file_name
+        return GalaxyFileResponse(file_name, headers=headers, method=request.method)
+
+    @router.get(
         "/api/histories/{history_id}/contents/{history_content_id}/display",
         name="history_contents_display",
         summary="Displays (preview) or downloads dataset content.",

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -357,11 +357,16 @@ class TestDatasetsApi(ApiTestCase):
         )
         self.dataset_populator.wait_for_job(response["jobs"][0]["id"])
         directory_dataset = response["outputs"][0]
+        # Check that we can access extra_files/1.fasta via the display endpoint.
         display_response = self._get(
             f"histories/{history_id}/contents/{directory_dataset['id']}/display?filename=/1.fasta"
         )
         display_response.raise_for_status()
         assert display_response.text == fasta_contents
+        # Check that we can access extra_files/1.fasta via the extra_files/raw endpoint.
+        extra_files_response = self._get(f"datasets/{directory_dataset['id']}/extra_files/raw/1.fasta")
+        extra_files_response.raise_for_status()
+        assert extra_files_response.text == fasta_contents
 
     def test_display_error_handling(self, history_id):
         hda1 = self.dataset_populator.create_deferred_hda(


### PR DESCRIPTION
We need this for the vitessce visualization, that will build urls based on the path of the current url. In practice, to get the file expected at `obs/.zattrs` the visualization will build
https://usegalaxy.org/api/datasets/f9cad7b01a4721358531a44ecfb1aff6/display/obs/.zattrs?filename=A/1/bdbd683b-1870-4c11-ae29-b35ff0be59b2.adata.zarr, because it reasonably assumes the query parameter is independent of the path.
With this change we can access the file in question via https://usegalaxy.org/api/datasets/f9cad7b01a4721358531a44ecfb1aff6/extra_files/raw/A/1/bdbd683b-1870-4c11-ae29-b35ff0be59b2.adata.zarr/obs/.zattrs.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
