### PR TITLE
[25.0] Fix description and metadata of some packages

### DIFF
--- a/packages/schema/setup.cfg
+++ b/packages/schema/setup.cfg
@@ -17,7 +17,7 @@ classifiers =
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing
-description = Galaxy auth framework and implementations
+description = Pydantic models for Galaxy
 keywords =
     Galaxy
 license = AFL

--- a/packages/tool_shed/setup.cfg
+++ b/packages/tool_shed/setup.cfg
@@ -17,7 +17,7 @@ classifiers =
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing
-description = Galaxy auth framework and implementations
+description = Galaxy Tool Shed
 keywords =
     Galaxy
 license = AFL

--- a/packages/tool_shed_schema/setup.cfg
+++ b/packages/tool_shed_schema/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -19,7 +18,7 @@ classifiers =
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing
-description = Galaxy tool and tool dependency utilities
+description = Pydantic models for the Galaxy Tool Shed
 keywords =
     Galaxy
 license = AFL
@@ -38,7 +37,7 @@ install_requires =
     pydantic>=2,!=2.6.0,!=2.6.1
     typing-extensions
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.entry_points]
 console_scripts =

--- a/packages/tool_util_models/setup.cfg
+++ b/packages/tool_util_models/setup.cfg
@@ -19,10 +19,10 @@ classifiers =
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing
-description = Galaxy tool and tool dependency utilities
+description = Pydantic models for Galaxy tools
 keywords =
     Galaxy
-license = AFL
+license = MIT
 license_files =
     LICENSE
 long_description = file: README.rst, HISTORY.rst


### PR DESCRIPTION
Pretty sure everything in galaxy-tool-util-models was added after we switched to require MIT (or is from people that agreed to relicense their past contributions under MIT).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
