### PR TITLE
[24.2] Relax validation of XML test assertion parsing

### DIFF
--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -12,7 +12,10 @@ from packaging.version import Version
 
 from galaxy.tool_util.lint import Linter
 from galaxy.tool_util.parameters import validate_test_cases_for_tool_source
-from galaxy.tool_util.verify.assertion_models import assertion_list, relaxed_assertion_list
+from galaxy.tool_util.verify.assertion_models import (
+    assertion_list,
+    relaxed_assertion_list,
+)
 from galaxy.tool_util.verify.parse import tag_structure_to_that_structure
 from galaxy.util import asbool
 from ._util import is_datasource

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -148,6 +148,8 @@ class TestsAssertionValidation(Linter):
             lint_ctx.warn("Failed to parse test dictionaries from tool - cannot lint assertions")
             return
         assert "tests" in raw_tests_dict
+        # This really only allows coercion from strings, the values themselves will still be validated
+        strict_validation = tool_source.language != "xml"
         for test_idx, test in enumerate(raw_tests_dict["tests"], start=1):
             # TODO: validate command, command_version, element tests. What about children?
             for output in test["outputs"]:
@@ -156,7 +158,7 @@ class TestsAssertionValidation(Linter):
                 for raw_assert in asserts_raw:
                     to_yaml_assertions.append({"that": raw_assert["tag"], **raw_assert.get("attributes", {})})
                 try:
-                    assertion_list.model_validate(to_yaml_assertions)
+                    assertion_list.model_validate(to_yaml_assertions, strict=strict_validation)
                 except Exception as e:
                     error_str = _cleanup_pydantic_error(e)
                     lint_ctx.warn(

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -12,7 +12,8 @@ from packaging.version import Version
 
 from galaxy.tool_util.lint import Linter
 from galaxy.tool_util.parameters import validate_test_cases_for_tool_source
-from galaxy.tool_util.verify.assertion_models import assertion_list
+from galaxy.tool_util.verify.assertion_models import assertion_list, relaxed_assertion_list
+from galaxy.tool_util.verify.parse import tag_structure_to_that_structure
 from galaxy.util import asbool
 from ._util import is_datasource
 
@@ -149,16 +150,16 @@ class TestsAssertionValidation(Linter):
             return
         assert "tests" in raw_tests_dict
         # This really only allows coercion from strings, the values themselves will still be validated
-        strict_validation = tool_source.language != "xml"
+        assert_list_model = relaxed_assertion_list if tool_source.language == "xml" else assertion_list
         for test_idx, test in enumerate(raw_tests_dict["tests"], start=1):
             # TODO: validate command, command_version, element tests. What about children?
             for output in test["outputs"]:
                 asserts_raw = output.get("attributes", {}).get("assert_list") or []
-                to_yaml_assertions = []
+                processed_assertions = []
                 for raw_assert in asserts_raw:
-                    to_yaml_assertions.append({"that": raw_assert["tag"], **raw_assert.get("attributes", {})})
+                    processed_assertions.append(tag_structure_to_that_structure(raw_assert))
                 try:
-                    assertion_list.model_validate(to_yaml_assertions, strict=strict_validation)
+                    assert_list_model.model_validate(processed_assertions)
                 except Exception as e:
                     error_str = _cleanup_pydantic_error(e)
                     lint_ctx.warn(

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -850,6 +850,23 @@ VALID_CENTER_OF_MASS = """
     </tests>
 </tool>
 """
+ASSERTS_STRING_COERCION = """
+<tool id="id" name="name">
+    <outputs>
+        <data name="data_name" format="ome.tiff"/>
+    </outputs>
+    <tests>
+        <test>
+            <output name="data_name">
+               <assert_contents>
+                    <!-- channels is defined as an integer, so coercion from string must be applied on validation -->
+                    <has_image_channels channels="3" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>
+"""
 TESTS_VALID = """
 <tool id="id" name="name">
     <outputs>
@@ -1943,6 +1960,12 @@ def test_tests_asserts(lint_ctx):
     assert "Test 1: 'has_n_columns' needs to specify 'n', 'min', or 'max'" in lint_ctx.error_messages
     assert "Test 1: 'has_n_lines' needs to specify 'n', 'min', or 'max'" in lint_ctx.error_messages
     assert len(lint_ctx.error_messages) == 9
+
+
+def test_tests_asserts_string_coercion(lint_ctx):
+    tool_source = get_xml_tool_source(ASSERTS_STRING_COERCION)
+    run_lint_module(lint_ctx, tests, tool_source)
+    assert len(lint_ctx.warn_messages) == 0, lint_ctx.warn_messages
 
 
 def test_tests_assertion_models_valid(lint_ctx):


### PR DESCRIPTION
when tool source is XML. We can't really encode these attributes as JSON in XML, and while we could make it work it doesn't feel great to force tool authors to use such a hypothetical syntax.

I think we still keep all the nice validation here, it's just a little more lenient.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
