### PR TITLE
Add Dataverse template

### DIFF
--- a/client/src/api/fileSources.ts
+++ b/client/src/api/fileSources.ts
@@ -62,6 +62,10 @@ export const templateTypes: FileSourceTypesDetail = {
         icon: faNetworkWired,
         message: "This is a remote file source that connects with the Gallery of an RSpace instance.",
     },
+    dataverse: {
+        icon: faNetworkWired,
+        message: "This is a repository plugin that connects with a Dataverse.org instance.",
+    },
 };
 
 export const FileSourcesValidFilters = {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -10712,7 +10712,8 @@ export interface components {
                 | "elabftw"
                 | "inveniordm"
                 | "zenodo"
-                | "rspace";
+                | "rspace"
+                | "dataverse";
             /** Variables */
             variables?:
                 | (
@@ -20463,7 +20464,8 @@ export interface components {
                 | "elabftw"
                 | "inveniordm"
                 | "zenodo"
-                | "rspace";
+                | "rspace"
+                | "dataverse";
             /** Uri Root */
             uri_root: string;
             /**

--- a/client/src/components/FileSources/FileSourceTypeSpan.vue
+++ b/client/src/components/FileSources/FileSourceTypeSpan.vue
@@ -16,6 +16,7 @@ const MESSAGES = {
     inveniordm: "This is a repository plugin that connects with an InvenioRDM instance.",
     zenodo: "This is a repository plugin that connects with https://zenodo.org/.",
     rspace: "This is a repository plugin that connects with an RSpace instance.",
+    dataverse: "This is a repository plugin that connects with a Dataverse.org instance.",
 };
 
 interface Props {

--- a/lib/galaxy/files/sources/dataverse.py
+++ b/lib/galaxy/files/sources/dataverse.py
@@ -9,6 +9,7 @@ from typing import (
     Optional,
     Tuple,
 )
+from urllib.error import HTTPError
 from urllib.parse import quote
 
 from typing_extensions import (
@@ -377,7 +378,7 @@ class DataverseRepositoryInteractor(RDMRepositoryInteractor):
                 return stream_to_open_named_file(
                     page, f.fileno(), file_path, source_encoding=get_charset_from_http_headers(page.headers)
                 )
-        except urllib.error.HTTPError as e:
+        except HTTPError as e:
             # TODO: We can only download files from published datasets for now
             if e.code in [401, 403, 404]:
                 raise NotFoundException(
@@ -436,21 +437,21 @@ class DataverseRepositoryInteractor(RDMRepositoryInteractor):
 
     def _ensure_response_has_expected_status_code(self, response, expected_status_code: int):
         if response.status_code != expected_status_code:
-            if response.status_code == 403:
-                self._raise_auth_required()
             error_message = self._get_response_error_message(response)
+            if response.status_code == 403:
+                self._raise_auth_required(error_message)
             raise Exception(
                 f"Request to {response.url} failed with status code {response.status_code}: {error_message}"
             )
 
-    def _raise_auth_required(self):
+    def _raise_auth_required(self, message: Optional[str] = None):
         raise AuthenticationRequired(
-            f"Please provide a personal access token in your user's preferences for '{self.plugin.label}'"
+            message or f"Please provide a personal access token in your user's preferences for '{self.plugin.label}'"
         )
 
     def _get_response_error_message(self, response):
         response_json = response.json()
-        error_message = response_json.get("message") if response.status_code == 400 else response.text
+        error_message = response_json.get("message") or response.text
         errors = response_json.get("errors", [])
         for error in errors:
             error_message += f"\n{json.dumps(error)}"

--- a/lib/galaxy/files/sources/dataverse.py
+++ b/lib/galaxy/files/sources/dataverse.py
@@ -79,7 +79,7 @@ class DataverseRDMFilesSource(RDMFilesSource):
         self.repository: DataverseRepositoryInteractor
 
     def get_scheme(self) -> str:
-        return "dataverse"
+        return self.scheme if self.scheme and self.scheme != DEFAULT_SCHEME else self.plugin_type
 
     def score_url_match(self, url: str) -> int:
         if match := self._scheme_regex.match(url):

--- a/lib/galaxy/files/templates/examples/production_dataverse.yml
+++ b/lib/galaxy/files/templates/examples/production_dataverse.yml
@@ -1,0 +1,43 @@
+- id: dataverse
+  version: 0
+  name: Dataverse
+  description: |
+      [The Dataverse Project](https://dataverse.org) is an open-source web application for sharing, preserving, citing, exploring, and analyzing research data. 
+      It enables institutions and researchers to host and manage datasets with rich metadata and persistent identifiers. 
+      This configuration allows you to connect Galaxy to a Dataverse instance of your choice.
+
+      **Note:** Your **registered email address** will be used to create datasets in Dataverse.
+  variables:
+      url:
+          label: Dataverse instance endpoint (e.g. https://demo.dataverse.org)
+          type: string
+          help: |
+              The endpoint of the Dataverse server you are connecting to. This should be the full URL including the protocol
+              (http or https) and the domain name.
+      writable:
+          label: Allow Galaxy to export data to Dataverse?
+          type: boolean
+          default: true
+          help: |
+              Allow Galaxy to write data to this Dataverse instance. Set it to "Yes" if you want to export data from Galaxy to
+              Dataverse, set it to "No" if you only need to import data from Dataverse to Galaxy.
+      public_name:
+          label: Publication Name
+          type: string
+          help: |
+              The name of the person or organization creating the datasets. This will be used in the dataset metadata as the
+              creator. You can update this information later by editing the dataset in Dataverse. If left blank, an anonymous user will be used as the creator.
+              **Note:** Your **registered email address** will be used to create datasets in Dataverse.
+  secrets:
+      token:
+          label: API Token
+          help: |
+              The personal API token used to authenticate with the Dataverse server. You can generate this token in your
+              Dataverse account settings under "API Token". It is required to access private data or upload datasets from Galaxy.
+
+  configuration:
+      type: dataverse
+      url: "{{ variables.url }}"
+      token: "{{ secrets.token }}"
+      writable: "{{ variables.writable }}"
+      public_name: "{{ variables.public_name }}"

--- a/lib/galaxy/files/templates/models.py
+++ b/lib/galaxy/files/templates/models.py
@@ -49,6 +49,7 @@ FileSourceTemplateType = Literal[
     "inveniordm",
     "zenodo",
     "rspace",
+    "dataverse",
 ]
 
 
@@ -282,6 +283,24 @@ class RSpaceFileSourceConfiguration(StrictModel):
     writable: bool = True
 
 
+class DataverseFileSourceTemplateConfiguration(StrictModel):
+    type: Literal["dataverse"]
+    url: Union[str, TemplateExpansion]
+    public_name: Union[str, TemplateExpansion]
+    token: Union[str, TemplateExpansion]
+    writable: Union[bool, TemplateExpansion] = True
+    template_start: Optional[str] = None
+    template_end: Optional[str] = None
+
+
+class DataverseFileSourceConfiguration(StrictModel):
+    type: Literal["dataverse"]
+    url: str
+    public_name: str
+    token: str
+    writable: bool = True
+
+
 FileSourceTemplateConfiguration = Annotated[
     Union[
         PosixFileSourceTemplateConfiguration,
@@ -296,6 +315,7 @@ FileSourceTemplateConfiguration = Annotated[
         InvenioFileSourceTemplateConfiguration,
         ZenodoFileSourceTemplateConfiguration,
         RSpaceFileSourceTemplateConfiguration,
+        DataverseFileSourceTemplateConfiguration,
     ],
     Field(discriminator="type"),
 ]
@@ -314,6 +334,7 @@ FileSourceConfiguration = Annotated[
         InvenioFileSourceConfiguration,
         ZenodoFileSourceConfiguration,
         RSpaceFileSourceConfiguration,
+        DataverseFileSourceConfiguration,
     ],
     Field(discriminator="type"),
 ]
@@ -390,6 +411,7 @@ TypesToConfigurationClasses: Dict[FileSourceTemplateType, Type[FileSourceConfigu
     "inveniordm": InvenioFileSourceConfiguration,
     "zenodo": ZenodoFileSourceConfiguration,
     "rspace": RSpaceFileSourceConfiguration,
+    "dataverse": DataverseFileSourceConfiguration,
 }
 
 


### PR DESCRIPTION
Adds a new template to connect to a Dataverse.org instance.

![image](https://github.com/user-attachments/assets/25a0d530-2821-4377-8006-027195a98222)


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Add a new entry in your `file_source_templates.yml` with `- include: ./lib/galaxy/files/templates/examples/production_dataverse.yml`
  - Create a Dataverse User and API Token in the Demo:
    Generate a token via "Your username" → "My Data" → "API token" or directly at this URL: https://demo.dataverse.org/dataverseuser.xhtml?selectTab=apiTokenTab.
  - Go to http://127.0.0.1:8081/file_source_templates/dataverse/new and fill out the template

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
