### PR TITLE
[25.0] Bump Gravity to 1.1.1

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -70,7 +70,7 @@ frozenlist==1.6.0
 fs==2.4.16
 fsspec==2025.3.2
 future==1.0.0
-gravity==1.1.0
+gravity==1.1.1
 greenlet==3.2.1 ; (python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'WIN32') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'ppc64le') or (python_full_version < '3.14' and platform_machine == 'win32') or (python_full_version < '3.14' and platform_machine == 'x86_64')
 gunicorn==23.0.0
 gxformat2==0.20.0

--- a/packages/config/test-requirements.txt
+++ b/packages/config/test-requirements.txt
@@ -1,2 +1,2 @@
-gravity>=1.0
+gravity>=1.1.1
 pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "fissix",
     "fs",
     "future>=1.0.0",  # Python 3.12 support
-    "gravity>=1.0.4",
+    "gravity>=1.1.1",
     "gunicorn",
     "gxformat2",
     "h5grove>=1.2.1",


### PR DESCRIPTION
Fixes the invocation of standalone (handler) Galaxy servers when installed.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
