### PR TITLE
Add username_key setting to configure python-social-auth OIDC

### DIFF
--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -176,6 +176,8 @@ class AuthnzManager:
             rtv["pkce_support"] = asbool(config_xml.find("pkce_support").text)
         if config_xml.find("accepted_audiences") is not None:
             rtv["accepted_audiences"] = config_xml.find("accepted_audiences").text
+        if config_xml.find("username_key") is not None:
+            rtv["username_key"] = config_xml.find("username_key").text
         # this is a EGI Check-in specific config
         if config_xml.find("checkin_env") is not None:
             rtv["checkin_env"] = config_xml.find("checkin_env").text

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -152,6 +152,8 @@ class PSAAuthnz(IdentityProvider):
             self.config[setting_name("API_URL")] = oidc_backend_config.get("api_url")
         if oidc_backend_config.get("url") is not None:
             self.config[setting_name("URL")] = oidc_backend_config.get("url")
+        if oidc_backend_config.get("username_key") is not None:
+            self.config[setting_name("USERNAME_KEY")] = oidc_backend_config.get("username_key")
 
     def _get_helper(self, name, do_import=False):
         this_config = self.config.get(setting_name(name), DEFAULTS.get(name, None))

--- a/lib/galaxy/authnz/xsd/oidc_backends_config.xsd
+++ b/lib/galaxy/authnz/xsd/oidc_backends_config.xsd
@@ -156,6 +156,13 @@
                                     </xs:documentation>
                                 </xs:annotation>
                             </xs:element>
+                            <xs:element name="username_key" type="xs:string" minOccurs="0">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Claim that will be used for the username (python-social-auth uses 'preferred_username' by default)
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
                         </xs:all>
                         <xs:attribute name="name" type="xs:string" use="required">
                             <xs:annotation>

