### PR TITLE
[25.0] Remove rename modal from List Collection Creator

### DIFF
--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import "ui/hoverhighlight";
 
-import { faEdit, faSquare } from "@fortawesome/free-regular-svg-icons";
-import { faGripLines, faMinus, faSortAlphaDown, faTimes, faUndo } from "@fortawesome/free-solid-svg-icons";
+import { faSquare } from "@fortawesome/free-regular-svg-icons";
+import { faMinus, faSortAlphaDown, faTimes, faUndo } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
@@ -18,7 +18,6 @@ import { type Mode, useCollectionCreator } from "./common/useCollectionCreator";
 
 import GButton from "../BaseComponents/GButton.vue";
 import GButtonGroup from "../BaseComponents/GButtonGroup.vue";
-import GModal from "../BaseComponents/GModal.vue";
 import FormSelectMany from "../Form/Elements/FormSelectMany/FormSelectMany.vue";
 import HelpText from "../Help/HelpText.vue";
 import CollectionCreator from "@/components/Collections/common/CollectionCreator.vue";
@@ -344,14 +343,6 @@ function addUploadedFiles(files: HDASummary[]) {
     });
 }
 
-/** If we are creating a collection from a history (not a pre-selection of elements),
- * once we have some selected elements, we provide an option to rename them in a modal.
- */
-const canRenameElements = computed(() => {
-    return !props.fromSelection && inListElements.value.length > 0;
-});
-/** A toggle for the modal that allows renaming elements in the selected list */
-const renamingElements = ref(false);
 /** find the element in the workingElements array and update its name */
 function renameElement(element: any, name: string) {
     // We do this whole process of removing and readding because inListElements
@@ -441,13 +432,11 @@ function selectionAsHdaSummary(value: any): HDASummary {
                 :show-buttons="showButtonsForModal"
                 :collection-name="collectionName"
                 :mode="mode"
-                :can-rename-elements="canRenameElements"
                 @on-update-collection-name="onUpdateCollectionName"
                 @add-uploaded-files="addUploadedFiles"
                 @on-update-datatype-toggle="changeDatatypeFilter"
                 @onUpdateHideSourceItems="onUpdateHideSourceItems"
                 @remove-extensions-toggle="removeExtensionsToggle"
-                @clicked-rename="renamingElements = true"
                 @clicked-create="attemptCreate">
                 <template v-slot:help-content>
                     <p>
@@ -473,12 +462,12 @@ function selectionAsHdaSummary(value: any): HDASummary {
                         <li v-if="!fromSelection">
                             The filter textbox can be used to rapidly find the datasets of interest by name.
                         </li>
-                        <li v-if="fromSelection">
+                        <li>
                             {{ localize("Change the identifier of elements in the list by clicking on") }}
                             <i data-target=".collection-element .name">
                                 {{ localize("the existing name") }}
                             </i>
-                            {{ localize(".") }}
+                            {{ localize("in the 'Selected' column.") }}
                         </li>
 
                         <li>
@@ -549,24 +538,6 @@ function selectionAsHdaSummary(value: any): HDASummary {
                             {{ localize("Create list") }}
                         </i>
                         {{ localize(".") }}
-                    </p>
-
-                    <p v-if="!fromSelection">
-                        <strong>
-                            {{ localize("Optional:") }}
-                        </strong>
-                        {{
-                            localize(
-                                [
-                                    "Once you have made your selection, if you wish to rename identifiers for elements in the list",
-                                    " or change/set the order in which they exist in the final list, you can click on ",
-                                ].join("")
-                            )
-                        }}
-                        <i data-target=".rename-elements">
-                            {{ localize("Rename/Reorder list elements") }}
-                        </i>
-                        {{ localize(". This opens a modal where you can perform these actions.") }}
                     </p>
                 </template>
 
@@ -694,7 +665,6 @@ function selectionAsHdaSummary(value: any): HDASummary {
                         <draggable
                             v-model="workingElements"
                             class="collection-elements scroll-container flex-row drop-zone"
-                            style="max-height: 400px"
                             chosen-class="bg-secondary">
                             <DatasetCollectionElementView
                                 v-for="element in workingElements"
@@ -716,51 +686,22 @@ function selectionAsHdaSummary(value: any): HDASummary {
                         maintain-selection-order
                         :placeholder="localize('Filter datasets by name')"
                         :options="workingElements.map((e) => ({ label: e.name || '', value: e }))">
-                        <template v-slot:label-area="{ value }">
+                        <template v-slot:selected-heading-end>
+                            <i style="font-weight: normal">
+                                {{ localize("(Click name to edit") }}
+                            </i>
+                        </template>
+                        <template v-slot:label-area="selectValue">
                             <DatasetCollectionElementView
                                 text-only
-                                not-editable
-                                :element="selectionAsHdaSummary(value)"
-                                :hide-extension="!showElementExtension" />
+                                :not-editable="!selectValue.selected"
+                                :element="selectionAsHdaSummary(selectValue.option.value)"
+                                :hide-extension="!showElementExtension"
+                                @onRename="(name) => renameElement(selectValue.option.value, name)" />
                         </template>
                     </FormSelectMany>
                 </template>
             </CollectionCreator>
-
-            <GModal
-                class="rename-elements-modal"
-                :show.sync="renamingElements"
-                fixed-height
-                size="small"
-                title="Rename and Reorder List Elements">
-                <div>
-                    <FontAwesomeIcon :icon="faEdit" fixed-width />
-                    {{ localize("Here, you can change the identifiers of the elements in the list.") }}
-                    {{
-                        localize(
-                            "The final list will then have these identifiers, and this does not modify the original datasets."
-                        )
-                    }}
-                </div>
-                <div>
-                    <FontAwesomeIcon :icon="faGripLines" fixed-width />
-                    {{ localize("Also, you can click and drag to reorder the elements in the list.") }}
-                </div>
-                <hr class="w-100 my-2" />
-                <draggable
-                    v-model="inListElements"
-                    class="collection-elements scroll-container flex-row"
-                    chosen-class="bg-secondary"
-                    @wheel.stop>
-                    <DatasetCollectionElementView
-                        v-for="value in inListElements"
-                        :key="value.id"
-                        class="w-100"
-                        :element="selectionAsHdaSummary(value)"
-                        :hide-extension="!showElementExtension"
-                        @onRename="(name) => renameElement(value, name)" />
-                </draggable>
-            </GModal>
         </div>
     </div>
 </template>
@@ -770,15 +711,6 @@ function selectionAsHdaSummary(value: any): HDASummary {
 @import "theme/blue.scss";
 
 .list-collection-creator {
-    .rename-elements-modal {
-        .collection-element {
-            cursor: grab;
-            &:focus {
-                cursor: grabbing;
-            }
-        }
-    }
-
     .footer {
         margin-top: 8px;
     }
@@ -802,6 +734,7 @@ function selectionAsHdaSummary(value: any): HDASummary {
     }
 
     .collection-elements {
+        max-height: 400px;
         border: 0px solid lightgrey;
         overflow-y: auto;
         overflow-x: hidden;

--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -345,18 +345,16 @@ function addUploadedFiles(files: HDASummary[]) {
 
 /** find the element in the workingElements array and update its name */
 function renameElement(element: any, name: string) {
-    // We do this whole process of removing and readding because inListElements
-    // might be reacting to changes in workingElements, and we want to
-    // prevent that from causing issues with producing duplicate elements in either list:
+    // We do this whole process of removing and readding because, in the case that the element
+    // is in the list, inListElements might be reacting to changes in workingElements, and we
+    // want to prevent that from causing issues with producing duplicate elements in either array:
 
     // first check at what index of inlistElements the element is
     const index = inListElements.value.findIndex((e) => e.id === element.id);
-    if (index < 0) {
-        return;
+    if (index >= 0) {
+        // remove from inListElements
+        inListElements.value = inListElements.value.filter((e) => e.id !== element.id);
     }
-
-    // remove from inListElements
-    inListElements.value = inListElements.value.filter((e) => e.id !== element.id);
 
     // then find the element in workingElements, and rename it
     element = workingElements.value.find((e) => e.id === element.id);
@@ -467,7 +465,7 @@ function selectionAsHdaSummary(value: any): HDASummary {
                             <i data-target=".collection-element .name">
                                 {{ localize("the existing name") }}
                             </i>
-                            {{ localize("in the 'Selected' column.") }}
+                            {{ localize("in either column.") }}
                         </li>
 
                         <li>
@@ -686,15 +684,14 @@ function selectionAsHdaSummary(value: any): HDASummary {
                         maintain-selection-order
                         :placeholder="localize('Filter datasets by name')"
                         :options="workingElements.map((e) => ({ label: e.name || '', value: e }))">
-                        <template v-slot:selected-heading-end>
+                        <template v-slot:column-heading-end>
                             <i style="font-weight: normal">
-                                {{ localize("(Click name to edit") }}
+                                {{ localize("(Click name to edit)") }}
                             </i>
                         </template>
                         <template v-slot:label-area="selectValue">
                             <DatasetCollectionElementView
                                 text-only
-                                :not-editable="!selectValue.selected"
                                 :element="selectionAsHdaSummary(selectValue.option.value)"
                                 :hide-extension="!showElementExtension"
                                 @onRename="(name) => renameElement(selectValue.option.value, name)" />

--- a/client/src/components/Collections/ListDatasetCollectionElementView.vue
+++ b/client/src/components/Collections/ListDatasetCollectionElementView.vue
@@ -54,7 +54,7 @@ watch(
         tabindex="0"
         @keyup.enter="emit('element-is-selected', element)"
         @click="emit('element-is-selected', element)">
-        <span class="d-flex flex-gapx-1">
+        <span class="d-flex flex-gapx-1 align-items-center">
             <span v-if="!hideHid && (element.hid ?? true)">{{ element.hid }}:</span>
             <strong>
                 <ClickToEdit v-if="!notEditable" v-model="elementName" :title="localize('Click to rename')" />

--- a/client/src/components/Collections/ListDatasetCollectionElementView.vue
+++ b/client/src/components/Collections/ListDatasetCollectionElementView.vue
@@ -55,7 +55,7 @@ watch(
         @keyup.enter="emit('element-is-selected', element)"
         @click="emit('element-is-selected', element)">
         <span class="d-flex flex-gapx-1 align-items-center">
-            <span v-if="!hideHid && (element.hid ?? true)">{{ element.hid }}:</span>
+            <span v-if="!hideHid && (element.hid ?? true)" data-description="dataset hid">{{ element.hid }}:</span>
             <strong>
                 <ClickToEdit v-if="!notEditable" v-model="elementName" :title="localize('Click to rename')" />
                 <span v-else>{{ elementName }}</span>

--- a/client/src/components/Collections/common/ClickToEdit.vue
+++ b/client/src/components/Collections/common/ClickToEdit.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
-import { faSave } from "@fortawesome/free-solid-svg-icons";
+import { faLevelDownAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BFormInput } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
-
-import GButton from "@/components/BaseComponents/GButton.vue";
 
 interface Props {
     value: string;
@@ -47,15 +45,9 @@ watch(
     }
 );
 
-function onBlur(e: FocusEvent) {
+function onBlur() {
     if (props.noSaveOnBlur) {
-        const target = e.relatedTarget;
-        // if the user clicked the save button, do nothing
-        if (target instanceof HTMLElement && target.id === "save-btn") {
-            return;
-        } else {
-            revertToOriginal();
-        }
+        revertToOriginal();
     } else {
         editable.value = false;
     }
@@ -68,12 +60,12 @@ function revertToOriginal() {
 </script>
 
 <template>
-    <div v-if="editable" class="d-flex flex-gapx-1">
+    <div v-if="editable" class="d-flex flex-gapx-1 input-icon-wrapper">
         <BFormInput
             id="click-to-edit-input"
             ref="clickToEditInput"
             v-model="localValue"
-            class="w-100"
+            class="w-100 input-with-icon"
             tabindex="0"
             contenteditable
             max-rows="4"
@@ -81,10 +73,9 @@ function revertToOriginal() {
             @keyup.prevent.stop.enter="editable = false"
             @keyup.prevent.stop.escape="revertToOriginal"
             @click.prevent.stop />
-        <GButton id="save-btn" class="p-0" transparent color="blue" size="small" @click.prevent.stop="editable = false">
-            <FontAwesomeIcon :icon="faSave" />
-            <span class="sr-only">Save changes</span>
-        </GButton>
+        <div class="input-icon">
+            <FontAwesomeIcon :icon="faLevelDownAlt" class="enter-icon" />
+        </div>
     </div>
 
     <component
@@ -107,5 +98,26 @@ function revertToOriginal() {
     &:hover > * {
         text-decoration: underline;
     }
+}
+
+.input-icon-wrapper {
+    position: relative;
+}
+
+.input-with-icon {
+    padding-right: 15px;
+}
+
+.input-icon {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+}
+
+.enter-icon {
+    transform: rotate(90deg); // Rotates the arrow to look like the enter/return key
+    opacity: 0.7;
 }
 </style>

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -36,7 +36,6 @@ interface Props {
     showButtons?: boolean;
     collectionName: string;
     mode: "wizard" | "modal";
-    canRenameElements?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -47,14 +46,12 @@ const props = withDefaults(defineProps<Props>(), {
     collectionType: undefined,
     showButtons: true,
     mode: "modal",
-    canRenameElements: false,
 });
 
 const emit = defineEmits<{
     (e: "on-update-collection-name", name: string): void;
     (e: "remove-extensions-toggle"): void;
     (e: "clicked-create", value: string): void;
-    (e: "clicked-rename"): void;
     (e: "onUpdateHideSourceItems", value: boolean): void;
     (e: "on-update-datatype-toggle", value: "all" | "datatype" | "ext"): void;
     (e: "add-uploaded-files", value: HDASummary[]): void;
@@ -199,11 +196,9 @@ watch(
                         <CollectionCreatorFooterButtons
                             v-if="showButtons"
                             :short-what-is-being-created="shortWhatIsBeingCreated"
-                            :can-rename-elements="props.canRenameElements"
                             :valid-input="validInput"
                             @clicked-cancel="cancelCreate"
-                            @clicked-create="emit('clicked-create', collectionName)"
-                            @clicked-rename="emit('clicked-rename')" />
+                            @clicked-create="emit('clicked-create', collectionName)" />
                     </div>
                 </div>
             </BTab>

--- a/client/src/components/Collections/common/CollectionCreatorFooterButtons.vue
+++ b/client/src/components/Collections/common/CollectionCreatorFooterButtons.vue
@@ -6,14 +6,12 @@ import GButton from "@/components/BaseComponents/GButton.vue";
 interface Props {
     validInput: boolean;
     shortWhatIsBeingCreated: string;
-    canRenameElements?: boolean;
 }
 
 defineProps<Props>();
 
 const emit = defineEmits<{
     (e: "clicked-create"): void;
-    (e: "clicked-rename"): void;
     (e: "clicked-cancel"): void;
 }>();
 </script>
@@ -24,18 +22,8 @@ const emit = defineEmits<{
             {{ localize("Cancel") }}
         </GButton>
 
-        <span>
-            <GButton
-                v-if="canRenameElements"
-                class="rename-elements"
-                size="small"
-                :disabled="!validInput"
-                @click="emit('clicked-rename')">
-                {{ localize("Rename/Reorder " + shortWhatIsBeingCreated) + " elements" }}
-            </GButton>
-            <GButton class="create-collection" color="blue" :disabled="!validInput" @click="emit('clicked-create')">
-                {{ localize("Create " + shortWhatIsBeingCreated) }}
-            </GButton>
-        </span>
+        <GButton class="create-collection" color="blue" :disabled="!validInput" @click="emit('clicked-create')">
+            {{ localize("Create " + shortWhatIsBeingCreated) }}
+        </GButton>
     </div>
 </template>

--- a/client/src/components/Form/Elements/FormSelectMany/FormSelectMany.vue
+++ b/client/src/components/Form/Elements/FormSelectMany/FormSelectMany.vue
@@ -376,7 +376,7 @@ const selectedCount = computed(() => {
                     :class="{ highlighted: highlightUnselected.highlightedIndexes.includes(i) }"
                     @click="(e) => selectOption(e, i)"
                     @keydown="(e) => optionOnKey('unselected', e, i)">
-                    <slot name="label-area" v-bind="option">
+                    <slot name="label-area" v-bind="{ option, selected: false }">
                         {{ option.label }}
                     </slot>
                 </button>
@@ -390,6 +390,7 @@ const selectedCount = computed(() => {
                 <span>
                     Selected
                     <span class="font-weight-normal selected-count"> ({{ selectedCount }}) </span>
+                    <slot name="selected-heading-end" />
                 </span>
                 <GButton class="selection-button deselect" :title="deselectText" color="blue" @click="deselectAll">
                     <FontAwesomeIcon :icon="faLongArrowAltLeft" />
@@ -410,7 +411,7 @@ const selectedCount = computed(() => {
                     :class="{ highlighted: highlightSelected.highlightedIndexes.includes(i) }"
                     @click="(e) => deselectOption(e, i)"
                     @keydown="(e) => optionOnKey('selected', e, i)">
-                    <slot name="label-area" v-bind="option">
+                    <slot name="label-area" v-bind="{ option, selected: true }">
                         {{ option.label }}
                     </slot>
                 </button>

--- a/client/src/components/Form/Elements/FormSelectMany/FormSelectMany.vue
+++ b/client/src/components/Form/Elements/FormSelectMany/FormSelectMany.vue
@@ -351,6 +351,7 @@ const selectedCount = computed(() => {
                 <span>
                     Unselected
                     <span class="font-weight-normal unselected-count"> ({{ unselectedCount }}) </span>
+                    <slot name="column-heading-end" />
                 </span>
                 <GButton
                     class="selection-button select"
@@ -390,7 +391,7 @@ const selectedCount = computed(() => {
                 <span>
                     Selected
                     <span class="font-weight-normal selected-count"> ({{ selectedCount }}) </span>
-                    <slot name="selected-heading-end" />
+                    <slot name="column-heading-end" />
                 </span>
                 <GButton class="selection-button deselect" :title="deselectText" color="blue" @click="deselectAll">
                     <FontAwesomeIcon :icon="faLongArrowAltLeft" />

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -729,7 +729,7 @@ workflow_run:
         _: '[data-label="${label}"] .tabs'
         create: '${_} .create-collection'
         select_all: "${_} [data-description='select many select all']"
-        element_by_hid: "${_} [data-description='list dataset collection element'][data-hid='${hid}']"
+        element_by_hid: "${_} [data-description='list dataset collection element'][data-hid='${hid}'] [data-description='dataset hid']"
         <<: *upload_mixin
 
   form_element:


### PR DESCRIPTION
https://github.com/galaxyproject/galaxy/pull/20442 contained an unresolved comment for reverting the renaming of elements to the multiselect, and also removing the Rename/Reordering modal entirely. Here are the changes proposed in that comment.

https://github.com/user-attachments/assets/c1037f90-fde0-464a-92b0-edb05ada0b87

_Update: I've aligned the input better:_
![firefox_pQgRizindF](https://github.com/user-attachments/assets/653376ed-158d-46fa-8b0e-a69e52a65f6c)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
