### PR TITLE
[25.0] Prevent DCE collections from being renamed

### DIFF
--- a/client/src/components/Collections/common/ClickToEdit.vue
+++ b/client/src/components/Collections/common/ClickToEdit.vue
@@ -70,6 +70,7 @@ function revertToOriginal() {
             title="Press enter/return to save, esc to revert changes"
             contenteditable
             max-rows="4"
+            aria-label="Press enter/return to save, esc to revert changes"
             @blur.prevent.stop="onBlur"
             @keyup.prevent.stop.enter="editable = false"
             @keyup.prevent.stop.escape="revertToOriginal"

--- a/client/src/components/Collections/common/ClickToEdit.vue
+++ b/client/src/components/Collections/common/ClickToEdit.vue
@@ -67,6 +67,7 @@ function revertToOriginal() {
             v-model="localValue"
             class="w-100 input-with-icon"
             tabindex="0"
+            title="Press enter/return to save, esc to revert changes"
             contenteditable
             max-rows="4"
             @blur.prevent.stop="onBlur"

--- a/client/src/components/History/CurrentCollection/CollectionDetails.vue
+++ b/client/src/components/History/CurrentCollection/CollectionDetails.vue
@@ -24,6 +24,7 @@ const jobState = computed(() => {
         :name="dsc.name ?? ''"
         :tags="dsc.tags"
         :writeable="writeable"
+        :renameable="writeable"
         :show-annotation="false"
         @save="$emit('update:dsc', $event)">
         <template v-slot:description>

--- a/client/src/components/History/Layout/DetailsLayout.test.js
+++ b/client/src/components/History/Layout/DetailsLayout.test.js
@@ -7,11 +7,15 @@ import DetailsLayout from "./DetailsLayout";
 
 const localVue = getLocalVue();
 
-async function createWrapper(component, localVue, userData) {
+async function createWrapper(component, localVue, userData, unwritable = false) {
     const pinia = createPinia();
     const wrapper = mount(component, {
         localVue,
         pinia,
+        propsData: {
+            writeable: !unwritable,
+            renameable: !unwritable,
+        },
     });
     const userStore = useUserStore();
     userStore.currentUser = { ...userStore.currentUser, ...userData };
@@ -19,18 +23,39 @@ async function createWrapper(component, localVue, userData) {
 }
 
 describe("DetailsLayout", () => {
-    it("allows logged-in users to edit details", async () => {
+    it("allows logged-in users to edit all details", async () => {
         const wrapper = await createWrapper(DetailsLayout, localVue, {
             id: "user.id",
             email: "user.email",
         });
 
         expect(wrapper.find(".edit-button").attributes("title")).toBe("Edit");
+
+        // Click to edit and rename
+        expect(wrapper.find(".click-to-edit-label").exists()).toBe(true);
     });
 
-    it("prompts anonymous users to log in", async () => {
+    it("prompts anonymous users to log in to edit all details, but allows rename", async () => {
         const wrapper = await createWrapper(DetailsLayout, localVue, {});
 
         expect(wrapper.find(".edit-button").attributes("title")).toContain("Log in");
+
+        // Click to edit and rename should still be available
+        expect(wrapper.find(".click-to-edit-label").exists()).toBe(true);
+    });
+
+    it("disallows editing and renaming if props set them to false", async () => {
+        const wrapper = await createWrapper(
+            DetailsLayout,
+            localVue,
+            {
+                id: "user.id",
+                email: "user.email",
+            },
+            true
+        );
+
+        expect(wrapper.find(".edit-button").attributes("title")).toContain("Not Editable");
+        expect(wrapper.find(".click-to-edit-label").exists()).toBe(false);
     });
 });

--- a/client/src/components/History/Layout/DetailsLayout.vue
+++ b/client/src/components/History/Layout/DetailsLayout.vue
@@ -21,6 +21,7 @@ interface Props {
     name?: string;
     tags?: string[];
     writeable?: boolean;
+    renameable?: boolean;
     annotation?: string;
     showAnnotation?: boolean;
     summarized?: DetailsLayoutSummarized;
@@ -30,6 +31,7 @@ const props = withDefaults(defineProps<Props>(), {
     name: undefined,
     tags: undefined,
     writeable: true,
+    renameable: true,
     annotation: undefined,
     showAnnotation: true,
     summarized: undefined,
@@ -119,14 +121,19 @@ function selectText() {
 <template>
     <section :class="detailsClass" data-description="edit details">
         <div class="d-flex justify-content-between w-100">
-            <ClickToEdit
-                v-if="!summarized && !editing"
-                v-model="clickToEditName"
-                component="h3"
-                title="..."
-                data-description="name display"
-                no-save-on-blur
-                class="my-2 w-100" />
+            <template v-if="!summarized && !editing">
+                <ClickToEdit
+                    v-if="renameable"
+                    v-model="clickToEditName"
+                    component="h3"
+                    title="..."
+                    data-description="name display"
+                    no-save-on-blur
+                    class="my-2 w-100" />
+                <h3 v-else class="my-2 w-100">
+                    {{ props.name || "..." }}
+                </h3>
+            </template>
             <div v-else style="max-width: 80%">
                 <TextSummary
                     :description="name"


### PR DESCRIPTION
Fixes https://help.galaxyproject.org/t/how-can-i-rename-a-paired-fastq-file/15784

Adds a `renameable` prop to `DetailsLayout` in addition to the existing `writeable` prop, because this way, we allow anonymous user histories to still be renamed (https://github.com/galaxyproject/galaxy/issues/20197) and in the case of the collection layout, DCEs are made not-renameable and unwriteable.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
