### PR TITLE
[24.2] Make optional edam-ontology in datatypes registry optional

### DIFF
--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -57,18 +57,23 @@ class ConfigurationError(Exception):
 
 class Registry:
     def __init__(self, config=None):
-        edam_ontology_path = config.get("edam_toolbox_ontology_path", None) if config is not None else None
-
-        edam = load_edam_tree(
-            None if not edam_ontology_path or not os.path.exists(edam_ontology_path) else edam_ontology_path,
-            "format_",
-            "data_",
-            "operation_",
-            "topic_",
-        )
-
         self.log = logging.getLogger(__name__)
         self.log.addHandler(logging.NullHandler())
+
+        edam_ontology_path = config.get("edam_toolbox_ontology_path", None) if config is not None else None
+
+        try:
+            edam = load_edam_tree(
+                None if not edam_ontology_path or not os.path.exists(edam_ontology_path) else edam_ontology_path,
+                "format_",
+                "data_",
+                "operation_",
+                "topic_",
+            )
+        except AssertionError as exc:
+            self.log.warning(exc)
+            edam = None
+
         self.config = config
         self.edam = edam
         self.datatypes_by_extension: Dict[str, Data] = {}

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -72,7 +72,7 @@ class Registry:
             )
         except AssertionError as exc:
             self.log.warning(exc)
-            edam = None
+            edam = {}
 
         self.config = config
         self.edam = edam


### PR DESCRIPTION
Otherwise you get this when running `galaxy-set-metadata` from the `galaxy-job-execution` package.

```pytb
Traceback (most recent call last):
  File "/usr/local/bin/galaxy-set-metadata", line 10, in <module>
    sys.exit(set_metadata())
             ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/galaxy/metadata/set_metadata.py", line 153, in set_metadata
    set_metadata_portable()
  File "/usr/local/lib/python3.12/site-packages/galaxy/metadata/set_metadata.py", line 193, in set_metadata_portable
    datatypes_registry = validate_and_load_datatypes_config(datatypes_config)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/galaxy/metadata/set_metadata.py", line 554, in validate_and_load_datatypes_config
    datatypes_registry = galaxy.datatypes.registry.Registry()
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/galaxy/datatypes/registry.py", line 62, in __init__
    edam = load_edam_tree(
           ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/galaxy/tool_util/edam_util.py", line 25, in load_edam_tree
    tabular_stream is not None
AssertionError: Failed to load optional import from edam-ontology package, install using [pip install edam-ontology].
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