--- a/test/unit/authnz/test_authnz.py
+++ b/test/unit/authnz/test_authnz.py
@@ -21,6 +21,7 @@ OIDC_BACKEND_CONFIG_TEMPLATE = """<?xml version="1.0"?>
         <client_secret>{client_secret}</client_secret>
         <redirect_uri>$galaxy_url/authnz/keycloak/callback</redirect_uri>
         <enable_idp_logout>{enable_idp_logout}</enable_idp_logout>
+        <require_create_confirmation>{require_create_confirmation}</require_create_confirmation>
         <accepted_audiences>{accepted_audiences}</accepted_audiences>
         <username_key>{username_key}</username_key>
     </provider>
@@ -48,6 +49,7 @@ def create_backend_config(
         client_id="client_id",
         client_secret="client_secret",
         enable_idp_logout="true",
+        require_create_confirmation="false",
         accepted_audiences="https://audience.example.com",
         username_key="custom_username",
 ) -> (str, Path):
@@ -57,6 +59,7 @@ def create_backend_config(
         client_id=client_id,
         client_secret=client_secret,
         enable_idp_logout=enable_idp_logout,
+        require_create_confirmation=require_create_confirmation,
         accepted_audiences=accepted_audiences,
         username_key=username_key,
     )
@@ -71,6 +74,7 @@ def test_parse_backend_config(mock_app):
         "client_id": "example_app",
         "client_secret": "abcd1234",
         "enable_idp_logout": "true",
+        "require_create_confirmation": "false",
         "accepted_audiences": "https://audience.example.com",
         "username_key": "custom_username",
     }
@@ -85,9 +89,11 @@ def test_parse_backend_config(mock_app):
     assert parsed["url"] == config_values["url"]
     assert parsed["client_id"] == config_values["client_id"]
     assert parsed["client_secret"] == config_values["client_secret"]
-    assert parsed["enable_idp_logout"] == asbool(config_values["enable_idp_logout"])
     assert parsed["accepted_audiences"] == config_values["accepted_audiences"]
     assert parsed["username_key"] == config_values["username_key"]
+    # Boolean values should be parsed into bools
+    assert parsed["enable_idp_logout"] == asbool(config_values["enable_idp_logout"])
+    assert parsed["require_create_confirmation"] == asbool(config_values["require_create_confirmation"])
 
 
 

--- a/test/unit/authnz/test_authnz.py
+++ b/test/unit/authnz/test_authnz.py
@@ -1,5 +1,4 @@
 import tempfile
-from pathlib import Path
 from typing import Tuple
 from unittest.mock import MagicMock
 

--- a/test/unit/authnz/test_authnz.py
+++ b/test/unit/authnz/test_authnz.py
@@ -82,11 +82,8 @@ def test_parse_backend_config(mock_app):
     }
     oidc_contents, oidc_path = create_oidc_config()
     backend_contents, backend_path = create_backend_config(provider_name="oidc", **config_values)
-    print(backend_contents)
     manager = AuthnzManager(app=mock_app, oidc_config_file=oidc_path, oidc_backends_config_file=backend_path)
     assert isinstance(manager.oidc_backends_config["oidc"], dict)
-    print(manager.oidc_backends_config["oidc"])
-    print(mock_app.config.oidc["oidc"])
     parsed = manager.oidc_backends_config["oidc"]
     assert parsed["url"] == config_values["url"]
     assert parsed["client_id"] == config_values["client_id"]

--- a/test/unit/authnz/test_authnz.py
+++ b/test/unit/authnz/test_authnz.py
@@ -1,5 +1,6 @@
 import tempfile
 from pathlib import Path
+from typing import Tuple
 from unittest.mock import MagicMock
 
 import pytest
@@ -38,7 +39,7 @@ OIDC_CONFIG_TEMPLATE = """
 """
 
 
-def create_oidc_config(extra_properties: str = "") -> (str, Path):
+def create_oidc_config(extra_properties: str = "") -> Tuple[str, str]:
     contents = OIDC_CONFIG_TEMPLATE.format(extra_properties=extra_properties)
     file = tempfile.NamedTemporaryFile(mode="w", delete=False)
     file.write(contents)
@@ -54,7 +55,7 @@ def create_backend_config(
     require_create_confirmation="false",
     accepted_audiences="https://audience.example.com",
     username_key="custom_username",
-) -> (str, Path):
+) -> Tuple[str, str]:
     contents = OIDC_BACKEND_CONFIG_TEMPLATE.format(
         provider_name=provider_name,
         url=url,

--- a/test/unit/authnz/test_authnz.py
+++ b/test/unit/authnz/test_authnz.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -37,7 +37,8 @@ OIDC_CONFIG_TEMPLATE = """
 </OIDC>
 """
 
-def create_oidc_config(extra_properties: str = '') -> (str, Path):
+
+def create_oidc_config(extra_properties: str = "") -> (str, Path):
     contents = OIDC_CONFIG_TEMPLATE.format(extra_properties=extra_properties)
     file = tempfile.NamedTemporaryFile(mode="w", delete=False)
     file.write(contents)
@@ -45,14 +46,14 @@ def create_oidc_config(extra_properties: str = '') -> (str, Path):
 
 
 def create_backend_config(
-        provider_name="oidc",
-        url="https://example.com",
-        client_id="client_id",
-        client_secret="client_secret",
-        enable_idp_logout="true",
-        require_create_confirmation="false",
-        accepted_audiences="https://audience.example.com",
-        username_key="custom_username",
+    provider_name="oidc",
+    url="https://example.com",
+    client_id="client_id",
+    client_secret="client_secret",
+    enable_idp_logout="true",
+    require_create_confirmation="false",
+    accepted_audiences="https://audience.example.com",
+    username_key="custom_username",
 ) -> (str, Path):
     contents = OIDC_BACKEND_CONFIG_TEMPLATE.format(
         provider_name=provider_name,
@@ -114,9 +115,8 @@ def test_psa_authnz_config(mock_app):
     backend_contents, backend_path = create_backend_config(provider_name="oidc", **config_values)
     manager = AuthnzManager(app=mock_app, oidc_config_file=oidc_path, oidc_backends_config_file=backend_path)
     from galaxy.authnz.psa_authnz import PSAAuthnz
-    psa_authnz = PSAAuthnz(provider="oidc",
-                           oidc_config=manager.oidc_config,
-                           oidc_backend_config=manager.oidc_backends_config["oidc"])
+
+    psa_authnz = PSAAuthnz(
+        provider="oidc", oidc_config=manager.oidc_config, oidc_backend_config=manager.oidc_backends_config["oidc"]
+    )
     assert psa_authnz.config[setting_name("USERNAME_KEY")] == config_values["username_key"]
-
-

--- a/test/unit/authnz/test_authnz.py
+++ b/test/unit/authnz/test_authnz.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+
+from galaxy.authnz.managers import AuthnzManager
+from galaxy.util import asbool
+
+
+@pytest.fixture
+def mock_app():
+    yield MagicMock()
+
+
+OIDC_BACKEND_CONFIG_TEMPLATE = """<?xml version="1.0"?>
+<OIDC>
+    <provider name="{provider_name}">
+        <url>{url}</url>
+        <client_id>{client_id}</client_id>
+        <client_secret>{client_secret}</client_secret>
+        <redirect_uri>$galaxy_url/authnz/keycloak/callback</redirect_uri>
+        <enable_idp_logout>{enable_idp_logout}</enable_idp_logout>
+        <accepted_audiences>{accepted_audiences}</accepted_audiences>
+        <username_key>{username_key}</username_key>
+    </provider>
+</OIDC>
+"""
+
+
+OIDC_CONFIG_TEMPLATE = """
+<OIDC>
+    <Setter Property="VERIFY_SSL" Value="False" Type="bool"/>
+    {extra_properties}
+</OIDC>
+"""
+
+def create_oidc_config(extra_properties: str = '') -> (str, Path):
+    contents = OIDC_CONFIG_TEMPLATE.format(extra_properties=extra_properties)
+    file = tempfile.NamedTemporaryFile(mode="w", delete=False)
+    file.write(contents)
+    return contents, file.name
+
+
+def create_backend_config(
+        provider_name="oidc",
+        url="https://example.com",
+        client_id="client_id",
+        client_secret="client_secret",
+        enable_idp_logout="true",
+        accepted_audiences="https://audience.example.com",
+        username_key="custom_username",
+) -> (str, Path):
+    contents = OIDC_BACKEND_CONFIG_TEMPLATE.format(
+        provider_name=provider_name,
+        url=url,
+        client_id=client_id,
+        client_secret=client_secret,
+        enable_idp_logout=enable_idp_logout,
+        accepted_audiences=accepted_audiences,
+        username_key=username_key,
+    )
+    file = tempfile.NamedTemporaryFile(mode="w", delete=False)
+    file.write(contents)
+    return contents, file.name
+
+
+def test_parse_backend_config(mock_app):
+    config_values = {
+        "url": "https://example.com",
+        "client_id": "example_app",
+        "client_secret": "abcd1234",
+        "enable_idp_logout": "true",
+        "accepted_audiences": "https://audience.example.com",
+        "username_key": "custom_username",
+    }
+    oidc_contents, oidc_path = create_oidc_config()
+    backend_contents, backend_path = create_backend_config(provider_name="oidc", **config_values)
+    print(backend_contents)
+    manager = AuthnzManager(app=mock_app, oidc_config_file=oidc_path, oidc_backends_config_file=backend_path)
+    assert isinstance(manager.oidc_backends_config["oidc"], dict)
+    print(manager.oidc_backends_config["oidc"])
+    print(mock_app.config.oidc["oidc"])
+    parsed = manager.oidc_backends_config["oidc"]
+    assert parsed["url"] == config_values["url"]
+    assert parsed["client_id"] == config_values["client_id"]
+    assert parsed["client_secret"] == config_values["client_secret"]
+    assert parsed["enable_idp_logout"] == asbool(config_values["enable_idp_logout"])
+    assert parsed["accepted_audiences"] == config_values["accepted_audiences"]
+    assert parsed["username_key"] == config_values["username_key"]
+
+
+


### PR DESCRIPTION
This PR adds the [USERNAME_KEY](https://python-social-auth.readthedocs.io/en/latest/backends/openid.html#username) setting to the OIDC config, which is used by python-social-auth to extract the username. We are implementing an OIDC login system across multiple platforms and need to configure this so we can have a Galaxy-specific username.

`AuthnzManager` and `PSAAuthnz` did not seem to have existing unit tests so I've added basic tests of parsing the XML config to check that values are passed through correctly.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
