### PR TITLE
Fixes for invocation import.

### DIFF
--- a/client/src/components/History/SwitchToHistoryLink.vue
+++ b/client/src/components/History/SwitchToHistoryLink.vue
@@ -24,9 +24,15 @@ const userStore = useUserStore();
 interface Props {
     historyId: string;
     filters?: Record<string, string | boolean>;
+    inline?: boolean;
+    thin?: boolean;
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+    filters: undefined,
+    inline: false,
+    thin: true,
+});
 
 const history = computed(() => historyStore.getHistoryById(props.historyId));
 
@@ -56,6 +62,13 @@ const linkTitle = computed(() => {
     }
 });
 
+const tag = computed(() => {
+    if (props.inline) {
+        return "span";
+    }
+    return "div";
+});
+
 async function onClick(event: MouseEvent, history: HistorySummary) {
     const eventStore = useEventStore();
     const ctrlKey = eventStore.isMac ? event.metaKey : event.ctrlKey;
@@ -81,15 +94,19 @@ function viewHistoryInNewTab(history: HistorySummary) {
     const routeData = router.resolve(`/histories/view?id=${history.id}`);
     window.open(routeData.href, "_blank");
 }
+
+const linkClass = computed(() => {
+    return props.inline ? ["history-link-inline"] : ["history-link"];
+});
 </script>
 
 <template>
-    <div>
+    <component :is="tag">
         <LoadingSpan v-if="!history" />
-        <div v-else class="history-link" data-description="switch to history link">
+        <component :is="tag" v-else :class="linkClass" data-description="switch to history link">
             <GLink
                 tooltip
-                thin
+                :thin="thin"
                 data-description="switch to history link"
                 :title="linkTitle"
                 @click.stop="onClick($event, history)">
@@ -98,8 +115,8 @@ function viewHistoryInNewTab(history: HistorySummary) {
 
             <FontAwesomeIcon v-if="history.purged" :icon="faBurn" fixed-width />
             <FontAwesomeIcon v-else-if="history.archived" :icon="faArchive" fixed-width />
-        </div>
-    </div>
+        </component>
+    </component>
 </template>
 
 <style scoped>

--- a/client/src/components/HistoryImport.vue
+++ b/client/src/components/HistoryImport.vue
@@ -20,13 +20,12 @@
             <LoadingSpan :message="`Waiting on ${identifierText} import job, this may take a while.`" />
         </div>
         <div v-else-if="complete">
-            <b-alert :show="complete" variant="success" dismissible @dismissed="complete = false">
-                <span class="mb-1 h-sm">Done!</span>
-                <p>
-                    {{ identifierTextCapitalized }} imported, check out
-                    <router-link :to="linkToList">your {{ identifierTextPlural }}</router-link>
-                </p>
-            </b-alert>
+            <ImportSuccess
+                v-if="jobId"
+                :job-id="jobId"
+                :link-to-list="linkToList"
+                :identifier-text-plural="identifierTextPlural"
+                :identifier-text-capitalized="identifierTextCapitalized" />
         </div>
         <div v-else>
             <b-form @submit.prevent="submit">
@@ -48,6 +47,17 @@
                             Select a repository (e.g. Galaxy's FTP)
                             <FontAwesomeIcon icon="folder-open" />
                         </b-form-radio>
+                    </b-form-radio-group>
+                </b-form-group>
+
+                <b-form-group v-if="invocationImport" v-slot="{ ariaDescribedby }" :label="whereLabel">
+                    <b-form-radio-group
+                        v-model="importTarget"
+                        :aria-describedby="ariaDescribedby"
+                        name="import-target"
+                        stacked>
+                        <b-form-radio value="newHistory"> Import into a new history. </b-form-radio>
+                        <b-form-radio value="currentHistory"> Import into the current history. </b-form-radio>
                     </b-form-radio-group>
                 </b-form-group>
 
@@ -86,6 +96,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { refDebounced } from "@vueuse/core";
 import axios from "axios";
 import BootstrapVue from "bootstrap-vue";
+import ImportSuccess from "components/ImportSuccess";
 import JobError from "components/JobInformation/JobError";
 import { waitOnJob } from "components/JobStates/wait";
 import LoadingSpan from "components/LoadingSpan";
@@ -107,7 +118,7 @@ library.add(faExternalLinkAlt);
 Vue.use(BootstrapVue);
 
 export default {
-    components: { FilesInput, FontAwesomeIcon, JobError, LoadingSpan, ExternalLink, GButton },
+    components: { FilesInput, FontAwesomeIcon, ImportSuccess, JobError, LoadingSpan, ExternalLink, GButton },
     props: {
         invocationImport: {
             type: Boolean,
@@ -138,18 +149,23 @@ export default {
         return {
             initializing: true,
             importType: "externalUrl",
+            importTarget: "newHistory", // "newHistory" or "currentHistory" - where to do import (if invocation)
             sourceFile: null,
             sourceRemoteFilesUri: "",
             errorMessage: null,
             waitingOnJob: false,
             complete: false,
             jobError: null,
+            jobId: null,
             hasFileSources: false,
         };
     },
     computed: {
         howLabel() {
             return `How would you like to specify the ${this.identifierText} archive?`;
+        },
+        whereLabel() {
+            return `Where would you like to import the ${this.identifierText} archive?`;
         },
         urlLabel() {
             return `Archived ${this.identifierTextCapitalized} URL`;
@@ -209,10 +225,14 @@ export default {
             } else if (importType == "remoteFilesUri") {
                 formData.append("archive_source", this.sourceRemoteFilesUri);
             }
+            if (this.importTarget == "newHistory") {
+                formData.append("name", "History for Workflow Import");
+            }
             axios
                 .post(`${getAppRoot()}api/histories`, formData)
                 .then((response) => {
                     this.waitingOnJob = true;
+                    this.jobId = response.data.id;
                     waitOnJob(response.data.id)
                         .then((jobResponse) => {
                             this.waitingOnJob = false;

--- a/client/src/components/HistoryImport.vue
+++ b/client/src/components/HistoryImport.vue
@@ -30,7 +30,7 @@
         </div>
         <div v-else>
             <b-form @submit.prevent="submit">
-                <b-form-group v-slot="{ ariaDescribedby }" label="How would you like to specify the history archive?">
+                <b-form-group v-slot="{ ariaDescribedby }" :label="howLabel">
                     <b-form-radio-group
                         v-model="importType"
                         :aria-describedby="ariaDescribedby"
@@ -51,7 +51,7 @@
                     </b-form-radio-group>
                 </b-form-group>
 
-                <b-form-group v-if="importType === 'externalUrl'" label="Archived History URL">
+                <b-form-group v-if="importType === 'externalUrl'" :label="urlLabel">
                     <b-alert v-if="showImportUrlWarning" variant="warning" show>
                         It looks like you are trying to import a published history from another galaxy instance. You can
                         only import histories via an archive URL.
@@ -63,7 +63,7 @@
 
                     <b-form-input v-model="sourceURL" type="url" />
                 </b-form-group>
-                <b-form-group v-else-if="importType === 'upload'" label="Archived History File">
+                <b-form-group v-else-if="importType === 'upload'" :label="fileLabel">
                     <b-form-file v-model="sourceFile" />
                 </b-form-group>
                 <b-form-group v-show="importType === 'remoteFilesUri'" label="Repository">
@@ -148,6 +148,15 @@ export default {
         };
     },
     computed: {
+        howLabel() {
+            return `How would you like to specify the ${this.identifierText} archive?`;
+        },
+        urlLabel() {
+            return `Archived ${this.identifierTextCapitalized} URL`;
+        },
+        fileLabel() {
+            return `Archived ${this.identifierTextCapitalized} File`;
+        },
         importReady() {
             const importType = this.importType;
             if (importType == "externalUrl") {

--- a/client/src/components/ImportSuccess.vue
+++ b/client/src/components/ImportSuccess.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { computed, watch } from "vue";
+
+import { useJobStore } from "@/stores/jobStore";
+
+import SwitchToHistoryLink from "@/components/History/SwitchToHistoryLink.vue";
+
+interface Props {
+    jobId: string;
+    linkToList: string;
+    identifierTextPlural: string;
+    identifierTextCapitalized: string;
+}
+
+const props = defineProps<Props>();
+
+const emit = defineEmits<{
+    (e: "dismissed"): void;
+}>();
+
+const jobStore = useJobStore();
+
+const historyId = computed(() => {
+    return jobStore.getJob(props.jobId)?.history_id;
+});
+
+async function init() {
+    jobStore.fetchJob({ id: props.jobId });
+}
+
+watch(() => props.jobId, init, { immediate: true });
+</script>
+
+<template>
+    <b-alert show variant="success" dismissible @dismissed="emit('dismissed')">
+        <span class="mb-1 h-sm">Done!</span>
+        <p v-if="historyId">
+            {{ identifierTextCapitalized }} imported into
+            <SwitchToHistoryLink v-if="historyId" :thin="false" :inline="true" :history-id="historyId" />
+            (click the history name to switch to the history containing the import or check out
+            <router-link :to="linkToList">your {{ identifierTextPlural }}</router-link
+            >)
+        </p>
+        <p v-else>
+            {{ identifierTextCapitalized }} imported, check out
+            <router-link :to="linkToList">your {{ identifierTextPlural }}</router-link>
+        </p>
+    </b-alert>
+</template>

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -364,11 +364,11 @@ class HistoryManager(sharable.SharableModelManager[model.History], deletable.Pur
         stmt = select(Job).where(Job.history == history).where(Job.state.in_(Job.non_ready_states))
         return self.session().scalars(stmt)
 
-    def queue_history_import(self, trans, archive_type, archive_source):
+    def queue_history_import(self, trans, archive_type, archive_source, target_history=None):
         # Run job to do import.
         history_imp_tool = trans.app.toolbox.get_tool("__IMPORT_HISTORY__")
         incoming = {"__ARCHIVE_SOURCE__": archive_source, "__ARCHIVE_TYPE__": archive_type}
-        job, *_ = history_imp_tool.execute(trans, incoming=incoming)
+        job, *_ = history_imp_tool.execute(trans, incoming=incoming, history=target_history)
         trans.app.job_manager.enqueue(job, tool=history_imp_tool)
         return job
 


### PR DESCRIPTION
There are various language problems with history not being replaced with invocation that needed to be fixed. Also add a new option with a new default to export it to the new history.

<img width="574" alt="Screenshot 2025-06-19 at 3 08 42 PM" src="https://github.com/user-attachments/assets/4cb430a9-c0b5-4497-870c-b48ba437c078" />

This functionality unfortunately uses the history import API endpoint which already had a documented parameter "name" that says it is the name for the new history - so this implementation just supplies a name when targeting a new history and uses that dispatch on whether to create a new history or not. It is a bit ugly but arguably it makes the endpoint a little more holistic.

I've also re-worked the landing page on successful imports. Instead of just providing a link to the list of imported histories or invocations - there is now a link with the history name that the researcher can switch to.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Invocations -> Open Invocation List -> notice the new options and try them out.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
