### PR TITLE
[25.0] Use DatasetAsImage component for DatasetView image display

### DIFF
--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -185,7 +185,11 @@ watch(
                     </a>
                 </div>
             </div>
-            <DatasetAsImage v-else-if="isImageDataset" :history-dataset-id="datasetId" class="p-3" />
+            <DatasetAsImage
+                v-else-if="isImageDataset"
+                :history-dataset-id="datasetId"
+                :allow-size-toggle="true"
+                class="p-3" />
             <CenterFrame
                 v-else
                 :src="`/datasets/${datasetId}/display/?preview=True`"

--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -6,11 +6,13 @@ import { computed, ref, watch } from "vue";
 
 import { usePersistentToggle } from "@/composables/persistentToggle";
 import { useDatasetStore } from "@/stores/datasetStore";
+import { useDatatypesMapperStore } from "@/stores/datatypesMapperStore";
 import { useDatatypeStore } from "@/stores/datatypeStore";
 import { bytesToString } from "@/utils/utils";
 
 import DatasetError from "../DatasetInformation/DatasetError.vue";
 import LoadingSpan from "../LoadingSpan.vue";
+import DatasetAsImage from "./DatasetAsImage/DatasetAsImage.vue";
 import DatasetState from "./DatasetState.vue";
 import Heading from "@/components/Common/Heading.vue";
 import DatasetAttributes from "@/components/DatasetInformation/DatasetAttributes.vue";
@@ -21,6 +23,7 @@ import CenterFrame from "@/entry/analysis/modules/CenterFrame.vue";
 
 const datasetStore = useDatasetStore();
 const datatypeStore = useDatatypeStore();
+const datatypesMapperStore = useDatatypesMapperStore();
 const { toggled: headerCollapsed, toggle: toggleHeaderCollapse } = usePersistentToggle("dataset-header-collapsed");
 
 interface Props {
@@ -42,7 +45,7 @@ const isDatatypeLoading = ref(false);
 
 // Consolidated loading state
 const isLoading = computed(() => {
-    return datasetStore.isLoadingDataset(props.datasetId) || isDatatypeLoading.value;
+    return datasetStore.isLoadingDataset(props.datasetId) || isDatatypeLoading.value || datatypesMapperStore.loading;
 });
 
 const showError = computed(
@@ -54,6 +57,14 @@ const isAutoDownloadType = computed(
 const preferredVisualization = computed(
     () => dataset.value && datatypeStore.getPreferredVisualization(dataset.value.file_ext)
 );
+const isImageDataset = computed(() => {
+    if (!dataset.value?.file_ext || !datatypesMapperStore.datatypesMapper) {
+        return false;
+    }
+    return datatypesMapperStore.datatypesMapper.isSubTypeOfAny(dataset.value.file_ext, [
+        "galaxy.datatypes.images.Image",
+    ]);
+});
 
 // Watch for changes to the dataset to fetch datatype info
 watch(
@@ -61,7 +72,10 @@ watch(
     async () => {
         if (dataset.value && dataset.value.file_ext) {
             isDatatypeLoading.value = true;
-            await datatypeStore.fetchDatatypeDetails(dataset.value.file_ext);
+            await Promise.all([
+                datatypeStore.fetchDatatypeDetails(dataset.value.file_ext),
+                datatypesMapperStore.createMapper(),
+            ]);
             isDatatypeLoading.value = false;
         }
     },
@@ -171,6 +185,7 @@ watch(
                     </a>
                 </div>
             </div>
+            <DatasetAsImage v-else-if="isImageDataset" :history-dataset-id="datasetId" class="p-3" />
             <CenterFrame
                 v-else
                 :src="`/datasets/${datasetId}/display/?preview=True`"


### PR DESCRIPTION
Replaces iframe-based display with DatasetAsImage component for image datasets in the preview tab. If the datatype, however, has a preferred viz set (like .tiff or something), that takes precedence.

This provides better image scaling control and consistent display behavior across browsers, addressing Chrome's automatic image scaling in iframes.

Firefox did this natively before, but chrome did not.  This makes it consistent.

~WIP, want to add scaling and minor controls and other enhancements to the display (click to expand to full size, etc), but this fixes the bug where images would be way too large for the datasetview.~

Added simple toggle that controls whether it's displayed as fluid or not.  I want to follow up down the road with a display more similar to what I added for IWC workflows (https://iwc.galaxyproject.org/workflow/atacseq-main/#diagram), but that might be yagni.

https://github.com/user-attachments/assets/631acfe7-04f4-414b-b5d6-89615ac0c6b2



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
