### PR TITLE
[25.0] Fix activity bar reordering persistence

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -98,9 +98,20 @@ const emit = defineEmits<{
 // activities from store
 const { activities: storeActivities, isSideBarOpen, sidePanelWidth } = storeToRefs(activityStore);
 
-const activities = computed(() =>
-    storeActivities.value.filter((activity) => activity.id !== "user-defined-tools" || canUseUnprivilegedTools.value)
-);
+const activities = computed({
+    get() {
+        return storeActivities.value.filter(
+            (activity) => activity.id !== "user-defined-tools" || canUseUnprivilegedTools.value
+        );
+    },
+    set(newActivities: Activity[]) {
+        // Find any filtered-out activities and add them back
+        const filteredOut = storeActivities.value.filter(
+            (activity) => activity.id === "user-defined-tools" && !canUseUnprivilegedTools.value
+        );
+        storeActivities.value = [...newActivities, ...filteredOut];
+    },
+});
 
 // drag references
 const dragTarget: Ref<EventTarget | null> = ref(null);
@@ -219,7 +230,7 @@ defineExpose({
             @dragleave.prevent="onDragLeave">
             <b-nav vertical class="flex-nowrap p-1 h-100 vertical-overflow">
                 <draggable
-                    :list="activities"
+                    v-model="activities"
                     :class="{ 'activity-popper-disabled': isDragging }"
                     :disabled="!canDrag"
                     :force-fallback="true"


### PR DESCRIPTION
Activity bar reordering was broken when the activities computed property
was changed from a direct store reference to a read-only computed
property with filtering.

Fixes #20499


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
