### PR TITLE
[25.0] Fixes for static handling and the web_client package

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2502,9 +2502,9 @@
 
 :Description:
     Serve static content, which must be enabled if you're not serving
-    it via a proxy server.  These options should be self explanatory
-    and so are not documented individually.  You can use these paths
-    (or ones in the proxy server) to point to your own styles.
+    it via a proxy server. You can use these paths (or ones in the
+    proxy server) to point to your own styles. The static_* options
+    that refer to paths are relative to the current working directory.
 :Default: ``true``
 :Type: bool
 
@@ -2514,10 +2514,8 @@
 ~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Serve static content, which must be enabled if you're not serving
-    it via a proxy server.  These options should be self explanatory
-    and so are not documented individually.  You can use these paths
-    (or ones in the proxy server) to point to your own styles.
+    Value of cache time for static content served by Galaxy. Ignored
+    if static_enabled is false.
 :Default: ``360``
 :Type: int
 
@@ -2527,11 +2525,21 @@
 ~~~~~~~~~~~~~~
 
 :Description:
-    Serve static content, which must be enabled if you're not serving
-    it via a proxy server.  These options should be self explanatory
-    and so are not documented individually.  You can use these paths
-    (or ones in the proxy server) to point to your own styles.
+    Path to the static content dir. Ignored if static_enabled is
+    false.
 :Default: ``static/``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~
+``static_dist_dir``
+~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Path to the built Galaxy client application, static/dist/ in the
+    Galaxy source code after the build is complete. Ignored if
+    static_enabled is false.
+:Default: ``static/dist/``
 :Type: str
 
 
@@ -2540,11 +2548,9 @@
 ~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Serve static content, which must be enabled if you're not serving
-    it via a proxy server.  These options should be self explanatory
-    and so are not documented individually.  You can use these paths
-    (or ones in the proxy server) to point to your own styles.
-:Default: ``static/images``
+    Path to the static images directory. Ignored if static_enabled is
+    false.
+:Default: ``static/images/``
 :Type: str
 
 
@@ -2553,10 +2559,8 @@
 ~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Serve static content, which must be enabled if you're not serving
-    it via a proxy server.  These options should be self explanatory
-    and so are not documented individually.  You can use these paths
-    (or ones in the proxy server) to point to your own styles.
+    Path to favicon.ico, not the directory that contains it (the name
+    is a misnomer). Ignored if static_enabled is false.
 :Default: ``static/favicon.ico``
 :Type: str
 
@@ -2566,10 +2570,8 @@
 ~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Serve static content, which must be enabled if you're not serving
-    it via a proxy server.  These options should be self explanatory
-    and so are not documented individually.  You can use these paths
-    (or ones in the proxy server) to point to your own styles.
+    Path to the static scripts directory. Ignored if static_enabled is
+    false.
 :Default: ``static/scripts/``
 :Type: str
 
@@ -2579,11 +2581,9 @@
 ~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Serve static content, which must be enabled if you're not serving
-    it via a proxy server.  These options should be self explanatory
-    and so are not documented individually.  You can use these paths
-    (or ones in the proxy server) to point to your own styles.
-:Default: ``static/style``
+    Path to the static style directory. Ignored if static_enabled is
+    false.
+:Default: ``static/style/``
 :Type: str
 
 
@@ -2592,10 +2592,7 @@
 ~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Serve static content, which must be enabled if you're not serving
-    it via a proxy server.  These options should be self explanatory
-    and so are not documented individually.  You can use these paths
-    (or ones in the proxy server) to point to your own styles.
+    Path to robots.txt. Ignored if static_enabled is false.
 :Default: ``static/robots.txt``
 :Type: str
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1533,51 +1533,40 @@ galaxy:
   #terms_url: null
 
   # Serve static content, which must be enabled if you're not serving it
-  # via a proxy server.  These options should be self explanatory and so
-  # are not documented individually.  You can use these paths (or ones
-  # in the proxy server) to point to your own styles.
+  # via a proxy server. You can use these paths (or ones in the proxy
+  # server) to point to your own styles. The static_* options that refer
+  # to paths are relative to the current working directory.
   #static_enabled: true
 
-  # Serve static content, which must be enabled if you're not serving it
-  # via a proxy server.  These options should be self explanatory and so
-  # are not documented individually.  You can use these paths (or ones
-  # in the proxy server) to point to your own styles.
+  # Value of cache time for static content served by Galaxy. Ignored if
+  # static_enabled is false.
   #static_cache_time: 360
 
-  # Serve static content, which must be enabled if you're not serving it
-  # via a proxy server.  These options should be self explanatory and so
-  # are not documented individually.  You can use these paths (or ones
-  # in the proxy server) to point to your own styles.
+  # Path to the static content dir. Ignored if static_enabled is false.
   #static_dir: static/
 
-  # Serve static content, which must be enabled if you're not serving it
-  # via a proxy server.  These options should be self explanatory and so
-  # are not documented individually.  You can use these paths (or ones
-  # in the proxy server) to point to your own styles.
-  #static_images_dir: static/images
+  # Path to the built Galaxy client application, static/dist/ in the
+  # Galaxy source code after the build is complete. Ignored if
+  # static_enabled is false.
+  #static_dist_dir: static/dist/
 
