### PR TITLE
[25.0] Bump up python for for pulsar package tests

### DIFF
--- a/.github/workflows/test_galaxy_packages_for_pulsar.yaml
+++ b/.github/workflows/test_galaxy_packages_for_pulsar.yaml
@@ -16,11 +16,11 @@ concurrency:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-22.04  # Python 3.7 is not available via setup-python on ubuntu >=24.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7']  # don't upgrade, see https://github.com/galaxyproject/galaxy/pull/16649
+        python-version: ['3.8']  # don't upgrade, see https://github.com/galaxyproject/galaxy/pull/16649
     steps:
       - uses: actions/checkout@v4
         with:

--- a/packages/job_metrics/setup.cfg
+++ b/packages/job_metrics/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -37,7 +36,7 @@ install_requires =
     galaxy-util
     backports.zoneinfo;python_version<'3.9'
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.packages.find]
 exclude =

--- a/packages/objectstore/setup.cfg
+++ b/packages/objectstore/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -38,7 +37,7 @@ install_requires =
     pydantic>=2,!=2.6.0,!=2.6.1
     PyYAML
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.packages.find]
 exclude =

--- a/packages/tool_util/setup.cfg
+++ b/packages/tool_util/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -46,7 +45,7 @@ install_requires =
     sortedcontainers
     typing-extensions
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.entry_points]
 console_scripts =

--- a/packages/tool_util_models/setup.cfg
+++ b/packages/tool_util_models/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -37,7 +36,7 @@ install_requires =
     pydantic>=2,!=2.6.0,!=2.6.1
     typing-extensions
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.entry_points]
 console_scripts =

--- a/packages/util/setup.cfg
+++ b/packages/util/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -46,7 +45,7 @@ install_requires =
     typing-extensions
     zipstream-new
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.extras_require]
 image-util =


### PR DESCRIPTION
We kept it going for another 2 years almost, but
https://github.com/galaxyproject/galaxy/pull/20511 breaks 3.7 (at least for test validation, which isn't super-critical for pulsar I think?).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
