### PR TITLE
[25.0] Fix PDF preview functionality in dataset view

### DIFF
--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -66,6 +66,10 @@ const isImageDataset = computed(() => {
     ]);
 });
 
+const isPdfDataset = computed(() => {
+    return dataset.value?.file_ext === "pdf";
+});
+
 // Watch for changes to the dataset to fetch datatype info
 watch(
     () => dataset.value?.file_ext,
@@ -175,6 +179,11 @@ watch(
                 :dataset-id="datasetId"
                 :visualization="preferredVisualization"
                 @load="iframeLoading = false" />
+            <CenterFrame
+                v-else-if="isPdfDataset"
+                :src="`/datasets/${datasetId}/display/?preview=True`"
+                :is-preview="true"
+                @load="iframeLoading = false" />
             <div v-else-if="isAutoDownloadType" class="auto-download-message p-4">
                 <div class="alert alert-info">
                     <h4>Download Required</h4>
@@ -197,7 +206,12 @@ watch(
                 @load="iframeLoading = false" />
         </div>
         <div v-else-if="tab === 'raw'" class="h-100">
-            <div v-if="isAutoDownloadType" class="auto-download-message p-4">
+            <CenterFrame
+                v-if="isPdfDataset"
+                :src="`/datasets/${datasetId}/display/?preview=True`"
+                :is-preview="true"
+                @load="iframeLoading = false" />
+            <div v-else-if="isAutoDownloadType" class="auto-download-message p-4">
                 <div class="alert alert-info">
                     <h4>Download Required</h4>
                     <p>This file type ({{ dataset.file_ext }}) will download automatically when accessed directly.</p>


### PR DESCRIPTION
This is a quick fix for 25.0, but I want to think more about the right way to annotate these more cleanly moving froward.  PDFs were being caught by auto-download logic instead of rendering inline due to their display_behavior setting coupled with the fact that they're a subtype of Image.

We now explicitly handle PDFs before auto-download check to restore browser-based PDF viewing.

Fixes #20549 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
