### PR TITLE
Fix alembic down_revision for trigger replacement migration

### DIFF
--- a/lib/galaxy/model/migrations/alembic/versions_gxy/c716ee82337b_replace_triggers.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/c716ee82337b_replace_triggers.py
@@ -1,7 +1,7 @@
 """Replace triggers
 
 Revision ID: c716ee82337b
-Revises: a91ea1d97111
+Revises: fb16d09348db
 Create Date: 2025-06-16 12:43:36.193648
 
 """
@@ -15,7 +15,7 @@ from galaxy.model.migrations.util import (
 
 # revision identifiers, used by Alembic.
 revision = "c716ee82337b"
-down_revision = "a91ea1d97111"
+down_revision = "fb16d09348db"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Broken on merging 25.0 into dev

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
