### PR TITLE
[24.2] Do not expose user info to non authenticated users

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -204,7 +204,7 @@ class UsersService(ServiceBase):
     ) -> List[MaybeLimitedUserModel]:
         # never give any info to non-authenticated users
         if not trans.user:
-            return []
+            raise glx_exceptions.AuthenticationRequired("Only registered users can view the list of users")
 
         # check for early return conditions
         if deleted:

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -202,6 +202,10 @@ class UsersService(ServiceBase):
         f_name: Optional[str],
         f_any: Optional[str],
     ) -> List[MaybeLimitedUserModel]:
+        # never give any info to non-authenticated users
+        if not trans.user:
+            return []
+
         # check for early return conditions
         if deleted:
             if not trans.user_is_admin:
@@ -216,10 +220,7 @@ class UsersService(ServiceBase):
                 and not trans.app.config.expose_user_name
                 and not trans.app.config.expose_user_email
             ):
-                if trans.user:
-                    return [UserModel(**trans.user.to_dict())]
-                else:
-                    return []
+                return [UserModel(**trans.user.to_dict())]
 
         users = get_users_for_index(
             trans.sa_session,

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -51,7 +51,7 @@ class TestUsersApi(ApiTestCase):
     @requires_new_user
     def test_index_anon(self):
         user = self._setup_user(TEST_USER_EMAIL_INDEX_DELETED)
-        with self._different_user(anon=True)
+        with self._different_user(anon=True):
             all_users_response = self._get("users")
 
     @requires_new_user

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -47,12 +47,10 @@ class TestUsersApi(ApiTestCase):
         all_deleted_users = all_deleted_users_response_2.json()
         assert len([u for u in all_deleted_users if u["email"] == TEST_USER_EMAIL_INDEX_DELETED]) == 1
 
-    @requires_admin
-    @requires_new_user
     def test_index_anon(self):
-        user = self._setup_user(TEST_USER_EMAIL_INDEX_DELETED)
         with self._different_user(anon=True):
             all_users_response = self._get("users")
+            self._assert_status_code_is(all_users_response, 403)
 
     @requires_new_user
     def test_index_only_self_for_nonadmins(self):

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -47,6 +47,13 @@ class TestUsersApi(ApiTestCase):
         all_deleted_users = all_deleted_users_response_2.json()
         assert len([u for u in all_deleted_users if u["email"] == TEST_USER_EMAIL_INDEX_DELETED]) == 1
 
+    @requires_admin
+    @requires_new_user
+    def test_index_anon(self):
+        user = self._setup_user(TEST_USER_EMAIL_INDEX_DELETED)
+        with self._different_user(anon=True)
+            all_users_response = self._get("users")
+
     @requires_new_user
     def test_index_only_self_for_nonadmins(self):
         self._setup_user(TEST_USER_EMAIL)


### PR DESCRIPTION
fixes https://github.com/galaxyproject/galaxy/issues/20505 .. just do not understand https://github.com/galaxyproject/galaxy/issues/20505#issuecomment-2988177174

should be fine is non-authenticated users can't share anything (not sure about this)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
