### PR TITLE
[25.0] Use venv instead of virtualenv in package `make setup-venv`

### DIFF
--- a/packages/package.Makefile
+++ b/packages/package.Makefile
@@ -43,7 +43,7 @@ clean-tests:
 	rm -fr .tox/
 
 setup-venv:
-	if [ ! -d $(VENV) ]; then virtualenv $(VENV); exit; fi;
+	if [ ! -d $(VENV) ]; then python -m venv $(VENV); exit; fi;
 	$(IN_VENV) pip install -r dev-requirements.txt
 
 test:

--- a/packages/web_client/Makefile
+++ b/packages/web_client/Makefile
@@ -42,12 +42,13 @@ clean-pyc:
 clean-tests:
 	rm -fr .tox/
 
+# Removing .venv instead of $(VENV) is intentional, because we can't guarantee we created $(VENV)
 clean-web-client:
 	rm -rf .venv
 	rm -rf galaxy/web_client/dist galaxy/web_client/client_build_hash.txt
 
 setup-venv:
-	if [ ! -d $(VENV) ]; then virtualenv $(VENV); exit; fi;
+	if [ ! -d $(VENV) ]; then python -m venv $(VENV); exit; fi;
 	$(IN_VENV) pip install -r dev-requirements.txt
 
 test:


### PR DESCRIPTION
[The 25.0.1 package build](https://github.com/galaxyproject/galaxy/actions/runs/15787545273/job/44507084625) failed in GHA because unlike the rest of the packages, web_client's `make dist` depends on the `setup-venv` target and the GHA runner doesn't have `virtualenv`. This should fix the process for 25.0.2.

The reasoning for web_client's use of `setup-venv` is that it we install the pinned version of Node into it for the build. The venv is removed when `make clean` (a dependency of `make dist`) is run, to make sure the correct version is always used. As far as I know, no other process uses the `$(VENV)`/`$(IN_VENV)` functionality for packages, even though it's all plumbed.

We could instead do what every other package does and just fire away installing into whatever env is currently active, which is probably fine for release packages built in GHA. But in development, it means nodeenv is going to install node every time you run `make dist` because nodeenv is not idempotent, which is really annoying. The current Makefile avoids this by depending on `$(VENV)/bin/yarn` to determine whether nodeenv/node/yarn need to be installed (and you can set `$VENV` to something that won't be cleaned by `make dist`, but we can't do this when we don't know where yarn is installed to.

If we don't care about development annoyance I can just remove the `setup-venv` dependency and stick all the dep installation directly under `make dist`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
