### PR TITLE
[25.0] Fix Storage Dashboard Link to Dataset Details

### DIFF
--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -261,6 +261,7 @@ export function getRouter(Galaxy) {
                         // Consolidated route for dataset view with optional tab
                         // Handles /datasets/{id}, /datasets/{id}/details, /datasets/{id}/visualize, etc.
                         path: "datasets/:datasetId/:tab?",
+                        name: "DatasetDetails",
                         component: DatasetView,
                         props: (route) => ({
                             datasetId: route.params.datasetId,


### PR DESCRIPTION
Fixes #20564

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Go to the storage dashboard
  2. Explore the `Visually explore your disk usage by storage location`
  3. Select one of the bars (Storage Location) in the histogram and click `View`
  4. Select one of the bars (dataset) in the `Top 10 Datasets by Size` histogram and click `Explore content`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
