### PR TITLE
[25.0] Make collection download asynchronous

### DIFF
--- a/client/src/components/History/CurrentCollection/CollectionOperations.vue
+++ b/client/src/components/History/CurrentCollection/CollectionOperations.vue
@@ -5,6 +5,8 @@ import { useRouter } from "vue-router/composables";
 import type { HDCASummary } from "@/api";
 import { getAppRoot } from "@/onload/loadConfig";
 
+import StsDownloadButton from "@/components/StsDownloadButton.vue";
+
 const router = useRouter();
 
 const props = defineProps<{
@@ -12,6 +14,9 @@ const props = defineProps<{
 }>();
 
 const downloadUrl = computed(() => `${getAppRoot()}api/dataset_collections/${props.dsc.id}/download`);
+const asyncDownloadUrl = computed(() => {
+    return `${getAppRoot()}api/dataset_collections/${props.dsc.id}/prepare_download`;
+});
 const rerunUrl = computed(() =>
     props.dsc.job_source_type == "Job" ? `/root?job_id=${props.dsc.job_source_id}` : null
 );
@@ -19,26 +24,19 @@ const showCollectionDetailsUrl = computed(() =>
     props.dsc.job_source_type == "Job" ? `/jobs/${props.dsc.job_source_id}/view` : null
 );
 const disableDownload = props.dsc.populated_state !== "ok";
-
-function onDownload() {
-    window.location.href = downloadUrl.value;
-}
 </script>
 <template>
     <section>
         <nav class="content-operations d-flex justify-content-between bg-secondary">
             <b-button-group>
-                <b-button
-                    title="Download Collection"
-                    :disabled="disableDownload"
-                    class="rounded-0 text-decoration-none"
-                    size="sm"
-                    variant="link"
-                    :href="downloadUrl"
-                    @click="onDownload">
-                    <Icon class="mr-1" icon="download" />
-                    <span>Download</span>
-                </b-button>
+                <StsDownloadButton
+                    v-if="!disableDownload"
+                    :fallback-url="downloadUrl"
+                    :download-endpoint="asyncDownloadUrl"
+                    size="small"
+                    title="Download Collection as Zip"
+                    color="blue"
+                    outline />
                 <b-button
                     v-if="showCollectionDetailsUrl"
                     class="collection-job-details-btn px-1"

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -483,7 +483,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
     def prepare_collection_download(self, trans, id: DecodedDatabaseIdField) -> AsyncFile:
         ensure_celery_tasks_enabled(trans.app.config)
         dataset_collection_instance = self.__get_accessible_collection(trans, id)
-        archive_name = f"{dataset_collection_instance.hid}: {dataset_collection_instance.name}"
+        archive_name = f"{dataset_collection_instance.hid}: {dataset_collection_instance.name}.zip"
         short_term_storage_target = self.short_term_storage_allocator.new_target(
             filename=archive_name, mime_type="application/x-zip-compressed"
         )


### PR DESCRIPTION
Fixes #20559

In addition, it sets the extension for the output archive to .zip

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Create a collection with many elements or store it in a remote storage
  - Go to the collection details
  - Try to download the collection

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