-  # Serve static content, which must be enabled if you're not serving it
-  # via a proxy server.  These options should be self explanatory and so
-  # are not documented individually.  You can use these paths (or ones
-  # in the proxy server) to point to your own styles.
+  # Path to the static images directory. Ignored if static_enabled is
+  # false.
+  #static_images_dir: static/images/
+
+  # Path to favicon.ico, not the directory that contains it (the name is
+  # a misnomer). Ignored if static_enabled is false.
   #static_favicon_dir: static/favicon.ico
 
-  # Serve static content, which must be enabled if you're not serving it
-  # via a proxy server.  These options should be self explanatory and so
-  # are not documented individually.  You can use these paths (or ones
-  # in the proxy server) to point to your own styles.
+  # Path to the static scripts directory. Ignored if static_enabled is
+  # false.
   #static_scripts_dir: static/scripts/
 
-  # Serve static content, which must be enabled if you're not serving it
-  # via a proxy server.  These options should be self explanatory and so
-  # are not documented individually.  You can use these paths (or ones
-  # in the proxy server) to point to your own styles.
-  #static_style_dir: static/style
+  # Path to the static style directory. Ignored if static_enabled is
+  # false.
+  #static_style_dir: static/style/
 
-  # Serve static content, which must be enabled if you're not serving it
-  # via a proxy server.  These options should be self explanatory and so
-  # are not documented individually.  You can use these paths (or ones
-  # in the proxy server) to point to your own styles.
+  # Path to robots.txt. Ignored if static_enabled is false.
   #static_robots_txt: static/robots.txt
 
   # Incremental Display Options

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -1866,19 +1866,17 @@ mapping:
         required: false
         desc: |
           Serve static content, which must be enabled if you're not serving it via a
-          proxy server.  These options should be self explanatory and so are not
-          documented individually.  You can use these paths (or ones in the proxy
-          server) to point to your own styles.
+          proxy server. You can use these paths (or ones in the proxy server) to point to
+          your own styles. The static_* options that refer to paths are relative to the
+          current working directory.
 
       static_cache_time:
         type: int
         default: 360
         required: false
         desc: |
-          Serve static content, which must be enabled if you're not serving it via a
-          proxy server.  These options should be self explanatory and so are not
-          documented individually.  You can use these paths (or ones in the proxy
-          server) to point to your own styles.
+          Value of cache time for static content served by Galaxy. Ignored if
+          static_enabled is false.
 
       static_dir:
         type: str
@@ -1886,21 +1884,24 @@ mapping:
         per_host: true
         required: false
         desc: |
-          Serve static content, which must be enabled if you're not serving it via a
-          proxy server.  These options should be self explanatory and so are not
-          documented individually.  You can use these paths (or ones in the proxy
-          server) to point to your own styles.
+          Path to the static content dir. Ignored if static_enabled is false.
 
-      static_images_dir:
+      static_dist_dir:
         type: str
-        default: static/images
+        default: static/dist/
         per_host: true
         required: false
         desc: |
-          Serve static content, which must be enabled if you're not serving it via a
-          proxy server.  These options should be self explanatory and so are not
-          documented individually.  You can use these paths (or ones in the proxy
-          server) to point to your own styles.
+          Path to the built Galaxy client application, static/dist/ in the Galaxy source
+          code after the build is complete. Ignored if static_enabled is false.
+
+      static_images_dir:
+        type: str
+        default: static/images/
+        per_host: true
+        required: false
+        desc: |
+          Path to the static images directory. Ignored if static_enabled is false.
 
       static_favicon_dir:
         type: str
@@ -1908,10 +1909,8 @@ mapping:
         per_host: true
         required: false
         desc: |
-          Serve static content, which must be enabled if you're not serving it via a
-          proxy server.  These options should be self explanatory and so are not
-          documented individually.  You can use these paths (or ones in the proxy
-          server) to point to your own styles.
+          Path to favicon.ico, not the directory that contains it (the name is a
+          misnomer). Ignored if static_enabled is false.
 
       static_scripts_dir:
         type: str
@@ -1919,21 +1918,15 @@ mapping:
         per_host: true
         required: false
         desc: |
-          Serve static content, which must be enabled if you're not serving it via a
-          proxy server.  These options should be self explanatory and so are not
-          documented individually.  You can use these paths (or ones in the proxy
-          server) to point to your own styles.
+          Path to the static scripts directory. Ignored if static_enabled is false.
 
       static_style_dir:
         type: str
-        default: static/style
+        default: static/style/
         per_host: true
         required: false
         desc: |
-          Serve static content, which must be enabled if you're not serving it via a
-          proxy server.  These options should be self explanatory and so are not
-          documented individually.  You can use these paths (or ones in the proxy
-          server) to point to your own styles.
+          Path to the static style directory. Ignored if static_enabled is false.
 
       static_robots_txt:
         type: str
