### PR TITLE
[25.0] Recreate triggers

### DIFF
--- a/lib/galaxy/model/migrations/alembic/versions_gxy/c716ee82337b_replace_triggers.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/c716ee82337b_replace_triggers.py
@@ -1,0 +1,170 @@
+"""Replace triggers
+
+Revision ID: c716ee82337b
+Revises: a91ea1d97111
+Create Date: 2025-06-16 12:43:36.193648
+
+"""
+
+from alembic import op
+
+from galaxy.model.migrations.util import (
+    _is_sqlite,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "c716ee82337b"
+down_revision = "a91ea1d97111"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not _is_sqlite():
+        create_functions_and_triggers()
+
+
+def downgrade():
+    """This revision is a fix for the previous migration, so no downgrade is necessary."""
+
+
+def create_functions_and_triggers():
+    version_info = op.get_bind().engine.dialect.server_version_info
+    # For offline mode (version_info is None), we assume that version > 10
+    if version_info and version_info[0] > 10 or not version_info:
+        trigger_def = statement_trigger_def
+        trigger_fn = statement_trigger_fn
+        function_keyword = "FUNCTION"
+    else:
+        trigger_def = row_trigger_def
+        trigger_fn = row_trigger_fn
+        function_keyword = "PROCEDURE"
+
+    with transaction():
+        drop_triggers()
+        create_functions(trigger_fn)
+        create_triggers(trigger_def, function_keyword)
+
+
+def drop_triggers():
+    # Unlike sqlite, postgres triggers were only named with an "s" suffix (i.e., "*_aus" and never "*_aur").
+    op.execute("DROP TRIGGER IF EXISTS trigger_history_audit_by_id_aus ON history;")
+    op.execute("DROP TRIGGER IF EXISTS trigger_history_audit_by_id_ais ON history;")
+    op.execute("DROP TRIGGER IF EXISTS trigger_history_audit_by_history_id_aus ON history_dataset_association;")
+    op.execute("DROP TRIGGER IF EXISTS trigger_history_audit_by_history_id_ais ON history_dataset_association;")
+    op.execute(
+        "DROP TRIGGER IF EXISTS trigger_history_audit_by_history_id_aus ON history_dataset_collection_association;"
+    )
+    op.execute(
+        "DROP TRIGGER IF EXISTS trigger_history_audit_by_history_id_ais ON history_dataset_collection_association;"
+    )
+
+
+def create_functions(trigger_fn):
+    for id_field in ["history_id", "id"]:
+        function_name = get_function_name(id_field)
+        stmt = trigger_fn(function_name, id_field, "clock_timestamp()")
+        op.execute(stmt)
+
+
+def create_triggers(trigger_def, function_keyword):
+    op.execute(trigger_def("trigger_history_audit_by_id_aus", "UPDATE", "history", function_keyword, "id"))
+    op.execute(trigger_def("trigger_history_audit_by_id_ais", "INSERT", "history", function_keyword, "id"))
+    op.execute(
+        trigger_def(
+            "trigger_history_audit_by_history_id_aus",
+            "UPDATE",
+            "history_dataset_association",
+            function_keyword,
+            "history_id",
+        )
+    )
+    op.execute(
+        trigger_def(
+            "trigger_history_audit_by_history_id_ais",
+            "INSERT",
+            "history_dataset_association",
+            function_keyword,
+            "history_id",
+        )
+    )
+    op.execute(
+        trigger_def(
+            "trigger_history_audit_by_history_id_aus",
+            "UPDATE",
+            "history_dataset_collection_association",
+            function_keyword,
+            "history_id",
+        )
+    )
+    op.execute(
+        trigger_def(
+            "trigger_history_audit_by_history_id_ais",
+            "INSERT",
+            "history_dataset_collection_association",
+            function_keyword,
+            "history_id",
+        )
+    )
+
+
+def get_function_name(id_field):
+    return f"fn_audit_history_by_{id_field}"
+
+
+def statement_trigger_def(trigger_name, operation, table, function_keyword, id_field):
+    function_name = get_function_name(id_field)
+    return f"""
+        CREATE TRIGGER {trigger_name}
+        AFTER {operation} ON {table}
+        REFERENCING NEW TABLE AS new_table
+        FOR EACH STATEMENT EXECUTE {function_keyword} {function_name}();
+    """
+
+
+def row_trigger_def(trigger_name, operation, table, function_keyword, id_field):
+    function_name = get_function_name(id_field)
+    return f"""
+        CREATE TRIGGER {trigger_name}
+        AFTER {operation} ON {table}
+        FOR EACH ROW
+        WHEN (NEW.{id_field} IS NOT NULL)
+        EXECUTE {function_keyword} {function_name}();
+    """
+
+
+def statement_trigger_fn(function_name, id_field, timestamp):
+    # This function is identical to same function in down revision a91ea1d97111
+    return f"""
+        CREATE OR REPLACE FUNCTION {function_name}()
+            RETURNS TRIGGER
+            LANGUAGE 'plpgsql'
+        AS $BODY$
+            BEGIN
+                INSERT INTO history_audit (history_id, update_time)
+                SELECT DISTINCT {id_field}, {timestamp} AT TIME ZONE 'UTC'
+                FROM new_table
+                WHERE {id_field} IS NOT NULL
+                ON CONFLICT DO NOTHING;
+                RETURN NULL;
+            END;
+        $BODY$
+    """
+
+
+def row_trigger_fn(function_name, id_field, timestamp):
+    # This function is identical to same function in down revision a91ea1d97111
+    return f"""
+        CREATE OR REPLACE FUNCTION {function_name}()
+            RETURNS TRIGGER
+            LANGUAGE 'plpgsql'
+        AS $BODY$
+            BEGIN
+                INSERT INTO history_audit (history_id, update_time)
+                VALUES (NEW.{id_field}, {timestamp} AT TIME ZONE 'UTC')
+                ON CONFLICT DO NOTHING;
+                RETURN NULL;
+            END;
+        $BODY$
+    """

--- a/lib/galaxy/model/migrations/dbscript.py
+++ b/lib/galaxy/model/migrations/dbscript.py
@@ -46,8 +46,8 @@ REVISION_TAGS = {
     "24.1": "04288b6a5b25",
     "release_24.2": "a4c3ef999ab5",
     "24.2": "a4c3ef999ab5",
-    "release_25.0": "a91ea1d97111",
-    "25.0": "a91ea1d97111",
+    "release_25.0": "c716ee82337b",
+    "25.0": "c716ee82337b",
 }
 
 


### PR DESCRIPTION
Fixes #20461

I've tested this manually for both cases:
- pre-existing statement-level triggers 
- pre-existing row-level triggers 

This works as expected: triggers are dropped and recreated together with functions.
There is no downgrade since this migration is a fix for the previous migration.




## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
