### PR TITLE
[25.0] Fix import of ``galaxy.tool_util.cwl`` module

### DIFF
--- a/lib/galaxy/tool_util/cwl/cwltool_deps.py
+++ b/lib/galaxy/tool_util/cwl/cwltool_deps.py
@@ -14,7 +14,6 @@ from galaxy.util import requests
 
 try:
     from cwltool import (
-        job,
         main,
         pathmapper,
         process,
@@ -23,7 +22,6 @@ try:
 except ImportError:
     main = None  # type: ignore[assignment]
     workflow = None  # type: ignore[assignment]
-    job = None  # type: ignore[assignment]
     process = None  # type: ignore[assignment]
     pathmapper = None  # type: ignore[assignment]
 
@@ -61,6 +59,11 @@ try:
 except ImportError:
     default_loader = None  # type: ignore[assignment]
     resolve_and_validate_document = None  # type: ignore[assignment]
+
+try:
+    from cwltool.process import Process
+except ImportError:
+    Process = None  # type: ignore[assignment, misc]
 
 try:
     from cwltool.utils import (
@@ -131,6 +134,7 @@ __all__ = (
     "normalizeFilesDirs",
     "pathmapper",
     "process",
+    "Process",
     "ref_resolver",
     "relink_initialworkdir",
     "resolve_and_validate_document",

--- a/lib/galaxy/tool_util/cwl/parser.py
+++ b/lib/galaxy/tool_util/cwl/parser.py
@@ -70,6 +70,7 @@ if TYPE_CHECKING:
     from .cwltool_deps import (
         CWLObjectType,
         JobsType,
+        Process,
         workflow,
     )
     from .schema import RawProcessReference
@@ -124,7 +125,7 @@ class ToolProxy(metaclass=ABCMeta):
 
     def __init__(
         self,
-        tool: process.Process,
+        tool: "Process",
         uuid: Union[UUID, str],
         raw_process_reference: Optional["RawProcessReference"] = None,
         tool_path: Optional[str] = None,
@@ -828,7 +829,7 @@ def _to_cwl_tool_object(
 
 
 def _cwl_tool_object_to_proxy(
-    cwl_tool: process.Process,
+    cwl_tool: "Process",
     uuid: Union[UUID, str],
     raw_process_reference: Optional["RawProcessReference"] = None,
     tool_path: Optional[str] = None,


### PR DESCRIPTION
when cwltool is not installed.

Fix:

```
Traceback (most recent call last):
  File "/home/conda/feedstock_root/build_artifacts/galaxy-tool-util_1750355530639/test_tmp/run_test.py", line 11, in <module>
    import galaxy.tool_util.cwl
  File "/home/conda/feedstock_root/build_artifacts/galaxy-tool-util_1750355530639/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.9/site-packages/galaxy/tool_util/cwl/__init__.py", line 2, in <module>
    from .parser import (
  File "/home/conda/feedstock_root/build_artifacts/galaxy-tool-util_1750355530639/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.9/site-packages/galaxy/tool_util/cwl/parser.py", line 122, in <module>
    class ToolProxy(metaclass=ABCMeta):
  File "/home/conda/feedstock_root/build_artifacts/galaxy-tool-util_1750355530639/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.9/site-packages/galaxy/tool_util/cwl/parser.py", line 127, in ToolProxy
    tool: process.Process,
AttributeError: 'NoneType' object has no attribute 'Process'
```

Needed for https://github.com/conda-forge/galaxy-tool-util-feedstock/pull/34 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. python3 -m venv /tmp/test_tool_util
  2. . /tmp/test_tool_util/bin/activate
  3. cd packages/tool_util/
  4. pip install .
  5. python3 -c 'import galaxy.tool_util.cwl'

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