@@ -1941,10 +1934,7 @@ mapping:
         per_host: true
         required: false
         desc: |
-          Serve static content, which must be enabled if you're not serving it via a
-          proxy server.  These options should be self explanatory and so are not
-          documented individually.  You can use these paths (or ones in the proxy
-          server) to point to your own styles.
+          Path to robots.txt. Ignored if static_enabled is false.
 
       display_chunk_size:
         type: int

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -66,9 +66,9 @@ from galaxy.web.framework.middleware.static import CacheableStaticURLParser as S
 try:
     import galaxy.web_client
 
-    default_static_dir = os.path.dirname(galaxy.web_client.__file__)
+    default_static_dist_dir = os.path.join(os.path.dirname(galaxy.web_client.__file__), "dist")
 except ImportError:
-    default_static_dir = "static/"
+    default_static_dist_dir = None  # type: ignore[assignment]
 
 log = logging.getLogger(__name__)
 
@@ -1160,17 +1160,19 @@ def build_url_map(app, global_conf, **local_conf):
         return Static(config_val, cache_time, directory_per_host=per_host_config)
 
     # Define static mappings from config
-    static_dir = get_static_from_config("static_dir", default_static_dir)
+    static_dir = get_static_from_config("static_dir", "static/")
     static_dir_bare = static_dir.directory.rstrip("/")
+    static_dist_dir = get_static_from_config("static_dist_dir", default_static_dist_dir or f"{static_dir_bare}/dist/")
     urlmap["/static"] = static_dir
+    urlmap["/static/dist"] = static_dist_dir
     urlmap["/images"] = get_static_from_config("static_images_dir", f"{static_dir_bare}/images")
     urlmap["/static/scripts"] = get_static_from_config("static_scripts_dir", f"{static_dir_bare}/scripts/")
 
     urlmap["/static/welcome.html"] = get_static_from_config(
         "static_welcome_html", f"{static_dir_bare}/welcome.html", sample=default_url_path("static/welcome.sample.html")
     )
-    urlmap["/static/favicon.svg"] = get_static_from_config(
-        "static_favicon_dir", f"{static_dir_bare}/favicon.svg", sample=default_url_path("static/favicon.svg")
+    urlmap["/favicon.ico"] = get_static_from_config(
+        "static_favicon_dir", f"{static_dir_bare}/favicon.ico", sample=default_url_path("static/favicon.ico")
     )
     urlmap["/robots.txt"] = get_static_from_config(
         "static_robots_txt", f"{static_dir_bare}/robots.txt", sample=default_url_path("static/robots.txt")

--- a/packages/packages_by_dep_dag.txt
+++ b/packages/packages_by_dep_dag.txt
@@ -25,7 +25,5 @@ app
 
 web_apps
 
-web_client
-
 test_driver
 tool_shed

--- a/packages/packages_by_dep_dag.txt
+++ b/packages/packages_by_dep_dag.txt
@@ -25,5 +25,7 @@ app
 
 web_apps
 
+web_client
+
 test_driver
 tool_shed

--- a/packages/web_client/setup.cfg
+++ b/packages/web_client/setup.cfg
@@ -27,7 +27,7 @@ long_description = file: README.rst, HISTORY.rst
 long_description_content_type = text/x-rst
 name = galaxy-web-client
 url = https://github.com/galaxyproject/galaxy
-version = 25.0.dev0
+version = 25.0.1.dev0
 
 [options]
 include_package_data = True


### PR DESCRIPTION
A few static things from Galaxy that aren't part of the client are still referenced, this change makes sure they're loaded properly in all contexts (installed, run from source, static path options default, static path options configured) when `static_enabled` is true. I also made the path to the client dist configurable.

I undid a change I made to handle `/static/favicon.svg` (default masthead logo), not sure why I changed that but it's covered by `/static`. I restored the previous `/favicon.ico` handling to fix the default favicon.

I added `web_client` to the package dag so it will actually be updated next time we do a release.

The `galaxy-web-client-install` script now links or copies the non-client-dist static stuff for installed Galaxies so that you have both the client and the other static bits (favicons, robots.txt, style/jquery-ui) in a single directory you can point your proxy's `/static` at.

`make config-rebuild` (`lib/galaxy/config/config_manage.py`) claims to update the sample config and docs but doesn't actually change anything.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  ```sh-session
  cd packages
  while read pkg; do pushd $pkg; make dist; popd; done < <(grep -v '^$' packages_by_dep_dag.txt)
  python3 -m venv /tmp/testenv
  . /tmp/testenv/bin/activate
  pip install -r ../requirements.txt
  while read pkg; do pip install $pkg/dist/*.whl; done < <(grep -v '^$' packages_by_dep_dag.txt)
  pip install gravity==1.1.0
  cd /tmp
  galaxy-web-client-install static
  galaxy-config --config-dir galaxy
  cd galaxy
  galaxy
  ^C
  Set galaxy.yml `static_dir` to `/tmp/static`
  galaxy
  ```

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
