### PR TITLE
[24.2] Move definition of ``DatasetCollectionDescriptionT`` before its use

### DIFF
--- a/lib/galaxy/tool_util/parser/output_models.py
+++ b/lib/galaxy/tool_util/parser/output_models.py
@@ -29,6 +29,35 @@ class ToolOutputBaseModel(BaseModel):
     hidden: bool
 
 
+DiscoverViaT = Literal["tool_provided_metadata", "pattern"]
+SortKeyT = Literal["filename", "name", "designation", "dbkey"]
+SortCompT = Literal["lexical", "numeric"]
+
+
+class DatasetCollectionDescription(BaseModel):
+    discover_via: DiscoverViaT
+    format: Optional[str]
+    visible: bool
+    assign_primary_output: bool
+    directory: Optional[str]
+    recurse: bool
+    match_relative_path: bool
+
+
+class ToolProvidedMetadataDatasetCollection(DatasetCollectionDescription):
+    discover_via: Literal["tool_provided_metadata"]
+
+
+class FilePatternDatasetCollectionDescription(DatasetCollectionDescription):
+    discover_via: Literal["pattern"]
+    sort_key: SortKeyT
+    sort_comp: SortCompT
+    pattern: str
+
+
+DatasetCollectionDescriptionT = Union[FilePatternDatasetCollectionDescription, ToolProvidedMetadataDatasetCollection]
+
+
 class ToolOutputDataset(ToolOutputBaseModel):
     type: Literal["data"]
     format: str
@@ -68,35 +97,6 @@ class ToolOutputFloat(ToolOutputSimple):
 
 class ToolOutputBoolean(ToolOutputSimple):
     type: Literal["boolean"]
-
-
-DiscoverViaT = Literal["tool_provided_metadata", "pattern"]
-SortKeyT = Literal["filename", "name", "designation", "dbkey"]
-SortCompT = Literal["lexical", "numeric"]
-
-
-class DatasetCollectionDescription(BaseModel):
-    discover_via: DiscoverViaT
-    format: Optional[str]
-    visible: bool
-    assign_primary_output: bool
-    directory: Optional[str]
-    recurse: bool
-    match_relative_path: bool
-
-
-class ToolProvidedMetadataDatasetCollection(DatasetCollectionDescription):
-    discover_via: Literal["tool_provided_metadata"]
-
-
-class FilePatternDatasetCollectionDescription(DatasetCollectionDescription):
-    discover_via: Literal["pattern"]
-    sort_key: SortKeyT
-    sort_comp: SortCompT
-    pattern: str
-
-
-DatasetCollectionDescriptionT = Union[FilePatternDatasetCollectionDescription, ToolProvidedMetadataDatasetCollection]
 
 
 ToolOutputT = Union[


### PR DESCRIPTION
Fix the following error on py37-test_galaxy_packages_for_pulsar tests:

```
FAILED tests/tool_util/test_input_models.py::test_input_collection_type - pydantic.errors.PydanticUserError: `ParsedTool` is not fully defined; you should define `DatasetCollectionDescriptionT`, then call `ParsedTool.model_rebuild()`.
```

Backport of commit bb87560d8f45f0219e179a0da3e65de0e522ae89 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
