### PR TITLE
[25.0] Don't fit workflow if it doesn't have steps

### DIFF
--- a/client/src/components/Markdown/MarkdownToolBox.vue
+++ b/client/src/components/Markdown/MarkdownToolBox.vue
@@ -259,13 +259,15 @@ export default {
             const outputLabels = [];
             this.steps &&
                 Object.values(this.steps).forEach((step) => {
-                    step.workflow_outputs.forEach((workflowOutput) => {
-                        if (workflowOutput.label) {
-                            if (!filterByType || this.stepOutputMatchesType(step, workflowOutput, filterByType)) {
-                                outputLabels.push(workflowOutput.label);
+                    if (step.workflow_outputs) {
+                        step.workflow_outputs.forEach((workflowOutput) => {
+                            if (workflowOutput.label) {
+                                if (!filterByType || this.stepOutputMatchesType(step, workflowOutput, filterByType)) {
+                                    outputLabels.push(workflowOutput.label);
+                                }
                             }
-                        }
-                    });
+                        });
+                    }
                 });
             return outputLabels;
         },

--- a/client/src/components/Workflow/Editor/WorkflowGraph.vue
+++ b/client/src/components/Workflow/Editor/WorkflowGraph.vue
@@ -64,6 +64,10 @@ const { viewportBoundingBox, updateViewportBaseBoundingBox } = useViewportBoundi
 const { getWorkflowBoundingBox } = useWorkflowBoundingBox();
 
 function fitWorkflow(minimumFitZoom = 0.5, maximumFitZoom = 1.0, padding = 50.0) {
+    if (!Object.keys(props.steps).length) {
+        // If there are no steps, we cannot fit the workflow.
+        return;
+    }
     const aabb = getWorkflowBoundingBox();
     aabb.expand(padding);
 

--- a/client/src/components/Workflow/Editor/modules/labels.ts
+++ b/client/src/components/Workflow/Editor/modules/labels.ts
@@ -15,7 +15,7 @@ interface StepOutput {
 interface Step {
     label?: string;
     type: string;
-    workflow_outputs: StepOutput[];
+    workflow_outputs?: StepOutput[];
 }
 
 export type WorkflowLabels = WorkflowLabel[];
@@ -33,11 +33,13 @@ export function fromSteps(steps?: Step[]): WorkflowLabels {
                     labels.push({ type: "step", label: step.label });
                 }
             }
-            step.workflow_outputs.forEach((workflowOutput) => {
-                if (workflowOutput.label) {
-                    labels.push({ type: "output", label: workflowOutput.label });
-                }
-            });
+            if (step.workflow_outputs) {
+                step.workflow_outputs.forEach((workflowOutput) => {
+                    if (workflowOutput.label) {
+                        labels.push({ type: "output", label: workflowOutput.label });
+                    }
+                });
+            }
         });
     }
     return labels;


### PR DESCRIPTION
and properly handle `step.workflow_outputs` which doesn't need to be set on a step.
Fixes https://github.com/galaxyproject/galaxy/issues/19667, https://github.com/galaxyproject/galaxy/issues/20242 and https://github.com/galaxyproject/galaxy/issues/20316


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
