### PR TITLE
Remove deprecated tool document cache

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -24494,7 +24494,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Request Error */

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1217,22 +1217,6 @@
 :Type: str
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``enable_tool_document_cache``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    This option is deprecated, and the tool document cache will be
-    removed in the next release. Whether to enable the tool document
-    cache. This cache stores expanded XML strings. Enabling the tool
-    cache results in slightly faster startup times. The tool cache is
-    backed by a SQLite database, which cannot be stored on certain
-    network disks. The cache location is configurable with the
-    ``tool_cache_data_dir`` tag in tool config files.
-:Default: ``false``
-:Type: bool
-
-
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 ``tool_search_index_dir``
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -788,7 +788,6 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication, InstallationT
         self.datatypes_registry.load_external_metadata_tool(self.toolbox)
         # Load history import/export tools.
         load_lib_tools(self.toolbox)
-        self.toolbox.persist_cache(register_postfork=True)
         # visualizations registry: associates resources with visualizations, controls how to render
         self.visualizations_registry = self._register_singleton(
             VisualizationsRegistry,

--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -267,8 +267,6 @@ class MockAppConfig(GalaxyDataTestConfig, CommonConfigurationMixin):
         self.version_major = "19.09"
 
         # set by MockDir
-        self.enable_tool_document_cache = False
-        self.tool_cache_data_dir = os.path.join(self.root, "tool_cache")
         self.external_chown_script = None
         self.check_job_script_integrity = False
         self.check_job_script_integrity_count = 0

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -935,15 +935,6 @@ galaxy:
   # generated commands run in sh.
   #default_job_shell: /bin/bash
 
-  # This option is deprecated, and the tool document cache will be
-  # removed in the next release. Whether to enable the tool document
-  # cache. This cache stores expanded XML strings. Enabling the tool
-  # cache results in slightly faster startup times. The tool cache is
-  # backed by a SQLite database, which cannot be stored on certain
-  # network disks. The cache location is configurable with the
-  # ``tool_cache_data_dir`` tag in tool config files.
-  #enable_tool_document_cache: false
-
   # Directory in which the toolbox search index is stored. The value of
   # this option will be resolved with respect to <data_dir>.
   #tool_search_index_dir: tool_search_index

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -882,19 +882,6 @@ mapping:
           should be disabled. Containerized jobs always use /bin/sh - so more maximum
           portability tool authors should assume generated commands run in sh.
 
-      enable_tool_document_cache:
-        type: bool
-        default: false
-        required: false
-        desc: |
-          This option is deprecated, and the tool document cache will be removed
-          in the next release.
-          Whether to enable the tool document cache. This cache stores
-          expanded XML strings. Enabling the tool cache results in slightly faster startup
-          times. The tool cache is backed by a SQLite database, which cannot
-          be stored on certain network disks. The cache location is configurable
-          with the ``tool_cache_data_dir`` tag in tool config files.
-
       tool_search_index_dir:
         type: str
         default: tool_search_index

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -186,7 +186,6 @@ social-auth-core==4.6.1
 sortedcontainers==2.4.0
 spython==0.3.14
 sqlalchemy==2.0.40
-sqlitedict==2.1.0
 sqlparse==0.5.3
 starlette==0.46.2
 starlette-context==0.4.0

--- a/lib/galaxy/managers/tools.py
+++ b/lib/galaxy/managers/tools.py
@@ -213,9 +213,10 @@ class DynamicToolManager(ModelManager[DynamicTool]):
         session.execute(update_stmt)
         session.commit()
 
-    def deactivate(self, dynamic_tool):
-        self.update(dynamic_tool, {"active": False})
-        return dynamic_tool
+    def deactivate(self, dynamic_tool: DynamicTool) -> DynamicTool:
+        assert isinstance(dynamic_tool.uuid, UUID)
+        del self.app.toolbox._tools_by_uuid[dynamic_tool.uuid]
+        return self.update(dynamic_tool, {"active": False})
 
 
 class ToolFilterMixin:

--- a/lib/galaxy/managers/tools.py
+++ b/lib/galaxy/managers/tools.py
@@ -53,10 +53,10 @@ def tool_payload_to_tool(app, tool_dict: Dict[str, Any]) -> Optional[Tool]:
     return tool
 
 
-class DynamicToolManager(ModelManager[model.DynamicTool]):
+class DynamicToolManager(ModelManager[DynamicTool]):
     """Manages dynamic tools stored in Galaxy's database."""
 
-    model_class = model.DynamicTool
+    model_class = DynamicTool
 
     def ensure_can_use_unprivileged_tool(self, user: model.User):
         stmt = select(
@@ -70,7 +70,7 @@ class DynamicToolManager(ModelManager[model.DynamicTool]):
         if not self.session().execute(stmt).scalar():
             raise exceptions.InsufficientPermissionsException("User is not allowed to run unprivileged tools")
 
-    def get_tool_by_id_or_uuid(self, id_or_uuid: Union[int, str]):
+    def get_tool_by_id_or_uuid(self, id_or_uuid: Union[int, str]) -> Union[DynamicTool, None]:
         if isinstance(id_or_uuid, int):
             return self.get_tool_by_id(id_or_uuid)
         else:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -341,7 +341,7 @@ def get_uuid(uuid: Optional[Union[UUID, str]] = None) -> UUID:
         return uuid
     if not uuid:
         return uuid4()
-    return UUID(str(uuid))
+    return UUID(uuid)
 
 
 def to_json(sa_session, column, keys: List[str]):

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -190,7 +190,6 @@ def _get_new_toolbox(app, save_integrated_tool_panel=True):
     load_lib_tools(new_toolbox)
     [new_toolbox.register_tool(tool) for tool in new_toolbox.data_manager_tools.values()]
     app._toolbox = new_toolbox
-    app.toolbox.persist_cache()
 
 
 def reload_data_managers(app, **kwargs):

--- a/lib/galaxy/tool_shed/galaxy_install/tools/tool_panel_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/tools/tool_panel_manager.py
@@ -42,7 +42,6 @@ class ToolPanelManager:
             return
         old_toolbox = self.app.toolbox
         shed_tool_conf = shed_tool_conf_dict["config_filename"]
-        tool_cache_data_dir = shed_tool_conf_dict.get("tool_cache_data_dir")
         tool_path = shed_tool_conf_dict["tool_path"]
         config_elems = []
         # Ideally shed_tool_conf.xml would be created before the repo is cloned and added to the DB, but this is called
@@ -83,7 +82,7 @@ class ToolPanelManager:
                 else:
                     config_elems.append(elem_entry)
             # Persist the altered shed_tool_config file.
-            self.config_elems_to_xml_file(config_elems, shed_tool_conf, tool_path, tool_cache_data_dir)
+            self.config_elems_to_xml_file(config_elems, shed_tool_conf, tool_path)
             self.app.wait_for_toolbox_reload(old_toolbox)
         else:
             log.error(error_message)
@@ -135,16 +134,13 @@ class ToolPanelManager:
             self.app.toolbox.update_shed_config(shed_tool_conf_dict)
             self.add_to_shed_tool_config(shed_tool_conf_dict, elem_list)
 
-    def config_elems_to_xml_file(self, config_elems, config_filename, tool_path, tool_cache_data_dir=None) -> None:
+    def config_elems_to_xml_file(self, config_elems, config_filename, tool_path) -> None:
         """
         Persist the current in-memory list of config_elems to a file named by the
         value of config_filename.
         """
         try:
-            tool_cache_data_dir = f' tool_cache_data_dir="{tool_cache_data_dir}"' if tool_cache_data_dir else ""
-            root = parse_xml_string(
-                f'<?xml version="1.0"?>\n<toolbox tool_path="{tool_path}"{tool_cache_data_dir}></toolbox>'
-            )
+            root = parse_xml_string(f'<?xml version="1.0"?>\n<toolbox tool_path="{tool_path}"></toolbox>')
             for elem in config_elems:
                 root.append(elem)
             with RenamedTemporaryFile(config_filename, mode="w") as fh:

--- a/lib/galaxy/tool_shed/unittest_utils/__init__.py
+++ b/lib/galaxy/tool_shed/unittest_utils/__init__.py
@@ -2,10 +2,12 @@ import threading
 from pathlib import Path
 from typing import (
     Any,
+    cast,
     Dict,
     List,
     NamedTuple,
     Optional,
+    TYPE_CHECKING,
     Union,
 )
 
@@ -38,6 +40,10 @@ from galaxy.tool_util.toolbox.watcher import (
     get_tool_watcher,
 )
 from galaxy.util.tool_shed.tool_shed_registry import Registry
+
+if TYPE_CHECKING:
+    from galaxy.tools import Tool
+    from galaxy.util.path import StrPath
 
 
 class ToolShedTarget(NamedTuple):
@@ -100,8 +106,8 @@ class TestTool:
 
 
 class TestToolBox(AbstractToolBox):
-    def create_tool(self, config_file, tool_cache_data_dir=None, **kwds):
-        tool = TestTool(config_file, kwds["tool_shed_repository"], kwds["guid"])
+    def create_tool(self, config_file: "StrPath", **kwds) -> "Tool":
+        tool = cast("Tool", TestTool(config_file, kwds["tool_shed_repository"], kwds["guid"]))
         tool._lineage = self._lineage_map.register(tool)  # cleanup?
         return tool
 

--- a/lib/galaxy/tool_shed/unittest_utils/__init__.py
+++ b/lib/galaxy/tool_shed/unittest_utils/__init__.py
@@ -42,6 +42,7 @@ from galaxy.tool_util.toolbox.watcher import (
 from galaxy.util.tool_shed.tool_shed_registry import Registry
 
 if TYPE_CHECKING:
+    from galaxy.model.tool_shed_install import ToolShedRepository
     from galaxy.tools import Tool
     from galaxy.util.path import StrPath
 
@@ -89,7 +90,7 @@ class TestTool:
     params_with_missing_data_table_entry: list = []
     params_with_missing_index_file: list = []
 
-    def __init__(self, config_file, tool_shed_repository, guid):
+    def __init__(self, config_file: "StrPath", tool_shed_repository, guid: str) -> None:
         self.config_file = config_file
         self.tool_shed_repository = tool_shed_repository
         self.guid = guid
@@ -111,7 +112,9 @@ class TestToolBox(AbstractToolBox):
         tool._lineage = self._lineage_map.register(tool)  # cleanup?
         return tool
 
-    def _get_tool_shed_repository(self, tool_shed, name, owner, installed_changeset_revision):
+    def _get_tool_shed_repository(
+        self, tool_shed: str, name: str, owner: str, installed_changeset_revision: Optional[str]
+    ) -> "ToolShedRepository":
         return get_installed_repository(
             self.app,
             tool_shed=tool_shed,

--- a/lib/galaxy/tool_shed/util/repository_util.py
+++ b/lib/galaxy/tool_shed/util/repository_util.py
@@ -247,14 +247,14 @@ def get_absolute_path_to_file_in_repository(repo_files_dir, file_name):
 
 def get_installed_repository(
     app: "InstallationTarget",
-    tool_shed=None,
-    name=None,
-    owner=None,
-    changeset_revision=None,
-    installed_changeset_revision=None,
-    repository_id=None,
-    from_cache=False,
-):
+    tool_shed: Optional[str] = None,
+    name: Optional[str] = None,
+    owner: Optional[str] = None,
+    changeset_revision: Optional[str] = None,
+    installed_changeset_revision: Optional[str] = None,
+    repository_id: Optional[int] = None,
+    from_cache: bool = False,
+) -> ToolShedRepository:
     """
     Return a tool shed repository database record defined by the combination of a toolshed, repository name,
     repository owner and either current or originally installed changeset_revision.

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -400,7 +400,7 @@ class ToolSource(metaclass=ABCMeta):
         return []
 
     @property
-    def macro_paths(self):
+    def macro_paths(self) -> List[str]:
         return []
 
     @property

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -90,6 +90,7 @@ from .stdio import (
 )
 
 if TYPE_CHECKING:
+    from galaxy.util.path import StrPath
     from .output_objects import ToolOutputBase
 
 log = logging.getLogger(__name__)
@@ -158,7 +159,9 @@ class XmlToolSource(ToolSource):
 
     language = "xml"
 
-    def __init__(self, xml_tree: ElementTree, source_path=None, macro_paths=None):
+    def __init__(
+        self, xml_tree: ElementTree, source_path: Optional["StrPath"] = None, macro_paths: Optional[List[str]] = None
+    ) -> None:
         self.xml_tree = xml_tree
         self.root = self.xml_tree.getroot()
         self._source_path = source_path
@@ -683,7 +686,7 @@ class XmlToolSource(ToolSource):
         return HelpContent(format=help_format, content=content)
 
     @property
-    def macro_paths(self):
+    def macro_paths(self) -> List[str]:
         return self._macro_paths
 
     @property

--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -68,8 +68,12 @@ if TYPE_CHECKING:
     from galaxy.model import (
         DynamicTool,
         User,
+        Workflow,
     )
+    from galaxy.model.tool_shed_install import ToolShedRepository
     from galaxy.tools import Tool
+    from galaxy.tools.cache import ToolCache
+    from galaxy.util import Element
     from galaxy.util.path import StrPath
 
 log = logging.getLogger(__name__)
@@ -119,7 +123,7 @@ class ToolBoxRegistryImpl(ToolBoxRegistry):
     def get_tool(self, tool_id: str):
         return self.__toolbox.get_tool(tool_id)
 
-    def get_workflow(self, id: str):
+    def get_workflow(self, id: str) -> "Workflow":
         return self.__toolbox._workflows_by_id[id]
 
     def add_tool_to_tool_panel_view(self, tool, tool_panel_component) -> None:
@@ -166,13 +170,13 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
 
     def __init__(
         self,
-        config_filenames,
+        config_filenames: List[str],
         tool_root_dir,
         app,
         view_sources=None,
         default_panel_view="default",
-        save_integrated_tool_panel=True,
-    ):
+        save_integrated_tool_panel: bool = True,
+    ) -> None:
         """
         Create a toolbox from the config files named by `config_filenames`, using
         `tool_root_dir` as the base directory for finding individual tool config files.
@@ -182,21 +186,21 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
         # information about the tools defined in each shed-related
         # shed_tool_conf.xml file.
         self._dynamic_tool_confs = []
-        self._tools_by_id = {}
-        self._tools_by_uuid = {}
+        self._tools_by_id: Dict[str, Tool] = {}
+        self._tools_by_uuid: Dict[UUID, Tool] = {}
         # Tool lineages can contain chains of related tools with different ids
         # so each will be present once in the above dictionary. The following
         # dictionary can instead hold multiple tools with different versions.
-        self._tool_versions_by_id = {}
-        self._tools_by_old_id = {}
-        self._workflows_by_id = {}
+        self._tool_versions_by_id: Dict[str, Dict[Union[str, None], Tool]] = {}
+        self._tools_by_old_id: Dict[str, List[Tool]] = {}
+        self._workflows_by_id: Dict[str, Workflow] = {}
         # Cache for tool's to_dict calls specific to toolbox. Invalidates on toolbox reload.
-        self._tool_to_dict_cache = {}
-        self._tool_to_dict_cache_admin = {}
+        self._tool_to_dict_cache: Dict[str, Dict[str, Any]] = {}
+        self._tool_to_dict_cache_admin: Dict[str, Dict[str, Any]] = {}
         # In-memory dictionary that defines the layout of the tool panel.
         self._tool_panel = ToolPanelElements()
         self._index = 0
-        self.data_manager_tools = {}
+        self.data_manager_tools: Dict[str, Tool] = {}
         self._lineage_map = LineageMap(app)
         # Sets self._integrated_tool_panel and self._integrated_tool_panel_config_has_contents
         self._init_integrated_tool_panel(app.config)
@@ -270,20 +274,20 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
     def create_tool(self, config_file: "StrPath", **kwds) -> "Tool":
         raise NotImplementedError()
 
-    def create_dynamic_tool(self, dynamic_tool: "DynamicTool"):
+    def create_dynamic_tool(self, dynamic_tool: "DynamicTool") -> "Tool":
         raise NotImplementedError()
 
     def can_load_config_file(self, config_filename):
         return True
 
-    def _load_workflow(self, workflow_id):
+    def _load_workflow(self, workflow_id: str) -> "Workflow":
         raise NotImplementedError()
 
     def tool_tag_manager(self):
         """Build a tool tag manager according to app's configuration and return it."""
         raise NotImplementedError()
 
-    def _init_tools_from_configs(self, config_filenames):
+    def _init_tools_from_configs(self, config_filenames: List[str]) -> None:
         """Read through all tool config files and initialize tools in each
         with init_tools_from_config below.
         """
@@ -316,7 +320,7 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
                 log.exception("Error loading tools defined in config %s", config_filename)
         log.debug("Reading tools from config files finished %s", execution_timer)
 
-    def _init_tools_from_config(self, config_filename):
+    def _init_tools_from_config(self, config_filename: str) -> None:
         """
         Read the configuration file and load each tool.  The following tags are currently supported:
 
@@ -387,7 +391,7 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
                 )
                 self._dynamic_tool_confs.append(shed_tool_conf_dict)
 
-    def _get_tool_by_uuid(self, tool_uuid):
+    def _get_tool_by_uuid(self, tool_uuid: UUID) -> Union["Tool", None]:
         if tool_uuid in self._tools_by_uuid:
             return self._tools_by_uuid[tool_uuid]
 
@@ -403,16 +407,17 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
     def panel_view_dicts(self) -> Dict[str, Dict]:
         return {m.id: m.model_dump(mode="json") for m in self.panel_views()}
 
-    def panel_has_tool(self, tool, panel_view_id):
+    def panel_has_tool(self, tool: "Tool", panel_view_id: str) -> bool:
         panel_view_rendered = self._tool_panel_view_rendered[panel_view_id]
         return panel_view_rendered.has_item_recursive(tool)
 
-    def load_dynamic_tool(self, dynamic_tool: "DynamicTool"):
+    def load_dynamic_tool(self, dynamic_tool: "DynamicTool") -> Union["Tool", None]:
         if not dynamic_tool.active:
             return None
 
         tool = self.create_dynamic_tool(dynamic_tool)
         self.register_tool(tool)
+        assert isinstance(dynamic_tool.uuid, UUID)
         self._tools_by_uuid[dynamic_tool.uuid] = tool
         return tool
 
@@ -422,10 +427,10 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
         tool_path,
         panel_dict=None,
         integrated_panel_dict=None,
-        load_panel_dict=True,
+        load_panel_dict: bool = True,
         guid=None,
-        index=None,
-    ):
+        index: Optional[int] = None,
+    ) -> None:
         with self.app._toolbox_lock:
             item = ensure_tool_conf_item(item)
             item_type = item.type
@@ -529,7 +534,7 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
         log.debug(f"Loading new tool panel section: {str(tool_section.name)}")
         return tool_section
 
-    def get_section_for_tool(self, tool):
+    def get_section_for_tool(self, tool) -> Union[Tuple[str, str], Tuple[None, None]]:
         tool_id = tool.id
         return self._tool_panel.get_section_for_tool_id(tool_id)
 
@@ -616,8 +621,8 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
         if log_msg and (not hasattr(self.app, "tool_cache") or tool_id in self.app.tool_cache._new_tool_ids):
             log.debug(log_msg)
 
-    def _load_tool_panel_views(self):
-        self._tool_panel_view_rendered = {}
+    def _load_tool_panel_views(self) -> None:
+        self._tool_panel_view_rendered: Dict[str, ToolPanelElements] = {}
         registry = ToolBoxRegistryImpl(self)
         for key, view in self._tool_panel_views.items():
             self._tool_panel_view_rendered[key] = view.apply_view(self._integrated_tool_panel, registry)
@@ -729,24 +734,29 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
         user: Optional["User"] = None,
     ) -> Union[Optional["Tool"], List["Tool"]]:
         """Attempt to locate a tool in the tool box. Note that `exact` only refers to the `tool_id`, not the `tool_version`."""
-        if tool_uuid and user:
-            unprivileged_tool = self.get_unprivileged_tool_or_none(user, tool_uuid=tool_uuid)
-            if unprivileged_tool:
-                return unprivileged_tool
+        if tool_id is None:
+            if tool_uuid is None:
+                raise RequestParameterInvalidException(
+                    "get_tool cannot be called with both tool_id and tool_uuid as None"
+                )
+            if user:
+                unprivileged_tool = self.get_unprivileged_tool_or_none(user, tool_uuid=tool_uuid)
+                if unprivileged_tool:
+                    return unprivileged_tool
+            tool_uuid = tool_uuid if isinstance(tool_uuid, UUID) else UUID(tool_uuid)
+            tool_from_uuid = self._get_tool_by_uuid(tool_uuid)
+            if tool_from_uuid is None:
+                raise ObjectNotFound(f"Failed to find a tool with uuid [{tool_uuid}]")
+            tool_id = tool_from_uuid.id
+            assert tool_id
+
         if tool_version:
             tool_version = str(tool_version)
 
         if get_all_versions and exact:
-            raise AssertionError("Cannot specify get_tool with both get_all_versions and exact as True")
-
-        if tool_id is None:
-            if tool_uuid is not None:
-                tool_from_uuid = self._get_tool_by_uuid(tool_uuid)
-                if tool_from_uuid is None:
-                    raise ObjectNotFound(f"Failed to find a tool with uuid [{tool_uuid}]")
-                tool_id = tool_from_uuid.id
-            if tool_id is None:
-                raise AssertionError("get_tool called with tool_id as None")
+            raise RequestParameterInvalidException(
+                "get_tool cannot be called with both get_all_versions and exact as True"
+            )
 
         if "/repos/" in tool_id:  # test if tool came from a toolshed
             tool_id_without_tool_shed = tool_id.split("/repos/")[1]
@@ -904,10 +914,10 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
         panel_dict,
         integrated_panel_dict,
         tool_path,
-        load_panel_dict,
+        load_panel_dict: bool,
         guid=None,
-        index=None,
-    ):
+        index: Optional[int] = None,
+    ) -> None:
         try:
             path_template = item.get("file")
             template_kwds = self._path_template_kwds()
@@ -920,16 +930,15 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
             can_load_into_panel_dict = True
 
             tool = self.load_tool_from_cache(concrete_path)
-            from_cache = tool
-            if from_cache:
-                if guid and tool.id != guid:
-                    # In rare cases a tool shed tool is loaded into the cache without guid.
-                    # In that case recreating the tool will correct the cached version.
-                    from_cache = False
+            from_cache = tool is not None
+            if tool and guid and tool.id != guid:
+                # In rare cases a tool shed tool is loaded into the cache without guid.
+                # In that case recreating the tool will correct the cached version.
+                from_cache = False
             if guid and not from_cache:  # tool was not in cache and is a tool shed tool
                 tool_shed_repository = self.get_tool_repository_from_xml_item(item.elem, concrete_path)
                 if tool_shed_repository:
-                    if hasattr(tool_shed_repository, "deleted"):
+                    if not isinstance(tool_shed_repository, ToolConfRepository):
                         # The shed tool is in the install database
                         # Only load tools if the repository is not deactivated or uninstalled.
                         can_load_into_panel_dict = not tool_shed_repository.deleted
@@ -971,15 +980,26 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
         except Exception:
             log.exception("Error reading tool from path: %s", path)
 
-    def get_tool_repository_from_xml_item(self, elem, path):
-        tool_shed = elem.find("tool_shed").text
-        repository_name = elem.find("repository_name").text
-        repository_owner = elem.find("repository_owner").text
+    def get_tool_repository_from_xml_item(
+        self, elem: "Element", path: str
+    ) -> Union[ToolConfRepository, "ToolShedRepository"]:
+        tool_shed_el = elem.find("tool_shed")
+        assert tool_shed_el is not None
+        tool_shed = tool_shed_el.text
+        assert tool_shed
+        repository_name_el = elem.find("repository_name")
+        assert repository_name_el is not None
+        repository_name = repository_name_el.text
+        assert repository_name
+        repository_owner_el = elem.find("repository_owner")
+        assert repository_owner_el is not None
+        repository_owner = repository_owner_el.text
+        assert repository_owner
         # The definition of `installed_changeset_revision` for a repository is that it has been cloned at <tool_path/toolshed/repos/owner/name/installed_changeset_revision>
         # so if we load a tool it needs to be at a path that contains `installed_changeset_revision`.
         path_to_installed_changeset_revision = os.path.join(tool_shed, "repos", repository_owner, repository_name)
         if path_to_installed_changeset_revision in path:
-            installed_changeset_revision = path[
+            installed_changeset_revision: Optional[str] = path[
                 path.index(path_to_installed_changeset_revision) + len(path_to_installed_changeset_revision) :
             ].split(os.path.sep)[1]
         else:
@@ -987,8 +1007,9 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
             if installed_changeset_revision_elem is None:
                 # Backward compatibility issue - the tag used to be named 'changeset_revision'.
                 installed_changeset_revision_elem = elem.find("changeset_revision")
+                assert installed_changeset_revision_elem is not None
             installed_changeset_revision = installed_changeset_revision_elem.text
-        repository = self._get_tool_shed_repository(
+        repository: Union[ToolConfRepository, ToolShedRepository] = self._get_tool_shed_repository(
             tool_shed=tool_shed,
             name=repository_name,
             owner=repository_owner,
@@ -1001,6 +1022,7 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
             )
             log.warning(msg, repository_name, repository_owner)
             # Figure out path to repository on disk given the tool shed info and the path to the tool contained in the repo
+            assert installed_changeset_revision
             repository_path = os.path.join(
                 tool_shed, "repos", repository_owner, repository_name, installed_changeset_revision
             )
@@ -1020,12 +1042,15 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
                 tsr_cache.add_local_repository(repository)
         return repository
 
-    def _get_tool_shed_repository(self, tool_shed, name, owner, installed_changeset_revision):
+    @abc.abstractmethod
+    def _get_tool_shed_repository(
+        self, tool_shed: str, name: str, owner: str, installed_changeset_revision: Optional[str]
+    ) -> "ToolShedRepository":
         # Abstract class doesn't have a dependency on the database, for full Tool Shed
         # support the actual Galaxy ToolBox implements this method and returns a Tool Shed repository.
-        return None
+        ...
 
-    def __add_tool(self, tool, load_panel_dict, panel_dict):
+    def __add_tool(self, tool: "Tool", load_panel_dict: bool, panel_dict) -> None:
         # Allow for the same tool to be loaded into multiple places in the
         # tool panel.  We have to handle the case where the tool is contained
         # in a repository installed from the tool shed, and the Galaxy
@@ -1039,7 +1064,9 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
         if load_panel_dict:
             self.__add_tool_to_tool_panel(tool, panel_dict)
 
-    def _load_workflow_tag_set(self, item, panel_dict, integrated_panel_dict, load_panel_dict, index=None):
+    def _load_workflow_tag_set(
+        self, item, panel_dict, integrated_panel_dict, load_panel_dict: bool, index: Optional[int] = None
+    ) -> None:
         try:
             # TODO: should id be encoded?
             workflow_id = item.get("id")
@@ -1053,14 +1080,16 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
         except Exception:
             log.exception("Error loading workflow: %s", workflow_id)
 
-    def _load_label_tag_set(self, item, panel_dict, integrated_panel_dict, load_panel_dict, index=None):
+    def _load_label_tag_set(
+        self, item, panel_dict, integrated_panel_dict, load_panel_dict: bool, index: Optional[int] = None
+    ) -> None:
         label = ToolSectionLabel(item)
         key = f"label_{label.id}"
         if load_panel_dict:
             panel_dict[key] = label
         integrated_panel_dict.update_or_append(index, key, label)
 
-    def _load_section_tag_set(self, item, tool_path, load_panel_dict, index=None):
+    def _load_section_tag_set(self, item, tool_path, load_panel_dict: bool, index: Optional[int] = None) -> None:
         key = item.get("id")
         if key in self._tool_panel:
             section = self._tool_panel[key]
@@ -1097,7 +1126,7 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
         # Always load sections into the integrated_tool_panel.
         self._integrated_tool_panel.update_or_append(index, key, integrated_section)
 
-    def _load_tooldir_tag_set(self, item, elems, tool_path, integrated_elems, load_panel_dict):
+    def _load_tooldir_tag_set(self, item, elems, tool_path, integrated_elems, load_panel_dict: bool) -> None:
         directory = os.path.join(tool_path, item.get("dir"))
         recursive = string_as_bool(item.get("recursive", True))
         self.__watch_directory(
@@ -1111,14 +1140,14 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
 
     def __watch_directory(
         self,
-        directory,
+        directory: "StrPath",
         elems,
         integrated_elems,
-        load_panel_dict,
-        recursive,
-        force_watch=False,
-    ):
-        def quick_load(tool_file, async_load=True):
+        load_panel_dict: bool,
+        recursive: bool,
+        force_watch: bool = False,
+    ) -> None:
+        def quick_load(tool_file: "StrPath", async_load: bool = True) -> Union[str, None]:
             try:
                 tool = self.load_tool(tool_file)
                 self.__add_tool(tool, load_panel_dict, elems)
@@ -1139,7 +1168,7 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
                 log.error(f"Failed to load potential tool {tool_file} - {e}")
             except Exception:
                 log.exception("Failed to load potential tool %s.", tool_file)
-                return None
+            return None
 
         tool_loaded = False
         if not os.path.isdir(directory):
@@ -1199,13 +1228,13 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
             if self._tool_config_watcher:
                 [self._tool_config_watcher.watch_file(macro_path) for macro_path in tool._macro_paths]
 
-    def add_tool_to_cache(self, tool, config_file):
-        tool_cache = getattr(self.app, "tool_cache", None)
+    def add_tool_to_cache(self, tool: "Tool", config_file: "StrPath") -> None:
+        tool_cache: Optional[ToolCache] = getattr(self.app, "tool_cache", None)
         if tool_cache:
-            self.app.tool_cache.cache_tool(config_file, tool)
+            tool_cache.cache_tool(config_file, tool)
 
-    def load_tool_from_cache(self, config_file, recover_tool=False):
-        tool_cache = getattr(self.app, "tool_cache", None)
+    def load_tool_from_cache(self, config_file: "StrPath", recover_tool: bool = False) -> Union["Tool", None]:
+        tool_cache: Optional[ToolCache] = getattr(self.app, "tool_cache", None)
         tool = None
         if tool_cache:
             if recover_tool:
@@ -1226,8 +1255,9 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
         self.register_tool(tool)
         return tool
 
-    def register_tool(self, tool):
+    def register_tool(self, tool: "Tool") -> None:
         tool_id = tool.id
+        assert tool_id
         version = tool.version or None
         if tool_id not in self._tool_versions_by_id:
             self._tool_versions_by_id[tool_id] = {version: tool}
@@ -1242,9 +1272,10 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
         else:
             self._tools_by_id[tool_id] = tool
         old_id = tool.old_id
-        if old_id not in self._tools_by_old_id:
-            self._tools_by_old_id[old_id] = []
-        self._tools_by_old_id[old_id].append(tool)
+        if old_id:
+            if old_id not in self._tools_by_old_id:
+                self._tools_by_old_id[old_id] = []
+            self._tools_by_old_id[old_id].append(tool)
 
     def package_tool(self, trans, tool_id):
         """
@@ -1271,6 +1302,7 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
             status = "error"
         else:
             old_tool = self._tools_by_id[tool_id]
+            assert old_tool.config_file
             new_tool = self.load_tool(old_tool.config_file, use_cached=False)
             # The tool may have been installed from a tool shed, so set the tool shed attributes.
             # Since the tool version may have changed, we don't override it here.
@@ -1286,6 +1318,7 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
             # (Re-)Register the reloaded tool, this will handle
             #  _tools_by_id and _tool_versions_by_id
             self.register_tool(new_tool)
+            assert old_tool.id
             message = {"name": old_tool.name, "id": old_tool.id, "version": old_tool.version}
             status = "done"
         return message, status
@@ -1304,8 +1337,9 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
         else:
             tool = self._tools_by_id[tool_id]
             del self._tools_by_id[tool_id]
-            self._tools_by_old_id[tool.old_id].remove(tool)
-            tool_cache = getattr(self.app, "tool_cache", None)
+            if tool.old_id:
+                self._tools_by_old_id[tool.old_id].remove(tool)
+            tool_cache: Optional[ToolCache] = getattr(self.app, "tool_cache", None)
             if tool_cache:
                 tool_cache.expire_tool(tool_id)
             if remove_from_panel:
@@ -1360,29 +1394,32 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
             if elt:
                 yield elt
 
-    def get_tool_to_dict(self, trans, tool, tool_help=False):
+    def get_tool_to_dict(self, trans, tool: "Tool", tool_help: bool = False) -> Dict[str, Any]:
         """Return tool's to_dict.
         Use cache if present, store to cache otherwise.
         Note: The cached tool's to_dict is specific to the calls from toolbox.
         """
         to_dict = None
+        assert tool.id
         if not trans.user_is_admin:
             if not tool_help:
-                to_dict = self._tool_to_dict_cache.get(tool.id, None)
+                to_dict = self._tool_to_dict_cache.get(tool.id)
             if not to_dict:
                 to_dict = tool.to_dict(trans, link_details=True, tool_help=tool_help)
                 if not tool_help:
                     self._tool_to_dict_cache[tool.id] = to_dict
         else:
             if not tool_help:
-                to_dict = self._tool_to_dict_cache_admin.get(tool.id, None)
+                to_dict = self._tool_to_dict_cache_admin.get(tool.id)
             if not to_dict:
                 to_dict = tool.to_dict(trans, link_details=True, tool_help=tool_help)
                 if not tool_help:
                     self._tool_to_dict_cache_admin[tool.id] = to_dict
         return to_dict
 
-    def to_dict(self, trans, in_panel=True, tool_help=False, view=None, **kwds):
+    def to_dict(
+        self, trans, in_panel: bool = True, tool_help: bool = False, view: Optional[str] = None, **kwds
+    ) -> List[Dict[str, Any]]:
         """
         Create a dictionary representation of the toolbox.
         Uses primitive cache for toolbox-specific tool 'to_dict's.

--- a/lib/galaxy/tool_util/toolbox/lineages/factory.py
+++ b/lib/galaxy/tool_util/toolbox/lineages/factory.py
@@ -1,10 +1,14 @@
 from typing import (
     Dict,
     Optional,
+    TYPE_CHECKING,
 )
 
 from galaxy.util.tool_version import remove_version_from_guid
 from .interface import ToolLineage
+
+if TYPE_CHECKING:
+    from galaxy.tools import Tool
 
 
 class LineageMap:
@@ -14,8 +18,9 @@ class LineageMap:
         self.lineage_map: Dict[str, ToolLineage] = {}
         self.app = app
 
-    def register(self, tool) -> ToolLineage:
+    def register(self, tool: "Tool") -> ToolLineage:
         tool_id = tool.id
+        assert tool_id
         versionless_tool_id = remove_version_from_guid(tool_id)
         lineage: ToolLineage
         if versionless_tool_id not in self.lineage_map:
@@ -32,7 +37,7 @@ class LineageMap:
             self.lineage_map[tool_id] = lineage
         return self.lineage_map[tool_id]
 
-    def get(self, tool_id) -> Optional[ToolLineage]:
+    def get(self, tool_id: str) -> Optional[ToolLineage]:
         """
         Get lineage for `tool_id`.
 
@@ -55,13 +60,14 @@ class LineageMap:
             tool = toolbox and toolbox._tools_by_id.get(tool_id)
             if tool:
                 lineage = ToolLineage.from_tool(tool)
-            if lineage:
                 self.lineage_map[tool_id] = lineage
         return self.lineage_map.get(tool_id)
 
-    def _get_versionless(self, tool_id) -> Optional[ToolLineage]:
+    def _get_versionless(self, tool_id: str) -> Optional[ToolLineage]:
         versionless_tool_id = remove_version_from_guid(tool_id)
-        return self.lineage_map.get(versionless_tool_id, None)
+        if not versionless_tool_id:
+            return None
+        return self.lineage_map.get(versionless_tool_id)
 
 
 __all__ = ("LineageMap",)

--- a/lib/galaxy/tool_util/toolbox/lineages/interface.py
+++ b/lib/galaxy/tool_util/toolbox/lineages/interface.py
@@ -3,6 +3,7 @@ from typing import (
     Any,
     Dict,
     List,
+    TYPE_CHECKING,
 )
 
 from sortedcontainers import SortedSet
@@ -10,18 +11,21 @@ from sortedcontainers import SortedSet
 from galaxy.tool_util.version import parse_version
 from galaxy.util.tool_version import remove_version_from_guid
 
+if TYPE_CHECKING:
+    from galaxy.tools import Tool
+
 
 class ToolLineageVersion:
     """Represents a single tool in a lineage. If lineage is based
     around GUIDs that somehow encode the version (either using GUID
     or a simple tool id and a version)."""
 
-    def __init__(self, id, version):
+    def __init__(self, id: str, version: str) -> None:
         self.id = id
         self.version = version
 
     @property
-    def id_based(self):
+    def id_based(self) -> bool:
         """Return True if the lineage is defined by GUIDs (in this
         case the indexer of the tools (i.e. the ToolBox) should ignore
         the tool_version (because it is encoded in the GUID and managed
@@ -29,7 +33,7 @@ class ToolLineageVersion:
         """
         return self.version is None
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, str]:
         return dict(
             id=self.id,
             version=self.version,
@@ -44,7 +48,7 @@ class ToolLineage:
     lineages_by_id: Dict[str, "ToolLineage"] = {}
     lock = threading.Lock()
 
-    def __init__(self, tool_id, **kwds):
+    def __init__(self, tool_id: str) -> None:
         self.tool_id = tool_id
         self.tool_versions = SortedSet(key=parse_version)
 
@@ -54,22 +58,22 @@ class ToolLineage:
         tool_id = versionless_tool_id or self.tool_id
         return [f"{tool_id}/{version}" for version in self.tool_versions]
 
-    @staticmethod
-    def from_tool(tool) -> "ToolLineage":
+    @classmethod
+    def from_tool(cls, tool: "Tool") -> "ToolLineage":
         tool_id = tool.id
-        lineages_by_id = ToolLineage.lineages_by_id
-        with ToolLineage.lock:
+        assert tool_id is not None
+        lineages_by_id = cls.lineages_by_id
+        with cls.lock:
             if tool_id not in lineages_by_id:
                 lineages_by_id[tool_id] = ToolLineage(tool_id)
         lineage = lineages_by_id[tool_id]
         lineage.register_version(tool.version)
         return lineage
 
-    def register_version(self, tool_version) -> None:
-        assert tool_version is not None
-        self.tool_versions.add(str(tool_version))
+    def register_version(self, tool_version: str) -> None:
+        self.tool_versions.add(tool_version)
 
-    def get_versions(self):
+    def get_versions(self) -> List[ToolLineageVersion]:
         """
         Return an ordered list of lineages (ToolLineageVersion) in this
         chain, from oldest to newest.
@@ -79,7 +83,7 @@ class ToolLineage:
             for tool_id, tool_version in zip(self.tool_ids, self.tool_versions)
         ]
 
-    def get_version_ids(self, reverse=False) -> List[str]:
+    def get_version_ids(self, reverse: bool = False) -> List[str]:
         if reverse:
             return list(reversed(self.tool_ids))
         return self.tool_ids

--- a/lib/galaxy/tool_util/toolbox/parser.py
+++ b/lib/galaxy/tool_util/toolbox/parser.py
@@ -48,9 +48,6 @@ class XmlToolConfSource(ToolConfSource):
     def parse_tool_path(self):
         return self.root.get("tool_path")
 
-    def parse_tool_cache_data_dir(self):
-        return self.root.get("tool_cache_data_dir")
-
     def parse_items(self):
         return [ensure_tool_conf_item(_) for _ in self.root]
 
@@ -71,9 +68,6 @@ class YamlToolConfSource(ToolConfSource):
 
     def parse_tool_path(self):
         return self.as_dict.get("tool_path")
-
-    def parse_tool_cache_data_dir(self):
-        return self.as_dict.get("tool_cache_data_dir")
 
     def parse_items(self):
         return [ToolConfItem.from_dict(_) for _ in self.as_dict.get("items")]

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -233,7 +233,9 @@ if TYPE_CHECKING:
     from galaxy.model import (
         DynamicTool,
         LibraryFolder,
+        Workflow,
     )
+    from galaxy.model.tool_shed_install import ToolShedRepository
     from galaxy.objectstore import ObjectStore
     from galaxy.schema.schema import JobState
     from galaxy.tool_util.parser.output_objects import (
@@ -482,7 +484,9 @@ class ToolBox(AbstractToolBox):
 
     app: "UniverseApplication"
 
-    def __init__(self, config_filenames, tool_root_dir, app, save_integrated_tool_panel: bool = True):
+    def __init__(
+        self, config_filenames: List[str], tool_root_dir, app, save_integrated_tool_panel: bool = True
+    ) -> None:
         self._reload_count = 0
         self.tool_location_fetcher = ToolLocationFetcher()
         # This is here to deal with the old default value, which doesn't make
@@ -672,7 +676,9 @@ class ToolBox(AbstractToolBox):
             "model_tools_path": MODEL_TOOLS_PATH,
         }
 
-    def _get_tool_shed_repository(self, tool_shed, name, owner, installed_changeset_revision):
+    def _get_tool_shed_repository(
+        self, tool_shed: str, name: str, owner: str, installed_changeset_revision: Optional[str]
+    ) -> "ToolShedRepository":
         # Abstract toolbox doesn't have a dependency on the database, so
         # override _get_tool_shed_repository here to provide this information.
 
@@ -704,7 +710,7 @@ class ToolBox(AbstractToolBox):
             default_tool_dependency_dir=default_tool_dependency_dir,
         )
 
-    def _load_workflow(self, workflow_id):
+    def _load_workflow(self, workflow_id: str) -> "Workflow":
         """
         Return an instance of 'Workflow' identified by `id`,
         which is encoded in the tool panel.
@@ -1046,7 +1052,7 @@ class Tool(UsesDictVisibleKeys):
         self.populate_tool_shed_info(tool_shed_repository)
         # add tool resource parameters
         self.populate_resource_parameters(tool_source)
-        self.tool_errors = None
+        self.tool_errors: Optional[str] = None
         # Parse XML element containing configuration
         self.tool_source = tool_source
         self.outputs: Dict[str, ToolOutputBase] = {}
@@ -1229,7 +1235,7 @@ class Tool(UsesDictVisibleKeys):
         """
         return self.app.job_config.get_destination(self.__get_job_tool_configuration(job_params=job_params).destination)
 
-    def get_panel_section(self):
+    def get_panel_section(self) -> Union[Tuple[str, str], Tuple[None, None]]:
         return self.app.toolbox.get_section_for_tool(self)
 
     def allow_user_access(self, user, attempting_access=True):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -603,7 +603,13 @@ class ToolBox(AbstractToolBox):
             return None
 
     def dynamic_tool_to_tool(self, dynamic_tool: Optional["DynamicTool"]) -> Optional["Tool"]:
-        if not dynamic_tool or not dynamic_tool.active or (tool_representation := dynamic_tool.value) is None:
+        if not dynamic_tool:
+            return None
+        if not dynamic_tool.active:
+            log.debug("Tool %s is not active", dynamic_tool.uuid)
+            return None
+        if (tool_representation := dynamic_tool.value) is None:
+            log.debug("Tool %s has empty representation", dynamic_tool.uuid)
             return None
         if "name" not in tool_representation:
             tool_representation["name"] = f"dynamic tool {dynamic_tool.uuid}"

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -3,11 +3,19 @@ import os
 from threading import Lock
 from typing import (
     Dict,
+    List,
     Optional,
+    Set,
+    TYPE_CHECKING,
+    Union,
 )
 
 from galaxy.util import unicodify
 from galaxy.util.hash_util import md5_hash_file
+
+if TYPE_CHECKING:
+    from galaxy.tools import Tool
+    from galaxy.util.path import StrPath
 
 log = logging.getLogger(__name__)
 
@@ -18,30 +26,29 @@ class ToolCache:
     toolbox.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._lock = Lock()
         self._hash_by_tool_paths: Dict[str, ToolHash] = {}
-        self._tools_by_path = {}
-        self._tool_paths_by_id = {}
-        self._macro_paths_by_id = {}
-        self._new_tool_ids = set()
-        self._removed_tool_ids = set()
-        self._removed_tools_by_path = {}
+        self._tools_by_path: Dict[str, Tool] = {}
+        self._tool_paths_by_id: Dict[str, StrPath] = {}
+        self._new_tool_ids: Set[str] = set()
+        self._removed_tool_ids: Set[str] = set()
+        self._removed_tools_by_path: Dict[str, Tool] = {}
         self._hashes_initialized = False
 
-    def assert_hashes_initialized(self):
+    def assert_hashes_initialized(self) -> None:
         if not self._hashes_initialized:
             for tool_hash in self._hash_by_tool_paths.values():
                 tool_hash.hash  # noqa: B018
             self._hashes_initialized = True
 
-    def cleanup(self):
+    def cleanup(self) -> List[str]:
         """
         Remove uninstalled tools from tool cache if they are not on disk anymore or if their content has changed.
 
         Returns list of tool_ids that have been removed.
         """
-        removed_tool_ids = []
+        removed_tool_ids: List[str] = []
         try:
             with self._lock:
                 paths_to_cleanup = {
@@ -71,13 +78,13 @@ class ToolCache:
             log.debug(f"Removed the following tools from cache: {removed_tool_ids}")
         return removed_tool_ids
 
-    def _should_cleanup(self, config_filename):
+    def _should_cleanup(self, config_filename: str) -> bool:
         """Return True if `config_filename` does not exist or if modtime and hash have changes, else return False."""
         try:
             new_mtime = os.path.getmtime(config_filename)
             tool_hash = self._hash_by_tool_paths.get(config_filename)
-            if tool_hash and tool_hash.modtime_less_than(new_mtime):
-                if not tool_hash.hash_equals(md5_hash_file(config_filename)):
+            if tool_hash and tool_hash.modtime < new_mtime:
+                if not tool_hash.hash == md5_hash_file(config_filename):
                     return True
                 else:
                     # No change of content, so not necessary to calculate the md5 checksum every time
@@ -85,51 +92,49 @@ class ToolCache:
             tool = self._tools_by_path[config_filename]
             for macro_path in tool._macro_paths:
                 new_mtime = os.path.getmtime(macro_path)
-                if self._hash_by_tool_paths.get(macro_path).modtime < new_mtime:
+                if (macro_hash := self._hash_by_tool_paths.get(str(macro_path))) and macro_hash.modtime < new_mtime:
                     return True
         except FileNotFoundError:
             return True
         return False
 
-    def get_tool(self, config_filename):
+    def get_tool(self, config_filename: "StrPath") -> Union["Tool", None]:
         """Get the tool at `config_filename` from the cache if the tool is up to date."""
-        return self._tools_by_path.get(config_filename, None)
+        return self._tools_by_path.get(str(config_filename))
 
-    def get_removed_tool(self, config_filename):
-        return self._removed_tools_by_path.get(config_filename)
+    def get_removed_tool(self, config_filename: "StrPath") -> Union["Tool", None]:
+        return self._removed_tools_by_path.get(str(config_filename))
 
-    def get_tool_by_id(self, tool_id):
+    def get_tool_by_id(self, tool_id: str) -> Union["Tool", None]:
         """Get the tool with the id `tool_id` from the cache if the tool is up to date."""
-        return self.get_tool(self._tool_paths_by_id.get(tool_id))
+        if tool_path := self._tool_paths_by_id.get(tool_id):
+            return self.get_tool(tool_path)
+        return None
 
-    def expire_tool(self, tool_id):
+    def expire_tool(self, tool_id: str) -> None:
         with self._lock:
             if tool_id in self._tool_paths_by_id:
-                config_filename = self._tool_paths_by_id[tool_id]
+                config_filename = str(self._tool_paths_by_id[tool_id])
                 del self._hash_by_tool_paths[config_filename]
                 del self._tool_paths_by_id[tool_id]
                 del self._tools_by_path[config_filename]
                 if tool_id in self._new_tool_ids:
                     self._new_tool_ids.remove(tool_id)
 
-    def cache_tool(self, config_filename, tool):
+    def cache_tool(self, config_filename: "StrPath", tool: "Tool") -> None:
         tool_id = str(tool.id)
         # We defer hashing of the config file if we haven't called assert_hashes_initialized.
         # This allows startup to occur without having to read in and hash all tool and macro files
         lazy_hash = not self._hashes_initialized
         with self._lock:
-            self._hash_by_tool_paths[config_filename] = ToolHash(config_filename, lazy_hash=lazy_hash)
+            self._hash_by_tool_paths[str(config_filename)] = ToolHash(config_filename, lazy_hash=lazy_hash)
             self._tool_paths_by_id[tool_id] = config_filename
-            self._tools_by_path[config_filename] = tool
+            self._tools_by_path[str(config_filename)] = tool
             self._new_tool_ids.add(tool_id)
             for macro_path in tool._macro_paths:
-                self._hash_by_tool_paths[macro_path] = ToolHash(macro_path, lazy_hash=lazy_hash)
-                if tool_id not in self._macro_paths_by_id:
-                    self._macro_paths_by_id[tool_id] = {macro_path}
-                else:
-                    self._macro_paths_by_id[tool_id].add(macro_path)
+                self._hash_by_tool_paths[str(macro_path)] = ToolHash(macro_path, lazy_hash=lazy_hash)
 
-    def reset_status(self):
+    def reset_status(self) -> None:
         """
         Reset tracking of new and newly disabled tools.
         """
@@ -140,29 +145,15 @@ class ToolCache:
 
 
 class ToolHash:
-    def __init__(self, path: str, modtime: Optional[float] = None, lazy_hash: bool = False):
+    def __init__(self, path: "StrPath", modtime: Optional[float] = None, lazy_hash: bool = False) -> None:
         self.path = path
-        self._modtime = modtime or os.path.getmtime(path)
-        self._tool_hash = None
+        self.modtime = modtime or os.path.getmtime(path)
+        self._tool_hash: Optional[str] = None
         if not lazy_hash:
             self.hash  # noqa: B018
 
-    def modtime_less_than(self, other_modtime: float):
-        return self._modtime < other_modtime
-
-    def hash_equals(self, other_hash: Optional[str]):
-        return self.hash == other_hash
-
     @property
-    def modtime(self) -> float:
-        return self._modtime
-
-    @modtime.setter
-    def modtime(self, new_value: float):
-        self._modtime = new_value
-
-    @property
-    def hash(self):
+    def hash(self) -> Union[str, None]:
         if self._tool_hash is None:
             self._tool_hash = md5_hash_file(self.path)
         return self._tool_hash

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -172,6 +172,7 @@ class DataManager:
                 tool_elem is not None
             ), f"Error loading tool for data manager. Make sure that a tool_file attribute or a tool tag set has been defined:\n{util.xml_to_string(elem)}"
             path = tool_elem.get("file")
+            assert path is not None, f"A tool file path could not be determined:\n{util.xml_to_string(elem)}"
             tool_guid = tool_elem.get("guid")
             # need to determine repository info so that dependencies will work correctly
             tool_shed_repository = self.data_managers.app.toolbox.get_tool_repository_from_xml_item(tool_elem, path)
@@ -187,7 +188,6 @@ class DataManager:
                 shed_conf = self.data_managers.app.toolbox.get_shed_config_dict_by_filename(shed_conf_file)
                 if shed_conf:
                     tool_path = shed_conf.get("tool_path", tool_path)
-        assert path is not None, f"A tool file path could not be determined:\n{util.xml_to_string(elem)}"
         assert tool_path, "A tool root path is required"
         self._load_tool(
             os.path.join(tool_path, path),
@@ -221,6 +221,7 @@ class DataManager:
             tool_shed_repository=tool_shed_repository,
             use_cached=True,
         )
+        assert tool.id
         self.data_managers.app.toolbox.data_manager_tools[tool.id] = tool
         self.tool = tool
         return tool

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -99,6 +99,9 @@ try:
         def findall(self, path: str, namespaces: Optional[Mapping[str, str]] = None) -> List[Self]:  # type: ignore[override]
             return cast(List[Self], super().findall(path, namespaces))
 
+        def iterfind(self, path: str, namespaces: Optional[Mapping[str, str]] = None) -> Iterator[Self]:
+            return cast(Iterator[Self], super().iterfind(path, namespaces))
+
     def SubElement(parent: Element, tag: str, attrib: Optional[Dict[str, str]] = None, **extra) -> Element:
         return cast(Element, etree.SubElement(parent, tag, attrib, **extra))
 
@@ -194,6 +197,14 @@ def str_removeprefix(s: str, prefix: str):
         return s[len(prefix) :]
     else:
         return s
+
+
+@overload
+def remove_protocol_from_url(url: None) -> None: ...
+
+
+@overload
+def remove_protocol_from_url(url: str) -> str: ...
 
 
 def remove_protocol_from_url(url):
@@ -1956,14 +1967,14 @@ class classproperty:
 
 
 class ExecutionTimer:
-    def __init__(self):
+    def __init__(self) -> None:
         self.begin = time.time()
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"({self.elapsed * 1000:0.3f} ms)"
 
     @property
-    def elapsed(self):
+    def elapsed(self) -> float:
         return time.time() - self.begin
 
 

--- a/lib/galaxy/util/tool_shed/common_util.py
+++ b/lib/galaxy/util/tool_shed/common_util.py
@@ -266,10 +266,7 @@ def remove_protocol_and_user_from_clone_url(repository_clone_url: str) -> str:
     return tmp_url.rstrip("/")
 
 
-def remove_protocol_from_tool_shed_url(tool_shed_url: str) -> str:
-    """Return a partial Tool Shed URL, eliminating the protocol if it exists."""
-    return util.remove_protocol_from_url(tool_shed_url)
-
+remove_protocol_from_tool_shed_url = util.remove_protocol_from_url
 
 __all__ = (
     "accumulate_tool_dependencies",

--- a/lib/galaxy/util/tool_version.py
+++ b/lib/galaxy/util/tool_version.py
@@ -1,4 +1,7 @@
-def remove_version_from_guid(guid):
+from typing import Union
+
+
+def remove_version_from_guid(guid: str) -> Union[str, None]:
     """
     Removes version from toolshed-derived tool_id(=guid).
     """

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -1,23 +1,33 @@
 import os
 from copy import deepcopy
 from typing import (
+    Callable,
     Dict,
+    Iterable,
     List,
     Optional,
     Tuple,
+    TYPE_CHECKING,
+    TypeVar,
+    Union,
 )
 
 from galaxy.util import (
-    Element,
-    ElementTree,
     parse_xml,
+    unicodify,
 )
-from galaxy.util.path import StrPath
 
-REQUIRED_PARAMETER = object()
+if TYPE_CHECKING:
+    from galaxy.util import (
+        Element,
+        ElementTree,
+    )
+    from galaxy.util.path import StrPath
+
+MacrosDictT = Dict[str, List["Element"]]
 
 
-def load_with_references(path: StrPath) -> Tuple[ElementTree, Optional[List[str]]]:
+def load_with_references(path: "StrPath") -> Tuple["ElementTree", Optional[List[str]]]:
     """Load XML documentation from file system and preprocesses XML macros.
 
     Return the XML representation of the expanded tree and paths to
@@ -30,20 +40,24 @@ def load_with_references(path: StrPath) -> Tuple[ElementTree, Optional[List[str]
     if macros_el is None:
         return tree, []
 
-    macros: Dict[str, List[Element]] = {}
+    macros: MacrosDictT = {}
     macro_paths = _import_macros(macros_el, path, macros)
     macros_el.clear()
 
     # Collect tokens
-    tokens = {}
+    tokens: Dict[str, str] = {}
     for m in macros.get("token", []):
-        tokens[m.get("name")] = m.text or ""
+        token_name = m.get("name")
+        assert token_name
+        tokens[token_name] = m.text or ""
     tokens = expand_nested_tokens(tokens)
 
     # Expand xml macros
-    macro_dict = {}
+    macro_dict: Dict[str, XmlMacroDef] = {}
     for m in macros.get("xml", []):
-        macro_dict[m.get("name")] = XmlMacroDef(m)
+        macro_name = m.get("name")
+        assert macro_name
+        macro_dict[macro_name] = XmlMacroDef(m)
     _expand_macros([root], macro_dict, tokens)
 
     # reinsert template macro which are used during tool execution
@@ -53,25 +67,23 @@ def load_with_references(path: StrPath) -> Tuple[ElementTree, Optional[List[str]
     return tree, macro_paths
 
 
-def load(path: StrPath) -> ElementTree:
+def load(path: "StrPath") -> "ElementTree":
     tree, _ = load_with_references(path)
     return tree
 
 
-def template_macro_params(root):
+def template_macro_params(root: "Element") -> Dict[str, Union[str, None]]:
     """
     Look for template macros and populate param_dict (for cheetah)
     with these.
     """
-    param_dict = {}
     macros_el = _macros_el(root)
-    macro_dict = _macros_of_type(macros_el, "template", lambda el: el.text)
-    for key, value in macro_dict.items():
-        param_dict[key] = value
-    return param_dict
+    if macros_el is not None:
+        return _macros_of_type(macros_el, "template", lambda el: el.text)
+    return {}
 
 
-def raw_xml_tree(path: StrPath) -> ElementTree:
+def raw_xml_tree(path: "StrPath") -> "ElementTree":
     """Load raw (no macro expansion) tree representation of XML represented
     at the specified path.
     """
@@ -79,37 +91,43 @@ def raw_xml_tree(path: StrPath) -> ElementTree:
     return tree
 
 
-def imported_macro_paths(root):
+def imported_macro_paths(root: "Element") -> List[str]:
     macros_el = _macros_el(root)
+    if macros_el is None:
+        return []
     return _imported_macro_paths_from_el(macros_el)
 
 
-def _import_macros(macros_el, path, macros) -> Optional[List[str]]:
+def _import_macros(macros_el: "Element", path: "StrPath", macros: MacrosDictT) -> Optional[List[str]]:
     """
     root the parsed XML tree
     path the path to the main xml document
     """
     xml_base_dir = os.path.dirname(path)
-    if macros_el is not None:
-        macro_paths = _load_macros(macros_el, xml_base_dir, macros)
-        # _xml_set_children(macros_el, macro_els)
-        return macro_paths
-    return None
+    macro_paths = _load_macros(macros_el, xml_base_dir, macros)
+    # _xml_set_children(macros_el, macro_els)
+    return macro_paths
 
 
-def _macros_el(root):
+def _macros_el(root: "Element") -> Union["Element", None]:
     return root.find("macros")
 
 
-def _macros_of_type(macros_el, type, el_func):
-    if macros_el is None:
-        return {}
+T = TypeVar("T")
+
+
+def _macros_of_type(macros_el: "Element", type: str, el_func: Callable[["Element"], T]) -> Dict[str, T]:
     macro_els = macros_el.findall("macro")
-    filtered_els = [(macro_el.get("name"), el_func(macro_el)) for macro_el in macro_els if macro_el.get("type") == type]
-    return dict(filtered_els)
+    ret: Dict[str, T] = {}
+    for macro_el in macro_els:
+        if macro_el.get("type") == type:
+            macro_name = macro_el.get("name")
+            assert macro_name
+            ret[macro_name] = el_func(macro_el)
+    return ret
 
 
-def expand_nested_tokens(tokens):
+def expand_nested_tokens(tokens: Dict[str, str]) -> Dict[str, str]:
     for token_name in tokens.keys():
         for current_token_name, current_token_value in tokens.items():
             if token_name in current_token_value:
@@ -119,62 +137,67 @@ def expand_nested_tokens(tokens):
     return tokens
 
 
-def _expand_tokens(elements, tokens):
-    if not tokens or elements is None:
+def _expand_tokens(elements: Iterable["Element"], tokens: Dict[str, str]) -> None:
+    if not tokens:
         return
 
     for element in elements:
         _expand_tokens_for_el(element, tokens)
 
 
-def _expand_tokens_for_el(element, tokens):
+def _expand_tokens_for_el(element: "Element", tokens: Dict[str, str]) -> None:
     """
     expand tokens in element and (recursively) in its children
     replacements of text attributes and attribute values are
     possible
     """
-    value = element.text
-    if value:
-        new_value = _expand_tokens_str(element.text, tokens)
-        if new_value is not value:
+    element_text = element.text
+    if element_text:
+        new_value = _expand_tokens_str(element_text, tokens)
+        if new_value is not element_text:
             element.text = new_value
     for key, value in element.attrib.items():
-        new_value = _expand_tokens_str(value, tokens)
+        new_value = _expand_tokens_str(unicodify(value), tokens)
         if new_value is not value:
             element.attrib[key] = new_value
-        new_key = _expand_tokens_str(key, tokens)
+        new_key = _expand_tokens_str(unicodify(key), tokens)
         if new_key is not key:
             element.attrib[new_key] = element.attrib[key]
             del element.attrib[key]
     # recursively expand in childrens
-    _expand_tokens(list(element), tokens)
+    _expand_tokens(element.__iter__(), tokens)
 
 
-def _expand_tokens_str(s, tokens):
+def _expand_tokens_str(s: str, tokens: Dict[str, str]) -> str:
     for key, value in tokens.items():
         if key in s:
             s = s.replace(key, value)
     return s
 
 
-def _expand_macros(elements, macros, tokens, visited=None):
+def _expand_macros(
+    elements: Iterable["Element"],
+    macros: Dict[str, "XmlMacroDef"],
+    tokens: Dict[str, str],
+    visited: Optional[List[str]] = None,
+) -> None:
     if not macros and not tokens:
         return
 
     if visited is None:
-        v = []
-    else:
-        v = visited
+        visited = []
 
     for element in elements:
         while True:
             expand_el = element.find(".//expand")
             if expand_el is None:
                 break
-            _expand_macro(expand_el, macros, tokens, v)
+            _expand_macro(expand_el, macros, tokens, visited)
 
 
-def _expand_macro(expand_el, macros, tokens, visited):
+def _expand_macro(
+    expand_el: "Element", macros: Dict[str, "XmlMacroDef"], tokens: Dict[str, str], visited: List[str]
+) -> None:
     macro_name = expand_el.get("macro")
     assert macro_name is not None, "Attempted to expand macro with no 'macro' attribute defined."
     # check for cycles in the nested macro expansion
@@ -185,22 +208,22 @@ def _expand_macro(expand_el, macros, tokens, visited):
 
     assert macro_name in macros, f"No macro named {macro_name} found, known macros are {', '.join(macros.keys())}."
     macro_def = macros[macro_name]
-    expanded_elements = deepcopy(macro_def.element)
-    _expand_yield_statements(expanded_elements, expand_el)
+    macro_el = deepcopy(macro_def.element)
+    _expand_yield_statements(macro_el, expand_el)
 
     macro_tokens = macro_def.macro_tokens(expand_el)
     if macro_tokens:
-        _expand_tokens(expanded_elements, macro_tokens)
+        _expand_tokens(macro_el.__iter__(), macro_tokens)
 
     # Recursively expand contained macros.
-    _expand_macros(expanded_elements, macros, tokens, visited)
-    _xml_replace(expand_el, expanded_elements)
+    _expand_macros(macro_el.__iter__(), macros, tokens, visited)
+    _xml_replace(expand_el, macro_el.__iter__())
     del visited[-1]
 
 
-def _expand_yield_statements(macro_def, expand_el):
+def _expand_yield_statements(macro_el: "Element", expand_el: "Element") -> None:
     """
-    Modifies the macro_def element by replacing
+    Modifies the macro_el element by replacing
     1. all named yield tags by the content of the corresponding token tags
        - token tags need to be direct children of the expand
        - processed in order of definition of the token tags
@@ -208,40 +231,38 @@ def _expand_yield_statements(macro_def, expand_el):
     """
     # replace named yields
     for token_el in expand_el.findall("./token"):
-        name = token_el.attrib.get("name", None)
+        name = token_el.attrib.get("name")
         assert name is not None, "Found unnamed token" + str(token_el.attrib)
-        yield_els = list(macro_def.findall(f".//yield[@name='{name}']"))
+        yield_els = list(macro_el.findall(f".//yield[@name='{name}']"))
         assert len(yield_els) > 0, f"No named yield found for named token {name}"
-        token_el_children = list(token_el)
         for yield_el in yield_els:
-            _xml_replace(yield_el, token_el_children)
+            _xml_replace(yield_el, token_el.__iter__())
 
     # replace unnamed yields
-    yield_els = list(macro_def.findall(".//yield"))
+    yield_els = list(macro_el.findall(".//yield"))
     expand_el_children = [c for c in expand_el if c.tag != "token"]
     for yield_el in yield_els:
         _xml_replace(yield_el, expand_el_children)
 
 
-def _load_macros(macros_el, xml_base_dir, macros) -> List[str]:
+def _load_macros(macros_el: "Element", xml_base_dir: str, macros: MacrosDictT) -> List[str]:
     # Import macros from external files.
     macro_paths = _load_imported_macros(macros_el, xml_base_dir, macros)
     # Load all directly defined macros.
-    _load_embedded_macros(macros_el, xml_base_dir, macros)
+    _load_embedded_macros(macros_el, macros)
     return macro_paths
 
 
-def _load_embedded_macros(macros_el, xml_base_dir, macros):
-    if macros_el is None:
-        return
+def _load_embedded_macros(macros_el: "Element", macros: MacrosDictT) -> None:
     # attribute typed macro
     for macro in macros_el.iterfind("macro"):
         if "type" not in macro.attrib:
             macro.attrib["type"] = "xml"
+        macro_type = unicodify(macro.attrib["type"])
         try:
-            macros[macro.attrib["type"]].append(macro)
+            macros[macro_type].append(macro)
         except KeyError:
-            macros[macro.attrib["type"]] = [macro]
+            macros[macro_type] = [macro]
 
     # type shortcuts (<xml> is a shortcut for <macro type="xml",
     # likewise for <template>.
@@ -255,7 +276,7 @@ def _load_embedded_macros(macros_el, xml_base_dir, macros):
                 macros[tag] = [macro_el]
 
 
-def _load_imported_macros(macros_el, xml_base_dir, macros) -> List[str]:
+def _load_imported_macros(macros_el: "Element", xml_base_dir: str, macros: MacrosDictT) -> List[str]:
     macro_paths = []
 
     for tool_relative_import_path in _imported_macro_paths_from_el(macros_el):
@@ -266,28 +287,27 @@ def _load_imported_macros(macros_el, xml_base_dir, macros) -> List[str]:
     return macro_paths
 
 
-def _imported_macro_paths_from_el(macros_el):
+def _imported_macro_paths_from_el(macros_el: "Element") -> List[str]:
     imported_macro_paths = []
-    macro_import_els = []
-    if macros_el is not None:
-        macro_import_els = macros_el.findall("import")
-    for macro_import_el in macro_import_els:
+    for macro_import_el in macros_el.findall("import"):
         raw_import_path = macro_import_el.text
+        assert raw_import_path
         imported_macro_paths.append(raw_import_path)
     return imported_macro_paths
 
 
-def _load_macro_file(path: StrPath, xml_base_dir, macros) -> List[str]:
+def _load_macro_file(path: "StrPath", xml_base_dir: str, macros: MacrosDictT) -> List[str]:
     tree = parse_xml(path, strip_whitespace=False)
     root = tree.getroot()
     return _load_macros(root, xml_base_dir, macros)
 
 
-def _xml_replace(query, targets):
+def _xml_replace(query: "Element", targets: Iterable["Element"]) -> None:
     parent_el = query.find("..")
+    assert parent_el is not None
     matching_index = -1
     # for index, el in enumerate(parent_el.iter('.')):  ## Something like this for newer implementation
-    for index, el in enumerate(list(parent_el)):
+    for index, el in enumerate(parent_el):
         if el == query:
             matching_index = index
             break
@@ -308,47 +328,46 @@ class XmlMacroDef:
     - the quote character, default '@'
     - parameter name
 
-    parameter names can be given as comma separated list using the
-    `token` attribute or as attributes `token_XXX` (where `XXX` is the name).
+    Parameter names can be given as comma separated list using the
+    `tokens` attribute or as attributes `token_XXX` (where `XXX` is the name).
     The former option should be used to specify required attributes of the
-    macro and the latter for optional attributes if the macro (the value of
+    macro and the latter for optional attributes of the macro (the value of
     `token_XXX is used as default value).
 
     TODO: `token_quote` forbids `"quote"` as character name of optional
     parameters
     """
 
-    def __init__(self, el):
+    def __init__(self, el: "Element") -> None:
         self.element = el
-        parameters = {}
-        tokens = []
-        token_quote = "@"
+        tokens: Dict[str, Union[str, None]] = {}
+        self.token_quote = "@"
         for key, value in el.attrib.items():
+            key = unicodify(key)
+            value = unicodify(value)
             if key == "token_quote":
-                token_quote = value
+                self.token_quote = value
             if key == "tokens":
                 for token in value.split(","):
-                    tokens.append((token, REQUIRED_PARAMETER))
+                    tokens[token] = None  # here None means that the token is a required parameter
             elif key.startswith("token_"):
                 token = key[len("token_") :]
-                tokens.append((token, value))
-        for name, default in tokens:
-            parameters[name] = (token_quote, default)
-        self.parameters = parameters
+                tokens[token] = value
+        self.tokens = tokens
 
-    def macro_tokens(self, expand_el):
+    def macro_tokens(self, expand_el: "Element") -> Dict[str, str]:
         """
         get a dictionary mapping token names to values. The names are the
         parameter names surrounded by the quote character. Values are taken
         from the expand_el if absent default values of optional parameters are
         used.
         """
-        tokens = {}
-        for key, (wrap_char, default_val) in self.parameters.items():
+        tokens: Dict[str, str] = {}
+        for key, default_val in self.tokens.items():
             token_value = expand_el.attrib.get(key, default_val)
-            if token_value is REQUIRED_PARAMETER:
+            if token_value is None:
                 raise ValueError(f"Failed to expand macro - missing required parameter [{key}].")
-            token_name = f"{wrap_char}{key.upper()}{wrap_char}"
+            token_name = f"{self.token_quote}{key.upper()}{self.token_quote}"
             tokens[token_name] = token_value
         return tokens
 

--- a/lib/galaxy/webapps/galaxy/api/dynamic_tools.py
+++ b/lib/galaxy/webapps/galaxy/api/dynamic_tools.py
@@ -157,6 +157,8 @@ class DynamicToolApi:
         Deactivate the specified dynamic tool. Deactivated tools will not
         be loaded into the toolbox.
         """
-        dynamic_tool = dynamic_tool = self.dynamic_tools_manager.get_tool_by_id_or_uuid(dynamic_tool_id)
+        dynamic_tool = self.dynamic_tools_manager.get_tool_by_id_or_uuid(dynamic_tool_id)
+        if dynamic_tool is None:
+            raise ObjectNotFound()
         updated_dynamic_tool = self.dynamic_tools_manager.deactivate(dynamic_tool)
         return updated_dynamic_tool.to_dict()

--- a/lib/galaxy/webapps/galaxy/api/dynamic_tools.py
+++ b/lib/galaxy/webapps/galaxy/api/dynamic_tools.py
@@ -1,6 +1,8 @@
 import logging
 from datetime import datetime
 from typing import (
+    Any,
+    Dict,
     List,
     Optional,
     Union,
@@ -148,7 +150,7 @@ class DynamicToolApi:
         return dynamic_tool.to_dict()
 
     @router.delete("/api/dynamic_tools/{dynamic_tool_id}", require_admin=True)
-    def delete(self, dynamic_tool_id: DatabaseIdOrUUID):
+    def delete(self, dynamic_tool_id: DatabaseIdOrUUID) -> Dict[str, Any]:
         """
         DELETE /api/dynamic_tools/{encoded_dynamic_tool_id|tool_uuid}
 

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -11,6 +11,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    TYPE_CHECKING,
     Union,
 )
 
@@ -94,6 +95,9 @@ from galaxy.webapps.galaxy.api import (
 from galaxy.webapps.galaxy.api.common import UserIdPathParam
 from galaxy.webapps.galaxy.services.users import UsersService
 
+if TYPE_CHECKING:
+    from galaxy.work.context import SessionRequestContext
+
 log = logging.getLogger(__name__)
 
 router = Router(tags=["users"])
@@ -169,7 +173,7 @@ class FastAPIUsers:
     )
     def recalculate_disk_usage(
         self,
-        trans: ProvidesUserContext = DependsOnTrans,
+        trans: "SessionRequestContext" = DependsOnTrans,
     ):
         """This route will be removed in a future version.
 
@@ -191,7 +195,7 @@ class FastAPIUsers:
     def recalculate_disk_usage_by_user_id(
         self,
         user_id: UserIdPathParam,
-        trans: ProvidesUserContext = DependsOnTrans,
+        trans: "SessionRequestContext" = DependsOnTrans,
     ):
         result = self.service.recalculate_disk_usage(trans, user_id)
         return Response(status_code=status.HTTP_204_NO_CONTENT) if result is None else result

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -264,7 +264,7 @@ class ToolsService(ServiceBase):
         trans.security.encode_all_ids(rval, recursive=True)
         return rval
 
-    def _search(self, q, view):
+    def _search(self, q: str, view: Optional[str]) -> List[str]:
         """
         Perform the search on the given query.
         Boosts and numer of results are configurable in galaxy.ini file.

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -1,6 +1,7 @@
 from typing import (
     List,
     Optional,
+    TYPE_CHECKING,
     Union,
 )
 
@@ -40,6 +41,9 @@ from galaxy.webapps.galaxy.services.base import (
 )
 from galaxy.webapps.galaxy.services.roles import role_to_model
 
+if TYPE_CHECKING:
+    from galaxy.work.context import SessionRequestContext
+
 
 class UsersService(ServiceBase):
     """Common interface/service logic for interactions with users in the context of the API.
@@ -66,7 +70,7 @@ class UsersService(ServiceBase):
 
     def recalculate_disk_usage(
         self,
-        trans: ProvidesUserContext,
+        trans: "SessionRequestContext",
         user_id: int,
     ):
         if trans.anonymous:

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,6 +19,30 @@ warn_unused_ignores = True
 platform = linux
 
 # green list - work on growing these please!
+[mypy-galaxy.tool_util.toolbox.lineages.interface]
+disallow_any_generics = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+disallow_untyped_defs = True
+warn_return_any = True
+
+[mypy-galaxy.tools.cache]
+disallow_any_generics = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+disallow_untyped_defs = True
+warn_return_any = True
+
+[mypy-galaxy.tools.search]
+disallow_any_generics = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+disallow_untyped_defs = True
+warn_return_any = True
+
 [mypy-galaxy.util.compression_utils]
 disallow_any_generics = True
 disallow_subclassing_any = True
@@ -36,6 +60,14 @@ disallow_untyped_defs = True
 warn_return_any = True
 
 [mypy-galaxy.util.unittest_utils]
+disallow_any_generics = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+disallow_untyped_defs = True
+warn_return_any = True
+
+[mypy-galaxy.util.xml_macros]
 disallow_any_generics = True
 disallow_subclassing_any = True
 disallow_untyped_calls = True
@@ -510,8 +542,6 @@ check_untyped_defs = False
 [mypy-galaxy.managers.citations]
 check_untyped_defs = False
 [mypy-galaxy.config.script]
-check_untyped_defs = False
-[mypy-galaxy.tools.cache]
 check_untyped_defs = False
 [mypy-galaxy.tool_shed.cache]
 check_untyped_defs = False

--- a/packages/app/setup.cfg
+++ b/packages/app/setup.cfg
@@ -73,7 +73,6 @@ install_requires =
     regex
     requests
     SQLAlchemy>=2.0.37,<2.1,!=2.0.41
-    sqlitedict
     starlette
     svgwrite
     typing-extensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,6 @@ dependencies = [
     "social-auth-core>=4.5.0",  # to drop dependency on abandoned python-jose
     "sortedcontainers",
     "SQLAlchemy>=2.0.37,<2.1,!=2.0.41",  # https://github.com/sqlalchemy/sqlalchemy/issues/12019 , https://github.com/sqlalchemy/sqlalchemy/issues/12600
-    "sqlitedict",
     "sqlparse",
     "starlette",
     "starlette-context",

--- a/test/unit/tool_util/test_cwl.py
+++ b/test/unit/tool_util/test_cwl.py
@@ -358,8 +358,8 @@ def test_tool_reload():
     _inputs(tool_source)
 
 
-def _outputs(tool_source):
-    return tool_source.parse_outputs(object())
+def _outputs(tool_source: CwlToolSource):
+    return tool_source.parse_outputs(None)
 
 
 def _inputs(tool_source=None, path=None):


### PR DESCRIPTION
Close https://github.com/galaxyproject/galaxy/issues/20432 .

Also:
- Improve type annotations of tool-related code
- Small refactorings
- Drop dynamic tool from `toolbox._tools_by_uuid` dict when deactivated (see commit for details)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
