### PR TITLE
Show expose_user_name in `/api/configuration`

### DIFF
--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -206,6 +206,7 @@ class ConfigSerializer(base.ModelSerializer):
             "upload_from_form_button": _use_config,
             "release_doc_base_url": _use_config,
             "expose_user_email": _use_config,
+            "expose_user_name": _use_config,
             "enable_tool_source_display": _use_config,
             "enable_celery_tasks": _use_config,
             "quota_source_labels": lambda item, key, **context: list(


### PR DESCRIPTION
I noticed that `/api/configuration` does not show `expose_user_name` I guess this is the reason.

~~Also `/api/users/` does not show the user name at the moment. I guess this is the reason.~~ (I have not configured `expose_user_name`)

Guess this is a bugfix that we should backport.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
